### PR TITLE
Update logic to retrieve matching routes

### DIFF
--- a/examples/react/kitchen-sink-file-based/src/routes/expensive/-components/Expensive.tsx
+++ b/examples/react/kitchen-sink-file-based/src/routes/expensive/-components/Expensive.tsx
@@ -1,10 +1,14 @@
+import { RouteApi } from '@tanstack/react-router'
 import * as React from 'react'
 
+const routeApi = new RouteApi({ id: '/expensive/' })
+
 export default function Expensive() {
+  const { emoji } = routeApi.useLoaderData()
   return (
     <div className={`p-2`}>
       I am an "expensive" component... which really just means that I was
-      code-split 😉
+      code-split {emoji}
     </div>
   )
 }

--- a/examples/react/kitchen-sink-file-based/src/routes/expensive/index.tsx
+++ b/examples/react/kitchen-sink-file-based/src/routes/expensive/index.tsx
@@ -2,4 +2,5 @@ import { FileRoute, lazyRouteComponent } from '@tanstack/react-router'
 
 export const Route = new FileRoute('/expensive/').createRoute({
   component: lazyRouteComponent(() => import('./-components/Expensive')),
+  loader: () => ({ emoji: '😉' }),
 })

--- a/packages/react-router/src/Matches.tsx
+++ b/packages/react-router/src/Matches.tsx
@@ -289,6 +289,12 @@ function getRenderedMatches(state: RouterState) {
     : state.matches
 }
 
+function removeUnderscores(s?: string) {
+  if (s === rootRouteId) return s
+
+  return s?.replace(/(^_|_$)/, '').replace(/(\/_|_\/)/, '/')
+}
+
 export function useMatch<
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
   TFrom extends RouteIds<TRouteTree> = RouteIds<TRouteTree>,
@@ -309,11 +315,18 @@ export function useMatch<
 
   const matchRouteId = (() => {
     const matches = getRenderedMatches(router.state)
-    const match = opts?.from
-      ? matches.find((d) => d.routeId === opts?.from)
-      : matches.find((d) => d.id === nearestMatchId)
-    return match!.routeId
-  })()
+
+    if (!opts.from) {
+      return matches.find((d) => d.id === nearestMatchId)
+    }
+
+    const from = removeUnderscores(opts.from)
+
+    return (
+      matches.find((d) => d.routeId === from) ??
+      matches.find((d) => d.routeId === from?.replace(/\/$/, ''))
+    )
+  })()?.routeId
 
   if (opts?.strict ?? true) {
     invariant(


### PR DESCRIPTION
There's probably something I completely missed, but this seems to fix the issues I reported in #881.

Tried to modify the generator in the CLI to make the paths match the final IDs of the routes, but ran into issues since the underscores seem to get used in the TS magic and didn't feel comfortable changing those types.

Also made the route matching first try to match the routeId as given and fallback to the opts.from without a `/` as last char.

Also added an example of RouteApi being used in a lazy-loaded component.