### PR TITLE
fix: don't hydrate assets for notFound or redirected matches

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1953,15 +1953,23 @@ export class Router<
       if (dehydratedMatch) {
         const route = this.looseRoutesById[match.routeId]!
 
+        const assets =
+          dehydratedMatch.status === 'notFound' ||
+          dehydratedMatch.status === 'redirected'
+            ? {}
+            : {
+                meta: route.options.meta?.({
+                  params: match.params,
+                  loaderData: dehydratedMatch.loaderData,
+                }),
+                links: route.options.links?.(),
+                scripts: route.options.scripts?.(),
+              }
+
         return {
           ...match,
           ...dehydratedMatch,
-          meta: route.options.meta?.({
-            params: match.params,
-            loaderData: dehydratedMatch.loaderData,
-          }),
-          links: route.options.links?.(),
-          scripts: route.options.scripts?.(),
+          ...assets,
         }
       }
       return match


### PR DESCRIPTION
We currently add `meta` `links` and `scripts` on the client even if the route is redirected or not found. This causes hydration errors, because the server does not add those properties. 

(Aside from that it also just doesn't make sense to load assets for a route that was not found and can potentially reveal unwanted info) 