### PR TITLE
fix(router-generator): format the route template before writing to disk

### DIFF
--- a/docs/framework/react/guide/file-based-routing.md
+++ b/docs/framework/react/guide/file-based-routing.md
@@ -177,9 +177,11 @@ The following options are available for configuration via the `tsr.config.json` 
 - **`generatedRouteTree`**
   - (Required) The path to the file where the generated route tree will be saved, relative to the cwd.
 - **`quoteStyle`**
-  - (Optional, **Defaults to `single`**) whether to use `single` or `double` quotes when formatting the generated route tree file.`
+  - (Optional, **Defaults to `single`**) whether to use `single` or `double` quotes when formatting the generated route tree file or route generator.`
 - **`semicolons`**
-  - (Optional, **Defaults to `false`**) whether to use semicolons in the generated route tree file.
+  - (Optional, **Defaults to `false`**) whether to use semicolons in the generated route tree file or route generator.
+- **`tabWidth`**
+  - (Optional, **Defaults to `2`**) specify the number of spaces per indentation-level in the generated route tree file or route generator.
 - **`disableTypes`**
   - (Optional, **Defaults to `false`**) whether to disable generating types for the route tree
   - If set to `true`, the generated route tree will not include any types.

--- a/packages/router-generator/src/config.ts
+++ b/packages/router-generator/src/config.ts
@@ -10,6 +10,7 @@ export const configSchema = z.object({
   generatedRouteTree: z.string().optional().default('./src/routeTree.gen.ts'),
   quoteStyle: z.enum(['single', 'double']).optional().default('single'),
   semicolons: z.boolean().optional().default(false),
+  tabWidth: z.number().optional().default(2),
   disableTypes: z.boolean().optional().default(false),
   addExtensions: z.boolean().optional().default(false),
   disableLogging: z.boolean().optional().default(false),

--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -306,7 +306,13 @@ export async function generator(config: Config) {
 
       if (replaced !== routeCode) {
         logger.log(`🟡 Updating ${node.fullPath}`)
-        await fsp.writeFile(node.fullPath, replaced)
+        const formattedReplaced = await prettier.format(replaced, {
+          semi: config.semicolons,
+          singleQuote: config.quoteStyle === 'single',
+          tabWidth: config.tabWidth,
+          parser: 'typescript',
+        })
+        await fsp.writeFile(node.fullPath, formattedReplaced)
       }
     }
 
@@ -664,6 +670,7 @@ export async function generator(config: Config) {
     {
       semi: config.semicolons,
       singleQuote: config.quoteStyle === 'single',
+      tabWidth: config.tabWidth,
       parser: 'typescript',
     },
   )


### PR DESCRIPTION
- add `tabWidth` config to `router-generator`
- apply same formatting to route code generator
- update docs