### PR TITLE
feat(router-vite-plugin): wrap "use server" over callexprs/identifiers for createServerFn

### DIFF
--- a/packages/router-vite-plugin/src/compilers.ts
+++ b/packages/router-vite-plugin/src/compilers.ts
@@ -118,6 +118,68 @@ export async function compileFile(opts: {
                                   )
                                 }
                               }
+                            } else if (
+                              t.isIdentifier(fn) ||
+                              t.isCallExpression(fn)
+                            ) {
+                              // A function was passed to createServerFn in the form of an
+                              // identifier or a call expression that returns a function.
+
+                              // We wrap the identifier/call expression in a function
+                              // expression that accepts the same arguments as the original
+                              // function with the "use server" directive at the top of the
+                              // function scope.
+
+                              const args = t.restElement(t.identifier('args'))
+
+                              // Annotate args with the type:
+                              //  Parameters<Parameters<typeof createServerFn>[1]>
+
+                              args.typeAnnotation = t.tsTypeAnnotation(
+                                t.tsTypeReference(
+                                  t.identifier('Parameters'),
+                                  t.tsTypeParameterInstantiation([
+                                    t.tsIndexedAccessType(
+                                      t.tsTypeReference(
+                                        t.identifier('Parameters'),
+                                        t.tsTypeParameterInstantiation([
+                                          t.tsTypeQuery(
+                                            t.identifier('createServerFn'),
+                                          ),
+                                        ]),
+                                      ),
+                                      t.tsLiteralType(t.numericLiteral(1)),
+                                    ),
+                                  ]),
+                                ),
+                              )
+
+                              const wrappedFn = t.arrowFunctionExpression(
+                                [args],
+                                t.blockStatement(
+                                  [
+                                    t.returnStatement(
+                                      t.callExpression(
+                                        t.memberExpression(
+                                          fn,
+                                          t.identifier('apply'),
+                                        ),
+                                        [
+                                          t.identifier('this'),
+                                          t.identifier('args'),
+                                        ],
+                                      ),
+                                    ),
+                                  ],
+                                  [
+                                    t.directive(
+                                      t.directiveLiteral('use server'),
+                                    ),
+                                  ],
+                                ),
+                              )
+
+                              path.node.arguments[1] = wrappedFn
                             }
                           } else if (
                             path.node.callee.name === 'createRoute' ||
@@ -354,6 +416,68 @@ export async function splitFile(opts: {
                                   )
                                 }
                               }
+                            } else if (
+                              t.isIdentifier(fn) ||
+                              t.isCallExpression(fn)
+                            ) {
+                              // A function was passed to createServerFn in the form of an
+                              // identifier or a call expression that returns a function.
+
+                              // We wrap the identifier/call expression in a function
+                              // expression that accepts the same arguments as the original
+                              // function with the "use server" directive at the top of the
+                              // function scope.
+
+                              const args = t.restElement(t.identifier('args'))
+
+                              // Annotate args with the type:
+                              //  Parameters<Parameters<typeof createServerFn>[1]>
+
+                              args.typeAnnotation = t.tsTypeAnnotation(
+                                t.tsTypeReference(
+                                  t.identifier('Parameters'),
+                                  t.tsTypeParameterInstantiation([
+                                    t.tsIndexedAccessType(
+                                      t.tsTypeReference(
+                                        t.identifier('Parameters'),
+                                        t.tsTypeParameterInstantiation([
+                                          t.tsTypeQuery(
+                                            t.identifier('createServerFn'),
+                                          ),
+                                        ]),
+                                      ),
+                                      t.tsLiteralType(t.numericLiteral(1)),
+                                    ),
+                                  ]),
+                                ),
+                              )
+
+                              const wrappedFn = t.arrowFunctionExpression(
+                                [args],
+                                t.blockStatement(
+                                  [
+                                    t.returnStatement(
+                                      t.callExpression(
+                                        t.memberExpression(
+                                          fn,
+                                          t.identifier('apply'),
+                                        ),
+                                        [
+                                          t.identifier('this'),
+                                          t.identifier('args'),
+                                        ],
+                                      ),
+                                    ),
+                                  ],
+                                  [
+                                    t.directive(
+                                      t.directiveLiteral('use server'),
+                                    ),
+                                  ],
+                                ),
+                              )
+
+                              path.node.arguments[1] = wrappedFn
                             }
                           } else if (
                             path.node.callee.name === 'createRoute' ||

--- a/packages/router-vite-plugin/tests/snapshots/createServerFn.tsx
+++ b/packages/router-vite-plugin/tests/snapshots/createServerFn.tsx
@@ -1,4 +1,5 @@
 import { createServerFn } from '@tanstack/start';
+import { z } from 'zod';
 export const withUseServer = createServerFn('GET', async function () {
   "use server";
 
@@ -13,9 +14,27 @@ export const withoutUseServer = createServerFn('GET', async () => {
   await new Promise(r => setTimeout(r, 500));
   return axios.get<Array<PostType>>('https://jsonplaceholder.typicode.com/posts').then(r => r.data.slice(0, 10));
 });
-export const withVariable = createServerFn('GET', abstractedFunction);
+export const withVariable = createServerFn('GET', (...args: Parameters<Parameters<typeof createServerFn>[1]>) => {
+  "use server";
+
+  return abstractedFunction.apply(this, args);
+});
 async function abstractedFunction() {
   console.log('Fetching posts...');
   await new Promise(r => setTimeout(r, 500));
   return axios.get<Array<PostType>>('https://jsonplaceholder.typicode.com/posts').then(r => r.data.slice(0, 10));
 }
+function zodValidator<TSchema extends z.ZodSchema, TResult>(schema: TSchema, fn: (input: z.output<TSchema>) => TResult) {
+  return async (input: unknown) => {
+    return fn(schema.parse(input));
+  };
+}
+export const withZodValidator = createServerFn('GET', (...args: Parameters<Parameters<typeof createServerFn>[1]>) => {
+  "use server";
+
+  return zodValidator(z.number(), input => {
+    return {
+      'you gave': input
+    };
+  }).apply(this, args);
+});

--- a/packages/router-vite-plugin/tests/snapshots/createServerFn@split.tsx
+++ b/packages/router-vite-plugin/tests/snapshots/createServerFn@split.tsx
@@ -1,4 +1,5 @@
 import { createServerFn } from '@tanstack/start'
+import { z } from 'zod'
 
 export const withUseServer = createServerFn('GET', async function () {
   console.log('Fetching posts...')
@@ -25,3 +26,19 @@ async function abstractedFunction() {
     .get<Array<PostType>>('https://jsonplaceholder.typicode.com/posts')
     .then((r) => r.data.slice(0, 10))
 }
+
+function zodValidator<TSchema extends z.ZodSchema, TResult>(
+  schema: TSchema,
+  fn: (input: z.output<TSchema>) => TResult,
+) {
+  return async (input: unknown) => {
+    return fn(schema.parse(input))
+  }
+}
+
+export const withZodValidator = createServerFn(
+  'GET',
+  zodValidator(z.number(), (input) => {
+    return { 'you gave': input }
+  }),
+)

--- a/packages/router-vite-plugin/tests/test-files/createServerFn.tsx
+++ b/packages/router-vite-plugin/tests/test-files/createServerFn.tsx
@@ -1,4 +1,5 @@
 import { createServerFn } from '@tanstack/start'
+import { z } from 'zod'
 
 export const withUseServer = createServerFn('GET', async function () {
   console.log('Fetching posts...')
@@ -25,3 +26,19 @@ async function abstractedFunction() {
     .get<Array<PostType>>('https://jsonplaceholder.typicode.com/posts')
     .then((r) => r.data.slice(0, 10))
 }
+
+function zodValidator<TSchema extends z.ZodSchema, TResult>(
+  schema: TSchema,
+  fn: (input: z.output<TSchema>) => TResult,
+) {
+  return async (input: unknown) => {
+    return fn(schema.parse(input))
+  }
+}
+
+export const withZodValidator = createServerFn(
+  'GET',
+  zodValidator(z.number(), (input) => {
+    return { 'you gave': input }
+  }),
+)


### PR DESCRIPTION
Wrap identifiers/call expressions that are passed as the 2nd parameter to createServerFn with a function expression whose body is prepended with the "use server" directive.

This allows for functions that are passed to createServerFn to be wrapped with other functions that serve as middleware.

router-vite-plugin/tests/test-files/createServerFn.tsx has a Zod middleware function example which has the "use server" directive properly prepended.