### PR TITLE
Fix useNavigate hook

### DIFF
--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -544,13 +544,13 @@ export function useParams<
 export function useNavigate<
   TDefaultFrom extends keyof RegisteredAllRouteInfo['routeInfoById'] = '/',
 >(defaultOpts: { from?: TDefaultFrom }) {
+  const router = useRouter()
   return <
     TFrom extends keyof RegisteredAllRouteInfo['routeInfoById'] = TDefaultFrom,
     TTo extends string = '.',
   >(
     opts: MakeLinkOptions<TFrom, TTo>,
   ) => {
-    const router = useRouter()
     return router.navigate({ ...defaultOpts, ...(opts as any) })
   }
 }


### PR DESCRIPTION
The `useNavigate` hook currently returns a function. Inside this returned function, the `useRouter` hook is used. Since the returned function itself is not a hook, a violation of the react hook rules is triggered.

```
    Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:
You might have mismatching versions of React and the renderer (such as React DOM)
You might be breaking the Rules of Hooks
You might have more than one copy of React in the same app See for tips about how to debug and fix this problem.
```

Moving the `useRouter` call outside the return statement should mitigate this issue.
