### PR TITLE
fix: use resolved location when router is pending to build location, otherwise the most latest location

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -542,10 +542,6 @@ export function useLinkProps<
   options: UseLinkPropsOptions<TRouter, TFrom, TTo, TMaskFrom, TMaskTo>,
 ): React.AnchorHTMLAttributes<HTMLAnchorElement> {
   const router = useRouter()
-  const matchPathname = useMatch({
-    strict: false,
-    select: (s) => s.pathname,
-  })
   const [isTransitioning, setIsTransitioning] = React.useState(false)
 
   const {

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1101,12 +1101,22 @@ export class Router<
       } = {},
       matches?: Array<MakeRouteMatch<TRouteTree>>,
     ): ParsedLocation => {
-      const latestLocation =
-        dest._fromLocation ?? (this.latestLocation as ParsedLocation)
-      let fromPath = latestLocation.pathname
-      let fromSearch = dest.fromSearch || latestLocation.search
+      // if the router is loading the previous location is what
+      // we should use because the old matches are still around
+      // and the latest location has already been updated.
+      // If the router is not loading we should always use the
+      // latest location because resolvedLocation can lag behind
+      // and the new matches could already render
+      const currentLocation = this.state.isLoading
+        ? this.state.resolvedLocation
+        : this.latestLocation
 
-      const fromMatches = this.matchRoutes(latestLocation.pathname, fromSearch)
+      const location = dest._fromLocation ?? currentLocation
+
+      let fromPath = location.pathname
+      let fromSearch = dest.fromSearch || location.search
+
+      const fromMatches = this.matchRoutes(location.pathname, fromSearch)
 
       const fromMatch =
         dest.from != null

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -1093,7 +1093,11 @@ describe('Link', () => {
   })
 
   test('when navigating from /posts/$postId to /posts/$postId/info and the current route is /posts/$postId/details', async () => {
-    const rootRoute = createRootRoute()
+    const ErrorComponent = vi.fn(() => <div>Something went wrong!</div>)
+
+    const rootRoute = createRootRoute({
+      errorComponent: ErrorComponent,
+    })
 
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
@@ -1222,10 +1226,16 @@ describe('Link', () => {
     expect(window.location.pathname).toEqual('/posts/id1/info')
 
     expect(await screen.findByText('Params: id1'))
+
+    expect(ErrorComponent).not.toHaveBeenCalled()
   })
 
   test('when navigating from /posts/$postId with a trailing slash to /posts/$postId/info and the current route is /posts/$postId/details', async () => {
-    const rootRoute = createRootRoute()
+    const ErrorComponent = vi.fn(() => <div>Something went wrong!</div>)
+
+    const rootRoute = createRootRoute({
+      errorComponent: ErrorComponent,
+    })
 
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
@@ -1354,10 +1364,16 @@ describe('Link', () => {
     expect(window.location.pathname).toEqual('/posts/id1/info')
 
     expect(await screen.findByText('Params: id1'))
+
+    expect(ErrorComponent).not.toHaveBeenCalled()
   })
 
   test('when navigating from /posts/$postId to ./info and the current route is /posts/$postId/details', async () => {
-    const rootRoute = createRootRoute()
+    const ErrorComponent = vi.fn(() => <div>Something went wrong!</div>)
+
+    const rootRoute = createRootRoute({
+      errorComponent: ErrorComponent,
+    })
 
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
@@ -1486,10 +1502,136 @@ describe('Link', () => {
     expect(window.location.pathname).toEqual('/posts/id1/info')
 
     expect(await screen.findByText('Params: id1'))
+
+    expect(ErrorComponent).not.toHaveBeenCalled()
+  })
+
+  test('when navigating from /posts/$postId to / and the current route is /posts/$postId/details', async () => {
+    const ErrorComponent = vi.fn(() => <div>Something went wrong!</div>)
+
+    const rootRoute = createRootRoute({
+      errorComponent: ErrorComponent,
+    })
+
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => {
+        return (
+          <React.Fragment>
+            <h1>Index</h1>
+            <Link to="/posts">Posts</Link>
+            <Link to="/posts/$postId/details" params={{ postId: 'id1' }}>
+              To first post
+            </Link>
+          </React.Fragment>
+        )
+      },
+    })
+
+    const layoutRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      id: '_layout',
+      component: () => {
+        return (
+          <>
+            <h1>Layout</h1>
+            <Outlet />
+          </>
+        )
+      },
+    })
+
+    const PostsComponent = () => {
+      return (
+        <React.Fragment>
+          <h1>Posts</h1>
+          <Outlet />
+        </React.Fragment>
+      )
+    }
+
+    const postsRoute = createRoute({
+      getParentRoute: () => layoutRoute,
+      path: 'posts',
+      component: PostsComponent,
+    })
+
+    const PostComponent = () => {
+      const params = useParams({ strict: false })
+      return (
+        <React.Fragment>
+          <span>Params: {params.postId}</span>
+          <Outlet />
+        </React.Fragment>
+      )
+    }
+
+    const postRoute = createRoute({
+      getParentRoute: () => postsRoute,
+      path: '$postId',
+      component: PostComponent,
+    })
+
+    const DetailsComponent = () => {
+      return (
+        <>
+          <h1>Details!</h1>
+          <Link from="/posts/$postId" to="/">
+            To Root
+          </Link>
+        </>
+      )
+    }
+
+    const detailsRoute = createRoute({
+      getParentRoute: () => postRoute,
+      path: 'details',
+      component: DetailsComponent,
+    })
+
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([
+        indexRoute,
+        layoutRoute.addChildren([
+          postsRoute.addChildren([postRoute.addChildren([detailsRoute])]),
+        ]),
+      ]),
+    })
+
+    render(<RouterProvider router={router} />)
+
+    const postsLink = await screen.findByRole('link', { name: 'To first post' })
+
+    expect(postsLink).toHaveAttribute('href', '/posts/id1/details')
+
+    fireEvent.click(postsLink)
+
+    expect(await screen.findByText('Params: id1')).toBeInTheDocument()
+
+    expect(window.location.pathname).toEqual('/posts/id1/details')
+
+    const rootLink = await screen.findByRole('link', {
+      name: 'To Root',
+    })
+
+    expect(rootLink).toHaveAttribute('href', '/')
+
+    fireEvent.click(rootLink)
+
+    expect(await screen.findByText('Index')).toBeInTheDocument()
+
+    expect(window.location.pathname).toEqual('/')
+
+    expect(ErrorComponent).not.toHaveBeenCalled()
   })
 
   test('when navigating from /posts/$postId with search and to ./info with search and the current route is /posts/$postId/details', async () => {
-    const rootRoute = createRootRoute()
+    const ErrorComponent = vi.fn(() => <div>Something went wrong!</div>)
+
+    const rootRoute = createRootRoute({
+      errorComponent: ErrorComponent,
+    })
 
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
@@ -1631,10 +1773,16 @@ describe('Link', () => {
     expect(window.location.pathname).toEqual('/posts/id1/info')
 
     expect(await screen.findByText('Params: id1'))
+
+    expect(ErrorComponent).not.toHaveBeenCalled()
   })
 
   test('when navigating from /posts/$postId to ../$postId and the current route is /posts/$postId/details', async () => {
-    const rootRoute = createRootRoute()
+    const ErrorComponent = vi.fn(() => <div>Something went wrong!</div>)
+
+    const rootRoute = createRootRoute({
+      errorComponent: ErrorComponent,
+    })
 
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
@@ -1761,10 +1909,16 @@ describe('Link', () => {
     expect(await screen.findByText('Posts')).toBeInTheDocument()
 
     expect(window.location.pathname).toEqual('/posts/id1')
+
+    expect(ErrorComponent).not.toHaveBeenCalled()
   })
 
   test('when navigating from /posts/$postId with an index to ../$postId and the current route is /posts/$postId/details', async () => {
-    const rootRoute = createRootRoute()
+    const ErrorComponent = vi.fn(() => <div>Something went wrong!</div>)
+
+    const rootRoute = createRootRoute({
+      errorComponent: ErrorComponent,
+    })
 
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
@@ -1901,6 +2055,8 @@ describe('Link', () => {
     expect(await screen.findByText('Posts')).toBeInTheDocument()
 
     expect(window.location.pathname).toEqual('/posts/id1')
+
+    expect(ErrorComponent).not.toHaveBeenCalled()
   })
 
   test('when navigating from /invoices to ./invoiceId and the current route is /posts/$postId/details', async () => {
@@ -2055,7 +2211,11 @@ describe('Link', () => {
   })
 
   test('when navigating to /posts/$postId/info which is declaratively masked as /posts/$postId', async () => {
-    const rootRoute = createRootRoute()
+    const ErrorComponent = vi.fn(() => <div>Something went wrong!</div>)
+
+    const rootRoute = createRootRoute({
+      errorComponent: ErrorComponent,
+    })
 
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
@@ -2140,10 +2300,16 @@ describe('Link', () => {
     })
 
     expect(informationLink).toHaveAttribute('href', '/posts/id1')
+
+    expect(ErrorComponent).not.toHaveBeenCalled()
   })
 
   test('when navigating to /posts/$postId/info which is imperatively masked as /posts/$postId', async () => {
-    const rootRoute = createRootRoute()
+    const ErrorComponent = vi.fn(() => <div>Something went wrong!</div>)
+
+    const rootRoute = createRootRoute({
+      errorComponent: ErrorComponent,
+    })
 
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
@@ -2225,10 +2391,16 @@ describe('Link', () => {
     })
 
     expect(informationLink).toHaveAttribute('href', '/posts/id1')
+
+    expect(ErrorComponent).not.toHaveBeenCalled()
   })
 
   test('when preloading /post/$postId with a redirects to /login', async () => {
-    const rootRoute = createRootRoute()
+    const ErrorComponent = vi.fn(() => <div>Something went wrong!</div>)
+
+    const rootRoute = createRootRoute({
+      errorComponent: ErrorComponent,
+    })
 
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
@@ -2351,10 +2523,16 @@ describe('Link', () => {
     fireEvent.click(postLink)
 
     expect(await screen.findByText('Login!')).toBeInTheDocument()
+
+    expect(ErrorComponent).not.toHaveBeenCalled()
   })
 
   test('when preloading /post/$postId with a beforeLoad that navigates to /login', async () => {
-    const rootRoute = createRootRoute()
+    const ErrorComponent = vi.fn(() => <div>Something went wrong!</div>)
+
+    const rootRoute = createRootRoute({
+      errorComponent: ErrorComponent,
+    })
 
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
@@ -2443,10 +2621,16 @@ describe('Link', () => {
     fireEvent.click(postLink)
 
     expect(await screen.findByText('Login!')).toBeInTheDocument()
+
+    expect(ErrorComponent).not.toHaveBeenCalled()
   })
 
   test('when preloading /post/$postId with a loader that navigates to /login', async () => {
-    const rootRoute = createRootRoute()
+    const ErrorComponent = vi.fn(() => <div>Something went wrong!</div>)
+
+    const rootRoute = createRootRoute({
+      errorComponent: ErrorComponent,
+    })
 
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
@@ -2537,6 +2721,8 @@ describe('Link', () => {
     fireEvent.click(postLink)
 
     expect(await screen.findByText('Login!')).toBeInTheDocument()
+
+    expect(ErrorComponent).not.toHaveBeenCalled()
   })
 })
 


### PR DESCRIPTION
When router is loading it has already updated the `latestLocation`. This means any `buildLocation` call will match `from` against the next location. This can result in the invariant triggering if `from` doesn't match the next location but we're still rendering the matches from the previous location. Instead when the router has pending matches, we can use `resolvedLocation` as it lags behind. But when the router has loaded then we need to switch back to the `latestLocation` because any new match needs match `from` against the next location.