### PR TITLE
fix: typsafety of BuildLocationFn missing Generics

### DIFF
--- a/packages/react-router/src/RouterProvider.tsx
+++ b/packages/react-router/src/RouterProvider.tsx
@@ -43,8 +43,13 @@ export type NavigateFn<TRouteTree extends AnyRoute> = <
   opts: NavigateOptions<TRouteTree, TFrom, TTo, TMaskFrom, TMaskTo>,
 ) => Promise<void>
 
-export type BuildLocationFn<TRouteTree extends AnyRoute> = (
-  opts: ToOptions<TRouteTree> & {
+export type BuildLocationFn<TRouteTree extends AnyRoute> = <
+  TFrom extends RoutePaths<TRouteTree> | string = RoutePaths<TRouteTree>,
+  TTo extends string = '',
+  TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
+  TMaskTo extends string = '',
+>(
+  opts: ToOptions<TRouteTree, TFrom, TTo, TMaskFrom, TMaskTo> & {
     leaveParams?: boolean
   },
 ) => ParsedLocation


### PR DESCRIPTION
I was having problems with the `buildLocation` function which was giving me inconsistent type errors when compared to the `navigate` function and the `Link` component. After some investigation it became clear that the root cause of the problem is a simple mistake in the `BuildLocationFn` type definition, which is missing some generics..... maybe someone forgot to add them.

Making a comparison with the `NavigationFn` type, which is right above:
```tsx
export type NavigateFn<TRouteTree extends AnyRoute> = <
  TFrom extends RoutePaths<TRouteTree> | string = string,
  TTo extends string = '',
  TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
  TMaskTo extends string = '',
>(
  opts: NavigateOptions<TRouteTree, TFrom, TTo, TMaskFrom, TMaskTo>,
) => Promise<void>
```
`BuildLocationFn` works pretty much the same way but the generics are not declared for some reason.
```tsx
export type BuildLocationFn<TRouteTree extends AnyRoute> = (
  opts: ToOptions<TRouteTree> & {
    leaveParams?: boolean
  },
) => ParsedLocation
```

Look at the `ToOptions` type, it has the same generic arguments as the `NavigateOptions`, so it's only fair that the `NavigationFn` and `BuildLocationFn` should pass their generics the same way.
```tsx
export type NavigateOptions<
  TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
  TFrom extends RoutePaths<TRouteTree> | string = RoutePaths<TRouteTree>,
  TTo extends string = '',
  TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
  TMaskTo extends string = '',
> = ToOptions<TRouteTree, TFrom, TTo, TMaskFrom, TMaskTo> & {
  // `replace` is a boolean that determines whether the navigation should replace the current history entry or push a new one.
  replace?: boolean
  resetScroll?: boolean
  // If set to `true`, the link's underlying navigate() call will be wrapped in a `React.startTransition` call. Defaults to `true`.
  startTransition?: boolean
}

export type ToOptions<
  TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
  TFrom extends RoutePaths<TRouteTree> | string = RoutePaths<TRouteTree>,
  TTo extends string = '',
  TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
  TMaskTo extends string = '',
> = ToSubOptions<TRouteTree, TFrom, TTo> & {
  mask?: ToMaskOptions<TRouteTree, TMaskFrom, TMaskTo>
}
```


In my tests this PR fixes the typesafety issues I was having 🙂
Basically we are losing type information along the line if we don't pass the generics correctly.