### PR TITLE
docs: add missing comma to from an example in the router-context guide

### DIFF
--- a/docs/framework/react/guide/router-context.md
+++ b/docs/framework/react/guide/router-context.md
@@ -190,7 +190,7 @@ export const Route = createFileRoute('/todos')({
     return {
       bar: true,
     }
-  }
+  },
   loader: ({ context }) => {
     context.foo // true
     context.bar // true


### PR DESCRIPTION
Big fix incoming :smile: 

Adding what looks to be a missing comma in a `todos.tsx` example.

Thanks for all your work on TanStack Router and the docs!