### PR TITLE
docs: fixed broken authenticated routes example url

### DIFF
--- a/docs/framework/react/guide/authenticated-routes.md
+++ b/docs/framework/react/guide/authenticated-routes.md
@@ -83,7 +83,7 @@ If your authentication flow relies on interactions with React context and/or hoo
 
 We'll cover the `router.context` options in-detail in the [Router Context](./guide/router-context) section.
 
-Here's an example that uses React context and hooks for protecting authenticated routes in Tanstack Router. See the entire working setup in the [Authenticated Routes with Context example](./examples/react/authenticated-routes-context).
+Here's an example that uses React context and hooks for protecting authenticated routes in Tanstack Router. See the entire working setup in the [Authenticated Routes with Context example](./examples/authenticated-routes-context).
 
 - `src/routes/__root.tsx`
 


### PR DESCRIPTION
This extra `/react` was causing the Stackblitz to try and import a non existing path.
Checked the rest of codebase for similar errors, and couldn't find any other.

![image](https://github.com/TanStack/router/assets/28123106/95f75fd7-e1fa-45c2-b0e0-149827c2fdd2)
