### PR TITLE
fix: make restKey reactive

### DIFF
--- a/packages/react-router/src/Matches.tsx
+++ b/packages/react-router/src/Matches.tsx
@@ -89,10 +89,14 @@ export function Matches() {
     },
   })
 
+  const resetKey = useRouterState({
+    select: (s) => s.resolvedLocation.state?.key!,
+  })
+
   return (
     <matchContext.Provider value={matchId}>
       <CatchBoundary
-        getResetKey={() => router.state.resolvedLocation.state?.key!}
+        getResetKey={() => resetKey}
         errorComponent={ErrorComponent}
         onCatch={(error) => {
           warning(
@@ -159,11 +163,15 @@ export function Match({ matchId }: { matchId: string }) {
     ? CatchNotFound
     : SafeFragment
 
+  const resetKey = useRouterState({
+    select: (s) => s.resolvedLocation.state?.key!,
+  })
+
   return (
     <matchContext.Provider value={matchId}>
       <ResolvedSuspenseBoundary fallback={pendingElement}>
         <ResolvedCatchBoundary
-          getResetKey={() => router.state.resolvedLocation.state?.key!}
+          getResetKey={() => resetKey}
           errorComponent={routeErrorComponent}
           onCatch={(error) => {
             // Forward not found errors (we don't want to show the error component for these)


### PR DESCRIPTION
accessing `router.state` is an imperative way of reading something from the router - it does not re-render the component; with this fix, we will always re-render the match if the `resetKey` changes, so that the `CatchBoundary` can reset accordingly.

This should fix cases where navigating away from a route did not reset errors correctly

fixes #1127
fixes #1348