### PR TITLE
fix: `to` should autocomplete for `MatchRoute`

### DIFF
--- a/packages/react-router/src/Matches.tsx
+++ b/packages/react-router/src/Matches.tsx
@@ -482,13 +482,7 @@ export type MakeMatchRouteOptions<
   TTo extends string = '',
   TMaskFrom extends RoutePaths<TRouter['routeTree']> = TFrom,
   TMaskTo extends string = '',
-> = UseMatchRouteOptions<
-  TRouter['routeTree'],
-  TFrom,
-  TTo,
-  TMaskFrom,
-  TMaskTo
-> & {
+> = UseMatchRouteOptions<TRouter, TFrom, TTo, TMaskFrom, TMaskTo> & {
   // If a function is passed as a child, it will be given the `isActive` boolean to aid in further styling on the element it returns
   children?:
     | ((
@@ -508,15 +502,7 @@ export function MatchRoute<
   TTo extends string = '',
   TMaskFrom extends RoutePaths<TRouter['routeTree']> = TFrom,
   TMaskTo extends string = '',
->(
-  props: MakeMatchRouteOptions<
-    TRouter['routeTree'],
-    TFrom,
-    TTo,
-    TMaskFrom,
-    TMaskTo
-  >,
-): any {
+>(props: MakeMatchRouteOptions<TRouter, TFrom, TTo, TMaskFrom, TMaskTo>): any {
   const matchRoute = useMatchRoute()
   const params = matchRoute(props as any)
 

--- a/packages/react-router/tests/Matches.test-d.tsx
+++ b/packages/react-router/tests/Matches.test-d.tsx
@@ -1,5 +1,6 @@
 import { expectTypeOf, test } from 'vitest'
 import {
+  MatchRoute,
   createRootRoute,
   createRoute,
   createRouter,
@@ -46,6 +47,21 @@ test('when matching a route with params', () => {
   const matchRoute = useDefaultMatchRoute()
 
   expectTypeOf(matchRoute<string, '/invoices/$invoiceId'>)
+    .parameter(0)
+    .toHaveProperty('to')
+    .toEqualTypeOf<
+      | ''
+      | '/'
+      | './'
+      | '../'
+      | '/invoices'
+      | '/invoices/$invoiceId'
+      | 'invoices'
+      | 'invoices/$invoiceId'
+      | undefined
+    >()
+
+  expectTypeOf(MatchRoute<DefaultRouter, any, '/invoices/$invoiceId'>)
     .parameter(0)
     .toHaveProperty('to')
     .toEqualTypeOf<


### PR DESCRIPTION
Silly mistake by me! I've added a type test to cover it.

fixes #1533