### PR TITLE
fix: import in kitchen-sink-multi-file example

### DIFF
--- a/examples/react/kitchen-sink-multi-file/src/routes/dashboard/dashboard.tsx
+++ b/examples/react/kitchen-sink-multi-file/src/routes/dashboard/dashboard.tsx
@@ -1,7 +1,8 @@
 import { useLoader } from '@tanstack/react-loaders'
 import { Route } from '@tanstack/router'
 import * as React from 'react'
-import { dashboardRoute, invoicesLoader } from '.'
+import { dashboardRoute } from '.'
+import { invoicesLoader } from './invoices'
 
 export const dashboardIndexRoute = new Route({
   getParentRoute: () => dashboardRoute,


### PR DESCRIPTION
The kitchen-sink-multi-file example was showing following error when I was checking it out.

![bug](https://github.com/TanStack/router/assets/24877606/198a1a59-a301-49b8-8c14-607e47043fef)

The fix was to write the correct import path.

![fix](https://github.com/TanStack/router/assets/24877606/ef2a37e3-0ddc-4b8e-a6f8-3931184b15ae)
