### PR TITLE
chore(workspace): prettier to ignore the `.vercel` output directories

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@
 **/dist
 pnpm-lock.yaml
 **/snapshots
+**/.vercel


### PR DESCRIPTION
Change pretty much only affects local-development, as in CI these `.output` directories wouldn't exist.