### PR TITLE
fix: typo on navigation.md

### DIFF
--- a/docs/guide/navigation.md
+++ b/docs/guide/navigation.md
@@ -41,7 +41,7 @@ type ToOptions<
     | ((prevSearch: Record<string, unknown>) => Record<string, unknown>)
   // `hash` is either a string or a function that supplies the previous hash and allows you to return a new one.
   hash?: string | ((prevHash: string) => string)
-  // `state` is either an object of state or a function that supplies the previous state and allows you to return a new one. State is stored in the history API and can be useful for passing data between routes that you do not with to permanently store in URL search params.
+  // `state` is either an object of state or a function that supplies the previous state and allows you to return a new one. State is stored in the history API and can be useful for passing data between routes that you do not want to permanently store in URL search params.
   state?:
     | Record<string, any>
     | ((prevState: Record<string, unknown>) => Record<string, unknown>)


### PR DESCRIPTION
- fixes a typo in the docs for the `ToOptions` interface in the [navigation page](https://tanstack.com/router/v1/docs/guide/navigation#tooptions-interface).