### PR TITLE
docs: fix links in Decisions on DX page

### DIFF
--- a/docs/framework/react/decisions-on-dx.md
+++ b/docs/framework/react/decisions-on-dx.md
@@ -161,7 +161,7 @@ We went with **module declaration**, as it is what we found to be the most scala
 
 Something you'll notice (quite soon) in the Tanstack Router documentation is that we push for **file-based routing** as the preferred method for defining your routes. This is because we've found that file-based routing is the most scalable and maintainable way to define your routes.
 
-> ⚠️ Before you continue, it's important you have a good understanding of [code-based routing](./guide/code-based-routing.md) and [file-based routing](./guide/file-based-routing.md).
+> ⚠️ Before you continue, it's important you have a good understanding of [code-based routing](./guide/code-based-routing) and [file-based routing](./guide/file-based-routing).
 
 As mentioned in the beginning, Tanstack Router was designed for complex applications that require a high degree of type-safety and maintainability. And to achieve this, the configuration of the router has be done in an precise way that allows Typescript to infer the types of your routes as much as possible.
 
@@ -243,4 +243,4 @@ That's it! No need to worry about defining the `getParentRoute` function, stitch
 
 At no point does the Tanstack Router CLI take away your control over your route configurations. It's designed to be as flexible as possible, allowing you to define your routes in a way that suits your application whilst reducing the boilerplate and complexity of the route configuration.
 
-> 🧠 Check out the guides for [file-based routing](./guide/file-based-routing.md) and [code-splitting](./guide/code-splitting.md) for a more in-depth explanation of how they work in Tanstack Router.
+> 🧠 Check out the guides for [file-based routing](./guide/file-based-routing) and [code-splitting](./guide/code-splitting) for a more in-depth explanation of how they work in Tanstack Router.


### PR DESCRIPTION
Removed the '.md' portion from the links, which was causing the incorrect redirect.