### PR TITLE
fix: allow 'to' to be a string

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -242,12 +242,11 @@ export type ParamOptions<
       ? TToParams
       : MakeDifferenceOptional<TFromParams, TToParams>,
   TReducer = ParamsReducer<TFromParams, TRelativeToParams>,
-> =
-  Expand<WithoutEmpty<PickRequired<TRelativeToParams>>> extends never
-    ? Partial<MakeParamOption<TParamVariant, true | TReducer>>
-    : TFromParams extends Expand<WithoutEmpty<PickRequired<TRelativeToParams>>>
-      ? MakeParamOption<TParamVariant, true | TReducer>
-      : MakeParamOption<TParamVariant, TReducer>
+> = keyof PickRequired<TRelativeToParams> extends never
+  ? Partial<MakeParamOption<TParamVariant, true | TReducer>>
+  : TFromParams extends Expand<WithoutEmpty<PickRequired<TRelativeToParams>>>
+    ? MakeParamOption<TParamVariant, true | TReducer>
+    : MakeParamOption<TParamVariant, TReducer>
 
 type MakeParamOption<
   TParamVariant extends ParamVariant,

--- a/packages/react-router/src/routeInfo.ts
+++ b/packages/react-router/src/routeInfo.ts
@@ -25,7 +25,9 @@ export type RoutesByPath<TRouteTree extends AnyRoute> = {
 }
 
 export type RouteByPath<TRouteTree extends AnyRoute, TPath> = Extract<
-  RoutesByPath<TRouteTree>[TPath],
+  string extends TPath
+    ? ParseRoute<TRouteTree>
+    : RoutesByPath<TRouteTree>[TPath],
   AnyRoute
 >
 


### PR DESCRIPTION
- `Extract` would get a union of all routes when `string`. Keep the performance benefits but just return all routes if it is defaulted to a string
- I'm not sure if `ParamOptions` was handling if `TToParams` being a union of all params correctly as I was recieving issues where `search` was required where it should not have been