### PR TITLE
fix: `createBrowserHistory`'s `createHref` option

### DIFF
--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -264,7 +264,7 @@ export function createBrowserHistory(opts?: {
     }
 
     // Update the location in memory
-    currentLocation = parseHref(destHref, state)
+    currentLocation = parseHref(href, state)
 
     // Keep track of the next location we need to flush to the URL
     next = {


### PR DESCRIPTION
Related to my comment at the bottom of https://github.com/TanStack/router/issues/1441#issue-2230182849, this looks to me like a minor typo.

It looks like `createHref` option is not currently used by `@tanstack/react-router` itself and I'm actually not sure what's the main use case, but as explained in the issue comment, I'm thinking to use this to fix history location encoding issue on my framework.

Please let me know if I missed something. Also I wasn't sure where a test belong to (or whether a new test is needed), so any pointers about testing would be appreciated. Thanks!