### PR TITLE
docs: remove references to `@tanstack/loaders`

### DIFF
--- a/docs/framework/react/guide/external-data-loading.md
+++ b/docs/framework/react/guide/external-data-loading.md
@@ -15,7 +15,6 @@ Router is designed to be a perfect **coordinator** for external data fetching an
 
 Any data fetching library that supports asynchronous promises can be used with TanStack Router. This includes:
 
-- [TanStack Loaders](#tanstack-loaders)
 - [TanStack Query](https://tanstack.com/query/latest/docs/react/overview)
 - [SWR](https://swr.vercel.app/)
 - [RTK Query](https://redux-toolkit.js.org/rtk-query/overview)

--- a/docs/framework/react/guide/navigation.md
+++ b/docs/framework/react/guide/navigation.md
@@ -362,7 +362,7 @@ const link = (
 
 With preloading enabled and relatively quick asynchronous route dependencies (if any), this simple trick can increase the perceived performance of your application with very little effort.
 
-What's even better is that by using a cache-first library like `@tanstack/loaders` or `@tanstack/query`, preloaded routes will stick around and be ready for a stale-while-revalidate experience if the user decides to navigate to the route later on.
+What's even better is that by using a cache-first library like `@tanstack/query`, preloaded routes will stick around and be ready for a stale-while-revalidate experience if the user decides to navigate to the route later on.
 
 ### Link Preloading Timeout
 


### PR DESCRIPTION
Removed references in the docs to TanStack Loaders (`@tanstack/loaders`) since we don't publish this package anymore for use with Router, and have the user rely on either the built-in loaders or external libraries like TanStack Query. 