### PR TITLE
Update peerDependency react-location to match higher versions

### DIFF
--- a/packages/react-location-devtools/package.json
+++ b/packages/react-location-devtools/package.json
@@ -37,7 +37,7 @@
   "peerDependencies": {
     "react": ">=16",
     "react-dom": ">=16",
-    "@tanstack/react-location": "3.4.4"
+    "@tanstack/react-location": ">=3.4.4"
   },
   "dependencies": {
     "@babel/runtime": "^7.16.7"


### PR DESCRIPTION
When installing anything in my project I get this error:

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: @tanstack/react-location-devtools@3.4.4
npm ERR! Found: @tanstack/react-location@3.7.4
npm ERR! node_modules/@tanstack/react-location
npm ERR!   @tanstack/react-location@"^3.7.4" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @tanstack/react-location@"3.4.4" from @tanstack/react-location-devtools@3.4.4
npm ERR! node_modules/@tanstack/react-location-devtools
npm ERR!   @tanstack/react-location-devtools@"^3.4.4" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: @tanstack/react-location@3.4.4
npm ERR! node_modules/@tanstack/react-location
npm ERR!   peer @tanstack/react-location@"3.4.4" from @tanstack/react-location-devtools@3.4.4
npm ERR!   node_modules/@tanstack/react-location-devtools
npm ERR!     @tanstack/react-location-devtools@"^3.4.4" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

I hope by changing the peerDependency to match also higher versions of react-location this could be fixed.