### PR TITLE
Make use of router-generator's getConfig function at router-vite-plugin

### DIFF
--- a/packages/router-generator/src/config.ts
+++ b/packages/router-generator/src/config.ts
@@ -13,9 +13,11 @@ export const configSchema = z.object({
 
 export type Config = z.infer<typeof configSchema>
 
-const configFilePathJson = path.resolve(process.cwd(), 'tsr.config.json')
-
-export async function getConfig(inlineConfig: Partial<Config> = {}): Promise<Config> {
+export async function getConfig(inlineConfig: Partial<Config> = {}, configDirectory?: string): Promise<Config> {
+  if (configDirectory === undefined) {
+    configDirectory = process.cwd();
+  }
+  const configFilePathJson = path.resolve(configDirectory, 'tsr.config.json')
   const exists = existsSync(configFilePathJson)
 
   let config: Config

--- a/packages/router-generator/src/config.ts
+++ b/packages/router-generator/src/config.ts
@@ -23,10 +23,10 @@ export async function getConfig(inlineConfig: Partial<Config> = {}, configDirect
   let config: Config
 
   if (exists) {
-    config = configSchema.parse(
-      JSON.parse(readFileSync(configFilePathJson, 'utf-8')),
+    config = configSchema.parse({
+      ...JSON.parse(readFileSync(configFilePathJson, 'utf-8')),
       ...inlineConfig
-    )
+    })
   } else {
     config = configSchema.parse(inlineConfig)
   }

--- a/packages/router-generator/src/config.ts
+++ b/packages/router-generator/src/config.ts
@@ -15,7 +15,7 @@ export type Config = z.infer<typeof configSchema>
 
 const configFilePathJson = path.resolve(process.cwd(), 'tsr.config.json')
 
-export async function getConfig(): Promise<Config> {
+export async function getConfig(inlineConfig: Partial<Config> = {}): Promise<Config> {
   const exists = existsSync(configFilePathJson)
 
   let config: Config
@@ -23,9 +23,10 @@ export async function getConfig(): Promise<Config> {
   if (exists) {
     config = configSchema.parse(
       JSON.parse(readFileSync(configFilePathJson, 'utf-8')),
+      ...inlineConfig
     )
   } else {
-    config = configSchema.parse({})
+    config = configSchema.parse(inlineConfig)
   }
 
   // If typescript is disabled, make sure the generated route tree is a .js file

--- a/packages/router-vite-plugin/src/index.ts
+++ b/packages/router-vite-plugin/src/index.ts
@@ -13,11 +13,7 @@ const CONFIG_FILE_NAME = 'tsr.config.json'
 type UserConfig = Partial<Config>
 
 async function buildConfig(config: UserConfig): Promise<Config> {
-  const tsrConfig = await getConfig();
-  return {
-    ...tsrConfig,
-    ...config
-  };
+  return await getConfig(config);
 }
 
 export function TanStackRouterVite(inlineConfig: UserConfig = {}): Plugin {

--- a/packages/router-vite-plugin/src/index.ts
+++ b/packages/router-vite-plugin/src/index.ts
@@ -26,13 +26,13 @@ export function TanStackRouterVite(inlineConfig: Partial<Config> = {}): Plugin {
     name: 'vite-plugin-tanstack-router',
     configResolved: async (vite) => {
       ROOT = vite.root
-      userConfig = await getConfig(inlineConfig)
+      userConfig = await getConfig(inlineConfig, ROOT)
       await generate()
     },
     handleHotUpdate: async ({ file }) => {
       const filePath = normalize(file)
       if (filePath === join(ROOT, CONFIG_FILE_NAME)) {
-        userConfig = await getConfig(inlineConfig)
+        userConfig = await getConfig(inlineConfig, ROOT)
         return
       }
       if (filePath.startsWith(join(ROOT, userConfig.routesDirectory))) {

--- a/packages/router-vite-plugin/src/index.ts
+++ b/packages/router-vite-plugin/src/index.ts
@@ -11,10 +11,6 @@ const CONFIG_FILE_NAME = 'tsr.config.json'
 
 type UserConfig = Partial<Config>
 
-async function buildConfig(inlineConfig: UserConfig): Promise<Config> {
-  return getConfig(inlineConfig);
-}
-
 export function TanStackRouterVite(inlineConfig: UserConfig = {}): Plugin {
   let ROOT: string
   let userConfig: Config
@@ -32,13 +28,13 @@ export function TanStackRouterVite(inlineConfig: UserConfig = {}): Plugin {
     name: 'vite-plugin-tanstack-router',
     configResolved: async (vite) => {
       ROOT = vite.root
-      userConfig = await buildConfig(inlineConfig)
+      userConfig = await getConfig(inlineConfig)
       await generate()
     },
     handleHotUpdate: async ({ file }) => {
       const filePath = normalize(file)
       if (filePath === join(ROOT, CONFIG_FILE_NAME)) {
-        userConfig = await buildConfig(inlineConfig)
+        userConfig = await getConfig(inlineConfig)
         return
       }
       if (filePath.startsWith(join(ROOT, userConfig.routesDirectory))) {

--- a/packages/router-vite-plugin/src/index.ts
+++ b/packages/router-vite-plugin/src/index.ts
@@ -3,7 +3,6 @@ import { join, normalize } from 'path'
 import { readFile } from 'fs/promises'
 import {
   type Config,
-  configSchema,
   getConfig,
   generator,
 } from '@tanstack/router-generator'
@@ -13,7 +12,7 @@ const CONFIG_FILE_NAME = 'tsr.config.json'
 type UserConfig = Partial<Config>
 
 async function buildConfig(config: UserConfig): Promise<Config> {
-  return await getConfig(config);
+  return getConfig(config);
 }
 
 export function TanStackRouterVite(inlineConfig: UserConfig = {}): Plugin {

--- a/packages/router-vite-plugin/src/index.ts
+++ b/packages/router-vite-plugin/src/index.ts
@@ -9,9 +9,7 @@ import {
 
 const CONFIG_FILE_NAME = 'tsr.config.json'
 
-type UserConfig = Partial<Config>
-
-export function TanStackRouterVite(inlineConfig: UserConfig = {}): Plugin {
+export function TanStackRouterVite(inlineConfig: Partial<Config> = {}): Plugin {
   let ROOT: string
   let userConfig: Config
 

--- a/packages/router-vite-plugin/src/index.ts
+++ b/packages/router-vite-plugin/src/index.ts
@@ -11,8 +11,8 @@ const CONFIG_FILE_NAME = 'tsr.config.json'
 
 type UserConfig = Partial<Config>
 
-async function buildConfig(config: UserConfig): Promise<Config> {
-  return getConfig(config);
+async function buildConfig(inlineConfig: UserConfig): Promise<Config> {
+  return getConfig(inlineConfig);
 }
 
 export function TanStackRouterVite(inlineConfig: UserConfig = {}): Plugin {


### PR DESCRIPTION
Hey,
I noticed that the vite-plugin was not using `getConfig` of `router-generator`. Therefore the disableTypes logic with the ts|tsx replacement in the `generatedRoutTree`-File did not work.

This PR fixes the issue.

best regards  