### PR TITLE
fix(react-router): using the initialized history instance for creating the href on the Link component

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -571,8 +571,8 @@ export function useLinkProps<
     href: disabled
       ? undefined
       : next.maskedLocation
-        ? next.maskedLocation.href
-        : next.href,
+        ? router.history.createHref(next.maskedLocation.href)
+        : router.history.createHref(next.href),
     onClick: composeHandlers([onClick, handleClick]),
     onFocus: composeHandlers([onFocus, handleFocus]),
     onMouseEnter: composeHandlers([onMouseEnter, handleEnter]),


### PR DESCRIPTION
Closes #457 

This fix is applied to the `useLinkProps` hook, to use the initialized history instance to then `router.history.createHref` the actual `href` being returned by the hook.