### PR TITLE
fix: correctly infer loader data type

### DIFF
--- a/packages/react-router/src/route.ts
+++ b/packages/react-router/src/route.ts
@@ -330,7 +330,7 @@ export type RouteLoaderFn<
   TLoaderData = unknown,
 > = (
   match: LoaderFnContext<TAllParams, TLoaderDeps, TAllContext, TRouteContext>,
-) => Promise<TLoaderData> | TLoaderData | void
+) => Promise<TLoaderData> | TLoaderData
 
 export interface LoaderFnContext<
   TAllParams = {},


### PR DESCRIPTION
fixes #1409