### PR TITLE
fix: add `to` path when syncing url

### DIFF
--- a/packages/react-router/src/RouterProvider.tsx
+++ b/packages/react-router/src/RouterProvider.tsx
@@ -143,6 +143,7 @@ function Transitioner() {
     })
 
     const nextLocation = router.buildLocation({
+      to: router.latestLocation.pathname,
       search: true,
       params: true,
       hash: true,


### PR DESCRIPTION
Fixes router url syncing for non-existent routes