### PR TITLE
fix(typings): remove Error.cause type which conflicts with es2022

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -61,14 +61,6 @@ declare global {
   interface Window {
     __TSR_DEHYDRATED__?: HydrationCtx
   }
-
-  interface Error {
-    cause: unknown
-  }
-
-  interface ErrorConstructor {
-    new (reason: string, options?: { cause?: unknown }): Error
-  }
 }
 
 export interface Register {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "target": "ES2020",
     "module": "ES2020",
     "moduleResolution": "node",


### PR DESCRIPTION
This type was causing conflicts with projects which use ES2022. The correct way of adding this type is updating ES2020 to ES2022 in tsconfig, unless there is an issue with that. As far as I tested, project builds correctly, so I guess there is no issue.

Alternatively, it could be written as `cause?: unknown` to avoid conflicts. It is better to leave this to TS though.