### PR TITLE
fix(react-router): allow root route to be wrapped in suspense

### DIFF
--- a/packages/react-router/src/Matches.tsx
+++ b/packages/react-router/src/Matches.tsx
@@ -184,7 +184,8 @@ export function Match({ matchId }: { matchId: string }) {
     : route.options.notFoundComponent
 
   const ResolvedSuspenseBoundary =
-    !route.isRoot &&
+    // If we're on the root route, allow forcefully wrapping in suspense
+    (!route.isRoot || route.options.wrapInSuspense) &&
     (route.options.wrapInSuspense ??
       PendingComponent ??
       (route.options.errorComponent as any)?.preload)


### PR DESCRIPTION
By default, the root route isn't wrapped in a `Suspense` which causes the pendingComponent to not be shown while beforeLoad is resolving. 
This is needed for SSR, but leaves SPA users unable to show a loading component while loaders resolve.

This patch checks the `wrapInSuspense` option to forcefully enable React.Suspense in the root route.

Fixes #1601 