### PR TITLE
docs: add TS performance guidance with prefetching

### DIFF
--- a/docs/framework/react/guide/type-safety.md
+++ b/docs/framework/react/guide/type-safety.md
@@ -117,13 +117,12 @@ As your application scales, TypeScript check times will naturally increase. Ther
 
 ### Only infer types you need
 
-A great pattern with client side data caches (TanStack Query etc.) is to prefetch data. For example with TanStack Query you might have a route which calls `ensureQueryData` in a `loader`.
+A great pattern with client side data caches (TanStack Query, etc.) is to prefetch data. For example with TanStack Query you might have a route which calls `queryClient.ensureQueryData` in a `loader`.
 
 ```tsx
 export const Route = createFileRoute('/posts/$postId/deep')({
   loader: ({ context: { queryClient }, params: { postId } }) =>
     queryClient.ensureQueryData(postQueryOptions(postId)),
-  errorComponent: PostErrorComponent as any,
   component: PostDeepComponent,
 })
 
@@ -135,14 +134,13 @@ function PostDeepComponent() {
 }
 ```
 
-This may look fine and for small route trees you may not notice any TS performance issues. However in this case TS has to infer the loader return type despite it never beng used in your route. If the loader data is a complex type and many routes prefetch in this manner it can slow down editor performance. In this case the change is simple and you can let `Promise<void>` be inferred
+This may look fine and for small route trees and you may not notice any TS performance issues. However in this case TS has to infer the loader's return type, despite it never being used in your route. If the loader data is a complex type with many routes that prefetch in this manner, it can slow down editor performance. In this case, the change is quite simple and let typescript infer Promise<void>.
 
 ```tsx
 export const Route = createFileRoute('/posts/$postId/deep')({
   loader: async ({ context: { queryClient }, params: { postId } }) => {
     await queryClient.ensureQueryData(postQueryOptions(postId))
   },
-  errorComponent: PostErrorComponent as any,
   component: PostDeepComponent,
 })
 

--- a/docs/framework/react/guide/type-safety.md
+++ b/docs/framework/react/guide/type-safety.md
@@ -115,6 +115,47 @@ const router = createRouter({
 
 As your application scales, TypeScript check times will naturally increase. There are a few things to keep in mind when your application scales to keep your TS check times down.
 
+### Only infer types you need
+
+A great pattern with client side data caches (TanStack Query etc.) is to prefetch data. For example with TanStack Query you might have a route which calls `ensureQueryData` in a `loader`.
+
+```tsx
+export const Route = createFileRoute('/posts/$postId/deep')({
+  loader: ({ context: { queryClient }, params: { postId } }) =>
+    queryClient.ensureQueryData(postQueryOptions(postId)),
+  errorComponent: PostErrorComponent as any,
+  component: PostDeepComponent,
+})
+
+function PostDeepComponent() {
+  const params = Route.useParams()
+  const data = useSuspenseQuery(postQueryOptions(params.postId))
+
+  return <></>
+}
+```
+
+This may look fine and for small route trees you may not notice any TS performance issues. However in this case TS has to infer the loader return type despite it never beng used in your route. If the loader data is a complex type and many routes prefetch in this manner it can slow down editor performance. In this case the change is simple and you can let `Promise<void>` be inferred
+
+```tsx
+export const Route = createFileRoute('/posts/$postId/deep')({
+  loader: async ({ context: { queryClient }, params: { postId } }) => {
+    await queryClient.ensureQueryData(postQueryOptions(postId))
+  },
+  errorComponent: PostErrorComponent as any,
+  component: PostDeepComponent,
+})
+
+function PostDeepComponent() {
+  const params = Route.useParams()
+  const data = useSuspenseQuery(postQueryOptions(params.postId))
+
+  return <></>
+}
+```
+
+This way the loader data is never infered and it moves the inference out of the route tree to the first time you use `useSuspenseQuery`.
+
 ### Narrow to relevant routes as much as you possibly can
 
 Consider the following usage of `Link`


### PR DESCRIPTION
When using TanStack Query or other client side caches, you might want to use `loader` to only prefetch data. In this case it is more performance for TS to never infer the complex type returned from `ensureQueryData`. Just to be clear, we're talking about this:

```tsx
  loader: (opts) => opts.context.queryClient.ensureQueryData(searchQueryOptions),
```

vs this

```tsx
  loader: (opts) => {
    opts.context.queryClient.ensureQueryData(searchQueryOptions)
  },
```

The second is more performant because the complex type is never inferred

I've profiled this with the large file based example and the difference can be quite large. 3.1s to type check the route tree vs 2.1s



