### PR TITLE
docs(examples): inline the `PickAsRequired` type in the "kitchen-sink-react-query" example

### DIFF
--- a/examples/react/kitchen-sink-react-query/src/mockTodos.ts
+++ b/examples/react/kitchen-sink-react-query/src/mockTodos.ts
@@ -1,8 +1,11 @@
-import { PickAsPartial, PickAsRequired } from '@tanstack/react-router'
 import { match } from 'assert'
 import axios from 'redaxios'
 import { produce } from 'immer'
 import { actionDelayFn, loaderDelayFn, shuffle } from './utils'
+
+type PickAsRequired<TValue, TKey extends keyof TValue> = Omit<TValue, TKey> &
+  Required<Pick<TValue, TKey>>
+
 export type Invoice = {
   id: number
   title: string


### PR DESCRIPTION
Fix https://github.com/TanStack/router/issues/1651