### PR TITLE
fix(router-generator): invalid formation of `id`s and attaching of child layout routes 

### DIFF
--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -455,16 +455,8 @@ export async function generator(config: Config) {
       const existingPreNode = preRouteNodes.filter(
         (d) => d.routePath === route.routePath,
       )
-      const existingVirtualNode = acc.find(
-        (d) => d.routePath === route.routePath,
-      )
 
       if (existingPreNode.length === 0) {
-        logger.debug(
-          route.filePath,
-          'existing virtual node',
-          existingVirtualNode?.routePath,
-        )
         acc.push(route)
       }
 

--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -258,8 +258,8 @@ export async function generator(config: Config) {
           replaced = [
             `import { createLazyFileRoute } from '@tanstack/react-router'`,
             `export const Route = createLazyFileRoute('${escapedRoutePath}')({
-    component: () => <div>Hello ${escapedRoutePath}!</div>
-  })`,
+  component: () => <div>Hello ${escapedRoutePath}!</div>
+})`,
           ].join('\n\n')
         } else if (
           node.isRoute ||
@@ -271,8 +271,8 @@ export async function generator(config: Config) {
           replaced = [
             `import { createFileRoute } from '@tanstack/react-router'`,
             `export const Route = createFileRoute('${escapedRoutePath}')({
-    component: () => <div>Hello ${escapedRoutePath}!</div>
-  })`,
+  component: () => <div>Hello ${escapedRoutePath}!</div>
+})`,
           ].join('\n\n')
         }
       } else {

--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -228,9 +228,7 @@ export async function generator(config: Config) {
 
     if (parentRoute) node.parent = parentRoute
 
-    node.path = node.parent
-      ? node.routePath?.replace(node.parent.routePath!, '') || '/'
-      : node.routePath
+    node.path = determineNodePath(node)
 
     const trimmedPath = trimPathLeft(node.path ?? '')
 
@@ -368,6 +366,11 @@ export async function generator(config: Config) {
         parentNode.children.push(node)
 
         node.parent = parentNode
+
+        if (node.isLayout) {
+          // since `node.path` is used as the `id` on the route definition, we need to update it
+          node.path = determineNodePath(node)
+        }
 
         await handleNode(parentNode)
       } else {
@@ -705,6 +708,18 @@ function replaceBackslash(s: string) {
 
 function removeGroups(s: string) {
   return s.replaceAll(routeGroupPatternRegex, '').replaceAll('//', '/')
+}
+
+/**
+ * The `node.path` is used as the `id` in the route definition.
+ * This function checks if the given node has a parent and if so, it determines the correct path for the given node.
+ * @param node - The node to determine the path for.
+ * @returns The correct path for the given node.
+ */
+function determineNodePath(node: RouteNode) {
+  return (node.path = node.parent
+    ? node.routePath?.replace(node.parent.routePath!, '') || '/'
+    : node.routePath)
 }
 
 /**

--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -338,12 +338,17 @@ export async function generator(config: Config) {
       return
     }
 
-    node.isVirtualParentRequired =
-      removeGroups(node.path ?? '')
-        .split('')
-        .filter((char) => char === '/').length >= 2 && // check that the parent route wouldn't be the root route
-      !node.parent &&
-      node.isLayout
+    // node.isVirtualParentRequired =
+    //   removeGroups(node.path ?? '')
+    //     .split('')
+    //     .filter((char) => char === '/').length >= 2 && // check that the parent route wouldn't be the root route
+    //   !node.parent &&
+    //   node.isLayout
+
+    const cleanedPathIsEmpty = (node.cleanedPath || '').length === 0
+    node.isVirtualParentRequired = node.isLayout
+      ? !cleanedPathIsEmpty && !node.parent
+      : false
 
     if (!node.isVirtual && node.isVirtualParentRequired) {
       const parentRoutePath = removeLastSegmentFromPath(node.routePath) || '/'

--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -338,13 +338,6 @@ export async function generator(config: Config) {
       return
     }
 
-    // node.isVirtualParentRequired =
-    //   removeGroups(node.path ?? '')
-    //     .split('')
-    //     .filter((char) => char === '/').length >= 2 && // check that the parent route wouldn't be the root route
-    //   !node.parent &&
-    //   node.isLayout
-
     const cleanedPathIsEmpty = (node.cleanedPath || '').length === 0
     node.isVirtualParentRequired = node.isLayout
       ? !cleanedPathIsEmpty && !node.parent


### PR DESCRIPTION
* fix: invalid generation of the route `id`s for layout routes in a nested folder (without a `route.tsx`) definition.
* fix: unintended spaces are being added into the initial *on-save* template.
* fix: child layout routes of already nested layouts not being attached correctly to their parents.
```
src/routes
  index.tsx
  nested/
    _layout-a.tsx
    _layout-a/
      _layout-b.tsx <- parent will be `_layout-a.tsx`
      _layout-b/
        foo.tsx
```

closes #1279 