### PR TITLE
perf: improve typescript performance for Link and useNavigate absolut…

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -74,46 +74,53 @@ export type RelativeToPathAutoComplete<
   AllPaths extends string,
   TFrom extends string,
   TTo extends string,
-  SplitPaths extends string[] = Split<AllPaths, false>,
 > = TTo extends `..${infer _}`
-  ? SplitPaths extends [
-      ...Split<ResolveRelativePath<TFrom, TTo>, false>,
-      ...infer TToRest,
-    ]
-    ? `${CleanPath<
-        Join<
-          [
-            ...Split<TTo, false>,
-            ...(
-              | TToRest
-              | (Split<
-                  ResolveRelativePath<TFrom, TTo>,
-                  false
-                >['length'] extends 1
-                  ? never
-                  : ['../'])
-            ),
-          ]
-        >
-      >}`
+  ? Split<AllPaths, false> extends infer SplitPaths
+    ? SplitPaths extends [
+        ...Split<ResolveRelativePath<TFrom, TTo>, false>,
+        ...infer TToRest,
+      ]
+      ? `${CleanPath<
+          Join<
+            [
+              ...Split<TTo, false>,
+              ...(
+                | TToRest
+                | (Split<
+                    ResolveRelativePath<TFrom, TTo>,
+                    false
+                  >['length'] extends 1
+                    ? never
+                    : ['../'])
+              ),
+            ]
+          >
+        >}`
+      : never
     : never
   : TTo extends `./${infer RestTTo}`
-    ? SplitPaths extends [
-        ...Split<TFrom, false>,
-        ...Split<RestTTo, false>,
-        ...infer RestPath,
-      ]
-      ? `${TTo}${Join<RestPath>}`
+    ? Split<AllPaths, false> extends infer SplitPaths
+      ? SplitPaths extends [
+          ...Split<TFrom, false>,
+          ...Split<RestTTo, false>,
+          ...infer RestPath,
+        ]
+        ? `${TTo}${Join<RestPath>}`
+        : never
       : never
     :
-        | (TFrom extends `/`
-            ? never
-            : SplitPaths extends [...Split<TFrom, false>, ...infer RestPath]
-              ? Join<RestPath> extends { length: 0 }
-                ? never
-                : './'
-              : never)
-        | (TFrom extends `/` ? never : '../')
+        | (string extends TFrom
+            ? '/'
+            : TFrom extends `/`
+              ? never
+              : Split<AllPaths, false> extends infer SplitPaths
+                ? SplitPaths extends [...Split<TFrom, false>, ...infer RestPath]
+                  ? Join<RestPath> extends { length: 0 }
+                    ? never
+                    : './'
+                  : never
+                : never)
+        | (string extends TFrom ? '../' : TFrom extends `/` ? never : '../')
         | AllPaths
 
 export type NavigateOptions<

--- a/packages/react-router/src/useNavigate.tsx
+++ b/packages/react-router/src/useNavigate.tsx
@@ -5,12 +5,26 @@ import { LinkOptions, NavigateOptions } from './link'
 import { AnyRoute } from './route'
 import { RoutePaths } from './routeInfo'
 import { RegisteredRouter } from './router'
-import { StringLiteral } from './utils'
+
+export type UseNavigateResult<TDefaultFrom extends string> = <
+  TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
+  TFrom extends RoutePaths<TRouteTree> | string = TDefaultFrom,
+  TTo extends string = '',
+  TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
+  TMaskTo extends string = '',
+>({
+  from,
+  ...rest
+}: NavigateOptions<TRouteTree, TFrom, TTo, TMaskFrom, TMaskTo>) => Promise<void>
 
 export function useNavigate<
-  TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
-  TDefaultFrom extends RoutePaths<TRouteTree> | string = RoutePaths<TRouteTree>,
->(_defaultOpts?: { from?: StringLiteral<TDefaultFrom> }) {
+  TDefaultFrom extends string = string,
+>(_defaultOpts?: {
+  from?:
+    | TDefaultFrom
+    | RoutePaths<RegisteredRouter['routeTree']>
+    | (string & {})
+}) {
   const { navigate } = useRouter()
 
   const matchPathname = useMatch({
@@ -18,23 +32,14 @@ export function useNavigate<
     select: (s) => s.pathname,
   })
 
-  return React.useCallback(
-    <
-      TFrom extends RoutePaths<TRouteTree> | string = TDefaultFrom,
-      TTo extends string = '',
-      TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
-      TMaskTo extends string = '',
-    >({
-      from,
-      ...rest
-    }: NavigateOptions<TRouteTree, TFrom, TTo, TMaskFrom, TMaskTo>) => {
-      return navigate({
-        from: rest?.to ? matchPathname : undefined,
-        ...(rest as any),
-      })
-    },
-    [],
-  )
+  const result: UseNavigateResult<TDefaultFrom> = ({ from, ...rest }) => {
+    return navigate({
+      from: rest?.to ? matchPathname : undefined,
+      ...(rest as any),
+    })
+  }
+
+  return React.useCallback(result, [])
 }
 
 // NOTE: I don't know of anyone using this. It's undocumented, so let's wait until someone needs it


### PR DESCRIPTION
I've been looking into improving typescript performance for Link and useNavigate. 

After tracing I noticed it was related to relative pathing for Link. SplitPaths was being defaulted to the result of splitting all paths. This is very slow when you have a large number of routes. I've inlined SplitPaths because when TFrom isn't specified, you should not need to use it as we're dealing with absolute paths. This improved performance significantly.

useNavigate was even slower, it looks like Typescript was doing some eager checking of the route tree. I've solved this the following - useNavigate was defaulting TFrom and TDefaultFrom to all paths but it was always a union of string | RoutePaths. Defaulting this to string and not constraining it to all paths limits the possibility distributing over such a huge union and auto complete can be kept intact by using TDefaultFrom | RoutePaths<TRouteTree> | (string & {})

I'm wondering if TFrom should be defaulted to '/' as mentioned in the docs

With testing I was able to get like Link down from around 12s to around 2s with around 600 routes.

Thinking and exploring further performance improvements. It will harder to approach improving performance of relative paths but it would be good to improve this too. But apart from that there is a slightly faster way of creating the ParseRoute union

fixes #1091