### PR TITLE
Remove .md suffix from guide links

### DIFF
--- a/docs/framework/react/api/router/NotFoundRouteClass.md
+++ b/docs/framework/react/api/router/NotFoundRouteClass.md
@@ -5,7 +5,7 @@ title: NotFoundRoute class
 
 ## ⚠️ Deprecated
 
-The `NotFoundRoute` API has been deprecated in favor of the `notFoundComponent` route option. See the [not found errors guide](./guide/not-found-errors.md) for more information.
+The `NotFoundRoute` API has been deprecated in favor of the `notFoundComponent` route option. See the [not found errors guide](./guide/not-found-errors) for more information.
 
 The `NotFoundRoute` class extends the `Route` class and can be used to create a not found route instance. A not found route instance can be passed to the `routerOptions.notFoundRoute` option to configure a default not-found/404 route for every branch of the route tree.
 

--- a/docs/framework/react/guide/code-splitting.md
+++ b/docs/framework/react/guide/code-splitting.md
@@ -38,7 +38,7 @@ TanStack Router separates code into two categories:
 
 ## Using the `.lazy.tsx` suffix
 
-If you're using the recommended [File-Based Routing](../guide/route-trees.md) approach, code splitting is **as easy as moving your code into a separate file with a `.lazy.tsx` suffix** and use the `createLazyFileRoute` function instead of the `FileRoute` class or `createFileRoute` function.
+If you're using the recommended [File-Based Routing](../guide/route-trees) approach, code splitting is **as easy as moving your code into a separate file with a `.lazy.tsx` suffix** and use the `createLazyFileRoute` function instead of the `FileRoute` class or `createFileRoute` function.
 
 Here are the options currently supported by the `createLazyFileRoute` function:
 

--- a/docs/framework/react/guide/file-based-routing.md
+++ b/docs/framework/react/guide/file-based-routing.md
@@ -106,7 +106,7 @@ The following options are available for configuration via the `tsr.config.json` 
 
 ## File Naming Conventions
 
-File-based routing requires that you follow a few simple file naming conventions to ensure that your routes are generated correctly. The concepts these conventions enable are covered in detail in the [Route Trees & Nesting](./guide/route-trees.md) guide.
+File-based routing requires that you follow a few simple file naming conventions to ensure that your routes are generated correctly. The concepts these conventions enable are covered in detail in the [Route Trees & Nesting](./guide/route-trees) guide.
 
 - **`__root.tsx`**
   - The root route file must be named `__root.tsx` and must be placed in the root of the configured `routesDirectory`.

--- a/docs/framework/react/guide/not-found-errors.md
+++ b/docs/framework/react/guide/not-found-errors.md
@@ -121,7 +121,7 @@ export const Route = createFileRoute('/posts/$postId')({
 
 ## Usage With SSR
 
-See [SSR guide](./guide/ssr.md) for more information.
+See [SSR guide](./guide/ssr) for more information.
 
 ## Migrating from `NotFoundRoute`
 

--- a/docs/framework/react/guide/route-masking.md
+++ b/docs/framework/react/guide/route-masking.md
@@ -9,7 +9,7 @@ Route masking is a way to mask the actual URL of a route that gets persisted to 
 - Navigating to a route with the search param `?showLogin=true`, but masking the the URL to _not_ contain the search param
 - Navigating to a route with the search param `?modal=settings`, but masking the the URL as `/settings'
 
-Each of these scenarios can be achieved with route masking and even extended to support more advanced patterns like [parallel routes](./guide/parallel-routes.md)
+Each of these scenarios can be achieved with route masking and even extended to support more advanced patterns like [parallel routes](./guide/parallel-routes)
 
 ## How does route masking work?
 


### PR DESCRIPTION
Few links seems to be broken