### PR TITLE
fix(react-router): when navigating without `to` the layout segments are not being stripped out

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -936,7 +936,7 @@ export class Router<
         fromMatches.find((e) => e.routeId === d.routeId),
       )
 
-      const fromPathMatched = stayingMatches?.find(
+      const fromRouteByFromPath = stayingMatches?.find(
         (d) => d.pathname === fromPath,
       )
 
@@ -944,8 +944,8 @@ export class Router<
         ? this.resolvePathWithBase(fromPath, `${dest.to}`)
         : this.resolvePathWithBase(
             fromPath,
-            fromPathMatched
-              ? removeLayoutSegments(fromPathMatched.routeId)
+            fromRouteByFromPath
+              ? removeLayoutSegments(fromRouteByFromPath.routeId)
               : fromPath,
           )
 

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -11,6 +11,7 @@ import {
   functionalUpdate,
   last,
   pick,
+  removeLayoutSegments,
   replaceEqualDeep,
 } from './utils'
 import { getRouteMatch } from './RouterProvider'
@@ -935,12 +936,17 @@ export class Router<
         fromMatches.find((e) => e.routeId === d.routeId),
       )
 
+      const fromPathMatched = stayingMatches?.find(
+        (d) => d.pathname === fromPath,
+      )
+
       let pathname = dest.to
         ? this.resolvePathWithBase(fromPath, `${dest.to}`)
         : this.resolvePathWithBase(
             fromPath,
-            stayingMatches?.find((d) => d.pathname === fromPath)?.routeId ||
-              fromPath,
+            fromPathMatched
+              ? removeLayoutSegments(fromPathMatched.routeId)
+              : fromPath,
           )
 
       const prevParams = { ...last(fromMatches)?.params }

--- a/packages/react-router/src/utils.ts
+++ b/packages/react-router/src/utils.ts
@@ -339,3 +339,17 @@ export function createControlledPromise<T>(onResolve?: () => void) {
 
   return controlledPromise
 }
+
+/**
+ * Removes all segments from a given path that start with an underscore ('_').
+ *
+ * @param {string} routePath - The path from which to remove segments. Defaults to '/'.
+ * @returns {string} The path with all underscore-prefixed segments removed.
+ * @example
+ * removeLayoutSegments('/workspace/_auth/foo') // '/workspace/foo'
+ */
+export function removeLayoutSegments(routePath: string): string {
+  const segments = routePath.split('/')
+  const newSegments = segments.filter((segment) => !segment.startsWith('_'))
+  return newSegments.join('/')
+}

--- a/packages/react-router/tests/redirects.test.ts
+++ b/packages/react-router/tests/redirects.test.ts
@@ -399,7 +399,7 @@ describe('router.navigate navigation using layout routes resolves correctly', as
     await router.load()
 
     expect(router.state.location.pathname).toBe('/u/tanner')
-    // console.log(router.state)
+
     await router.navigate({
       params: { username: 'tkdodo' },
     })

--- a/packages/react-router/tests/redirects.test.ts
+++ b/packages/react-router/tests/redirects.test.ts
@@ -373,7 +373,7 @@ describe('router.navigate navigation using multiple path params - function synta
 })
 
 describe('router.navigate navigation using layout routes resolves correctly', async () => {
-  it('should resolve "/u/$username" to "/u/tkdodo"', async () => {
+  it('should resolve "/u/tanner" in "/u/_layout/$username" to "/u/tkdodo"', async () => {
     const { router } = createTestRouter(
       createMemoryHistory({ initialEntries: ['/u/tanner'] }),
     )
@@ -391,7 +391,7 @@ describe('router.navigate navigation using layout routes resolves correctly', as
     expect(router.state.location.pathname).toBe('/u/tkdodo')
   })
 
-  it('should resolve "/u/$username" to "/u/tkdodo" w/o "to" path being provided', async () => {
+  it('should resolve "/u/tanner" in "/u/_layout/$username" to "/u/tkdodo" w/o "to" path being provided', async () => {
     const { router } = createTestRouter(
       createMemoryHistory({ initialEntries: ['/u/tanner'] }),
     )

--- a/packages/react-router/tests/redirects.test.ts
+++ b/packages/react-router/tests/redirects.test.ts
@@ -40,16 +40,33 @@ function createTestRouter(initialHistory?: RouterHistory) {
     path: '/$framework',
   })
 
+  const userRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/u',
+  })
+  const userLayoutRoute = createRoute({
+    id: '_layout',
+    getParentRoute: () => userRoute,
+  })
+  const usernameRoute = createRoute({
+    getParentRoute: () => userLayoutRoute,
+    path: '$username',
+  })
+
   const projectTree = projectRoute.addChildren([
     projectIdRoute.addChildren([
       projectVersionRoute.addChildren([projectFrameRoute]),
     ]),
+  ])
+  const userTree = userRoute.addChildren([
+    userLayoutRoute.addChildren([usernameRoute]),
   ])
 
   const routeTree = rootRoute.addChildren([
     indexRoute,
     postsRoute.addChildren([postIdRoute]),
     projectTree,
+    userTree,
   ])
   const router = createRouter({ routeTree, history })
 
@@ -352,5 +369,42 @@ describe('router.navigate navigation using multiple path params - function synta
     await router.invalidate()
 
     expect(router.state.location.pathname).toBe('/p/router/v1/vue')
+  })
+})
+
+describe('router.navigate navigation using layout routes resolves correctly', async () => {
+  it('should resolve "/u/$username" to "/u/tkdodo"', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/u/tanner'] }),
+    )
+
+    await router.load()
+
+    expect(router.state.location.pathname).toBe('/u/tanner')
+
+    await router.navigate({
+      to: '/u/$username',
+      params: { username: 'tkdodo' },
+    })
+    await router.invalidate()
+
+    expect(router.state.location.pathname).toBe('/u/tkdodo')
+  })
+
+  it('should resolve "/u/$username" to "/u/tkdodo" w/o "to" path being provided', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/u/tanner'] }),
+    )
+
+    await router.load()
+
+    expect(router.state.location.pathname).toBe('/u/tanner')
+    // console.log(router.state)
+    await router.navigate({
+      params: { username: 'tkdodo' },
+    })
+    await router.invalidate()
+
+    expect(router.state.location.pathname).toBe('/u/tkdodo')
   })
 })

--- a/packages/react-router/tests/utils.test.ts
+++ b/packages/react-router/tests/utils.test.ts
@@ -363,49 +363,49 @@ describe('exactPathTest', () => {
 })
 
 describe('removeLayoutSegments', () => {
-  it('should remove the "_layout" segment from "/_layout/" and return "/""', () => {
+  it('should remove the "_layout" segment from "/_layout/" and return "/"', () => {
     const path = '/_layout/'
     const result = removeLayoutSegments(path)
     expect(result).toBe('/')
   })
 
-  it('should remove the "_layout" segment from "/_layout/blog" and return "/blog""', () => {
+  it('should remove the "_layout" segment from "/_layout/blog" and return "/blog"', () => {
     const path = '/_layout/blog'
     const result = removeLayoutSegments(path)
     expect(result).toBe('/blog')
   })
 
-  it('should remove the "_layout1" and "_layout2" segments from "/_layout1/" and return "/""', () => {
+  it('should remove the "_layout1" and "_layout2" segments from "/_layout1/" and return "/"', () => {
     const path = '/_layout1/_layout2/'
     const result = removeLayoutSegments(path)
     expect(result).toBe('/')
   })
 
-  it('should remove the "_layout1" and "_layout2" segments from "/_layout1/blog" and return "/blog""', () => {
+  it('should remove the "_layout1" and "_layout2" segments from "/_layout1/blog" and return "/blog"', () => {
     const path = '/_layout1/_layout2/blog'
     const result = removeLayoutSegments(path)
     expect(result).toBe('/blog')
   })
 
-  it('should remove the "_layout" segment from "/posts/_layout/" and return "/posts/""', () => {
+  it('should remove the "_layout" segment from "/posts/_layout/" and return "/posts/"', () => {
     const path = '/posts/_layout/1'
     const result = removeLayoutSegments(path)
     expect(result).toBe('/posts/1')
   })
 
-  it('should remove the "_layout" segment from "/posts/_layout/1" and return "/posts/1""', () => {
+  it('should remove the "_layout" segment from "/posts/_layout/1" and return "/posts/1"', () => {
     const path = '/posts/_layout/1'
     const result = removeLayoutSegments(path)
     expect(result).toBe('/posts/1')
   })
 
-  it('should remove the "_layout" segment from "/posts/_layout/" and return "/posts""', () => {
+  it('should remove the "_layout" segment from "/posts/_layout/" and return "/posts"', () => {
     const path = '/posts/_layout/'
     const result = removeLayoutSegments(path)
     expect(result).toBe('/posts/')
   })
 
-  it('should remove the "_layout" segment from "/posts/_layout/blog" and return "/posts/blog""', () => {
+  it('should remove the "_layout" segment from "/posts/_layout/blog" and return "/posts/blog"', () => {
     const path = '/posts/_layout/blog'
     const result = removeLayoutSegments(path)
     expect(result).toBe('/posts/blog')

--- a/packages/react-router/tests/utils.test.ts
+++ b/packages/react-router/tests/utils.test.ts
@@ -4,6 +4,7 @@ import {
   isPlainArray,
   removeTrailingSlash,
   replaceEqualDeep,
+  removeLayoutSegments,
 } from '../src/utils'
 
 describe('replaceEqualDeep', () => {
@@ -358,5 +359,55 @@ describe('exactPathTest', () => {
     const path2 = '/'
     const result = exactPathTest(path1, path2)
     expect(result).toBe(true)
+  })
+})
+
+describe('removeLayoutSegments', () => {
+  it('should remove the "_layout" segment from "/_layout/" and return "/""', () => {
+    const path = '/_layout/'
+    const result = removeLayoutSegments(path)
+    expect(result).toBe('/')
+  })
+
+  it('should remove the "_layout" segment from "/_layout/blog" and return "/blog""', () => {
+    const path = '/_layout/blog'
+    const result = removeLayoutSegments(path)
+    expect(result).toBe('/blog')
+  })
+
+  it('should remove the "_layout1" and "_layout2" segments from "/_layout1/" and return "/""', () => {
+    const path = '/_layout1/_layout2/'
+    const result = removeLayoutSegments(path)
+    expect(result).toBe('/')
+  })
+
+  it('should remove the "_layout1" and "_layout2" segments from "/_layout1/blog" and return "/blog""', () => {
+    const path = '/_layout1/_layout2/blog'
+    const result = removeLayoutSegments(path)
+    expect(result).toBe('/blog')
+  })
+
+  it('should remove the "_layout" segment from "/posts/_layout/" and return "/posts/""', () => {
+    const path = '/posts/_layout/1'
+    const result = removeLayoutSegments(path)
+    expect(result).toBe('/posts/1')
+  })
+
+  it('should remove the "_layout" segment from "/posts/_layout/1" and return "/posts/1""', () => {
+    const path = '/posts/_layout/1'
+    const result = removeLayoutSegments(path)
+    expect(result).toBe('/posts/1')
+  })
+
+  it('should remove the "_layout" segment from "/posts/_layout/" and return "/posts""', () => {
+    const path = '/posts/_layout/'
+    const result = removeLayoutSegments(path)
+    expect(result).toBe('/posts/')
+  })
+
+  it('should remove the "_layout" segment from "/posts/_layout/blog" and return "/posts/blog""', () => {
+    const path = '/posts/_layout/blog'
+    const result = removeLayoutSegments(path)
+    expect(result).toBe('/posts/blog')
   })
 })


### PR DESCRIPTION
#1548 didn't account for layout routes as pointed out in #1560.

FIxes #1560 