### PR TITLE
fix: broken "Authenticated Routes with Context" example link

### DIFF
--- a/docs/framework/react/guide/authenticated-routes.md
+++ b/docs/framework/react/guide/authenticated-routes.md
@@ -83,7 +83,7 @@ If your authentication flow relies on interactions with React context and/or hoo
 
 We'll cover the `router.context` options in-detail in the [Router Context](../router-context) section.
 
-Here's an example that uses React context and hooks for protecting authenticated routes in TanStack Router. See the entire working setup in the [Authenticated Routes with Context example](./examples/authenticated-routes-context).
+Here's an example that uses React context and hooks for protecting authenticated routes in TanStack Router. See the entire working setup in the [Authenticated Routes with Context example](../../examples/authenticated-routes-context).
 
 - `src/routes/__root.tsx`
 


### PR DESCRIPTION
In the v1 and latest docs "Authenticated Routes with Context"  in the [Authenticated Routes Guide](https://tanstack.com/router/v1/docs/framework/react/guide/authenticated-routes) page is broken.

When I click goes to 404 page:
![image](https://github.com/TanStack/router/assets/20212776/f23c17be-a0c0-4a55-bbf5-63c248155208)

The correct link to the guide is: https://tanstack.com/router/v1/docs/framework/react/examples/authenticated-routes-context

The path was wrong, since all docs should be relative to `docs/` path I fixed by changing 

TO:
```md
[Authenticated Routes with Context example](./examples/authenticated-routes-context)
```
FROM:
```md
[Authenticated Routes with Context example](../../examples/authenticated-routes-context)
```