### PR TITLE
chore: fix broken link to layout-routes page

### DIFF
--- a/docs/guide/route-paths.md
+++ b/docs/guide/route-paths.md
@@ -46,4 +46,4 @@ const routeConfig = rootRoute.addChildren([
 
 ## Layout Routes
 
-A layout route is a route that does not have a path, but allows wrapping it's child routes with wrapper elements or shared logic. See [Layout Routes](./layout-routes) for more information.
+A layout route is a route that does not have a path, but allows wrapping it's child routes with wrapper elements or shared logic. See [Layout Routes](./guide/layout-routes) for more information.


### PR DESCRIPTION
I wasn't sure if this is exactly the correct way to fix it, but I couldn't find easy docs on how the docs are getting generated. I believe the correct fix should the docs while being generated correct the links to their siblings pages