### PR TITLE
fix: prevent props being populated with undefined or empty values

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -409,7 +409,7 @@ export function useLinkProps<
   // null for LinkUtils
 
   const dest = {
-    from: options.to ? matchPathname : undefined,
+    ...(options.to && { from: matchPathname }),
     ...options,
   }
 
@@ -548,6 +548,20 @@ export function useLinkProps<
   const resolvedInactiveProps: React.HTMLAttributes<HTMLAnchorElement> =
     isActive ? {} : functionalUpdate(inactiveProps, {})
 
+  const resolvedClassName = [
+    className,
+    resolvedActiveProps.className,
+    resolvedInactiveProps.className,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  const resolvedStyle = {
+    ...style,
+    ...resolvedActiveProps.style,
+    ...resolvedInactiveProps.style,
+  }
+
   return {
     ...resolvedActiveProps,
     ...resolvedInactiveProps,
@@ -563,26 +577,13 @@ export function useLinkProps<
     onMouseLeave: composeHandlers([onMouseLeave, handleLeave]),
     onTouchStart: composeHandlers([onTouchStart, handleTouchStart]),
     target,
-    style: {
-      ...style,
-      ...resolvedActiveProps.style,
-      ...resolvedInactiveProps.style,
-    },
-    className:
-      [
-        className,
-        resolvedActiveProps.className,
-        resolvedInactiveProps.className,
-      ]
-        .filter(Boolean)
-        .join(' ') || undefined,
-    ...(disabled
-      ? {
-          role: 'link',
-          'aria-disabled': true,
-        }
-      : undefined),
-    ['data-status']: isActive ? 'active' : undefined,
+    ...(Object.keys(resolvedStyle).length && { style: resolvedStyle }),
+    ...(resolvedClassName && { className: resolvedClassName }),
+    ...(disabled && {
+      role: 'link',
+      'aria-disabled': true,
+    }),
+    ...(isActive && { 'data-status': 'active' }),
   }
 }
 


### PR DESCRIPTION
When customising `Link` using `createLink` some props are set to undefined or an empty object.

When deconstructing these into the component they overwrite any props set by the component (as intended, if the props were actually set by the consumer).

eg the className set in the example below is overwritten with undefined from the props.

```
const MyStyledRouterLink = createLink(MyStyledLink);

function MyStyledLink({ children, ...props }: React.ComponentProps<"a">) {
  return (
    <a className="foo-bar" {...props}>
      {children}
    </a>
  );
}
```

This PR contains a new example which can be removed if desired once the issue & fixed are confirmed.