### PR TITLE
fix: allow search routes to define search params that differ in types

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -172,11 +172,9 @@ export type SearchParamOptions<
   TFromSearchEnsured = '/' extends TFrom
     ? FullSearchSchema<TRouteTree>
     : Expand<
-        UnionToIntersection<
           PickRequired<
             RouteByPath<TRouteTree, TFrom>['types']['fullSearchSchema']
           >
-        >
       >,
   TFromSearchOptional = Omit<
     FullSearchSchema<TRouteTree>,

--- a/packages/react-router/src/routeInfo.ts
+++ b/packages/react-router/src/routeInfo.ts
@@ -1,5 +1,5 @@
 import { AnyRoute, Route } from './route'
-import { Expand, UnionToIntersection } from './utils'
+import { Expand, UnionToIntersection, UnionToTuple } from './utils'
 
 export type ParseRoute<TRouteTree extends AnyRoute> =
   | TRouteTree
@@ -59,9 +59,23 @@ export type RoutePaths<TRouteTree extends AnyRoute> =
   | ParseRoute<TRouteTree>['fullPath']
   | '/'
 
+type UnionizeCollisions<T, U> = {
+  [P in keyof T & keyof U]: T[P] extends U[P] ? T[P] : T[P] | U[P]
+}
+type Reducer<T, U, C = UnionizeCollisions<T, U>> = C &
+  Omit<T, keyof C> &
+  Omit<U, keyof C>
+
+type Reduce<T extends any[], Result = unknown> = T extends [
+  infer First,
+  ...infer Rest,
+]
+  ? Reduce<Rest, Reducer<Result, First>>
+  : Result
+
 export type FullSearchSchema<TRouteTree extends AnyRoute> = Partial<
   Expand<
-    UnionToIntersection<ParseRoute<TRouteTree>['types']['fullSearchSchema']>
+    Reduce<UnionToTuple<ParseRoute<TRouteTree>['types']['fullSearchSchema']>>
   >
 >
 

--- a/packages/react-router/src/utils.ts
+++ b/packages/react-router/src/utils.ts
@@ -133,6 +133,16 @@ export type PickExclude<T, U> = {
   [K in keyof T as T[K] extends U ? never : K]: T[K]
 }
 
+// from https://github.com/type-challenges/type-challenges/issues/737
+type LastInUnion<U> = UnionToIntersection<
+  U extends unknown ? (x: U) => 0 : never
+> extends (x: infer L) => 0
+  ? L
+  : never
+export type UnionToTuple<U, Last = LastInUnion<U>> = [U] extends [never]
+  ? []
+  : [...UnionToTuple<Exclude<U, Last>>, Last]
+
 //
 
 export const isServer = typeof document === 'undefined'


### PR DESCRIPTION
fixes #859