### PR TITLE
Adding wrappers around the error boundaries for temporary patch

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -494,7 +494,7 @@ importers:
       use-sync-external-store: ^1.2.0
     dependencies:
       '@astrojs/netlify': 1.2.1
-      '@astrojs/react': 1.2.2_biqbaboplfbrettd7655fr4n2y
+      '@astrojs/react': 1.2.2_yqqa5ithnjtlkxisuaub7c4kpa
       '@tanstack/react-loaders': link:../../../packages/react-loaders
       '@tanstack/react-router': link:../../../packages/react-router
       '@tanstack/react-router-devtools': link:../../../packages/react-router-devtools
@@ -721,20 +721,28 @@ importers:
     specifiers:
       '@tanstack/actions': workspace:*
       '@tanstack/react-store': workspace:*
+      react: '>=16'
+      react-dom: '>=16'
       tiny-invariant: ^1.0.5
     dependencies:
       '@tanstack/actions': link:../actions
       '@tanstack/react-store': link:../react-store
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
       tiny-invariant: 1.3.1
 
   packages/react-loaders:
     specifiers:
       '@tanstack/loaders': workspace:*
       '@tanstack/react-store': workspace:*
+      react: '>=16'
+      react-dom: '>=16'
       tiny-invariant: ^1.0.5
     dependencies:
       '@tanstack/loaders': link:../loaders
       '@tanstack/react-store': link:../react-store
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
       tiny-invariant: 1.3.1
 
   packages/react-router:
@@ -743,10 +751,14 @@ importers:
       '@tanstack/react-store': workspace:*
       '@tanstack/router': workspace:*
       babel-plugin-transform-async-to-promises: ^0.8.18
+      react: '>=16'
+      react-dom: '>=16'
     dependencies:
       '@babel/runtime': 7.20.6
       '@tanstack/react-store': link:../react-store
       '@tanstack/router': link:../router
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
     devDependencies:
       babel-plugin-transform-async-to-promises: 0.8.18
 
@@ -755,19 +767,27 @@ importers:
       '@babel/runtime': ^7.16.7
       '@tanstack/react-router': workspace:*
       date-fns: ^2.29.1
+      react: '>=16'
+      react-dom: '>=16'
     dependencies:
       '@babel/runtime': 7.20.6
       '@tanstack/react-router': link:../react-router
       date-fns: 2.29.3
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
 
   packages/react-store:
     specifiers:
       '@tanstack/store': workspace:*
       '@types/use-sync-external-store': ^0.0.3
+      react: '>=16'
+      react-dom: '>=16'
       use-sync-external-store: ^1.2.0
     dependencies:
       '@tanstack/store': link:../store
-      use-sync-external-store: 1.2.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      use-sync-external-store: 1.2.0_react@18.2.0
     devDependencies:
       '@types/use-sync-external-store': 0.0.3
 
@@ -827,11 +847,13 @@ importers:
       '@tanstack/actions': workspace:*
       '@tanstack/solid-store': workspace:*
       babel-plugin-transform-async-to-promises: ^0.8.18
+      solid-js: '>=1.6'
       tiny-invariant: ^1.0.5
     dependencies:
       '@babel/runtime': 7.20.6
       '@tanstack/actions': link:../actions
       '@tanstack/solid-store': link:../solid-store
+      solid-js: 1.6.10
       tiny-invariant: 1.3.1
     devDependencies:
       babel-plugin-transform-async-to-promises: 0.8.18
@@ -842,11 +864,13 @@ importers:
       '@tanstack/loaders': workspace:*
       '@tanstack/solid-store': workspace:*
       babel-plugin-transform-async-to-promises: ^0.8.18
+      solid-js: '>=1.6'
       tiny-invariant: ^1.0.5
     dependencies:
       '@babel/runtime': 7.20.6
       '@tanstack/loaders': link:../loaders
       '@tanstack/solid-store': link:../solid-store
+      solid-js: 1.6.10
       tiny-invariant: 1.3.1
     devDependencies:
       babel-plugin-transform-async-to-promises: 0.8.18
@@ -857,10 +881,12 @@ importers:
       '@tanstack/router': workspace:*
       '@tanstack/solid-store': workspace:*
       babel-plugin-transform-async-to-promises: ^0.8.18
+      solid-js: '>=1.6'
     dependencies:
       '@babel/runtime': 7.20.6
       '@tanstack/router': link:../router
       '@tanstack/solid-store': link:../solid-store
+      solid-js: 1.6.10
     devDependencies:
       babel-plugin-transform-async-to-promises: 0.8.18
 
@@ -869,9 +895,11 @@ importers:
       '@babel/runtime': ^7.16.7
       '@tanstack/store': workspace:*
       '@types/use-sync-external-store': ^0.0.3
+      solid-js: '>=1.6'
     dependencies:
       '@babel/runtime': 7.20.6
       '@tanstack/store': link:../store
+      solid-js: 1.6.10
     devDependencies:
       '@types/use-sync-external-store': 0.0.3
 
@@ -968,7 +996,7 @@ packages:
       prismjs: 1.29.0
     dev: false
 
-  /@astrojs/react/1.2.2_biqbaboplfbrettd7655fr4n2y:
+  /@astrojs/react/1.2.2_yqqa5ithnjtlkxisuaub7c4kpa:
     resolution: {integrity: sha512-ab9fYvzkC74J7N+M3DWQuZgwu7sYjW0aLO3sEAdCX/jZZz+0BhrqS8m9QjtGJyQK/niF4tgJjpPfadopxKc56g==}
     engines: {node: ^14.18.0 || >=16.12.0}
     peerDependencies:
@@ -979,6 +1007,8 @@ packages:
     dependencies:
       '@babel/core': 7.20.5
       '@babel/plugin-transform-react-jsx': 7.19.0_@babel+core@7.20.5
+      '@types/react': 18.0.26
+      '@types/react-dom': 18.0.9
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     transitivePeerDependencies:
@@ -3889,7 +3919,6 @@ packages:
 
   /@types/prop-types/15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
-    dev: true
 
   /@types/qs/6.9.7:
     resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==}
@@ -3909,7 +3938,6 @@ packages:
     resolution: {integrity: sha512-qnVvHxASt/H7i+XG1U1xMiY5t+IHcPGUK7TDMDzom08xa7e86eCeKOiLZezwCKVxJn6NEiiy2ekgX8aQssjIKg==}
     dependencies:
       '@types/react': 18.0.26
-    dev: true
 
   /@types/react-test-renderer/18.0.0:
     resolution: {integrity: sha512-C7/5FBJ3g3sqUahguGi03O79b8afNeSD6T8/GU50oQrJCU0bVCCGQHaGKUbg2Ce8VQEEqTw8/HiS6lXHHdgkdQ==}
@@ -3939,7 +3967,6 @@ packages:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
       csstype: 3.1.1
-    dev: true
 
   /@types/resolve/1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
@@ -3948,7 +3975,6 @@ packages:
 
   /@types/scheduler/0.16.2:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
-    dev: true
 
   /@types/semver/7.3.13:
     resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
@@ -11151,12 +11177,6 @@ packages:
     dependencies:
       punycode: 2.1.1
     dev: true
-
-  /use-sync-external-store/1.2.0:
-    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dev: false
 
   /use-sync-external-store/1.2.0_react@18.2.0:
     resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -83,48 +83,48 @@ export const packages: Package[] = [
     entryFile: 'src/index.tsx',
     globals: { react: 'React', '@tanstack/react-router': 'ReactRouter' },
   },
-  // {
-  //   name: '@tanstack/solid-store',
-  //   packageDir: 'solid-store',
-  //   srcDir: 'src',
-  //   jsName: 'SolidStore',
-  //   entryFile: 'src/index.ts',
-  //   globals: {
-  //     'solid-js': 'Solid',
-  //   },
-  // },
-  // {
-  //   name: '@tanstack/solid-loaders',
-  //   packageDir: 'solid-loaders',
-  //   srcDir: 'src',
-  //   jsName: 'SolidLoaders',
-  //   entryFile: 'src/index.tsx',
-  //   globals: {
-  //     'solid-js': 'Solid',
-  //   },
-  // },
-  // {
-  //   name: '@tanstack/solid-actions',
-  //   packageDir: 'solid-actions',
-  //   srcDir: 'src',
-  //   jsName: 'SolidActions',
-  //   entryFile: 'src/index.tsx',
-  //   globals: {
-  //     'solid-js': 'Solid',
-  //   },
-  // },
-  // {
-  //   name: '@tanstack/solid-router',
-  //   packageDir: 'solid-router',
-  //   srcDir: 'src',
-  //   jsName: 'SolidRouter',
-  //   entryFile: 'src/index.ts',
-  //   globals: {
-  //     'solid-js/store': 'SolidStore',
-  //     'solid-js': 'Solid',
-  //     '@tanstack/router': 'RouterCore',
-  //   },
-  // },
+  {
+    name: '@tanstack/solid-store',
+    packageDir: 'solid-store',
+    srcDir: 'src',
+    jsName: 'SolidStore',
+    entryFile: 'src/index.tsx',
+    globals: {
+      'solid-js': 'Solid',
+    },
+  },
+  {
+    name: '@tanstack/solid-loaders',
+    packageDir: 'solid-loaders',
+    srcDir: 'src',
+    jsName: 'SolidLoaders',
+    entryFile: 'src/index.tsx',
+    globals: {
+      'solid-js': 'Solid',
+    },
+  },
+  {
+    name: '@tanstack/solid-actions',
+    packageDir: 'solid-actions',
+    srcDir: 'src',
+    jsName: 'SolidActions',
+    entryFile: 'src/index.tsx',
+    globals: {
+      'solid-js': 'Solid',
+    },
+  },
+  {
+    name: '@tanstack/solid-router',
+    packageDir: 'solid-router',
+    srcDir: 'src',
+    jsName: 'SolidRouter',
+    entryFile: 'src/index.tsx',
+    globals: {
+      'solid-js/store': 'SolidStore',
+      'solid-js': 'Solid',
+      '@tanstack/router': 'RouterCore',
+    },
+  },
   {
     name: '@tanstack/router-cli',
     packageDir: 'router-cli',


### PR DESCRIPTION
Posted two issues in the solid repo for suspense and error boundaries that we need to be resolved. In the meantime I've wrapped error boundary children with a div to resolve this.

https://github.com/solidjs/solid/issues/1542
https://github.com/solidjs/solid/issues/1543