### PR TITLE
fix(router-cli generator): fix generated import

### DIFF
--- a/packages/router-cli/src/generator.ts
+++ b/packages/router-cli/src/generator.ts
@@ -280,16 +280,20 @@ export async function generator(config: Config) {
 
       routeConfigImports.push(
         `import { routeConfig as ${node.variable}Route } from './${removeExt(
-          path.relative(config.routeGenDirectory, node.genPath),
+          path
+            .relative(config.routeGenDirectory, node.genPath)
+            .replace(/\\/gi, '/'),
         )}'`,
       )
 
       routeConfigClientImports.push(
         `import { routeConfig as ${node.variable}Route } from './${removeExt(
-          path.relative(
-            config.routeGenDirectory,
-            path.resolve(node.genDir, node.clientFilename),
-          ),
+          path
+            .relative(
+              config.routeGenDirectory,
+              path.resolve(node.genDir, node.clientFilename),
+            )
+            .replace(/\\/gi, '/'),
         )}'`,
       )
 


### PR DESCRIPTION
This PR fixes the backslash import when generating routes on windows, replace ```\``` to ```/```
https://github.com/TanStack/router/issues/465