### PR TITLE
fix(react-router-server): do not spread a key prop including keys from manifest

### DIFF
--- a/packages/react-router-server/src/client/Meta.tsx
+++ b/packages/react-router-server/src/client/Meta.tsx
@@ -73,13 +73,25 @@ export const Meta = () => {
         })) as Array<RouterManagedTag>,
   })
 
-  const manifestMeta = router.options.context?.assets.filter(
-    (d: any) => d.tag !== 'script',
-  ) as Array<RouterManagedTag>
+  const manifestMeta =
+    (
+      router.options.context?.assets.filter((d: any) => d.tag !== 'script') as
+        | Array<RouterManagedTag>
+        | undefined
+    )?.map(({ tag, children, attrs }) => {
+      const { key, ...rest } = attrs || {}
+      return {
+        tag,
+        attrs: rest,
+        children,
+      }
+    }) ?? []
+
+  const allMeta = [...meta, ...links, ...manifestMeta] as RouterManagedTag[]
 
   return (
     <>
-      {[...meta, ...links, ...manifestMeta].map((asset, i) => (
+      {allMeta.map((asset, i) => (
         <Asset {...asset} key={`tsr-meta-${asset.tag}-${i}`} />
       ))}
     </>

--- a/packages/react-router-server/src/client/Scripts.tsx
+++ b/packages/react-router-server/src/client/Scripts.tsx
@@ -12,9 +12,18 @@ export const Scripts = () => {
   const router = useRouter()
 
   const manifestScripts =
-    (router.options.context?.assets.filter((d: any) => d.tag === 'script') as
-      | Array<RouterManagedTag>
-      | undefined) ?? []
+    (
+      router.options.context?.assets.filter((d: any) => d.tag === 'script') as
+        | Array<RouterManagedTag>
+        | undefined
+    )?.map(({ tag, children, attrs }) => {
+      const { key, ...rest } = attrs || {}
+      return {
+        tag,
+        attrs: rest,
+        children,
+      }
+    }) ?? []
 
   const { scripts } = useRouterState({
     select: (state) => ({


### PR DESCRIPTION
add additional logic to handle key props that were missed in the previous pr (#1399 ) specifically assets coming from vite manifest.