### PR TITLE
test(react-router): check the availability of the route context after a redirect on the first load

### DIFF
--- a/packages/react-router/tests/routeContext.test.tsx
+++ b/packages/react-router/tests/routeContext.test.tsx
@@ -526,6 +526,35 @@ describe('useRouteContext in the component', () => {
     expect(content).toBeInTheDocument()
   })
 
+  // Check if context that is updated at the root, is the same in the index route
+  test('modified route context, present in the index route', async () => {
+    const rootRoute = createRootRoute({
+      beforeLoad: async ({ context }) => {
+        await sleep(WAIT_TIME)
+        return {
+          ...context,
+          foo: 'sean',
+        }
+      },
+    })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => {
+        const context = useRouteContext({ from: rootRouteId })
+        return <div>{JSON.stringify(context)}</div>
+      },
+    })
+    const routeTree = rootRoute.addChildren([indexRoute])
+    const router = createRouter({ routeTree, context: { foo: 'bar' } })
+
+    render(<RouterProvider router={router} />)
+
+    const content = await screen.findByText(JSON.stringify({ foo: 'sean' }))
+
+    expect(content).toBeInTheDocument()
+  })
+
   // Check if context the context is available after a redirect
   test('route context is present in the /about route after a redirect is thrown in the beforeLoad of the index route', async () => {
     const rootRoute = createRootRoute()

--- a/packages/react-router/tests/routeContext.test.tsx
+++ b/packages/react-router/tests/routeContext.test.tsx
@@ -163,6 +163,7 @@ describe('beforeLoad in the route definition', () => {
     await waitFor(() => expect(mock).toHaveBeenCalledOnce())
     expect(mock).toHaveBeenCalledWith({ foo: 'bar' })
     expect(mock).toHaveBeenCalledTimes(1)
+    expect(router.state.location.pathname).toBe('/about')
   })
 
   test('route context is present in the /about route after a redirect is thrown in the loader of the index route', async () => {
@@ -192,6 +193,7 @@ describe('beforeLoad in the route definition', () => {
     await waitFor(() => expect(mock).toHaveBeenCalledOnce())
     expect(mock).toHaveBeenCalledWith({ foo: 'bar' })
     expect(mock).toHaveBeenCalledTimes(1)
+    expect(router.state.location.pathname).toBe('/about')
   })
 })
 
@@ -336,6 +338,7 @@ describe('loader in the route definition', () => {
     await waitFor(() => expect(mock).toHaveBeenCalledOnce())
     expect(mock).toHaveBeenCalledWith({ foo: 'bar' })
     expect(mock).toHaveBeenCalledTimes(1)
+    expect(router.state.location.pathname).toBe('/about')
   })
 
   test('route context is present in the /about route after a redirect is thrown in loader of the index route', async () => {
@@ -365,6 +368,7 @@ describe('loader in the route definition', () => {
     await waitFor(() => expect(mock).toHaveBeenCalledOnce())
     expect(mock).toHaveBeenCalledWith({ foo: 'bar' })
     expect(mock).toHaveBeenCalledTimes(1)
+    expect(router.state.location.pathname).toBe('/about')
   })
 })
 

--- a/packages/react-router/tests/routeContext.test.tsx
+++ b/packages/react-router/tests/routeContext.test.tsx
@@ -134,6 +134,65 @@ describe('beforeLoad in the route definition', () => {
     expect(mock).toHaveBeenCalledWith({ foo: 'sean' })
     expect(mock).toHaveBeenCalledTimes(1)
   })
+
+  // Check if context the context is available after a redirect
+  test('route context is present in the /about route after a redirect is thrown in the beforeLoad of the index route', async () => {
+    const mock = vi.fn()
+
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      beforeLoad: async () => {
+        await sleep(WAIT_TIME)
+        throw redirect({ to: '/about' })
+      },
+    })
+    const aboutRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/about',
+      beforeLoad: async ({ context }) => {
+        mock(context)
+      },
+    })
+    const routeTree = rootRoute.addChildren([aboutRoute, indexRoute])
+    const router = createRouter({ routeTree, context: { foo: 'bar' } })
+
+    render(<RouterProvider router={router} />)
+
+    await waitFor(() => expect(mock).toHaveBeenCalledOnce())
+    expect(mock).toHaveBeenCalledWith({ foo: 'bar' })
+    expect(mock).toHaveBeenCalledTimes(1)
+  })
+
+  test('route context is present in the /about route after a redirect is thrown in the loader of the index route', async () => {
+    const mock = vi.fn()
+
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      loader: async () => {
+        await sleep(WAIT_TIME)
+        throw redirect({ to: '/about' })
+      },
+    })
+    const aboutRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/about',
+      beforeLoad: async ({ context }) => {
+        mock(context)
+      },
+    })
+    const routeTree = rootRoute.addChildren([aboutRoute, indexRoute])
+    const router = createRouter({ routeTree, context: { foo: 'bar' } })
+
+    render(<RouterProvider router={router} />)
+
+    await waitFor(() => expect(mock).toHaveBeenCalledOnce())
+    expect(mock).toHaveBeenCalledWith({ foo: 'bar' })
+    expect(mock).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('loader in the route definition', () => {
@@ -246,6 +305,65 @@ describe('loader in the route definition', () => {
 
     await waitFor(() => expect(mock).toHaveBeenCalledOnce())
     expect(mock).toHaveBeenCalledWith({ foo: 'sean' })
+    expect(mock).toHaveBeenCalledTimes(1)
+  })
+
+  // Check if context the context is available after a redirect
+  test('route context is present in the /about route after a redirect is thrown in beforeLoad of the index route', async () => {
+    const mock = vi.fn()
+
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      beforeLoad: async () => {
+        await sleep(WAIT_TIME)
+        throw redirect({ to: '/about' })
+      },
+    })
+    const aboutRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/about',
+      loader: async ({ context }) => {
+        mock(context)
+      },
+    })
+    const routeTree = rootRoute.addChildren([aboutRoute, indexRoute])
+    const router = createRouter({ routeTree, context: { foo: 'bar' } })
+
+    render(<RouterProvider router={router} />)
+
+    await waitFor(() => expect(mock).toHaveBeenCalledOnce())
+    expect(mock).toHaveBeenCalledWith({ foo: 'bar' })
+    expect(mock).toHaveBeenCalledTimes(1)
+  })
+
+  test('route context is present in the /about route after a redirect is thrown in loader of the index route', async () => {
+    const mock = vi.fn()
+
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      loader: async () => {
+        await sleep(WAIT_TIME)
+        throw redirect({ to: '/about' })
+      },
+    })
+    const aboutRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/about',
+      loader: async ({ context }) => {
+        mock(context)
+      },
+    })
+    const routeTree = rootRoute.addChildren([aboutRoute, indexRoute])
+    const router = createRouter({ routeTree, context: { foo: 'bar' } })
+
+    render(<RouterProvider router={router} />)
+
+    await waitFor(() => expect(mock).toHaveBeenCalledOnce())
+    expect(mock).toHaveBeenCalledWith({ foo: 'bar' })
     expect(mock).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
This change checks the availability of the route context being correct on the first load.

This does not check the route context availability of the route context after navigation.