### PR TITLE
types: expose `BeforeLoadFn` type

### DIFF
--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -153,6 +153,7 @@ export {
   type SearchSchemaValidator,
   type SearchSchemaValidatorObj,
   type SearchSchemaValidatorFn,
+  type BeforeLoadFn,
   type RouteLoaderFn,
   type LoaderFnContext,
   type SearchFilter,

--- a/packages/react-router/src/route.ts
+++ b/packages/react-router/src/route.ts
@@ -205,7 +205,7 @@ export type BaseRouteOptions<
     getParentRoute: () => TParentRoute
   }
 
-type BeforeLoadFn<
+export type BeforeLoadFn<
   in out TFullSearchSchema,
   in out TParentRoute extends AnyRoute,
   in out TAllParams,


### PR DESCRIPTION
I encountered this issue when creating a function that needs the `BeforeLoadFn` types. I also noticed that other types such as `RouteLoaderFn` are exposed.

This PR is to expose the `BeforeLoadFn` type.