### PR TITLE
Remove extraneous console log statements

### DIFF
--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -4,7 +4,6 @@ import { useSyncExternalStore } from 'use-sync-external-store/shim'
 // @ts-ignore
 // import { useSyncExternalStore } from './uSES/useSyncExternalStoreShim'
 import { createEffect, createRoot, untrack, unwrap } from '@solidjs/reactivity'
-import { createStore } from '@solidjs/reactivity'
 
 import {
   Route,
@@ -333,27 +332,6 @@ export const __useStoreValue = <TSeed, TReturn>(
 
   return useSyncExternalStore(getStore, getSnapshot, getSnapshot)
 }
-
-const [store, setStore] = createStore({ foo: 'foo', bar: { baz: 'baz' } })
-
-createRoot(() => {
-  let prev: any
-
-  createEffect(() => {
-    console.log('effect')
-    const next = sharedClone(prev, store)
-    console.log(next)
-    prev = untrack(() => next)
-  })
-})
-
-setStore((s) => {
-  s.foo = '1'
-})
-
-setStore((s) => {
-  s.bar.baz = '2'
-})
 
 export function createReactRouter<
   TRouteConfig extends AnyRouteConfig = RouteConfig,


### PR DESCRIPTION
First of all, great work on this package. Really cool stuff!

I noticed some extraneous logs cluttering up the console while I was setting things up. Looks like this section was maybe missed during the migration to vitest in this PR: https://github.com/TanStack/router/commit/6d3c0686d086d98eeff80d98aa213ef5af4b0c2c#diff-d59f1a00dff1823e6f16ddf621c708682b1acc37566b17d047bbe4263a580058R337

I know things are moving fast, so feel free to ignore this if it's not worth the time or if you already have it on your radar.