### PR TITLE
fix: correct package name for example

### DIFF
--- a/examples/react/basic-react-query-file-based/package.json
+++ b/examples/react/basic-react-query-file-based/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tanstack-router-react-example-basic-file-based",
+  "name": "tanstack-router-react-example-basic-react-query-file-based",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/examples/react/location-masking/package.json
+++ b/examples/react/location-masking/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tanstack-router-react-example-basic",
+  "name": "tanstack-router-react-example-location-masking",
   "version": "0.0.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
duplicate package name leads to the following error when trying to run `npm run dev` inside on any of the examples:

````
Error: must not have multiple workspaces with the same name
package 'tanstack-router-react-example-basic' has conflicts in the following paths:
    /Users/user/source/tanstack/router/examples/react/basic
    /Users/user/source/tanstack/router/examples/react/location-masking
    at getError (/Users/user/.nvm/versions/node/v18.16.1/lib/node_modules/npm/node_modules/@npmcli/map-workspaces/lib/index.js:66:24)
    at mapWorkspaces (/Users/user/.nvm/versions/node/v18.16.1/lib/node_modules/npm/node_modules/@npmcli/map-workspaces/lib/index.js:146:11)
    at async Config.loadLocalPrefix (/Users/user/.nvm/versions/node/v18.16.1/lib/node_modules/npm/node_modules/@npmcli/config/lib/index.js:677:28)
    at async Config.loadProjectConfig (/Users/user/.nvm/versions/node/v18.16.1/lib/node_modules/npm/node_modules/@npmcli/config/lib/index.js:608:5)
    at async Config.load (/Users/user/.nvm/versions/node/v18.16.1/lib/node_modules/npm/node_modules/@npmcli/config/lib/index.js:281:5)
    at async #load (/Users/user/.nvm/versions/node/v18.16.1/lib/node_modules/npm/lib/npm.js:213:5)
    at async module.exports (/Users/user/.nvm/versions/node/v18.16.1/lib/node_modules/npm/lib/cli.js:114:5)