### PR TITLE
working gradual autocomplete for relative paths

### DIFF
--- a/packages/router-core/src/createRoutes.test.ts
+++ b/packages/router-core/src/createRoutes.test.ts
@@ -419,22 +419,7 @@ router.link({
   }),
 })
 
-router.getRoute('/dashboard/invoices/:invoiceId').link({
-  to: '..',
-  test: (arg) => {},
-  // params: {
-  //   userId: '2',
-  // },
-  // search: (prev) => ({
-  //   usersView: {
-  //     sortBy: 'email',
-  //     filterBy: `${prev.version}`,
-  //   },
-  // }),
+router.link({
+  from: '/dashboard/invoices',
+  to: '/dashboard',
 })
-
-///
-
-//
-
-//


### PR DESCRIPTION
I have added the typescript types for gradual autocomplete of the paths as mentioned in Matt's discord

Now when autocompleting on `route.link` it will suggest relative paths
