### PR TITLE
fix(react-router): remove unnecessary `load` call after redirect

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1548,7 +1548,6 @@ export class Router<
           redirect = err
           if (!this.isServer) {
             this.navigate({ ...err, replace: true, __isRedirect: true })
-            this.load()
           }
         } else if (isNotFound(err)) {
           notFound = err


### PR DESCRIPTION
Possibly fixes #1650 