### PR TITLE
fix(react-router): broken navigation for links inheriting path params when using `from`

### DIFF
--- a/examples/react/quickstart-file-based/src/routeTree.gen.ts
+++ b/examples/react/quickstart-file-based/src/routeTree.gen.ts
@@ -13,6 +13,9 @@
 import { Route as rootRoute } from './routes/__root'
 import { Route as AboutImport } from './routes/about'
 import { Route as IndexImport } from './routes/index'
+import { Route as PostsIdImport } from './routes/posts.$id'
+import { Route as PostsIdSummaryImport } from './routes/posts.$id.summary'
+import { Route as PostsIdNotesImport } from './routes/posts.$id.notes'
 
 // Create/Update Routes
 
@@ -24,6 +27,21 @@ const AboutRoute = AboutImport.update({
 const IndexRoute = IndexImport.update({
   path: '/',
   getParentRoute: () => rootRoute,
+} as any)
+
+const PostsIdRoute = PostsIdImport.update({
+  path: '/posts/$id',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const PostsIdSummaryRoute = PostsIdSummaryImport.update({
+  path: '/summary',
+  getParentRoute: () => PostsIdRoute,
+} as any)
+
+const PostsIdNotesRoute = PostsIdNotesImport.update({
+  path: '/notes',
+  getParentRoute: () => PostsIdRoute,
 } as any)
 
 // Populate the FileRoutesByPath interface
@@ -38,11 +56,27 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AboutImport
       parentRoute: typeof rootRoute
     }
+    '/posts/$id': {
+      preLoaderRoute: typeof PostsIdImport
+      parentRoute: typeof rootRoute
+    }
+    '/posts/$id/notes': {
+      preLoaderRoute: typeof PostsIdNotesImport
+      parentRoute: typeof PostsIdImport
+    }
+    '/posts/$id/summary': {
+      preLoaderRoute: typeof PostsIdSummaryImport
+      parentRoute: typeof PostsIdImport
+    }
   }
 }
 
 // Create and export the route tree
 
-export const routeTree = rootRoute.addChildren([IndexRoute, AboutRoute])
+export const routeTree = rootRoute.addChildren([
+  IndexRoute,
+  AboutRoute,
+  PostsIdRoute.addChildren([PostsIdNotesRoute, PostsIdSummaryRoute]),
+])
 
 /* prettier-ignore-end */

--- a/examples/react/quickstart-file-based/src/routes/posts.$id.notes.tsx
+++ b/examples/react/quickstart-file-based/src/routes/posts.$id.notes.tsx
@@ -1,0 +1,6 @@
+// REMOVE & REGENERATE THE ROUTE_TREE BEFORE MERGE
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts/$id/notes')({
+  component: () => <div>Hello /posts/$id/notes!</div>,
+})

--- a/examples/react/quickstart-file-based/src/routes/posts.$id.summary.tsx
+++ b/examples/react/quickstart-file-based/src/routes/posts.$id.summary.tsx
@@ -1,0 +1,6 @@
+// REMOVE & REGENERATE THE ROUTE_TREE BEFORE MERGE
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts/$id/summary')({
+  component: () => <div>Hello /posts/$id/summary!</div>,
+})

--- a/examples/react/quickstart-file-based/src/routes/posts.$id.tsx
+++ b/examples/react/quickstart-file-based/src/routes/posts.$id.tsx
@@ -1,0 +1,47 @@
+// REMOVE & REGENERATE THE ROUTE_TREE BEFORE MERGE
+import * as React from 'react'
+import {
+  Link,
+  Outlet,
+  createFileRoute,
+  useNavigate,
+} from '@tanstack/react-router'
+
+export const Route = createFileRoute('/posts/$id')({
+  component: Comp,
+})
+
+function Comp() {
+  const navigate = useNavigate()
+  return (
+    <>
+      <div>Hello /posts/$id!</div>
+      <div className="flex gap-2">
+        <Link from="/posts/$id" to="/posts/$id/summary">
+          Summary
+        </Link>
+        <Link from="/posts/$id" to="/posts/$id/notes">
+          Notes
+        </Link>
+      </div>
+      <div className="flex gap-2">
+        <button
+          onClick={() =>
+            navigate({ from: '/posts/$id', to: '/posts/$id/summary' })
+          }
+        >
+          Go to summary
+        </button>
+        <button
+          onClick={() =>
+            navigate({ from: '/posts/$id', to: '/posts/$id/notes' })
+          }
+        >
+          Go to notes
+        </button>
+      </div>
+      <hr />
+      <Outlet />
+    </>
+  )
+}

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -537,8 +537,8 @@ export function useLinkProps<
   // null for LinkUtils
 
   const dest = {
-    ...(options.to && { from: matchPathname }),
     ...options,
+    ...(options.to && { from: matchPathname }),
   }
 
   let type: 'internal' | 'external' = 'internal'


### PR DESCRIPTION
I'm not sure if this is the right place to be making the fix for this.

Making the change in the `<Link>` component does indeed fix the problem.

I took a stab at trying to track this in the `Router.buildLocation` method, but that honestly took me down a rabbit hole, which kind of lead me nowhere.

Feel free to close if you've got a better solution for this.

Closes #1474 