### PR TITLE
fix(react-router): changing path params without specifying the `to` destination

### DIFF
--- a/packages/react-router/tests/redirects.test.ts
+++ b/packages/react-router/tests/redirects.test.ts
@@ -67,7 +67,7 @@ function createTestRouter(initialHistory?: RouterHistory) {
   }
 }
 
-describe('router.navigate navigation using a single path param', () => {
+describe('router.navigate navigation using a single path param - object syntax for updates', () => {
   it('should change $slug in "/posts/$slug" from "tanner" to "tkdodo"', async () => {
     const { router } = createTestRouter(
       createMemoryHistory({ initialEntries: ['/posts/tanner'] }),
@@ -104,7 +104,44 @@ describe('router.navigate navigation using a single path param', () => {
   })
 })
 
-describe('router.navigate navigation using multiple path params', () => {
+describe('router.navigate navigation using a single path param - function syntax for updates', () => {
+  it('should change $slug in "/posts/$slug" from "tanner" to "tkdodo"', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/posts/tanner'] }),
+    )
+
+    await router.load()
+
+    expect(router.state.resolvedLocation.pathname).toBe('/posts/tanner')
+
+    await router.navigate({
+      to: '/posts/$slug',
+      params: (p: any) => ({ ...p, slug: 'tkdodo' }),
+    })
+    await router.invalidate()
+
+    expect(router.state.location.pathname).toBe('/posts/tkdodo')
+  })
+
+  it('should change $slug in "/posts/$slug" from "tanner" to "tkdodo" w/o "to" path being provided', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/posts/tanner'] }),
+    )
+
+    await router.load()
+
+    expect(router.state.resolvedLocation.pathname).toBe('/posts/tanner')
+
+    await router.navigate({
+      params: (p: any) => ({ ...p, slug: 'tkdodo' }),
+    })
+    await router.invalidate()
+
+    expect(router.state.location.pathname).toBe('/posts/tkdodo')
+  })
+})
+
+describe('router.navigate navigation using multiple path params - object syntax for updates', () => {
   it('should change $projectId in "/p/$projectId/$version/$framework" from "router" to "query"', async () => {
     const { router } = createTestRouter(
       createMemoryHistory({ initialEntries: ['/p/router/v1/react'] }),
@@ -204,6 +241,113 @@ describe('router.navigate navigation using multiple path params', () => {
 
     await router.navigate({
       params: { framework: 'vue' },
+    })
+    await router.invalidate()
+
+    expect(router.state.location.pathname).toBe('/p/router/v1/vue')
+  })
+})
+
+describe('router.navigate navigation using multiple path params - function syntax for updates', () => {
+  it('should change $projectId in "/p/$projectId/$version/$framework" from "router" to "query"', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/p/router/v1/react'] }),
+    )
+
+    await router.load()
+
+    expect(router.state.location.pathname).toBe('/p/router/v1/react')
+
+    await router.navigate({
+      to: '/p/$projectId/$version/$framework',
+      params: (p: any) => ({ ...p, projectId: 'query' }),
+    })
+    await router.invalidate()
+
+    expect(router.state.location.pathname).toBe('/p/query/v1/react')
+  })
+
+  it('should change $projectId in "/p/$projectId/$version/$framework" from "router" to "query" w/o "to" path being provided', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/p/router/v1/react'] }),
+    )
+
+    await router.load()
+
+    expect(router.state.location.pathname).toBe('/p/router/v1/react')
+
+    await router.navigate({
+      params: (p: any) => ({ ...p, projectId: 'query' }),
+    })
+    await router.invalidate()
+
+    expect(router.state.location.pathname).toBe('/p/query/v1/react')
+  })
+
+  it('should change $version in "/p/$projectId/$version/$framework" from "v1" to "v3"', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/p/router/v1/react'] }),
+    )
+
+    await router.load()
+
+    expect(router.state.location.pathname).toBe('/p/router/v1/react')
+
+    await router.navigate({
+      to: '/p/$projectId/$version/$framework',
+      params: (p: any) => ({ ...p, version: 'v3' }),
+    })
+    await router.invalidate()
+
+    expect(router.state.location.pathname).toBe('/p/router/v3/react')
+  })
+
+  it('should change $version in "/p/$projectId/$version/$framework" from "v1" to "v3" w/o "to" path being provided', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/p/router/v1/react'] }),
+    )
+
+    await router.load()
+
+    expect(router.state.location.pathname).toBe('/p/router/v1/react')
+
+    await router.navigate({
+      params: (p: any) => ({ ...p, version: 'v3' }),
+    })
+    await router.invalidate()
+
+    expect(router.state.location.pathname).toBe('/p/router/v3/react')
+  })
+
+  it('should change $framework in "/p/$projectId/$version/$framework" from "react" to "vue"', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/p/router/v1/react'] }),
+    )
+
+    await router.load()
+
+    expect(router.state.location.pathname).toBe('/p/router/v1/react')
+
+    await router.navigate({
+      to: '/p/$projectId/$version/$framework',
+      params: (p: any) => ({ ...p, framework: 'vue' }),
+    })
+    await router.invalidate()
+
+    expect(router.state.location.pathname).toBe('/p/router/v1/vue')
+  })
+
+  it('should change $framework in "/p/$projectId/$version/$framework" from "react" to "vue" w/o "to" path being provided', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/p/router/v1/react'] }),
+    )
+
+    await router.load()
+
+    expect(router.state.location.pathname).toBe('/p/router/v1/react')
+
+    await router.navigate({
+      params: (p: any) => ({ ...p, framework: 'vue' }),
     })
     await router.invalidate()
 

--- a/packages/react-router/tests/redirects.test.ts
+++ b/packages/react-router/tests/redirects.test.ts
@@ -67,8 +67,8 @@ function createTestRouter(initialHistory?: RouterHistory) {
   }
 }
 
-describe('navigate for simple route with one param', () => {
-  it('"/posts/tanner" to "/posts/tkdodo"', async () => {
+describe('router.navigate navigation using a single path param', () => {
+  it('should change $slug in "/posts/$slug" from "tanner" to "tkdodo"', async () => {
     const { router } = createTestRouter(
       createMemoryHistory({ initialEntries: ['/posts/tanner'] }),
     )
@@ -78,7 +78,25 @@ describe('navigate for simple route with one param', () => {
     expect(router.state.resolvedLocation.pathname).toBe('/posts/tanner')
 
     await router.navigate({
-      params: (prev: any) => ({ ...prev, slug: 'tkdodo' }),
+      to: '/posts/$slug',
+      params: { slug: 'tkdodo' },
+    })
+    await router.invalidate()
+
+    expect(router.state.location.pathname).toBe('/posts/tkdodo')
+  })
+
+  it('should change $slug in "/posts/$slug" from "tanner" to "tkdodo" w/o "to" path being provided', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/posts/tanner'] }),
+    )
+
+    await router.load()
+
+    expect(router.state.resolvedLocation.pathname).toBe('/posts/tanner')
+
+    await router.navigate({
+      params: { slug: 'tkdodo' },
     })
     await router.invalidate()
 
@@ -86,8 +104,8 @@ describe('navigate for simple route with one param', () => {
   })
 })
 
-describe('navigate for complex route with two params', () => {
-  it('"/p/router/v1/react to /p/router/v3/react"', async () => {
+describe('router.navigate navigation using multiple path params', () => {
+  it('should change $projectId in "/p/$projectId/$version/$framework" from "router" to "query"', async () => {
     const { router } = createTestRouter(
       createMemoryHistory({ initialEntries: ['/p/router/v1/react'] }),
     )
@@ -97,69 +115,98 @@ describe('navigate for complex route with two params', () => {
     expect(router.state.location.pathname).toBe('/p/router/v1/react')
 
     await router.navigate({
-      params: (prev: any) => {
-        return { ...prev, version: 'v3' }
-      },
+      to: '/p/$projectId/$version/$framework',
+      params: { projectId: 'query' },
+    })
+    await router.invalidate()
+
+    expect(router.state.location.pathname).toBe('/p/query/v1/react')
+  })
+
+  it('should change $projectId in "/p/$projectId/$version/$framework" from "router" to "query" w/o "to" path being provided', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/p/router/v1/react'] }),
+    )
+
+    await router.load()
+
+    expect(router.state.location.pathname).toBe('/p/router/v1/react')
+
+    await router.navigate({
+      params: { projectId: 'query' },
+    })
+    await router.invalidate()
+
+    expect(router.state.location.pathname).toBe('/p/query/v1/react')
+  })
+
+  it('should change $version in "/p/$projectId/$version/$framework" from "v1" to "v3"', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/p/router/v1/react'] }),
+    )
+
+    await router.load()
+
+    expect(router.state.location.pathname).toBe('/p/router/v1/react')
+
+    await router.navigate({
+      to: '/p/$projectId/$version/$framework',
+      params: { version: 'v3' },
     })
     await router.invalidate()
 
     expect(router.state.location.pathname).toBe('/p/router/v3/react')
   })
 
-  it('"/p/router/latest/react to /p/router/latest/vue"', async () => {
+  it('should change $version in "/p/$projectId/$version/$framework" from "v1" to "v3" w/o "to" path being provided', async () => {
     const { router } = createTestRouter(
-      createMemoryHistory({ initialEntries: ['/p/router/latest/react'] }),
+      createMemoryHistory({ initialEntries: ['/p/router/v1/react'] }),
     )
 
     await router.load()
 
-    expect(router.state.location.pathname).toBe('/p/router/latest/react')
+    expect(router.state.location.pathname).toBe('/p/router/v1/react')
 
     await router.navigate({
-      params: (prev: any) => {
-        return { ...prev, framework: 'vue' }
-      },
+      params: { version: 'v3' },
     })
     await router.invalidate()
 
-    expect(router.state.location.pathname).toBe('/p/router/latest/vue')
+    expect(router.state.location.pathname).toBe('/p/router/v3/react')
   })
 
-  it('"/p/router/latest/react to /p/router/latest/react?framework=vue"', async () => {
+  it('should change $framework in "/p/$projectId/$version/$framework" from "react" to "vue"', async () => {
     const { router } = createTestRouter(
-      createMemoryHistory({ initialEntries: ['/p/form/latest/angular'] }),
+      createMemoryHistory({ initialEntries: ['/p/router/v1/react'] }),
     )
 
     await router.load()
 
-    expect(router.state.location.pathname).toBe('/p/form/latest/angular')
+    expect(router.state.location.pathname).toBe('/p/router/v1/react')
 
     await router.navigate({
-      params: (prev: any) => {
-        return { ...prev, projectId: 'query' }
-      },
+      to: '/p/$projectId/$version/$framework',
+      params: { framework: 'vue' },
     })
     await router.invalidate()
 
-    expect(router.state.location.pathname).toBe('/p/query/latest/angular')
+    expect(router.state.location.pathname).toBe('/p/router/v1/vue')
   })
 
-  it('"/p/table/latest/angular to /p/router/latest/react"', async () => {
+  it('should change $framework in "/p/$projectId/$version/$framework" from "react" to "vue" w/o "to" path being provided', async () => {
     const { router } = createTestRouter(
-      createMemoryHistory({ initialEntries: ['/p/table/latest/angular'] }),
+      createMemoryHistory({ initialEntries: ['/p/router/v1/react'] }),
     )
 
     await router.load()
 
-    expect(router.state.location.pathname).toBe('/p/table/latest/angular')
+    expect(router.state.location.pathname).toBe('/p/router/v1/react')
 
     await router.navigate({
-      params: (prev: any) => {
-        return { ...prev, projectId: 'router', framework: 'react' }
-      },
+      params: { framework: 'vue' },
     })
     await router.invalidate()
 
-    expect(router.state.location.pathname).toBe('/p/router/latest/react')
+    expect(router.state.location.pathname).toBe('/p/router/v1/vue')
   })
 })

--- a/packages/react-router/tests/router.test.ts
+++ b/packages/react-router/tests/router.test.ts
@@ -301,47 +301,4 @@ describe('encoding: splat param for /$', () => {
       'framework/react/guide/file-based-routing tanstack',
     )
   })
-
-  it('router.navigate with `params` and `to`, should transition from "/posts/tanner" to "/posts/tkdodo"', async () => {
-    const { router, routes } = createTestRouter(
-      createMemoryHistory({ initialEntries: ['/posts/tanner'] }),
-    )
-
-    await router.load()
-
-    expect(router.state.location.pathname).toBe('/posts/tanner')
-
-    await router.navigate({
-      to: routes.postIdRoute.to,
-      params: (prev: any) => {
-        console.log(prev)
-        return { ...prev, slug: 'tkdodo' }
-      },
-    })
-    // Not sure why I have to do this
-    await router.invalidate()
-
-    expect(router.state.location.pathname).toBe('/posts/tkdodo')
-  })
-
-  it('router.navigate with `params` and no `to`, should transition from "/posts/tanner" to "/posts/tkdodo"', async () => {
-    const { router } = createTestRouter(
-      createMemoryHistory({ initialEntries: ['/posts/tanner'] }),
-    )
-
-    await router.load()
-
-    expect(router.state.location.pathname).toBe('/posts/tanner')
-
-    await router.navigate({
-      params: (prev: any) => ({ ...prev, slug: 'tkdodo' }),
-    })
-    await router.invalidate()
-
-    // This fails but should succeed
-    expect(router.state.location.pathname).toBe('/posts/tkdodo')
-
-    // This succeeds but should fail
-    // expect(router.state.location.pathname).toBe('/posts/tanner')
-  })
 })

--- a/packages/react-router/tests/router.test.ts
+++ b/packages/react-router/tests/router.test.ts
@@ -316,7 +316,7 @@ describe('encoding: splat param for /$', () => {
       params: (prev: any) => {
         console.log(prev)
         return { ...prev, slug: 'tkdodo' }
-      }
+      },
     })
     // Not sure why I have to do this
     await router.invalidate()
@@ -333,7 +333,9 @@ describe('encoding: splat param for /$', () => {
 
     expect(router.state.location.pathname).toBe('/posts/tanner')
 
-    await router.navigate({ params: (prev: any) => ({ ...prev, slug: 'tkdodo' }) })
+    await router.navigate({
+      params: (prev: any) => ({ ...prev, slug: 'tkdodo' }),
+    })
     await router.invalidate()
 
     // This fails but should succeed

--- a/packages/react-router/tests/router.test.ts
+++ b/packages/react-router/tests/router.test.ts
@@ -301,4 +301,45 @@ describe('encoding: splat param for /$', () => {
       'framework/react/guide/file-based-routing tanstack',
     )
   })
+
+  it('router.navigate with `params` and `to`, should transition from "/posts/tanner" to "/posts/tkdodo"', async () => {
+    const { router, routes } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/posts/tanner'] }),
+    )
+
+    await router.load()
+
+    expect(router.state.location.pathname).toBe('/posts/tanner')
+
+    await router.navigate({
+      to: routes.postIdRoute.to,
+      params: (prev: any) => {
+        console.log(prev)
+        return { ...prev, slug: 'tkdodo' }
+      }
+    })
+    // Not sure why I have to do this
+    await router.invalidate()
+
+    expect(router.state.location.pathname).toBe('/posts/tkdodo')
+  })
+
+  it('router.navigate with `params` and no `to`, should transition from "/posts/tanner" to "/posts/tkdodo"', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/posts/tanner'] }),
+    )
+
+    await router.load()
+
+    expect(router.state.location.pathname).toBe('/posts/tanner')
+
+    await router.navigate({ params: (prev: any) => ({ ...prev, slug: 'tkdodo' }) })
+    await router.invalidate()
+
+    // This fails but should succeed
+    expect(router.state.location.pathname).toBe('/posts/tkdodo')
+
+    // This succeeds but should fail
+    // expect(router.state.location.pathname).toBe('/posts/tanner')
+  })
 })


### PR DESCRIPTION
Add fixes and tests for `router.navigate` when using the `params: (prevParams) => newParams` option (with no extra `to` or `from` option).

Thanks to @SeanCassiere for the suggestion to patch `router.ts`

Fixes #1525
Should also fix https://github.com/TanStack/tanstack.com/issues/218 