### PR TITLE
Fix type error when passing a function to Link's children

### DIFF
--- a/examples/react/basic/src/main.tsx
+++ b/examples/react/basic/src/main.tsx
@@ -61,13 +61,10 @@ function RootComponent() {
         >
           Home
         </Link>{' '}
-        <Link
-          to={'/posts'}
-          activeProps={{
-            className: 'font-bold',
-          }}
-        >
-          Posts
+        <Link to={'/posts'}>
+          {({ isActive }) => (
+            <span className={isActive ? 'font-bold' : ''}>Posts</span>
+          )}
         </Link>
       </div>
       <Outlet />

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -630,7 +630,7 @@ type LinkComponent<TComp> = <
       (TComp extends React.FC<infer TProps> | React.Component<infer TProps>
         ? TProps
         : TComp extends keyof JSX.IntrinsicElements
-          ? React.HTMLProps<TComp>
+          ? Omit<React.HTMLProps<TComp>, 'children'>
           : never)
   > &
     React.RefAttributes<


### PR DESCRIPTION
Fixes #1302 by omitting the children property from `HTMLProps` when merging with `LinkProps`. Hopefully this fix isn't naive, this is one of my first OSS contributions.

I've also added some "function as child" usage to the basic example to act as a test, as I know this project doesn't have a proper test setup as of yet.