### PR TITLE
fix: make router a peerDependency of the devtools

### DIFF
--- a/examples/react/start-basic/app/routes/deferred.tsx
+++ b/examples/react/start-basic/app/routes/deferred.tsx
@@ -5,7 +5,9 @@ export const Route = createFileRoute('/deferred')({
   loader: () => {
     return {
       deferredStuff: defer(
-        new Promise<string>((r) => setTimeout(() => r('Hello deferred!'), 5000))
+        new Promise<string>((r) =>
+          setTimeout(() => r('Hello deferred!'), 5000),
+        ),
       ),
     }
   },

--- a/packages/router-devtools/package.json
+++ b/packages/router-devtools/package.json
@@ -56,7 +56,6 @@
     "src"
   ],
   "dependencies": {
-    "@tanstack/react-router": "workspace:*",
     "clsx": "^2.1.0",
     "date-fns": "^2.29.1",
     "goober": "^2.1.14"
@@ -67,6 +66,7 @@
     "react-dom": "^18.2.0"
   },
   "peerDependencies": {
+    "@tanstack/react-router": "workspace:^",
     "react": ">=16.8",
     "react-dom": ">=16.8"
   }


### PR DESCRIPTION
this makes sure we don't get specific versions pulled in transitively (by using `:^` instead of `:*`). If you use the router-devtools, you must also use the router itself.