### PR TITLE
perf(react-router): only Omit in Assign when there are overlapping keys

### DIFF
--- a/examples/react/large-file-based/src/routes/__root.tsx
+++ b/examples/react/large-file-based/src/routes/__root.tsx
@@ -7,14 +7,16 @@ import {
 import { type QueryClient } from '@tanstack/react-query'
 import { TanStackRouterDevtools } from '@tanstack/router-devtools'
 
-export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
-  {
-    component: RootComponent,
-    notFoundComponent: () => {
-      return <p>Not Found (on root route)</p>
-    },
+export interface Context {
+  queryClient: QueryClient
+}
+
+export const Route = createRootRouteWithContext<Context>()({
+  component: RootComponent,
+  notFoundComponent: () => {
+    return <p>Not Found (on root route)</p>
   },
-)
+})
 
 function RootComponent() {
   return (

--- a/examples/react/large-file-based/src/routes/search/route.tsx
+++ b/examples/react/large-file-based/src/routes/search/route.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react'
 import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
+
+const search = z.object({
+  rootSearch: z.number(),
+})
 
 export const Route = createFileRoute('/search')({
   component: () => <div>Hello /search!</div>,
+  validateSearch: search,
 })

--- a/examples/react/large-file-based/src/routes/search/searchPlaceholder.tsx
+++ b/examples/react/large-file-based/src/routes/search/searchPlaceholder.tsx
@@ -44,6 +44,7 @@ function SearchComponent() {
           page: 0,
           offset: 10,
           search: 'search',
+          rootSearch: 0,
         }}
       >
         Search

--- a/packages/react-router/src/utils.ts
+++ b/packages/react-router/src/utils.ts
@@ -51,7 +51,9 @@ export type Assign<TLeft, TRight> = keyof TLeft extends never
   ? TRight
   : keyof TRight extends never
     ? TLeft
-    : Omit<TLeft, keyof TRight> & TRight
+    : keyof TLeft & keyof TRight extends never
+      ? TLeft & TRight
+      : Omit<TLeft, keyof TRight> & TRight
 
 export type Timeout = ReturnType<typeof setTimeout>
 


### PR DESCRIPTION
When there are no overlapping keys when merging `search`, `params` or `context` from the parent `Omit` is not necessary, we can use a plain intersection. 

Lowers instantiations a bit more

Before:
```
> tsc --extendedDiagnostics

Files:                         644
Lines of Library:            38411
Lines of Definitions:        82801
Lines of TypeScript:         19754
Lines of JavaScript:             0
Lines of JSON:                   0
Lines of Other:                  0
Identifiers:                134792
Symbols:                    327437
Types:                      115995
Instantiations:             829877
Memory used:               398942K
Assignability cache size:    49740
Identity cache size:          8548
Subtype cache size:           2426
Strict subtype cache size:     413
I/O Read time:               0.08s
Parse time:                  0.56s
ResolveModule time:          0.13s
ResolveTypeReference time:   0.00s
ResolveLibrary time:         0.02s
Program time:                0.88s
Bind time:                   0.27s
Check time:                  5.33s
printTime time:              0.00s
Emit time:                   0.00s
Total time:                  6.48s
```

After

```
> tsc --extendedDiagnostics

Files:                         644
Lines of Library:            38411
Lines of Definitions:        82801
Lines of TypeScript:         19754
Lines of JavaScript:             0
Lines of JSON:                   0
Lines of Other:                  0
Identifiers:                134796
Symbols:                    327336
Types:                      115796
Instantiations:             814838
Memory used:               353196K
Assignability cache size:    48649
Identity cache size:          8548
Subtype cache size:           2426
Strict subtype cache size:     413
I/O Read time:               0.08s
Parse time:                  0.56s
ResolveModule time:          0.13s
ResolveTypeReference time:   0.00s
ResolveLibrary time:         0.02s
Program time:                0.88s
Bind time:                   0.24s
Check time:                  5.26s
printTime time:              0.00s
Emit time:                   0.00s
Total time:                  6.37s
```