### PR TITLE
fix: type safe paths when using nested layout routes in file-based routing

### DIFF
--- a/examples/react/basic-file-based/src/routeTree.gen.ts
+++ b/examples/react/basic-file-based/src/routeTree.gen.ts
@@ -1,86 +1,96 @@
-import { lazyFn, lazyRouteComponent } from '@tanstack/react-router'
+import { FileRoute, lazyFn, lazyRouteComponent } from "@tanstack/react-router"
 
-import { Route as rootRoute } from './routes/__root'
-import { Route as PostsImport } from './routes/posts'
-import { Route as LayoutImport } from './routes/_layout'
-import { Route as IndexImport } from './routes/index'
-import { Route as PostsPostIdImport } from './routes/posts.$postId'
-import { Route as LayoutLayoutBImport } from './routes/_layout/layout-b'
-import { Route as LayoutLayoutAImport } from './routes/_layout/layout-a'
-import { Route as PostsIndexImport } from './routes/posts.index'
-import { Route as PostsPostIdDeepImport } from './routes/posts_.$postId.deep'
+import { Route as rootRoute } from "./routes/__root"
+import { Route as PostsImport } from "./routes/posts"
+import { Route as LayoutImport } from "./routes/_layout"
+import { Route as IndexImport } from "./routes/index"
+import { Route as PostsPostIdImport } from "./routes/posts.$postId"
+import { Route as Layoutlayout2Import } from "./routes/_layout/_layout-2"
+import { Route as PostsIndexImport } from "./routes/posts.index"
+import { Route as PostsPostIdDeepImport } from "./routes/posts_.$postId.deep"
+import { Route as Layoutlayout2LayoutBImport } from "./routes/_layout/_layout-2/layout-b"
+import { Route as Layoutlayout2LayoutAImport } from "./routes/_layout/_layout-2/layout-a"
 
 const PostsRoute = PostsImport.update({
-  path: '/posts',
+  path: "/posts",
   getParentRoute: () => rootRoute,
 } as any)
 
 const LayoutRoute = LayoutImport.update({
-  id: '/_layout',
+  id: "/_layout",
   getParentRoute: () => rootRoute,
 } as any)
 
 const IndexRoute = IndexImport.update({
-  path: '/',
+  path: "/",
   getParentRoute: () => rootRoute,
 } as any)
 
 const PostsPostIdRoute = PostsPostIdImport.update({
-  path: '/$postId',
+  path: "/$postId",
   getParentRoute: () => PostsRoute,
 } as any)
 
-const LayoutLayoutBRoute = LayoutLayoutBImport.update({
-  path: '/layout-b',
-  getParentRoute: () => LayoutRoute,
-} as any)
-
-const LayoutLayoutARoute = LayoutLayoutAImport.update({
-  path: '/layout-a',
+const Layoutlayout2Route = Layoutlayout2Import.update({
+  id: "/_layout-2",
   getParentRoute: () => LayoutRoute,
 } as any)
 
 const PostsIndexRoute = PostsIndexImport.update({
-  path: '/',
+  path: "/",
   getParentRoute: () => PostsRoute,
 } as any)
 
 const PostsPostIdDeepRoute = PostsPostIdDeepImport.update({
-  path: '/posts/$postId/deep',
+  path: "/posts/$postId/deep",
   getParentRoute: () => rootRoute,
 } as any)
 
-declare module '@tanstack/react-router' {
+const Layoutlayout2LayoutBRoute = Layoutlayout2LayoutBImport.update({
+  path: "/layout-b",
+  getParentRoute: () => Layoutlayout2Route,
+} as any)
+
+const Layoutlayout2LayoutARoute = Layoutlayout2LayoutAImport.update({
+  path: "/layout-a",
+  getParentRoute: () => Layoutlayout2Route,
+} as any)
+
+declare module "@tanstack/react-router" {
   interface FileRoutesByPath {
-    '/': {
+    "/": {
       preLoaderRoute: typeof IndexImport
       parentRoute: typeof rootRoute
     }
-    '/_layout': {
+    "/_layout": {
       preLoaderRoute: typeof LayoutImport
       parentRoute: typeof rootRoute
     }
-    '/posts': {
+    "/posts": {
       preLoaderRoute: typeof PostsImport
       parentRoute: typeof rootRoute
     }
-    '/posts/': {
+    "/posts/": {
       preLoaderRoute: typeof PostsIndexImport
       parentRoute: typeof PostsRoute
     }
-    '/_layout/layout-a': {
-      preLoaderRoute: typeof LayoutLayoutAImport
+    "/_layout/_layout-2": {
+      preLoaderRoute: typeof Layoutlayout2Import
       parentRoute: typeof LayoutRoute
     }
-    '/_layout/layout-b': {
-      preLoaderRoute: typeof LayoutLayoutBImport
-      parentRoute: typeof LayoutRoute
-    }
-    '/posts/$postId': {
+    "/posts/$postId": {
       preLoaderRoute: typeof PostsPostIdImport
       parentRoute: typeof PostsRoute
     }
-    '/posts_/$postId/deep': {
+    "/_layout/_layout-2/layout-a": {
+      preLoaderRoute: typeof Layoutlayout2LayoutAImport
+      parentRoute: typeof Layoutlayout2Route
+    }
+    "/_layout/_layout-2/layout-b": {
+      preLoaderRoute: typeof Layoutlayout2LayoutBImport
+      parentRoute: typeof Layoutlayout2Route
+    }
+    "/posts_/$postId/deep": {
       preLoaderRoute: typeof PostsPostIdDeepImport
       parentRoute: typeof rootRoute
     }
@@ -89,7 +99,12 @@ declare module '@tanstack/react-router' {
 
 export const routeTree = rootRoute.addChildren([
   IndexRoute,
-  LayoutRoute.addChildren([LayoutLayoutARoute, LayoutLayoutBRoute]),
+  LayoutRoute.addChildren([
+    Layoutlayout2Route.addChildren([
+      Layoutlayout2LayoutARoute,
+      Layoutlayout2LayoutBRoute,
+    ]),
+  ]),
   PostsRoute.addChildren([PostsIndexRoute, PostsPostIdRoute]),
   PostsPostIdDeepRoute,
 ])

--- a/examples/react/basic-file-based/src/routes/_layout.tsx
+++ b/examples/react/basic-file-based/src/routes/_layout.tsx
@@ -9,24 +9,6 @@ function LayoutComponent() {
   return (
     <div>
       <div>I'm a layout</div>
-      <div className="flex gap-2">
-        <Link
-          to="/layout-a"
-          activeProps={{
-            className: 'font-bold',
-          }}
-        >
-          Layout A
-        </Link>
-        <Link
-          to="/layout-b"
-          activeProps={{
-            className: 'font-bold',
-          }}
-        >
-          Layout B
-        </Link>
-      </div>
       <div>
         <Outlet />
       </div>

--- a/examples/react/basic-file-based/src/routes/_layout/_layout-2.tsx
+++ b/examples/react/basic-file-based/src/routes/_layout/_layout-2.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { Link, Outlet, FileRoute } from '@tanstack/react-router';
+
+export const Route = new FileRoute('/_layout/_layout-2').createRoute({
+  component: LayoutComponent,
+});
+
+function LayoutComponent() {
+  return (
+    <div>
+      <div>I'm a nested layout</div>
+      <div className="flex gap-2">
+        <Link
+          to="/layout-a"
+          activeProps={{
+            className: 'font-bold',
+          }}
+        >
+          Layout A
+        </Link>
+        <Link
+          to="/layout-b"
+          activeProps={{
+            className: 'font-bold',
+          }}
+        >
+          Layout B
+        </Link>
+      </div>
+      <div>
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/examples/react/basic-file-based/src/routes/_layout/_layout-2/layout-a.tsx
+++ b/examples/react/basic-file-based/src/routes/_layout/_layout-2/layout-a.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react'
 import { FileRoute } from '@tanstack/react-router'
 
-export const Route = new FileRoute('/_layout/layout-a').createRoute({
+export const Route = new FileRoute('/_layout/_layout-2/layout-a').createRoute({
   component: LayoutAComponent,
 })
+
 
 function LayoutAComponent() {
   return <div>I'm A!</div>
 }
+
+

--- a/examples/react/basic-file-based/src/routes/_layout/_layout-2/layout-b.tsx
+++ b/examples/react/basic-file-based/src/routes/_layout/_layout-2/layout-b.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { FileRoute } from '@tanstack/react-router'
 
-export const Route = new FileRoute('/_layout/layout-b').createRoute({
+export const Route = new FileRoute('/_layout/_layout-2/layout-b').createRoute({
   component: LayoutBComponent,
 })
 

--- a/packages/react-router/src/fileRoute.ts
+++ b/packages/react-router/src/fileRoute.ts
@@ -56,12 +56,20 @@ export type RemoveUnderScores<T extends string> = Replace<
   '/'
 >
 
+type ReplaceFirstOccurrence<
+  T extends string,
+  Search extends string,
+  Replacement extends string,
+> = T extends `${infer Prefix}${Search}${infer Suffix}`
+  ? `${Prefix}${Replacement}${Suffix}`
+  : T
+
 export type ResolveFilePath<
   TParentRoute extends AnyRoute,
   TFilePath extends string,
 > = TParentRoute['id'] extends RootRouteId
   ? TrimPathLeft<TFilePath>
-  : Replace<
+  : ReplaceFirstOccurrence<
       TrimPathLeft<TFilePath>,
       TrimPathLeft<TParentRoute['types']['customId']>,
       ''
@@ -72,7 +80,9 @@ export type FileRoutePath<
   TFilePath extends string,
 > = ResolveFilePath<TParentRoute, TFilePath> extends `_${infer _}`
   ? string
-  : ResolveFilePath<TParentRoute, TFilePath>
+  : ResolveFilePath<TParentRoute, TFilePath> extends `/_${infer _}`
+    ? string
+    : ResolveFilePath<TParentRoute, TFilePath>
 
 export class FileRoute<
   TFilePath extends keyof FileRoutesByPath,


### PR DESCRIPTION
fixes #899