### PR TITLE
fix(useSearch): undefined params

### DIFF
--- a/packages/router/src/react.tsx
+++ b/packages/router/src/react.tsx
@@ -452,7 +452,7 @@ export function useSearch<
   strict?: TStrict
   track?: (search: TSearch) => TSelected
 }): TStrict extends true ? TSelected : TSelected | undefined {
-  const { track, ...matchOpts } = opts as any
+  const { track, ...matchOpts } = (opts ?? {}) as any
   const match = useMatch(matchOpts)
   useStore(match.__store, (d: any) => opts?.track?.(d.search) ?? d.search)
 


### PR DESCRIPTION
This PR fix `useSearch` code that destructure the opts that maybe undefined