### PR TITLE
fix: correct usage of singular or plural in log message

### DIFF
--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -537,7 +537,9 @@ export async function generator(config: Config) {
   }
 
   console.log(
-    `✅ Processed ${routeNodes.length} routes in ${Date.now() - start}ms`,
+    `✅ Processed ${routeNodes.length === 1 ? 'route' : 'routes'} in ${
+      Date.now() - start
+    }ms`,
   )
 }
 


### PR DESCRIPTION
Ensure proper usage of singular or plural form for the word 'routes' following generation of the route tree.