### PR TITLE
fix: Ensure consistent dev tools panel direction in RTL projects

### DIFF
--- a/packages/router-devtools/src/devtools.tsx
+++ b/packages/router-devtools/src/devtools.tsx
@@ -288,6 +288,7 @@ export function TanStackRouterDevtools({
           {...otherPanelProps}
           router={router}
           style={{
+            direction: 'ltr',
             position: 'fixed',
             bottom: '0',
             right: '0',


### PR DESCRIPTION
### Problem
The dev tools respect the project's direction whether It's `ltr` or `rtl`
If the direction was `rtl`, the panel's layout will result in the following image

<img width="700" alt="image" src="https://github.com/TanStack/router/assets/74133458/a7ea5103-78ef-465a-bbc3-81b541710871">

### Solution

Make the panel's direction consistent by setting Its direction to `ltr`
That would make the layout the same in both directions

<img width="700" alt="image" src="https://github.com/TanStack/router/assets/74133458/1a875e46-d989-4913-be34-411367890b26">


