### PR TITLE
feat(router-vite-plugin): trigger the route-tree generation using `watchChange` hook

### DIFF
--- a/packages/router-vite-plugin/src/index.ts
+++ b/packages/router-vite-plugin/src/index.ts
@@ -37,9 +37,6 @@ export function TanStackRouterVite(inlineConfig: Partial<Config> = {}): Plugin {
       userConfig = await getConfig(inlineConfig, ROOT)
       await generate()
     },
-    handleHotUpdate: async ({ file }) => {
-      await handleFile(file)
-    },
     watchChange: async (file, context) => {
       if (['create', 'update', 'delete'].includes(context.event)) {
         await handleFile(file)

--- a/packages/router-vite-plugin/src/index.ts
+++ b/packages/router-vite-plugin/src/index.ts
@@ -17,6 +17,20 @@ export function TanStackRouterVite(inlineConfig: Partial<Config> = {}): Plugin {
     }
   }
 
+  const handleFile = async (file: string) => {
+    const filePath = normalize(file)
+    if (filePath === join(ROOT, CONFIG_FILE_NAME)) {
+      userConfig = await getConfig(inlineConfig, ROOT)
+      return
+    }
+    const routesDirectoryPath = isAbsolute(userConfig.routesDirectory)
+      ? userConfig.routesDirectory
+      : join(ROOT, userConfig.routesDirectory)
+    if (filePath.startsWith(routesDirectoryPath)) {
+      await generate()
+    }
+  }
+
   return {
     name: 'vite-plugin-tanstack-router',
     configResolved: async () => {
@@ -24,17 +38,10 @@ export function TanStackRouterVite(inlineConfig: Partial<Config> = {}): Plugin {
       await generate()
     },
     handleHotUpdate: async ({ file }) => {
-      const filePath = normalize(file)
-      if (filePath === join(ROOT, CONFIG_FILE_NAME)) {
-        userConfig = await getConfig(inlineConfig, ROOT)
-        return
-      }
-      const routesDirectoryPath = isAbsolute(userConfig.routesDirectory)
-        ? userConfig.routesDirectory
-        : join(ROOT, userConfig.routesDirectory)
-      if (filePath.startsWith(routesDirectoryPath)) {
-        await generate()
-      }
+      await handleFile(file)
+    },
+    watchChange: async (file) => {
+      await handleFile(file)
     },
   }
 }

--- a/packages/router-vite-plugin/src/index.ts
+++ b/packages/router-vite-plugin/src/index.ts
@@ -40,8 +40,10 @@ export function TanStackRouterVite(inlineConfig: Partial<Config> = {}): Plugin {
     handleHotUpdate: async ({ file }) => {
       await handleFile(file)
     },
-    watchChange: async (file) => {
-      await handleFile(file)
+    watchChange: async (file, context) => {
+      if (['create', 'update', 'delete'].includes(context.event)) {
+        await handleFile(file)
+      }
     },
   }
 }


### PR DESCRIPTION
Something I've noticed, as stated in [this comment](https://github.com/TanStack/router/issues/1312#issuecomment-1999304792), is that the `router-vite-plugin` doesn't actually perform the whole route-tree generation process on file create and delete events.
* On create: You need to create the file, and then save it, to have the plugin actually do anything.
* On delete: You need to delete the file, and then go to another file and hit *save*, to have the plugin do anything.

This change uses the `watchChange` hook to trigger the route-tree generation process based on `create`, `update`, and `delete` events.
