### PR TITLE
docs: remove formatted {' '} on Quick Start 

### DIFF
--- a/docs/framework/react/quick-start.md
+++ b/docs/framework/react/quick-start.md
@@ -53,7 +53,7 @@ export const Route = createRootRoute({
       <div className="p-2 flex gap-2">
         <Link to="/" className="[&.active]:font-bold">
           Home
-        </Link>{' '}
+        </Link>
         <Link to="/about" className="[&.active]:font-bold">
           About
         </Link>


### PR DESCRIPTION
remove formatted {' '} on https://tanstack.com/router/latest/docs/framework/react/quick-start#srcroutes__roottsx

If we do not need it, close it!