### PR TITLE
fix: show pending component for routes with a loader

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1496,6 +1496,7 @@ export class Router<
 
           const shouldPending =
             !preload &&
+            route.options.loader &&
             typeof pendingMs === 'number' &&
             (route.options.pendingComponent ??
               this.options.defaultPendingComponent)


### PR DESCRIPTION
The default pending component was popping up in routes without loader in the case when `pendingMs` [was evaluated as a number <= 0](https://github.com/TanStack/router/blob/main/packages/react-router/src/router.ts#L1239-L1240).

Since [these were met](https://github.com/TanStack/router/blob/main/packages/react-router/src/router.ts#L1499-L1501) in case @TkDodo outlined and the [`pendingPromise`](https://github.com/TanStack/router/blob/main/packages/react-router/src/router.ts#L1506) is indeed a promise in the [<= 0 number case](https://github.com/TanStack/router/blob/main/packages/react-router/src/router.ts#L1243), we observed the pending state.

Checking if route actually has a loader should fix it.

fixes #1349 

