### PR TITLE
fix: linking with from prop and a param containing slash

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -982,9 +982,20 @@ export class Router<
 
       const loaderDepsHash = loaderDeps ? JSON.stringify(loaderDeps) : ''
 
+      const encodedParams: Record<string, string> = {}
+
+      for (const [key, value] of Object.entries(routeParams)) {
+        if (['*', '_splat'].includes(key)) {
+          // the splat/catch-all routes shouldn't have the '/' encoded out
+          encodedParams[key] = encodeURI(value)
+        } else {
+          encodedParams[key] = encodeURIComponent(value)
+        }
+      }
+
       const interpolatedPath = interpolatePath({
         path: route.fullPath,
-        params: routeParams,
+        params: encodedParams,
       })
 
       const matchId =

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -982,20 +982,9 @@ export class Router<
 
       const loaderDepsHash = loaderDeps ? JSON.stringify(loaderDeps) : ''
 
-      const encodedParams: Record<string, string> = {}
-
-      for (const [key, value] of Object.entries(routeParams)) {
-        if (['*', '_splat'].includes(key)) {
-          // the splat/catch-all routes shouldn't have the '/' encoded out
-          encodedParams[key] = encodeURI(value)
-        } else {
-          encodedParams[key] = encodeURIComponent(value)
-        }
-      }
-
       const interpolatedPath = interpolatePath({
         path: route.fullPath,
-        params: encodedParams,
+        params: routeParams,
       })
 
       const matchId =
@@ -1180,16 +1169,6 @@ export class Router<
             nextParams = { ...nextParams!, ...fn!(nextParams) }
           })
       }
-
-      // encode all path params so the generated href is valid and stable
-      Object.keys(nextParams).forEach((key) => {
-        if (['*', '_splat'].includes(key)) {
-          // the splat/catch-all routes shouldn't have the '/' encoded out
-          nextParams[key] = encodeURI(nextParams[key])
-        } else {
-          nextParams[key] = encodeURIComponent(nextParams[key])
-        }
-      })
 
       pathname = interpolatePath({
         path: pathname,

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -3031,7 +3031,7 @@ describe('Link', () => {
     expect(ErrorComponent).not.toHaveBeenCalled()
   })
 
-  test.only('when linking to self with from prop set and param containing a slash', async () => {
+  test('when linking to self with from prop set and param containing a slash', async () => {
     const rootRoute = createRootRoute({})
 
     const indexRoute = createRoute({

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -3032,7 +3032,11 @@ describe('Link', () => {
   })
 
   test('when linking to self with from prop set and param containing a slash', async () => {
-    const rootRoute = createRootRoute({})
+    const ErrorComponent = vi.fn(() => <h1>Something went wrong!</h1>)
+
+    const rootRoute = createRootRoute({
+      errorComponent: ErrorComponent,
+    })
 
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
@@ -3063,6 +3067,8 @@ describe('Link', () => {
       name: 'Go to post',
     })
 
+    expect(postLink).toHaveAttribute('href', '/id%2Fwith-slash')
+
     fireEvent.click(postLink)
 
     const selfLink = await screen.findByRole('link', {
@@ -3070,6 +3076,7 @@ describe('Link', () => {
     })
 
     expect(selfLink).toBeInTheDocument()
+    expect(ErrorComponent).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -3030,6 +3030,47 @@ describe('Link', () => {
 
     expect(ErrorComponent).not.toHaveBeenCalled()
   })
+
+  test.only('when linking to self with from prop set and param containing a slash', async () => {
+    const rootRoute = createRootRoute({})
+
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => (
+        <Link to="/$postId" params={{ postId: 'id/with-slash' }}>
+          Go to post
+        </Link>
+      ),
+    })
+
+    const postRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/$postId',
+      component: () => (
+        <Link from="/$postId" to="/$postId">
+          Link to self with from prop set
+        </Link>
+      ),
+    })
+
+    const routeTree = rootRoute.addChildren([indexRoute, postRoute])
+    const router = createRouter({ routeTree })
+
+    render(<RouterProvider router={router} />)
+
+    const postLink = await screen.findByRole('link', {
+      name: 'Go to post',
+    })
+
+    fireEvent.click(postLink)
+
+    const selfLink = await screen.findByRole('link', {
+      name: 'Link to self with from prop set',
+    })
+
+    expect(selfLink).toBeInTheDocument()
+  })
 })
 
 describe('createLink', () => {


### PR DESCRIPTION
A failing test case for #1762 that sets up a page on /$postId with a `<Link from="/$postId" to="/$postId">Link to self with from prop set</Link>`. When this page is visited and the $postId params contains a slash, the router crashes with `Invariant failed: Could not find match for from: /$postId`