### PR TITLE
docs: fix internal links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,3 +20,6 @@
   - `pnpm dev`
 - Make changes to the code
   - If you ran `pnpm dev` the dev watcher will automatically rebuild the code that has changed
+- Changes to the docs
+  - Be sure that internal links are written always relative to `docs` folder.
+    E.g. `./guide/data-loading`

--- a/docs/guide/custom-search-param-serialization.md
+++ b/docs/guide/custom-search-param-serialization.md
@@ -6,7 +6,7 @@ title: Custom Search Param Serialization
 
 By default, TanStack Router parses and serializes your search params automatically using `JSON.stringify/JSON.parse`. Depending on your needs though, you may want to customize the serialization process.
 
-To do so, [use `Router`'s `parseSearch` and `stringifySearch` options](../docs/api#search-param-parsing-and-serialization):
+To do so, [use `Router`'s `parseSearch` and `stringifySearch` options](./guide/custom-search-param-serialization):
 
 ```tsx
 import {
@@ -33,7 +33,7 @@ const router = new Router({
 })
 ```
 
-Additionally, you can [use the `parseSearchWith` and `stringifySearchWith` utilities](../docs/api#search-param-parsing-and-serialization) to parse and serialize the search values specifically.
+Additionally, you can [use the `parseSearchWith` and `stringifySearchWith` utilities](./guide/custom-search-param-serialization) to parse and serialize the search values specifically.
 
 For example, we can reimplement the default parser/serializer with the following code:
 

--- a/docs/guide/data-loading.md
+++ b/docs/guide/data-loading.md
@@ -205,7 +205,7 @@ To opt out of preloading, don't turn it on via the `routerOptions.defaultPreload
 
 ## Passing all loader events to an external cache
 
-We break down this use case in the [External Data Loading](./external-data-loading) page, but if you'd like to use an external cache like TanStack Query, you can do so by passing all loader events to your external cache. As long as you are using the defaults, the only change you'll need to make is to set the `defaultPreloadStaleTime` option on the router to `0`:
+We break down this use case in the [External Data Loading](../guide/external-data-loading) page, but if you'd like to use an external cache like TanStack Query, you can do so by passing all loader events to your external cache. As long as you are using the defaults, the only change you'll need to make is to set the `defaultPreloadStaleTime` option on the router to `0`:
 
 ```tsx
 const router = new Router({
@@ -372,7 +372,7 @@ const postsRoute = new Route({
 
 Ideally most route loaders can resolve their data within a short moment, removing the need to render a placeholder spinner and simply rely on suspense to render the next route when it's completely ready. When critical data that is required to render a route's component is slow though, you have 2 options:
 
-- Split up your fast and slow data into separate promises and `defer` the slow data until after the fast data is loaded (see [deferred-data-loading](./deferred-data-loading))
+- Split up your fast and slow data into separate promises and `defer` the slow data until after the fast data is loaded (see [deferred-data-loading](./guide/deferred-data-loading))
 - Show a pending component after an optimistic suspense threshold until all of the data is ready (See below).
 
 ## Showing a pending component

--- a/docs/guide/external-data-loading.md
+++ b/docs/guide/external-data-loading.md
@@ -3,7 +3,7 @@ id: external-data-loading
 title: External Data Loading
 ---
 
-> ⚠️ This guide is geared towards external state management libraries and their integration with TanStack Router for data fetching, ssr, hydration/dehydration and streaming. If you haven't read the standard [Data Loading](./data-loading) guide
+> ⚠️ This guide is geared towards external state management libraries and their integration with TanStack Router for data fetching, ssr, hydration/dehydration and streaming. If you haven't read the standard [Data Loading](./guide/data-loading) guide
 
 ## To **Store** or to **Coordinate**?
 

--- a/docs/guide/route-masking.md
+++ b/docs/guide/route-masking.md
@@ -9,7 +9,7 @@ Route masking is a way to mask the actual URL of a route that gets persisted to 
 - Navigating to a route with the search param `?showLogin=true`, but masking the the URL to _not_ contain the search param
 - Navigating to a route with the search param `?modal=settings`, but masking the the URL as `/settings'
 
-Each of these scenarios can be achieved with route masking and even extended to support more advanced patterns like [parallel routes](./parallel-routes.md)
+Each of these scenarios can be achieved with route masking and even extended to support more advanced patterns like [parallel routes](./guide/parallel-routes.md)
 
 ## How does route masking work?
 

--- a/docs/guide/route-matching.md
+++ b/docs/guide/route-matching.md
@@ -94,7 +94,7 @@ Using that route tree, let's follow the matching process for a few different URL
 
 ## Pathless Route Matching
 
-During matching, [pathless routes](../route-paths#pathless-routes) are treated as if they are flat. If a route is not found in a pathless route's children, matching will continue out of the pathless route's children and on through the rest of the parent subtree like normal.
+During matching, [pathless routes](./guide/route-paths#pathless-routes) are treated as if they are flat. If a route is not found in a pathless route's children, matching will continue out of the pathless route's children and on through the rest of the parent subtree like normal.
 
 ## `NotFoundRoute`s and Matching
 

--- a/docs/guide/routes.md
+++ b/docs/guide/routes.md
@@ -16,7 +16,7 @@ import { RootRoute } from '@tanstack/react-router'
 const rootRoute = new RootRoute()
 ```
 
-> 🧠 You can also create a root route via the `rootRouteWithContext<TContext>()` function, which is a type-safe way of doing dependency injection for the entire router. Read more about this in the [Context Section](./router-context)
+> 🧠 You can also create a root route via the `rootRouteWithContext<TContext>()` function, which is a type-safe way of doing dependency injection for the entire router. Read more about this in the [Context Section](./guide/router-context)
 
 ## Outlets
 

--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -122,7 +122,7 @@ Resolved loader data fetched by routes is automatically dehydrated and rehydrate
 
 ⚠️ If you are using deferred data streaming, you will also need to ensure that you have implemented the [SSR Streaming & Stream Transform](#ssr-streaming) pattern near the end of this guide.
 
-For more information on how to utilize data loading and data streaming, see the [Data Loading](./data-loading) and [Data Streaming](./data-streaming) guides.
+For more information on how to utilize data loading and data streaming, see the [Data Loading](./guide/data-loading) and [Data Streaming](./guide/data-streaming) guides.
 
 ### Dehydrating the Router
 


### PR DESCRIPTION
Hello,
while reading the doc I've noticed that some of the internal links are not working

### Reproduction

1. Go on a section with a link to another docs section: E.g.:
    https://tanstack.com/router/v1/docs/guide/route-matching#pathless-route-matching
2. Click on "pathless routes" link
3. 404 page is shown

### Occurrences 

<details>
  <summary>Here a complete list (from VS code find inside `docs` folder)</summary>

```
docs/guide/custom-search-param-serialization.md:
   8  
   9: To do so, [use `Router`'s `parseSearch` and `stringifySearch` options](../docs/api#search-param-parsing-and-serialization):
  10  

  35  
  36: Additionally, you can [use the `parseSearchWith` and `stringifySearchWith` utilities](../docs/api#search-param-parsing-and-serialization) to parse and serialize the search values specifically.
  37  

docs/guide/data-loading.md:
   50  
   51: > 🧠 If you know right away that you'd like to or need to use something more robust like TanStack Query, [skip to the External Data Loading page](./guide/external-data-loading)
   52  

  206  
  207: We break down this use case in the [External Data Loading](./external-data-loading) page, but if you'd like to use an external cache like TanStack Query, you can do so by passing through all loader events to your external cache. As long as you are using the defaults, the only change you'll need to make is to set the `defaultPreloadStaleTime` option on the router to `0`:
  208  

  373  
  374: - Split up your fast and slow data into separate promises and `defer` the slow data until after the fast data is loaded (see [deferred-data-loading](./deferred-data-loading))
  375  - Show a pending component after an optimistic suspense threshold until all of the data is ready (See below).

docs/guide/external-data-loading.md:
  5  
  6: > ⚠️ This guide is geared towards external state management libraries and their integration with TanStack Router for data fetching, ssr, hydration/dehydration and streaming. If you haven't read the standard [Data Loading](./data-loading) guide
  7  

docs/guide/route-masking.md:
  11  
  12: Each of these scenarios can be achieved with route masking and even extended to support more advanced patterns like [parallel routes](./parallel-routes.md)
  13  

docs/guide/route-matching.md:
  96  
  97: During matching, [pathless routes](../route-paths#pathless-routes) are treated as if they are flat. If a route is not found in a pathless route's children, matching will continue out of the pathless route's children and on through the rest of the parent subtree like normal.
  98  

docs/guide/ssr.md:
  124  
  125: For more information on how to utilize data loading and data streaming, see the [Data Loading](./data-loading) and [Data Streaming](./data-streaming) guides.
  126  

```
</details>

### Missing guide on ssr.md

In `ssr.md` in "Automatic Loader Dehydration/Hydration" section there is a link to a `data-streaming`, however I haven't found a page with this name.

### Possbile fix

The only link I found working was the one inside [Data loading page](https://tanstack.com/router/v1/docs/guide/data-loading#to-router-cache-or-not-to-router-cache) in the quote of "To Router Cache or not to Router Cache?" section:

> 🧠 If you know right away that you'd like to or need to use something more robust like TanStack Query, skip to the External Data Loading page

which has `./guide/external-data-loading` as path. This makes me think that all links are resolved starting from `docs` directory.
So I changed all internal links between different pages to start from `docs`.
I also added a note about this in CONTRIBUTING.md 

---

Since I haven't found a method to test the documentation on my machine I might be completely wrong 😅 so let me know if I need to change something!

