### PR TITLE
fix history when hash history is used with search params

### DIFF
--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -36,6 +36,8 @@
     "clean": "rimraf ./dist && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
     "test:types": "tsc --noEmit",
+    "test:unit": "vitest --typecheck",
+    "test:unit:dev": "pnpm run test:unit --watch",
     "test:build": "publint --strict",
     "build": "vite build"
   },

--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -338,11 +338,14 @@ export function createHashHistory(opts?: { window?: any }): RouterHistory {
   return createBrowserHistory({
     window: win,
     parseLocation: () => {
+      const search = win.location.search
       const hashHref = win.location.hash.split('#').slice(1).join('#') ?? '/'
-      return parseHref(hashHref, win.history.state)
+      return parseHref(`${hashHref}${search}`, win.history.state)
     },
-    createHref: (href) =>
-      `${win.location.pathname}${win.location.search}#${href}`,
+    createHref: (href) => {
+      const searchHref = href.split('?').slice(1).join()
+      return `${win.location.pathname}${searchHref ? `?${searchHref}` : ''}#${href}`
+    },
   })
 }
 

--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -346,8 +346,10 @@ export function createHashHistory(opts?: { window?: any }): RouterHistory {
       // with how createHashHistory worked before
       const [cleanHashHref, ...otherSearch] = hashHref.split('?')
 
-      if (search && otherSearch) search = [search, ...otherSearch].join('&')
-      else if (!search && otherSearch) search = `?${otherSearch.join()}`
+      if (search && otherSearch.length > 0)
+        search = [search, ...otherSearch].join('&')
+      else if (!search && otherSearch.length > 0)
+        search = `?${otherSearch.join()}`
 
       return parseHref(`${cleanHashHref}${search}`, win.history.state)
     },

--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -351,11 +351,15 @@ export function createHashHistory(opts?: { window?: any }): RouterHistory {
       else if (!search && otherSearch.length > 0)
         search = `?${otherSearch.join()}`
 
-      return parseHref(`${cleanHashHref}${search}`, win.history.state)
+      const res = parseHref(`${cleanHashHref}`, win.history.state)
+      res.search = search
+      res.href = `${res.href}${search}`
+      return res
     },
     createHref: (href) => {
-      const searchHref = href.split('?').slice(1).join()
-      return `${win.location.pathname}${searchHref ? `?${searchHref}` : ''}#${href}`
+      const [cleanHref, ...searchParams] = href.split('?')
+      const search = searchParams.length > 0 ? `?${searchParams.join('&')}` : ''
+      return `${win.location.pathname}${search}#${cleanHref}`
     },
   })
 }

--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -338,9 +338,18 @@ export function createHashHistory(opts?: { window?: any }): RouterHistory {
   return createBrowserHistory({
     window: win,
     parseLocation: () => {
-      const search = win.location.search
+      let search = win.location.search
       const hashHref = win.location.hash.split('#').slice(1).join('#') ?? '/'
-      return parseHref(`${hashHref}${search}`, win.history.state)
+
+      // If there are duplicate query parameters in the hash we merge them with the
+      // once found in window.location.search to be backwards compatible
+      // with how createHashHistory worked before
+      const [cleanHashHref, ...otherSearch] = hashHref.split('?')
+
+      if (search && otherSearch) search = [search, ...otherSearch].join('&')
+      else if (!search && otherSearch) search = `?${otherSearch.join()}`
+
+      return parseHref(`${cleanHashHref}${search}`, win.history.state)
     },
     createHref: (href) => {
       const searchHref = href.split('?').slice(1).join()

--- a/packages/history/tests/index.test.ts
+++ b/packages/history/tests/index.test.ts
@@ -1,58 +1,61 @@
 import { describe, expect, it } from 'vitest'
 import { createHashHistory } from '../src/index'
 
+const createWindow: () => {
+  addEventListener: Window['addEventListener']
+  location: Window['location']
+  history: Window['history']
+} = () => ({
+  location: {
+    ancestorOrigins: undefined as unknown as DOMStringList,
+    hash: '',
+    host: '',
+    hostname: '',
+    href: '',
+    origin: '',
+    pathname: '',
+    port: '',
+    protocol: '',
+    search: '',
+    assign: function (): void {
+      throw new Error('Function not implemented.')
+    },
+    reload: function (): void {
+      throw new Error('Function not implemented.')
+    },
+    replace: function (): void {
+      throw new Error('Function not implemented.')
+    },
+  },
+  history: {
+    length: 0,
+    scrollRestoration: 'auto',
+    state: undefined,
+    back: function (): void {
+      throw new Error('Function not implemented.')
+    },
+    forward: function (): void {
+      throw new Error('Function not implemented.')
+    },
+    go: function (): void {
+      throw new Error('Function not implemented.')
+    },
+    pushState: function (): void {
+      throw new Error('Function not implemented.')
+    },
+    replaceState: function (): void {
+      /* No-op */
+    },
+  },
+  addEventListener: () => {
+    /* No-op */
+  },
+})
+
 describe('createHashHistory', () => {
-  it('should use correct query parameters', () => {
-    const win: {
-      addEventListener: Window['addEventListener']
-      location: Window['location']
-      history: Window['history']
-    } = {
-      location: {
-        ancestorOrigins: undefined as unknown as DOMStringList,
-        hash: '',
-        host: '',
-        hostname: '',
-        href: '',
-        origin: '',
-        pathname: '',
-        port: '',
-        protocol: '',
-        search: '',
-        assign: function (): void {
-          throw new Error('Function not implemented.')
-        },
-        reload: function (): void {
-          throw new Error('Function not implemented.')
-        },
-        replace: function (): void {
-          throw new Error('Function not implemented.')
-        },
-      },
-      history: {
-        length: 0,
-        scrollRestoration: 'auto',
-        state: undefined,
-        back: function (): void {
-          throw new Error('Function not implemented.')
-        },
-        forward: function (): void {
-          throw new Error('Function not implemented.')
-        },
-        go: function (): void {
-          throw new Error('Function not implemented.')
-        },
-        pushState: function (): void {
-          throw new Error('Function not implemented.')
-        },
-        replaceState: function (): void {
-          /* No-op */
-        },
-      },
-      addEventListener: () => {
-        /* No-op */
-      },
-    }
+  it('should read and write query parameters', () => {
+    const win = createWindow()
+
     win.location.search = '?hello=world'
     win.location.hash = '#/some/route'
     const history = createHashHistory({ window: win })
@@ -75,5 +78,24 @@ describe('createHashHistory', () => {
       '/other/route/2?real=query#/some/hash?false=query',
     )
     expect(history.location.search).toBe('?real=query')
+  })
+
+  it('should respect query parameters in hash route', () => {
+    const win = createWindow()
+    win.location.hash = '#/some/route?other=parameters'
+    const history = createHashHistory({ window: win })
+    expect(history.location.href).toBe('/some/route?other=parameters')
+    expect(history.location.search).toBe('?other=parameters')
+  })
+
+  it('should merge query parameters in hash route', () => {
+    const win = createWindow()
+    win.location.search = '?hello=world'
+    win.location.hash = '#/some/route?other=parameters'
+    const history = createHashHistory({ window: win })
+    expect(history.location.href).toBe(
+      '/some/route?hello=world&other=parameters',
+    )
+    expect(history.location.search).toBe('?hello=world&other=parameters')
   })
 })

--- a/packages/history/tests/index.test.ts
+++ b/packages/history/tests/index.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { createHashHistory } from '../src/index'
+
+describe('createHashHistory', () => {
+  it('should use correct query parameters', () => {
+    const win: {
+      addEventListener: Window['addEventListener']
+      location: Window['location']
+      history: Window['history']
+    } = {
+      location: {
+        ancestorOrigins: undefined as unknown as DOMStringList,
+        hash: '',
+        host: '',
+        hostname: '',
+        href: '',
+        origin: '',
+        pathname: '',
+        port: '',
+        protocol: '',
+        search: '',
+        assign: function (): void {
+          throw new Error('Function not implemented.')
+        },
+        reload: function (): void {
+          throw new Error('Function not implemented.')
+        },
+        replace: function (): void {
+          throw new Error('Function not implemented.')
+        },
+      },
+      history: {
+        length: 0,
+        scrollRestoration: 'auto',
+        state: undefined,
+        back: function (): void {
+          throw new Error('Function not implemented.')
+        },
+        forward: function (): void {
+          throw new Error('Function not implemented.')
+        },
+        go: function (): void {
+          throw new Error('Function not implemented.')
+        },
+        pushState: function (): void {
+          throw new Error('Function not implemented.')
+        },
+        replaceState: function (): void {
+          /* No-op */
+        },
+      },
+      addEventListener: () => {
+        /* No-op */
+      },
+    }
+    win.location.search = '?hello=world'
+    win.location.hash = '#/some/route'
+    const history = createHashHistory({ window: win })
+    expect(history.location.href).toBe('/some/route?hello=world')
+    expect(history.location.search).toBe('?hello=world')
+
+    history.replace('/other/route?other=query')
+
+    expect(history.location.href).toBe('/other/route?other=query')
+    expect(history.location.search).toBe('?other=query')
+
+    history.replace('/other/route/2')
+
+    expect(history.location.href).toBe('/other/route/2')
+    expect(history.location.search).toBe('')
+
+    history.replace('/other/route/2?real=query#/some/hash?false=query')
+
+    expect(history.location.href).toBe(
+      '/other/route/2?real=query#/some/hash?false=query',
+    )
+    expect(history.location.search).toBe('?real=query')
+  })
+})

--- a/packages/history/tests/index.test.ts
+++ b/packages/history/tests/index.test.ts
@@ -60,6 +60,7 @@ describe('createHashHistory', () => {
     win.location.hash = '#/some/route'
     const history = createHashHistory({ window: win })
     expect(history.location.href).toBe('/some/route?hello=world')
+    expect(history.location.pathname).toBe('/some/route')
     expect(history.location.search).toBe('?hello=world')
 
     history.replace('/other/route?other=query')
@@ -82,20 +83,25 @@ describe('createHashHistory', () => {
 
   it('should respect query parameters in hash route', () => {
     const win = createWindow()
+    win.location.href = '/#/some/route?other=parameters'
+    win.location.search = ''
     win.location.hash = '#/some/route?other=parameters'
     const history = createHashHistory({ window: win })
     expect(history.location.href).toBe('/some/route?other=parameters')
+    expect(history.location.pathname).toBe('/some/route')
     expect(history.location.search).toBe('?other=parameters')
   })
 
   it('should merge query parameters in hash route', () => {
     const win = createWindow()
+    win.location.href = '/?hello=world#/some/route?other=parameters'
     win.location.search = '?hello=world'
     win.location.hash = '#/some/route?other=parameters'
     const history = createHashHistory({ window: win })
     expect(history.location.href).toBe(
       '/some/route?hello=world&other=parameters',
     )
+    expect(history.location.pathname).toBe('/some/route')
     expect(history.location.search).toBe('?hello=world&other=parameters')
   })
 })

--- a/packages/history/tsconfig.json
+++ b/packages/history/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src", "vite.config.ts"],
+  "include": ["src", "tests", "vite.config.ts"],
 }


### PR DESCRIPTION
When search params where used with hash history then the search parameters where not read nore writen to the correct location in the href. The correct location for search params according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986#section-3) is:

`URI = scheme ":" hier-part [ "?" query ] [ "#" fragment ]`

Those are the parameters found in `window.location.search` but the hash
history read and wrote them here:

`URI = scheme ":" hier-part [ "#" fragment ] [ "?" query ]`

To fix that we need to account for the search parameters when
transforming the href to and from the hash route url.

The fix is split into two commits, the first commit makes the router compatible with RFC 3986 but introduces a breaking change as seen bellow. The second commit patches the breaking change but make the overall behaviour more hacky.

BREAKING CHANGE: Any website that relies on the previous none RFC 3986
compatible format and use that format when linking to a page with search
parameters and a hash route will no longer get their search parameters
parsed.

closes #1449