### PR TITLE
fix(router-plugin): `experimental.enableCodeSplitting` - allow the use of inlined wrappers for the route options when splitting nodes

### DIFF
--- a/packages/router-plugin/src/compilers.ts
+++ b/packages/router-plugin/src/compilers.ts
@@ -446,7 +446,7 @@ export async function splitFile(opts: {
 
                         if (!statement) {
                           throw new Error(
-                            `Failed to parse the generated code for "${splitType}" in the node type "${splitNode.type}" as no expression was found in the program body`,
+                            `Failed to parse the generated code for "${splitType}" in the node type "${splitNode.type}" as no statement was found in the program body`,
                           )
                         }
 

--- a/packages/router-plugin/tests/code-splitter/snapshots/destructured-react-memo-imported-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/destructured-react-memo-imported-component.tsx
@@ -1,0 +1,9 @@
+const $$splitLoaderImporter = () => import('tsr-split:destructured-react-memo-imported-component.tsx?tsr-split');
+import { lazyFn } from '@tanstack/react-router';
+const $$splitComponentImporter = () => import('tsr-split:destructured-react-memo-imported-component.tsx?tsr-split');
+import { lazyRouteComponent } from '@tanstack/react-router';
+import { createFileRoute } from '@tanstack/react-router';
+export const Route = createFileRoute('/')({
+  component: lazyRouteComponent($$splitComponentImporter, 'component'),
+  loader: lazyFn($$splitLoaderImporter, 'loader')
+});

--- a/packages/router-plugin/tests/code-splitter/snapshots/destructured-react-memo-imported-component@split.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/destructured-react-memo-imported-component@split.tsx
@@ -1,0 +1,9 @@
+import { memo } from 'react';
+import { importedLoader } from '../shared/imported';
+function Component() {
+  return <div>Component</div>;
+}
+const component = memo(Component);
+export { component };
+const loader = importedLoader;
+export { loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react-memo-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react-memo-component.tsx
@@ -1,0 +1,9 @@
+const $$splitLoaderImporter = () => import('tsr-split:react-memo-component.tsx?tsr-split');
+import { lazyFn } from '@tanstack/react-router';
+const $$splitComponentImporter = () => import('tsr-split:react-memo-component.tsx?tsr-split');
+import { lazyRouteComponent } from '@tanstack/react-router';
+import { createFileRoute } from '@tanstack/react-router';
+export const Route = createFileRoute('/')({
+  component: lazyRouteComponent($$splitComponentImporter, 'component'),
+  loader: lazyFn($$splitLoaderImporter, 'loader')
+});

--- a/packages/router-plugin/tests/code-splitter/snapshots/react-memo-component@split.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react-memo-component@split.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { importedLoader } from '../shared/imported';
+function Component() {
+  return <div>Component</div>;
+}
+const component = React.memo(Component);
+export { component };
+const loader = importedLoader;
+export { loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react-memo-imported-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react-memo-imported-component.tsx
@@ -1,0 +1,9 @@
+const $$splitLoaderImporter = () => import('tsr-split:react-memo-imported-component.tsx?tsr-split');
+import { lazyFn } from '@tanstack/react-router';
+const $$splitComponentImporter = () => import('tsr-split:react-memo-imported-component.tsx?tsr-split');
+import { lazyRouteComponent } from '@tanstack/react-router';
+import { createFileRoute } from '@tanstack/react-router';
+export const Route = createFileRoute('/')({
+  component: lazyRouteComponent($$splitComponentImporter, 'component'),
+  loader: lazyFn($$splitLoaderImporter, 'loader')
+});

--- a/packages/router-plugin/tests/code-splitter/snapshots/react-memo-imported-component@split.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react-memo-imported-component@split.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { importedLoader, importedComponent } from '../shared/imported';
+const component = React.memo(importedComponent);
+export { component };
+const loader = importedLoader;
+export { loader };

--- a/packages/router-plugin/tests/code-splitter/test-files/destructured-react-memo-imported-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/test-files/destructured-react-memo-imported-component.tsx
@@ -1,0 +1,13 @@
+import { memo } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+
+import { importedLoader } from '../shared/imported'
+
+export const Route = createFileRoute('/')({
+  component: memo(Component),
+  loader: importedLoader,
+})
+
+function Component() {
+  return <div>Component</div>
+}

--- a/packages/router-plugin/tests/code-splitter/test-files/react-memo-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/test-files/react-memo-component.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+
+import { importedLoader } from '../shared/imported'
+
+export const Route = createFileRoute('/')({
+  component: React.memo(Component),
+  loader: importedLoader,
+})
+
+function Component() {
+  return <div>Component</div>
+}

--- a/packages/router-plugin/tests/code-splitter/test-files/react-memo-imported-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/test-files/react-memo-imported-component.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+
+import { importedLoader, importedComponent } from '../shared/imported'
+
+export const Route = createFileRoute('/')({
+  component: React.memo(importedComponent),
+  loader: importedLoader,
+})


### PR DESCRIPTION
It's 4:00 AM here, I really should be sleeping...

fixes #1801 