### PR TITLE
fix(types): remove typeof this in static method causing typescript errors

### DIFF
--- a/packages/router-core/src/route.ts
+++ b/packages/router-core/src/route.ts
@@ -842,7 +842,7 @@ export class Route<
     return this
   }
 
-  static __onInit = (route: typeof this) => {
+  static __onInit = (route: Route) => {
     // This is a dummy static method that should get
     // replaced by a framework specific implementation if necessary
   }


### PR DESCRIPTION
This was a weird one. Although it doesn't cause Typescript build to fail, it was generating a code like this when built:

```ts
static __onInit: (route: typeof this$1) => void;
```

This is obviously a wrong Typescript code and it was causing errors in my project. Not sure if this is a common error for everyone. But I think not using `typeof this` here would be safer.

On another note, I see that `__onInit` method is used as some form of polymorphism. Imho, real polymorphism should be used and each framework should export their own `Route` class. (And the base Route class could be renamed to `BaseRoute` or `AbstractRoute` to avoid confusion maybe). Eventually someone may need to have two different frameworks in the same runtime and it wouldn't work because both frameworks are overwriting the `__onInit` method.