### PR TITLE
Fix router-cli duplicating code for splat routes

### DIFF
--- a/packages/router-cli/src/generator.ts
+++ b/packages/router-cli/src/generator.ts
@@ -175,9 +175,14 @@ export async function generator(config: Config) {
       }
 
       // Ensure that new FileRoute(anything?) is replace with FileRoute(${node.routePath})
+      // routePath can contain $ characters, which have special meaning when used in replace
+      // so we have to escape it by turning all $ into $$. But since we do it through a replace call
+      // we have to double escape it into $$$$. For more information, see
+      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement
+      const escapedRoutePath = node.routePath?.replaceAll('$', '$$$$') ?? ''
       const replaced = routeCode.replace(
         fileRouteRegex,
-        `new FileRoute('${node.routePath}')`,
+        `new FileRoute('${escapedRoutePath}')`,
       )
 
       if (replaced !== routeCode) {
@@ -226,7 +231,7 @@ export async function generator(config: Config) {
           parentRoute: typeof ${routeNode.parent?.variableName ?? 'root'}Route
         }`
       })
-      .join('\n')}  
+      .join('\n')}
   }
 }`
 


### PR DESCRIPTION
Running `tsr generate` with a route ending in `$` (a splat/wildcard/catch-all route) causes code in the route to be duplicated. If you run `tsr watch` it will endlessly duplicate the code, causing resource exhaustion of cpu and disk.

The underlying cause is that `$` has a special meaning when used in the replacement string for `.replace` and `.replaceAll` calls. Specifically `$'` means "replace this with everything after the matched string". Since splat routes end in `$` and the next character is `'` to represent the end of the routePath string, together it tells `.replace` to copy everything after the match, which is the entirety of the remainder of the file. This behavior is documented at https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement

The fix is to first escape all `$` in the routePath, but since we are doing the escaping through a `replaceAll` call we actually have to double escape it with `$$$$`. I've also left a comment explaining why the escaping exists, but can make it less verbose if desired.