### PR TITLE
fix: correct typing when directly returing a `DeferredPromise` in a loader

### DIFF
--- a/packages/react-router/src/route.ts
+++ b/packages/react-router/src/route.ts
@@ -20,6 +20,7 @@ import type { Assign, Expand, IsAny, NoInfer, PickRequired } from './utils'
 import type { BuildLocationFn, NavigateFn } from './RouterProvider'
 import type { NotFoundError } from './not-found'
 import type { LazyRoute } from './fileRoute'
+import type { DeferredPromise } from './defer'
 
 export type AnyPathParams = {}
 
@@ -318,10 +319,10 @@ export type RouteLoaderFn<
   in out TAllParams = {},
   in out TLoaderDeps extends Record<string, any> = {},
   in out TAllContext = AnyContext,
-  TLoaderData = undefined,
+  TLoaderDataReturn = undefined,
 > = (
   match: LoaderFnContext<TAllParams, TLoaderDeps, TAllContext>,
-) => Promise<TLoaderData> | TLoaderData
+) => TLoaderDataReturn
 
 export interface LoaderFnContext<
   in out TAllParams = {},
@@ -415,7 +416,13 @@ export type ResolveLoaderData<TLoaderDataReturn> = [TLoaderDataReturn] extends [
   never,
 ]
   ? undefined
-  : TLoaderDataReturn
+  : TLoaderDataReturn extends Promise<never>
+    ? undefined
+    : TLoaderDataReturn extends DeferredPromise<infer T>
+      ? DeferredPromise<T>
+      : TLoaderDataReturn extends Promise<infer T>
+        ? T
+        : TLoaderDataReturn
 
 export interface AnyRoute
   extends Route<

--- a/packages/react-router/tests/route.test-d.tsx
+++ b/packages/react-router/tests/route.test-d.tsx
@@ -4,6 +4,8 @@ import {
   createRootRouteWithContext,
   createRoute,
   createRouter,
+  defer,
+  DeferredPromise,
 } from '../src'
 
 test('when creating the root', () => {
@@ -628,4 +630,21 @@ test('when creating a child route with context, search, params, loader, loaderDe
     onStay: (match) => expectTypeOf(match).toMatchTypeOf<TExpectedMatch>(),
     onLeave: (match) => expectTypeOf(match).toMatchTypeOf<TExpectedMatch>(),
   })
+})
+
+test('when creating a child route with a loader that returns a DeferredPromise', () => {
+  const rootRoute = createRootRoute()
+
+  const invoicesRoute = createRoute({
+    path: 'invoices',
+    getParentRoute: () => rootRoute,
+    loader: (opt) => {
+      expectTypeOf(opt).toMatchTypeOf<{ context: {} }>()
+      return defer(new Promise<string>(() => {}))
+    },
+  })
+
+  expectTypeOf(invoicesRoute.useLoaderData()).toEqualTypeOf<
+    DeferredPromise<string>
+  >()
 })


### PR DESCRIPTION
fixes #1818

however, we first need to make sure that returning a deferred promise directly works correct at runtime!