### PR TITLE
fix: link to react adapter

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -35,7 +35,7 @@
       "children": [
         {
           "label": "React",
-          "to": "adapters/router"
+          "to": "adapters/react-router"
         },
         {
           "label": "Preact",


### PR DESCRIPTION
The link to React Adapter is not working

<img width="1096" alt="image" src="https://github.com/TanStack/router/assets/87611/3a01adb1-2e2a-4e9f-b045-6c85c0b60195">

This is the correct URL:

<img width="1095" alt="image" src="https://github.com/TanStack/router/assets/87611/b13a5eff-0ec7-43cd-a35a-ce38472353fd">
