### PR TITLE
Docs: Cleanup Zipson example

### DIFF
--- a/docs/src/pages/guides/custom-search-param-serialization.md
+++ b/docs/src/pages/guides/custom-search-param-serialization.md
@@ -77,29 +77,10 @@ const reactLocation = new ReactLocation({
     parse(decodeURIComponent(atob(value))),
   ),
   stringifySearch: stringifySearchWith((value) =>
-    btoa(encodeURIComponent(stringify(value))),
+    stringify(encodeURIComponent(stringify(value))),
   ),
 })
-
-export function encodeToBinary(str: string): string {
-  return btoa(
-    encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function (match, p1) {
-      return String.fromCharCode(parseInt(p1, 16))
-    }),
-  )
-}
-export function decodeFromBinary(str: string): string {
-  return decodeURIComponent(
-    Array.prototype.map
-      .call(atob(str), function (c) {
-        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
-      })
-      .join(''),
-  )
-}
 ```
-
-> [⚠️ Why does this snippet not use atob/btoa?](#safe-binary-encodingdecoding)
 
 ## Using JSURL
 

--- a/docs/src/pages/guides/custom-search-param-serialization.md
+++ b/docs/src/pages/guides/custom-search-param-serialization.md
@@ -74,12 +74,29 @@ import { stringify, parse } from 'zipson'
 
 const reactLocation = new ReactLocation({
   parseSearch: parseSearchWith((value) =>
-    parse(decodeURIComponent(atob(value))),
+    parse(decodeURIComponent(decodeFromBinary(value))),
   ),
   stringifySearch: stringifySearchWith((value) =>
-    stringify(encodeURIComponent(stringify(value))),
+    encodeToBinary(encodeURIComponent(stringify(value))),
   ),
 })
+
+export function encodeToBinary(str: string): string {
+  return btoa(
+    encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function (match, p1) {
+      return String.fromCharCode(parseInt(p1, 16))
+    }),
+  )
+}
+export function decodeFromBinary(str: string): string {
+  return decodeURIComponent(
+    Array.prototype.map
+      .call(atob(str), function (c) {
+        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+      })
+      .join(''),
+  )
+}
 ```
 
 ## Using JSURL

--- a/docs/src/pages/guides/custom-search-param-serialization.md
+++ b/docs/src/pages/guides/custom-search-param-serialization.md
@@ -99,6 +99,8 @@ export function decodeFromBinary(str: string): string {
 }
 ```
 
+> [⚠️ Why does this snippet not use atob/btoa?](#safe-binary-encodingdecoding)
+
 ## Using JSURL
 
 [JSURL](https://github.com/Sage/jsurl) is a non-standard library that can both compress URLs while still maintaining readability. This can be done with the following code:


### PR DESCRIPTION
Update: In https://github.com/TanStack/router/commit/59cd694ecadd9ea626d0284cced1adc2c6ac3ef1#diff-e9e4886c0ad5e55485f3f74b95980d5f1271e4d360a6be9c7bc96f5e81fd4c5aR83-R99 you added the custom encoder/decoder but did not use the inside the Zipson example, which is what this PR fixes.

~~Zipson provides it's own parse/stringify methods, which are correctly imported in the example. However, when the example was added, instead of using `parse` the code said 'btoa' which is likely a copy-paste-error, see https://github.com/TanStack/router/commit/6dd728355b7a4b3be112b7eb897bac06b48fa65b#diff-e9e4886c0ad5e55485f3f74b95980d5f1271e4d360a6be9c7bc96f5e81fd4c5aR42-R58. And later in https://github.com/TanStack/router/commit/59cd694ecadd9ea626d0284cced1adc2c6ac3ef1#diff-e9e4886c0ad5e55485f3f74b95980d5f1271e4d360a6be9c7bc96f5e81fd4c5aR75-R99 when the docs where updated to explain the limitations of `btoa` the section about Zipson god an update as well.~~
