### PR TITLE
fix: do not use intersection for search and path params

### DIFF
--- a/packages/react-router/src/RouterProvider.tsx
+++ b/packages/react-router/src/RouterProvider.tsx
@@ -31,10 +31,10 @@ export interface MatchLocation {
 }
 
 export type NavigateFn<TRouteTree extends AnyRoute> = <
-  TFrom extends RoutePaths<TRouteTree> = '/',
-  TTo extends string = '',
-  TMaskFrom extends RoutePaths<TRouteTree> = TFrom,
-  TMaskTo extends string = '',
+  TFrom extends RoutePaths<TRouteTree> | string = string,
+  TTo extends string | undefined = undefined,
+  TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
+  TMaskTo extends string | undefined = undefined,
 >(
   opts: NavigateOptions<TRouteTree, TFrom, TTo, TMaskFrom, TMaskTo>,
 ) => Promise<void>

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -116,10 +116,10 @@ export type RelativeToPathAutoComplete<
 
 export type NavigateOptions<
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
-  TFrom extends RoutePaths<TRouteTree> = '/',
-  TTo extends string = '',
-  TMaskFrom extends RoutePaths<TRouteTree> = TFrom,
-  TMaskTo extends string = '',
+  TFrom extends RoutePaths<TRouteTree> | string = string,
+  TTo extends string | undefined = undefined,
+  TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
+  TMaskTo extends string | undefined = undefined,
 > = ToOptions<TRouteTree, TFrom, TTo, TMaskFrom, TMaskTo> & {
   // `replace` is a boolean that determines whether the navigation should replace the current history entry or push a new one.
   replace?: boolean
@@ -130,26 +130,26 @@ export type NavigateOptions<
 
 export type ToOptions<
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
-  TFrom extends RoutePaths<TRouteTree> = '/',
-  TTo extends string = '',
-  TMaskFrom extends RoutePaths<TRouteTree> = '/',
-  TMaskTo extends string = '',
+  TFrom extends RoutePaths<TRouteTree> | string = string,
+  TTo extends string | undefined = undefined,
+  TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
+  TMaskTo extends string | undefined = undefined,
 > = ToSubOptions<TRouteTree, TFrom, TTo> & {
   mask?: ToMaskOptions<TRouteTree, TMaskFrom, TMaskTo>
 }
 
 export type ToMaskOptions<
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
-  TMaskFrom extends RoutePaths<TRouteTree> = '/',
-  TMaskTo extends string = '',
+  TMaskFrom extends RoutePaths<TRouteTree> | string = string,
+  TMaskTo extends string | undefined = undefined,
 > = ToSubOptions<TRouteTree, TMaskFrom, TMaskTo> & {
   unmaskOnReload?: boolean
 }
 
 export type ToSubOptions<
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
-  TFrom extends RoutePaths<TRouteTree> = '/',
-  TTo extends string = '',
+  TFrom extends RoutePaths<TRouteTree> | string = string,
+  TTo extends string | undefined = undefined,
   TResolved = ResolveRelativePath<TFrom, NoInfer<TTo>>,
 > = {
   to?: ToPathOption<TRouteTree, TFrom, TTo>
@@ -169,27 +169,16 @@ export type SearchParamOptions<
   TFrom,
   TTo,
   TResolved = ResolveRelativePath<TFrom, NoInfer<TTo>>,
-  TFromSearchEnsured = '/' extends TFrom
-    ? FullSearchSchema<TRouteTree>
-    : Expand<
-        PickRequired<
-          RouteByPath<TRouteTree, TFrom>['types']['fullSearchSchema']
-        >
-      >,
-  TFromSearchOptional = Omit<
-    FullSearchSchema<TRouteTree>,
-    keyof TFromSearchEnsured
-  >,
-  TFromSearch = Expand<TFromSearchEnsured & TFromSearchOptional>,
-  TToSearch = '' extends TTo
-    ? FullSearchSchema<TRouteTree>
+  TFromSearch = RouteByPath<TRouteTree, TFrom>['types']['fullSearchSchema'],
+  TToSearch = undefined extends TTo
+    ? TFromSearch
     : Expand<RouteByPath<TRouteTree, TResolved>['types']['fullSearchSchema']>,
-> = keyof PickRequired<TToSearch> extends never
+> = never extends keyof PickRequired<TToSearch>
   ? {
       search?: true | SearchReducer<TFromSearch, TToSearch>
     }
   : {
-      search: TFromSearchEnsured extends PickRequired<TToSearch>
+      search: TFromSearch extends PickRequired<TToSearch>
         ? true | SearchReducer<TFromSearch, TToSearch>
         : SearchReducer<TFromSearch, TToSearch>
     }
@@ -226,8 +215,8 @@ type ParamsReducer<TFrom, TTo> = TTo | ((current: TFrom) => TTo)
 
 export type ToPathOption<
   TRouteTree extends AnyRoute = AnyRoute,
-  TFrom extends RoutePaths<TRouteTree> = '/',
-  TTo extends string = '',
+  TFrom extends RoutePaths<TRouteTree> | string = string,
+  TTo extends string | undefined = undefined,
 > =
   | TTo
   | RelativeToPathAutoComplete<
@@ -238,8 +227,8 @@ export type ToPathOption<
 
 export type ToIdOption<
   TRouteTree extends AnyRoute = AnyRoute,
-  TFrom extends RoutePaths<TRouteTree> = '/',
-  TTo extends string = '',
+  TFrom extends RoutePaths<TRouteTree> | undefined = undefined,
+  TTo extends string | undefined = undefined,
 > =
   | TTo
   | RelativeToPathAutoComplete<
@@ -256,10 +245,10 @@ export interface ActiveOptions {
 
 export type LinkOptions<
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
-  TFrom extends RoutePaths<TRouteTree> = '/',
-  TTo extends string = '',
-  TMaskFrom extends RoutePaths<TRouteTree> = TFrom,
-  TMaskTo extends string = '',
+  TFrom extends RoutePaths<TRouteTree> | string = string,
+  TTo extends string | undefined = undefined,
+  TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
+  TMaskTo extends string | undefined = undefined,
 > = NavigateOptions<TRouteTree, TFrom, TTo, TMaskFrom, TMaskTo> & {
   // The standard anchor tag target attribute
   target?: HTMLAnchorElement['target']
@@ -348,20 +337,13 @@ const preloadWarning = 'Error preloading route! ☝️'
 
 export function useLinkProps<
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
-  TFrom extends RoutePaths<TRouteTree> = '/',
-  TTo extends string = '',
-  TMaskFrom extends RoutePaths<TRouteTree> = '/',
-  TMaskTo extends string = '',
->({
-  from,
-  ...options
-}: UseLinkPropsOptions<
-  TRouteTree,
-  TFrom,
-  TTo,
-  TMaskFrom,
-  TMaskTo
->): React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  TFrom extends RoutePaths<TRouteTree> | string = string,
+  TTo extends string | undefined = undefined,
+  TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
+  TMaskTo extends string | undefined = undefined,
+>(
+  options: UseLinkPropsOptions<TRouteTree, TFrom, TTo, TMaskFrom, TMaskTo>,
+): React.AnchorHTMLAttributes<HTMLAnchorElement> {
   const router = useRouter()
   const matchPathname = useMatch({
     strict: false,
@@ -574,10 +556,10 @@ export function useLinkProps<
 export interface LinkComponent<TProps extends Record<string, any> = {}> {
   <
     TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
-    TFrom extends RoutePaths<TRouteTree> = '/',
-    TTo extends string = '',
-    TMaskFrom extends RoutePaths<TRouteTree> = '/',
-    TMaskTo extends string = '',
+    TFrom extends RoutePaths<TRouteTree> | string = string,
+    TTo extends string | undefined = undefined,
+    TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
+    TMaskTo extends string | undefined = undefined,
   >(
     props: LinkProps<TRouteTree, TFrom, TTo, TMaskFrom, TMaskTo> &
       TProps &

--- a/packages/react-router/src/useNavigate.tsx
+++ b/packages/react-router/src/useNavigate.tsx
@@ -5,11 +5,10 @@ import { LinkOptions, NavigateOptions } from './link'
 import { AnyRoute } from './route'
 import { RoutePaths } from './routeInfo'
 import { RegisteredRouter } from './router'
-import { useLayoutEffect } from './utils'
 
 export function useNavigate<
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
-  TDefaultFrom extends RoutePaths<TRouteTree> = '/',
+  TDefaultFrom extends RoutePaths<TRouteTree> | string = string,
 >(_defaultOpts?: { from?: TDefaultFrom }) {
   const { navigate, buildLocation } = useRouter()
 
@@ -20,10 +19,10 @@ export function useNavigate<
 
   return React.useCallback(
     <
-      TFrom extends RoutePaths<TRouteTree> = TDefaultFrom,
-      TTo extends string = '',
-      TMaskFrom extends RoutePaths<TRouteTree> = '/',
-      TMaskTo extends string = '',
+      TFrom extends RoutePaths<TRouteTree> | string = TDefaultFrom,
+      TTo extends string | undefined = undefined,
+      TMaskFrom extends RoutePaths<TRouteTree>| string = TFrom,
+      TMaskTo extends string | undefined = undefined,
     >({
       from,
       ...rest
@@ -54,10 +53,10 @@ export function useNavigate<
 
 export function Navigate<
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
-  TFrom extends RoutePaths<TRouteTree> = '/',
-  TTo extends string = '',
-  TMaskFrom extends RoutePaths<TRouteTree> = '/',
-  TMaskTo extends string = '',
+  TFrom extends RoutePaths<TRouteTree> | string = string,
+  TTo extends string | undefined = undefined,
+  TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
+  TMaskTo extends string | undefined = undefined,
 >(props: NavigateOptions<TRouteTree, TFrom, TTo, TMaskFrom, TMaskTo>): null {
   const { navigate } = useRouter()
   const match = useMatch({ strict: false })
@@ -74,19 +73,19 @@ export function Navigate<
 
 export type UseLinkPropsOptions<
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
-  TFrom extends RoutePaths<TRouteTree> = '/',
-  TTo extends string = '',
-  TMaskFrom extends RoutePaths<TRouteTree> = '/',
-  TMaskTo extends string = '',
+  TFrom extends RoutePaths<TRouteTree> | string = string,
+  TTo extends string | undefined= undefined,
+  TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
+  TMaskTo extends string | undefined = undefined,
 > = ActiveLinkOptions<TRouteTree, TFrom, TTo, TMaskFrom, TMaskTo> &
   React.AnchorHTMLAttributes<HTMLAnchorElement>
 
 export type LinkProps<
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
-  TFrom extends RoutePaths<TRouteTree> = '/',
-  TTo extends string = '',
-  TMaskFrom extends RoutePaths<TRouteTree> = '/',
-  TMaskTo extends string = '',
+  TFrom extends RoutePaths<TRouteTree> | string = string,
+  TTo extends string| undefined = undefined,
+  TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
+  TMaskTo extends string | undefined = undefined,
 > = ActiveLinkOptions<TRouteTree, TFrom, TTo, TMaskFrom, TMaskTo> &
   Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'children'> & {
     // If a function is passed as a child, it will be given the `isActive` boolean to aid in further styling on the element it returns
@@ -97,10 +96,10 @@ export type LinkProps<
 
 export type ActiveLinkOptions<
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
-  TFrom extends RoutePaths<TRouteTree> = '/',
-  TTo extends string = '',
-  TMaskFrom extends RoutePaths<TRouteTree> = '/',
-  TMaskTo extends string = '',
+  TFrom extends RoutePaths<TRouteTree> | string = string,
+  TTo extends string | undefined = undefined,
+  TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
+  TMaskTo extends string | undefined = undefined,
 > = LinkOptions<TRouteTree, TFrom, TTo, TMaskFrom, TMaskTo> & {
   // A function that returns additional props for the `active` state of this link. These props override other props passed to the link (`style`'s are merged, `className`'s are concatenated)
   activeProps?:

--- a/packages/react-router/src/utils.ts
+++ b/packages/react-router/src/utils.ts
@@ -26,6 +26,9 @@ export type PickRequired<T> = {
   [K in keyof T as undefined extends T[K] ? never : K]: T[K]
 }
 
+// from https://stackoverflow.com/a/76458160
+export type WithoutEmpty<T> = T extends T ? ({} extends T ? never : T) : never
+
 // export type Expand<T> = T
 export type Expand<T> = T extends object
   ? T extends infer O


### PR DESCRIPTION
Given the following example:

```tsx
import React from 'react'
import ReactDOM from 'react-dom/client'
import {
  Outlet,
  RouterProvider,
  Route,
  Router,
  rootRouteWithContext,
  useNavigate,
} from '@tanstack/react-router'
import { z } from 'zod'

const rootRoute = rootRouteWithContext()({
  component: () => <Outlet />,
})

const routeWithSearchAndPath = new Route({
  getParentRoute: () => rootRoute,
  path: '/routeWithSearchAndPath/$id',
  validateSearch: z.object({
    foo: z.number().catch(1),
    filter: z.string().optional().catch(''),
  }),
  component: () => {
    return null
  },
})

const routeWithoutSearchOrPath = new Route({
  getParentRoute: () => rootRoute,
  path: '/routeWithoutSearchOrPath',
  component: () => null,
})

const routeWithSearch = new Route({
  getParentRoute: () => rootRoute,
  path: '/routeWithSearch',
  validateSearch: z.object({
    foo: z.enum(['x', 'y']).catch('x'),
    bar: z.number(),
  }),
  component: () => null,
})

const routeWithPath = new Route({
  getParentRoute: () => rootRoute,
  path: '/routeWithPath/$someId',
  component: () => null,
})

const routeTree = rootRoute.addChildren([
  routeWithSearchAndPath,
  routeWithoutSearchOrPath,
  routeWithSearch,
  routeWithPath,
])

const router = new Router({
  routeTree,
})

declare module '@tanstack/react-router' {
  interface Register {
    router: typeof router
  }
}

const rootElement = document.getElementById('app')!

if (!rootElement.innerHTML) {
  const root = ReactDOM.createRoot(rootElement)

  root.render(<RouterProvider router={router} />)
}
```

I tested the following scenarios:

neither `to` nor `from` are specified:
```tsx
const routeWithSearchAndPath = new Route({
  getParentRoute: () => rootRoute,
  path: '/routeWithSearchAndPath/$id',
  validateSearch: z.object({
    foo: z.number().catch(1),
    filter: z.string().optional().catch(''),
  }),
  component: () => {
    const navigate = useNavigate()

    navigate({
      search: (prev) => {
        /**
         *  prev: {} | {
         *    foo: number;
         *    filter?: string | undefined;
         * } | {} | {
         *    foo: "x" | "y";
         *    bar: number;
         * }
         */
      },
      params: (prev) => {
        /**
         * prev: {} | {
         *    id: string;
         * } | {} | {
         *     someId: string;
         * }
         */
      },
    })
    return null
  },
})
```

`from` is specified as const, `to` is not specified => `to` = `from`:
```tsx
const routeWithSearchAndPath = new Route({
  getParentRoute: () => rootRoute,
  path: '/routeWithSearchAndPath/$id',
  validateSearch: z.object({
    foo: z.number().catch(1),
    filter: z.string().optional().catch(''),
  }),
  component: () => {
    const navigate = useNavigate({from: '/routeWithSearchAndPath/$id' as const})
    navigate({
      search: (prev) => {
        /**
         *  prev: {
         *    foo: number;
         *    filter?: string | undefined;
         * }
         */
        return prev
      },
      params: (prev) => {
        /**
         * prev: {
         *    id: string;
         * } 
         */
        return prev
      },
    })
    return null
  },
})
```

both `from` and `to` are specified as const, `to` = `from`:
```tsx
const routeWithSearchAndPath = new Route({
  getParentRoute: () => rootRoute,
  path: '/routeWithSearchAndPath/$id',
  validateSearch: z.object({
    foo: z.number().catch(1),
    filter: z.string().optional().catch(''),
  }),
  component: () => {
    const navigate = useNavigate({from: '/routeWithSearchAndPath/$id' as const})
    navigate({
      to: '/routeWithSearchAndPath/$id',
      search: (prev) => {
        /**
         *  prev: {
         *    foo: number;
         *    filter?: string | undefined;
         * }
         */
        return prev
      },
      params: (prev) => {
        /**
         * prev: {
         *    id: string;
         * } 
         */
        return prev
      },
    })
    return null
  },
})
```

both `from` and `to` are specified as const, `to` != `from` (1):
```tsx
const routeWithSearchAndPath = new Route({
  getParentRoute: () => rootRoute,
  path: '/routeWithSearchAndPath/$id',
  validateSearch: z.object({
    foo: z.number().catch(1),
    filter: z.string().optional().catch(''),
  }),
  component: () => {
    const navigate = useNavigate({from: '/routeWithSearchAndPath/$id' as const})
    navigate({
      to: '/routeWithPath/$someId',
      params: (prev) => {
        /**
         * prev: {
         *    id: string;
         * } 
         */
        return {someId: prev.id}
      },
    })
    return null
  },
})
```


both `from` and `to` are specified as const, `to` != `from` (2)
```tsx
const routeWithSearchAndPath = new Route({
  getParentRoute: () => rootRoute,
  path: '/routeWithSearchAndPath/$id',
  validateSearch: z.object({
    foo: z.number().catch(1),
    filter: z.string().optional().catch(''),
  }),
  component: () => {
    const navigate = useNavigate({
      from: '/routeWithSearchAndPath/$id' as const,
    })
    navigate({
      to: '/routeWithSearch',
      search: (prev) => {
        /**
         *  prev: {
         *    foo: number;
         *    filter?: string | undefined;
         * }
         */
        return { bar: prev.foo, foo: 'x' }
      },
    })
    return null
  },
})
```

`from` is specified as const, `to` is specified as runtime string
```tsx
const routeWithSearchAndPath = new Route({
  getParentRoute: () => rootRoute,
  path: '/routeWithSearchAndPath/$id',
  validateSearch: z.object({
    foo: z.number().catch(1),
    filter: z.string().optional().catch(''),
  }),
  component: () => {
    let to = '/routeWithSearch'
    const navigate = useNavigate({
      from: '/routeWithSearchAndPath/$id' as const,
    })
    navigate({
      to,
      search: (prev) => {
        // runtime dependent search params
      },
      params: (prev) => {
        // runtime dependent path params
      }
    })
    return null
  },
})
```

`to` is specified as runtime string, `from` is not specified
```tsx
const routeWithSearchAndPath = new Route({
  getParentRoute: () => rootRoute,
  path: '/routeWithSearchAndPath/$id',
  validateSearch: z.object({
    foo: z.number().catch(1),
    filter: z.string().optional().catch(''),
  }),
  component: () => {
    let to = '/routeWithSearch'
    const navigate = useNavigate()
    navigate({
      to,
      search: (prev) => {
        // runtime dependent search params
      },
      params: (prev) => {
        // runtime dependent path params
      }
    })
    return null
  },
})
```