### PR TITLE
fix: prefer global `setTimeout`'s return type

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -226,7 +226,7 @@ export class Router<
     Math.random() * 10000000,
   )}`
   resetNextScroll: boolean = true
-  navigateTimeout: NodeJS.Timeout | null = null
+  navigateTimeout: ReturnType<typeof setTimeout> | null = null
   latestLoadPromise: Promise<void> = Promise.resolve()
   subscribers = new Set<RouterListener<RouterEvent>>()
   pendingMatches: AnyRouteMatch[] = []

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -30,6 +30,7 @@ import {
   functionalUpdate,
   last,
   pick,
+  Timeout,
 } from './utils'
 import {
   ErrorRouteComponent,
@@ -226,7 +227,7 @@ export class Router<
     Math.random() * 10000000,
   )}`
   resetNextScroll: boolean = true
-  navigateTimeout: ReturnType<typeof setTimeout> | null = null
+  navigateTimeout: Timeout | null = null
   latestLoadPromise: Promise<void> = Promise.resolve()
   subscribers = new Set<RouterListener<RouterEvent>>()
   pendingMatches: AnyRouteMatch[] = []


### PR DESCRIPTION
I know this is a niche issue but bear with me.

When using `@tanstack/react-router` in a monorepo setup and:

1. having `@types/node` installed at the root for build scripts
2. disabling `@types/node` in `packages/*/tsconfig.json` (i.e., `"types": []`) for react stuff

`@tanstack/react-router`'s use of the `NodeJS` namespace pollutes the monorepo's packages' global scope with Node's globals (e.g., `process`, etc.).

I hope this PR will fix that.