### PR TITLE
docs: add suspense note for lazy devtools component

### DIFF
--- a/docs/framework/react/devtools.md
+++ b/docs/framework/react/devtools.md
@@ -40,6 +40,14 @@ const TanStackRouterDevtools =
       )
 ```
 
+Then wrap the `TanStackRouterDevtools` component in suspense. 
+
+```tsx
+<Suspense>
+    <TanStackRouterDevtools />
+</Suspense>
+```
+
 ## Using inside of the `RouterProvider`
 
 The easiest way for the devtools to work is to render them inside of your root route (or any other route). This will automatically connect the devtools to the router instance.


### PR DESCRIPTION
When including the lazy devtools component into the root route as described in the docs I received this error. 

![image](https://github.com/TanStack/router/assets/1559451/c8086990-c85b-455b-8733-2f1dd3c16306)

It might be nice to mention that this should be wrapped in a suspense component. If there is a better way of handling this I'm open to tweaking the docs. 