### PR TITLE
fix(react-router): incorrectly always returning `undefined` as `parentMatchPromise` in the loader in the child route

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1603,8 +1603,8 @@ export class Router<
             const validResolvedMatches = matches.slice(0, firstBadMatchIndex)
             const matchPromises: Array<Promise<any>> = []
 
-            await Promise.all(
-              validResolvedMatches.map(async (match, index) => {
+            validResolvedMatches.forEach((match, index) => {
+              const createValidateResolvedMatchPromise = async () => {
                 const parentMatchPromise = matchPromises[index - 1]
                 const route = this.looseRoutesById[match.routeId]!
 
@@ -1815,8 +1815,14 @@ export class Router<
                 if (match.status !== 'success') {
                   await fetchWithRedirectAndNotFound()
                 }
-              }),
-            )
+
+                return
+              }
+
+              matchPromises.push(createValidateResolvedMatchPromise())
+            })
+
+            await Promise.all(matchPromises)
 
             checkLatest()
 


### PR DESCRIPTION
Fixes #1540 

The current implementation doesn't push any promises into the `matchPromises` [array](https://github.com/TanStack/router/blob/a4a5b5e56879c7e27107bc9ac6408ce7c15207a6/packages/react-router/src/router.ts#L1582) and as such, the `parentMatchPromise` is always `undefined` in the loader.

This change now pushes the routes into the `matchPromises` array restoring its outer shell to what it was prior to Tanner's [commit](https://github.com/TanStack/router/commit/d09db60415b4a6e8b32ec771f53015666a5c52e2#diff-2ac234f610fa0e0c2146252c10a5266af9c5b6d0b63659a0fa4c9f2c4472596a) in 1.28.2.

Not sure if there's a reason why the current implementation doesn't make use of the `matchPromises` array, but this fix restores the lost functionality.