### PR TITLE
fix(react-router): route context being undefined in `StrictMode` on initial render

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1565,6 +1565,17 @@ export class Router<
                 const parentContext =
                   parentMatch?.context ?? this.options.context ?? {}
 
+                // Make sure the match has parent context set before going further
+                matches[index] = match = updateMatch(match.id, (prev) => ({
+                  ...prev,
+                  routeContext: replaceEqualDeep(
+                    match.routeContext,
+                    parentContext,
+                  ),
+                  context: replaceEqualDeep(match.context, parentContext),
+                  abortController,
+                }))
+
                 const beforeLoadContext =
                   (await route.options.beforeLoad?.({
                     search: match.search,


### PR DESCRIPTION
Side-effects like URL updates due to default search params being set or redirects can cause scenarios where the route context can become undefined when using `StrictMode`.