### PR TITLE
fix contributing guide to explicilty mention build:all command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,8 @@
   - This installs dependencies for all of the packages in the monorepo, even examples!
   - Dependencies inside of the packages and examples are automatically linked together as local/dynamic dependencies.
 - Run the build or dev watcher
-  - `pnpm build` or
+  - `pnpm build:all` (build all packages) or
+  - `pnpm build` (cached build with [nx affected](https://nx.dev/nx-api/nx/documents/affected)) or
   - `pnpm dev`
 - Navigate to an example
   - `cd examples/react/basic`

--- a/README.md
+++ b/README.md
@@ -57,4 +57,7 @@ Enjoy this library? Try the entire [TanStack](https://tanstack.com)! [React Quer
 - Layout Routes
 - Easy Integration w/ external caches and storage (eg. React Query, Apollo, SWR, RTKQuery)
 
+## Example Usage
+To run example React projects with Tanstack Router, see [CONTRIBUTING.md](./CONTRIBUTING.md)
+
 <!-- Use the force, Luke! -->


### PR DESCRIPTION
## Purpose
I cloned the repo as the StackBlitz examples where a bit slow and got confused a bit when the `pnpm build` command did not work as I am unfamiliar with `nx`.

## Changes
I updated the CONTRIBUTING.md guide to reflect that `pnpm build:all` should be run on initial clone.

## Additional Suggestions
May I suggest adding more info about running examples in the main README.md? A simple link to the CONTRIBUTING section like "To run examples, see CONTRIBUTING.md"