### PR TITLE
docs: fix `queryKey` to be compliant with the current tanstack-query v5 syntax

### DIFF
--- a/docs/framework/react/guide/external-data-loading.md
+++ b/docs/framework/react/guide/external-data-loading.md
@@ -78,7 +78,7 @@ Let's take a look at a more realistic example using TanStack Query.
 // src/routes/posts.tsx
 
 const postsQueryOptions = queryOptions({
-  queryKey: 'posts',
+  queryKey: ['posts'],
   queryFn: () => fetchPosts,
 })
 

--- a/docs/framework/react/guide/external-data-loading.md
+++ b/docs/framework/react/guide/external-data-loading.md
@@ -79,7 +79,7 @@ Let's take a look at a more realistic example using TanStack Query.
 
 const postsQueryOptions = queryOptions({
   queryKey: ['posts'],
-  queryFn: () => fetchPosts,
+  queryFn: () => fetchPosts(),
 })
 
 export const Route = createFileRoute('/posts')({


### PR DESCRIPTION
Just gave a codebase a once-over for anything regarding Tanstack Query that used anything that wouldn't be available in v5.
Didn't touch anything under `examples/react/wip-*`.