### PR TITLE
fix: hot reload not working on windows

### DIFF
--- a/packages/router-vite-plugin/src/index.ts
+++ b/packages/router-vite-plugin/src/index.ts
@@ -1,5 +1,5 @@
 import { Plugin } from 'vite'
-import { join } from 'path'
+import { join, normalize } from 'path'
 import { readFile } from 'fs/promises'
 import {
   type Config,
@@ -49,11 +49,12 @@ export function TanStackRouterVite(inlineConfig: UserConfig = {}): Plugin {
       await generate()
     },
     handleHotUpdate: async ({ file }) => {
-      if (file === join(ROOT, CONFIG_FILE_NAME)) {
+      const filePath = normalize(file)
+      if (filePath === join(ROOT, CONFIG_FILE_NAME)) {
         userConfig = await buildConfig(inlineConfig, ROOT)
         return
       }
-      if (file.startsWith(join(ROOT, userConfig.routesDirectory))) {
+      if (filePath.startsWith(join(ROOT, userConfig.routesDirectory))) {
         await generate()
       }
     },


### PR DESCRIPTION
Hot reload is not working properly on windows, `file` contains forward slashes, whereas `path.join(...)` contains backslashes.

One way to fix that is to normalize the file path before comparing the two.