### PR TITLE
Handle router prop update in RouterProvider

### DIFF
--- a/packages/react-router/src/RouterProvider.tsx
+++ b/packages/react-router/src/RouterProvider.tsx
@@ -88,8 +88,8 @@ export function RouterProvider<
 }
 
 function Transitioner() {
-  const mountLoadCount = React.useRef(0)
   const router = useRouter()
+  const mountLoadForRouter = React.useRef({ router, mounted: false })
   const routerState = useRouterState({
     select: (s) =>
       pick(s, ['isLoading', 'location', 'resolvedLocation', 'isTransitioning']),
@@ -192,11 +192,16 @@ function Transitioner() {
   ])
 
   useLayoutEffect(() => {
-    if (!window.__TSR_DEHYDRATED__ && !mountLoadCount.current) {
-      mountLoadCount.current++
-      tryLoad()
+    if (window.__TSR_DEHYDRATED__) return
+    if (
+      mountLoadForRouter.current.router === router &&
+      mountLoadForRouter.current.mounted
+    ) {
+      return
     }
-  }, [])
+    mountLoadForRouter.current = { router, mounted: true }
+    tryLoad()
+  }, [router])
 
   return null
 }


### PR DESCRIPTION
Without this HMR of routes just doesn't work for code base routing.

I think the example should be updated to provide better HMR pattern, and least have something like:
```tsx
// App.tsx
export function App() {
   return <RouterProvider router={router} />;
}

// main.tsx
createRoot(document.getElementById('app')!).render(<App />);
```

Also the current setup for file base routing is lying to the Refresh runtime by using export with capital letter that are not React component. This leads to broken HMR update when updating the props of the exported Route. This seems to be an issue way deeper in the architecture so I can't really fix it here. 