### PR TITLE
fix: Link children types

### DIFF
--- a/packages/router/src/react.tsx
+++ b/packages/router/src/react.tsx
@@ -103,10 +103,11 @@ export type MakeLinkOptions<
   TFrom extends RegisteredRoutesInfo['routePaths'] = '/',
   TTo extends string = '',
 > = LinkPropsOptions<TFrom, TTo> &
-  React.AnchorHTMLAttributes<HTMLAnchorElement> &
   Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'children'> & {
     // If a function is passed as a child, it will be given the `isActive` boolean to aid in further styling on the element it returns
-    children?: ReactNode | ((state: { isActive: boolean }) => ReactNode)
+    children?:
+      | React.ReactNode
+      | ((state: { isActive: boolean }) => React.ReactNode)
   }
 
 export type PromptProps = {


### PR DESCRIPTION
## Motivation
Due to usage of `type ReactNode = any` it is not possible to correctly infer `isActive` argument type in Links with function as children.

![2023-06-27 at 15 40 34](https://github.com/TanStack/router/assets/6313377/9a48d810-e6c4-4e0f-afc8-337431d58e8e)

## Description

I changed types to use `React.ReactNode` instead of `any`, and removed `React.AnchorHTMLAttributes<HTMLAnchorElement>` that were doubled and resulted in overriding `children`.

outcome:
![2023-06-27 at 15 46 05](https://github.com/TanStack/router/assets/6313377/34090912-dd5d-41ee-8775-709b18955684)
