### PR TITLE
Update quick-start.md to include installation of devtools

### DIFF
--- a/docs/framework/react/quick-start.md
+++ b/docs/framework/react/quick-start.md
@@ -10,10 +10,10 @@ File based route generation (via Vite) is the recommended way to use TanStack Ro
 
 > 🧠 You can also use the Router CLI (the `tsr` binary) to generate routes if you are unable to use Vite. See [File-Based Routing](./guide/file-based-routing) for more info.
 
-### Install the Vite Plugin
+### Install the Vite Plugin and the Router Devtools
 
 ```bash
-npm install --save-dev @tanstack/router-vite-plugin
+npm install --save-dev @tanstack/router-vite-plugin @tanstack/router-devtools
 ```
 
 ### Configure the Vite Plugin


### PR DESCRIPTION
A developer following the Quick Start as it is currently written will run into an error when they create the first file, `src/routes/__root.tsx`:

```
Cannot find module '@tanstack/router-devtools' or its corresponding type declarations.ts(2307)
```

This is because the Quick Start does not instruct the reader to install this package anywhere in the guide. Many developers will understand that the package is missing from their project, and will install it on their own, but the lack of explicitness could discourage those with less experience or those for whom English is not their native language.