### PR TITLE
docs: add reference pages for `createLazyFileRoute` and `createLazyRoute`

### DIFF
--- a/docs/framework/react/api/router.md
+++ b/docs/framework/react/api/router.md
@@ -9,6 +9,7 @@ title: Router API
   - [`createRootRoute`](./api/router/createRootRouteFunction)
   - [`createRootRouteWithContext`](./api/router/createRootRouteWithContextFunction)
   - [`createRoute`](./api/router/createRouteFunction)
+  - [`createLazyRoute`](./api/router/createLazyRouteFunction)
   - [`createRouteMask`](./api/router/createRouteMaskFunction)
   - [`createRouter`](./api/router/createRouterFunction)
   - [`defer`](./api/router/deferFunction)

--- a/docs/framework/react/api/router.md
+++ b/docs/framework/react/api/router.md
@@ -5,6 +5,7 @@ title: Router API
 
 - Functions
   - [`createFileRoute`](./api/router/createFileRouteFunction)
+  - [`createLazyFileRoute`](./api/router/createLazyFileRouteFunction)
   - [`createRootRoute`](./api/router/createRootRouteFunction)
   - [`createRootRouteWithContext`](./api/router/createRootRouteWithContextFunction)
   - [`createRoute`](./api/router/createRouteFunction)

--- a/docs/framework/react/api/router/createLazyFileRouteFunction.md
+++ b/docs/framework/react/api/router/createLazyFileRouteFunction.md
@@ -17,7 +17,7 @@ The `createLazyFileRoute` function accepts a single argument of type `string` th
 
 ### createLazyFileRoute returns
 
-The `createLazyFileRoute` function a partial of the [`FileRoute`](./api/router/LazyFileRouteClass) instance, only letting you configure the non-critical parts of the route.
+The `createLazyFileRoute` function a partial of the [`FileRoute`](./api/router/FileRouteClass) instance, only letting you configure the non-critical parts of the route.
 
 #### `component`
 

--- a/docs/framework/react/api/router/createLazyFileRouteFunction.md
+++ b/docs/framework/react/api/router/createLazyFileRouteFunction.md
@@ -11,7 +11,7 @@ The `createLazyFileRoute` function accepts a single argument of type `string` th
 
 ### `path`
 
-- Type: `string` literal
+- Type: `string`
 - Required, but **automatically inserted and updated by the `tsr generate` and `tsr watch` commands**
 - The full path of the file that the route will be generated from.
 

--- a/docs/framework/react/api/router/createLazyFileRouteFunction.md
+++ b/docs/framework/react/api/router/createLazyFileRouteFunction.md
@@ -1,0 +1,57 @@
+---
+id: createLazyFileRouteFunction
+title: createLazyFileRoute function
+---
+
+The `createLazyFileRoute` function is used for creating a partial file-based route route instance that is lazily loaded when matched. This route instance can only be used to configure the [non-critical properties](./guide/code-splitting#how-does-tanstack-router-split-code) of the route, such as `component`, `pendingComponent`, `errorComponent`, and the `notFoundComponent`.
+
+## createLazyFileRoute options
+
+The `createLazyFileRoute` function accepts a single argument of type `string` that represents the `path` of the file that the route will be generated from.
+
+### `path`
+
+- Type: `string` literal
+- Required, but **automatically inserted and updated by the `tsr generate` and `tsr watch` commands**
+- The full path of the file that the route will be generated from.
+
+### createLazyFileRoute returns
+
+The `createLazyFileRoute` function a partial of the [`FileRoute`](./api/router/LazyFileRouteClass) instance, only letting you configure the non-critical parts of the route.
+
+#### `component`
+
+- Type: `RouteComponent`
+- The component to render when the route is matched.
+
+#### `pendingComponent`
+
+- Type: `RouteComponent`
+- The component to render while the route is loading.
+
+#### `errorComponent`
+
+- Type: `ErrorRouteComponent`
+- The component to render when an error has been thrown by the router for the route.
+
+#### `notFoundComponent`
+
+- Type: `NotFoundRouteComponent`
+- The component to render when the route is not found.
+
+> ⚠️ Note: For `tsr generate` and `tsr watch` to work properly, the file route instance must be exported from the file using the `Route` identifier.
+
+### Examples
+
+```tsx
+import { createLazyFileRoute } from '@tanstack/react-router'
+
+export const Route = createLazyFileRoute('/')({
+  component: IndexComponent,
+})
+
+function IndexComponent() {
+  const data = Route.useLoaderData()
+  return <div>{data}</div>
+}
+```

--- a/docs/framework/react/api/router/createLazyFileRouteFunction.md
+++ b/docs/framework/react/api/router/createLazyFileRouteFunction.md
@@ -17,7 +17,7 @@ The `createLazyFileRoute` function accepts a single argument of type `string` th
 
 ### createLazyFileRoute returns
 
-The `createLazyFileRoute` function a partial of the [`FileRoute`](./api/router/FileRouteClass) instance, only letting you configure the non-critical parts of the route.
+The `createLazyFileRoute` function a partial set of configuration options of the [`createFileRoute`](./api/router/createFileRouteFunction) function, only letting you configure the non-critical parts of the route.
 
 #### `component`
 

--- a/docs/framework/react/api/router/createLazyRouteFunction.md
+++ b/docs/framework/react/api/router/createLazyRouteFunction.md
@@ -1,0 +1,80 @@
+---
+id: createLazyRouteFunction
+title: createLazyRoute function
+---
+
+The `createLazyRoute` function is used for creating a partial code-based route route instance that is lazily loaded when matched. This route instance can only be used to configure the [non-critical properties](./guide/code-splitting#how-does-tanstack-router-split-code) of the route, such as `component`, `pendingComponent`, `errorComponent`, and the `notFoundComponent`.
+
+## createLazyRoute options
+
+The `createLazyRoute` function accepts a single argument of type `string` that represents the `id` of the route.
+
+### `id`
+
+- Type: `string`
+- Required
+- The route id of the route.
+
+### createLazyRoute returns
+
+The `createLazyRoute` function a partial set of the configuration options of [`createRoute`](./api/router/createRouteFunction) function, only letting you configure the non-critical parts of the route.
+
+#### `component`
+
+- Type: `RouteComponent`
+- The component to render when the route is matched.
+
+#### `pendingComponent`
+
+- Type: `RouteComponent`
+- The component to render while the route is loading.
+
+#### `errorComponent`
+
+- Type: `ErrorRouteComponent`
+- The component to render when an error has been thrown by the router for the route.
+
+#### `notFoundComponent`
+
+- Type: `NotFoundRouteComponent`
+- The component to render when the route is not found.
+
+> ⚠️ Note: This route instance must be manually lazily loaded against its critical route instance using the `lazy` method returned by the `createRoute` function.
+
+### Examples
+
+```tsx
+// src/route-pages/index.tsx
+import { createLazyRoute } from '@tanstack/react-router'
+
+export const Route = createLazyRoute('/')({
+  component: IndexComponent,
+})
+
+function IndexComponent() {
+  const data = Route.useLoaderData()
+  return <div>{data}</div>
+}
+
+// src/routeTree.tsx
+import {
+  createRootRouteWithContext,
+  createRoute,
+  Outlet,
+} from '@tanstack/react-router'
+
+interface MyRouterContext {
+  foo: string
+}
+
+const rootRoute = createRootRouteWithContext<MyRouterContext>()({
+  component: () => <Outlet />,
+})
+
+const indexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/',
+}).lazy(() => import('./route-pages/index').then((d) => d.Route))
+
+export const routeTree = rootRoute.addChildren([indexRoute])
+```


### PR DESCRIPTION
Closes #1231 