### PR TITLE
Preserve whitespace and trailing comma during cli path replacement

### DIFF
--- a/packages/router-cli/src/generator.ts
+++ b/packages/router-cli/src/generator.ts
@@ -6,7 +6,7 @@ import { cleanPath, trimPathLeft } from '@tanstack/react-router'
 
 let latestTask = 0
 export const rootPathId = '__root'
-export const fileRouteRegex = /new\s+FileRoute\(([^)]*)\)/g
+export const fileRouteRegex = /new\s+FileRoute\((\s*)(.*?)([\s,]*)\)/g
 
 export type RouteNode = {
   filePath: string
@@ -187,7 +187,7 @@ export async function generator(config: Config) {
       const quote = config.quoteStyle === 'single' ? `'` : `"`
       const replaced = routeCode.replace(
         fileRouteRegex,
-        `new FileRoute(${quote}${escapedRoutePath}${quote})`,
+        `new FileRoute($1${quote}${escapedRoutePath}${quote}$3)`,
       )
 
       if (replaced !== routeCode) {


### PR DESCRIPTION
Formatters such as Prettier and Biome break the path to a new line as soon as the line length exceeds X characters:

```typescript
export const Route = new FileRoute(
  '/dashboard/invoices/$invoiceId',
).createRoute({
```

However, the router CLI expects the path to be on the same line with no trailing comma:
```typescript
export const Route = new FileRoute('/dashboard/invoices/$invoiceId').createRoute({
```

**Example**: Try saving `src/routes/dashboard.invoices.$invoiceId.tsx` in the [kitchen-sink-file-based example](https://tanstack.com/router/v1/docs/examples/react/kitchen-sink-file-based). First, Prettier formats the file, and then the formatted file is overwritten by the router CLI.

This fix maintains the whitespace and the trailing comma (if present) within the constructor parentheses of FileRoute during the string replacement. I've also replaced `[^)]*` with a non-greedy any character match `.*?`.