### PR TITLE
fix: return action from init

### DIFF
--- a/packages/actions/src/index.ts
+++ b/packages/actions/src/index.ts
@@ -153,6 +153,7 @@ export class Action<
   init = (key: TKey, client: ActionClient<any, any>) => {
     this.client = client
     this.key = key as TKey
+    return this as Action<TKey, TPayload, TResponse, TError>
   }
 
   #resolveState = (


### PR DESCRIPTION
Hello 👋

I see that `ActionClient` was reworked to be more in line with `LoaderClient`. The initialization uses the `getActions` to iterate over all actions and add them to `ActionClient` instance. However, the `Action#init` method doesn't return the action itself currently - causing errors when trying to access the action later with `useAction({key: 'foo_bar'})`.

This PR adds return to the `Action#init` method. 

Here you can see that result is used in `ActionClient#init` method:

https://github.com/TanStack/router/blob/6277e92a6f5ea94749802526794dfffa4ba5bedc/packages/actions/src/index.ts#L78

And here `Loader#init` for comparison:

https://github.com/TanStack/router/blob/6277e92a6f5ea94749802526794dfffa4ba5bedc/packages/loaders/src/index.ts#L314