### PR TITLE
docs: Update `useBlocker` function signature

### DIFF
--- a/docs/framework/react/guide/navigation-blocking.md
+++ b/docs/framework/react/guide/navigation-blocking.md
@@ -54,7 +54,7 @@ function MyComponent() {
 
 The `useBlocker` hook takes 2 arguments:
 
-- `message: () => string` **Required** - A function that returns a string to show to the user when they attempt to navigate away
+- `message: BlockerFn` **Required** - A function that returns a boolean or Promise<boolean> indicating whether to allow navigation.
 - `condition?: boolean` Optional, defaults to `true` - Any expression or variable to be tested for truthiness to determine if navigation should be blocked
 
 ## Component-based blocking

--- a/docs/framework/react/guide/navigation-blocking.md
+++ b/docs/framework/react/guide/navigation-blocking.md
@@ -54,7 +54,7 @@ function MyComponent() {
 
 The `useBlocker` hook takes 2 arguments:
 
-- `message: BlockerFn` **Required** - A function that returns a boolean or Promise<boolean> indicating whether to allow navigation.
+- `blockerFn: BlockerFn` **Required** - A function that returns a `boolean` or `Promise<boolean>` indicating whether to allow navigation.
 - `condition?: boolean` Optional, defaults to `true` - Any expression or variable to be tested for truthiness to determine if navigation should be blocked
 
 ## Component-based blocking


### PR DESCRIPTION
According to the [signature](https://github.com/TanStack/router/blob/05941e5ef2b7d2776e885cf473fdcc3970548b22/packages/react-router/src/useBlocker.tsx#L7) the blocking function has `BlockerFn` type and not `() => string`