### PR TITLE
fix: correct typing for route groups

### DIFF
--- a/docs/framework/react/guide/file-based-routing.md
+++ b/docs/framework/react/guide/file-based-routing.md
@@ -103,8 +103,6 @@ The following options are available for configuration via the `tsr.config.json` 
   - If set to `true` and the `generatedRouteTree` file ends with `.ts` or `.tsx`, the generated route tree will be written as a `.js` file instead.
 - **`addExtensions`**
   - (Optional, **Defaults to `false`**) add file extensions to the route names in the generated route tree
-- **`routeGroupPattern`**
-  - (Optional, **Defaults to `'\\(.+\\)'`**) A folder that matches this pattern is treated as a **route group** which prevents this folder to be included in the route's URL path.
 
 ## File Naming Conventions
 
@@ -120,12 +118,14 @@ File-based routing requires that you follow a few simple file naming conventions
   - Routes segments with the `_` prefix are considered layout-routes and will not be used when matching its child routes against the URL pathname.
 - **`_` Suffix**
   - Routes segments with the `_` suffix exclude the route from being nested under any parent routes.
+- **`(folder)` folder name pattern**:
+  - A folder that matches this pattern is treated as a **route group** which prevents this folder to be included in the route's URL path.
 - **`index` Token**
   - Routes segments ending with the `index` token (but before any file types) will be used to match the parent route when the URL pathname matches the parent route exactly.
 - **`.route.tsx` File Type**
   - When using directories to organize your routes, the `route` suffix can be used to create a route file at the directory's path. For example, `blog/post/route.tsx` will be used at the route file for the `/blog/post` route.
 - **`.lazy.tsx` File Type**
-  - The `lazy` suffix can be used to code-split components for a route. For example, `blog.post.lazy.tsx` will be used as the component for the `blog.post` route.  
+  - The `lazy` suffix can be used to code-split components for a route. For example, `blog.post.lazy.tsx` will be used as the component for the `blog.post` route.
 - **`.component.tsx` File Type (⚠️ deprecated)**
 - **`.errorComponent.tsx` File Type (⚠️ deprecated)**
 - **`.pendingComponent.tsx` File Type (⚠️ deprecated)**

--- a/examples/react/kitchen-sink-file-based/src/routes/(this-folder-is-not-in-the-url)/route-group.tsx
+++ b/examples/react/kitchen-sink-file-based/src/routes/(this-folder-is-not-in-the-url)/route-group.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute(
   '/(this-folder-is-not-in-the-url)/route-group',

--- a/packages/react-router/src/fileRoute.ts
+++ b/packages/react-router/src/fileRoute.ts
@@ -63,6 +63,16 @@ export type RemoveUnderScores<T extends string> = Replace<
   '/'
 >
 
+type RemoveRouteGroups<S extends string> =
+  S extends `${infer Before}(${infer RouteGroup})${infer After}`
+    ? RemoveRouteGroups<`${Before}${After}`>
+    : S
+
+type NormalizeSlashes<S extends string> =
+  S extends `${infer Before}//${infer After}`
+    ? NormalizeSlashes<`${Before}/${After}`>
+    : S
+
 type ReplaceFirstOccurrence<
   T extends string,
   Search extends string,
@@ -102,7 +112,7 @@ export function createFileRoute<
   >,
   TFullPath extends RouteConstraints['TFullPath'] = ResolveFullPath<
     TParentRoute,
-    RemoveUnderScores<TPath>
+    NormalizeSlashes<RemoveRouteGroups<RemoveUnderScores<TPath>>>
   >,
 >(path: TFilePath) {
   return new FileRoute<TFilePath, TParentRoute, TId, TPath, TFullPath>(path, {

--- a/packages/router-generator/src/config.ts
+++ b/packages/router-generator/src/config.ts
@@ -6,7 +6,6 @@ export const configSchema = z.object({
   routeFilePrefix: z.string().optional(),
   routeFileIgnorePrefix: z.string().optional().default('-'),
   routesDirectory: z.string().optional().default('./src/routes'),
-  routeGroupPattern: z.string().optional().default('\\(.+\\)'),
   generatedRouteTree: z.string().optional().default('./src/routeTree.gen.ts'),
   quoteStyle: z.enum(['single', 'double']).optional().default('single'),
   disableTypes: z.boolean().optional().default(false),

--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -7,6 +7,7 @@ import { cleanPath, trimPathLeft } from './utils'
 
 let latestTask = 0
 export const rootPathId = '__root'
+const routeGroupPatternRegex = /\(.+\)/g
 
 export type RouteNode = {
   filePath: string
@@ -201,8 +202,6 @@ export async function generator(config: Config) {
   // build up a tree based on the routeNodes' routePath
   let routeNodes: RouteNode[] = []
 
-  const routeGroupPatternRegex = new RegExp(config.routeGroupPattern, 'g')
-
   const handleNode = async (node: RouteNode) => {
     const parentRoute = hasParentRoute(routeNodes, node.routePath)
     if (parentRoute) node.parent = parentRoute
@@ -218,10 +217,7 @@ export async function generator(config: Config) {
 
     node.isNonPath = first.startsWith('_')
     node.isNonLayout = first.endsWith('_')
-    node.cleanedPath = removeGroups(
-      removeUnderscores(node.path) ?? '',
-      routeGroupPatternRegex,
-    )
+    node.cleanedPath = removeGroups(removeUnderscores(node.path) ?? '')
 
     // Ensure the boilerplate for the route exists
     const routeCode = fs.readFileSync(node.fullPath, 'utf-8')
@@ -635,8 +631,8 @@ function replaceBackslash(s: string) {
   return s.replaceAll(/\\/gi, '/')
 }
 
-function removeGroups(s: string, rx: RegExp) {
-  return s.replaceAll(rx, '').replaceAll('//', '/')
+function removeGroups(s: string) {
+  return s.replaceAll(routeGroupPatternRegex, '').replaceAll('//', '/')
 }
 
 export function hasParentRoute(


### PR DESCRIPTION
since we need to handle the path replacements in typescript as well, we cannot let the user configure the route group pattern