### PR TITLE
docs: make loader function async in deferred-data-loading guide

### DIFF
--- a/docs/framework/react/guide/deferred-data-loading.md
+++ b/docs/framework/react/guide/deferred-data-loading.md
@@ -18,7 +18,7 @@ import * as React from 'react'
 import { createFileRoute, defer } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/posts/$postId')({
-  loader: () => {
+  loader: async () => {
     // Fetch some slower data, but do not await it
     const slowDataPromise = fetchSlowData()
 


### PR DESCRIPTION
Encountered a lack of async keyword resulting in TypeScript error: `TS1308: 'await' expressions are only allowed within async functions and at the top levels of modules.`