### PR TITLE
docs: fix some mistakes in the example of the SSR guide

### DIFF
--- a/docs/framework/react/guide/ssr.md
+++ b/docs/framework/react/guide/ssr.md
@@ -39,11 +39,11 @@ Since your router will exist both on the server and the client, it's important t
 
 ```tsx
 import * as React from 'react'
-import { createRouter } from '@tanstack/react-router'
-import { routeTree } from 'routeTree.gen'
+import { createRouter as createTanstackRouter } from '@tanstack/react-router'
+import { routeTree } from './routeTree.gen'
 
 export function createRouter() {
-  return createRouter({ routeTree })
+  return createTanstackRouter({ routeTree })
 }
 
 declare module '@tanstack/react-router' {


### PR DESCRIPTION
Fix conflicts with local declaration of 'createRouter' and correct import path for 'routeTree.gen'

- Resolved naming conflict by renaming the local 'createRouter' function.
- Added missing './' in the import path for 'routeTree.gen'.
