### PR TITLE
docs: broken hyperlink on the "route-matching" guide

### DIFF
--- a/docs/framework/react/guide/route-matching.md
+++ b/docs/framework/react/guide/route-matching.md
@@ -92,9 +92,9 @@ Using that route tree, let's follow the matching process for a few different URL
     ✅ *
   ```
 
-## Pathless Route Matching
+## Pathless / Layout Route Matching
 
-During matching, [pathless routes](../route-trees#pathless-routes) are treated as if they are flat. If a route is not found in a pathless route's children, matching will continue out of the pathless route's children and on through the rest of the parent subtree like normal.
+During matching, [pathless / layout routes](../routing-concepts#pathless--layout-routes) are treated as if they are flat. If a route is not found in a pathless route's children, matching will continue out of the pathless route's children and on through the rest of the parent subtree like normal.
 
 ## `NotFoundRoute`s and Matching
 


### PR DESCRIPTION
Fixed a broken hyperlink as reported in this discussion: https://github.com/TanStack/router/discussions/1580