### PR TITLE
feat: add option `experimental_returnIntersection`

### DIFF
--- a/packages/react-router/src/useParams.tsx
+++ b/packages/react-router/src/useParams.tsx
@@ -1,7 +1,7 @@
 import { AnyRoute } from './route'
-import { RouteIds, RouteById } from './routeInfo'
+import { RouteIds, RouteById, AllParams } from './routeInfo'
 import { RegisteredRouter } from './router'
-import { last } from './utils'
+import { Expand, last } from './utils'
 import { useRouterState } from './useRouterState'
 import { StrictOrFrom } from './utils'
 import { getRenderedMatches } from './Matches'
@@ -9,10 +9,13 @@ import { getRenderedMatches } from './Matches'
 export function useParams<
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
   TFrom extends RouteIds<TRouteTree> = RouteIds<TRouteTree>,
-  TParams = RouteById<TRouteTree, TFrom>['types']['allParams'],
+  TReturnIntersection extends boolean = false,
+  TParams = TReturnIntersection extends false
+    ? RouteById<TRouteTree, TFrom>['types']['allParams']
+    : Expand<Partial<AllParams<TRouteTree>>>,
   TSelected = TParams,
 >(
-  opts: StrictOrFrom<TFrom> & {
+  opts: StrictOrFrom<TFrom, TReturnIntersection> & {
     select?: (params: TParams) => TSelected
   },
 ): TSelected {

--- a/packages/react-router/src/useSearch.tsx
+++ b/packages/react-router/src/useSearch.tsx
@@ -1,20 +1,21 @@
 import { AnyRoute, RootSearchSchema } from './route'
-import { RouteIds, RouteById } from './routeInfo'
+import { RouteIds, RouteById, FullSearchSchema } from './routeInfo'
 import { RegisteredRouter } from './router'
 import { RouteMatch } from './Matches'
 import { useMatch } from './Matches'
-import { StrictOrFrom } from './utils'
+import { Expand, StrictOrFrom } from './utils'
 
 export function useSearch<
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
   TFrom extends RouteIds<TRouteTree> = RouteIds<TRouteTree>,
-  TSearch = Exclude<
+  TReturnIntersection extends boolean = false,
+  TSearch = TReturnIntersection extends false ? Exclude<
     RouteById<TRouteTree, TFrom>['types']['fullSearchSchema'],
     RootSearchSchema
-  >,
+  > : Expand<Partial<Omit<FullSearchSchema<TRouteTree>, keyof RootSearchSchema>>>,
   TSelected = TSearch,
 >(
-  opts: StrictOrFrom<TFrom> & {
+  opts: StrictOrFrom<TFrom, TReturnIntersection> & {
     select?: (search: TSearch) => TSelected
   },
 ): TSelected {

--- a/packages/react-router/src/utils.ts
+++ b/packages/react-router/src/utils.ts
@@ -300,7 +300,7 @@ export type StringLiteral<T> = T extends string
     : T
   : never
 
-export type StrictOrFrom<TFrom> =
+export type StrictOrFrom<TFrom, TReturnIntersection extends boolean = false> =
   | {
       from: StringLiteral<TFrom> | TFrom
       strict?: true
@@ -308,6 +308,7 @@ export type StrictOrFrom<TFrom> =
   | {
       from?: never
       strict: false
+      experimental_returnIntersection?: TReturnIntersection
     }
 
 export const useLayoutEffect =


### PR DESCRIPTION
type path / search params as a partial intersection in `useMatch`, `useMatches`, `useParentMatches`, `useParams` and `useSearch`