### PR TITLE
docs: Fix Core API 404 and Typos

### DIFF
--- a/docs/adapters/react-router.md
+++ b/docs/adapters/react-router.md
@@ -2,19 +2,13 @@
 title: React Router
 ---
 
-You can install TanStack Router with [NPM](https://npmjs.com),
-[Yarn](https://yarnpkg.com), or a good ol' `<script>` via
-[unpkg.com](https://unpkg.com).
+You can install TanStack Router with [NPM](https://npmjs.com), [Yarn](https://yarnpkg.com), or a good ol' `<script>` via [unpkg.com](https://unpkg.com).
 
 ### NPM
 
 ```sh
 npm install @tanstack/react-router@beta --save
-```
-
-or
-
-```sh
+# or
 yarn add @tanstack/react-router@beta
 ```
 

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -1,0 +1,5 @@
+---
+title: Core
+---
+
+TODO

--- a/docs/config.json
+++ b/docs/config.json
@@ -181,11 +181,11 @@
           "to": "examples/react/with-react-query?file=src%2Fmain.tsx"
         },
         {
-          "label": "With TRPC",
+          "label": "With tRPC",
           "to": "examples/react/with-trpc?file=client%2Fmain.tsx"
         },
         {
-          "label": "With TRPC & React Query",
+          "label": "With tRPC & React Query",
           "to": "examples/react/with-trpc-react-query?file=client%2Fmain.tsx"
         }
       ]

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -25,7 +25,7 @@ TanStack Router is a UI router for building applications in React, Preact, Vue, 
 
 TanStack Router builds on concepts and patterns popularized by many other OSS projects, including:
 
-- [TRPC](https://trpc.io/)
+- [tRPC](https://trpc.io/)
 - [Remix](https://remix.run)
 - [Chicane](https://swan-io.github.io/chicane/)
 - [Next.js](https://nextjs.org)

--- a/docs/tools/ranked-routes.md
+++ b/docs/tools/ranked-routes.md
@@ -18,8 +18,6 @@ npm i @tanstack/router-rank-routes
 import { Router } from '@tanstack/react-router'
 import { rankRoutes } from '@tanstack/router-rank-routes'
 
-//
-
 function App() {
   return (
     <Router

--- a/examples/react/with-trpc-react-query/client/main.tsx
+++ b/examples/react/with-trpc-react-query/client/main.tsx
@@ -62,7 +62,7 @@ const postsRoute = rootRoute.createRoute({
   loaderMaxAge: 0,
   errorComponent: () => 'Oh crap!',
   loader: async () => {
-    // TODO: Prefetch posts using TRPC
+    // TODO: Prefetch posts using tRPC
     return {}
   },
   component: () => {
@@ -109,7 +109,7 @@ const postsIndexRoute = postsRoute.createRoute({
 const postRoute = postsRoute.createRoute({
   path: '$postId',
   loader: async ({ params: { postId } }) => {
-    // TODO: Prefetch post using TRPC
+    // TODO: Prefetch post using tRPC
     return {}
   },
   component: () => {

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -132,7 +132,7 @@ async function run() {
     `Parsing ${commitsSinceLatestTag.length} commits since ${latestTag}...`,
   )
 
-  // Pares the commit messsages, log them, and determine the type of release needed
+  // Pares the commit messages, log them, and determine the type of release needed
   let recommendedReleaseLevel: number = commitsSinceLatestTag.reduce(
     (releaseLevel, commit) => {
       if (['fix', 'refactor', 'perf'].includes(commit.parsed.type!)) {
@@ -567,7 +567,7 @@ async function run() {
 
   if (branchConfig.ghRelease) {
     console.info(`Creating github release...`)
-    // Stringify the markdown to excape any quotes
+    // Stringify the markdown to escape any quotes
     execSync(
       `gh release create v${version} ${
         !isLatestBranch ? '--prerelease' : ''


### PR DESCRIPTION
The current link to `https://tanstack.com/router/v1/docs/api/core` results in a 404 so I created a `core.md` file in `docs/api`. I had a few other questions as well about overall documentation contributions.

## How do I doc?

I was wondering if it's possible to build and run the docs site locally? I didn't see anyway to do so by looking at the scripts in the `package.json`.

I wanted to fix the weird anchor link behavior for the Solid/Svelte/Vue coming soon links which result in things like:

```
https://tanstack.com/router/v1/docs/vue-coming-soon
https://tanstack.com/router/v1/docs/#solid-coming-soon
https://tanstack.com/router/v1/docs/vue-coming-soon#svelte-coming-soon
```

My intuition is that the solution would something along the lines of uncommenting these:

```ts
// scripts/config.ts

export const examplesDirs = [
  'examples/react',
  'examples/solid',
  'examples/svelte',
  'examples/vue',
]
```

Fixing the `to` routes defined under the Solid, Svelte, and Vue tutorials in `config.json`.

```json
{
  "menu": [
    {
      "label": "Solid Examples",
      "children": [
        {
          "label": "Coming Soon!",
          "to": "examples/solid/basic"
        }
      ]
    },
    {
      "label": "Svelte Examples",
      "children": [
        {
          "label": "Coming Soon!",
          "to": "examples/svelte/basic"
        }
      ]
    },
    {
      "label": "Vue Examples",
      "children": [
        {
          "label": "Coming Soon!",
          "to": "examples/vue/basic"
        }
      ]
    }
  ]
}
```

And then create the following directories and markdown files with Todo messages in each:

```bash
mkdir -p examples/solid/basic
mkdir -p examples/svelte/basic
mkdir -p examples/vue/basic
echo '# Solid Basic Example\n\nComing soon!' > examples/solid/basic/README.md
echo '# Svelte Basic Example\n\nComing soon!' > examples/svelte/basic/README.md
echo '# Vue Basic Example\n\nComing soon!' > examples/vue/basic/README.md
```

Problem is, I have no idea how these markdown files are being built and packaged and I have no way of knowing whether this would break in some ways until I can test it somehow.

## Possible Additions to the Quick Start

Final thought I had was, I always personally find it useful when Quick Start guides include all or at least most of the steps you'd need to get from 0 to 1. In that spirit, I'd add something like this before the primary code block:

```bash
npm create vite@latest tanstack-router-react -- --template react-ts
cd tanstack-router-react
npm i @tanstack/react-router@beta
```

And then this after the code block:

```bash
npm run dev
```