### PR TITLE
Add 404 handler for lazyRouteComponent

### DIFF
--- a/packages/react-router/src/lazyRouteComponent.tsx
+++ b/packages/react-router/src/lazyRouteComponent.tsx
@@ -1,6 +1,18 @@
 import * as React from 'react'
 import { AsyncRouteComponent } from './route'
 
+// If the load fails due to module not found, it may mean a new version of
+// the build was deployed and the user's browser is still using an old version.
+// If this happens, the old version in the user's browser would have an outdated
+// URL to the lazy module.
+// In that case, we want to attempt one window refresh to get the latest.
+function isModuleNotFoundError(error: any): boolean {
+  return (
+    typeof error?.message === 'string' &&
+    /Failed to fetch dynamically imported module/.test(error.message)
+  )
+}
+
 export function lazyRouteComponent<
   T extends Record<string, any>,
   TKey extends keyof T = 'default',
@@ -10,23 +22,71 @@ export function lazyRouteComponent<
 ): T[TKey] extends (props: infer TProps) => any
   ? AsyncRouteComponent<TProps>
   : never {
-  let loadPromise: Promise<any>
+  let loadPromise: Promise<any> & {
+    moduleNotFoundError?: Error
+  }
 
   const load = () => {
     if (!loadPromise) {
-      loadPromise = importer()
+      loadPromise = importer().catch((error) => {
+        if (isModuleNotFoundError(error)) {
+          // We don't want an error thrown from preload in this case, because
+          // there's nothing we want to do about module not found during preload.
+          // Record the error, recover the promise with a null return,
+          // and we will attempt module not found resolution during the render path.
+
+          loadPromise.moduleNotFoundError = error
+
+          return null
+        }
+        throw error
+      })
     }
 
     return loadPromise
   }
 
   const lazyComp = React.lazy(async () => {
-    const moduleExports = await load()
-    const comp = moduleExports[exportName ?? 'default']
-    return {
-      default: comp,
+    try {
+      const promise = load()
+
+      // Now that we're out of preload and into actual render path,
+      // throw the error if it was a module not found error during preload
+      if (promise.moduleNotFoundError) {
+        throw promise.moduleNotFoundError
+      }
+      const moduleExports = await promise
+
+      const comp = moduleExports[exportName ?? 'default']
+      return {
+        default: comp,
+      }
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        isModuleNotFoundError(error) &&
+        typeof window !== 'undefined' &&
+        typeof sessionStorage !== 'undefined'
+      ) {
+        // Again, we want to reload one time on module not found error and not enter
+        // a reload loop if there is some other issue besides an old deploy.
+        // That's why we store our reload attempt in sessionStorage.
+        // Use error.message as key because it contains the module path that failed.
+        const storageKey = `tanstack_router_reload:${error.message}`
+        if (!sessionStorage.getItem(storageKey)) {
+          sessionStorage.setItem(storageKey, '1')
+          window.location.reload()
+
+          // Return empty component while we wait for window to reload
+          return {
+            default: () => null,
+          }
+        }
+      }
+      throw error
     }
   })
+
   ;(lazyComp as any).preload = load
 
   return lazyComp as any


### PR DESCRIPTION
Fixes #1077 

- Video before fix: https://d.pr/v/IYi6II/wd5rvcvkBl
- Video working after fix: https://d.pr/v/r3qnuk/7TSXXTOfUz

It's a very weird thing to fix, so really not sure how we test this properly in the repo.

Also, I think window.location.reload isn't the right answer when in-memory router is used, since in this case the context won't be preserved on refresh.

**Todos**

- [ ] How to add check for memory router and do nothing in this case?