### PR TITLE
docs: new doc page on the dx design decisions

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -38,8 +38,8 @@
               "to": "framework/react/migrate-from-react-router"
             },
             {
-              "label": "DX Design Decisions",
-              "to": "framework/react/dx-design-decisions"
+              "label": "Decisions on DX",
+              "to": "framework/react/decisions-on-dx"
             }
           ]
         },

--- a/docs/config.json
+++ b/docs/config.json
@@ -36,6 +36,10 @@
             {
               "label": "Migrate from React Router",
               "to": "framework/react/migrate-from-react-router"
+            },
+            {
+              "label": "DX Design Decisions",
+              "to": "framework/react/dx-design-decisions"
             }
           ]
         },

--- a/docs/framework/react/decisions-on-dx.md
+++ b/docs/framework/react/decisions-on-dx.md
@@ -32,6 +32,8 @@ But to achieve this, we had to make some decisions that deviate from the norms i
 2. [**Typescript module declaration for the router?**](#2-declaring-the-router-instance-for-type-inference): You have to pass the `Router` instance to the rest of your application using Typescript's module declaration.
 3. [**Why push for file-based routing over code-based?**](#3-why-is-file-based-routing-the-preferred-way-to-define-routes): We push for file-based routing as the preferred way to define your routes.
 
+> TLDR; All the design decisions in the developer experience of using Tanstack Router are made so that you can have a best-in-class type-safety experience without compromising on the control, flexibility, and maintainability of your route configurations.
+
 ## 1. Why is the Router's configuration done this way?
 
 When you want to leverage the Typescript's inference features to its fullest, you'll quickly realize that *Generics* are your best friend. And so, Tanstack Router uses Generics everywhere to ensure that the types of your routes are inferred as much as possible.

--- a/docs/framework/react/decisions-on-dx.md
+++ b/docs/framework/react/decisions-on-dx.md
@@ -1,5 +1,5 @@
 ---
-title: DX Design Decisions
+title: Decisions on Developer Experience
 ---
 
 When people first start using Tanstack Router, they often have a lot of questions that revolve around the following themes:

--- a/docs/framework/react/dx-design-decisions.md
+++ b/docs/framework/react/dx-design-decisions.md
@@ -27,3 +27,91 @@ And so, from Tanstack Router's very inception, every facet of it's design was me
 Every aspect of Tanstack Router is designed to be as type-safe as possible, and this is achieved by leveraging Typescript's type system to its fullest extent. This involves using some very advanced and complex types, type inference, and other features to ensure that the developer experience is as smooth as possible.
 
 But to achieve this, we had to make some decisions that deviate from the norms in the routing world.
+
+## Why is the Route configuration done this way?
+
+When you want to leverage the Typescript's inference features to its fullest, you'll quickly realize that *Generics* are your best friend. And so, Tanstack Router uses Generics everywhere to ensure that the types of your routes are inferred as much as possible.
+
+Once you've constructed your routes into a tree and passed it into your Router instance (using `createRouter`) with all the generics working correctly, you then need to somehow pass this information to the rest of your application.
+
+There were two approaches we considered for this:
+
+1. **Imports**: You could import the `Router` instance from the file where you created it and use it directly in your components.
+
+```tsx
+import { router } from '@/config/router';
+export const PostsIdLink = () => {
+ return (
+   <Link<typeof router>
+     to='/posts/$postId'
+     params={{ postId: '123' }}
+   >
+     Go to post 123
+   </Link>
+ )
+}
+```
+A downside to this approach is that you'd have to import the entire `Router` instance into every file where you want to use it. This can lead to increased bundle sizes and can be cumbersome to manage, and only get worse as your application grows and you use more features of the router.
+
+2. **Module declaration**: You can use Typescript's module declaration to declare the `Router` instance as a module that can be used for type inference anywhere in your application without having to import it.
+
+You'll do this once in your application.
+```tsx
+// src/config/router
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router
+  }
+}
+```
+And then you can use it anywhere in your application without having to import it.
+```tsx
+export const PostsIdLink = () => {
+ return (
+   <Link
+     to='/posts/$postId'
+     params={{ postId: '123' }}
+   >
+     Go to post 123
+   </Link>
+ )
+}
+```
+
+**Module declaration** is what we went with, as it allows you to easily access the `Router` instance from anywhere in your application without having to import it.
+
+
+
+### Why can't I use JSX to define my routes?
+
+> Why not? I'm used to defining my routes like this:
+
+```tsx
+function App() {
+  return (
+    <Router>
+      <Route path="/posts" component={PostsPage} />
+      <Route path="/posts/$postId" component={PostIdPage} />
+    </Router>
+  );
+}
+```
+
+Something like this is very common in the routing world. But it has no way of being type-safe, because Typescript will not be able to infer the types of the `/posts` and `/posts/$postId` routes since they are just lone React components. So, when you are creating a `<Link>` to these routes, you'll have to manually type the `to/href` prop.
+
+### Ok then, why can't I define my routes as a tree of nested objects?
+
+> This seems way easier to me, and lets me easily view the entire route hierarchy in one go.
+
+```tsx
+const router = createRouter({
+  posts: {
+    component: PostsPage,     // /posts
+    children: {
+      "$postId": {
+        component: PostIdPage // /posts/$postId
+      }
+    }
+  }
+})
+```

--- a/docs/framework/react/dx-design-decisions.md
+++ b/docs/framework/react/dx-design-decisions.md
@@ -1,0 +1,5 @@
+---
+title: DX Design Decisions
+---
+
+foo=bar

--- a/docs/framework/react/dx-design-decisions.md
+++ b/docs/framework/react/dx-design-decisions.md
@@ -49,6 +49,7 @@ function App() {
     <Router>
       <Route path="/posts" component={PostsPage} />
       <Route path="/posts/$postId" component={PostIdPage} />
+      {/* ... */}
     </Router>
     // ^? Typescript cannot infer the routes in this configuration
   );
@@ -59,6 +60,7 @@ And since this would mean that you'd have to manually type the `to` prop of the 
 > Maybe I could define my routes as a tree of nested objects?
 
 ```tsx
+// ⛔️ This file will just keep growing and growing...
 const router = createRouter({
   routes: {
     posts: {
@@ -68,7 +70,8 @@ const router = createRouter({
           component: PostIdPage // /posts/$postId
         }
       }
-    }
+    },
+    // ...
   }
 })
 ```
@@ -82,7 +85,7 @@ This only get worse as your begin to use more features of the router, such as ne
 
 > So, what's the best way to define my routes?
 
-What we found to be the best way to define your routes is to abstract the definition of the route configuration into a separate file which is then added into a route-tree that is then passed into the `createRouter` function.
+What we found to be the best way to define your routes is to abstract the definition of the route configuration outside of the route-tree. Then stitch together your route configurations into a single cohesive route-tree that is then passed into the `createRouter` function.
 
 You can read more about [code-based routing](/docs/framework/react/guide/code-based-routing) to see how to define your routes in this way.
 

--- a/docs/framework/react/dx-design-decisions.md
+++ b/docs/framework/react/dx-design-decisions.md
@@ -153,4 +153,69 @@ We went with **module declaration**, as it is what we found to be the most scala
 
 ## 3. Why is file-based routing the preferred way to define routes?
 
-foo
+> Why are the docs pushing for file-based routing?
+
+> I'm used to defining my routes in a single file, why should I change?
+
+Something you'll notice (quite soon) in the Tanstack Router documentation is that we push for **file-based routing** as the preferred method for defining your routes. This is because we've found that file-based routing is the most scalable and maintainable way to define your routes.
+
+> ⚠️ Before you continue, it's important you have a good understanding of [code-based routing](./guide/code-based-routing.md) and [file-based routing](./guide/file-based-routing.md).
+
+As mentioned in the beginning, Tanstack Router was designed for complex applications that require a high degree of type-safety and maintainability. And to achieve this, the configuration of the router has be done in an precise way that allows Typescript to infer the types of your routes as much as possible.
+
+A key difference in the set-up of a *basic* application with Tanstack Router, is that your route configurations require a function to be provided to `getParentRoute`, that returns the parent route of the current route.
+
+```tsx
+import { createRoute } from '@tanstack/react-router';
+import { postsRoute } from './postsRoute';
+
+export const postsIndexRoute = createRoute({
+  getParentRoute: () => postsRoute,
+  path: '/',
+})
+```
+
+At this stage, this is done so the definition of `postsIndexRoute` can be aware of its location in the route tree and so that it can correctly infer the types of the `context`, `path params`, `search params` returned by the parent route. Incorrectly defining the `getParentRoute` function means that the properties of the parent route will not be correctly inferred by the child route.
+
+As such, this is a critical part of the route configuration and a point of failure if not done correctly.
+
+But this is only one part of setting up a basic application. Tanstack Router requires the all the routes (including the root route) to be stitched into a ***route-tree*** so that it may be passed into the `createRouter` function before declaring the `Router` instance on the module for type inference. This is another critical part of the route configuration and a point of failure if not done correctly.
+
+> 🤯 If this route-tree were in its own file for an application with ~40-50 routes, it can easily grow up to 700+ lines.
+
+```tsx
+const routeTree = rootRoute.addChildren([
+  postsRoute.addChildren([
+    postsIndexRoute,
+    postsIdRoute
+  ])
+])
+```
+
+This complexity only increases as you begin to use more features of the router, such as nested context, loaders, search param validation, etc. As such, it no longer becomes feasible to define your routes in a single file. And so, users end up building their own *semi consistent* way of defining their routes across multiple files. This can lead to inconsistencies and errors in the route configuration.
+
+Finally, comes the issue of code-splitting. As your application grows, you'll want to code-split your components to reduce the initial bundle size of your application. This can be a bit of a headache to manage when you're defining your routes in a single file or even across multiple files.
+
+```tsx
+import {
+  createRoute,
+  lazyRouteComponent
+} from '@tanstack/react-router';
+import { postsRoute } from './postsRoute';
+
+export const postsIndexRoute = createRoute({
+  getParentRoute: () => postsRoute,
+  path: '/',
+  component: lazyRouteComponent(
+    () => import('../page-components/posts/index')
+  )
+})
+```
+
+All of this boilerplate, no matter how essential for providing a best-in-class type-inference experience, can be a bit overwhelming and can lead to inconsistencies and errors in the route configuration.
+
+... and this example configuration is just for a single route. Imagine having to do this for 40-50 routes. Now remember that you still haven't touched the `context`, `loaders`, `search param validation`, and other features of the router 🤕.
+
+> So, why's file-based routing the preferred way?
+
+m

--- a/docs/framework/react/dx-design-decisions.md
+++ b/docs/framework/react/dx-design-decisions.md
@@ -214,8 +214,31 @@ export const postsIndexRoute = createRoute({
 
 All of this boilerplate, no matter how essential for providing a best-in-class type-inference experience, can be a bit overwhelming and can lead to inconsistencies and errors in the route configuration.
 
-... and this example configuration is just for a single route. Imagine having to do this for 40-50 routes. Now remember that you still haven't touched the `context`, `loaders`, `search param validation`, and other features of the router 🤕.
+... and this example configuration is just for rendering a single codes-split route. Imagine having to do this for 40-50 routes. Now remember that you still haven't touched the `context`, `loaders`, `search param validation`, and other features of the router 🤕.
 
 > So, why's file-based routing the preferred way?
 
-m
+Tanstack Router's file-based routing is designed to solve all of these issues. It allows you to define your routes in a predictable way that is easy to manage and maintain, and is scalable as your application grows.
+
+The file-based routing approach is powered by the Tanstack Router CLI. It performs 3 essential tasks that solve the pain points in route configuration when using code-based routing:
+
+1. **Route configuration boilerplate**: It generates the boilerplate for your route configurations.
+2. **Route tree stitching**: It stitches together your route configurations into a single cohesive route-tree. Also in the background, it correctly updates the route configurations to define the `getParentRoute` function match the routes with their parent routes. 
+3. **Code-splitting**: It automatically code-splits your components and handles updating your route configurations with the correct lazy imports.
+
+Let's take a look at how the route configuration for the previous example would look like with file-based routing.
+
+```tsx
+// src/routes/posts/index.lazy.ts
+import { createLazyFileRoute } from '@tanstack/react-router';
+
+export const Route = createLazyFileRoute('/posts/')({
+  component: () => "Posts index component goes here!!!"
+})
+```
+
+That's it! No need to worry about defining the `getParentRoute` function, stitching together the route-tree, or code-splitting your components. The CLI handles all of this for you.
+
+At no point does the Tanstack Router CLI take away your control over your route configurations. It's designed to be as flexible as possible, allowing you to define your routes in a way that suits your application whilst reducing the boilerplate and complexity of the route configuration.
+
+> 🧠 Check out the guides for [file-based routing](./guide/file-based-routing.md) and [code-splitting](./guide/code-splitting.md) for a more in-depth explanation of how they work in Tanstack Router.

--- a/docs/framework/react/dx-design-decisions.md
+++ b/docs/framework/react/dx-design-decisions.md
@@ -108,12 +108,12 @@ There were two approaches we considered for this:
 import { router } from '@/src/app'
 export const PostsIdLink = () => {
  return (
-   <Link<typeof router>
-     to='/posts/$postId'
-     params={{ postId: '123' }}
-   >
-     Go to post 123
-   </Link>
+    <Link<typeof router>
+      to='/posts/$postId'
+      params={{ postId: '123' }}
+    >
+      Go to post 123
+    </Link>
  )
 }
 ```
@@ -132,17 +132,19 @@ declare module '@tanstack/react-router' {
   }
 }
 ```
+
 And then you can benefit from its auto-complete anywhere in your app without having to import it.
 
 ```tsx
 export const PostsIdLink = () => {
  return (
-   <Link
-     to='/posts/$postId'
-     params={{ postId: '123' }}
-   >
-     Go to post 123
-   </Link>
+    <Link
+      to='/posts/$postId'
+      // ^? Typescript will auto-complete this for you
+      params={{ postId: '123' }} // and this too!
+    >
+      Go to post 123
+    </Link>
  )
 }
 ```

--- a/docs/framework/react/dx-design-decisions.md
+++ b/docs/framework/react/dx-design-decisions.md
@@ -2,7 +2,7 @@
 title: DX Design Decisions
 ---
 
-When people first start using Tanstack Router, they often have a lot of questions that revolve around the following:
+When people first start using Tanstack Router, they often have a lot of questions that revolve around the following themes:
 
 > Why do I have to do things this way?
 
@@ -16,7 +16,7 @@ But Tanstack Router is different. It's not your average routing library. It's no
 
 ## Tanstack Router's origin story
 
-It's important remember that Tanstack Router's origins stem from [Nozzle.io](https://nozzle.io)'s need for a client-side routing solution that offered a first-in-class *URL Search Parameters* experience without compromising on the ***type-safety*** that was required to power their complex dashboards.
+It's important remember that Tanstack Router's origins stem from [Nozzle.io](https://nozzle.io)'s need for a client-side routing solution that offered a first-in-class *URL Search Parameters* experience without compromising on the ***type-safety*** that was required to power its complex dashboards.
 
 And so, from Tanstack Router's very inception, every facet of it's design was meticulously thought out to ensure that its type-safety and developer experience were second to none.
 

--- a/docs/framework/react/dx-design-decisions.md
+++ b/docs/framework/react/dx-design-decisions.md
@@ -2,6 +2,20 @@
 title: DX Design Decisions
 ---
 
+When people first start using Tanstack Router, they often have a lot of questions that revolve around the following:
+
+> Why do I have to do things this way?
+
+> Why is it done this way? and not that way?
+
+> I'm used to doing it this way, why should I change?
+
+And they are all valid questions. For the most part, people are used to using routing libraries that are very similar to each other. They all have a similar API, similar concepts, and similar ways of doing things.
+
+But Tanstack Router is different. It's not your average routing library. It's not your average state management library. It's not your average anything.
+
+## Tanstack Router's origin story
+
 It's important remember that Tanstack Router's origins stem from [Nozzle.io](https://nozzle.io)'s need for a client-side routing solution that offered a first-in-class *URL Search Parameters* experience without compromising on the ***type-safety*** that was required to power their complex dashboards.
 
 And so, from Tanstack Router's very inception, every facet of it's design was meticulously thought out to ensure that its type-safety and developer experience were second to none.

--- a/docs/framework/react/dx-design-decisions.md
+++ b/docs/framework/react/dx-design-decisions.md
@@ -55,6 +55,7 @@ function App() {
   );
 }
 ```
+
 And since this would mean that you'd have to manually type the `to` prop of the `<Link>` component and wouldn't catch any errors until runtime, it's not a viable option.
 
 > Maybe I could define my routes as a tree of nested objects?
@@ -91,7 +92,6 @@ You can read more about [code-based routing](/docs/framework/react/guide/code-ba
 
 > 🙋🏼 Finding Code-based routing to be a bit too cumbersome? See why [file-based routing](#3-why-is-file-based-routing-the-preferred-way-to-define-routes) is the preferred way to define your routes.
 
-
 ## 2. Declaring the Router instance for type inference
 
 > Why do I have to declare the `Router`?
@@ -105,7 +105,7 @@ There were two approaches we considered for this:
 1. **Imports**: You could import the `Router` instance from the file where you created it and use it directly in your components.
 
 ```tsx
-import { router } from '@/config/router';
+import { router } from '@/src/app'
 export const PostsIdLink = () => {
  return (
    <Link<typeof router>
@@ -117,13 +117,15 @@ export const PostsIdLink = () => {
  )
 }
 ```
+
 A downside to this approach is that you'd have to import the entire `Router` instance into every file where you want to use it. This can lead to increased bundle sizes and can be cumbersome to manage, and only get worse as your application grows and you use more features of the router.
 
 2. **Module declaration**: You can use Typescript's module declaration to declare the `Router` instance as a module that can be used for type inference anywhere in your application without having to import it.
 
 You'll do this once in your application.
+
 ```tsx
-// src/config/router
+// src/app.tsx
 declare module '@tanstack/react-router' {
   interface Register {
     router: typeof router
@@ -131,6 +133,7 @@ declare module '@tanstack/react-router' {
 }
 ```
 And then you can benefit from its auto-complete anywhere in your app without having to import it.
+
 ```tsx
 export const PostsIdLink = () => {
  return (

--- a/docs/framework/react/dx-design-decisions.md
+++ b/docs/framework/react/dx-design-decisions.md
@@ -107,14 +107,14 @@ There were two approaches we considered for this:
 ```tsx
 import { router } from '@/src/app'
 export const PostsIdLink = () => {
- return (
+  return (
     <Link<typeof router>
       to='/posts/$postId'
       params={{ postId: '123' }}
     >
       Go to post 123
     </Link>
- )
+  )
 }
 ```
 
@@ -137,7 +137,7 @@ And then you can benefit from its auto-complete anywhere in your app without hav
 
 ```tsx
 export const PostsIdLink = () => {
- return (
+  return (
     <Link
       to='/posts/$postId'
       // ^? Typescript will auto-complete this for you
@@ -145,7 +145,7 @@ export const PostsIdLink = () => {
     >
       Go to post 123
     </Link>
- )
+  )
 }
 ```
 

--- a/docs/framework/react/dx-design-decisions.md
+++ b/docs/framework/react/dx-design-decisions.md
@@ -2,4 +2,7 @@
 title: DX Design Decisions
 ---
 
-foo=bar
+It's important remember that Tanstack Router's origins stem from [Nozzle.io](https://nozzle.io)'s need for a client-side routing solution that offered a first-in-class *URL Search Parameters* experience without compromising on the ***type-safety*** that was required to power their complex dashboards.
+
+And so, from Tanstack Router's very inception, every facet of it's design was meticulously thought out to ensure that its type-safety and developer experience were second to none.
+

--- a/docs/framework/react/dx-design-decisions.md
+++ b/docs/framework/react/dx-design-decisions.md
@@ -6,3 +6,10 @@ It's important remember that Tanstack Router's origins stem from [Nozzle.io](htt
 
 And so, from Tanstack Router's very inception, every facet of it's design was meticulously thought out to ensure that its type-safety and developer experience were second to none.
 
+## How does Tanstack Router achieve this?
+
+> Typescript! Typescript! Typescript!
+
+Every aspect of Tanstack Router is designed to be as type-safe as possible, and this is achieved by leveraging Typescript's type system to its fullest extent. This involves using some very advanced and complex types, type inference, and other features to ensure that the developer experience is as smooth as possible.
+
+But to achieve this, we had to make some decisions that deviate from the norms in the routing world.


### PR DESCRIPTION
Prompted from this [discord thread](https://discord.com/channels/719702312431386674/1210411302405672980), this page covers why the DX decisions that have been made TSR are what they are.

It covers:
1. Why the router's configuration is done the way that it is.
2. Why typescript module declaration is used for propagating the types across a project.
3. Why is file-based routing preferred over code-based routing.

I did my best to write it in such a way that it makes it easy for more items to be added onto this list in the future.