### PR TITLE
feat: disableLogging

### DIFF
--- a/docs/framework/react/guide/file-based-routing.md
+++ b/docs/framework/react/guide/file-based-routing.md
@@ -103,6 +103,8 @@ The following options are available for configuration via the `tsr.config.json` 
   - If set to `true` and the `generatedRouteTree` file ends with `.ts` or `.tsx`, the generated route tree will be written as a `.js` file instead.
 - **`addExtensions`**
   - (Optional, **Defaults to `false`**) add file extensions to the route names in the generated route tree
+- **`disableLogging`**
+  - (Optional, **Defaults to `false`**) disables logging for the route generation process
 
 ## File Naming Conventions
 

--- a/packages/router-generator/src/config.ts
+++ b/packages/router-generator/src/config.ts
@@ -10,6 +10,7 @@ export const configSchema = z.object({
   quoteStyle: z.enum(['single', 'double']).optional().default('single'),
   disableTypes: z.boolean().optional().default(false),
   addExtensions: z.boolean().optional().default(false),
+  disableLogging: z.boolean().optional().default(false),
 })
 
 export type Config = z.infer<typeof configSchema>

--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs'
 import * as fsp from 'fs/promises'
 import * as prettier from 'prettier'
 import { Config } from './config'
-import { cleanPath, trimPathLeft } from './utils'
+import { cleanPath, logging, trimPathLeft } from './utils'
 
 let latestTask = 0
 export const rootPathId = '__root'
@@ -32,6 +32,7 @@ export type RouteNode = {
 
 async function getRouteNodes(config: Config) {
   const { routeFilePrefix, routeFileIgnorePrefix } = config
+  const logger = logging({ disabled: config.disableLogging })
 
   let routeNodes: RouteNode[] = []
 
@@ -97,7 +98,7 @@ async function getRouteNodes(config: Config) {
             ] as const
           ).forEach(([isType, type]) => {
             if (isType) {
-              console.warn(
+              logger.warn(
                 `WARNING: The \`.${type}.tsx\` suffix used for the ${filePath} file is deprecated. Use the new \`.lazy.tsx\` suffix instead.`,
               )
             }
@@ -150,17 +151,16 @@ type RouteSubNode = {
 }
 
 export async function generator(config: Config) {
-  if (!config.disableLogging) {
-    console.log('')
+  const logger = logging({ disabled: config.disableLogging })
+  logger.log('')
 
-    if (!first) {
-      console.log('♻️  Generating routes...')
-      first = true
-    } else if (skipMessage) {
-      skipMessage = false
-    } else {
-      console.log('♻️  Regenerating routes...')
-    }
+  if (!first) {
+    logger.log('♻️  Generating routes...')
+    first = true
+  } else if (skipMessage) {
+    skipMessage = false
+  } else {
+    logger.log('♻️  Regenerating routes...')
   }
 
   const taskId = latestTask + 1
@@ -269,7 +269,7 @@ export async function generator(config: Config) {
     }
 
     if (replaced !== routeCode) {
-      if (!config.disableLogging) console.log(`🟡 Updating ${node.fullPath}`)
+      logger.log(`🟡 Updating ${node.fullPath}`)
       await fsp.writeFile(node.fullPath, replaced)
     }
 
@@ -555,12 +555,11 @@ export async function generator(config: Config) {
     )
   }
 
-  if (!config.disableLogging)
-    console.log(
-      `✅ Processed ${routeNodes.length === 1 ? 'route' : 'routes'} in ${
-        Date.now() - start
-      }ms`,
-    )
+  logger.log(
+    `✅ Processed ${routeNodes.length === 1 ? 'route' : 'routes'} in ${
+      Date.now() - start
+    }ms`,
+  )
 }
 
 function routePathToVariable(d: string): string {

--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -150,15 +150,17 @@ type RouteSubNode = {
 }
 
 export async function generator(config: Config) {
-  console.log('')
+  if (!config.disableLogging) {
+    console.log('')
 
-  if (!first) {
-    console.log('♻️  Generating routes...')
-    first = true
-  } else if (skipMessage) {
-    skipMessage = false
-  } else {
-    console.log('♻️  Regenerating routes...')
+    if (!first) {
+      console.log('♻️  Generating routes...')
+      first = true
+    } else if (skipMessage) {
+      skipMessage = false
+    } else {
+      console.log('♻️  Regenerating routes...')
+    }
   }
 
   const taskId = latestTask + 1
@@ -267,7 +269,7 @@ export async function generator(config: Config) {
     }
 
     if (replaced !== routeCode) {
-      console.log(`🟡 Updating ${node.fullPath}`)
+      if (!config.disableLogging) console.log(`🟡 Updating ${node.fullPath}`)
       await fsp.writeFile(node.fullPath, replaced)
     }
 
@@ -553,11 +555,12 @@ export async function generator(config: Config) {
     )
   }
 
-  console.log(
-    `✅ Processed ${routeNodes.length === 1 ? 'route' : 'routes'} in ${
-      Date.now() - start
-    }ms`,
-  )
+  if (!config.disableLogging)
+    console.log(
+      `✅ Processed ${routeNodes.length === 1 ? 'route' : 'routes'} in ${
+        Date.now() - start
+      }ms`,
+    )
 }
 
 function routePathToVariable(d: string): string {

--- a/packages/router-generator/src/utils.ts
+++ b/packages/router-generator/src/utils.ts
@@ -6,3 +6,23 @@ export function cleanPath(path: string) {
 export function trimPathLeft(path: string) {
   return path === '/' ? path : path.replace(/^\/{1,}/, '')
 }
+
+export function logging(config: { disabled: boolean }) {
+  return {
+    log: (...args: any[]) => {
+      if (!config.disabled) console.log(...args)
+    },
+    debug: (...args: any[]) => {
+      if (!config.disabled) console.debug(...args)
+    },
+    info: (...args: any[]) => {
+      if (!config.disabled) console.info(...args)
+    },
+    warn: (...args: any[]) => {
+      if (!config.disabled) console.warn(...args)
+    },
+    error: (...args: any[]) => {
+      if (!config.disabled) console.error(...args)
+    },
+  }
+}


### PR DESCRIPTION
Proposal to have a property on the config object to optionally disable logging. This would be relevant for my use-case, because I am experimenting with creating my own-stack on top of TanStack Router, and the logging of the route generation is messing with my logging.

- Adds `disableLogging` property to the config
- Adds `logging` function to utils
- Adds docs to document it