### PR TITLE
fix: Type error when passing props to `Link` via destructed `LinkProps`.

### DIFF
--- a/examples/react/basic/src/main.tsx
+++ b/examples/react/basic/src/main.tsx
@@ -176,5 +176,5 @@ if (!rootElement.innerHTML) {
 
 // Test that `Link` can be supplied its properties from a destructed `LinkProps` object without causing a type error.
 // TODO: Move into a defined test once a testing framework is set up.
-const testLinkOptions: LinkProps = { to: '/' }
-const testLink = <Link {...testLinkOptions}>test</Link>
+const testLinkProps: LinkProps = { to: '/' }
+const testLink = <Link {...testLinkProps}>test</Link>

--- a/examples/react/basic/src/main.tsx
+++ b/examples/react/basic/src/main.tsx
@@ -10,7 +10,7 @@ import {
   createRootRoute,
   ErrorComponentProps,
   createRoute,
-  LinkOptions,
+  LinkProps,
 } from '@tanstack/react-router'
 import { TanStackRouterDevtools } from '@tanstack/router-devtools'
 import axios from 'axios'
@@ -174,7 +174,7 @@ if (!rootElement.innerHTML) {
   root.render(<RouterProvider router={router} />)
 }
 
-// Test that `Link` can be supplied its properties from a destructed `LinkOptions` object without causing a type error.
-// TODO: Move into a defined test once a testing framework is setup.
-const testLinkOptions: LinkOptions = { to: '/' }
+// Test that `Link` can be supplied its properties from a destructed `LinkProps` object without causing a type error.
+// TODO: Move into a defined test once a testing framework is set up.
+const testLinkOptions: LinkProps = { to: '/' }
 const testLink = <Link {...testLinkOptions}>test</Link>

--- a/examples/react/basic/src/main.tsx
+++ b/examples/react/basic/src/main.tsx
@@ -10,6 +10,7 @@ import {
   createRootRoute,
   ErrorComponentProps,
   createRoute,
+  LinkOptions,
 } from '@tanstack/react-router'
 import { TanStackRouterDevtools } from '@tanstack/router-devtools'
 import axios from 'axios'
@@ -172,3 +173,8 @@ if (!rootElement.innerHTML) {
 
   root.render(<RouterProvider router={router} />)
 }
+
+// Test that `Link` can be supplied its properties from a destructed `LinkOptions` object without causing a type error.
+// TODO: Move into a defined test once a testing framework is setup.
+const testLinkOptions: LinkOptions = { to: '/' }
+const testLink = <Link {...testLinkOptions}>test</Link>

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -630,7 +630,7 @@ type LinkComponent<TComp> = <
       (TComp extends React.FC<infer TProps> | React.Component<infer TProps>
         ? TProps
         : TComp extends keyof JSX.IntrinsicElements
-          ? Omit<React.HTMLProps<TComp>, 'children'>
+          ? Omit<React.HTMLProps<TComp>, 'children' | 'preload'>
           : never)
   > &
     React.RefAttributes<


### PR DESCRIPTION
Fixes a bug where [destructing `LinkProps` into the props for a `Link` causes a type error](https://stackblitz.com/edit/tanstack-router-qmueor?file=src%2Fmain.tsx).

Similar to #1307, this omits the `preload` prop when merging `HTMLProps` and `LinkProps`.

I've also added a test to `examples/react/basic/src/main.tsx` with the intention of moving it to a more appropriate location once a testing framework is setup.