### PR TITLE
perf: improve performance of Link when navigating to unique routes

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -620,9 +620,9 @@ export type LinkProps<
 
 type LinkComponent<TComp> = <
   TRouteTree extends AnyRoute = RegisteredRouter['routeTree'],
-  TFrom extends RoutePaths<TRouteTree> = string,
+  TFrom extends RoutePaths<TRouteTree> | string = string,
   TTo extends string = '',
-  TMaskFrom extends RoutePaths<TRouteTree> = TFrom,
+  TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
   TMaskTo extends string = '',
 >(
   props: React.PropsWithoutRef<

--- a/packages/react-router/src/routeInfo.ts
+++ b/packages/react-router/src/routeInfo.ts
@@ -25,9 +25,10 @@ export type RoutesByPath<TRouteTree extends AnyRoute> = {
 }
 
 export type RouteByPath<TRouteTree extends AnyRoute, TPath> = Extract<
-  Extract<ParseRoute<TRouteTree>, { fullPath: TPath }>,
+  RoutesByPath<TRouteTree>[TPath],
   AnyRoute
 >
+
 export type RoutePaths<TRouteTree extends AnyRoute> =
   | ParseRoute<TRouteTree>['fullPath']
   | '/'


### PR DESCRIPTION
- `TFrom` was being defaulted to `RoutePaths` due to the generic constraint. Causing performance issues.
- Use `RoutesByPath` instead of `Extract` for `RouteByPath`. This improves performance where `Link` has unique props and cannot be cached.

Ran diagnostics in `large-file-based`

Before:

```
Files:                         590
Lines of Library:            38118
Lines of Definitions:        77176
Lines of TypeScript:         12777
Lines of JavaScript:             0
Lines of JSON:                   0
Lines of Other:                  0
Identifiers:                113150
Symbols:                    376438
Types:                       81173
Instantiations:            4239852
Memory used:               403967K
Assignability cache size:   525762
Identity cache size:          3721
Subtype cache size:              0
Strict subtype cache size:  162006
I/O Read time:               0.11s
Parse time:                  0.83s
ResolveModule time:          0.16s
ResolveTypeReference time:   0.01s
ResolveLibrary time:         0.03s
Program time:                1.26s
Bind time:                   0.34s
Check time:                 11.88s
printTime time:              0.00s
Emit time:                   0.00s
Total time:                 13.48s
```

After:

```
Files:                         590
Lines of Library:            38118
Lines of Definitions:        77174
Lines of TypeScript:         12777
Lines of JavaScript:             0
Lines of JSON:                   0
Lines of Other:                  0
Identifiers:                113148
Symbols:                    362165
Types:                       78815
Instantiations:            1529661
Memory used:               327228K
Assignability cache size:   117510
Identity cache size:          3728
Subtype cache size:              0
Strict subtype cache size:  162006
I/O Read time:               0.07s
Parse time:                  0.52s
ResolveModule time:          0.10s
ResolveTypeReference time:   0.01s
ResolveLibrary time:         0.02s
Program time:                0.80s
Bind time:                   0.24s
Check time:                  5.59s
printTime time:              0.00s
Emit time:                   0.00s
Total time:                  6.63s
```
