### PR TITLE
Fix trailing comma in JSON file

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -232,6 +232,6 @@
           "to": "examples/react/with-trpc-react-query?file=client%2Fmain.tsx"
         }
       ]
-    },
+    }
   ]
 }


### PR DESCRIPTION
It caused the error in documentation site.