### PR TITLE
fix: hash values was incorrectly parsed in browser history mode

### DIFF
--- a/packages/router/src/history.ts
+++ b/packages/router/src/history.ts
@@ -255,8 +255,8 @@ function parseLocation(href: string, state: any): RouterLocation {
         ? searchIndex
         : href.length,
     ),
-    hash: hashIndex > -1 ? href.slice(hashIndex, searchIndex) : '',
-    search: searchIndex > -1 ? href.substring(searchIndex) : '',
+    hash: hashIndex > -1 ? href.substring(hashIndex) : '',
+    search: searchIndex > -1 ? href.slice(searchIndex, hashIndex === -1 ? undefined : hashIndex) : '',
     state,
   }
 }

--- a/packages/router/src/history.ts
+++ b/packages/router/src/history.ts
@@ -255,7 +255,7 @@ function parseLocation(href: string, state: any): RouterLocation {
         ? searchIndex
         : href.length,
     ),
-    hash: hashIndex > -1 ? href.substring(hashIndex, searchIndex) : '',
+    hash: hashIndex > -1 ? href.slice(hashIndex, searchIndex) : '',
     search: searchIndex > -1 ? href.substring(searchIndex) : '',
     state,
   }

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1215,11 +1215,13 @@ export class Router<
     )
 
     const searchStr = this.options.stringifySearch(search)
-    let hash =
+
+    const hash =
       dest.hash === true
         ? this.state.latestLocation.hash
         : functionalUpdate(dest.hash!, this.state.latestLocation.hash)
-    hash = hash ? `#${hash}` : ''
+
+    const hashStr = hash ? `#${hash}` : ''
 
     const nextState =
       dest.state === true
@@ -1232,7 +1234,7 @@ export class Router<
       searchStr,
       state: nextState,
       hash,
-      href: this.history.createHref(`${pathname}${searchStr}${hash}`),
+      href: this.history.createHref(`${pathname}${searchStr}${hashStr}`),
       key: dest.key,
     }
   }

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1260,7 +1260,7 @@ export class Router<
     }
 
     const href = `${next.pathname}${next.searchStr}${
-      next.hash ? `${next.hash}` : ''
+      next.hash ? `#${next.hash}` : ''
     }`
 
     this.history[nextAction === 'push' ? 'push' : 'replace'](href, {


### PR DESCRIPTION
I stumbled across the same problems that can be observed in https://github.com/TanStack/router/issues/542.

Found out that `parseLocation` was using `substring` and feeding it `-1` as the last parameter - which doesn't do what you'd expect it to. Replacing `substring` with `slice` fixes the hash-parsing.

I also observed that `#buildLocation` was prepending the returned hash-property with `#` even though the hash value already had the `#` prefix. This caused problems later on. Solved it by not prepending the `#`, but I'm unsure if this is the correct approach to the problem (?). Might be that the `#` prefix shouldn't have been in the `this.state.latestLocation.hash` value at all? In that case, the following might be the culprit:
https://github.com/TanStack/router/blob/7d3bfbfe3942220931c68f9c26169c6e0c84097a/packages/router/src/router.ts#L1135