### PR TITLE
Add store tests

### DIFF
--- a/packages/store/__tests__/index.test.tsx
+++ b/packages/store/__tests__/index.test.tsx
@@ -28,4 +28,20 @@ describe('store', () => {
 
     expect(store.state).toEqual(4)
   })
+
+  test(`updateFn acts as state transformer`, () => {
+    const store = new Store(1, {
+      updateFn: v => updater => Number(updater(v))
+    });
+
+    store.setState((v) => `${v + 1}` as never);
+
+    expect(store.state).toEqual(2)
+
+    store.setState((v) => `${v + 2}` as never);
+
+    expect(store.state).toEqual(4)
+
+    expect(typeof store.state).toEqual("number")
+  })
 })

--- a/packages/store/__tests__/index.test.tsx
+++ b/packages/store/__tests__/index.test.tsx
@@ -52,4 +52,32 @@ describe('store', () => {
 
     expect(typeof store.state).toEqual("number")
   })
+
+  test("Batch prevents listeners from being called during repeated setStates", () => {
+    const store = new Store(0);
+
+    const listener = vi.fn();
+
+    store.subscribe(listener);
+
+    store.batch(() => {
+      store.setState(() => 1);
+      store.setState(() => 2);
+      store.setState(() => 3);
+      store.setState(() => 4);
+    })
+
+    expect(store.state).toEqual(4);
+    // Listener is only called once because of batching
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    store.setState(() => 1);
+    store.setState(() => 2);
+    store.setState(() => 3);
+    store.setState(() => 4);
+
+    expect(store.state).toEqual(4);
+    // Listener is called 4 times because of a lack of batching
+    expect(listener).toHaveBeenCalledTimes(5);
+  })
 })

--- a/packages/store/__tests__/index.test.tsx
+++ b/packages/store/__tests__/index.test.tsx
@@ -1,7 +1,31 @@
-import {describe, test, expect} from 'vitest'
+import {describe, test, expect, vi} from 'vitest'
+import {Store} from "../src/index";
 
 describe('store', () => {
-  test(`true is true`, () => {
-    expect(true).toEqual(true)
+  test(`should set the initial value`, () => {
+    const store = new Store(0);
+
+    expect(store.state).toEqual(0)
+  })
+
+  test(`basic subscriptions should work`, () => {
+    const store = new Store(0);
+
+    const subscription = vi.fn();
+
+    store.subscribe(subscription)
+
+    store.setState(() => 1);
+
+    expect(store.state).toEqual(1)
+    expect(subscription).toHaveBeenCalled()
+  })
+
+  test(`setState passes previous state`, () => {
+    const store = new Store(3);
+
+    store.setState((v) => v + 1);
+
+    expect(store.state).toEqual(4)
   })
 })

--- a/packages/store/__tests__/index.test.tsx
+++ b/packages/store/__tests__/index.test.tsx
@@ -13,12 +13,20 @@ describe('store', () => {
 
     const subscription = vi.fn();
 
-    store.subscribe(subscription)
+    const unsub = store.subscribe(subscription)
 
     store.setState(() => 1);
 
     expect(store.state).toEqual(1)
     expect(subscription).toHaveBeenCalled()
+
+    unsub();
+
+    store.setState(() => 2);
+
+    expect(store.state).toEqual(2)
+
+    expect(subscription).toHaveBeenCalledTimes(1)
   })
 
   test(`setState passes previous state`, () => {

--- a/packages/store/__tests__/index.test.tsx
+++ b/packages/store/__tests__/index.test.tsx
@@ -1,0 +1,7 @@
+import {describe, test, expect} from 'vitest'
+
+describe('store', () => {
+  test(`true is true`, () => {
+    expect(true).toEqual(true)
+  })
+})

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -7,7 +7,9 @@
   "homepage": "https://tanstack.com/store",
   "description": "",
   "scripts": {
-    "build": "rollup --config rollup.config.js"
+    "build": "rollup --config rollup.config.js",
+    "test": "vitest",
+    "test:dev": "vitest --watch"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/packages/store/vitest.config.ts
+++ b/packages/store/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: 'store',
+    watch: false,
+    // deps: {
+    //   interopDefault: true,
+    //   inline: true,
+    // },
+  },
+})


### PR DESCRIPTION
This PR works to add initial tests for TanStack Store, as an early method of helping me understand the store codebase and rationale.

The initial tests written include:

- [x] `setState`
- [x] Subscriptions
- [x] `updateFn`
- [x] Batching

> This PR does not implement tests for the priority, as I could not figure out what intended behavior is supposed to be for that yet