### PR TITLE
fix(react-router): do not over-eagerly garbage collect

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1257,7 +1257,9 @@ export class Router<
         let pendingMatches!: Array<AnyRouteMatch>
 
         this.__store.batch(() => {
-          this.cleanCache()
+          // this call breaks a route context of destination route after a redirect
+          // we should be fine not eagerly calling this since we call it later
+          // this.cleanCache()
 
           // Match the routes
           pendingMatches = this.matchRoutes(next.pathname, next.search)


### PR DESCRIPTION
When the user sets a `defaultGcTime` on the router or a `gcTime` on a route to the value of `0`, the current eager garbage collection we've got going on ends up setting the route-context to `undefined`.

This normally wouldn't matter on direct navigation, however, when redirects come into play this results in the route trying to execute its options (`beforeLoad`, `loader`, `component`, etc) without its processed route context being available. The current setup looks to perform garbage collection both before and after a `this.loadMatches` has been called in `router.load`.

This change makes it so that garbage collection is done after the `this.loadMatches` call has resolved.

This is part of the fix for #1531.