### PR TITLE
fix: memoize matches provider data

### DIFF
--- a/packages/react-location/src/index.tsx
+++ b/packages/react-location/src/index.tsx
@@ -482,10 +482,24 @@ export type MatchesProviderProps<TGenerics> = {
   children: React.ReactNode
 }
 
+function arrayShallowEqual(arr1: unknown[], arr2: unknown[]): boolean {
+  if(arr1 === arr2) {
+    return true
+  }
+  if (arr1.length !== arr2.length) {
+    return false
+  }
+  return arr1.every((v, i) => v === arr2[i])
+}
+
 export function MatchesProvider<TGenerics>(
-  props: MatchesProviderProps<TGenerics>,
+  {value, children}: MatchesProviderProps<TGenerics>,
 ) {
-  return <MatchesContext.Provider {...props} />
+  const prevValueRef = React.useRef<RouteMatch<TGenerics>[]>(value);
+  const matches = arrayShallowEqual(prevValueRef.current, value) ? prevValueRef.current : value
+  prevValueRef.current = matches;
+
+  return <MatchesContext.Provider value={matches}>{children}</MatchesContext.Provider>
 }
 
 export function Router<TGenerics extends PartialGenerics = DefaultGenerics>({


### PR DESCRIPTION
The `MatchesProvider` value changes on every render every time the provider is rendered. This causes any component using the `useMatch` or `useMatches` hook to re-render 3 times when navigating. Two of these renders occur before the routes update.

I am using the `useMatch` hook to access route loader data on my pages, and they currently re-render twice before unmounting because of a route change.

This PR fixes this by performing a shallow compare on the RouteMatch array and returning the old value if they are equal.