### PR TITLE
fix: deserialize notFound errors

### DIFF
--- a/packages/react-router/src/Matches.tsx
+++ b/packages/react-router/src/Matches.tsx
@@ -232,7 +232,7 @@ function MatchInner({
       error = deserializeError(match.error.data)
     } else {
       error = match.error
-    } 
+    }
 
     invariant(isNotFound(error), 'Expected a notFound error')
 

--- a/packages/react-router/src/Matches.tsx
+++ b/packages/react-router/src/Matches.tsx
@@ -224,9 +224,19 @@ function MatchInner({
     ErrorComponent
 
   if (match.status === 'notFound') {
-    invariant(isNotFound(match.error), 'Expected a notFound error')
+    let error: unknown
+    if (isServerSideError(match.error)) {
+      const deserializeError =
+        router.options.errorSerializer?.deserialize ?? defaultDeserializeError
 
-    return renderRouteNotFound(router, route, match.error.data)
+      error = deserializeError(match.error.data)
+    } else {
+      error = match.error
+    } 
+
+    invariant(isNotFound(error), 'Expected a notFound error')
+
+    return renderRouteNotFound(router, route, error)
   }
 
   if (match.status === 'redirected') {


### PR DESCRIPTION
Fixes `notFound` errors not being deserialized on the client, leading to a failed `invariant` call. Reproduced [here](https://codesandbox.io/p/github/iDarkLightning/tsr-not-found-err/main?import=true). 

GH Repo of reproduction [here](https://github.com/iDarkLightning/tsr-not-found-err)