### PR TITLE
Docs: Add missing docs pages

### DIFF
--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -1,0 +1,5 @@
+---
+title: Actions
+---
+
+TODO

--- a/docs/guide/caching.md
+++ b/docs/guide/caching.md
@@ -1,0 +1,5 @@
+---
+title: Caching
+---
+
+TODO

--- a/docs/guide/links.md
+++ b/docs/guide/links.md
@@ -1,0 +1,5 @@
+---
+title: Links
+---
+
+TODO

--- a/docs/guide/loaders.md
+++ b/docs/guide/loaders.md
@@ -1,0 +1,5 @@
+---
+title: Loaders
+---
+
+TODO

--- a/docs/guide/preloading.md
+++ b/docs/guide/preloading.md
@@ -1,0 +1,5 @@
+---
+title: Preloading
+---
+
+TODO

--- a/docs/guide/route-matches.md
+++ b/docs/guide/route-matches.md
@@ -1,0 +1,5 @@
+---
+title: Route Matches
+---
+
+TODO

--- a/docs/guide/router.md
+++ b/docs/guide/router.md
@@ -1,0 +1,5 @@
+---
+title: Router
+---
+
+TODO

--- a/docs/guide/routes.md
+++ b/docs/guide/routes.md
@@ -1,0 +1,5 @@
+---
+title: Routes
+---
+
+TODO


### PR DESCRIPTION
A couple of the documentation pages already have TODO placeholders but others are currently 404ing due to a missing markdown file. This PR fills in TODO placeholders for each guide that returns a 404.

https://tanstack.com/router/v1/docs/guide/router
https://tanstack.com/router/v1/docs/guide/links
https://tanstack.com/router/v1/docs/guide/routes
https://tanstack.com/router/v1/docs/guide/route-matches
https://tanstack.com/router/v1/docs/guide/loaders
https://tanstack.com/router/v1/docs/guide/actions
https://tanstack.com/router/v1/docs/guide/caching
https://tanstack.com/router/v1/docs/guide/preloading