### PR TITLE
Fix formatting in Data Loading guide

### DIFF
--- a/docs/framework/react/guide/data-loading.md
+++ b/docs/framework/react/guide/data-loading.md
@@ -19,7 +19,7 @@ Every time a URL/history update is detected, the router executes the following s
 - Route Pre-Loading (Serial)
   - `route.beforeLoad`
   - `route.onError`
-    - `route.errorComponent' / `parentRoute.errorComponent`/`router.defaultErrorComponent`
+    - `route.errorComponent` / `parentRoute.errorComponent`/`router.defaultErrorComponent`
 - Route Loading (Parallel)
   - `route.component.preload?`
   - `route.loader`

--- a/docs/framework/react/guide/data-loading.md
+++ b/docs/framework/react/guide/data-loading.md
@@ -19,14 +19,14 @@ Every time a URL/history update is detected, the router executes the following s
 - Route Pre-Loading (Serial)
   - `route.beforeLoad`
   - `route.onError`
-    - `route.errorComponent` / `parentRoute.errorComponent`/`router.defaultErrorComponent`
+    - `route.errorComponent` / `parentRoute.errorComponent` / `router.defaultErrorComponent`
 - Route Loading (Parallel)
   - `route.component.preload?`
   - `route.loader`
     - `route.pendingComponent` (Optional)
     - `route.component`
   - `route.onError`
-    - `route.errorComponent` / `parentRoute.errorComponent`/`router.defaultErrorComponent`
+    - `route.errorComponent` / `parentRoute.errorComponent` / `router.defaultErrorComponent`
 
 ## To Router Cache or not to Router Cache?
 


### PR DESCRIPTION
Previously, there was a wrong type of a backtick which caused weird formatting.

Before:
![image](https://github.com/TanStack/router/assets/9213880/2ae7f6c4-a68e-4f4e-afc5-ec94356bc23e)


Now:
![image](https://github.com/TanStack/router/assets/9213880/32078fae-b7c6-4829-9524-c61b221cdd5c)
