### PR TITLE
test(react-router): resolving an incorrect configuration checking the route-bound hooks on `createFileRoute`

### DIFF
--- a/packages/react-router/tests/fileRoute.test.ts
+++ b/packages/react-router/tests/fileRoute.test.ts
@@ -17,7 +17,7 @@ describe('createFileRoute has the same hooks as getRouteApi', () => {
   it.each(hookNames.map((name) => [name]))(
     'should have the "%s" hook defined',
     (hookName) => {
-      expect(hookName as keyof LazyRoute<any>).toBeDefined()
+      expect(route[hookName as keyof LazyRoute<any>]).toBeDefined()
     },
   )
 })


### PR DESCRIPTION
The test for checking if the same hooks are defined when using the createFileRoute function wasn't actually doing its job.