### PR TITLE
fix(react-router): match route location when pending has not been set

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -2250,7 +2250,10 @@ export class Router<
       return false
     }
 
-    const baseLocation = opts?.pending
+    const pending =
+      opts?.pending === undefined ? !this.state.isLoading : opts.pending
+
+    const baseLocation = pending
       ? this.latestLocation
       : this.state.resolvedLocation
 


### PR DESCRIPTION
When pending has not been set for matchRoute we should determine the base location based on if the router is loading or not.

- If the router is loading then use the previous location like `Link`
- If the router is not loading then we can safely use the latest location.

This allows the user to conditionally render a `Link` with `from` without any errors