### PR TITLE
fix: handle formdata correctly from form action

### DIFF
--- a/packages/start/src/server-handler/handler.tsx
+++ b/packages/start/src/server-handler/handler.tsx
@@ -49,7 +49,10 @@ export async function handleRequest(request: Request) {
             ] as const
           }
 
-          if (request.headers.get(serverFnPayloadTypeHeader) === 'formData') {
+          if (
+            request.headers.get(serverFnPayloadTypeHeader) === 'formData' ||
+            request.headers.get('Content-Type')?.includes('multipart/form-data')
+          ) {
             return [
               method.toLowerCase() === 'get'
                 ? (() => {


### PR DESCRIPTION
When using a form like so:

```jsx
export const handleForm = createServerFn('POST', async (formData: FormData, ctx) => {
});

<form action={handleForm.url} method="post" encType={"multipart/form-data"}/>
```

The form action would not be passed to the server handler appropriately. This PR fixes this behavior to work as-intended