### PR TITLE
fix: @tanstack/history version to match release

### DIFF
--- a/packages/router-core/package.json
+++ b/packages/router-core/package.json
@@ -48,7 +48,7 @@
     "tiny-invariant": "^1.3.1",
     "tiny-warning": "^1.0.3",
     "@tanstack/store": "^0.0.1",
-    "@tanstack/history": "0.0.1-beta.194",
+    "@tanstack/history": "0.0.1-beta.196",
     "@gisatcz/cross-package-react-context": "^0.2.0"
   }
 }


### PR DESCRIPTION
Update @tanstack/history version to match release.

```
pnpm i @tanstack/react-router@beta
 ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @tanstack/history@0.0.1-beta.194

This error happened while installing the dependencies of @tanstack/react-router@0.0.1-beta.196
 at @tanstack/router-core@0.0.1-beta.196

The latest release of @tanstack/history is "0.0.1-beta.193".

Other releases are:
  * beta: 0.0.1-beta.196

If you need the full list of all 2 published versions run "$ pnpm view @tanstack/history versions".
Progress: resolved 534, reused 504, downloaded 0, added 0
❯ pnpm view @tanstack/history versions
[ '0.0.1-beta.193', '0.0.1-beta.196' ]
```