### PR TITLE
fix(history): index and entries for pushState using memoryHistory could fall out of sync

### DIFF
--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -353,7 +353,7 @@ export function createMemoryHistory(
     pushState: (path, state) => {
       currentState = state
       entries.push(path)
-      index++
+      index = Math.max(entries.length - 1, 0)
     },
     replaceState: (path, state) => {
       currentState = state


### PR DESCRIPTION
This change only affects memory history.

When using the `history.back`, it decrements the `index` by `-1`.

This is correct, since calling `history.forward` would require the `index` to be incremented by `+1` and would require an `entries` value to be present.

However, this then causes a scenario where calling `history.pushState` would cause the `entries` array to have an extra item with the `index` lagging behind by one.

This change affects the `history.pushState`, whereby assigns the `index` a number based on `entries.length - 1` or `0`.

Fixes #1555 