### PR TITLE
fix(router-devtools): non-nested usage of `TanStackRouterDevtools` and missing context with the usage of `TanStackRouterDevtoolsPanel`

### DIFF
--- a/packages/router-devtools/src/devtools.tsx
+++ b/packages/router-devtools/src/devtools.tsx
@@ -306,17 +306,21 @@ export function TanStackRouterDevtools({
 }
 
 function RouteComp({
+  router,
   route,
   isRoot,
   activeId,
   setActiveId,
 }: {
+  router: AnyRouter
   route: AnyRootRoute | AnyRoute
   isRoot?: boolean
   activeId: string | undefined
   setActiveId: (id: string) => void
 }) {
-  const routerState = useRouterState()
+  const routerState = useRouterState({
+    router,
+  } as any)
   const matches =
     routerState.status === 'pending'
       ? routerState.pendingMatches ?? []
@@ -368,7 +372,7 @@ function RouteComp({
             </code>
             <code className={getStyles().routeParamInfo}>{param}</code>
           </div>
-          <AgeTicker match={match} />
+          <AgeTicker match={match} router={router} />
         </div>
       </div>
       {(route.children as Route[])?.length ? (
@@ -380,6 +384,7 @@ function RouteComp({
             .map((r) => (
               <RouteComp
                 key={r.id}
+                router={router}
                 route={r}
                 activeId={activeId}
                 setActiveId={setActiveId}
@@ -597,6 +602,7 @@ export const TanStackRouterDevtoolsPanel = React.forwardRef<
           <div className={cx(getStyles().routesContainer)}>
             {!showMatches ? (
               <RouteComp
+                router={router}
                 route={router.routeTree}
                 isRoot
                 activeId={activeId}
@@ -629,7 +635,7 @@ export const TanStackRouterDevtoolsPanel = React.forwardRef<
                       <code
                         className={getStyles().matchID}
                       >{`${match.routeId === rootRouteId ? rootRouteId : match.pathname}`}</code>
-                      <AgeTicker match={match} />
+                      <AgeTicker match={match} router={router} />
                     </div>
                   )
                 })}
@@ -665,7 +671,7 @@ export const TanStackRouterDevtoolsPanel = React.forwardRef<
 
                     <code className={getStyles().matchID}>{`${match.id}`}</code>
 
-                    <AgeTicker match={match} />
+                    <AgeTicker match={match} router={router} />
                   </div>
                 )
               })}
@@ -758,9 +764,13 @@ export const TanStackRouterDevtoolsPanel = React.forwardRef<
   )
 })
 
-function AgeTicker({ match }: { match?: AnyRouteMatch }) {
-  const router = useRouter()
-
+function AgeTicker({
+  match,
+  router,
+}: {
+  match?: AnyRouteMatch
+  router: AnyRouter
+}) {
   const rerender = React.useReducer(
     () => ({}),
     () => ({}),

--- a/packages/router-devtools/src/devtools.tsx
+++ b/packages/router-devtools/src/devtools.tsx
@@ -253,7 +253,7 @@ export function TanStackRouterDevtools({
           onCloseClick: onCloseClick ?? (() => {}),
         }}
       >
-        <TanStackRouterDevtoolsPanel
+        <BaseTanStackRouterDevtoolsPanel
           ref={panelRef as any}
           {...otherPanelProps}
           router={router}
@@ -304,6 +304,21 @@ export function TanStackRouterDevtools({
     </Container>
   )
 }
+
+export const TanStackRouterDevtoolsPanel = React.forwardRef<
+  HTMLDivElement,
+  DevtoolsPanelOptions
+>(function TanStackRouterDevtoolsPanel(props, ref) {
+  return (
+    <DevtoolsOnCloseContext.Provider
+      value={{
+        onCloseClick: () => {},
+      }}
+    >
+      <BaseTanStackRouterDevtoolsPanel ref={ref} {...props} />
+    </DevtoolsOnCloseContext.Provider>
+  )
+})
 
 function RouteComp({
   router,
@@ -396,10 +411,10 @@ function RouteComp({
   )
 }
 
-export const TanStackRouterDevtoolsPanel = React.forwardRef<
+const BaseTanStackRouterDevtoolsPanel = React.forwardRef<
   HTMLDivElement,
   DevtoolsPanelOptions
->(function TanStackRouterDevtoolsPanel(props, ref): React.ReactElement {
+>(function BaseTanStackRouterDevtoolsPanel(props, ref): React.ReactElement {
   const {
     isOpen = true,
     setIsOpen,


### PR DESCRIPTION
This PR fixes two bugs.

1. Non-nested usage of the `TanStackRouterDevtools`.
This now works!
```tsx
const router = createRouter({ ... })

function App() {
  return (
    <RouterProivder router={router} />
    <TanStackRouterDevtools router={router} />
  )
}
```

2. Just the usage of the `TanStackRouterDevtoolsPanel` in general.
This no longer throws error because of the missing `DevtoolsOnCloseContext.Provider` as the component exposed to the user has a `no-op` function passed into the *Provider*.