### PR TITLE
fix: omit `RootSearchSchema` from search param type

### DIFF
--- a/packages/react-router/src/Matches.tsx
+++ b/packages/react-router/src/Matches.tsx
@@ -13,7 +13,7 @@ import {
   RoutePaths,
 } from './routeInfo'
 import { RegisteredRouter, RouterState } from './router'
-import { GetTFrom, NoInfer, StrictOrFrom, pick } from './utils'
+import { NoInfer, StrictOrFrom, pick } from './utils'
 
 export const matchContext = React.createContext<string | undefined>(undefined)
 
@@ -36,7 +36,10 @@ export interface RouteMatch<
   loaderData?: RouteById<TRouteTree, TRouteId>['types']['loaderData']
   routeContext: RouteById<TRouteTree, TRouteId>['types']['routeContext']
   context: RouteById<TRouteTree, TRouteId>['types']['allContext']
-  search: Exclude<RouteById<TRouteTree, TRouteId>['types']['fullSearchSchema'], RootSearchSchema>
+  search: Exclude<
+    RouteById<TRouteTree, TRouteId>['types']['fullSearchSchema'],
+    RootSearchSchema
+  >
   fetchCount: number
   abortController: AbortController
   cause: 'preload' | 'enter' | 'stay'
@@ -291,14 +294,12 @@ export function getRenderedMatches(state: RouterState) {
 }
 
 export function useMatch<
-  TOpts extends StrictOrFrom<TFrom>,
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
   TFrom extends RouteIds<TRouteTree> = RouteIds<TRouteTree>,
-  TFromInferred extends RouteIds<TRouteTree> = GetTFrom<TOpts, TRouteTree>,
-  TRouteMatchState = RouteMatch<TRouteTree, TFromInferred>,
+  TRouteMatchState = RouteMatch<TRouteTree, TFrom>,
   TSelected = TRouteMatchState,
 >(
-  opts: TOpts & {
+  opts: StrictOrFrom<TFrom> & {
     select?: (match: TRouteMatchState) => TSelected
   },
 ): TSelected {
@@ -377,17 +378,15 @@ export function useParentMatches<T = RouteMatch[]>(opts?: {
 }
 
 export function useLoaderDeps<
-  TOpts extends StrictOrFrom<TFrom>,
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
   TFrom extends RouteIds<TRouteTree> = RouteIds<TRouteTree>,
-  TFromInferred extends RouteIds<TRouteTree> = GetTFrom<TOpts, TRouteTree>,
-  TRouteMatch extends RouteMatch<TRouteTree, TFromInferred> = RouteMatch<
+  TRouteMatch extends RouteMatch<TRouteTree, TFrom> = RouteMatch<
     TRouteTree,
-    TFromInferred
+    TFrom
   >,
   TSelected = Required<TRouteMatch>['loaderDeps'],
 >(
-  opts: TOpts & {
+  opts: StrictOrFrom<TFrom> & {
     select?: (match: TRouteMatch) => TSelected
   },
 ): TSelected {
@@ -402,17 +401,15 @@ export function useLoaderDeps<
 }
 
 export function useLoaderData<
-  TOpts extends StrictOrFrom<TFrom>,
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
   TFrom extends RouteIds<TRouteTree> = RouteIds<TRouteTree>,
-  TFromInferred extends RouteIds<TRouteTree> = GetTFrom<TOpts, TRouteTree>,
-  TRouteMatch extends RouteMatch<TRouteTree, TFromInferred> = RouteMatch<
+  TRouteMatch extends RouteMatch<TRouteTree, TFrom> = RouteMatch<
     TRouteTree,
-    TFromInferred
+    TFrom
   >,
   TSelected = Required<TRouteMatch>['loaderData'],
 >(
-  opts: TOpts & {
+  opts: StrictOrFrom<TFrom> & {
     select?: (match: TRouteMatch) => TSelected
   },
 ): TSelected {

--- a/packages/react-router/src/Matches.tsx
+++ b/packages/react-router/src/Matches.tsx
@@ -4,7 +4,7 @@ import warning from 'tiny-warning'
 import { CatchBoundary, ErrorComponent } from './CatchBoundary'
 import { useRouter, useRouterState } from './RouterProvider'
 import { ResolveRelativePath, ToOptions } from './link'
-import { AnyRoute, ReactNode } from './route'
+import { AnyRoute, ReactNode, RootSearchSchema } from './route'
 import {
   ParseRoute,
   RouteById,
@@ -36,7 +36,7 @@ export interface RouteMatch<
   loaderData?: RouteById<TRouteTree, TRouteId>['types']['loaderData']
   routeContext: RouteById<TRouteTree, TRouteId>['types']['routeContext']
   context: RouteById<TRouteTree, TRouteId>['types']['allContext']
-  search: RouteById<TRouteTree, TRouteId>['types']['fullSearchSchema']
+  search: Exclude<RouteById<TRouteTree, TRouteId>['types']['fullSearchSchema'], RootSearchSchema>
   fetchCount: number
   abortController: AbortController
   cause: 'preload' | 'enter' | 'stay'

--- a/packages/react-router/src/useParams.tsx
+++ b/packages/react-router/src/useParams.tsx
@@ -1,20 +1,18 @@
 import { AnyRoute } from './route'
-import { RouteIds, RouteById, AllParams } from './routeInfo'
+import { RouteIds, RouteById } from './routeInfo'
 import { RegisteredRouter } from './router'
 import { last } from './utils'
 import { useRouterState } from './RouterProvider'
-import { StrictOrFrom, GetTFrom } from './utils'
+import { StrictOrFrom } from './utils'
 import { getRenderedMatches } from './Matches'
 
 export function useParams<
-  TOpts extends StrictOrFrom<TFrom>,
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
   TFrom extends RouteIds<TRouteTree> = RouteIds<TRouteTree>,
-  TFromInferred = GetTFrom<TOpts, TRouteTree>,
-  TParams = RouteById<TRouteTree, TFromInferred>['types']['allParams'],
+  TParams = RouteById<TRouteTree, TFrom>['types']['allParams'],
   TSelected = TParams,
 >(
-  opts: TOpts & {
+  opts: StrictOrFrom<TFrom> & {
     select?: (params: TParams) => TSelected
   },
 ): TSelected {

--- a/packages/react-router/src/useSearch.tsx
+++ b/packages/react-router/src/useSearch.tsx
@@ -1,4 +1,4 @@
-import { AnyRoute } from './route'
+import { AnyRoute, RootSearchSchema } from './route'
 import { RouteIds, RouteById } from './routeInfo'
 import { RegisteredRouter } from './router'
 import { RouteMatch } from './Matches'
@@ -10,7 +10,7 @@ export function useSearch<
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
   TFrom extends RouteIds<TRouteTree> = RouteIds<TRouteTree>,
   TFromInferred = GetTFrom<TOpts, TRouteTree>,
-  TSearch = RouteById<TRouteTree, TFromInferred>['types']['fullSearchSchema'],
+  TSearch = Exclude<RouteById<TRouteTree, TFromInferred>['types']['fullSearchSchema'], RootSearchSchema>,
   TSelected = TSearch,
 >(
   opts: TOpts & {

--- a/packages/react-router/src/useSearch.tsx
+++ b/packages/react-router/src/useSearch.tsx
@@ -3,17 +3,15 @@ import { RouteIds, RouteById } from './routeInfo'
 import { RegisteredRouter } from './router'
 import { RouteMatch } from './Matches'
 import { useMatch } from './Matches'
-import { StrictOrFrom, GetTFrom } from './utils'
+import { StrictOrFrom } from './utils'
 
 export function useSearch<
-  TOpts extends StrictOrFrom<TFrom>,
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
   TFrom extends RouteIds<TRouteTree> = RouteIds<TRouteTree>,
-  TFromInferred = GetTFrom<TOpts, TRouteTree>,
-  TSearch = Exclude<RouteById<TRouteTree, TFromInferred>['types']['fullSearchSchema'], RootSearchSchema>,
+  TSearch = Exclude<RouteById<TRouteTree, TFrom>['types']['fullSearchSchema'], RootSearchSchema>,
   TSelected = TSearch,
 >(
-  opts: TOpts & {
+  opts: StrictOrFrom<TFrom> & {
     select?: (search: TSearch) => TSelected
   },
 ) : TSelected {

--- a/packages/react-router/src/utils.ts
+++ b/packages/react-router/src/utils.ts
@@ -306,12 +306,6 @@ export type StrictOrFrom<TFrom> =
       strict: false
     }
 
-export type GetTFrom<T, TRouteTree extends AnyRoute> = T extends StrictOrFrom<
-  infer TFrom extends RouteIds<TRouteTree>
->
-  ? TFrom
-  : never
-
 export function useRouteContext<
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
   TFrom extends RouteIds<TRouteTree> = RouteIds<TRouteTree>,


### PR DESCRIPTION
also fix typing in select function of useSearch, useParams, useMatch etc.

fixes #1007