### PR TITLE
fix(react-router-server): do not spread a `key` prop inside the `<Asset>` component

### DIFF
--- a/packages/react-router-server/src/client/Meta.tsx
+++ b/packages/react-router-server/src/client/Meta.tsx
@@ -7,29 +7,6 @@ import * as React from 'react'
 import { Asset } from './Asset'
 import type { RouterManagedTag } from './RouterManagedTag'
 
-function getMetaKey(asset: RouterManagedTag, index: number) {
-  if (asset.tag === 'title') {
-    return `tsr-meta-title-${index}`
-  }
-
-  if (asset.tag === 'meta') {
-    const ident = [
-      asset.attrs.name,
-      asset.attrs.content,
-      asset.attrs.httpEquiv,
-      asset.attrs.charSet,
-    ].join('')
-    return `tsr-meta-meta-${ident || index}`
-  }
-
-  if (asset.tag === 'link') {
-    const ident = [asset.attrs.rel, asset.attrs.href].join('')
-    return `tsr-meta-link-${ident || index}`
-  }
-
-  return `tsr-meta-${asset.tag}-${index}`
-}
-
 export const Meta = () => {
   const router = useRouter()
 
@@ -103,7 +80,7 @@ export const Meta = () => {
   return (
     <>
       {[...meta, ...links, ...manifestMeta].map((asset, i) => (
-        <Asset {...asset} key={getMetaKey(asset, i)} />
+        <Asset {...asset} key={`tsr-meta-${asset.tag}-${i}`} />
       ))}
     </>
   )

--- a/packages/react-router-server/src/client/Meta.tsx
+++ b/packages/react-router-server/src/client/Meta.tsx
@@ -44,7 +44,6 @@ export const Meta = () => {
             tag: 'meta',
             attrs: {
               ...m,
-              key: `meta-${[m.name, m.content, m.httpEquiv, m.charSet].join('')}`,
             },
           })
         }
@@ -70,7 +69,6 @@ export const Meta = () => {
           tag: 'link',
           attrs: {
             ...link,
-            key: `link-${[link.rel, link.href].join('')}`,
           },
         })) as Array<RouterManagedTag>,
   })
@@ -82,7 +80,7 @@ export const Meta = () => {
   return (
     <>
       {[...meta, ...links, ...manifestMeta].map((asset, i) => (
-        <Asset {...asset} key={i} />
+        <Asset {...asset} key={`tsr-meta-${asset.tag}-${i}`} />
       ))}
     </>
   )

--- a/packages/react-router-server/src/client/Meta.tsx
+++ b/packages/react-router-server/src/client/Meta.tsx
@@ -7,6 +7,29 @@ import * as React from 'react'
 import { Asset } from './Asset'
 import type { RouterManagedTag } from './RouterManagedTag'
 
+function getMetaKey(asset: RouterManagedTag, index: number) {
+  if (asset.tag === 'title') {
+    return `tsr-meta-title`
+  }
+
+  if (asset.tag === 'meta') {
+    const ident = [
+      asset.attrs.name,
+      asset.attrs.content,
+      asset.attrs.httpEquiv,
+      asset.attrs.charSet,
+    ].join('')
+    return `tsr-meta-meta-${ident}`
+  }
+
+  if (asset.tag === 'link') {
+    const ident = [asset.attrs.rel, asset.attrs.href].join('')
+    return `tsr-meta-link-${ident}`
+  }
+
+  return `tsr-meta-${asset.tag}-${index}`
+}
+
 export const Meta = () => {
   const router = useRouter()
 
@@ -80,7 +103,7 @@ export const Meta = () => {
   return (
     <>
       {[...meta, ...links, ...manifestMeta].map((asset, i) => (
-        <Asset {...asset} key={`tsr-meta-${asset.tag}-${i}`} />
+        <Asset {...asset} key={getMetaKey(asset, i)} />
       ))}
     </>
   )

--- a/packages/react-router-server/src/client/Meta.tsx
+++ b/packages/react-router-server/src/client/Meta.tsx
@@ -9,7 +9,7 @@ import type { RouterManagedTag } from './RouterManagedTag'
 
 function getMetaKey(asset: RouterManagedTag, index: number) {
   if (asset.tag === 'title') {
-    return `tsr-meta-title`
+    return `tsr-meta-title-${index}`
   }
 
   if (asset.tag === 'meta') {
@@ -19,12 +19,12 @@ function getMetaKey(asset: RouterManagedTag, index: number) {
       asset.attrs.httpEquiv,
       asset.attrs.charSet,
     ].join('')
-    return `tsr-meta-meta-${ident}`
+    return `tsr-meta-meta-${ident || index}`
   }
 
   if (asset.tag === 'link') {
     const ident = [asset.attrs.rel, asset.attrs.href].join('')
-    return `tsr-meta-link-${ident}`
+    return `tsr-meta-link-${ident || index}`
   }
 
   return `tsr-meta-${asset.tag}-${index}`

--- a/packages/react-router-server/src/client/Scripts.tsx
+++ b/packages/react-router-server/src/client/Scripts.tsx
@@ -27,7 +27,6 @@ export const Scripts = () => {
           attrs: {
             ...script,
             suppressHydrationWarning: true,
-            key: `script-${script.src}`,
           },
           children,
         })),
@@ -40,7 +39,7 @@ export const Scripts = () => {
     <>
       <DehydrateRouter />
       {allScripts.map((asset, i) => (
-        <Asset {...asset} key={i} />
+        <Asset {...asset} key={`tsr-scripts-${asset.tag}-${i}`} />
       ))}
     </>
   )

--- a/packages/react-router-server/src/client/Scripts.tsx
+++ b/packages/react-router-server/src/client/Scripts.tsx
@@ -8,13 +8,6 @@ import { DehydrateRouter } from './DehydrateRouter'
 import { Asset } from './Asset'
 import type { RouterManagedTag } from './RouterManagedTag'
 
-function getScriptKey(src: string, index: number) {
-  if (!src) {
-    return `tsr-scripts-${index}`
-  }
-  return `tsr-scripts-${src}`
-}
-
 export const Scripts = () => {
   const router = useRouter()
 
@@ -46,7 +39,7 @@ export const Scripts = () => {
     <>
       <DehydrateRouter />
       {allScripts.map((asset, i) => (
-        <Asset {...asset} key={getScriptKey(asset.attrs?.src || '', i)} />
+        <Asset {...asset} key={`tsr-scripts-${asset.tag}-${i}`} />
       ))}
     </>
   )

--- a/packages/react-router-server/src/client/Scripts.tsx
+++ b/packages/react-router-server/src/client/Scripts.tsx
@@ -8,6 +8,13 @@ import { DehydrateRouter } from './DehydrateRouter'
 import { Asset } from './Asset'
 import type { RouterManagedTag } from './RouterManagedTag'
 
+function getScriptKey(src: string, index: number) {
+  if (!src) {
+    return `tsr-scripts-${index}`
+  }
+  return `tsr-scripts-${src}`
+}
+
 export const Scripts = () => {
   const router = useRouter()
 
@@ -39,7 +46,7 @@ export const Scripts = () => {
     <>
       <DehydrateRouter />
       {allScripts.map((asset, i) => (
-        <Asset {...asset} key={`tsr-scripts-${asset.tag}-${i}`} />
+        <Asset {...asset} key={getScriptKey(asset.attrs?.src || '', i)} />
       ))}
     </>
   )


### PR DESCRIPTION
The props/attrs being spread into the `<Asset>` component of the `@tanstack/react-router-server` package contains a `key` attribute which when spread goes against how React expects that attribute to be used.

This sets the key to the asset component itself at render.

Could look at further optimization to not rely on the array index position, rather to be calculated based on the individual identifiable values.

Closes #1138 