### PR TITLE
examples: fix routerContext circular dependency

### DIFF
--- a/examples/react/kitchen-sink-multi-file/src/router.tsx
+++ b/examples/react/kitchen-sink-multi-file/src/router.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Router, RouterContext } from '@tanstack/router'
+import { Router } from '@tanstack/router'
 
 import { rootRoute } from './routes/root'
 import { indexRoute } from './routes'
@@ -22,11 +22,6 @@ import { layoutRouteB } from './routes/layout/layout-b'
 import { Spinner } from './components/Spinner'
 import { loaderClient } from './loaderClient'
 import { actionClient } from './actionClient'
-
-export const routerContext = new RouterContext<{
-  loaderClient: typeof loaderClient
-  actionClient: typeof actionClient
-}>()
 
 const routeTree = rootRoute.addChildren([
   indexRoute,

--- a/examples/react/kitchen-sink-multi-file/src/routerContext.ts
+++ b/examples/react/kitchen-sink-multi-file/src/routerContext.ts
@@ -1,0 +1,8 @@
+import { RouterContext } from '@tanstack/router'
+import { loaderClient } from './loaderClient'
+import { actionClient } from './actionClient'
+
+export const routerContext = new RouterContext<{
+  loaderClient: typeof loaderClient
+  actionClient: typeof actionClient
+}>()

--- a/examples/react/kitchen-sink-multi-file/src/routes/root.tsx
+++ b/examples/react/kitchen-sink-multi-file/src/routes/root.tsx
@@ -3,7 +3,7 @@ import { Link, Outlet, useRouter } from '@tanstack/router'
 import { Spinner } from '../components/Spinner'
 import { TanStackRouterDevtools } from '@tanstack/router-devtools'
 import { useLoaderClient } from '@tanstack/react-loaders'
-import { routerContext } from '../router'
+import { routerContext } from '../routerContext'
 
 export const rootRoute = routerContext.createRootRoute({
   component: () => {


### PR DESCRIPTION
Without this change I get a blank page with the error `Uncaught ReferenceError: Cannot access 'routerContext' before initialization at root.tsx`. Here's a StackBlitz of the latest commit showing the issue: https://stackblitz.com/github/tanstack/router/tree/5547d5f0f3f142ce0a64047d476bc0f59d11f15b/examples/react/kitchen-sink-multi-file

Turns out it's because there's a circular dependency between `router.tsx` and `routes/root.tsx`. To fix this I've extracted `routerCounter` into its own file.