### PR TITLE
(fix) routers - update url search params according to validate search

### DIFF
--- a/packages/react-router/src/RouterProvider.tsx
+++ b/packages/react-router/src/RouterProvider.tsx
@@ -142,6 +142,17 @@ function Transitioner() {
       }
     })
 
+		const nextLocation = router.buildLocation({
+			search: true,
+			params: true,
+			hash: true,
+			state: true,
+		});
+
+		if (routerState.location.href !== nextLocation.href) {
+			router.commitLocation({ ...nextLocation, replace: true });
+		}
+
     return () => {
       unsub()
     }

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -873,7 +873,7 @@ export class Router<
           ? prevParams
           : { ...prevParams, ...functionalUpdate(dest.params!, prevParams) }
 
-      if (nextParams) {
+      if (Object.keys(nextParams).length > 0) {
         matches
           ?.map((d) => this.looseRoutesById[d.routeId]!.options.stringifyParams)
           .filter(Boolean)


### PR DESCRIPTION
Should fix: #1268 

With this fix, it should update the url search params according to the validateSearch zod schema so the visible url should match the router search state (except if masked is activated).

Update on` packages/react-router/src/RouterProvider.tsx` is a "revert" from changes made between `1.18.3` & `1.18.4`.
I don't know why this was deleted, maybe it's part of something I miss. If it's the case, ignore this PR.

If you need more precisions, let me know.