### PR TITLE
perf: improve performance of Link and routes

### DIFF
--- a/packages/react-router/src/Matches.tsx
+++ b/packages/react-router/src/Matches.tsx
@@ -603,10 +603,10 @@ export function useLoaderData<
     ...opts,
     select: (s) => {
       return typeof opts.select === 'function'
-        ? opts.select(s.loaderData)
+        ? opts.select(s.loaderData as TRouteMatch)
         : s.loaderData
     },
-  })
+  }) as TSelected
 }
 
 export function isServerSideError(error: unknown): error is {

--- a/packages/react-router/src/fileRoute.ts
+++ b/packages/react-router/src/fileRoute.ts
@@ -24,7 +24,7 @@ import type {
   TrimPathLeft,
   UpdatableRouteOptions,
 } from './route'
-import type { Assign, Expand, IsAny } from './utils'
+import type { Assign, IsAny } from './utils'
 import type { RouteMatch } from './Matches'
 import type { NoInfer } from '@tanstack/react-store'
 import type { RegisteredRouter } from './router'
@@ -67,7 +67,7 @@ export type RemoveUnderScores<T extends string> = Replace<
 >
 
 type RemoveRouteGroups<T extends string> =
-  T extends `${infer Before}(${infer RouteGroup})${infer After}`
+  T extends `${infer Before}(${string})${infer After}`
     ? RemoveRouteGroups<`${Before}${After}`>
     : T
 
@@ -76,32 +76,22 @@ type NormalizeSlashes<T extends string> =
     ? NormalizeSlashes<`${Before}/${After}`>
     : T
 
-type ReplaceFirstOccurrence<
-  TValue extends string,
-  TSearch extends string,
-  TReplacement extends string,
-> = TValue extends `${infer Prefix}${TSearch}${infer Suffix}`
-  ? `${Prefix}${TReplacement}${Suffix}`
-  : TValue
-
 export type ResolveFilePath<
   TParentRoute extends AnyRoute,
   TFilePath extends string,
 > = TParentRoute['id'] extends RootRouteId
   ? TrimPathLeft<TFilePath>
-  : ReplaceFirstOccurrence<
-      TrimPathLeft<TFilePath>,
-      TrimPathLeft<TParentRoute['types']['customId']>,
-      ''
-    >
+  : TFilePath extends `${TParentRoute['types']['customId']}${infer TRest}`
+    ? TRest
+    : TFilePath
 
 export type FileRoutePath<
   TParentRoute extends AnyRoute,
   TFilePath extends string,
   TResolvedFilePath = ResolveFilePath<TParentRoute, TFilePath>,
-> = TResolvedFilePath extends `_${infer _}`
+> = TResolvedFilePath extends `_${string}`
   ? ''
-  : TResolvedFilePath extends `/_${infer _}`
+  : TResolvedFilePath extends `/_${string}`
     ? ''
     : TResolvedFilePath
 
@@ -154,34 +144,27 @@ export class FileRoute<
   createRoute = <
     TSearchSchemaInput extends RouteConstraints['TSearchSchema'] = {},
     TSearchSchema extends RouteConstraints['TSearchSchema'] = {},
-    TSearchSchemaUsed extends Record<
-      string,
-      any
-    > = TSearchSchemaInput extends SearchSchemaInput
+    TSearchSchemaUsed = TSearchSchemaInput extends SearchSchemaInput
       ? Omit<TSearchSchemaInput, keyof SearchSchemaInput>
       : TSearchSchema,
-    TFullSearchSchemaInput extends
-      RouteConstraints['TFullSearchSchema'] = ResolveFullSearchSchemaInput<
+    TFullSearchSchemaInput = ResolveFullSearchSchemaInput<
       TParentRoute,
       TSearchSchemaUsed
     >,
     TFullSearchSchema = ResolveFullSearchSchema<TParentRoute, TSearchSchema>,
-    TParams extends RouteConstraints['TParams'] = Expand<
-      Record<ParsePathParams<TPath>, string>
-    >,
-    TAllParams extends RouteConstraints['TAllParams'] = MergeFromFromParent<
+    TParams = Record<ParsePathParams<TPath>, string>,
+    TAllParams = MergeFromFromParent<
       TParentRoute['types']['allParams'],
       TParams
     >,
     TRouteContextReturn extends
       RouteConstraints['TRouteContext'] = RouteContext,
-    TRouteContext extends RouteConstraints['TRouteContext'] = [
-      TRouteContextReturn,
-    ] extends [never]
+    TRouteContext = [TRouteContextReturn] extends [never]
       ? RouteContext
       : TRouteContextReturn,
-    TAllContext = Expand<
-      Assign<IsAny<TParentRoute['types']['allContext'], {}>, TRouteContext>
+    TAllContext = Assign<
+      IsAny<TParentRoute['types']['allContext'], {}>,
+      TRouteContext
     >,
     TRouterContext extends RouteConstraints['TRouterContext'] = AnyContext,
     TLoaderDeps extends Record<string, any> = {},
@@ -190,7 +173,6 @@ export class FileRoute<
       ? undefined
       : TLoaderDataReturn,
     TChildren extends RouteConstraints['TChildren'] = unknown,
-    TRouteTree extends RouteConstraints['TRouteTree'] = AnyRoute,
   >(
     options?: FileBaseRouteOptions<
       TParentRoute,
@@ -228,8 +210,7 @@ export class FileRoute<
     TLoaderDeps,
     TLoaderDataReturn,
     TLoaderData,
-    TChildren,
-    TRouteTree
+    TChildren
   > => {
     warning(
       this.silent,
@@ -294,7 +275,7 @@ export class LazyRoute<TRoute extends AnyRoute> {
 
   useMatch = <
     TRouteMatchState = RouteMatch<
-      TRoute['types']['routeTree'],
+      RegisteredRouter['routeTree'],
       TRoute['types']['id']
     >,
     TSelected = TRouteMatchState,

--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -67,7 +67,6 @@ export {
   type ActiveOptions,
   type LinkOptions,
   type CheckPath,
-  type CheckPathError,
   type ResolveRelativePath,
   type UseLinkPropsOptions,
   type ActiveLinkOptions,

--- a/packages/react-router/src/route.ts
+++ b/packages/react-router/src/route.ts
@@ -5,6 +5,7 @@ import { useParams } from './useParams'
 import { useSearch } from './useSearch'
 import { notFound } from './not-found'
 import { useNavigate } from './useNavigate'
+import type { UseNavigateResult } from './useNavigate'
 import type * as React from 'react'
 import type { RouteMatch } from './Matches'
 import type { AnyRouteMatch } from './Matches'
@@ -59,13 +60,13 @@ export type RouteOptions<
   TPath extends string = string,
   TSearchSchemaInput extends Record<string, any> = {},
   TSearchSchema extends Record<string, any> = {},
-  TSearchSchemaUsed extends Record<string, any> = {},
-  TFullSearchSchemaInput extends Record<string, any> = TSearchSchemaUsed,
+  TSearchSchemaUsed = {},
+  TFullSearchSchemaInput = TSearchSchemaUsed,
   TFullSearchSchema = TSearchSchema,
-  TParams extends AnyPathParams = AnyPathParams,
-  TAllParams extends AnyPathParams = TParams,
+  TParams = AnyPathParams,
+  TAllParams = TParams,
   TRouteContextReturn extends RouteContext = RouteContext,
-  TRouteContext extends RouteContext = RouteContext,
+  TRouteContext = RouteContext,
   TRouterContext extends RouteConstraints['TRouterContext'] = AnyContext,
   TAllContext = AnyContext,
   TLoaderDeps extends Record<string, any> = {},
@@ -108,10 +109,10 @@ export type FileBaseRouteOptions<
   TSearchSchemaInput extends Record<string, any> = {},
   TSearchSchema extends Record<string, any> = {},
   TFullSearchSchema = TSearchSchema,
-  TParams extends AnyPathParams = {},
+  TParams = {},
   TAllParams = ParamsFallback<TPath, TParams>,
   TRouteContextReturn extends RouteContext = RouteContext,
-  TRouteContext extends RouteContext = RouteContext,
+  TRouteContext = RouteContext,
   TRouterContext extends RouteConstraints['TRouterContext'] = AnyContext,
   TAllContext = AnyContext,
   TLoaderDeps extends Record<string, any> = {},
@@ -171,13 +172,13 @@ export type BaseRouteOptions<
   TPath extends string = string,
   TSearchSchemaInput extends Record<string, any> = {},
   TSearchSchema extends Record<string, any> = {},
-  TSearchSchemaUsed extends Record<string, any> = {},
-  TFullSearchSchemaInput extends Record<string, any> = TSearchSchemaUsed,
+  TSearchSchemaUsed = {},
+  TFullSearchSchemaInput = TSearchSchemaUsed,
   TFullSearchSchema = TSearchSchema,
-  TParams extends AnyPathParams = {},
+  TParams = {},
   TAllParams = ParamsFallback<TPath, TParams>,
   TRouteContextReturn extends RouteContext = RouteContext,
-  TRouteContext extends RouteContext = RouteContext,
+  TRouteContext = RouteContext,
   TRouterContext extends RouteConstraints['TRouterContext'] = AnyContext,
   TAllContext = AnyContext,
   TLoaderDeps extends Record<string, any> = {},
@@ -202,12 +203,12 @@ export type BaseRouteOptions<
   }
 
 type BeforeLoadFn<
-  TFullSearchSchema,
-  TParentRoute extends AnyRoute,
-  TAllParams,
+  in out TFullSearchSchema,
+  in out TParentRoute extends AnyRoute,
+  in out TAllParams,
   TRouteContextReturn extends RouteContext,
-  TRouterContext extends RouteConstraints['TRouterContext'] = AnyContext,
-  TContext = IsAny<TParentRoute['types']['allContext'], TRouterContext>,
+  in out TRouterContext extends RouteConstraints['TRouterContext'] = AnyContext,
+  in out TContext = IsAny<TParentRoute['types']['allContext'], TRouterContext>,
 > = (opts: {
   search: TFullSearchSchema
   abortController: AbortController
@@ -220,51 +221,48 @@ type BeforeLoadFn<
   cause: 'preload' | 'enter' | 'stay'
 }) => Promise<TRouteContextReturn> | TRouteContextReturn | void
 
-export type UpdatableRouteOptions<
-  TAllParams extends Record<string, any>,
-  TFullSearchSchema,
-  TLoaderData,
-> = {
-  // test?: (args: TAllContext) => void
-  // If true, this route will be matched as case-sensitive
-  caseSensitive?: boolean
-  // If true, this route will be forcefully wrapped in a suspense boundary
-  wrapInSuspense?: boolean
-  // The content to be rendered when the route is matched. If no component is provided, defaults to `<Outlet />`
-  component?: RouteComponent
-  errorComponent?: false | null | ErrorRouteComponent
-  notFoundComponent?: NotFoundRouteComponent
-  pendingComponent?: RouteComponent
-  pendingMs?: number
-  pendingMinMs?: number
-  staleTime?: number
-  gcTime?: number
-  preloadStaleTime?: number
-  preloadGcTime?: number
-  // Filter functions that can manipulate search params *before* they are passed to links and navigate
-  // calls that match this route.
-  preSearchFilters?: Array<SearchFilter<TFullSearchSchema>>
-  // Filter functions that can manipulate search params *after* they are passed to links and navigate
-  // calls that match this route.
-  postSearchFilters?: Array<SearchFilter<TFullSearchSchema>>
-  onError?: (err: any) => void
-  // These functions are called as route matches are loaded, stick around and leave the active
-  // matches
-  onEnter?: (match: AnyRouteMatch) => void
-  onStay?: (match: AnyRouteMatch) => void
-  onLeave?: (match: AnyRouteMatch) => void
-  meta?: (ctx: {
-    params: TAllParams
-    loaderData: TLoaderData
-  }) =>
-    | Array<JSX.IntrinsicElements['meta']>
-    | Promise<Array<JSX.IntrinsicElements['meta']>>
-  links?: () => Array<JSX.IntrinsicElements['link']>
-  scripts?: () => Array<JSX.IntrinsicElements['script']>
-  headers?: (ctx: {
-    loaderData: TLoaderData
-  }) => Promise<Record<string, string>> | Record<string, string>
-} & UpdatableStaticRouteOption
+export type UpdatableRouteOptions<TAllParams, TFullSearchSchema, TLoaderData> =
+  {
+    // test?: (args: TAllContext) => void
+    // If true, this route will be matched as case-sensitive
+    caseSensitive?: boolean
+    // If true, this route will be forcefully wrapped in a suspense boundary
+    wrapInSuspense?: boolean
+    // The content to be rendered when the route is matched. If no component is provided, defaults to `<Outlet />`
+    component?: RouteComponent
+    errorComponent?: false | null | ErrorRouteComponent
+    notFoundComponent?: NotFoundRouteComponent
+    pendingComponent?: RouteComponent
+    pendingMs?: number
+    pendingMinMs?: number
+    staleTime?: number
+    gcTime?: number
+    preloadStaleTime?: number
+    preloadGcTime?: number
+    // Filter functions that can manipulate search params *before* they are passed to links and navigate
+    // calls that match this route.
+    preSearchFilters?: Array<SearchFilter<TFullSearchSchema>>
+    // Filter functions that can manipulate search params *after* they are passed to links and navigate
+    // calls that match this route.
+    postSearchFilters?: Array<SearchFilter<TFullSearchSchema>>
+    onError?: (err: any) => void
+    // These functions are called as route matches are loaded, stick around and leave the active
+    // matches
+    onEnter?: (match: AnyRouteMatch) => void
+    onStay?: (match: AnyRouteMatch) => void
+    onLeave?: (match: AnyRouteMatch) => void
+    meta?: (ctx: {
+      params: TAllParams
+      loaderData: TLoaderData
+    }) =>
+      | Array<JSX.IntrinsicElements['meta']>
+      | Promise<Array<JSX.IntrinsicElements['meta']>>
+    links?: () => Array<JSX.IntrinsicElements['link']>
+    scripts?: () => Array<JSX.IntrinsicElements['script']>
+    headers?: (ctx: {
+      loaderData: TLoaderData
+    }) => Promise<Record<string, string>> | Record<string, string>
+  } & UpdatableStaticRouteOption
 
 export type UpdatableStaticRouteOption =
   {} extends PickRequired<StaticDataRouteOption>
@@ -323,26 +321,26 @@ export type SearchSchemaValidatorFn<TInput, TReturn> = (
 ) => TReturn
 
 export type RouteLoaderFn<
-  TAllParams = {},
-  TLoaderDeps extends Record<string, any> = {},
-  TAllContext = AnyContext,
-  TRouteContext extends Record<string, any> = AnyContext,
+  in out TAllParams = {},
+  in out TLoaderDeps extends Record<string, any> = {},
+  in out TAllContext = AnyContext,
+  in out TRouteContext = AnyContext,
   TLoaderData = unknown,
 > = (
   match: LoaderFnContext<TAllParams, TLoaderDeps, TAllContext, TRouteContext>,
 ) => Promise<TLoaderData> | TLoaderData
 
 export interface LoaderFnContext<
-  TAllParams = {},
-  TLoaderDeps = {},
-  TAllContext = AnyContext,
-  TRouteContext extends Record<string, any> = AnyContext,
+  in out TAllParams = {},
+  in out TLoaderDeps = {},
+  in out TAllContext = AnyContext,
+  in out TRouteContext = AnyContext,
 > {
   abortController: AbortController
   preload: boolean
   params: TAllParams
   deps: TLoaderDeps
-  context: Expand<Assign<TAllContext, TRouteContext>>
+  context: Assign<TAllContext, TRouteContext>
   location: ParsedLocation // Do not supply search schema here so as to demotivate people from trying to shortcut loaderDeps
   /**
    * @deprecated Use `throw redirect({ to: '/somewhere' })` instead
@@ -382,30 +380,25 @@ export type InferFullSearchSchemaInput<TRoute> = TRoute extends {
 export type ResolveFullSearchSchema<
   TParentRoute extends AnyRoute,
   TSearchSchema,
-> = Expand<
-  Assign<
-    TParentRoute['id'] extends RootRouteId
-      ? Omit<TParentRoute['types']['searchSchema'], keyof RootSearchSchema>
-      : TParentRoute['types']['fullSearchSchema'],
-    TSearchSchema
-  >
+> = Assign<
+  TParentRoute['id'] extends RootRouteId
+    ? Omit<TParentRoute['types']['searchSchema'], keyof RootSearchSchema>
+    : TParentRoute['types']['fullSearchSchema'],
+  TSearchSchema
 >
 
 export type ResolveFullSearchSchemaInput<
   TParentRoute extends AnyRoute,
   TSearchSchemaUsed,
-> = Expand<
-  Assign<
-    TParentRoute['id'] extends RootRouteId
-      ? Omit<TParentRoute['types']['searchSchemaInput'], keyof RootSearchSchema>
-      : TParentRoute['types']['fullSearchSchemaInput'],
-    TSearchSchemaUsed
-  >
+> = Assign<
+  TParentRoute['id'] extends RootRouteId
+    ? Omit<TParentRoute['types']['searchSchemaInput'], keyof RootSearchSchema>
+    : TParentRoute['types']['fullSearchSchemaInput'],
+  TSearchSchemaUsed
 >
 
 export interface AnyRoute
   extends Route<
-    any,
     any,
     any,
     any,
@@ -431,15 +424,10 @@ export interface AnyRoute
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export type MergeFromFromParent<T, U> = IsAny<T, U, T & U>
 
-export type ResolveAllParams<
-  TParentRoute extends AnyRoute,
-  TParams extends AnyPathParams,
-> =
+export type ResolveAllParams<TParentRoute extends AnyRoute, TParams> =
   Record<never, string> extends TParentRoute['types']['allParams']
     ? TParams
-    : Expand<
-        UnionToIntersection<TParentRoute['types']['allParams'] & TParams> & {}
-      >
+    : UnionToIntersection<TParentRoute['types']['allParams'] & TParams> & {}
 
 export type RouteConstraints = {
   TParentRoute: AnyRoute
@@ -463,9 +451,9 @@ export function getRouteApi<
   TId extends RouteIds<RegisteredRouter['routeTree']>,
   TRoute extends AnyRoute = RouteById<RegisteredRouter['routeTree'], TId>,
   TFullSearchSchema = TRoute['types']['fullSearchSchema'],
-  TAllParams extends AnyPathParams = TRoute['types']['allParams'],
+  TAllParams = TRoute['types']['allParams'],
   TAllContext = TRoute['types']['allContext'],
-  TLoaderDeps extends Record<string, any> = TRoute['types']['loaderDeps'],
+  TLoaderDeps = TRoute['types']['loaderDeps'],
   TLoaderData = TRoute['types']['loaderData'],
 >(id: TId) {
   return new RouteApi<
@@ -483,9 +471,9 @@ export class RouteApi<
   TId extends RouteIds<RegisteredRouter['routeTree']>,
   TRoute extends AnyRoute = RouteById<RegisteredRouter['routeTree'], TId>,
   TFullSearchSchema = TRoute['types']['fullSearchSchema'],
-  TAllParams extends AnyPathParams = TRoute['types']['allParams'],
+  TAllParams = TRoute['types']['allParams'],
   TAllContext = TRoute['types']['allContext'],
-  TLoaderDeps extends Record<string, any> = TRoute['types']['loaderDeps'],
+  TLoaderDeps = TRoute['types']['loaderDeps'],
   TLoaderData = TRoute['types']['loaderData'],
 > {
   id: TId
@@ -507,8 +495,8 @@ export class RouteApi<
     return useMatch({ select: opts?.select, from: this.id })
   }
 
-  useRouteContext = <TSelected = TAllContext>(opts?: {
-    select?: (s: TAllContext) => TSelected
+  useRouteContext = <TSelected = Expand<TAllContext>>(opts?: {
+    select?: (s: Expand<TAllContext>) => TSelected
   }): TSelected => {
     return useMatch({
       from: this.id,
@@ -516,14 +504,14 @@ export class RouteApi<
     })
   }
 
-  useSearch = <TSelected = TFullSearchSchema>(opts?: {
-    select?: (s: TFullSearchSchema) => TSelected
+  useSearch = <TSelected = Expand<TFullSearchSchema>>(opts?: {
+    select?: (s: Expand<TFullSearchSchema>) => TSelected
   }): TSelected => {
     return useSearch({ ...opts, from: this.id })
   }
 
-  useParams = <TSelected = TAllParams>(opts?: {
-    select?: (s: TAllParams) => TSelected
+  useParams = <TSelected = Expand<TAllParams>>(opts?: {
+    select?: (s: Expand<TAllParams>) => TSelected
   }): TSelected => {
     return useParams({ ...opts, from: this.id })
   }
@@ -550,55 +538,48 @@ export class RouteApi<
 }
 
 export class Route<
-  TParentRoute extends RouteConstraints['TParentRoute'] = AnyRoute,
+  in out TParentRoute extends RouteConstraints['TParentRoute'] = AnyRoute,
   in out TPath extends RouteConstraints['TPath'] = '/',
-  TFullPath extends RouteConstraints['TFullPath'] = ResolveFullPath<
+  in out TFullPath extends RouteConstraints['TFullPath'] = ResolveFullPath<
     TParentRoute,
     TPath
   >,
-  TCustomId extends RouteConstraints['TCustomId'] = string,
-  TId extends RouteConstraints['TId'] = ResolveId<
+  in out TCustomId extends RouteConstraints['TCustomId'] = string,
+  in out TId extends RouteConstraints['TId'] = ResolveId<
     TParentRoute,
     TCustomId,
     TPath
   >,
-  TSearchSchemaInput extends RouteConstraints['TSearchSchema'] = {},
-  TSearchSchema extends RouteConstraints['TSearchSchema'] = {},
-  TSearchSchemaUsed extends Record<
-    string,
-    any
-  > = TSearchSchemaInput extends SearchSchemaInput
+  in out TSearchSchemaInput extends RouteConstraints['TSearchSchema'] = {},
+  in out TSearchSchema extends RouteConstraints['TSearchSchema'] = {},
+  in out TSearchSchemaUsed = TSearchSchemaInput extends SearchSchemaInput
     ? Omit<TSearchSchemaInput, keyof SearchSchemaInput>
     : TSearchSchema,
-  TFullSearchSchemaInput extends Record<
-    string,
-    any
-  > = ResolveFullSearchSchemaInput<TParentRoute, TSearchSchemaUsed>,
-  TFullSearchSchema = ResolveFullSearchSchema<TParentRoute, TSearchSchema>,
-  TParams extends RouteConstraints['TParams'] = Expand<
-    Record<ParsePathParams<TPath>, string>
-  >,
-  TAllParams extends RouteConstraints['TAllParams'] = ResolveAllParams<
+  in out TFullSearchSchemaInput = ResolveFullSearchSchemaInput<
     TParentRoute,
-    TParams
+    TSearchSchemaUsed
   >,
+  in out TFullSearchSchema = ResolveFullSearchSchema<
+    TParentRoute,
+    TSearchSchema
+  >,
+  in out TParams = Record<ParsePathParams<TPath>, string>,
+  in out TAllParams = ResolveAllParams<TParentRoute, TParams>,
   TRouteContextReturn extends RouteConstraints['TRouteContext'] = RouteContext,
-  in out TRouteContext extends RouteConstraints['TRouteContext'] = [
-    TRouteContextReturn,
-  ] extends [never]
+  in out TRouteContext = [TRouteContextReturn] extends [never]
     ? RouteContext
     : TRouteContextReturn,
-  in out TAllContext = Expand<
-    Assign<IsAny<TParentRoute['types']['allContext'], {}>, TRouteContext>
+  in out TAllContext = Assign<
+    IsAny<TParentRoute['types']['allContext'], {}>,
+    TRouteContext
   >,
-  TRouterContext extends RouteConstraints['TRouterContext'] = AnyContext,
-  TLoaderDeps extends Record<string, any> = {},
+  in out TRouterContext extends RouteConstraints['TRouterContext'] = AnyContext,
+  in out TLoaderDeps extends Record<string, any> = {},
   TLoaderDataReturn = unknown,
-  TLoaderData = [TLoaderDataReturn] extends [never]
+  in out TLoaderData = [TLoaderDataReturn] extends [never]
     ? undefined
     : TLoaderDataReturn,
-  TChildren extends RouteConstraints['TChildren'] = unknown,
-  TRouteTree extends RouteConstraints['TRouteTree'] = AnyRoute,
+  in out TChildren extends RouteConstraints['TChildren'] = unknown,
 > {
   isRoot: TParentRoute extends Route<any> ? true : false
   options: RouteOptions<
@@ -687,13 +668,12 @@ export class Route<
     routeContext: TRouteContext
     allContext: TAllContext
     children: TChildren
-    routeTree: TRouteTree
     routerContext: TRouterContext
     loaderData: TLoaderData
     loaderDeps: TLoaderDeps
   }
 
-  init = (opts: { originalIndex: number }) => {
+  init = (opts: { originalIndex: number }): void => {
     this.originalIndex = opts.originalIndex
 
     const options = this.options as
@@ -768,7 +748,7 @@ export class Route<
     this.to = fullPath as TrimPathRight<TFullPath>
   }
 
-  addChildren = <TNewChildren extends Array<AnyRoute>>(
+  addChildren = <const TNewChildren extends ReadonlyArray<AnyRoute>>(
     children: TNewChildren,
   ): Route<
     TParentRoute,
@@ -790,8 +770,7 @@ export class Route<
     TLoaderDeps,
     TLoaderDataReturn,
     TLoaderData,
-    TNewChildren,
-    TRouteTree
+    TNewChildren
   > => {
     this.children = children as any
     return this as any
@@ -826,19 +805,18 @@ export class Route<
       TRouterContext,
       TLoaderDeps,
       TNewLoaderData,
-      TChildren,
-      TRouteTree
+      TChildren
     >
   }
 
   update = (
     options: UpdatableRouteOptions<TAllParams, TFullSearchSchema, TLoaderData>,
-  ) => {
+  ): this => {
     Object.assign(this.options, options)
     return this
   }
 
-  lazy = (lazyFn: () => Promise<LazyRoute<any>>) => {
+  lazy = (lazyFn: () => Promise<LazyRoute<any>>): this => {
     this.lazyFn = lazyFn
     return this
   }
@@ -854,8 +832,8 @@ export class Route<
     return useMatch({ ...opts, from: this.id })
   }
 
-  useRouteContext = <TSelected = TAllContext>(opts?: {
-    select?: (search: TAllContext) => TSelected
+  useRouteContext = <TSelected = Expand<TAllContext>>(opts?: {
+    select?: (search: Expand<TAllContext>) => TSelected
   }): TSelected => {
     return useMatch({
       ...opts,
@@ -864,14 +842,14 @@ export class Route<
     })
   }
 
-  useSearch = <TSelected = TFullSearchSchema>(opts?: {
-    select?: (search: TFullSearchSchema) => TSelected
+  useSearch = <TSelected = Expand<TFullSearchSchema>>(opts?: {
+    select?: (search: Expand<TFullSearchSchema>) => TSelected
   }): TSelected => {
     return useSearch({ ...opts, from: this.id })
   }
 
-  useParams = <TSelected = TAllParams>(opts?: {
-    select?: (search: TAllParams) => TSelected
+  useParams = <TSelected = Expand<TAllParams>>(opts?: {
+    select?: (search: Expand<TAllParams>) => TSelected
   }): TSelected => {
     return useParams({ ...opts, from: this.id })
   }
@@ -888,7 +866,7 @@ export class Route<
     return useLoaderData({ ...opts, from: this.id } as any)
   }
 
-  useNavigate = () => {
+  useNavigate = (): UseNavigateResult<string> => {
     return useNavigate({ from: this.id })
   }
 }
@@ -908,32 +886,23 @@ export function createRoute<
   >,
   TSearchSchemaInput extends RouteConstraints['TSearchSchema'] = {},
   TSearchSchema extends RouteConstraints['TSearchSchema'] = {},
-  TSearchSchemaUsed extends Record<
-    string,
-    any
-  > = TSearchSchemaInput extends SearchSchemaInput
+  TSearchSchemaUsed = TSearchSchemaInput extends SearchSchemaInput
     ? Omit<TSearchSchemaInput, keyof SearchSchemaInput>
     : TSearchSchema,
-  TFullSearchSchemaInput extends Record<
-    string,
-    any
-  > = ResolveFullSearchSchemaInput<TParentRoute, TSearchSchemaUsed>,
-  TFullSearchSchema = ResolveFullSearchSchema<TParentRoute, TSearchSchema>,
-  TParams extends RouteConstraints['TParams'] = Expand<
-    Record<ParsePathParams<TPath>, string>
-  >,
-  TAllParams extends RouteConstraints['TAllParams'] = ResolveAllParams<
+  TFullSearchSchemaInput = ResolveFullSearchSchemaInput<
     TParentRoute,
-    TParams
+    TSearchSchemaUsed
   >,
+  TFullSearchSchema = ResolveFullSearchSchema<TParentRoute, TSearchSchema>,
+  TParams = Record<ParsePathParams<TPath>, string>,
+  TAllParams = ResolveAllParams<TParentRoute, TParams>,
   TRouteContextReturn extends RouteConstraints['TRouteContext'] = RouteContext,
-  TRouteContext extends RouteConstraints['TRouteContext'] = [
-    TRouteContextReturn,
-  ] extends [never]
+  TRouteContext = [TRouteContextReturn] extends [never]
     ? RouteContext
     : TRouteContextReturn,
-  TAllContext = Expand<
-    Assign<IsAny<TParentRoute['types']['allContext'], {}>, TRouteContext>
+  TAllContext = Assign<
+    IsAny<TParentRoute['types']['allContext'], {}>,
+    TRouteContext
   >,
   TRouterContext extends RouteConstraints['TRouterContext'] = AnyContext,
   TLoaderDeps extends Record<string, any> = {},
@@ -942,7 +911,6 @@ export function createRoute<
     ? undefined
     : TLoaderDataReturn,
   TChildren extends RouteConstraints['TChildren'] = unknown,
-  TRouteTree extends RouteConstraints['TRouteTree'] = AnyRoute,
 >(
   options: RouteOptions<
     TParentRoute,
@@ -984,8 +952,7 @@ export function createRoute<
     TLoaderDeps,
     TLoaderDataReturn,
     TLoaderData,
-    TChildren,
-    TRouteTree
+    TChildren
   >(options)
 }
 
@@ -1008,7 +975,7 @@ export function createRootRouteWithContext<TRouterContext extends {}>() {
   >(
     options?: Omit<
       RouteOptions<
-        AnyRoute, // TParentRoute
+        any, // TParentRoute
         RootRouteId, // TCustomId
         '', // TPath
         TSearchSchemaInput, // TSearchSchemaInput
@@ -1021,7 +988,7 @@ export function createRootRouteWithContext<TRouterContext extends {}>() {
         TRouteContextReturn, // TRouteContextReturn
         TRouteContext, // TRouteContext
         TRouterContext,
-        Expand<Assign<TRouterContext, TRouteContext>>, // TAllContext
+        Assign<TRouterContext, TRouteContext>, // TAllContext
         TLoaderDeps,
         TLoaderDataReturn, // TLoaderDataReturn,
         TLoaderData // TLoaderData,
@@ -1057,17 +1024,19 @@ export type RootSearchSchema = {
 }
 
 export class RootRoute<
-  TSearchSchemaInput extends Record<string, any> = RootSearchSchema,
-  TSearchSchema extends Record<string, any> = RootSearchSchema,
-  TSearchSchemaUsed extends Record<string, any> = RootSearchSchema,
+  in out TSearchSchemaInput extends Record<string, any> = RootSearchSchema,
+  in out TSearchSchema extends Record<string, any> = RootSearchSchema,
+  in out TSearchSchemaUsed extends Record<string, any> = RootSearchSchema,
   TRouteContextReturn extends RouteContext = RouteContext,
-  TRouteContext extends RouteContext = [TRouteContextReturn] extends [never]
+  in out TRouteContext extends RouteContext = [TRouteContextReturn] extends [
+    never,
+  ]
     ? RouteContext
     : TRouteContextReturn,
-  TRouterContext extends {} = {},
+  in out TRouterContext extends {} = {},
   TLoaderDeps extends Record<string, any> = {},
   TLoaderDataReturn = unknown,
-  TLoaderData = [TLoaderDataReturn] extends [never]
+  in out TLoaderData = [TLoaderDataReturn] extends [never]
     ? undefined
     : TLoaderDataReturn,
 > extends Route<
@@ -1090,8 +1059,7 @@ export class RootRoute<
   TLoaderDeps,
   TLoaderDataReturn,
   TLoaderData,
-  any, // TChildren
-  any // TRouteTree
+  any // TChildren
 > {
   /**
    * @deprecated `RootRoute` is now an internal implementation detail. Use `createRootRoute()` instead.
@@ -1099,7 +1067,7 @@ export class RootRoute<
   constructor(
     options?: Omit<
       RouteOptions<
-        AnyRoute, // TParentRoute
+        any, // TParentRoute
         RootRouteId, // TCustomId
         '', // TPath
         TSearchSchemaInput, // TSearchSchemaInput
@@ -1146,7 +1114,7 @@ export function createRootRoute<
 >(
   options?: Omit<
     RouteOptions<
-      AnyRoute, // TParentRoute
+      any, // TParentRoute
       RootRouteId, // TCustomId
       '', // TPath
       TSearchSchemaInput, // TSearchSchemaInput
@@ -1295,8 +1263,9 @@ export class NotFoundRoute<
   TFullSearchSchema = ResolveFullSearchSchema<TParentRoute, TSearchSchema>,
   TRouteContextReturn extends RouteConstraints['TRouteContext'] = AnyContext,
   TRouteContext extends RouteConstraints['TRouteContext'] = RouteContext,
-  TAllContext = Expand<
-    Assign<IsAny<TParentRoute['types']['allContext'], {}>, TRouteContext>
+  TAllContext = Assign<
+    IsAny<TParentRoute['types']['allContext'], {}>,
+    TRouteContext
   >,
   TRouterContext extends RouteConstraints['TRouterContext'] = AnyContext,
   TLoaderDeps extends Record<string, any> = {},
@@ -1305,7 +1274,6 @@ export class NotFoundRoute<
     ? undefined
     : TLoaderDataReturn,
   TChildren extends RouteConstraints['TChildren'] = unknown,
-  TRouteTree extends RouteConstraints['TRouteTree'] = AnyRoute,
 > extends Route<
   TParentRoute,
   '/404',
@@ -1326,8 +1294,7 @@ export class NotFoundRoute<
   TLoaderDeps,
   TLoaderDataReturn,
   TLoaderData,
-  TChildren,
-  TRouteTree
+  TChildren
 > {
   constructor(
     options: Omit<

--- a/packages/react-router/src/routeInfo.ts
+++ b/packages/react-router/src/routeInfo.ts
@@ -4,7 +4,7 @@ import type { Expand, UnionToIntersection, UnionToTuple } from './utils'
 export type ParseRoute<TRouteTree, TAcc = TRouteTree> = TRouteTree extends {
   types: { children: infer TChildren }
 }
-  ? TChildren extends Array<unknown>
+  ? TChildren extends ReadonlyArray<unknown>
     ? ParseRoute<TChildren[number], TAcc | TChildren[number]>
     : TAcc
   : TAcc
@@ -14,7 +14,7 @@ export type RoutesById<TRouteTree extends AnyRoute> = {
 }
 
 export type RouteById<TRouteTree extends AnyRoute, TId> = Extract<
-  Extract<ParseRoute<TRouteTree>, { id: TId }>,
+  RoutesById<TRouteTree>[TId],
   AnyRoute
 >
 
@@ -56,11 +56,9 @@ type Reduce<TValue extends Array<any>, TResult = unknown> = TValue extends [
   : TResult
 
 export type FullSearchSchema<TRouteTree extends AnyRoute> = Partial<
-  Expand<
-    Reduce<UnionToTuple<ParseRoute<TRouteTree>['types']['fullSearchSchema']>>
-  >
+  Reduce<UnionToTuple<ParseRoute<TRouteTree>['types']['fullSearchSchema']>>
 >
 
-export type AllParams<TRouteTree extends AnyRoute> = Expand<
-  UnionToIntersection<ParseRoute<TRouteTree>['types']['allParams']>
+export type AllParams<TRouteTree extends AnyRoute> = UnionToIntersection<
+  ParseRoute<TRouteTree>['types']['allParams']
 >

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -261,9 +261,9 @@ export function createRouter<
 }
 
 export class Router<
-  TRouteTree extends AnyRoute = AnyRoute,
-  TDehydrated extends Record<string, any> = Record<string, any>,
-  TSerializedError extends Record<string, any> = Record<string, any>,
+  in out TRouteTree extends AnyRoute = AnyRoute,
+  in out TDehydrated extends Record<string, any> = Record<string, any>,
+  in out TSerializedError extends Record<string, any> = Record<string, any>,
 > {
   // Option-independent properties
   tempLocationKey: string | undefined = `${Math.round(
@@ -1268,8 +1268,8 @@ export class Router<
             preload: !!preload,
             context: parentContext,
             location,
-            navigate: (opts) =>
-              this.navigate({ ...opts, from: match.pathname } as any),
+            navigate: (opts: any) =>
+              this.navigate({ ...opts, from: match.pathname }),
             buildLocation: this.buildLocation,
             cause: preload ? 'preload' : match.cause,
           })) ?? ({} as any)

--- a/packages/react-router/src/useParams.tsx
+++ b/packages/react-router/src/useParams.tsx
@@ -21,7 +21,7 @@ export function useParams<
   return useMatch({
     ...opts,
     select: (match) => {
-      return opts.select ? opts.select(match.params) : match.params
+      return opts.select ? opts.select(match.params as TParams) : match.params
     },
-  })
+  }) as TSelected
 }

--- a/packages/react-router/src/utils.ts
+++ b/packages/react-router/src/utils.ts
@@ -15,12 +15,14 @@ export type PickRequired<T> = {
 }
 
 // from https://stackoverflow.com/a/76458160
-export type WithoutEmpty<T> = T extends T ? ({} extends T ? never : T) : never
+export type WithoutEmpty<T> = T extends any ? ({} extends T ? never : T) : never
 
 // export type Expand<T> = T
 export type Expand<T> = T extends object
   ? T extends infer O
-    ? { [K in keyof O]: O[K] }
+    ? O extends Function
+      ? O
+      : { [K in keyof O]: O[K] }
     : never
   : T
 
@@ -36,10 +38,12 @@ export type DeepPartial<T> = T extends object
     }
   : T
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export type MakeDifferenceOptional<T, U> = Omit<U, keyof T> &
-  Partial<Pick<U, keyof T & keyof U>> &
-  PickRequired<Omit<U, keyof PickRequired<T>>>
+export type MakeDifferenceOptional<TLeft, TRight> = Omit<
+  TRight,
+  keyof TLeft
+> & {
+  [K in keyof TLeft & keyof TRight]?: TRight[K]
+}
 
 // from https://stackoverflow.com/a/53955431
 // eslint-disable-next-line @typescript-eslint/naming-convention


### PR DESCRIPTION
### TS Performance Improvments

## Purpose

Type checking large code bases with many `Route`'s and `Link`'s can get quite sluggish. This PR introduces a number of performance optimizations I've discovered while profiling on the large file based example. The purpose of this PR is to improve suggestion times for such code bases and build times

## Extended Diagnostics

On main the following diagnostics are present for the example large file based

```
> tsc --extendedDiagnostics

Files:                         589
Lines of Library:            38118
Lines of Definitions:        77132
Lines of TypeScript:         12777
Lines of JavaScript:             0
Lines of JSON:                   0
Lines of Other:                  0
Identifiers:                113478
Symbols:                    351283
Types:                       62925
Instantiations:            1541766
Memory used:               311542K
Assignability cache size:   113357
Identity cache size:          3707
Subtype cache size:              0
Strict subtype cache size:  162006
I/O Read time:               0.08s
Parse time:                  0.55s
ResolveModule time:          0.11s
ResolveTypeReference time:   0.01s
ResolveLibrary time:         0.02s
Program time:                0.84s
Bind time:                   0.24s
Check time:                  5.64s
printTime time:              0.00s
Emit time:                   0.00s
Total time:                  6.72s
```

After the changes introduced in this PR the instantiations and check time are reduced

```
> tsc --extendedDiagnostics

Files:                         589
Lines of Library:            38118
Lines of Definitions:        77133
Lines of TypeScript:         12777
Lines of JavaScript:             0
Lines of JSON:                   0
Lines of Other:                  0
Identifiers:                113461
Symbols:                    189848
Types:                       50776
Instantiations:             592405
Memory used:               222842K
Assignability cache size:    34415
Identity cache size:          3718
Subtype cache size:              0
Strict subtype cache size:       0
I/O Read time:               0.07s
Parse time:                  0.54s
ResolveModule time:          0.11s
ResolveTypeReference time:   0.01s
ResolveLibrary time:         0.02s
Program time:                0.83s
Bind time:                   0.23s
Check time:                  3.82s
printTime time:              0.00s
Emit time:                   0.00s
Total time:                  4.88s
```

## Profiling

This is the profile for the large file route on main.

![image](https://github.com/TanStack/router/assets/7883601/542a6399-1b33-41ab-952e-a8b35ba67ead)

Going deep into each wall of the profile. The biggest wall is the route tree definition. There is a number of things to improve here.

- Performance of each individual file route types
- Variance checks on each Route
- Type parameter constraints on each Route
- Improving performance of merging properties from each parent route
- Only `Expand` when necessary and not eagerly

![image](https://github.com/TanStack/router/assets/7883601/3c73a3c3-1f2e-416c-a85c-f4aace9fd88a)

And the next significant thing is each `Link`. Each `Link` can be improved by the following:

- Separating `LinkComponentProps` to cache props for a component passed to `createLink`
- Use the resolved route for relative paths to narrow down the union of paths relevant for autocomplete
- Use `CheckPath` directly on the `to` prop to avoid an intersection
- Evaluate less of `params` and `search` until the user use these props

![image](https://github.com/TanStack/router/assets/7883601/a7b84d57-e0c6-437c-b0a2-cced0c9ddc1a)

After the performance improvements the route tree looks more like this

![image](https://github.com/TanStack/router/assets/7883601/86a2626b-1776-4eff-8cf8-eddde4cffc1e)

and each `Link` looks like this

![image](https://github.com/TanStack/router/assets/7883601/6d3a9c3c-d9b3-408f-9783-aaca02f7f583)

`Link` may seem like a small improvement for one `Link` but when you have many in large code bases this quickly accumulates
