### PR TITLE
fix(search-params): prevent detail loss when decoding search params

### DIFF
--- a/packages/router/src/qss.ts
+++ b/packages/router/src/qss.ts
@@ -30,8 +30,7 @@ function toValue(mix) {
   var str = decodeURIComponent(mix)
   if (str === 'false') return false
   if (str === 'true') return true
-  if (str.charAt(0) === '0') return str
-  return +str * 0 === 0 ? +str : str
+  return +str * 0 === 0 && +str + '' === str ? +str : str
 }
 
 export function decode(str) {


### PR DESCRIPTION
When parsing search params, strings are coerced to numbers at the whims of Javascript. This caused some weird conversions, like whitespace(s) being converted to `0`.

The new code checks if there is a detail loss before coercing, and doesn't convert if the detail is lost. This makes it possible to invert the conversion with zod or something else, because the converted number can be simply converted back to string without any loss of detail.

Should fix #537

![image](https://github.com/TanStack/router/assets/6034931/b88ed0cd-91da-4343-a127-ce26d8b00e83)
