### PR TITLE
fix: avoid "Type instantiation is excessively deep and possibly infin…

### DIFF
--- a/packages/react-router/src/useSearch.tsx
+++ b/packages/react-router/src/useSearch.tsx
@@ -14,9 +14,7 @@ export function useSearch<
         RouteById<TRouteTree, TFrom>['types']['fullSearchSchema'],
         RootSearchSchema
       >
-    : Expand<
-        Partial<Omit<FullSearchSchema<TRouteTree>, keyof RootSearchSchema>>
-      >,
+    : Partial<Omit<FullSearchSchema<TRouteTree>, keyof RootSearchSchema>>,
   TSelected = TSearch,
 >(
   opts: StrictOrFrom<TFrom, TReturnIntersection> & {


### PR DESCRIPTION
…ite" error with `useSearch(strict: false, experimental_returnIntersection: true)`

fixes #1217