### PR TITLE
fix: incorrect route generation for nested layout routes

### DIFF
--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -214,8 +214,16 @@ export async function generator(config: Config) {
   const handleNode = async (node: RouteNode) => {
     let parentRoute = hasParentRoute(routeNodes, node.routePath)
 
+    // if the parent route is a virtual parent route, we need to find the real parent route
     if (parentRoute?.isVirtualParentRoute && parentRoute.children?.length) {
-      parentRoute = hasParentRoute(parentRoute.children, node.routePath)
+      // only if this sub-parent route returns a valid parent route, we use it, if not leave it as it
+      const possibleParentRoute = hasParentRoute(
+        parentRoute.children,
+        node.routePath,
+      )
+      if (possibleParentRoute) {
+        parentRoute = possibleParentRoute
+      }
     }
 
     if (parentRoute) node.parent = parentRoute

--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -449,7 +449,8 @@ export async function generator(config: Config) {
           `const ${node.variableName}Route = ${node.variableName}Import.update({
           ${[
             node.isNonPath
-              ? `id: '${node.path}'${!node.isNonLayout && node.cleanedPath ? `, path: '${node.cleanedPath}'` : ''}`
+              ? // this is still not satisfied on the ts-side of react-router with the paths.
+                `id: '${node.path}'${!node.isNonLayout && node.cleanedPath ? `, path: '${node.cleanedPath}'` : ''}`
               : `path: '${node.cleanedPath}'`,
             `getParentRoute: () => ${node.parent?.variableName ?? 'root'}Route`,
           ]

--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -18,7 +18,6 @@ export type RouteNode = {
   path?: string
   isNonPath?: boolean
   isNonLayout?: boolean
-  isParentRoot?: boolean
   isLayout?: boolean
   isVirtualParentRequired?: boolean
   isVirtualParentRoute?: boolean

--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -696,7 +696,7 @@ function removeGroups(s: string) {
  * @param {string} path - The path from which to remove the last segment. Defaults to '/'.
  * @returns {string} The path with the last segment removed.
  * @example
- * removeLastSegment('/workspace/_auth/foo') // '/workspace/_auth'
+ * removeLastSegmentFromPath('/workspace/_auth/foo') // '/workspace/_auth'
  */
 export function removeLastSegmentFromPath(path: string = '/'): string {
   const segments = path.split('/')
@@ -710,8 +710,8 @@ export function removeLastSegmentFromPath(path: string = '/'): string {
  * @param {string} variableName - The variable name from which to remove the last segment. Defaults to an empty string.
  * @returns {string} The variable name with the last segment removed.
  * @example
- * removeLastVariableSegment('RouteBBarTanRoute') // 'RouteBBarTan'
- * removeLastVariableSegment('RouteAFoo') // 'RouteA'
+ * removeLastSegmentFromVariableName('RouteBBarTanRoute') // 'RouteBBarTan'
+ * removeLastSegmentFromVariableName('RouteAFoo') // 'RouteA'
  */
 export function removeLastSegmentFromVariableName(
   variableName: string = '',

--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -339,25 +339,37 @@ export async function generator(config: Config) {
 
     if (!node.isVirtual && node.isVirtualParentRequired) {
       const parentRoutePath = removeLastSegmentFromPath(node.routePath) || '/'
-      const parentNode = {
-        ...node,
-        path: removeLastSegmentFromPath(node.path) || '/',
-        filePath: removeLastSegmentFromPath(node.filePath) || '/',
-        fullPath: removeLastSegmentFromPath(node.fullPath) || '/',
-        routePath: parentRoutePath,
-        variableName: routePathToVariable(parentRoutePath),
-        isVirtual: true,
-        isLayout: false,
-        isVirtualParentRoute: true,
-        isVirtualParentRequired: false,
+
+      const anchorRoute = routeNodes.find(
+        (d) => d.routePath === parentRoutePath,
+      )
+
+      if (!anchorRoute) {
+        const parentNode = {
+          ...node,
+          path: removeLastSegmentFromPath(node.path) || '/',
+          filePath: removeLastSegmentFromPath(node.filePath) || '/',
+          fullPath: removeLastSegmentFromPath(node.fullPath) || '/',
+          routePath: parentRoutePath,
+          variableName: routePathToVariable(parentRoutePath),
+          isVirtual: true,
+          isLayout: false,
+          isVirtualParentRoute: true,
+          isVirtualParentRequired: false,
+        }
+
+        parentNode.children = parentNode.children ?? []
+        parentNode.children.push(node)
+
+        node.parent = parentNode
+
+        await handleNode(parentNode)
+      } else {
+        anchorRoute.children = anchorRoute.children ?? []
+        anchorRoute.children.push(node)
+
+        node.parent = anchorRoute
       }
-
-      parentNode.children = parentNode.children ?? []
-      parentNode.children.push(node)
-
-      node.parent = parentNode
-
-      await handleNode(parentNode)
     }
 
     if (node.parent) {


### PR DESCRIPTION
I fully acknowledge that this looks jank... there's no escaping this fact.
Most of it stems from having to short-circuit the `handleNode` function.

Fixes #1150 