### PR TITLE
fix(react-router): only instantiate the confirmation promise when required in the `useBlocker` hook

### DIFF
--- a/packages/react-router/src/useBlocker.tsx
+++ b/packages/react-router/src/useBlocker.tsx
@@ -44,17 +44,6 @@ export function useBlocker(
     reset: () => {},
   })
 
-  const createPromise = () =>
-    new Promise<boolean>((resolve) => {
-      setResolver({
-        status: 'idle',
-        proceed: () => resolve(true),
-        reset: () => resolve(false),
-      })
-    })
-
-  const [promise, setPromise] = React.useState(createPromise)
-
   React.useEffect(() => {
     const blockerFnComposed = async () => {
       // If a function is provided, it takes precedence over the promise blocker
@@ -62,19 +51,27 @@ export function useBlocker(
         return await blockerFn()
       }
 
-      setResolver((prev) => ({
-        ...prev,
-        status: 'blocked',
-      }))
-      const canNavigateAsync = await promise
+      const promise = new Promise<boolean>((resolve) => {
+        setResolver({
+          status: "blocked",
+          proceed: () => resolve(true),
+          reset: () => resolve(false),
+        });
+      });
 
-      setPromise(createPromise)
+      const canNavigateAsync = await promise;
+
+      setResolver({
+        status: "idle",
+        proceed: () => {},
+        reset: () => {},
+      });
 
       return canNavigateAsync
     }
 
     return !blockerCondition ? undefined : history.block(blockerFnComposed)
-  }, [blockerFn, blockerCondition, history, promise])
+  }, [blockerFn, blockerCondition, history])
 
   return resolver
 }

--- a/packages/react-router/src/useBlocker.tsx
+++ b/packages/react-router/src/useBlocker.tsx
@@ -53,19 +53,19 @@ export function useBlocker(
 
       const promise = new Promise<boolean>((resolve) => {
         setResolver({
-          status: "blocked",
+          status: 'blocked',
           proceed: () => resolve(true),
           reset: () => resolve(false),
-        });
-      });
+        })
+      })
 
-      const canNavigateAsync = await promise;
+      const canNavigateAsync = await promise
 
       setResolver({
-        status: "idle",
+        status: 'idle',
         proceed: () => {},
         reset: () => {},
-      });
+      })
 
       return canNavigateAsync
     }


### PR DESCRIPTION
Open this PR as @schiller-manuel encouraged based on my bug comment in  https://github.com/TanStack/router/pull/1649#discussion_r1614737330.

Since this is my first contribution to this repo, I only strive to make this dead simple.

I manually tested this code in my own project to see it is now working as expected. I checked the PR #1649 to see if I can amend a test suite. But I found it is tricky to add one because the promise is now only a transient instance. 

c.c. @Balastrong 
