### PR TITLE
feat(router-generator): add option to format with semicolons in the generated route-tree

### DIFF
--- a/docs/framework/react/guide/file-based-routing.md
+++ b/docs/framework/react/guide/file-based-routing.md
@@ -99,6 +99,8 @@ The following options are available for configuration via the `tsr.config.json` 
   - (Required) The path to the file where the generated route tree will be saved, relative to the cwd.
 - **`quoteStyle`**
   - (Optional, **Defaults to `single`**) whether to use `single` or `double` quotes when formatting the generated route tree file.`
+- **`semicolons`**
+  - (Optional, **Defaults to `false`**) whether to use semicolons in the generated route tree file.
 - **`disableTypes`**
   - (Optional, **Defaults to `false`**) whether to disable generating types for the route tree
   - If set to `true`, the generated route tree will not include any types.

--- a/packages/router-generator/src/config.ts
+++ b/packages/router-generator/src/config.ts
@@ -9,6 +9,7 @@ export const configSchema = z.object({
   routesDirectory: z.string().optional().default('./src/routes'),
   generatedRouteTree: z.string().optional().default('./src/routeTree.gen.ts'),
   quoteStyle: z.enum(['single', 'double']).optional().default('single'),
+  semicolons: z.boolean().optional().default(false),
   disableTypes: z.boolean().optional().default(false),
   addExtensions: z.boolean().optional().default(false),
   disableLogging: z.boolean().optional().default(false),

--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -609,7 +609,7 @@ export async function generator(config: Config) {
     .join('\n\n')
 
   const routeConfigFileContent = await prettier.format(routeImports, {
-    semi: false,
+    semi: config.semicolons,
     singleQuote: config.quoteStyle === 'single',
     parser: 'typescript',
   })


### PR DESCRIPTION
Accepts a `semicolon` property as part of the config that is used in the `router-generator` to format the generated `routeTree.gen.ts` with or without semicolons.

The *default* for the `semicolon` configuration property will be `false` (as it is currently).

Closes #1375 