### PR TITLE
Fix links to router-cli in router-vite-plugin

### DIFF
--- a/docs/api/router-vite-plugin.md
+++ b/docs/api/router-vite-plugin.md
@@ -3,7 +3,7 @@ id: Router Vite Plugin
 title: Route Vite Plugin (Route Generation)
 ---
 
-The `@tanstack/router-vite-plugin` package is a vite plugin that can be used instead of the [`@tanstack/router-cli`](./router-cli) package to generate routes for your project. It is a drop-in replacement for the CLI and can be used in the same way, but instead of calling `tsr generate` or `tsr watch`, you simply add the plugin to your vite config!
+The `@tanstack/router-vite-plugin` package is a vite plugin that can be used instead of the [`@tanstack/router-cli`](./api/router-cli) package to generate routes for your project. It is a drop-in replacement for the CLI and can be used in the same way, but instead of calling `tsr generate` or `tsr watch`, you simply add the plugin to your vite config!
 
 ## Installation
 
@@ -29,4 +29,4 @@ export default defineConfig({
 
 ## Configuration
 
-Configuration is done via the `tsr.config.json` file. Please see the [Router CLI](./router-cli) documentation for more information on the configuration options.
+Configuration is done via the `tsr.config.json` file. Please see the [Router CLI](./api/router-cli) documentation for more information on the configuration options.


### PR DESCRIPTION
The current links to the router-cli in the [Route Vite Plugin](https://tanstack.com/router/v1/docs/api/router-vite-plugin) are not working. 