### PR TITLE
fix: allow `preload=false` on the `<Link>` component

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -630,7 +630,7 @@ type LinkComponent<TComp> = <
       (TComp extends React.FC<infer TProps> | React.Component<infer TProps>
         ? TProps
         : TComp extends keyof JSX.IntrinsicElements
-          ? Omit<React.HTMLProps<TComp>, 'children'>
+          ? Omit<React.HTMLProps<TComp>, 'children' | 'preload'>
           : never)
   > &
     React.RefAttributes<


### PR DESCRIPTION
fixes not being able to set `preload=false`.

`preload` should be able to accept the following type `preload?: false | 'intent' | undefined`, however, currently it only allows `preload?: "intent" | undefined`.

Setting `false`, should disable the default configured preload behaviour (on the router) for that specific `<Link>`. This current behaviour already functionally works, but it looks like somewhere along the way (possibly with the introduction of the `createLink` function), the *preload* typing between `LinkProps` and the `LinkComponent` look to have drifted.
<br>
<br>
This isn't the only drift, there seems to be drift between the `mask` property on the `LinkProps` type and what is actually accepted on the `<Link>` component.
```
Types of property 'mask' are incompatible.
      Type 'ToMaskOptions<Route<any, "/", "/", string, "__root__", RootSearchSchema, RootSearchSchema, RootSearchSchema, RootSearchSchema, ... 11 more ..., any>, string, ""> | undefined'
      is not assignable to type 
           'ToMaskOptions<Route<any, "/", "/", string, "__root__", RootSearchSchema, RootSearchSchema, RootSearchSchema, RootSearchSchema, ... 11 more ..., any>, RoutePaths<...>, ""> | undefined'.
```
Possibly also with the `params` property?
I'm not able to fully debug this during my break, but I figured this was an easy enough fix to get shipped.