### PR TITLE
fix `pendingComponent` not shown when `pendingMs` is 0

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1060,9 +1060,9 @@ export class Router<
 
           const pendingMs =
             route.options.pendingMs ?? this.options.defaultPendingMs
-          const pendingPromise = new Promise<void>((r) =>
-            setTimeout(r, pendingMs),
-          )
+          const pendingPromise = pendingMs <= 0
+            ? Promise.resolve()
+            : new Promise<void>((r) => setTimeout(r, pendingMs))
 
           const beforeLoadContext =
             (await route.options.beforeLoad?.({

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1060,7 +1060,7 @@ export class Router<
 
           const pendingMs =
             route.options.pendingMs ?? this.options.defaultPendingMs
-          const pendingPromise = pendingMs <= 0
+          const pendingPromise = typeof pendingMs === 'number' && pendingMs <= 0
             ? Promise.resolve()
             : new Promise<void>((r) => setTimeout(r, pendingMs))
 

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1145,7 +1145,7 @@ export class Router<
             route.options.pendingMinMs ?? this.options.defaultPendingMinMs
           const shouldPending =
             !preload &&
-            pendingMs &&
+            typeof pendingMs === 'number' &&
             (route.options.pendingComponent ??
               this.options.defaultPendingComponent)
 


### PR DESCRIPTION
`pendingConponent` is not shown when `pendingMs` is 0.
Is that a bug or intended behavior?
I am using `Number.EPSILON` in the meantime.
