### PR TITLE
docs: update nextjs link

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -73,6 +73,7 @@ Feature/Capability Key:
 [bpl-react-router]: https://bundlephobia.com/result?p=react-router-dom
 [bpl-history]: https://bundlephobia.com/result?p=history
 [_]: _
+[nextjs]: https://github.com/vercel/next.js
 [bp-nextjs]: https://badgen.net/bundlephobia/minzip/next.js?label=💾
 [gh-nextjs]: https://github.com/vercel/next.js
 [stars-nextjs]: https://img.shields.io/github/stars/vercel/next.js?label=%F0%9F%8C%9F


### PR DESCRIPTION
Updated the documentation's Next.JS link: https://tanstack.com/router/v1/docs/comparison