### PR TITLE
fix: widen signature of event

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -532,8 +532,8 @@ export function useLinkProps<
 
   const composeHandlers =
     (handlers: Array<undefined | ((e: any) => void)>) =>
-    (e: React.SyntheticEvent) => {
-      e.persist()
+    (e: { persist?: () => void; defaultPrevented: boolean }) => {
+      e.persist?.()
       handlers.filter(Boolean).forEach((handler) => {
         if (e.defaultPrevented) return
         handler!(e)


### PR DESCRIPTION
There are situations where persist doesn't exist, see: https://github.com/TanStack/router/pull/1365#discussion_r1552986706