### PR TITLE
fix(react-router): incorrectly splitting the key-values pairs from the querystring

### DIFF
--- a/packages/react-router/src/qss.ts
+++ b/packages/react-router/src/qss.ts
@@ -2,6 +2,17 @@
 
 // qss has been slightly modified and inlined here for our use cases (and compression's sake). We've included it as a hard dependency for MIT license attribution.
 
+/**
+ * Encodes an object into a query string.
+ * @param obj - The object to encode into a query string.
+ * @param [pfx] - An optional prefix to add before the query string.
+ * @returns The encoded query string.
+ * @example
+ * ```
+ * // Example input: encode({ token: 'foo', key: 'value' })
+ * // Expected output: "token=foo&key=value"
+ * ```
+ */
 export function encode(obj, pfx?: string) {
   let k,
     i,
@@ -25,6 +36,14 @@ export function encode(obj, pfx?: string) {
   return (pfx || '') + str
 }
 
+/**
+ * Converts a string value to its appropriate type (string, number, boolean).
+ * @param mix - The string value to convert.
+ * @returns The converted value.
+ * @example
+ * // Example input: toValue("123")
+ * // Expected output: 123
+ */
 function toValue(mix) {
   if (!mix) return ''
   const str = decodeURIComponent(mix)
@@ -33,6 +52,15 @@ function toValue(mix) {
   return +str * 0 === 0 && +str + '' === str ? +str : str
 }
 
+/**
+ * Decodes a query string into an object.
+ * @param str - The query string to decode.
+ * @param [pfx] - An optional prefix to filter out from the query string.
+ * @returns The decoded key-value pairs in an object format.
+ * @example
+ * // Example input: decode("token=foo&key=value")
+ * // Expected output: { "token": "foo", "key": "value" }
+ */
 export function decode(str, pfx?: string) {
   let tmp, k
   const out = {},

--- a/packages/react-router/src/qss.ts
+++ b/packages/react-router/src/qss.ts
@@ -39,12 +39,18 @@ export function decode(str, pfx?: string) {
     arr = (pfx ? str.substr(pfx.length) : str).split('&')
 
   while ((tmp = arr.shift())) {
-    tmp = tmp.split('=')
-    k = tmp.shift()
-    if (out[k] !== void 0) {
-      out[k] = [].concat(out[k], toValue(tmp.shift()))
+    const equalIndex = tmp.indexOf('=')
+    if (equalIndex !== -1) {
+      k = tmp.slice(0, equalIndex)
+      const value = tmp.slice(equalIndex + 1)
+      if (out[k] !== void 0) {
+        out[k] = [].concat(out[k], toValue(value))
+      } else {
+        out[k] = toValue(value)
+      }
     } else {
-      out[k] = toValue(tmp.shift())
+      k = tmp
+      out[k] = ''
     }
   }
 

--- a/packages/react-router/tests/qss.test.ts
+++ b/packages/react-router/tests/qss.test.ts
@@ -9,11 +9,11 @@ describe('encode function', () => {
     expect(queryString).toEqual('token=foo&key=value')
   })
 
-  // it('should encode an object into a query string with a prefix', () => {
-  //   const obj = { token: 'foo', key: 'value' }
-  //   const queryString = encode(obj, 'prefix_')
-  //   expect(queryString).toEqual('prefix_token=foo&prefix_key=value')
-  // })
+  it('should encode an object into a query string with a prefix', () => {
+    const obj = { token: 'foo', key: 'value' }
+    const queryString = encode(obj, 'prefix_/*&?')
+    expect(queryString).toEqual('prefix_/*&?token=foo&key=value')
+  })
 
   it('should handle encoding an object with empty values and trailing equal signs', () => {
     const obj = { token: '', key: 'value=' }
@@ -41,11 +41,11 @@ describe('decode function', () => {
     expect(decodedObj).toEqual({ token: 'foo', key: 'value' })
   })
 
-  // it('should decode a query string with a prefix', () => {
-  //   const queryString = 'prefix_token=foo&prefix_key=value'
-  //   const decodedObj = decode(queryString, 'prefix_')
-  //   expect(decodedObj).toEqual({ token: 'foo', key: 'value' })
-  // })
+  it('should decode a query string with a prefix', () => {
+    const queryString = 'prefix_/*&?token=foo&key=value'
+    const decodedObj = decode(queryString, 'prefix_/*&?')
+    expect(decodedObj).toEqual({ token: 'foo', key: 'value' })
+  })
 
   it('should handle missing values and trailing equal signs', () => {
     const queryString = 'token=&key=value='

--- a/packages/react-router/tests/qss.test.ts
+++ b/packages/react-router/tests/qss.test.ts
@@ -1,0 +1,67 @@
+/* eslint-disable */
+import { describe, it, expect } from 'vitest'
+import { encode, decode } from '../src/qss'
+
+describe('encode function', () => {
+  it('should encode an object into a query string without a prefix', () => {
+    const obj = { token: 'foo', key: 'value' }
+    const queryString = encode(obj)
+    expect(queryString).toEqual('token=foo&key=value')
+  })
+
+  // it('should encode an object into a query string with a prefix', () => {
+  //   const obj = { token: 'foo', key: 'value' }
+  //   const queryString = encode(obj, 'prefix_')
+  //   expect(queryString).toEqual('prefix_token=foo&prefix_key=value')
+  // })
+
+  it('should handle encoding an object with empty values and trailing equal signs', () => {
+    const obj = { token: '', key: 'value=' }
+    const queryString = encode(obj)
+    expect(queryString).toEqual('token=&key=value=%3D') // token=&key=value=
+  })
+
+  it('should handle encoding an object with array values', () => {
+    const obj = { token: ['foo', 'bar'], key: 'value' }
+    const queryString = encode(obj)
+    expect(queryString).toEqual('token=foo&token=bar&key=value')
+  })
+
+  it('should handle encoding an object with special characters', () => {
+    const obj = { token: 'foo?', key: 'value=' }
+    const queryString = encode(obj)
+    expect(queryString).toEqual('token=foo%3F&key=value%3D')
+  })
+})
+
+describe('decode function', () => {
+  it('should decode a query string without a prefix', () => {
+    const queryString = 'token=foo&key=value'
+    const decodedObj = decode(queryString)
+    expect(decodedObj).toEqual({ token: 'foo', key: 'value' })
+  })
+
+  // it('should decode a query string with a prefix', () => {
+  //   const queryString = 'prefix_token=foo&prefix_key=value'
+  //   const decodedObj = decode(queryString, 'prefix_')
+  //   expect(decodedObj).toEqual({ token: 'foo', key: 'value' })
+  // })
+
+  it('should handle missing values and trailing equal signs', () => {
+    const queryString = 'token=&key=value='
+    const decodedObj = decode(queryString)
+    expect(decodedObj).toEqual({ token: '', key: 'value=' })
+  })
+
+  it('should handle decoding a query string with array values', () => {
+    const queryString = 'token=foo&token=bar&key=value'
+    const decodedObj = decode(queryString)
+    expect(decodedObj).toEqual({ token: ['foo', 'bar'], key: 'value' })
+  })
+
+  it('should handle decoding a query string with special characters', () => {
+    const queryString = 'token=foo%3F&key=value%3D'
+    const decodedObj = decode(queryString)
+    expect(decodedObj).toEqual({ token: 'foo?', key: 'value=' })
+  })
+})

--- a/packages/react-router/tests/qss.test.ts
+++ b/packages/react-router/tests/qss.test.ts
@@ -18,7 +18,7 @@ describe('encode function', () => {
   it('should handle encoding an object with empty values and trailing equal signs', () => {
     const obj = { token: '', key: 'value=' }
     const queryString = encode(obj)
-    expect(queryString).toEqual('token=&key=value=%3D') // token=&key=value=
+    expect(queryString).toEqual('token=&key=value%3D') // token=&key=value=
   })
 
   it('should handle encoding an object with array values', () => {


### PR DESCRIPTION
Updates the ﻿decode function to address parsing issues with querystrings with values containing trailing equal signs.

Previously, query strings like ﻿`token=foo=` were parsed incorrectly as ﻿`{ token: 'foo' }` instead of `﻿{ token: 'foo=' }`.

Closes #1404.