### PR TITLE
docs(examples): set correct correct server entry-point for production for "basic-ssr"

### DIFF
--- a/examples/react/basic-ssr-file-based/server.js
+++ b/examples/react/basic-ssr-file-based/server.js
@@ -68,7 +68,7 @@ export async function createServer(
         if (!isProd) {
           return vite.ssrLoadModule('/src/entry-server.tsx')
         } else {
-          return import('./dist/server/entry-server.tsx')
+          return import('./dist/server/entry-server.js')
         }
       })()
 

--- a/examples/react/basic-ssr-streaming-file-based/server.js
+++ b/examples/react/basic-ssr-streaming-file-based/server.js
@@ -68,7 +68,7 @@ export async function createServer(
         if (!isProd) {
           return vite.ssrLoadModule('/src/entry-server.tsx')
         } else {
-          return import('./dist/server/entry-server.tsx')
+          return import('./dist/server/entry-server.js')
         }
       })()
 

--- a/examples/react/wip-with-bling/server.js
+++ b/examples/react/wip-with-bling/server.js
@@ -126,7 +126,7 @@ export async function createServer(
         if (!isProd) {
           return vite.ssrLoadModule('/src/entry-server.tsx')
         } else {
-          return import('./dist/server/entry-server.tsx')
+          return import('./dist/server/entry-server.js')
         }
       })()
 


### PR DESCRIPTION
The server for the "Basic + SSR" (and the wip-with-bling) example is specifiying the wrong file name that gets built into the dist folder.


To reproduce:

1. Open the Stackblitz project: https://tanstack.com/router/latest/docs/framework/react/examples/basic-ssr-file-based
2. `npm i`
3. `npm run build`
4. `npm run serve`

Produces the following error:

```properties
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/projects/wmaivvaxx.github/dist/server/entry-server.tsx' imported from /home/projects/wmaivvaxx.github/server.js
    at __node_internal_captureLargerStackTrace2 (https://wmaivvaxxgithub-vsdf.w-staticblitz.com/builtins.575e820e.js:101:5528)
    at new NodeError (https://wmaivvaxxgithub-vsdf.w-staticblitz.com/builtins.575e820e.js:101:4214)
    at finalizeResolution (https://wmaivvaxxgithub-vsdf.w-staticblitz.com/builtins.575e820e.js:158:11255)
```