### PR TITLE
test(react-router): check the route context at `beforeLoad`, `loader`, and `component`

### DIFF
--- a/packages/react-router/tests/routeContext.test.tsx
+++ b/packages/react-router/tests/routeContext.test.tsx
@@ -1,0 +1,301 @@
+import React from 'react'
+import '@testing-library/jest-dom/vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+
+import {
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+  useRouteContext,
+  rootRouteId,
+} from '../src'
+
+import { sleep } from './utils'
+
+afterEach(() => {
+  window.history.replaceState(null, 'root', '/')
+  cleanup()
+})
+
+const WAIT_TIME = 150
+
+describe('beforeLoad', () => {
+  test('sync route context, present in beforeLoad, root route', () => {
+    const mock = vi.fn()
+
+    const rootRoute = createRootRoute({
+      beforeLoad: ({ context }) => {
+        mock(context)
+      },
+    })
+    const routeTree = rootRoute.addChildren([])
+    const router = createRouter({ routeTree, context: { foo: 'bar' } })
+
+    render(<RouterProvider router={router} />)
+
+    waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
+  })
+
+  test('async route context, present in beforeLoad, root route', () => {
+    const mock = vi.fn()
+
+    const rootRoute = createRootRoute({
+      beforeLoad: async ({ context }) => {
+        await sleep(WAIT_TIME)
+        mock(context)
+      },
+    })
+    const routeTree = rootRoute.addChildren([])
+    const router = createRouter({ routeTree, context: { foo: 'bar' } })
+
+    render(<RouterProvider router={router} />)
+
+    waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
+  })
+
+  test('sync route context, present in beforeLoad, index route', () => {
+    const mock = vi.fn()
+
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      beforeLoad: ({ context }) => {
+        mock(context)
+      },
+    })
+    const routeTree = rootRoute.addChildren([indexRoute])
+    const router = createRouter({ routeTree, context: { foo: 'bar' } })
+
+    render(<RouterProvider router={router} />)
+
+    waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
+  })
+
+  test('async route context, present in beforeLoad, index route', () => {
+    const mock = vi.fn()
+
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      beforeLoad: async ({ context }) => {
+        await sleep(WAIT_TIME)
+        mock(context)
+      },
+    })
+    const routeTree = rootRoute.addChildren([indexRoute])
+    const router = createRouter({ routeTree, context: { foo: 'bar' } })
+
+    render(<RouterProvider router={router} />)
+
+    waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
+  })
+})
+
+describe('loader', () => {
+  test('sync route context, present in loader, root route', () => {
+    const mock = vi.fn()
+
+    const rootRoute = createRootRoute({
+      loader: ({ context }) => {
+        mock(context)
+      },
+    })
+    const routeTree = rootRoute.addChildren([])
+    const router = createRouter({ routeTree, context: { foo: 'bar' } })
+
+    render(<RouterProvider router={router} />)
+
+    waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
+  })
+
+  test('async route context, present in loader, root route', () => {
+    const mock = vi.fn()
+
+    const rootRoute = createRootRoute({
+      loader: async ({ context }) => {
+        await sleep(WAIT_TIME)
+        mock(context)
+      },
+    })
+    const routeTree = rootRoute.addChildren([])
+    const router = createRouter({ routeTree, context: { foo: 'bar' } })
+
+    render(<RouterProvider router={router} />)
+
+    waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
+  })
+
+  test('sync route context, present in loader, index route', () => {
+    const mock = vi.fn()
+
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      loader: ({ context }) => {
+        mock(context)
+      },
+    })
+    const routeTree = rootRoute.addChildren([indexRoute])
+    const router = createRouter({ routeTree, context: { foo: 'bar' } })
+
+    render(<RouterProvider router={router} />)
+
+    waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
+  })
+
+  test('async route context, present in loader, index route', () => {
+    const mock = vi.fn()
+
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      loader: async ({ context }) => {
+        await sleep(WAIT_TIME)
+        mock(context)
+      },
+    })
+    const routeTree = rootRoute.addChildren([indexRoute])
+    const router = createRouter({ routeTree, context: { foo: 'bar' } })
+
+    render(<RouterProvider router={router} />)
+
+    waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
+  })
+})
+
+describe('useRouteContext', () => {
+  test('sync route context, present in component, root route', async () => {
+    const rootRoute = createRootRoute({
+      component: () => {
+        const context = useRouteContext({ from: rootRouteId })
+        return <div id="root-route-content">{JSON.stringify(context)}</div>
+      },
+    })
+    const routeTree = rootRoute.addChildren([])
+    const ctx = { foo: 'bar' }
+    const router = createRouter({ routeTree, context: ctx })
+
+    render(<RouterProvider router={router} />)
+
+    const content = await screen.findByText(JSON.stringify(ctx))
+
+    expect(content).toBeInTheDocument()
+  })
+
+  test('async route context beforeLoad, present in component, root route', async () => {
+    const rootRoute = createRootRoute({
+      beforeLoad: async () => {
+        await sleep(WAIT_TIME)
+      },
+      component: () => {
+        const context = useRouteContext({ from: rootRouteId })
+        return <div id="root-route-content">{JSON.stringify(context)}</div>
+      },
+    })
+    const routeTree = rootRoute.addChildren([])
+    const ctx = { foo: 'bar' }
+    const router = createRouter({ routeTree, context: ctx })
+
+    render(<RouterProvider router={router} />)
+
+    const content = await screen.findByText(JSON.stringify(ctx))
+
+    expect(content).toBeInTheDocument()
+  })
+
+  test('async route context loader, present in component, root route', async () => {
+    const rootRoute = createRootRoute({
+      loader: async () => {
+        await sleep(WAIT_TIME)
+      },
+      component: () => {
+        const context = useRouteContext({ from: rootRouteId })
+        return <div id="root-route-content">{JSON.stringify(context)}</div>
+      },
+    })
+    const routeTree = rootRoute.addChildren([])
+    const ctx = { foo: 'bar' }
+    const router = createRouter({ routeTree, context: ctx })
+
+    render(<RouterProvider router={router} />)
+
+    const content = await screen.findByText(JSON.stringify(ctx))
+
+    expect(content).toBeInTheDocument()
+  })
+
+  test('sync route context, present in component, index route', async () => {
+    const rootRoute = createRootRoute({})
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => {
+        const context = useRouteContext({ from: rootRouteId })
+        return <div id="index-route-content">{JSON.stringify(context)}</div>
+      },
+    })
+    const routeTree = rootRoute.addChildren([indexRoute])
+    const ctx = { foo: 'bar' }
+    const router = createRouter({ routeTree, context: ctx })
+
+    render(<RouterProvider router={router} />)
+
+    const content = await screen.findByText(JSON.stringify(ctx))
+
+    expect(content).toBeInTheDocument()
+  })
+
+  test('async route context beforeLoad, present in component, index route', async () => {
+    const rootRoute = createRootRoute({})
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      beforeLoad: async () => {
+        await sleep(WAIT_TIME)
+      },
+      component: () => {
+        const context = useRouteContext({ from: rootRouteId })
+        return <div id="index-route-content">{JSON.stringify(context)}</div>
+      },
+    })
+    const routeTree = rootRoute.addChildren([indexRoute])
+    const ctx = { foo: 'bar' }
+    const router = createRouter({ routeTree, context: ctx })
+
+    render(<RouterProvider router={router} />)
+
+    const content = await screen.findByText(JSON.stringify(ctx))
+
+    expect(content).toBeInTheDocument()
+  })
+
+  test('async route context loader, present in component, index route', async () => {
+    const rootRoute = createRootRoute({})
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      loader: async () => {
+        await sleep(WAIT_TIME)
+      },
+      component: () => {
+        const context = useRouteContext({ from: rootRouteId })
+        return <div id="index-route-content">{JSON.stringify(context)}</div>
+      },
+    })
+    const routeTree = rootRoute.addChildren([indexRoute])
+    const ctx = { foo: 'bar' }
+    const router = createRouter({ routeTree, context: ctx })
+
+    render(<RouterProvider router={router} />)
+
+    const content = await screen.findByText(JSON.stringify(ctx))
+
+    expect(content).toBeInTheDocument()
+  })
+})

--- a/packages/react-router/tests/routeContext.test.tsx
+++ b/packages/react-router/tests/routeContext.test.tsx
@@ -21,9 +21,9 @@ afterEach(() => {
 
 const WAIT_TIME = 150
 
-describe('beforeLoad', () => {
+describe('beforeLoad in the route definition', () => {
   // Present at the root route
-  test('sync route context, present in beforeLoad, root route', () => {
+  test('route context, present in the root route', () => {
     const mock = vi.fn()
 
     const rootRoute = createRootRoute({
@@ -39,7 +39,7 @@ describe('beforeLoad', () => {
     waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
   })
 
-  test('async route context, present in beforeLoad, root route', () => {
+  test('route context (sleep), present in the root route', () => {
     const mock = vi.fn()
 
     const rootRoute = createRootRoute({
@@ -57,7 +57,7 @@ describe('beforeLoad', () => {
   })
 
   // Present at the index route
-  test('sync route context, present in beforeLoad, index route', () => {
+  test('route context, present in the index route', () => {
     const mock = vi.fn()
 
     const rootRoute = createRootRoute()
@@ -76,7 +76,7 @@ describe('beforeLoad', () => {
     waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
   })
 
-  test('async route context, present in beforeLoad, index route', () => {
+  test('route context (sleep), present in the index route', () => {
     const mock = vi.fn()
 
     const rootRoute = createRootRoute()
@@ -97,7 +97,7 @@ describe('beforeLoad', () => {
   })
 
   // Check if context that is updated at the root, is the same in the index route
-  test('modified route context, present in beforeLoad, index route', async () => {
+  test('modified route context, present in the index route', async () => {
     const mock = vi.fn()
 
     const rootRoute = createRootRoute({
@@ -125,9 +125,9 @@ describe('beforeLoad', () => {
   })
 })
 
-describe('loader', () => {
+describe('loader in the route definition', () => {
   // Present at the root route
-  test('sync route context, present in loader, root route', () => {
+  test('route context, present in the root route', () => {
     const mock = vi.fn()
 
     const rootRoute = createRootRoute({
@@ -143,7 +143,7 @@ describe('loader', () => {
     waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
   })
 
-  test('async route context, present in loader, root route', () => {
+  test('route context (sleep), present in the root route', () => {
     const mock = vi.fn()
 
     const rootRoute = createRootRoute({
@@ -161,7 +161,7 @@ describe('loader', () => {
   })
 
   // Present at the index route
-  test('sync route context, present in loader, index route', () => {
+  test('route context, present in the index route', () => {
     const mock = vi.fn()
 
     const rootRoute = createRootRoute()
@@ -180,7 +180,7 @@ describe('loader', () => {
     waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
   })
 
-  test('async route context, present in loader, index route', () => {
+  test('route context (sleep), present in the index route', () => {
     const mock = vi.fn()
 
     const rootRoute = createRootRoute()
@@ -201,7 +201,7 @@ describe('loader', () => {
   })
 
   // Check if context that is updated at the root, is the same in the index route
-  test('modified route context, present in loader, index route', async () => {
+  test('modified route context, present in the index route', async () => {
     const mock = vi.fn()
 
     const rootRoute = createRootRoute({
@@ -229,9 +229,9 @@ describe('loader', () => {
   })
 })
 
-describe('useRouteContext', () => {
+describe('useRouteContext in the component', () => {
   // Present at the root route
-  test('sync route context, present in component, root route', async () => {
+  test('route context, present in the root route', async () => {
     const rootRoute = createRootRoute({
       component: () => {
         const context = useRouteContext({ from: rootRouteId })
@@ -249,7 +249,7 @@ describe('useRouteContext', () => {
     expect(content).toBeInTheDocument()
   })
 
-  test('async route context beforeLoad, present in component, root route', async () => {
+  test('route context (sleep in beforeLoad), present in the root route', async () => {
     const rootRoute = createRootRoute({
       beforeLoad: async () => {
         await sleep(WAIT_TIME)
@@ -270,7 +270,7 @@ describe('useRouteContext', () => {
     expect(content).toBeInTheDocument()
   })
 
-  test('async route context loader, present in component, root route', async () => {
+  test('route context (sleep in loader), present root route', async () => {
     const rootRoute = createRootRoute({
       loader: async () => {
         await sleep(WAIT_TIME)
@@ -292,7 +292,7 @@ describe('useRouteContext', () => {
   })
 
   // Present at the index route
-  test('sync route context, present in component, index route', async () => {
+  test('route context, present in the index route', async () => {
     const rootRoute = createRootRoute({})
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
@@ -313,7 +313,7 @@ describe('useRouteContext', () => {
     expect(content).toBeInTheDocument()
   })
 
-  test('async route context beforeLoad, present in component, index route', async () => {
+  test('route context (sleep in beforeLoad), present in the index route', async () => {
     const rootRoute = createRootRoute({})
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
@@ -337,7 +337,7 @@ describe('useRouteContext', () => {
     expect(content).toBeInTheDocument()
   })
 
-  test('async route context loader, present in component, index route', async () => {
+  test('route context (sleep in loader), present in the index route', async () => {
     const rootRoute = createRootRoute({})
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
@@ -362,7 +362,7 @@ describe('useRouteContext', () => {
   })
 
   // Check if context that is updated at the root, is the same in the root route
-  test('modified route context, present in component, root route', async () => {
+  test('modified route context, present in the root route', async () => {
     const rootRoute = createRootRoute({
       beforeLoad: async ({ context }) => {
         await sleep(WAIT_TIME)
@@ -388,7 +388,7 @@ describe('useRouteContext', () => {
   })
 
   // Check if context that is updated at the root, is the same in the index route
-  test('modified route context, present in component, index route', async () => {
+  test('modified route context, present in the index route', async () => {
     const rootRoute = createRootRoute({
       beforeLoad: async ({ context }) => {
         await sleep(WAIT_TIME)

--- a/packages/react-router/tests/routeContext.test.tsx
+++ b/packages/react-router/tests/routeContext.test.tsx
@@ -23,7 +23,7 @@ const WAIT_TIME = 150
 
 describe('beforeLoad in the route definition', () => {
   // Present at the root route
-  test('route context, present in the root route', () => {
+  test('route context, present in the root route', async () => {
     const mock = vi.fn()
 
     const rootRoute = createRootRoute({
@@ -36,10 +36,12 @@ describe('beforeLoad in the route definition', () => {
 
     render(<RouterProvider router={router} />)
 
-    waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
+    await waitFor(() => expect(mock).toHaveBeenCalledOnce())
+    expect(mock).toHaveBeenCalledWith({ foo: 'bar' })
+    expect(mock).toHaveBeenCalledTimes(1)
   })
 
-  test('route context (sleep), present in the root route', () => {
+  test('route context (sleep), present in the root route', async () => {
     const mock = vi.fn()
 
     const rootRoute = createRootRoute({
@@ -53,11 +55,13 @@ describe('beforeLoad in the route definition', () => {
 
     render(<RouterProvider router={router} />)
 
-    waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
+    await waitFor(() => expect(mock).toHaveBeenCalledOnce())
+    expect(mock).toHaveBeenCalledWith({ foo: 'bar' })
+    expect(mock).toHaveBeenCalledTimes(1)
   })
 
   // Present at the index route
-  test('route context, present in the index route', () => {
+  test('route context, present in the index route', async () => {
     const mock = vi.fn()
 
     const rootRoute = createRootRoute()
@@ -73,10 +77,12 @@ describe('beforeLoad in the route definition', () => {
 
     render(<RouterProvider router={router} />)
 
-    waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
+    await waitFor(() => expect(mock).toHaveBeenCalledOnce())
+    expect(mock).toHaveBeenCalledWith({ foo: 'bar' })
+    expect(mock).toHaveBeenCalledTimes(1)
   })
 
-  test('route context (sleep), present in the index route', () => {
+  test('route context (sleep), present in the index route', async () => {
     const mock = vi.fn()
 
     const rootRoute = createRootRoute()
@@ -93,7 +99,9 @@ describe('beforeLoad in the route definition', () => {
 
     render(<RouterProvider router={router} />)
 
-    waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
+    await waitFor(() => expect(mock).toHaveBeenCalledOnce())
+    expect(mock).toHaveBeenCalledWith({ foo: 'bar' })
+    expect(mock).toHaveBeenCalledTimes(1)
   })
 
   // Check if context that is updated at the root, is the same in the index route
@@ -121,13 +129,15 @@ describe('beforeLoad in the route definition', () => {
 
     render(<RouterProvider router={router} />)
 
-    waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'sean' }))
+    await waitFor(() => expect(mock).toHaveBeenCalledOnce())
+    expect(mock).toHaveBeenCalledWith({ foo: 'sean' })
+    expect(mock).toHaveBeenCalledTimes(1)
   })
 })
 
 describe('loader in the route definition', () => {
   // Present at the root route
-  test('route context, present in the root route', () => {
+  test('route context, present in the root route', async () => {
     const mock = vi.fn()
 
     const rootRoute = createRootRoute({
@@ -140,10 +150,12 @@ describe('loader in the route definition', () => {
 
     render(<RouterProvider router={router} />)
 
-    waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
+    await waitFor(() => expect(mock).toHaveBeenCalledOnce())
+    expect(mock).toHaveBeenCalledWith({ foo: 'bar' })
+    expect(mock).toHaveBeenCalledTimes(1)
   })
 
-  test('route context (sleep), present in the root route', () => {
+  test('route context (sleep), present in the root route', async () => {
     const mock = vi.fn()
 
     const rootRoute = createRootRoute({
@@ -157,11 +169,13 @@ describe('loader in the route definition', () => {
 
     render(<RouterProvider router={router} />)
 
-    waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
+    await waitFor(() => expect(mock).toHaveBeenCalledOnce())
+    expect(mock).toHaveBeenCalledWith({ foo: 'bar' })
+    expect(mock).toHaveBeenCalledTimes(1)
   })
 
   // Present at the index route
-  test('route context, present in the index route', () => {
+  test('route context, present in the index route', async () => {
     const mock = vi.fn()
 
     const rootRoute = createRootRoute()
@@ -177,10 +191,12 @@ describe('loader in the route definition', () => {
 
     render(<RouterProvider router={router} />)
 
-    waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
+    await waitFor(() => expect(mock).toHaveBeenCalledOnce())
+    expect(mock).toHaveBeenCalledWith({ foo: 'bar' })
+    expect(mock).toHaveBeenCalledTimes(1)
   })
 
-  test('route context (sleep), present in the index route', () => {
+  test('route context (sleep), present in the index route', async () => {
     const mock = vi.fn()
 
     const rootRoute = createRootRoute()
@@ -197,7 +213,9 @@ describe('loader in the route definition', () => {
 
     render(<RouterProvider router={router} />)
 
-    waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
+    await waitFor(() => expect(mock).toHaveBeenCalledOnce())
+    expect(mock).toHaveBeenCalledWith({ foo: 'bar' })
+    expect(mock).toHaveBeenCalledTimes(1)
   })
 
   // Check if context that is updated at the root, is the same in the index route
@@ -225,7 +243,9 @@ describe('loader in the route definition', () => {
 
     render(<RouterProvider router={router} />)
 
-    waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'sean' }))
+    await waitFor(() => expect(mock).toHaveBeenCalledOnce())
+    expect(mock).toHaveBeenCalledWith({ foo: 'sean' })
+    expect(mock).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/react-router/tests/routeContext.test.tsx
+++ b/packages/react-router/tests/routeContext.test.tsx
@@ -235,7 +235,7 @@ describe('useRouteContext', () => {
     const rootRoute = createRootRoute({
       component: () => {
         const context = useRouteContext({ from: rootRouteId })
-        return <div id="root-route-content">{JSON.stringify(context)}</div>
+        return <div>{JSON.stringify(context)}</div>
       },
     })
     const routeTree = rootRoute.addChildren([])
@@ -256,7 +256,7 @@ describe('useRouteContext', () => {
       },
       component: () => {
         const context = useRouteContext({ from: rootRouteId })
-        return <div id="root-route-content">{JSON.stringify(context)}</div>
+        return <div>{JSON.stringify(context)}</div>
       },
     })
     const routeTree = rootRoute.addChildren([])
@@ -277,7 +277,7 @@ describe('useRouteContext', () => {
       },
       component: () => {
         const context = useRouteContext({ from: rootRouteId })
-        return <div id="root-route-content">{JSON.stringify(context)}</div>
+        return <div>{JSON.stringify(context)}</div>
       },
     })
     const routeTree = rootRoute.addChildren([])
@@ -299,7 +299,7 @@ describe('useRouteContext', () => {
       path: '/',
       component: () => {
         const context = useRouteContext({ from: rootRouteId })
-        return <div id="index-route-content">{JSON.stringify(context)}</div>
+        return <div>{JSON.stringify(context)}</div>
       },
     })
     const routeTree = rootRoute.addChildren([indexRoute])
@@ -323,7 +323,7 @@ describe('useRouteContext', () => {
       },
       component: () => {
         const context = useRouteContext({ from: rootRouteId })
-        return <div id="index-route-content">{JSON.stringify(context)}</div>
+        return <div>{JSON.stringify(context)}</div>
       },
     })
     const routeTree = rootRoute.addChildren([indexRoute])
@@ -347,7 +347,7 @@ describe('useRouteContext', () => {
       },
       component: () => {
         const context = useRouteContext({ from: rootRouteId })
-        return <div id="index-route-content">{JSON.stringify(context)}</div>
+        return <div>{JSON.stringify(context)}</div>
       },
     })
     const routeTree = rootRoute.addChildren([indexRoute])
@@ -373,7 +373,7 @@ describe('useRouteContext', () => {
       },
       component: () => {
         const context = useRouteContext({ from: rootRouteId })
-        return <div id="index-route-content">{JSON.stringify(context)}</div>
+        return <div>{JSON.stringify(context)}</div>
       },
     })
 
@@ -403,7 +403,7 @@ describe('useRouteContext', () => {
       path: '/',
       component: () => {
         const context = useRouteContext({ from: rootRouteId })
-        return <div id="index-route-content">{JSON.stringify(context)}</div>
+        return <div>{JSON.stringify(context)}</div>
       },
     })
     const routeTree = rootRoute.addChildren([indexRoute])

--- a/packages/react-router/tests/routeContext.test.tsx
+++ b/packages/react-router/tests/routeContext.test.tsx
@@ -22,7 +22,7 @@ afterEach(() => {
 const WAIT_TIME = 150
 
 describe('beforeLoad', () => {
-  // At the root route
+  // Present at the root route
   test('sync route context, present in beforeLoad, root route', () => {
     const mock = vi.fn()
 
@@ -56,7 +56,7 @@ describe('beforeLoad', () => {
     waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
   })
 
-  // At the index route
+  // Present at the index route
   test('sync route context, present in beforeLoad, index route', () => {
     const mock = vi.fn()
 
@@ -95,10 +95,38 @@ describe('beforeLoad', () => {
 
     waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
   })
+
+  // Check if context that is updated at the root, is the same in the index route
+  test('modified route context, present in beforeLoad, index route', async () => {
+    const mock = vi.fn()
+
+    const rootRoute = createRootRoute({
+      beforeLoad: async ({ context }) => {
+        await sleep(WAIT_TIME)
+        return {
+          ...context,
+          foo: 'sean',
+        }
+      },
+    })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      beforeLoad: async ({ context }) => {
+        mock(context)
+      },
+    })
+    const routeTree = rootRoute.addChildren([indexRoute])
+    const router = createRouter({ routeTree, context: { foo: 'bar' } })
+
+    render(<RouterProvider router={router} />)
+
+    waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'sean' }))
+  })
 })
 
 describe('loader', () => {
-  // At the root route
+  // Present at the root route
   test('sync route context, present in loader, root route', () => {
     const mock = vi.fn()
 
@@ -132,7 +160,7 @@ describe('loader', () => {
     waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
   })
 
-  // At the index route
+  // Present at the index route
   test('sync route context, present in loader, index route', () => {
     const mock = vi.fn()
 
@@ -171,10 +199,38 @@ describe('loader', () => {
 
     waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
   })
+
+  // Check if context that is updated at the root, is the same in the index route
+  test('modified route context, present in loader, index route', async () => {
+    const mock = vi.fn()
+
+    const rootRoute = createRootRoute({
+      beforeLoad: async ({ context }) => {
+        await sleep(WAIT_TIME)
+        return {
+          ...context,
+          foo: 'sean',
+        }
+      },
+    })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      loader: async ({ context }) => {
+        mock(context)
+      },
+    })
+    const routeTree = rootRoute.addChildren([indexRoute])
+    const router = createRouter({ routeTree, context: { foo: 'bar' } })
+
+    render(<RouterProvider router={router} />)
+
+    waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'sean' }))
+  })
 })
 
 describe('useRouteContext', () => {
-  // At the root route
+  // Present at the root route
   test('sync route context, present in component, root route', async () => {
     const rootRoute = createRootRoute({
       component: () => {
@@ -235,7 +291,7 @@ describe('useRouteContext', () => {
     expect(content).toBeInTheDocument()
   })
 
-  // At the index route
+  // Present at the index route
   test('sync route context, present in component, index route', async () => {
     const rootRoute = createRootRoute({})
     const indexRoute = createRoute({
@@ -301,6 +357,61 @@ describe('useRouteContext', () => {
     render(<RouterProvider router={router} />)
 
     const content = await screen.findByText(JSON.stringify(ctx))
+
+    expect(content).toBeInTheDocument()
+  })
+
+  // Check if context that is updated at the root, is the same in the root route
+  test('modified route context, present in component, root route', async () => {
+    const rootRoute = createRootRoute({
+      beforeLoad: async ({ context }) => {
+        await sleep(WAIT_TIME)
+        return {
+          ...context,
+          foo: 'sean',
+        }
+      },
+      component: () => {
+        const context = useRouteContext({ from: rootRouteId })
+        return <div id="index-route-content">{JSON.stringify(context)}</div>
+      },
+    })
+
+    const routeTree = rootRoute.addChildren([])
+    const router = createRouter({ routeTree, context: { foo: 'bar' } })
+
+    render(<RouterProvider router={router} />)
+
+    const content = await screen.findByText(JSON.stringify({ foo: 'sean' }))
+
+    expect(content).toBeInTheDocument()
+  })
+
+  // Check if context that is updated at the root, is the same in the index route
+  test('modified route context, present in component, index route', async () => {
+    const rootRoute = createRootRoute({
+      beforeLoad: async ({ context }) => {
+        await sleep(WAIT_TIME)
+        return {
+          ...context,
+          foo: 'sean',
+        }
+      },
+    })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => {
+        const context = useRouteContext({ from: rootRouteId })
+        return <div id="index-route-content">{JSON.stringify(context)}</div>
+      },
+    })
+    const routeTree = rootRoute.addChildren([indexRoute])
+    const router = createRouter({ routeTree, context: { foo: 'bar' } })
+
+    render(<RouterProvider router={router} />)
+
+    const content = await screen.findByText(JSON.stringify({ foo: 'sean' }))
 
     expect(content).toBeInTheDocument()
   })

--- a/packages/react-router/tests/routeContext.test.tsx
+++ b/packages/react-router/tests/routeContext.test.tsx
@@ -22,6 +22,7 @@ afterEach(() => {
 const WAIT_TIME = 150
 
 describe('beforeLoad', () => {
+  // At the root route
   test('sync route context, present in beforeLoad, root route', () => {
     const mock = vi.fn()
 
@@ -55,6 +56,7 @@ describe('beforeLoad', () => {
     waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
   })
 
+  // At the index route
   test('sync route context, present in beforeLoad, index route', () => {
     const mock = vi.fn()
 
@@ -96,6 +98,7 @@ describe('beforeLoad', () => {
 })
 
 describe('loader', () => {
+  // At the root route
   test('sync route context, present in loader, root route', () => {
     const mock = vi.fn()
 
@@ -129,6 +132,7 @@ describe('loader', () => {
     waitFor(() => expect(mock).toHaveBeenCalledWith({ foo: 'bar' }))
   })
 
+  // At the index route
   test('sync route context, present in loader, index route', () => {
     const mock = vi.fn()
 
@@ -170,6 +174,7 @@ describe('loader', () => {
 })
 
 describe('useRouteContext', () => {
+  // At the root route
   test('sync route context, present in component, root route', async () => {
     const rootRoute = createRootRoute({
       component: () => {
@@ -230,6 +235,7 @@ describe('useRouteContext', () => {
     expect(content).toBeInTheDocument()
   })
 
+  // At the index route
   test('sync route context, present in component, index route', async () => {
     const rootRoute = createRootRoute({})
     const indexRoute = createRoute({


### PR DESCRIPTION
This is just the start to making sure that route context is correctly tested.

Route context should be checked at 3 distinct points:
* In the `beforeLoad` callback function.
* In the `loader` callback function.
* In the `component` rendered on the screen.

The idea here is that each scenario context scenario we come up with should be checked at all three points to make sure the route context experience is consistent at all levels.

Currently, these tests check for the following:
* Context available at the root route.
* Context available at the index route.
* Context modified at the root route, is correctly available at the index route.

This can be used as a base for building the tests to fix the context issues we are currently facing.