### PR TITLE
fix: loosen strict check in `useMatch`

### DIFF
--- a/docs/framework/react/api/router/useMatchHook.md
+++ b/docs/framework/react/api/router/useMatchHook.md
@@ -3,7 +3,7 @@ id: useMatchHook
 title: useMatch hook
 ---
 
-The `useMatch` hook returns the closest [`RouteMatch`](./api/router/RouteMatchType) in the component tree. The raw route match contains all of the information about a route match in the router and also powers many other hooks under the hood like `useParams`, `useLoaderData`, `useRouteContext`, and `useSearch`.
+The `useMatch` hook returns a parent [`RouteMatch`](./api/router/RouteMatchType) in the component tree. The raw route match contains all of the information about a route match in the router and also powers many other hooks under the hood like `useParams`, `useLoaderData`, `useRouteContext`, and `useSearch`.
 
 ## useMatch options
 
@@ -12,7 +12,8 @@ The `useMatch` hook accepts a single argument, an `options` object.
 ### `opts.from` option
 
 - Type: `string`
-- The route id of the closest parent match
+- The route id of a parent match
+- The route id of the root route is `__root__`!
 - Optional, but recommended for full type safety.
 - If `opts.strict` is `true`, `from` is required and TypeScript will warn for this option if it is not provided.
 - If `opts.strict` is `false`, `from` must not be set and TypeScript will provided loosened types for the returned [`RouteMatch`](./api/router/RouteMatchType).

--- a/docs/framework/react/api/router/useMatchHook.md
+++ b/docs/framework/react/api/router/useMatchHook.md
@@ -13,7 +13,6 @@ The `useMatch` hook accepts a single argument, an `options` object.
 
 - Type: `string`
 - The route id of a match
-- The route id of the root route is `__root__`!
 - Optional, but recommended for full type safety.
 - If `opts.strict` is `true`, `from` is required and TypeScript will warn for this option if it is not provided.
 - If `opts.strict` is `false`, `from` must not be set and TypeScript will provided loosened types for the returned [`RouteMatch`](./api/router/RouteMatchType).
@@ -37,11 +36,26 @@ The `useMatch` hook accepts a single argument, an `options` object.
 
 ## Examples
 
+### accessing a route match
+
 ```tsx
 import { useMatch } from '@tanstack/react-router'
 
 function Component() {
-  const match = useMatch({ from: '/posts/$postId', strict: true })
+  const match = useMatch({ from: '/posts/$postId' })
+  //     ^? strict match for RouteMatch
+  // ...
+}
+```
+
+### accessing the root route's match
+
+```tsx
+import { useMatch } from '@tanstack/react-router'
+import { rootRouteId } from '@tanstack/react-router'
+
+function Component() {
+  const match = useMatch({ from: rootRouteId })
   //     ^? strict match for RouteMatch
   // ...
 }

--- a/docs/framework/react/api/router/useMatchHook.md
+++ b/docs/framework/react/api/router/useMatchHook.md
@@ -3,7 +3,7 @@ id: useMatchHook
 title: useMatch hook
 ---
 
-The `useMatch` hook returns a parent [`RouteMatch`](./api/router/RouteMatchType) in the component tree. The raw route match contains all of the information about a route match in the router and also powers many other hooks under the hood like `useParams`, `useLoaderData`, `useRouteContext`, and `useSearch`.
+The `useMatch` hook returns a [`RouteMatch`](./api/router/RouteMatchType) in the component tree. The raw route match contains all of the information about a route match in the router and also powers many other hooks under the hood like `useParams`, `useLoaderData`, `useRouteContext`, and `useSearch`.
 
 ## useMatch options
 
@@ -12,7 +12,7 @@ The `useMatch` hook accepts a single argument, an `options` object.
 ### `opts.from` option
 
 - Type: `string`
-- The route id of a parent match
+- The route id of a match
 - The route id of the root route is `__root__`!
 - Optional, but recommended for full type safety.
 - If `opts.strict` is `true`, `from` is required and TypeScript will warn for this option if it is not provided.

--- a/docs/framework/react/api/router/useMatchHook.md
+++ b/docs/framework/react/api/router/useMatchHook.md
@@ -51,8 +51,10 @@ function Component() {
 ### accessing the root route's match
 
 ```tsx
-import { useMatch } from '@tanstack/react-router'
-import { rootRouteId } from '@tanstack/react-router'
+import {
+  useMatch,
+  rootRouteId, // <<<< use this token!
+} from '@tanstack/react-router'
 
 function Component() {
   const match = useMatch({ from: rootRouteId })

--- a/packages/react-router/src/Matches.tsx
+++ b/packages/react-router/src/Matches.tsx
@@ -472,39 +472,7 @@ export function useMatch<
     select?: (match: TRouteMatchState) => TSelected
   },
 ): TSelected {
-  const router = useRouter()
   const nearestMatchId = React.useContext(matchContext)
-
-  const nearestMatchRouteId = getRenderedMatches(router.state).find(
-    (d) => d.id === nearestMatchId,
-  )?.routeId
-
-  const strict = opts?.strict ?? true
-
-  const matchRouteId = (() => {
-    const matches = getRenderedMatches(router.state)
-    const match = opts?.from
-      ? matches.find((d) => d.routeId === opts?.from)
-      : matches.find((d) => d.id === nearestMatchId)
-    return match?.routeId
-  })()
-
-  if (strict) {
-    invariant(
-      matchRouteId,
-      `No match found for route '${opts?.from}' while rendering the '${nearestMatchRouteId}' route. Did you mean to pass '{ strict: false }' instead?`,
-    )
-    invariant(
-      nearestMatchRouteId == matchRouteId,
-      `useMatch("${
-        matchRouteId as string
-      }") is being called in a component that is meant to render the '${nearestMatchRouteId}' route. Did you mean to 'useMatch("${
-        matchRouteId as string
-      }", { strict: false })' or 'useRoute("${
-        matchRouteId as string
-      }")' instead?`,
-    )
-  }
 
   const matchSelection = useRouterState({
     select: (state) => {


### PR DESCRIPTION
allows any currently rendered match to be retrieved