### PR TITLE
docs: broken link to "using search params in loaders" in data-loading.md from search-params.md

### DIFF
--- a/docs/framework/react/guide/search-params.md
+++ b/docs/framework/react/guide/search-params.md
@@ -178,7 +178,7 @@ Once your search params have been validated and typed, you're finally ready to s
 
 ### Using Search Params in Loaders
 
-Please read the [Search Params in Loaders](#search-params-in-loaders) section for more information about how to read search params in loaders with the `loaderDeps` option.
+Please read the [Search Params in Loaders](./guide/data-loading#using-loaderdeps-to-access-search-params) section for more information about how to read search params in loaders with the `loaderDeps` option.
 
 ### Search Params are inherited from Parent Routes
 


### PR DESCRIPTION
Self explaining. Fixing a wrong link.