### PR TITLE
examples: fix invalid root route usage in multi file usage example

### DIFF
--- a/examples/react/kitchen-sink-multi-file/src/routes/root.tsx
+++ b/examples/react/kitchen-sink-multi-file/src/routes/root.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react'
-import { Link, Outlet, useRouter } from '@tanstack/router'
+import { Link, Outlet, useRouter, RootRoute } from '@tanstack/router'
 import { Spinner } from '../components/Spinner'
 import { TanStackRouterDevtools } from '@tanstack/router-devtools'
 import { useLoaderClient } from '@tanstack/react-loaders'
-import { routerContext } from '../router'
 
-export const rootRoute = routerContext.createRootRoute({
+export const rootRoute = new RootRoute({
   component: () => {
     const router = useRouter()
     const loaderClient = useLoaderClient()


### PR DESCRIPTION
# Original example 
In the original example, the page doesn't show anything and gives an error in the dev tools.

https://codesandbox.io/s/github/tanstack/router/tree/beta/examples/react/kitchen-sink-multi-file

<img width="821" alt="image" src="https://github.com/TanStack/router/assets/39755201/640429d7-899b-4b8b-a991-d333c85d8d09">

<img width="275" alt="image" src="https://github.com/TanStack/router/assets/39755201/b8ad1d73-f83a-4700-81c4-7463a17fc351">

# Resolved example

https://codesandbox.io/p/sandbox/unruffled-dan-p3w7jg