### PR TITLE
fix: Syntax error in example with loader and useSuspenseQuery

### DIFF
--- a/docs/framework/react/guide/external-data-loading.md
+++ b/docs/framework/react/guide/external-data-loading.md
@@ -86,7 +86,7 @@ export const Route = createFileRoute('/posts')({
   loader: () => queryClient.ensureQueryData(postsQueryOptions),
   component: () => {
     // Read the data from the cache and subscribe to updates
-    const posts = useSuspenseQuery(postsQueryOptions)
+    const {data: {posts}} = useSuspenseQuery(postsQueryOptions)
 
     return (
       <div>


### PR DESCRIPTION
This will fix the example with useSuspenseQuery for the Router loader. You cannot just write `const posts = useSuspenseQuery(...)` but have to resolve the data property as so `const {data: {posts}} = useSuspenseQuery(...)`