### PR TITLE
fix: fix route variable generation for paths with leading digits

### DIFF
--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -539,6 +539,7 @@ export async function generator(config: Config) {
 function routePathToVariable(d: string): string {
   return (
     removeUnderscores(d)
+      ?.replace(/^(\d)/g, '_$1')
       ?.replace(/\/\$\//g, '/splat/')
       ?.replace(/\$$/g, 'splat')
       ?.replace(/\$/g, '')


### PR DESCRIPTION
Fixes #1110

## Context

See #1110.

## Changes

Prefixes route path variables with a `_` if the leading character is numeric, e.g. turning `500IndexRouteImport ` into `_500IndexRouteImport `.

From my testing, this seems to be the only change required to fix the issue. And feel free to change the prefixed character to something more suitable!