### PR TITLE
Declare `handleDragStart` as optional

### DIFF
--- a/packages/router-devtools/src/devtools.tsx
+++ b/packages/router-devtools/src/devtools.tsx
@@ -89,7 +89,7 @@ interface DevtoolsPanelOptions {
   /**
    * Handles the opening and closing the devtools panel
    */
-  handleDragStart: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
+  handleDragStart?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
   /**
    * A boolean variable indicating if the "lite" version of the library is being used
    */
@@ -617,19 +617,21 @@ export const TanStackRouterDevtoolsPanel = React.forwardRef<
           `,
           }}
         />
-        <div
-          style={{
-            position: 'absolute',
-            left: 0,
-            top: 0,
-            width: '100%',
-            height: '4px',
-            marginBottom: '-4px',
-            cursor: 'row-resize',
-            zIndex: 100000,
-          }}
-          onMouseDown={handleDragStart}
-        ></div>
+        {handleDragStart ? (
+          <div
+            style={{
+              position: 'absolute',
+              left: 0,
+              top: 0,
+              width: '100%',
+              height: '4px',
+              marginBottom: '-4px',
+              cursor: 'row-resize',
+              zIndex: 100000,
+            }}
+            onMouseDown={handleDragStart}
+          ></div>
+        ) : null}
         <div
           style={{
             flex: '1 1 500px',


### PR DESCRIPTION
I want to use `TanStackRouterDevtoolsPanel` in my app because i have custom trigger button, but if i don't want to implement the resize functionality myself and i have to pass `()=>{}` to `handleDragStart`, which i want to avoid.