### PR TITLE
Fix types for useNavigate and useMatchRoute

### DIFF
--- a/packages/react-router/src/react.tsx
+++ b/packages/react-router/src/react.tsx
@@ -907,13 +907,7 @@ export function useNavigate<
       TMaskFrom extends RoutePaths<TRouteTree> = '/',
       TMaskTo extends string = '',
     >(
-      opts?: NavigateOptions<
-        RegisteredRouter['routeTree'],
-        TFrom,
-        TTo,
-        TMaskFrom,
-        TMaskTo
-      >,
+      opts?: NavigateOptions<TRouteTree, TFrom, TTo, TMaskFrom, TMaskTo>,
     ) => {
       return router.navigate({ ...defaultOpts, ...(opts as any) })
     },
@@ -921,16 +915,18 @@ export function useNavigate<
   )
 }
 
-export function useMatchRoute() {
+export function useMatchRoute<
+  TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
+>() {
   const router = useRouter()
 
   return React.useCallback(
     <
-      TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
       TFrom extends RoutePaths<TRouteTree> = '/',
       TTo extends string = '',
       TMaskFrom extends RoutePaths<TRouteTree> = '/',
       TMaskTo extends string = '',
+      TResolved extends string = ResolveRelativePath<TFrom, NoInfer<TTo>>,
     >(
       opts: MakeUseMatchRouteOptions<
         TRouteTree,
@@ -939,7 +935,7 @@ export function useMatchRoute() {
         TMaskFrom,
         TMaskTo
       >,
-    ) => {
+    ): false | RouteById<TRouteTree, TResolved>['types']['allParams'] => {
       const { pending, caseSensitive, ...rest } = opts
 
       return router.matchRoute(rest as any, {


### PR DESCRIPTION
Addresses #722 and also fixes the `any` typing for `useMatchRoute` that I noticed while working on this.

The root of the problem seems to be that `rollup-plugin-dts` sees `RegisteredRouter` as `AnyRouter` while generating types, so any types using it get compiled down into `any` and `unknown`. The trick appears to be to define dynamic types that are set to `RegisteredRouter` by default, which tricks `dts` into leaving it alone.

For `useMatchRoute` because `const router = useRouter()` comes out typed as `AnyRouter` (since `useRouter` returns type `RegisteredRouter`), the `.matchRoute` call returns `any`. Therefore we have to explicitly type the return value to be the same as `Router.matchRoute`.

In `useMatchRoute` I also changed the type of `TFrom` to `RoutePaths<TRouteTree>` instead of `string` to match `Router.matchRoute`. Please let me know if this was incorrect.

Also for `useMatchRoute` I noticed that the parameter splitting of `opts` only extracts `pending` and `caseSensitive`, but `MatchRouteOptions` also includes `includeSearch` and `fuzzy`. I was unsure if this was a bug or not so I left it alone, but wanted to bring it up.