### PR TITLE
Fix location of `new Router` @deprecated comment

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -249,9 +249,6 @@ export function createRouter<
   return new Router<TRouteTree, TDehydrated, TSerializedError>(options)
 }
 
-/**
- * @deprecated Use the `createRouter` function instead
- */
 export class Router<
   TRouteTree extends AnyRoute = AnyRoute,
   TDehydrated extends Record<string, any> = Record<string, any>,
@@ -287,6 +284,9 @@ export class Router<
   routesByPath!: RoutesByPath<TRouteTree>
   flatRoutes!: AnyRoute[]
 
+  /**
+   * @deprecated Use the `createRouter` function instead
+   */
   constructor(
     options: RouterConstructorOptions<
       TRouteTree,


### PR DESCRIPTION
Currently any usage of Router is displayed as deprecated, eg. even in parameter definitions such as `function myFn(router: Router, ...) { ... }`.

I believe the intention was to only deprecate the constructor so move the comment there instead.