### PR TITLE
fix(history): subscribers not being notified on go, back, and forward functions

### DIFF
--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -117,16 +117,19 @@ export function createHistory(opts: {
     go: (index) => {
       tryNavigation(() => {
         opts.go(index)
+        onUpdate()
       })
     },
     back: () => {
       tryNavigation(() => {
         opts.back()
+        onUpdate()
       })
     },
     forward: () => {
       tryNavigation(() => {
         opts.forward()
+        onUpdate()
       })
     },
     createHref: (str) => opts.createHref(str),


### PR DESCRIPTION
Closes #1407 

Trying to use the `go`, `back`, and `forward`, when using memory-history didn't work in the `@tanstack/react-router` package, since its subscribers weren't being notified when the action had been completed to then set the new location within memory and notify all the subscribers.

This fix ensures that the mentioned actions work when using the memory router, and I observed no regressions on my-part when using the browser-history either.