### PR TITLE
Link component throws when clicked on React < 18

### DIFF
--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -327,9 +327,9 @@ export function createReactRouter<
         } = linkInfo
 
         const reactHandleClick = (e: Event) => {
-          React.startTransition(() => {
-            handleClick(e)
-          })
+          if (React.startTransition) // This is a hack for react < 18
+            React.startTransition(() => {handleClick(e)})
+          else handleClick(e)
         }
 
         const composeHandlers =


### PR DESCRIPTION
The problem seems to be the fault of `startTransition` from React 18.
I applied a plaster fix to check whether that method exists and if not to go and execute `handleClick` directly.