### PR TITLE
fix(react-router): only update the route-context during `beforeLoad`

### DIFF
--- a/examples/react/start-basic-rsc/app/routes/posts.tsx
+++ b/examples/react/start-basic-rsc/app/routes/posts.tsx
@@ -25,7 +25,7 @@ const renderPosts = createServerFn('GET', async () => {
                 </Link>
               </li>
             )
-          }
+          },
         )}
       </ul>
       <hr />

--- a/examples/react/start-basic-rsc/app/server-components.tsx
+++ b/examples/react/start-basic-rsc/app/server-components.tsx
@@ -59,7 +59,7 @@ export default eventHandler(async (event) => {
     await reactServerManifest.inputs[reactServerManifest.handler].assets()
   ).filter(
     (m) =>
-      (m.tag === 'link' && m.attrs.rel === 'stylesheet') || m.tag === 'style'
+      (m.tag === 'link' && m.attrs.rel === 'stylesheet') || m.tag === 'style',
   )
 
   const assets = await clientManifest.inputs[clientManifest.handler].assets()
@@ -72,7 +72,7 @@ export default eventHandler(async (event) => {
           {assets.map((m) => renderAsset(m))}
         </Suspense>
       }
-    />
+    />,
   )
 
   // // @ts-ignore

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1738,14 +1738,12 @@ export class Router<
                 const parentContext =
                   parentMatch?.context ?? this.options.context ?? {}
 
-                // Make sure the match has parent context set before going further
                 matches[index] = match = updateMatch(match.id, (prev) => ({
                   ...prev,
                   routeContext: replaceEqualDeep(
                     match.routeContext,
                     parentContext,
                   ),
-                  context: replaceEqualDeep(match.context, parentContext),
                   abortController,
                 }))
 

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1738,6 +1738,7 @@ export class Router<
                 const parentContext =
                   parentMatch?.context ?? this.options.context ?? {}
 
+                // Make sure the match has parent context set before going further
                 matches[index] = match = updateMatch(match.id, (prev) => ({
                   ...prev,
                   routeContext: replaceEqualDeep(


### PR DESCRIPTION
Closes #1637 