### PR TITLE
fix(router-devtools): correctly compose button toggle styles

### DIFF
--- a/packages/router-devtools/src/devtools.tsx
+++ b/packages/router-devtools/src/devtools.tsx
@@ -236,8 +236,8 @@ export function TanStackRouterDevtools({
   } = closeButtonProps
 
   const {
-    style: toggleButtonStyle = {},
     onClick: onToggleClick,
+    className: toggleButtonClassName,
     ...otherToggleButtonProps
   } = toggleButtonProps
 
@@ -288,6 +288,7 @@ export function TanStackRouterDevtools({
           getStyles().mainCloseBtn,
           getStyles().mainCloseBtnPosition(position),
           getStyles().mainCloseBtnAnimation(!isButtonClosed),
+          toggleButtonClassName,
         )}
       >
         <div className={getStyles().mainCloseBtnIconContainer}>


### PR DESCRIPTION
Currently, router-devtools fails to correctly compose the provided `toggleButtonProps` with the toggle button styles, resulting in provided properties not being applied to the button element.

This patch correctly composes `style` and `className` back into the toggle.