### PR TITLE
fix: `MatchRoute` now uses same props as `useMatchRoute`

### DIFF
--- a/docs/framework/react/api/router/matchRouteComponent.md
+++ b/docs/framework/react/api/router/matchRouteComponent.md
@@ -16,7 +16,7 @@ A component version of the `useMatchRoute` hook. It accepts the same options as 
 - Optional
 - `JSX.Element`
   - The component that will be rendered if the route is matched
-- ((params: TParams | false) => JSX.Element)`
+- `((params: TParams | false) => JSX.Element)`
   - A function that will be called with the matched route's params or `false` if no route was matched. This can be useful for components that need to always render, but render different props based on a route match or not.
 
 ### Returns

--- a/packages/react-router/src/Matches.tsx
+++ b/packages/react-router/src/Matches.tsx
@@ -328,28 +328,27 @@ export function useMatchRoute<
 
 export type MakeMatchRouteOptions<
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
-  TFrom extends RoutePaths<TRouteTree> = '/',
+  TFrom extends RoutePaths<TRouteTree> = RoutePaths<TRouteTree>,
   TTo extends string = '',
-  TMaskFrom extends RoutePaths<TRouteTree> = '/',
+  TMaskFrom extends RoutePaths<TRouteTree> = TFrom,
   TMaskTo extends string = '',
-> = ToOptions<TRouteTree, TFrom, TTo, TMaskFrom, TMaskTo> &
-  MatchRouteOptions & {
-    // If a function is passed as a child, it will be given the `isActive` boolean to aid in further styling on the element it returns
-    children?:
-      | ((
-          params?: RouteByPath<
-            TRouteTree,
-            ResolveRelativePath<TFrom, NoInfer<TTo>>
-          >['types']['allParams'],
-        ) => ReactNode)
-      | React.ReactNode
-  }
+> = UseMatchRouteOptions<TRouteTree, TFrom, TTo, TMaskFrom, TMaskTo> & {
+  // If a function is passed as a child, it will be given the `isActive` boolean to aid in further styling on the element it returns
+  children?:
+    | ((
+        params?: RouteByPath<
+          TRouteTree,
+          ResolveRelativePath<TFrom, NoInfer<TTo>>
+        >['types']['allParams'],
+      ) => ReactNode)
+    | React.ReactNode
+}
 
 export function MatchRoute<
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
-  TFrom extends RoutePaths<TRouteTree> = '/',
+  TFrom extends RoutePaths<TRouteTree> = RoutePaths<TRouteTree>,
   TTo extends string = '',
-  TMaskFrom extends RoutePaths<TRouteTree> = '/',
+  TMaskFrom extends RoutePaths<TRouteTree> = TFrom,
   TMaskTo extends string = '',
 >(
   props: MakeMatchRouteOptions<TRouteTree, TFrom, TTo, TMaskFrom, TMaskTo>,


### PR DESCRIPTION
do not require to specify path params