### PR TITLE
fix: Link children types

### DIFF
--- a/packages/router/src/react.tsx
+++ b/packages/router/src/react.tsx
@@ -103,10 +103,11 @@ export type MakeLinkOptions<
   TFrom extends RegisteredRoutesInfo['routePaths'] = '/',
   TTo extends string = '',
 > = LinkPropsOptions<TFrom, TTo> &
-  React.AnchorHTMLAttributes<HTMLAnchorElement> &
   Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'children'> & {
     // If a function is passed as a child, it will be given the `isActive` boolean to aid in further styling on the element it returns
-    children?: ReactNode | ((state: { isActive: boolean }) => ReactNode)
+    children?:
+      | React.ReactNode
+      | ((state: { isActive: boolean }) => React.ReactNode)
   }
 
 export type PromptProps = {


### PR DESCRIPTION
Reverts TanStack/router#621