### PR TITLE
fix(router-vite-plugin): use `cwd` instead of `vite.root`

### DIFF
--- a/packages/router-vite-plugin/src/index.ts
+++ b/packages/router-vite-plugin/src/index.ts
@@ -88,7 +88,7 @@ export function TanStackRouterViteGenerator(
   return {
     name: 'vite-plugin-tanstack-router-generator',
     configResolved: async (config) => {
-      ROOT = config.root
+      ROOT = process.cwd()
       userConfig = await getConfig(inlineConfig, ROOT)
 
       if (userConfig.enableRouteGeneration ?? true) {


### PR DESCRIPTION
fixes #1550.

Based on the issue, I was experiencing issues with the vite plugin generation not working when using a non-standard vite `root` configuration. This was caused by a mismatch between most of the code using `./` or `process.cwd()` as the relative root, and this line using `vite.root`.

I don't think vite's `root` config is strictly necessary here, because the TSR configuration already allows you to configure your `routesDirectory` and `generatedRouteTree` if using a non-standard directory structure.