### PR TITLE
perf: improve typescript performance of relative pathing and larger route trees

### DIFF
--- a/packages/react-router/src/RouterProvider.tsx
+++ b/packages/react-router/src/RouterProvider.tsx
@@ -37,6 +37,7 @@ export interface MatchLocation {
 export type NavigateFn = <
   TTo extends string,
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
+  TFrom extends RoutePaths<TRouteTree> | string = string,
   TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
   TMaskTo extends string = '',
 >(
@@ -45,7 +46,7 @@ export type NavigateFn = <
 
 export type BuildLocationFn<TRouteTree extends AnyRoute> = <
   TTo extends string,
-  TFrom extends RoutePaths<TRouteTree> | string = RoutePaths<TRouteTree>,
+  TFrom extends RoutePaths<TRouteTree> | string = string,
   TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
   TMaskTo extends string = '',
 >(

--- a/packages/react-router/src/RouterProvider.tsx
+++ b/packages/react-router/src/RouterProvider.tsx
@@ -34,9 +34,9 @@ export interface MatchLocation {
   from?: string
 }
 
-export type NavigateFn<TRouteTree extends AnyRoute> = <
-  TFrom extends RoutePaths<TRouteTree> | string = string,
-  TTo extends string = '',
+export type NavigateFn = <
+  TTo extends string,
+  TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
   TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
   TMaskTo extends string = '',
 >(
@@ -44,8 +44,8 @@ export type NavigateFn<TRouteTree extends AnyRoute> = <
 ) => Promise<void>
 
 export type BuildLocationFn<TRouteTree extends AnyRoute> = <
+  TTo extends string,
   TFrom extends RoutePaths<TRouteTree> | string = RoutePaths<TRouteTree>,
-  TTo extends string = '',
   TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
   TMaskTo extends string = '',
 >(

--- a/packages/react-router/src/fileRoute.ts
+++ b/packages/react-router/src/fileRoute.ts
@@ -327,7 +327,7 @@ export class LazyRoute<TRoute extends AnyRoute> {
 
 export function createLazyRoute<
   TId extends RouteIds<RegisteredRouter['routeTree']>,
-  TRoute extends RouteById<RegisteredRouter['routeTree'], TId> = AnyRoute,
+  TRoute extends AnyRoute = RouteById<RegisteredRouter['routeTree'], TId>,
 >(id: TId) {
   return (opts: LazyRouteOptions) => {
     return new LazyRoute<TRoute>({ id: id as any, ...opts })

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -124,7 +124,7 @@ export type RelativeToPathAutoComplete<
 
 export type NavigateOptions<
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
-  TFrom extends RoutePaths<TRouteTree> | string = RoutePaths<TRouteTree>,
+  TFrom extends RoutePaths<TRouteTree> | string = string,
   TTo extends string = '',
   TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
   TMaskTo extends string = '',
@@ -138,7 +138,7 @@ export type NavigateOptions<
 
 export type ToOptions<
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
-  TFrom extends RoutePaths<TRouteTree> | string = RoutePaths<TRouteTree>,
+  TFrom extends RoutePaths<TRouteTree> | string = string,
   TTo extends string = '',
   TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
   TMaskTo extends string = '',
@@ -148,7 +148,7 @@ export type ToOptions<
 
 export type ToMaskOptions<
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
-  TMaskFrom extends RoutePaths<TRouteTree> | string = RoutePaths<TRouteTree>,
+  TMaskFrom extends RoutePaths<TRouteTree> | string = string,
   TMaskTo extends string = '',
 > = ToSubOptions<TRouteTree, TMaskFrom, TMaskTo> & {
   unmaskOnReload?: boolean
@@ -156,7 +156,7 @@ export type ToMaskOptions<
 
 export type ToSubOptions<
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
-  TFrom extends RoutePaths<TRouteTree> | string = RoutePaths<TRouteTree>,
+  TFrom extends RoutePaths<TRouteTree> | string = string,
   TTo extends string = '',
   TResolved = ResolveRelativePath<TFrom, NoInfer<TTo>>,
 > = {

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -320,7 +320,7 @@ export type ResolveRelativePath<TFrom, TTo = '.'> = TFrom extends string
             : Split<TTo> extends ['..', ...infer ToRest]
               ? Split<TFrom> extends [...infer FromRest, infer FromTail]
                 ? ToRest extends ['/']
-                  ? Join<[...FromRest, '/']>
+                  ? Join<['/', ...FromRest, '/']>
                   : ResolveRelativePath<Join<FromRest>, Join<ToRest>>
                 : never
               : Split<TTo> extends ['.', ...infer ToRest]

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -103,14 +103,16 @@ export type RelativeToCurrentPathAutoComplete<
 > = SearchRelativePathAutoComplete<TTo, TResolvedPath, TPaths>
 
 export type AbsolutePathAutoComplete<TFrom extends string, TPaths> =
-  | (TFrom extends `/`
+  | (string extends TFrom
       ? never
-      : TPaths extends `${RemoveTrailingSlashes<TFrom>}/${infer TRest}`
-        ? RemoveLeadingSlashes<TRest> extends ''
-          ? never
-          : './'
-        : never)
-  | (TFrom extends `/` ? never : '../')
+      : TFrom extends `/`
+        ? never
+        : TPaths extends `${RemoveTrailingSlashes<TFrom>}/${infer TRest}`
+          ? RemoveLeadingSlashes<TRest> extends ''
+            ? never
+            : './'
+          : never)
+  | (string extends TFrom ? never : TFrom extends `/` ? never : '../')
   | TPaths
 
 export type RelativeToPathAutoComplete<

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -167,7 +167,7 @@ export type ToSubOptions<
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
   TFrom extends RoutePaths<TRouteTree> | string = string,
   TTo extends string = '',
-  TResolved = RemoveTrailingSlashes<ResolveRelativePath<TFrom, NoInfer<TTo>>>,
+  TResolved = ResolveRelativePath<TFrom, NoInfer<TTo>>,
 > = {
   to?: ToPathOption<TRouteTree, TFrom, TTo>
   // The new has string or a function to update it

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -4,7 +4,7 @@ import { useRouterState } from './useRouterState'
 import { useRouter } from './useRouter'
 import { Trim } from './fileRoute'
 import { AnyRoute, ReactNode, RootSearchSchema } from './route'
-import { RouteByPath, RouteIds, RoutePaths } from './routeInfo'
+import { RouteByPath, RoutePaths, RoutePathsAutoComplete } from './routeInfo'
 import { RegisteredRouter } from './router'
 import { LinkProps, UseLinkPropsOptions } from './useNavigate'
 import {
@@ -14,7 +14,6 @@ import {
   NoInfer,
   NonNullableUpdater,
   PickRequired,
-  StringLiteral,
   Updater,
   WithoutEmpty,
   deepEqual,
@@ -167,7 +166,7 @@ export type ToSubOptions<
   // State to pass to the history stack
   state?: true | NonNullableUpdater<HistoryState>
   // The source route path. This is automatically set when using route-level APIs, but for type-safe relative routing on the router itself, this is required
-  from?: StringLiteral<TFrom>
+  from?: RoutePathsAutoComplete<TRouteTree, TFrom>
   // // When using relative route paths, this option forces resolution from the current path, instead of the route API's path or `from` path
 } & CheckPath<TRouteTree, NoInfer<TResolved>, {}> &
   SearchParamOptions<TRouteTree, TFrom, TTo, TResolved> &

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -79,17 +79,17 @@ export type RemoveLeadingSlashes<T> = T extends `/${infer R}`
 
 export type SearchRelativePathAutoComplete<
   TTo extends string,
-  TSearchPath,
+  TSearchPath extends string,
   TPaths,
-> = TPaths extends `${TSearchPath & string}/${infer TRest}`
-  ? `${TTo}/${RemoveLeadingSlashes<TRest>}`
-  : never
+> = TPaths extends `${TSearchPath}/${infer TRest}` ? `${TTo}/${TRest}` : never
 
 export type RelativeToParentPathAutoComplete<
   TFrom extends string,
   TTo extends string,
   TPaths,
-  TResolvedPath = RemoveTrailingSlashes<ResolveRelativePath<TFrom, TTo>>,
+  TResolvedPath extends string = RemoveTrailingSlashes<
+    ResolveRelativePath<TFrom, TTo>
+  >,
 > =
   | SearchRelativePathAutoComplete<TTo, TResolvedPath, TPaths>
   | (TResolvedPath extends '' ? never : `${TTo}/../`)
@@ -99,7 +99,8 @@ export type RelativeToCurrentPathAutoComplete<
   TTo extends string,
   TRestTo extends string,
   TPaths,
-  TResolvedPath = RemoveTrailingSlashes<`${RemoveTrailingSlashes<TFrom>}/${RemoveLeadingSlashes<TRestTo>}`>,
+  TResolvedPath extends
+    string = RemoveTrailingSlashes<`${RemoveTrailingSlashes<TFrom>}/${RemoveLeadingSlashes<TRestTo>}`>,
 > = SearchRelativePathAutoComplete<TTo, TResolvedPath, TPaths>
 
 export type AbsolutePathAutoComplete<TFrom extends string, TPaths> =
@@ -307,10 +308,17 @@ export type LinkOptions<
   disabled?: boolean
 }
 
-export type CheckPath<TRouteTree extends AnyRoute, TPath, TPass> =
-  Exclude<TPath, RoutePaths<TRouteTree>> extends never
+export type CheckPath<
+  TRouteTree extends AnyRoute,
+  TPath,
+  TPass,
+  TNormalisedPath = RemoveTrailingSlashes<TPath>,
+> =
+  Exclude<`${TNormalisedPath & string}/`, RoutePaths<TRouteTree>> extends never
     ? TPass
-    : CheckPathError<TRouteTree, Exclude<TPath, RoutePaths<TRouteTree>>>
+    : Exclude<TNormalisedPath, RoutePaths<TRouteTree>> extends never
+      ? TPass
+      : CheckPathError<TRouteTree, Exclude<TPath, RoutePaths<TRouteTree>>>
 
 export type CheckPathError<TRouteTree extends AnyRoute, TInvalids> = {
   to: RoutePaths<TRouteTree>

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -165,7 +165,7 @@ export type ToSubOptions<
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
   TFrom extends RoutePaths<TRouteTree> | string = string,
   TTo extends string = '',
-  TResolved = ResolveRelativePath<TFrom, NoInfer<TTo>>,
+  TResolved = RemoveTrailingSlashes<ResolveRelativePath<TFrom, NoInfer<TTo>>>,
 > = {
   to?: ToPathOption<TRouteTree, TFrom, TTo>
   // The new has string or a function to update it

--- a/packages/react-router/src/route.ts
+++ b/packages/react-router/src/route.ts
@@ -180,7 +180,7 @@ type BeforeLoadFn<
   params: TAllParams
   context: TContext
   location: ParsedLocation
-  navigate: NavigateFn<AnyRoute>
+  navigate: NavigateFn
   buildLocation: BuildLocationFn<TParentRoute>
   cause: 'preload' | 'enter' | 'stay'
 }) => Promise<TRouteContextReturn> | TRouteContextReturn | void

--- a/packages/react-router/src/route.ts
+++ b/packages/react-router/src/route.ts
@@ -600,7 +600,7 @@ export class RouteApi<
  */
 export class Route<
   TParentRoute extends RouteConstraints['TParentRoute'] = AnyRoute,
-  TPath extends RouteConstraints['TPath'] = '/',
+  in out TPath extends RouteConstraints['TPath'] = '/',
   TFullPath extends RouteConstraints['TFullPath'] = ResolveFullPath<
     TParentRoute,
     TPath
@@ -636,12 +636,12 @@ export class Route<
     TParams
   >,
   TRouteContextReturn extends RouteConstraints['TRouteContext'] = RouteContext,
-  TRouteContext extends RouteConstraints['TRouteContext'] = [
+  in out TRouteContext extends RouteConstraints['TRouteContext'] = [
     TRouteContextReturn,
   ] extends [never]
     ? RouteContext
     : TRouteContextReturn,
-  TAllContext extends Expand<
+  in out TAllContext extends Expand<
     Assign<IsAny<TParentRoute['types']['allContext'], {}>, TRouteContext>
   > = Expand<
     Assign<IsAny<TParentRoute['types']['allContext'], {}>, TRouteContext>

--- a/packages/react-router/src/routeInfo.ts
+++ b/packages/react-router/src/routeInfo.ts
@@ -63,6 +63,11 @@ export type RoutePaths<TRouteTree extends AnyRoute> =
   | ParseRoute<TRouteTree>['fullPath']
   | '/'
 
+export type RoutePathsAutoComplete<TRouteTree extends AnyRoute, T> =
+  | T
+  | RoutePaths<TRouteTree>
+  | (string & {})
+
 type UnionizeCollisions<T, U> = {
   [P in keyof T & keyof U]: T[P] extends U[P] ? T[P] : T[P] | U[P]
 }

--- a/packages/react-router/src/routeInfo.ts
+++ b/packages/react-router/src/routeInfo.ts
@@ -1,51 +1,21 @@
-import { AnyRoute, Route } from './route'
+import { AnyRoute } from './route'
 import { Expand, UnionToIntersection, UnionToTuple } from './utils'
 
-export type ParseRoute<TRouteTree extends AnyRoute> =
-  | TRouteTree
-  | ParseRouteChildren<TRouteTree>
-
-export type ParseRouteChildren<TRouteTree extends AnyRoute> =
-  TRouteTree extends Route<
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    infer TChildren,
-    any
-  >
-    ? unknown extends TChildren
-      ? never
-      : TChildren extends AnyRoute[]
-        ? {
-            [TId in TChildren[number]['id'] as string]: ParseRoute<
-              TChildren[number]
-            >
-          }[string]
-        : never
-    : never
+export type ParseRoute<TRouteTree, TAcc = TRouteTree> = TRouteTree extends {
+  types: { children: infer TChildren }
+}
+  ? TChildren extends unknown[]
+    ? ParseRoute<TChildren[number], TAcc | TChildren[number]>
+    : TAcc
+  : TAcc
 
 export type RoutesById<TRouteTree extends AnyRoute> = {
   [K in ParseRoute<TRouteTree> as K['id']]: K
 }
 
 export type RouteById<TRouteTree extends AnyRoute, TId> = Extract<
-  ParseRoute<TRouteTree>,
-  { id: TId }
+  Extract<ParseRoute<TRouteTree>, { id: TId }>,
+  AnyRoute
 >
 
 export type RouteIds<TRouteTree extends AnyRoute> = ParseRoute<TRouteTree>['id']
@@ -55,10 +25,9 @@ export type RoutesByPath<TRouteTree extends AnyRoute> = {
 }
 
 export type RouteByPath<TRouteTree extends AnyRoute, TPath> = Extract<
-  ParseRoute<TRouteTree>,
-  { fullPath: TPath }
+  Extract<ParseRoute<TRouteTree>, { fullPath: TPath }>,
+  AnyRoute
 >
-
 export type RoutePaths<TRouteTree extends AnyRoute> =
   | ParseRoute<TRouteTree>['fullPath']
   | '/'

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1067,7 +1067,7 @@ export class Router<
     })
   }
 
-  navigate: NavigateFn<TRouteTree> = ({ from, to, ...rest }) => {
+  navigate: NavigateFn = ({ from, to, ...rest }) => {
     // If this link simply reloads the current route,
     // make sure it has a new key so it will trigger a data refresh
 

--- a/packages/react-router/src/useNavigate.tsx
+++ b/packages/react-router/src/useNavigate.tsx
@@ -7,9 +7,9 @@ import { RoutePaths, RoutePathsAutoComplete } from './routeInfo'
 import { RegisteredRouter } from './router'
 
 export type UseNavigateResult<TDefaultFrom extends string> = <
+  TTo extends string,
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
   TFrom extends RoutePaths<TRouteTree> | string = TDefaultFrom,
-  TTo extends string = '',
   TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
   TMaskTo extends string = '',
 >({

--- a/packages/react-router/src/useNavigate.tsx
+++ b/packages/react-router/src/useNavigate.tsx
@@ -3,7 +3,7 @@ import { useMatch } from './Matches'
 import { useRouter } from './useRouter'
 import { LinkOptions, NavigateOptions } from './link'
 import { AnyRoute } from './route'
-import { RoutePaths } from './routeInfo'
+import { RoutePaths, RoutePathsAutoComplete } from './routeInfo'
 import { RegisteredRouter } from './router'
 
 export type UseNavigateResult<TDefaultFrom extends string> = <
@@ -20,10 +20,7 @@ export type UseNavigateResult<TDefaultFrom extends string> = <
 export function useNavigate<
   TDefaultFrom extends string = string,
 >(_defaultOpts?: {
-  from?:
-    | TDefaultFrom
-    | RoutePaths<RegisteredRouter['routeTree']>
-    | (string & {})
+  from?: RoutePathsAutoComplete<RegisteredRouter['routeTree'], TDefaultFrom>
 }) {
   const { navigate } = useRouter()
 


### PR DESCRIPTION
### Performance improvements

- Use template literal types to autocomplete relative paths. This eliminates recursion depth limits and is faster than splitting the union into tuples
- Only remove trailing and leading slashes instead of cleaning the whole path. I'm hoping that this is OK as its more performant
- Reduce instantiations by using a more concise way of writing `ParseRoutes`
- navigate now has the same performance improvements as useNavigate
- Make `TPath`, `TContext` and `TAllContext` invariant as this reduced extra checking

### Fixes
- Resolving the full path for relative paths wasn't always including '/' at the beginning
- Checking the resolved path wasn't working due to the resolved path including '/' at the end
- The documentation suggests that the default for `TFrom` should be '/'. This makes the logic simpler but I think this is correct but please let me know if I should revert it
- TTo would not autocomplete in useNavigate. Seems to be related to a typescript issue. It cannot be defaulted for now