### PR TITLE
fix(react-router): revert the `Assign` type to what was used prior in `1.26.11`

### DIFF
--- a/packages/react-router/src/route.ts
+++ b/packages/react-router/src/route.ts
@@ -383,8 +383,8 @@ export type ResolveFullSearchSchema<
   TParentRoute['isRoot'] extends true
     ? TParentRoute['types']['searchSchema']
     : TParentRoute['types']['fullSearchSchema'],
-  TSearchSchema,
-  keyof RootSearchSchema
+  TSearchSchema
+  // keyof RootSearchSchema
 >
 
 export type ResolveFullSearchSchemaInput<
@@ -394,8 +394,8 @@ export type ResolveFullSearchSchemaInput<
   TParentRoute['isRoot'] extends true
     ? TParentRoute['types']['searchSchemaInput']
     : TParentRoute['types']['fullSearchSchemaInput'],
-  TSearchSchemaUsed,
-  keyof RootSearchSchema
+  TSearchSchemaUsed
+  // keyof RootSearchSchema
 >
 
 export interface AnyRoute

--- a/packages/react-router/src/route.ts
+++ b/packages/react-router/src/route.ts
@@ -383,8 +383,8 @@ export type ResolveFullSearchSchema<
   TParentRoute['isRoot'] extends true
     ? TParentRoute['types']['searchSchema']
     : TParentRoute['types']['fullSearchSchema'],
-  TSearchSchema
-  // keyof RootSearchSchema
+  TSearchSchema,
+  keyof RootSearchSchema
 >
 
 export type ResolveFullSearchSchemaInput<
@@ -394,8 +394,8 @@ export type ResolveFullSearchSchemaInput<
   TParentRoute['isRoot'] extends true
     ? TParentRoute['types']['searchSchemaInput']
     : TParentRoute['types']['fullSearchSchemaInput'],
-  TSearchSchemaUsed
-  // keyof RootSearchSchema
+  TSearchSchemaUsed,
+  keyof RootSearchSchema
 >
 
 export interface AnyRoute

--- a/packages/react-router/src/utils.ts
+++ b/packages/react-router/src/utils.ts
@@ -57,11 +57,11 @@ export type IsUnion<T, U extends T = T> = (
 //       ? TLeft[K]
 //       : never
 // }
-export type Assign<
+export type Assign<TLeft, TRight, TExclude = never> = Omit<
   TLeft,
-  TRight,
-  TExclude extends string | number | symbol = never,
-> = Omit<TLeft, keyof TRight | TExclude> & TRight
+  keyof TRight | (TExclude & string)
+> &
+  TRight
 
 export type Timeout = ReturnType<typeof setTimeout>
 

--- a/packages/react-router/src/utils.ts
+++ b/packages/react-router/src/utils.ts
@@ -57,7 +57,11 @@ export type IsUnion<T, U extends T = T> = (
 //       ? TLeft[K]
 //       : never
 // }
-export type Assign<TLeft, TRight> = Omit<TLeft, keyof TRight> & TRight
+export type Assign<
+  TLeft,
+  TRight,
+  TExclude extends string | number | symbol = never,
+> = Omit<TLeft, keyof TRight | TExclude> & TRight
 
 export type Timeout = ReturnType<typeof setTimeout>
 

--- a/packages/react-router/src/utils.ts
+++ b/packages/react-router/src/utils.ts
@@ -49,13 +49,15 @@ export type IsUnion<T, U extends T = T> = (
   ? false
   : true
 
-export type Assign<TLeft, TRight, TExclude = never> = {
-  [K in Exclude<keyof TLeft | keyof TRight, TExclude>]: K extends keyof TRight
-    ? TRight[K]
-    : K extends keyof TLeft
-      ? TLeft[K]
-      : never
-}
+// reverted from https://github.com/TanStack/router/pull/1436
+// export type Assign<TLeft, TRight, TExclude = never> = {
+//   [K in Exclude<keyof TLeft | keyof TRight, TExclude>]: K extends keyof TRight
+//     ? TRight[K]
+//     : K extends keyof TLeft
+//       ? TLeft[K]
+//       : never
+// }
+export type Assign<TLeft, TRight> = Omit<TLeft, keyof TRight> & TRight
 
 export type Timeout = ReturnType<typeof setTimeout>
 


### PR DESCRIPTION
The new `Assign` type introduced in `1.26.12` (#1436) was removing the `optional` part of keys in the route search schema.

<img width="938" alt="image" src="https://github.com/TanStack/router/assets/33615041/0a811003-2d01-4da4-926a-a051e29ca1ba">

