### PR TITLE
docs: Fix a number of inconsistencies wrt. `getParentRoute()`

### DIFF
--- a/docs/guide/data-loading.md
+++ b/docs/guide/data-loading.md
@@ -87,7 +87,7 @@ Route loaders are functions that are called when a route match is loaded. They a
 import { Route } from '@tanstack/react-router'
 
 const postsRoute = new Route({
-  getParentPath: () => rootRoute,
+  getParentRoute: () => rootRoute,
   path: 'posts',
   loader: async () => {
     // Load our posts
@@ -147,7 +147,7 @@ const rootRoute = routerContext.createRootRoute()
 // This can be a powerful tool for dependency injection across your router
 // and routes.
 const postsRoute = new Route({
-  getParentPath: () => rootRoute,
+  getParentRoute: () => rootRoute,
   path: 'posts',
   loader({ context: { fetchPosts } }) => fetchPosts(),
 })
@@ -173,7 +173,7 @@ To use path params in your loader, access them via the `params` property on the 
 import { Route } from '@tanstack/react-router'
 
 const postRoute = new Route({
-  getParentPath: () => postsRoute,
+  getParentRoute: () => postsRoute,
   path: '$postId',
   loader: ({ params: { postId } }) => {
     const res = await fetch(`/api/posts/${postId}`)
@@ -197,7 +197,7 @@ const fetchPosts = async () => {
 }
 
 const postsRoute = new Route({
-  getParentPath: () => rootRoute,
+  getParentRoute: () => rootRoute,
   path: 'posts',
   // Pass the fetchPosts function to the route context
   beforeLoad: () => ({ fetchPosts }),
@@ -213,7 +213,7 @@ Search parameters can be accessed via the `loaderContext` function. The `loaderC
 import { Route } from '@tanstack/react-router'
 
 const postsRoute = new Route({
-  getParentPath: () => rootRoute,
+  getParentRoute: () => rootRoute,
   path: 'posts',
   // Use zod to validate and parse the search params
   validateSearch: z.object({
@@ -238,7 +238,7 @@ The `abortController` property of the `loader` function is an [AbortController](
 import { Route } from '@tanstack/react-router'
 
 const postsRoute = new Route({
-  getParentPath: () => rootRoute,
+  getParentRoute: () => rootRoute,
   path: 'posts',
   loader: ({ abortController }) => {
     const res = await fetch(`/api/posts?page=${pageIndex}`, {
@@ -273,7 +273,7 @@ const loaderClient = new LoaderClient({
 })
 
 const postsRoute = new Route({
-  getParentPath: () => rootRoute,
+  getParentRoute: () => rootRoute,
   path: 'posts',
   loader: async ({ preload }) => {
     // Passing the preload flag to the loader client
@@ -305,7 +305,7 @@ Let's retrieve the data from our loader using the `props.useLoader` hook:
 import { Route } from '@tanstack/react-router'
 
 const postsRoute = new Route({
-  getParentPath: () => rootRoute,
+  getParentRoute: () => rootRoute,
   path: 'posts',
   loader: async () => {
     // ...
@@ -325,7 +325,7 @@ By manipulating the `maxAge` option, we can create a stale-while-revalidate patt
 import { Route } from '@tanstack/react-router'
 
 const postsRoute = new Route({
-  getParentPath: () => rootRoute,
+  getParentRoute: () => rootRoute,
   path: 'posts',
   loader: async () => {
     // Load our posts
@@ -363,7 +363,7 @@ This property is `true` when the route match is being loaded and `false` when it
 import { Route } from '@tanstack/react-router'
 
 const postsRoute = new Route({
-  getParentPath: () => rootRoute,
+  getParentRoute: () => rootRoute,
   path: 'posts',
   loader: async () => {
     // ...

--- a/docs/guide/external-data-loading.md
+++ b/docs/guide/external-data-loading.md
@@ -72,7 +72,7 @@ const loaderClient = new LoaderClient({
 })
 
 const postsRoute = new Route({
-  getParentPath: () => rootRoute,
+  getParentRoute: () => rootRoute,
   path: 'posts',
   loader: async () => {
     // Ensure our loader is loaded with an "await"

--- a/docs/guide/router-context.md
+++ b/docs/guide/router-context.md
@@ -70,7 +70,7 @@ Once you have defined the router context type, you can use it in your route defi
 import { Route } from '@tanstack/react-router'
 
 const userRoute = new Route({
-  getRootRoute: () => rootRoute,
+  getParentRoute: () => rootRoute,
   path: 'todos',
   component: Todos,
   loader: ({ context }) => fetchTodosByUserId(context.user.id),
@@ -105,7 +105,7 @@ Then, in your route:
 import { Route } from '@tanstack/react-router'
 
 const userRoute = new Route({
-  getRootRoute: () => rootRoute,
+  getParentRoute: () => rootRoute,
   path: 'todos',
   component: Todos,
   loader: ({ context }) => context.fetchTodosByUserId(context.userId),
@@ -139,7 +139,7 @@ Then, in your route:
 import { Route } from '@tanstack/react-router'
 
 const userRoute = new Route({
-  getRootRoute: () => rootRoute,
+  getParentRoute: () => rootRoute,
   path: 'todos',
   component: Todos,
   loader: ({ context }) => {
@@ -176,7 +176,7 @@ const router = new Router({
 })
 
 const userRoute = new Route({
-  getRootRoute: () => rootRoute,
+  getParentRoute: () => rootRoute,
   path: 'admin',
   component: Todos,
   beforeLoad: () => {


### PR DESCRIPTION
`getParentRoute()` was called `getParentPath()` or `getRootRoute()` in a number of places. I can't be sure but hope these were just oversights and were not referring to something else.