### PR TITLE
[Discussion] using Apollo Client's `queryPreloader` in TanStack router loaders

### DIFF
--- a/examples/react/basic-ssr-streaming-file-based/package.json
+++ b/examples/react/basic-ssr-streaming-file-based/package.json
@@ -12,14 +12,15 @@
     "debug": "node --inspect-brk server"
   },
   "dependencies": {
+    "@apollo/client": "^3.10.4",
     "@tanstack/react-router": "^1.34.3",
-    "@tanstack/start": "^1.34.3",
     "@tanstack/router-devtools": "^1.34.4",
     "@tanstack/router-vite-plugin": "^1.34.1",
-    "redaxios": "^0.5.0",
+    "@tanstack/start": "^1.34.3",
     "get-port": "^7.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "redaxios": "^0.5.0",
     "superjson": "^2.2.1"
   },
   "devDependencies": {

--- a/examples/react/basic-ssr-streaming-file-based/src/apollo.ts
+++ b/examples/react/basic-ssr-streaming-file-based/src/apollo.ts
@@ -1,0 +1,9 @@
+import { ApolloClient, InMemoryCache } from '@apollo/client'
+
+export function makeClient() {
+  const client = new ApolloClient({
+    uri: 'https://flyby-router-demo.herokuapp.com/',
+    cache: new InMemoryCache(),
+  })
+  return client
+}

--- a/examples/react/basic-ssr-streaming-file-based/src/entry-client.tsx
+++ b/examples/react/basic-ssr-streaming-file-based/src/entry-client.tsx
@@ -2,16 +2,8 @@ import * as React from 'react'
 import ReactDOM from 'react-dom/client'
 
 import { StartClient } from '@tanstack/start'
-import { ApolloProvider } from '@apollo/client'
 import { createRouter } from './router'
-import { makeClient } from './apollo'
 
-const client = makeClient()
-const router = createRouter(client)
+const router = createRouter()
 
-ReactDOM.hydrateRoot(
-  document,
-  <ApolloProvider client={client}>
-    <StartClient router={router} />
-  </ApolloProvider>,
-)
+ReactDOM.hydrateRoot(document, <StartClient router={router} />)

--- a/examples/react/basic-ssr-streaming-file-based/src/entry-client.tsx
+++ b/examples/react/basic-ssr-streaming-file-based/src/entry-client.tsx
@@ -2,8 +2,16 @@ import * as React from 'react'
 import ReactDOM from 'react-dom/client'
 
 import { StartClient } from '@tanstack/start'
+import { ApolloProvider } from '@apollo/client'
 import { createRouter } from './router'
+import { makeClient } from './apollo'
 
-const router = createRouter()
+const client = makeClient()
+const router = createRouter(client)
 
-ReactDOM.hydrateRoot(document, <StartClient router={router} />)
+ReactDOM.hydrateRoot(
+  document,
+  <ApolloProvider client={client}>
+    <StartClient router={router} />
+  </ApolloProvider>,
+)

--- a/examples/react/basic-ssr-streaming-file-based/src/entry-server.tsx
+++ b/examples/react/basic-ssr-streaming-file-based/src/entry-server.tsx
@@ -3,7 +3,9 @@ import { StartServer } from '@tanstack/start/server'
 import { isbot } from 'isbot'
 import { renderToPipeableStream } from 'react-dom/server'
 import { createMemoryHistory } from '@tanstack/react-router'
+import { ApolloProvider, createQueryPreloader } from '@apollo/client'
 import { createRouter } from './router'
+import { makeClient } from './apollo'
 import type express from 'express'
 import type { ServerResponse } from 'http'
 
@@ -20,7 +22,8 @@ export async function render(opts: {
   req: express.Request
   res: ServerResponse
 }) {
-  const router = createRouter()
+  const client = makeClient()
+  const router = createRouter(client)
 
   const memoryHistory = createMemoryHistory({
     initialEntries: [opts.url],
@@ -30,6 +33,8 @@ export async function render(opts: {
   router.update({
     history: memoryHistory,
     context: {
+      // is this the official way to do this?
+      ...router.options.context,
       head: opts.head,
     },
   })
@@ -40,22 +45,27 @@ export async function render(opts: {
 
   const passthrough = new PassThrough()
 
-  const pipeable = renderToPipeableStream(<StartServer router={router} />, {
-    ...(isbot(opts.req.headers['user-agent'])
-      ? {
-          onAllReady() {
-            pipeable.pipe(passthrough)
-          },
-        }
-      : {
-          onShellReady() {
-            pipeable.pipe(passthrough)
-          },
-        }),
-    onShellError(err) {
-      throw err
+  const pipeable = renderToPipeableStream(
+    <ApolloProvider client={client}>
+      <StartServer router={router} />
+    </ApolloProvider>,
+    {
+      ...(isbot(opts.req.headers['user-agent'])
+        ? {
+            onAllReady() {
+              pipeable.pipe(passthrough)
+            },
+          }
+        : {
+            onShellReady() {
+              pipeable.pipe(passthrough)
+            },
+          }),
+      onShellError(err) {
+        throw err
+      },
     },
-  })
+  )
 
   opts.res.setHeader('Content-Type', 'text/html')
   opts.res.statusCode = router.state.statusCode

--- a/examples/react/basic-ssr-streaming-file-based/src/router.tsx
+++ b/examples/react/basic-ssr-streaming-file-based/src/router.tsx
@@ -1,17 +1,21 @@
 import { createRouter as createReactRouter } from '@tanstack/react-router'
 
 import SuperJSON from 'superjson'
-import { createQueryPreloader } from '@apollo/client'
+import { ApolloProvider, createQueryPreloader } from '@apollo/client'
 import { routeTree } from './routeTree.gen'
-import type { ApolloClient } from '@apollo/client'
+import { makeClient } from './apollo'
 
-export function createRouter(apolloClient: ApolloClient<any>) {
+export function createRouter() {
+  const apolloClient = makeClient()
   return createReactRouter({
     routeTree,
     context: {
       head: '',
       preloadQuery: createQueryPreloader(apolloClient),
       apolloClient,
+    },
+    Wrap({ children }) {
+      return <ApolloProvider client={apolloClient}>{children}</ApolloProvider>
     },
     defaultPreload: 'intent',
     // Maybe this is already possible if we provided some kind of

--- a/examples/react/basic-ssr-streaming-file-based/src/router.tsx
+++ b/examples/react/basic-ssr-streaming-file-based/src/router.tsx
@@ -1,15 +1,24 @@
 import { createRouter as createReactRouter } from '@tanstack/react-router'
 
-import { routeTree } from './routeTree.gen'
 import SuperJSON from 'superjson'
+import { createQueryPreloader } from '@apollo/client'
+import { routeTree } from './routeTree.gen'
+import type { ApolloClient } from '@apollo/client'
 
-export function createRouter() {
+export function createRouter(apolloClient: ApolloClient<any>) {
   return createReactRouter({
     routeTree,
     context: {
       head: '',
+      preloadQuery: createQueryPreloader(apolloClient),
+      apolloClient,
     },
     defaultPreload: 'intent',
+    // Maybe this is already possible if we provided some kind of
+    // `transformer: apolloTransformer(client)`
+    // here.
+    // Can a transformer return Promises?
+    // Maybe even streams or async iterables?
     transformer: SuperJSON,
   })
 }

--- a/examples/react/basic-ssr-streaming-file-based/src/routerContext.tsx
+++ b/examples/react/basic-ssr-streaming-file-based/src/routerContext.tsx
@@ -1,3 +1,9 @@
+import type { ApolloClient, PreloadQueryFunction } from '@apollo/client'
 export type RouterContext = {
   head: string
+  preloadQuery: PreloadQueryFunction
+  // userland code doesn't need this, but maybe it would
+  // be good to make `context` available to the deserialization
+  // process, so I'm already putting this here
+  apolloClient: ApolloClient<any>
 }

--- a/examples/react/basic-ssr-streaming-file-based/src/routes/posts.tsx
+++ b/examples/react/basic-ssr-streaming-file-based/src/routes/posts.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react'
-import { createFileRoute, Link, Outlet } from '@tanstack/react-router'
+import { Link, Outlet, createFileRoute } from '@tanstack/react-router'
+import { gql, useReadQuery } from '@apollo/client'
+import type { TypedDocumentNode } from '@apollo/client'
 
 export type PostType = {
   id: string
@@ -7,41 +9,75 @@ export type PostType = {
   body: string
 }
 
+const GET_LOCATIONS: TypedDocumentNode<{
+  locations: Array<{
+    id: string
+    name: string
+    description: string
+    photo: string
+  }>
+}> = gql`
+  query GetLocations {
+    locations {
+      id
+      name
+      description
+      photo
+    }
+  }
+`
+
 export const Route = createFileRoute('/posts')({
-  loader: async () => {
-    console.log('Fetching posts...')
-    await new Promise((r) =>
-      setTimeout(r, 300 + Math.round(Math.random() * 300)),
-    )
-    return fetch('https://jsonplaceholder.typicode.com/posts')
-      .then((d) => d.json() as Promise<PostType[]>)
-      .then((d) => d.slice(0, 10))
+  loader: async ({ context: { preloadQuery } }) => {
+    console.log('Fetching locations...')
+    return {
+      /**
+       * This creates a `QueryRef` object.
+       * This object is not serializable by default,
+       * so we'd love to be able to hook into the
+       * serialization process to provide our own serialization.
+       *
+       * The serialized value will contain static values and a Promise,
+       * although an AsyncIterator or some kind of Stream would be
+       * preferrable.
+       */
+      locationsRef: preloadQuery(GET_LOCATIONS),
+    }
   },
   component: PostsComponent,
 })
 
 function PostsComponent() {
-  const posts = Route.useLoaderData()
+  /**
+   * `locationsRef` needs to be deserialized here.
+   * But it doesn't only need to be deserialized:
+   * The deserialization also has a side effect.
+   *
+   * The QueryRef needs to be registered with the ApolloClient.
+   *
+   */
+  const { locationsRef } = Route.useLoaderData()
+
+  const { data } = useReadQuery(locationsRef)
 
   return (
     <div className="p-2 flex gap-2">
       <ul className="list-disc pl-4">
-        {posts?.map((post) => {
-          return (
-            <li key={post.id} className="whitespace-nowrap">
-              <Link
-                to="/posts/$postId"
-                params={{
-                  postId: post.id,
-                }}
-                className="block py-1 text-blue-800 hover:text-blue-600"
-                activeProps={{ className: 'text-black font-bold' }}
-              >
-                <div>{post.title.substring(0, 20)}</div>
-              </Link>
-            </li>
-          )
-        })}
+        {data.locations.map(({ id, name, description, photo }) => (
+          <div key={id}>
+            <h3>{name}</h3>
+            <img
+              width="400"
+              height="250"
+              alt="location-reference"
+              src={`${photo}`}
+            />
+            <br />
+            <b>About this location:</b>
+            <p>{description}</p>
+            <br />
+          </div>
+        ))}
         <li className="whitespace-nowrap">
           <Link
             to="/posts/$postId"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
 
   examples/react/basic:
     dependencies:
+      '@apollo/client':
+        specifier: ^3.10.4
+        version: 3.10.4(@types/react@18.3.1)(graphql@16.8.1)(react-dom@18.3.1)(react@18.3.1)
       '@tanstack/react-query':
         specifier: ^5.17.8
         version: 5.36.0(react@18.3.1)
@@ -438,6 +441,9 @@ importers:
 
   examples/react/basic-ssr-streaming-file-based:
     dependencies:
+      '@apollo/client':
+        specifier: ^3.10.4
+        version: 3.10.4(@types/react@18.3.1)(graphql@16.8.1)(react-dom@18.3.1)(react@18.3.1)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -1619,6 +1625,45 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
+
+  /@apollo/client@3.10.4(@types/react@18.3.1)(graphql@16.8.1)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-51gk0xOwN6Ls1EbTG5svFva1kdm2APHYTzmFhaAdvUQoJFDxfc0UwQgDxGptzH84vkPlo1qunY1FuboyF9LI3Q==}
+    peerDependencies:
+      graphql: ^15.0.0 || ^16.0.0
+      graphql-ws: ^5.5.5
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+      subscriptions-transport-ws: ^0.9.0 || ^0.11.0
+    peerDependenciesMeta:
+      graphql-ws:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      subscriptions-transport-ws:
+        optional: true
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.8.1)
+      '@wry/caches': 1.0.1
+      '@wry/equality': 0.5.7
+      '@wry/trie': 0.5.0
+      graphql: 16.8.1
+      graphql-tag: 2.12.6(graphql@16.8.1)
+      hoist-non-react-statics: 3.3.2
+      optimism: 0.18.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      rehackt: 0.1.0(@types/react@18.3.1)(react@18.3.1)
+      response-iterator: 0.2.6
+      symbol-observable: 4.0.0
+      ts-invariant: 0.10.3
+      tslib: 2.6.2
+      zen-observable-ts: 1.2.5
+    transitivePeerDependencies:
+      - '@types/react'
+    dev: false
 
   /@babel/code-frame@7.24.2:
     resolution: {integrity: sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==}
@@ -4118,6 +4163,14 @@ packages:
       fast-json-stringify: 5.8.0
     dev: false
 
+  /@graphql-typed-document-node/core@3.2.0(graphql@16.8.1):
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      graphql: 16.8.1
+    dev: false
+
   /@hono/node-server@1.4.1:
     resolution: {integrity: sha512-7jB8iMs6T2FhREs4Ugk+7rzn7d5aC6wEX3FAy67ZafzcQqqBVggcLkFPCMauaFJJyjc+bFvMOdFxJXKYsBM6MQ==}
     engines: {node: '>=18.14.1'}
@@ -6417,6 +6470,41 @@ packages:
     dependencies:
       '@webassemblyjs/ast': 1.12.1
       '@xtuc/long': 4.2.2
+    dev: false
+
+  /@wry/caches@1.0.1:
+    resolution: {integrity: sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+
+  /@wry/context@0.7.4:
+    resolution: {integrity: sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+
+  /@wry/equality@0.5.7:
+    resolution: {integrity: sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+
+  /@wry/trie@0.4.3:
+    resolution: {integrity: sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+
+  /@wry/trie@0.5.0:
+    resolution: {integrity: sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.2
     dev: false
 
   /@xtuc/ieee754@1.2.0:
@@ -9280,6 +9368,21 @@ packages:
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  /graphql-tag@2.12.6(graphql@16.8.1):
+    resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      graphql: 16.8.1
+      tslib: 2.6.2
+    dev: false
+
+  /graphql@16.8.1:
+    resolution: {integrity: sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+    dev: false
+
   /gzip-size@7.0.0:
     resolution: {integrity: sha512-O1Ld7Dr+nqPnmGpdhzLmMTQ4vAsD+rHwMm1NLUmoUFFymBOMKxCCrtDxqdBRYXdeEPEi3SyoR4TizJLQrnKBNA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -9349,6 +9452,12 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
     dev: true
+
+  /hoist-non-react-statics@3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+    dependencies:
+      react-is: 16.13.1
+    dev: false
 
   /homedir-polyfill@1.0.3:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
@@ -11071,6 +11180,15 @@ packages:
       yargs-parser: 21.1.1
     dev: false
 
+  /optimism@0.18.0:
+    resolution: {integrity: sha512-tGn8+REwLRNFnb9WmcY5IfpOqeX2kpaYJ1s6Ae3mn12AeydLkR3j+jSCmVQFoXqU8D41PAJ1RG1rCRNWmNZVmQ==}
+    dependencies:
+      '@wry/caches': 1.0.1
+      '@wry/context': 0.7.4
+      '@wry/trie': 0.4.3
+      tslib: 2.6.2
+    dev: false
+
   /optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
     engines: {node: '>= 0.8.0'}
@@ -11459,7 +11577,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-    dev: true
 
   /proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -11582,7 +11699,6 @@ packages:
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-    dev: true
 
   /react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -11880,6 +11996,21 @@ packages:
       jsesc: 0.5.0
     dev: true
 
+  /rehackt@0.1.0(@types/react@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: '*'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+    dependencies:
+      '@types/react': 18.3.1
+      react: 18.3.1
+    dev: false
+
   /remove-accents@0.4.2:
     resolution: {integrity: sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==}
     dev: false
@@ -11944,6 +12075,11 @@ packages:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
+
+  /response-iterator@0.2.6:
+    resolution: {integrity: sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==}
+    engines: {node: '>=0.8'}
+    dev: false
 
   /restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
@@ -12623,6 +12759,11 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  /symbol-observable@4.0.0:
+    resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
+    engines: {node: '>=0.10'}
+    dev: false
+
   /symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
     dev: true
@@ -12871,6 +13012,13 @@ packages:
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
+
+  /ts-invariant@0.10.3:
+    resolution: {integrity: sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
 
   /tsconfck@3.0.3(typescript@5.4.5):
     resolution: {integrity: sha512-4t0noZX9t6GcPTfBAbIbbIU4pfpCwh0ueq3S4O/5qXI1VwK1outmxhe9dOiEWqMz3MW2LKgDTpqWV+37IWuVbA==}
@@ -13972,6 +14120,16 @@ packages:
     optionalDependencies:
       commander: 9.5.0
     dev: true
+
+  /zen-observable-ts@1.2.5:
+    resolution: {integrity: sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==}
+    dependencies:
+      zen-observable: 0.8.15
+    dev: false
+
+  /zen-observable@0.8.15:
+    resolution: {integrity: sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==}
+    dev: false
 
   /zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}


### PR DESCRIPTION
Please don't merge, this is just a PR because it allows me to easily highlight code changes to the default example :)

We talked about support for Apollo Client's `queryPreloader` in TanStack router loaders yesterday, and I promised you a write-up what we need.

Having created this example, I'm not even sure if we need anything more at this point 😅 


Generally, we need these things:

* Hook into serialization of `loader` function return values
* Hook into deserialization of `loader` function values as soon as possible
  * Best would be directly after the loader data made it over the wire, but at the latest when `useLoaderData` is called
  * This deserialization needs access to the current Apollo Client instance and deserialzation triggers a side effect
  * This could be done by closing over `client` in `createRouter`, but it would be even better if the transformer had access to the current `context` in some way - this way, `router.update` could change the client instance without things breaking.

So, this is much less of a feature request than I initially imagined - more of a bunch of questions at this point:

* Can `transformer` return objects that contain `Promise` intances?
* What about streams? That would allow us to support GraphQL features like `@defer`, where the response arrives in chunks, so this would be *really* cool!
* When does deserialization happen? Immediately when data arrives?
* Do you see any chance of exposing `context` to the `transformer`?
* A bit of a quality-of-life thing: could you imagine to allow an array of transformers in `transformer`? Could be useful if more libraries start shipping transformers :)

Adding @jerelmiller to the discussion, too :)