### PR TITLE
fix(router-generator): generator should not infer trailing slash is not necessary for index routes

### DIFF
--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -585,14 +585,11 @@ export async function generator(config: Config) {
       .map((routeNode) => {
         const filePathId = removeTrailingUnderscores(routeNode.routePath)
         const id = removeGroups(filePathId ?? '')
-        const fullPath = removeGroups(
-          removeUnderscores(removeLayoutSegments(routeNode.routePath)) ?? '',
-        )
 
         return `'${filePathId}': {
           id: '${id}'
-          path: '${routeNode.cleanedPath}'
-          fullPath: '${fullPath}'
+          path: '${inferPath(routeNode)}'
+          fullPath: '${inferFullPath(routeNode)}'
           preLoaderRoute: typeof ${routeNode.variableName}Import
           parentRoute: typeof ${
             routeNode.isVirtualParentRequired
@@ -794,4 +791,24 @@ export function hasParentRoute(
   const parentRoutePath = segments.join('/')
 
   return hasParentRoute(routes, node, parentRoutePath)
+}
+
+/**
+ * Infers the full path for use by TS
+ */
+export const inferFullPath = (routeNode: RouteNode): string => {
+  const fullPath = removeGroups(
+    removeUnderscores(removeLayoutSegments(routeNode.routePath)) ?? '',
+  )
+
+  return routeNode.cleanedPath === '/' ? fullPath : fullPath.replace(/\/$/, '')
+}
+
+/**
+ * Infers the path for use by TS
+ */
+export const inferPath = (routeNode: RouteNode): string => {
+  return routeNode.cleanedPath === '/'
+    ? routeNode.cleanedPath
+    : routeNode.cleanedPath?.replace(/\/$/, '') ?? ''
 }

--- a/packages/router-generator/tests/generator/flat/routeTree.expected.ts
+++ b/packages/router-generator/tests/generator/flat/routeTree.expected.ts
@@ -123,15 +123,15 @@ declare module '@tanstack/react-router' {
     }
     '/blog/$slug/': {
       id: '/blog/$slug/'
-      path: '/$slug/'
-      fullPath: '/blog/$slug/'
+      path: '/$slug'
+      fullPath: '/blog/$slug'
       preLoaderRoute: typeof BlogSlugIndexImport
       parentRoute: typeof BlogRouteImport
     }
     '/posts/$postId/': {
       id: '/posts/$postId/'
-      path: '/$postId/'
-      fullPath: '/posts/$postId/'
+      path: '/$postId'
+      fullPath: '/posts/$postId'
       preLoaderRoute: typeof PostsPostIdIndexImport
       parentRoute: typeof PostsRouteImport
     }

--- a/packages/router-generator/tests/generator/nested/routeTree.expected.ts
+++ b/packages/router-generator/tests/generator/nested/routeTree.expected.ts
@@ -130,8 +130,8 @@ declare module '@tanstack/react-router' {
     }
     '/posts/$postId/': {
       id: '/posts/$postId/'
-      path: '/$postId/'
-      fullPath: '/posts/$postId/'
+      path: '/$postId'
+      fullPath: '/posts/$postId'
       preLoaderRoute: typeof PostsPostIdIndexImport
       parentRoute: typeof PostsRouteImport
     }


### PR DESCRIPTION
Trailing slashes should only be there if the index route has to be uniquely identified by it.

fixes #1596