### PR TITLE
fix: ensure generated routes with leading digits get prefixed correctly

### DIFF
--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -539,14 +539,14 @@ export async function generator(config: Config) {
 function routePathToVariable(d: string): string {
   return (
     removeUnderscores(d)
-      ?.replace(/^(\d)/g, '_$1')
       ?.replace(/\/\$\//g, '/splat/')
       ?.replace(/\$$/g, 'splat')
       ?.replace(/\$/g, '')
       ?.split(/[/-]/g)
       .map((d, i) => (i > 0 ? capitalize(d) : d))
       .join('')
-      .replace(/([^a-zA-Z0-9]|[\.])/gm, '') ?? ''
+      .replace(/([^a-zA-Z0-9]|[\.])/gm, '')
+      .replace(/^(\d)/g, 'R$1') ?? ''
   )
 }
 


### PR DESCRIPTION
The fix added in https://github.com/TanStack/router/pull/1111 doesn't actually get applied since the [replace on line 549](https://github.com/TanStack/router/blob/cd1b62f16cd35e601c32710049b4b7497cb1dc59/packages/router-generator/src/generator.ts#L549) removes any non-alpanumeric characters again. 🙈

This PR moves it to after the final replace and replaces the prefixed `_` with a `R` (for Route) in case the underscore removal is intentional for other reasons. Feel free to change it back if it's safe 👍 