### PR TITLE
docs: fix broken example import name

### DIFF
--- a/docs/guide/history-types.md
+++ b/docs/guide/history-types.md
@@ -23,7 +23,7 @@ import {
   createMemoryHistory,
   createReactRouter,
   createRouteConfig,
-} from '@tanstack/router'
+} from '@tanstack/react-router'
 
 const rootRoute = createRouteConfig()
 
@@ -49,7 +49,7 @@ import {
   createHashHistory,
   createReactRouter,
   createRouteConfig,
-} from '@tanstack/router'
+} from '@tanstack/react-router'
 
 const rootRoute = createRouteConfig()
 


### PR DESCRIPTION
package name is changed from `@tanstack/router` to `@tanstack/react-router`