### PR TITLE
Add a missing space in header of basic-react-query-file-based example

### DIFF
--- a/examples/react/basic-react-query-file-based/src/routes/__root.tsx
+++ b/examples/react/basic-react-query-file-based/src/routes/__root.tsx
@@ -34,7 +34,7 @@ function RootComponent() {
           }}
         >
           Posts
-        </Link>
+        </Link>{' '}
         <Link
           to="/layout-a"
           activeProps={{


### PR DESCRIPTION
Without the space, the header with links looks squashed and feels like there are only 2 links:
![image](https://github.com/TanStack/router/assets/9213880/146b395e-bee8-4e97-9997-9e9a1ba5cc2d)

With the space, the `Layout` link is separated as it should be:
![image](https://github.com/TanStack/router/assets/9213880/e564b4ac-e6a8-407d-8b76-c331497f2634)
