### PR TITLE
Clarify missing-outlet -> missing-children concept

### DIFF
--- a/docs/guide/route-paths.md
+++ b/docs/guide/route-paths.md
@@ -43,6 +43,7 @@ const routeConfig = rootRoute.addChildren([
   blogRoute.addChildren([blogIndexRoute]),
 ])
 ```
+If you put a component in the normal (non-index) route, it will render both when its route is terminal *and* when children are also active; children will render in its `<Outlet />`. If there is no outlet then the children will not render.
 
 ## Layout Routes
 


### PR DESCRIPTION
As [seen in the Issues](https://github.com/TanStack/router/issues/496#issuecomment-1386695452), there is possibility of confusion in the way that non-index routes render both when terminal *and when intermediate* in the whole URL path, and how this can cause children to be missing if the parent lacks an `<Outlet/>`.