### PR TITLE
Propagate beforeLoad errors to nearest errorComponent

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -669,7 +669,7 @@ export class Router<
               throw err
             }
 
-            firstBadMatchIndex = index
+            firstBadMatchIndex = firstBadMatchIndex ?? index
 
             const errorHandler = match.route.options.onBeforeLoadError ?? match.route.options.onError
             try {


### PR DESCRIPTION
Following on from #523, this PR ensures that errors thrown in `beforeLoad` and its error handler (either `onBeforeLoadError` or `onError`) are propagated to the nearest `errorComponent`.

Updated diagram from the previous PR (again assuming no preloading to keep things simple):

```mermaid
%%{
  init: {
    'theme': 'base',
    'themeVariables': {
      'secondaryColor': 'white',
      'tertiaryColor': '#fff'
    }
  },
}%%
graph LR
    subgraph Legend
        direction LR
        e1(( )) --->|Throw error| e2(( ))
        er1(( )) --->|Throw error or return| er2(( ))
        r1(( )) --->|Throw redirect| r2(( ))
        h1(( )) --->|Happy path| h2(( ))
    end

    A[Load]
    B[Render \n component]
    C[Navigate]

    D(beforeLoad)
    E(onBeforeLoadError \n or onError)

    F(validateSearch)
    G(onValidateSearchError \n or onError)

    H(onLoad)
    I(onLoadError \n or onError)

    J[Render nearest \n errorComponent]
    A --> D

    D --> C
    D --> E
    D --> F

    E ---> C
    E --> J

    F --> C
    F --> G
    F --> H

    G --> C
    G ---> J
  
    H --> C
    H --> I
    H --> B
  
    I --> C
    I ---> J

    B --> J

    style Legend color:black,padding:5px;

    linkStyle 0,6,11,16,20 stroke:red,stroke-width:3px;
    linkStyle 1,9,14,19 stroke:orange,stroke-width:3px;
    linkStyle 2,5,8,10,13,15,18 stroke:blue,stroke-width:3px;
    linkStyle 3,4,7,12,17 stroke:lightgreen,stroke-width:3px;
```