### PR TITLE
fix: render errorElement when route loader is rejected

### DIFF
--- a/packages/react-location/src/index.tsx
+++ b/packages/react-location/src/index.tsx
@@ -942,8 +942,8 @@ export class RouteMatch<TGenerics extends PartialGenerics = DefaultGenerics> {
 
               const loaderReady = (status: 'resolved' | 'rejected') => {
                 this.updatedAt = Date.now()
-                resolveLoader(this.ownData)
                 this.status = status
+                resolveLoader(this.ownData)
               }
 
               const resolve = (data: any) => {
@@ -985,7 +985,9 @@ export class RouteMatch<TGenerics extends PartialGenerics = DefaultGenerics> {
 
         return Promise.all([...elementPromises, dataPromise])
           .then(() => {
-            this.status = 'resolved'
+            if (!loader) {
+              this.status = 'resolved'
+            }
             this.isLoading = false
             this.startPending = undefined
           })


### PR DESCRIPTION
Fixes #255

- We set the `RouteMatch` status after loading the elements and (optional) loader
- The loader can also set the status
- Thus, we only set the `resolved` status for `RouteMatch`'es without loaders, to prevent overriding the status set by the loader

I guess you could rework this logic many ways but i thought this was the easiest to follow.