### PR TITLE
fix: access data-status from linkProps which got from useLinkProps no…

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -571,7 +571,7 @@ export const Link: LinkComponent = React.forwardRef((props: any, ref) => {
   const children =
     typeof props.children === 'function'
       ? props.children({
-          isActive: (props as any)['data-status'] === 'active',
+          isActive: (linkProps as any)['data-status'] === 'active',
         })
       : props.children
 


### PR DESCRIPTION
Currently (at least 1.14.6), `<Link />` component get `isActive` from component's `props` not `linkProps`. it should access `linkProps` which returned from `useLinkProps` for pass `isActive` to props children function as correctly.