### PR TITLE
fix(search-params): handle arrays and parseable strings when stringifying

### DIFF
--- a/packages/router-core/src/searchParams.ts
+++ b/packages/router-core/src/searchParams.ts
@@ -2,7 +2,10 @@ import { decode, encode } from './qss'
 import { AnySearchSchema } from './route'
 
 export const defaultParseSearch = parseSearchWith(JSON.parse)
-export const defaultStringifySearch = stringifySearchWith(JSON.stringify)
+export const defaultStringifySearch = stringifySearchWith(
+  JSON.stringify,
+  JSON.parse,
+)
 
 export function parseSearchWith(parser: (str: string) => any) {
   return (searchStr: string): AnySearchSchema => {
@@ -28,7 +31,30 @@ export function parseSearchWith(parser: (str: string) => any) {
   }
 }
 
-export function stringifySearchWith(stringify: (search: any) => string) {
+export function stringifySearchWith(
+  stringify: (search: any) => string,
+  parser?: (str: string) => any,
+) {
+  function stringifyValue(val: any) {
+    if (typeof val === 'object' && val !== null) {
+      try {
+        return stringify(val)
+      } catch (err) {
+        // silent
+      }
+    } else if (typeof val === 'string' && typeof parser === 'function') {
+      try {
+        // Check if it's a valid parseable string.
+        // If it is, then stringify it again.
+        parser(val)
+        return stringify(val)
+      } catch (err) {
+        // silent
+      }
+    }
+    return val
+  }
+
   return (search: Record<string, any>) => {
     search = { ...search }
 
@@ -37,12 +63,10 @@ export function stringifySearchWith(stringify: (search: any) => string) {
         const val = search[key]
         if (typeof val === 'undefined' || val === undefined) {
           delete search[key]
-        } else if (val && typeof val === 'object' && val !== null) {
-          try {
-            search[key] = stringify(val)
-          } catch (err) {
-            // silent
-          }
+        } else if (Array.isArray(val)) {
+          search[key] = val.map(stringifyValue)
+        } else {
+          search[key] = stringifyValue(val)
         }
       })
     }


### PR DESCRIPTION
This PR makes two changes.  I think these are better as the default behavior, but this could need reviewing.

- When stringifying arrays, individual elements are stringified first instead of the whole array. For example, `{ test: [1, 2, "a"] }` will be stringified as `?test=1&test=2&test=a` instead of `?test=[1,2,"a"]`
- When a string is already parseable, it will be stringified again, so that original value is returned when it is parsed again. This was an issue for strings like `'"test"'`, where when you tried to parse it was converted to `'test'` instead of `'"test"'`. This could be the issue described in #654. 

![image](https://github.com/TanStack/router/assets/6034931/a3ca7929-0bf9-432b-a1a0-2d9417b13b4c)
