### PR TITLE
fix(router-devtools): prefix`./` to the pathing for `main`, `types`, and `module` fields in the package.json

### DIFF
--- a/packages/router-devtools/package.json
+++ b/packages/router-devtools/package.json
@@ -15,9 +15,9 @@
     "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
-  "types": "dist/esm/index.d.ts",
-  "main": "dist/cjs/index.cjs",
-  "module": "dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
+  "main": "./dist/cjs/index.cjs",
+  "module": "./dist/esm/index.js",
   "exports": {
     ".": {
       "import": {


### PR DESCRIPTION
Found this since our Playwright E2E test was quite flaky. Traced to this import not being correctly resolved, since the package.json for the `@tanstack/router-devtools` package didn't use the `./` prefix for the pathing of the `main`, `types`, and `module` fields 😅.

This doesn't completely resolve our E2E test being flaky, but at least it brings the error count down to 1.

This is the next problem to resolve: https://cloud.nx.app/runs/IrBZdWTyNV