### PR TITLE
fix: persisting the 'disabled' prop for custom link elements using `createLink`

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -711,6 +711,7 @@ export function useLinkProps<
     onMouseEnter: composeHandlers([onMouseEnter, handleEnter]),
     onMouseLeave: composeHandlers([onMouseLeave, handleLeave]),
     onTouchStart: composeHandlers([onTouchStart, handleTouchStart]),
+    disabled,
     target,
     ...(Object.keys(resolvedStyle).length && { style: resolvedStyle }),
     ...(resolvedClassName && { className: resolvedClassName }),
@@ -809,6 +810,13 @@ export const Link: LinkComponent<'a'> = React.forwardRef((props: any, ref) => {
           isActive: (linkProps as any)['data-status'] === 'active',
         })
       : rest.children
+
+  // the ReturnType of useLinkProps returns the correct type for a <a> element, not a general component that has a delete prop
+  // @ts-expect-error
+  if (!_asChild && typeof linkProps?.disabled !== 'undefined') {
+    // @ts-expect-error
+    delete linkProps.disabled
+  }
 
   return React.createElement(
     _asChild ? _asChild : 'a',

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -711,7 +711,7 @@ export function useLinkProps<
     onMouseEnter: composeHandlers([onMouseEnter, handleEnter]),
     onMouseLeave: composeHandlers([onMouseLeave, handleLeave]),
     onTouchStart: composeHandlers([onTouchStart, handleTouchStart]),
-    disabled,
+    disabled: !!disabled,
     target,
     ...(Object.keys(resolvedStyle).length && { style: resolvedStyle }),
     ...(resolvedClassName && { className: resolvedClassName }),
@@ -811,9 +811,8 @@ export const Link: LinkComponent<'a'> = React.forwardRef((props: any, ref) => {
         })
       : rest.children
 
-  // the ReturnType of useLinkProps returns the correct type for a <a> element, not a general component that has a delete prop
-  // @ts-expect-error
-  if (!_asChild && typeof linkProps?.disabled !== 'undefined') {
+  if (typeof _asChild === 'undefined') {
+    // the ReturnType of useLinkProps returns the correct type for a <a> element, not a general component that has a delete prop
     // @ts-expect-error
     delete linkProps.disabled
   }

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+
+import {
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  RouterProvider,
+  createLink,
+  Link,
+} from '../src'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('Link', () => {
+  it('should NOT pass the disabled prop to the target element', async () => {
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => (
+        <Link to="/" disabled>
+          Index
+        </Link>
+      ),
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+
+    const rendered = render(<RouterProvider router={router} />)
+    const customElement = rendered.queryByRole('link')
+    customElement?.hasAttribute('disabled')
+
+    expect(customElement!.hasAttribute('disabled')).toBe(false)
+  })
+})
+
+describe('createLink', () => {
+  it('should pass the disabled prop to the target element', async () => {
+    const CustomLink = createLink('button')
+
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => (
+        <CustomLink to="/" disabled>
+          Index
+        </CustomLink>
+      ),
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+
+    const rendered = render(<RouterProvider router={router} />)
+    const customElement = rendered.queryByRole('link')
+    customElement?.hasAttribute('disabled')
+
+    expect(customElement!.hasAttribute('disabled')).toBe(true)
+    expect(customElement!.getAttribute('disabled')).toBe('')
+  })
+})

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -36,7 +36,7 @@ describe('Link', () => {
     await router.load()
 
     const rendered = render(<RouterProvider router={router} />)
-    const customElement = rendered.queryByRole('link')
+    const customElement = rendered.queryByText('Index')
 
     expect(customElement!.hasAttribute('disabled')).toBe(false)
   })
@@ -64,7 +64,7 @@ describe('createLink', () => {
     await router.load()
 
     const rendered = render(<RouterProvider router={router} />)
-    const customElement = rendered.queryByRole('link')
+    const customElement = rendered.queryByText('Index')
 
     expect(customElement!.hasAttribute('disabled')).toBe(true)
     expect(customElement!.getAttribute('disabled')).toBe('')

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -17,7 +17,7 @@ afterEach(() => {
 })
 
 describe('Link', () => {
-  it('should NOT pass the disabled prop to the target element', async () => {
+  it('should NOT pass the "disabled" prop to the rendered Link component', async () => {
     const rootRoute = createRootRoute()
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
@@ -37,14 +37,13 @@ describe('Link', () => {
 
     const rendered = render(<RouterProvider router={router} />)
     const customElement = rendered.queryByRole('link')
-    customElement?.hasAttribute('disabled')
 
     expect(customElement!.hasAttribute('disabled')).toBe(false)
   })
 })
 
 describe('createLink', () => {
-  it('should pass the disabled prop to the target element', async () => {
+  it('should pass the "disabled" prop to the rendered target element', async () => {
     const CustomLink = createLink('button')
 
     const rootRoute = createRootRoute()
@@ -66,9 +65,39 @@ describe('createLink', () => {
 
     const rendered = render(<RouterProvider router={router} />)
     const customElement = rendered.queryByRole('link')
-    customElement?.hasAttribute('disabled')
 
     expect(customElement!.hasAttribute('disabled')).toBe(true)
     expect(customElement!.getAttribute('disabled')).toBe('')
+  })
+
+  it('should pass the "foo" prop to the rendered target element', async () => {
+    const CustomLink = createLink('button')
+
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => (
+        <CustomLink
+          to="/"
+          // @ts-expect-error
+          foo="bar"
+        >
+          Index
+        </CustomLink>
+      ),
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+
+    const rendered = render(<RouterProvider router={router} />)
+    const customElement = rendered.queryByText('Index')
+
+    expect(customElement!.hasAttribute('foo')).toBe(true)
+    expect(customElement!.getAttribute('foo')).toBe('bar')
   })
 })


### PR DESCRIPTION
Closes #1542 