### PR TITLE
docs: improve links to not found pages

### DIFF
--- a/docs/framework/react/guide/code-based-routing.md
+++ b/docs/framework/react/guide/code-based-routing.md
@@ -12,7 +12,7 @@ title: Code-Based Routing
 
 Code-based routing is no different from file-based routing in that it uses the same route tree concept to organize, match and compose matching routes into a component tree. The only difference is that instead of using the filesystem to organize your routes, you use code.
 
-Let's consider the same route tree from the [File-Based Routing](./guide/file-based-routing) guide, but from a code-based perspective:
+Let's consider the same route tree from the [Route Trees & Nesting](./guide/route-trees#route-trees) guide, but from a code-based perspective:
 
 - _Root_
   - `/`
@@ -276,4 +276,4 @@ const routeTree = rootRoute.addChildren([
 
 ## 404 / `NotFoundRoute`s
 
-We'll cover how to configure a `NotFoundRoute` in the [Route Matching - Not-Found Routes](./guide/route-matching#not-found-routes) guide.
+We'll cover how to configure a `NotFoundRoute` in the [Not Found Errors](./guide/not-found-errors) guide.

--- a/docs/framework/react/guide/route-matching.md
+++ b/docs/framework/react/guide/route-matching.md
@@ -99,3 +99,5 @@ During matching, [pathless routes](./guide/route-trees#pathless-routes) are trea
 ## `NotFoundRoute`s and Matching
 
 If you choose to configure a `NotFoundRoute` for your router, it should be passed to the `notFoundRoute` option and not as part of your `routeTree`. This is because `NotFoundRoute`s are not considered during matching and only render as a fallback when no other suitable match is found.
+
+You can read more about `NotFoundRoute`s in the [Not Found Errors](./guide/not-found-errors) guide.


### PR DESCRIPTION
Hey! I'd like to suggest three changes which I think can improve the reading flow in the docs.

Code Based was pointing to File based saying "consider the same route tree" but there's no route tree on that page, it's on Route Trees & Nesting.

Same for the NotFound explanation, it's no longer in Route Matching but has a dedicated page so it's probably better to redirect the reader there.