### PR TITLE
fix: do not use global `JSX` namespace

### DIFF
--- a/packages/react-router/src/Matches.tsx
+++ b/packages/react-router/src/Matches.tsx
@@ -61,9 +61,9 @@ export interface RouteMatch<
   loaderDeps: TLoaderDeps
   preload: boolean
   invalid: boolean
-  meta?: Array<JSX.IntrinsicElements['meta']>
-  links?: Array<JSX.IntrinsicElements['link']>
-  scripts?: Array<JSX.IntrinsicElements['script']>
+  meta?: Array<React.JSX.IntrinsicElements['meta']>
+  links?: Array<React.JSX.IntrinsicElements['link']>
+  scripts?: Array<React.JSX.IntrinsicElements['script']>
   headers?: Record<string, string>
   globalNotFound?: boolean
   staticData: StaticDataRouteOption

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -809,7 +809,7 @@ export interface LinkPropsChildren {
 type LinkComponentReactProps<TComp> = React.PropsWithoutRef<
   TComp extends React.FC<infer TProps> | React.Component<infer TProps>
     ? TProps
-    : TComp extends keyof JSX.IntrinsicElements
+    : TComp extends keyof React.JSX.IntrinsicElements
       ? Omit<React.HTMLProps<TComp>, 'children' | 'preload'>
       : never
 > &
@@ -818,7 +818,7 @@ type LinkComponentReactProps<TComp> = React.PropsWithoutRef<
       | React.FC<{ ref: infer TRef }>
       | React.Component<{ ref: infer TRef }>
       ? TRef
-      : TComp extends keyof JSX.IntrinsicElements
+      : TComp extends keyof React.JSX.IntrinsicElements
         ? React.ComponentRef<TComp>
         : never
   >

--- a/packages/react-router/src/route.ts
+++ b/packages/react-router/src/route.ts
@@ -274,9 +274,9 @@ export type UpdatableRouteOptions<
     matches: Array<TRouteMatch>
     params: TAllParams
     loaderData: TLoaderData
-  }) => Array<JSX.IntrinsicElements['meta']>
-  links?: () => Array<JSX.IntrinsicElements['link']>
-  scripts?: () => Array<JSX.IntrinsicElements['script']>
+  }) => Array<React.JSX.IntrinsicElements['meta']>
+  links?: () => Array<React.JSX.IntrinsicElements['link']>
+  scripts?: () => Array<React.JSX.IntrinsicElements['script']>
   headers?: (ctx: { loaderData: TLoaderData }) => Record<string, string>
 } & UpdatableStaticRouteOption
 


### PR DESCRIPTION
This does not work with React 19 types.

https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript