### PR TITLE
Update the routeConfig import on windows.

### DIFF
--- a/packages/router-cli/src/transformCode.ts
+++ b/packages/router-cli/src/transformCode.ts
@@ -99,7 +99,7 @@ export async function ensureBoilerplate(node: RouteNode, code: string) {
                 if (!foundImport) {
                   programPath.node.body.unshift(
                     babel.template.statement(
-                      `import { routeConfig } from '${relativeImportPath}'`,
+                      `import { routeConfig } from '${relativeImportPath.replace(/\\/gi, '/')}'`,
                     )(),
                   )
                 }


### PR DESCRIPTION
Using posix style path for the routeConfig import statement in the transformed code. [This PR](https://github.com/TanStack/router/pull/469) corrected this issue in some areas but the transformed code is still affected.