### PR TITLE
feat(react-router): improve the blocker functionality for use with custom UI

### DIFF
--- a/docs/framework/react/api/router.md
+++ b/docs/framework/react/api/router.md
@@ -31,6 +31,7 @@ title: Router API
   - [`<Outlet>`](./outletComponent)
 - Hooks
   - [`useAwaited()`](./useAwaitedHook)
+  - [`useBlocker()`](./useBlockerHook)
   - [`useChildMatches()`](./useChildMatchesHook)
   - [`useLinkProps()`](./useLinkPropsHook)
   - [`useLoaderData()`](./useLoaderDataHook)

--- a/docs/framework/react/api/router/useBlockerHook.md
+++ b/docs/framework/react/api/router/useBlockerHook.md
@@ -1,0 +1,79 @@
+---
+id: useBlockerHook
+title: useBlocker hook
+---
+
+The `useBlocker` method is a hook that [blocks navigation](../../../guide/navigation-blocking) when a condition is met.
+
+## useBlocker options
+
+The `useBlocker` hook accepts a single _optional_ argument, an option object:
+
+### `options.blockerFn` option
+
+- Optional
+- Type: `BlockerFn`
+- The function that returns a `boolean` or `Promise<boolean>` indicating whether to allow navigation.
+
+### `options.condition` option
+
+- Optional - defaults to `true`
+- Type: `boolean`
+- A navigation attempt is blocked when this condition is `true`.
+
+## useBlocker returns
+
+An object with the controls to allow manual blocking and unblocking of navigation.
+
+- `status` - A string literal that can be either `'blocked'` or `'idle'`
+- `proceed` - A function that allows navigation to continue
+- `reset` - A function that cancels navigation (`status` will be be reset to `'idle'`)
+
+## Examples
+
+Two common use cases for the `useBlocker` hook are:
+
+### Basic usage
+
+```tsx
+import { useBlocker } from '@tanstack/react-router'
+
+function MyComponent() {
+  const [formIsDirty, setFormIsDirty] = useState(false)
+
+  useBlocker({
+    blockerfn: () => window.confirm('Are you sure you want to leave?'),
+    condition: formIsDirty,
+  })
+
+  // ...
+}
+```
+
+### Custom UI
+
+```tsx
+import { useBlocker } from '@tanstack/react-router'
+
+function MyComponent() {
+  const [formIsDirty, setFormIsDirty] = useState(false)
+
+  const { proceed, reset, status } = useBlocker({
+    condition: formIsDirty,
+  })
+
+  // ...
+
+  return (
+    <>
+      {/* ... */}
+      {status === 'blocked' && (
+        <div>
+          <p>Are you sure you want to leave?</p>
+          <button onClick={proceed}>Yes</button>
+          <button onClick={reset}>No</button>
+        </div>
+      )}
+    </>
+}
+```

--- a/docs/framework/react/guide/navigation-blocking.md
+++ b/docs/framework/react/guide/navigation-blocking.md
@@ -43,18 +43,18 @@ import { useBlocker } from '@tanstack/react-router'
 function MyComponent() {
   const [formIsDirty, setFormIsDirty] = useState(false)
 
-  useBlocker(
-    () => window.confirm('Are you sure you want to leave?'),
-    formIsDirty,
-  )
+  useBlocker({
+    blockerfn: () => window.confirm('Are you sure you want to leave?'),
+    condition: formIsDirty,
+  })
 
   // ...
 }
 ```
 
-The `useBlocker` hook takes 2 arguments:
+The `useBlocker` hook takes an object as argument with two optional fields:
 
-- `blockerFn: BlockerFn` **Required** - A function that returns a `boolean` or `Promise<boolean>` indicating whether to allow navigation.
+- `blockerFn?: BlockerFn` Optional, a function that returns a `boolean` or `Promise<boolean>` indicating whether to allow navigation.
 - `condition?: boolean` Optional, defaults to `true` - Any expression or variable to be tested for truthiness to determine if navigation should be blocked
 
 ## Component-based blocking
@@ -82,6 +82,77 @@ function MyComponent() {
       condition={formIsDirty}
     >
       {/* ... */}
+    </Block>
+  )
+}
+```
+
+## How can I show a custom UI?
+
+In most cases, passing `window.confirm` to the `blockerFn` field of the hook input is enough since it will clearly show the user that the navigation is being blocked.
+
+However, in some situations, you might want to show a custom UI that is intentionally less disruptive and more integrated with your app's design.
+
+**Note:** The return value of `blockerFn` takes precedence, do not pass it if you want to use the manual `proceed` and `reset` functions.
+
+### Hook/logical-based custom UI
+
+The `useBlocker` hook returns the state and two functions to lend control to you:
+
+- `status` - A string literal that can be either `'blocked'` or `'idle'`
+- `proceed` - A function that allows navigation to continue
+- `reset` - A function that cancels navigation (`status` will be be reset to `'idle'`)
+
+```tsx
+import { useBlocker } from '@tanstack/react-router'
+
+function MyComponent() {
+  const [formIsDirty, setFormIsDirty] = useState(false)
+
+  const { proceed, reset, status } = useBlocker({
+    condition: formIsDirty,
+  })
+
+  // ...
+
+  return (
+    <>
+      {/* ... */}
+      {status === 'blocked' && (
+        <div>
+          <p>Are you sure you want to leave?</p>
+          <button onClick={proceed}>Yes</button>
+          <button onClick={reset}>No</button>
+        </div>
+      )}
+    </>
+}
+```
+
+### Component-based custom UI
+
+Similarly to the hook, the `Block` component returns the same state and functions as render props:
+
+```tsx
+import { Block } from '@tanstack/react-router'
+
+function MyComponent() {
+  const [formIsDirty, setFormIsDirty] = useState(false)
+
+  return (
+    <Block condition={formIsDirty}>
+      {({ status, proceed, reset }) => (
+        <>
+          {/* ... */}
+          {status === 'blocked' && (
+            <div>
+              <p>Are you sure you want to leave?</p>
+              <button onClick={proceed}>Yes</button>
+              <button onClick={reset}>No</button>
+            </div>
+          )}
+        </>
+      )}
     </Block>
   )
 }

--- a/docs/framework/react/guide/navigation-blocking.md
+++ b/docs/framework/react/guide/navigation-blocking.md
@@ -52,10 +52,7 @@ function MyComponent() {
 }
 ```
 
-The `useBlocker` hook takes an object as argument with two optional fields:
-
-- `blockerFn?: BlockerFn` Optional, a function that returns a `boolean` or `Promise<boolean>` indicating whether to allow navigation.
-- `condition?: boolean` Optional, defaults to `true` - Any expression or variable to be tested for truthiness to determine if navigation should be blocked
+You can find more information about the `useBlocker` hook in the [API reference](../../api/router/useBlockerHook).
 
 ## Component-based blocking
 
@@ -96,12 +93,6 @@ However, in some situations, you might want to show a custom UI that is intentio
 **Note:** The return value of `blockerFn` takes precedence, do not pass it if you want to use the manual `proceed` and `reset` functions.
 
 ### Hook/logical-based custom UI
-
-The `useBlocker` hook returns the state and two functions to lend control to you:
-
-- `status` - A string literal that can be either `'blocked'` or `'idle'`
-- `proceed` - A function that allows navigation to continue
-- `reset` - A function that cancels navigation (`status` will be be reset to `'idle'`)
 
 ```tsx
 import { useBlocker } from '@tanstack/react-router'

--- a/examples/react/navigation-blocking/src/main.tsx
+++ b/examples/react/navigation-blocking/src/main.tsx
@@ -67,15 +67,13 @@ const editor1Route = createRoute({
 function Editor1Component() {
   const [value, setValue] = React.useState('')
   const [useCustomBlocker, setUseCustomBlocker] = React.useState(false)
-  const [showConfirm, setShowConfirm] = React.useState(false)
 
-  const { allow, deny } = useBlocker(
-    () =>
-      useCustomBlocker
-        ? setShowConfirm(true)
-        : window.confirm('Are you sure you want to leave editor 1?'),
-    value,
-  )
+  const { proceed, reset, status } = useBlocker({
+    blockerFn: useCustomBlocker
+      ? undefined
+      : () => window.confirm('Are you sure you want to leave editor 1?'),
+    condition: value,
+  })
 
   return (
     <div className="flex flex-col p-2">
@@ -95,24 +93,18 @@ function Editor1Component() {
           className="border"
         />
       </div>
-      {showConfirm && (
+      {status === 'blocked' && (
         <div className="mt-2">
           <div>Are you sure you want to leave editor 1?</div>
           <button
             className="bg-lime-500 text-white rounded p-1 px-2 mr-2"
-            onClick={() => {
-              setShowConfirm(false)
-              allow()
-            }}
+            onClick={proceed}
           >
             YES
           </button>
           <button
             className="bg-red-500 text-white rounded p-1 px-2"
-            onClick={() => {
-              setShowConfirm(false)
-              deny()
-            }}
+            onClick={reset}
           >
             NO
           </button>
@@ -134,10 +126,10 @@ const editor2Route = createRoute({
 function Editor2Component() {
   const [value, setValue] = React.useState('')
 
-  useBlocker(
-    () => window.confirm('Are you sure you want to leave editor 2?'),
-    value,
-  )
+  useBlocker({
+    blockerFn: () => window.confirm('Are you sure you want to leave editor 2?'),
+    condition: value,
+  })
 
   return (
     <div className="p-2">

--- a/examples/react/navigation-blocking/src/main.tsx
+++ b/examples/react/navigation-blocking/src/main.tsx
@@ -66,18 +66,35 @@ const editor1Route = createRoute({
 
 function Editor1Component() {
   const [value, setValue] = React.useState('')
+  const [useCustomBlocker, setUseCustomBlocker] = React.useState(false)
   const [showConfirm, setShowConfirm] = React.useState(false)
 
-  const { allow, deny } = useBlocker(() => setShowConfirm(true), value)
+  const { allow, deny } = useBlocker(
+    () =>
+      useCustomBlocker
+        ? setShowConfirm(true)
+        : window.confirm('Are you sure you want to leave editor 1?'),
+    value,
+  )
 
   return (
-    <div className="p-2">
+    <div className="flex flex-col p-2">
       <h3>Editor 1</h3>
-      <input
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        className="border"
-      />
+      <label>
+        <input
+          type="checkbox"
+          checked={useCustomBlocker}
+          onChange={(e) => setUseCustomBlocker(e.target.checked)}
+        />{' '}
+        Use custom blocker
+      </label>
+      <div>
+        <input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          className="border"
+        />
+      </div>
       {showConfirm && (
         <div className="mt-2">
           <div>Are you sure you want to leave editor 1?</div>

--- a/examples/react/navigation-blocking/src/main.tsx
+++ b/examples/react/navigation-blocking/src/main.tsx
@@ -1,15 +1,15 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
 import {
+  Link,
   Outlet,
   RouterProvider,
-  Link,
+  createRootRoute,
+  createRoute,
   createRouter,
   useBlocker,
-  createRoute,
-  createRootRoute,
 } from '@tanstack/react-router'
 import { TanStackRouterDevtools } from '@tanstack/router-devtools'
+import React from 'react'
+import ReactDOM from 'react-dom/client'
 
 const rootRoute = createRootRoute({
   component: RootComponent,
@@ -66,11 +66,9 @@ const editor1Route = createRoute({
 
 function Editor1Component() {
   const [value, setValue] = React.useState('')
+  const [showConfirm, setShowConfirm] = React.useState(false)
 
-  useBlocker(
-    () => window.confirm('Are you sure you want to leave editor 1?'),
-    value,
-  )
+  const { allow, deny } = useBlocker(() => setShowConfirm(true), value)
 
   return (
     <div className="p-2">
@@ -80,6 +78,29 @@ function Editor1Component() {
         onChange={(e) => setValue(e.target.value)}
         className="border"
       />
+      {showConfirm && (
+        <div className="mt-2">
+          <div>Are you sure you want to leave editor 1?</div>
+          <button
+            className="bg-lime-500 text-white rounded p-1 px-2 mr-2"
+            onClick={() => {
+              setShowConfirm(false)
+              allow()
+            }}
+          >
+            YES
+          </button>
+          <button
+            className="bg-red-500 text-white rounded p-1 px-2"
+            onClick={() => {
+              setShowConfirm(false)
+              deny()
+            }}
+          >
+            NO
+          </button>
+        </div>
+      )}
       <hr className="m-2" />
       <Link to="/editor-1/editor-2">Go to Editor 2</Link>
       <Outlet />

--- a/packages/react-router/src/useBlocker.tsx
+++ b/packages/react-router/src/useBlocker.tsx
@@ -9,11 +9,23 @@ type BlockerResolver = {
   reset: () => void
 }
 
-export function useBlocker(opts?: {
+type BlockerOpts = {
   blockerFn?: BlockerFn
-  condition: boolean | any
-}) {
-  const condition = opts?.condition ?? true
+  condition?: boolean | any
+}
+
+export function useBlocker(
+  blockerFnOrOpts?: BlockerFn | BlockerOpts,
+  condition?: boolean | any,
+) {
+  const { blockerFn, blockerCondition } = blockerFnOrOpts
+    ? typeof blockerFnOrOpts === 'function'
+      ? { blockerFn: blockerFnOrOpts, blockerCondition: condition ?? true }
+      : {
+          blockerFn: blockerFnOrOpts.blockerFn,
+          blockerCondition: blockerFnOrOpts.condition ?? true,
+        }
+    : { blockerFn: undefined, blockerCondition: true }
   const { history } = useRouter()
 
   const [resolver, setResolver] = React.useState<BlockerResolver>({
@@ -35,7 +47,7 @@ export function useBlocker(opts?: {
 
   React.useEffect(() => {
     const blockerFnComposed = async () => {
-      const canNavigateSync = opts?.blockerFn?.()
+      const canNavigateSync = blockerFn?.()
 
       if (canNavigateSync) return true
 
@@ -50,8 +62,8 @@ export function useBlocker(opts?: {
       return canNavigateAsync
     }
 
-    return !condition ? undefined : history.block(blockerFnComposed)
-  }, [opts?.blockerFn, condition, history, promise, opts])
+    return !blockerCondition ? undefined : history.block(blockerFnComposed)
+  }, [blockerFn, blockerCondition, history, promise])
 
   return resolver
 }

--- a/packages/react-router/src/useBlocker.tsx
+++ b/packages/react-router/src/useBlocker.tsx
@@ -25,7 +25,7 @@ export function useBlocker(
           blockerFn: blockerFnOrOpts.blockerFn,
           blockerCondition: blockerFnOrOpts.condition ?? true,
         }
-    : { blockerFn: undefined, blockerCondition: true }
+    : { blockerFn: undefined, blockerCondition: condition ?? true }
   const { history } = useRouter()
 
   const [resolver, setResolver] = React.useState<BlockerResolver>({

--- a/packages/react-router/src/useBlocker.tsx
+++ b/packages/react-router/src/useBlocker.tsx
@@ -3,16 +3,47 @@ import { useRouter } from './useRouter'
 import type { BlockerFn } from '@tanstack/history'
 import type { ReactNode } from './route'
 
-export function useBlocker(
-  blockerFn: BlockerFn,
-  condition: boolean | any = true,
-): void {
+type Resolver = {
+  allow: () => void
+  deny: () => void
+}
+
+export function useBlocker(blockerFn: BlockerFn, condition: boolean = true) {
   const { history } = useRouter()
 
-  React.useEffect(() => {
-    if (!condition) return
-    return history.block(blockerFn)
+  const [resolver, setResolver] = React.useState<Resolver>({
+    allow: () => {},
+    deny: () => {},
   })
+
+  const createPromise = () =>
+    new Promise<boolean>((resolve) => {
+      setResolver({
+        allow: () => resolve(true),
+        deny: () => resolve(false),
+      })
+    })
+
+  const [promise, setPromise] = React.useState(createPromise)
+
+  React.useEffect(() => {
+    const blockerFnComposed = async () => {
+      // Execute the blocker function
+      const canNavigateSync = blockerFn()
+
+      if (canNavigateSync) return true
+
+      const canNavigateAsync = await promise
+
+      if (!canNavigateAsync) setPromise(createPromise)
+
+      return canNavigateAsync
+    }
+
+    return !condition ? undefined : history.block(blockerFnComposed)
+  }, [blockerFn, condition, history, promise])
+
+  return resolver
 }
 
 export function Block({ blocker, condition, children }: PromptProps) {

--- a/packages/react-router/src/useBlocker.tsx
+++ b/packages/react-router/src/useBlocker.tsx
@@ -47,12 +47,16 @@ export function useBlocker(blockerFn: BlockerFn, condition: boolean = true) {
 }
 
 export function Block({ blocker, condition, children }: PromptProps) {
-  useBlocker(blocker, condition)
-  return children ?? null
+  const resolver = useBlocker(blocker, condition)
+  return children
+    ? typeof children === 'function'
+      ? children(resolver)
+      : children
+    : null
 }
 
 export type PromptProps = {
   blocker: BlockerFn
   condition?: boolean | any
-  children?: ReactNode
+  children?: ReactNode | (({ allow, deny }: Resolver) => ReactNode)
 }

--- a/packages/react-router/src/useBlocker.tsx
+++ b/packages/react-router/src/useBlocker.tsx
@@ -47,9 +47,10 @@ export function useBlocker(
 
   React.useEffect(() => {
     const blockerFnComposed = async () => {
-      const canNavigateSync = blockerFn?.()
-
-      if (canNavigateSync) return true
+      // If a function is provided, it takes precedence over the promise blocker
+      if (blockerFn) {
+        return await blockerFn()
+      }
 
       setResolver((prev) => ({
         ...prev,

--- a/packages/react-router/src/useBlocker.tsx
+++ b/packages/react-router/src/useBlocker.tsx
@@ -14,10 +14,20 @@ type BlockerOpts = {
   condition?: boolean | any
 }
 
+export function useBlocker(blockerFnOrOpts?: BlockerOpts): BlockerResolver
+
+/**
+ * @deprecated Use the BlockerOpts object syntax instead
+ */
+export function useBlocker(
+  blockerFnOrOpts?: BlockerOpts,
+  condition?: boolean | any,
+): BlockerResolver
+
 export function useBlocker(
   blockerFnOrOpts?: BlockerFn | BlockerOpts,
   condition?: boolean | any,
-) {
+): BlockerResolver {
   const { blockerFn, blockerCondition } = blockerFnOrOpts
     ? typeof blockerFnOrOpts === 'function'
       ? { blockerFn: blockerFnOrOpts, blockerCondition: condition ?? true }

--- a/packages/react-router/src/useBlocker.tsx
+++ b/packages/react-router/src/useBlocker.tsx
@@ -3,9 +3,9 @@ import { useRouter } from './useRouter'
 import type { BlockerFn } from '@tanstack/history'
 import type { ReactNode } from './route'
 
-type Resolver = {
-  allow: () => void
-  deny: () => void
+type BlockerResolver = {
+  proceed: () => void
+  reset: () => void
 }
 
 export function useBlocker(
@@ -14,16 +14,16 @@ export function useBlocker(
 ) {
   const { history } = useRouter()
 
-  const [resolver, setResolver] = React.useState<Resolver>({
-    allow: () => {},
-    deny: () => {},
+  const [resolver, setResolver] = React.useState<BlockerResolver>({
+    proceed: () => {},
+    reset: () => {},
   })
 
   const createPromise = () =>
     new Promise<boolean>((resolve) => {
       setResolver({
-        allow: () => resolve(true),
-        deny: () => resolve(false),
+        proceed: () => resolve(true),
+        reset: () => resolve(false),
       })
     })
 
@@ -60,5 +60,5 @@ export function Block({ blocker, condition, children }: PromptProps) {
 export type PromptProps = {
   blocker: BlockerFn
   condition?: boolean | any
-  children?: ReactNode | (({ allow, deny }: Resolver) => ReactNode)
+  children?: ReactNode | (({ proceed, reset }: BlockerResolver) => ReactNode)
 }

--- a/packages/react-router/src/useBlocker.tsx
+++ b/packages/react-router/src/useBlocker.tsx
@@ -20,7 +20,7 @@ export function useBlocker(blockerFnOrOpts?: BlockerOpts): BlockerResolver
  * @deprecated Use the BlockerOpts object syntax instead
  */
 export function useBlocker(
-  blockerFnOrOpts?: BlockerOpts,
+  blockerFn?: BlockerFn,
   condition?: boolean | any,
 ): BlockerResolver
 

--- a/packages/react-router/src/useBlocker.tsx
+++ b/packages/react-router/src/useBlocker.tsx
@@ -31,7 +31,6 @@ export function useBlocker(
 
   React.useEffect(() => {
     const blockerFnComposed = async () => {
-      // Execute the blocker function
       const canNavigateSync = blockerFn()
 
       if (canNavigateSync) return true

--- a/packages/react-router/src/useBlocker.tsx
+++ b/packages/react-router/src/useBlocker.tsx
@@ -8,7 +8,10 @@ type Resolver = {
   deny: () => void
 }
 
-export function useBlocker(blockerFn: BlockerFn, condition: boolean = true) {
+export function useBlocker(
+  blockerFn: BlockerFn,
+  condition: boolean | any = true,
+) {
   const { history } = useRouter()
 
   const [resolver, setResolver] = React.useState<Resolver>({
@@ -35,7 +38,7 @@ export function useBlocker(blockerFn: BlockerFn, condition: boolean = true) {
 
       const canNavigateAsync = await promise
 
-      if (!canNavigateAsync) setPromise(createPromise)
+      setPromise(createPromise)
 
       return canNavigateAsync
     }

--- a/packages/react-router/tests/useBlocker.test.tsx
+++ b/packages/react-router/tests/useBlocker.test.tsx
@@ -1,0 +1,42 @@
+import '@testing-library/jest-dom/vitest'
+import { cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { useBlocker } from '../src'
+
+const block = vi.fn()
+vi.mock('../src/useRouter', () => ({
+  useRouter: () => ({ history: { block } }),
+}))
+
+describe('useBlocker', () => {
+  beforeEach(() => {
+    block.mockClear()
+  })
+
+  describe('condition', () => {
+    test('should not add the blocker if condition is false', () => {
+      renderHook(() => useBlocker({ condition: false }))
+      expect(block).not.toHaveBeenCalled()
+    })
+
+    test('should not add the blocker if condition is false (deprecated API)', () => {
+      renderHook(() => useBlocker(undefined, false))
+      expect(block).not.toHaveBeenCalled()
+    })
+
+    test('should add the blocker if condition is true', () => {
+      renderHook(() => useBlocker({ condition: true }))
+      expect(block).toHaveBeenCalledOnce()
+    })
+
+    test('should add the blocker if condition is true (deprecated API)', () => {
+      renderHook(() => useBlocker(undefined, true))
+      expect(block).toHaveBeenCalledOnce()
+    })
+
+    test('should add the blocker if condition is not provided', () => {
+      renderHook(() => useBlocker())
+      expect(block).toHaveBeenCalledOnce()
+    })
+  })
+})


### PR DESCRIPTION
We were talking about this on discord, trying to find a handy way to display custom UI when blocking navigation.

I adapted a bit @freshgiammi's first draft and expanded it to the `Blocker` component to also have `allow`/`deny` in its children.
I also updated the example to validate it works as expected.

Basically we get these two functions to allow the user to show some custom UI (a modal?) when blocking the navigation and giving full control if resuming or blocking it.

If the API makes sense I'm happy to also update the docs.


cc @schiller-manuel 