### PR TITLE
refactor(router-plugin): use  `babel-dead-code-elimination` to handle the removal of unreferenced code (abandon)

### DIFF
--- a/packages/router-plugin/package.json
+++ b/packages/router-plugin/package.json
@@ -101,6 +101,7 @@
     "@types/babel__generator": "^7.6.8",
     "@types/babel__template": "^7.4.4",
     "@types/babel__traverse": "^7.20.6",
+    "babel-dead-code-elimination": "^1.0.1",
     "unplugin": "^1.10.1",
     "zod": "^3.22.4"
   }

--- a/packages/router-plugin/package.json
+++ b/packages/router-plugin/package.json
@@ -52,8 +52,8 @@
   "scripts": {
     "clean": "rimraf ./dist && rimraf ./coverage",
     "test": "pnpm test:eslint && pnpm test:types && pnpm test:build && pnpm test:unit",
-    "test:unit": "vitest --typecheck",
-    "test:unit:dev": "pnpm run test:unit --watch",
+    "test:unit": "vitest --watch=false",
+    "test:unit:dev": "vitest --watch",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
     "test:types": "tsc --noEmit",
     "test:build": "publint --strict",

--- a/packages/router-plugin/package.json
+++ b/packages/router-plugin/package.json
@@ -52,7 +52,8 @@
   "scripts": {
     "clean": "rimraf ./dist && rimraf ./coverage",
     "test": "pnpm test:eslint && pnpm test:types && pnpm test:build && pnpm test:unit",
-    "test:unit": "vitest --typecheck --watch=false",
+    "test:unit": "vitest --typecheck",
+    "test:unit:dev": "pnpm run test:unit --watch",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
     "test:types": "tsc --noEmit",
     "test:build": "publint --strict",

--- a/packages/router-plugin/src/ast.ts
+++ b/packages/router-plugin/src/ast.ts
@@ -1,15 +1,5 @@
 import * as babel from '@babel/core'
 
-export const compilePlugins: Array<babel.PluginItem> = [
-  ['@babel/plugin-syntax-jsx', {}],
-  [
-    '@babel/plugin-syntax-typescript',
-    {
-      isTSX: true,
-    },
-  ],
-]
-
 export type ParseAstOpts = {
   code: string
   filename: string
@@ -18,7 +8,15 @@ export type ParseAstOpts = {
 
 export function parseAst(opts: ParseAstOpts): babel.ParseResult | null {
   return babel.parse(opts.code, {
-    plugins: [...compilePlugins],
+    plugins: [
+      ['@babel/plugin-syntax-jsx', {}],
+      [
+        '@babel/plugin-syntax-typescript',
+        {
+          isTSX: true,
+        },
+      ],
+    ],
     root: opts.root,
     filename: opts.filename,
     sourceMaps: true,

--- a/packages/router-plugin/src/ast.ts
+++ b/packages/router-plugin/src/ast.ts
@@ -1,49 +1,27 @@
 import * as babel from '@babel/core'
 
-export type CompileAstFn = (compileOpts: {
+export const compilePlugins: Array<babel.PluginItem> = [
+  ['@babel/plugin-syntax-jsx', {}],
+  [
+    '@babel/plugin-syntax-typescript',
+    {
+      isTSX: true,
+    },
+  ],
+]
+
+export type ParseAstOpts = {
   code: string
   filename: string
-  getBabelConfig: () => { plugins: Array<any> }
-}) => Promise<{
-  code: string
-  map: any
-}>
+  root: string
+}
 
-export function compileAst(makeOpts: { root: string }) {
-  return async (opts: {
-    code: string
-    filename: string
-    getBabelConfig: () => { plugins: Array<any> }
-  }): Promise<{
-    code: string
-    map: any
-  }> => {
-    const res = babel.transformSync(opts.code, {
-      plugins: [
-        ['@babel/plugin-syntax-jsx', {}],
-        [
-          '@babel/plugin-syntax-typescript',
-          {
-            isTSX: true,
-          },
-        ],
-        ...opts.getBabelConfig().plugins,
-      ],
-      root: makeOpts.root,
-      filename: opts.filename,
-      sourceMaps: true,
-    })
-
-    if (res?.code) {
-      return {
-        code: res.code,
-        map: res.map,
-      }
-    }
-
-    return {
-      code: opts.code,
-      map: null,
-    }
-  }
+export function parseAst(opts: ParseAstOpts): babel.ParseResult | null {
+  return babel.parse(opts.code, {
+    plugins: [...compilePlugins],
+    root: opts.root,
+    filename: opts.filename,
+    sourceMaps: true,
+    sourceType: 'module',
+  })
 }

--- a/packages/router-plugin/src/code-splitter.ts
+++ b/packages/router-plugin/src/code-splitter.ts
@@ -1,8 +1,10 @@
 import { isAbsolute, join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
-import { compileAst } from './ast'
-import { compileFile, splitFile } from './compilers'
+import {
+  getCodeSplitReferenceRoute,
+  getCodeSplitVirtualRoute,
+} from './compilers'
 import { getConfig } from './config'
 import { splitPrefix } from './constants'
 
@@ -60,22 +62,18 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
   let userConfig = options as Config
 
   const handleSplittingFile = async (code: string, id: string) => {
-    const compiledAst = compileAst({
+    const splitOutput = getCodeSplitVirtualRoute({
+      code,
+      filename: id,
       root: ROOT,
     })
 
     if (debug) console.info('Splitting route: ', id)
 
-    const compiled = await splitFile({
-      code,
-      compileAst: compiledAst,
-      filename: id,
-    })
-
     if (debug) console.info('')
     if (debug) console.info('Split Output')
     if (debug) console.info('')
-    if (debug) console.info(compiled.code)
+    if (debug) console.info(splitOutput.code)
     if (debug) console.info('')
     if (debug) console.info('')
     if (debug) console.info('')
@@ -85,26 +83,22 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
     if (debug) console.info('')
     if (debug) console.info('')
 
-    return compiled
+    return splitOutput
   }
 
   const handleCompilingFile = async (code: string, id: string) => {
-    const compiledAst = compileAst({
+    const referenceOutput = getCodeSplitReferenceRoute({
+      code,
+      filename: id,
       root: ROOT,
     })
 
     if (debug) console.info('Handling createRoute: ', id)
 
-    const compiled = await compileFile({
-      code,
-      compileAst: compiledAst,
-      filename: id,
-    })
-
     if (debug) console.info('')
     if (debug) console.info('Compiled Output')
     if (debug) console.info('')
-    if (debug) console.info(compiled.code)
+    if (debug) console.info(referenceOutput.code)
     if (debug) console.info('')
     if (debug) console.info('')
     if (debug) console.info('')
@@ -116,7 +110,7 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
     if (debug) console.info('')
     if (debug) console.info('')
 
-    return compiled
+    return referenceOutput
   }
 
   return {

--- a/packages/router-plugin/src/compilers.ts
+++ b/packages/router-plugin/src/compilers.ts
@@ -26,6 +26,27 @@ interface State {
   splitModulesById: SplitModulesById
 }
 
+/**
+ * TODO: DELETE THIS BEFORE MERGING INTO MAIN
+ */
+export function exampleOfElimination(opts: ParseAstOpts) {
+  let ast = parseAst(opts)
+
+  if (!ast) {
+    throw new Error(
+      `Failed to compile ast for exampleOfElimination for the file: ${opts.filename}`,
+    )
+  }
+
+  traverse(ast, {
+    /** */
+  })
+
+  deadCodeElimination(ast)
+
+  return generate(ast)
+}
+
 export function getCodeSplitReferenceRoute(opts: ParseAstOpts) {
   let ast = parseAst(opts)
 

--- a/packages/router-plugin/src/eliminateUnreferencedIdentifiers.ts
+++ b/packages/router-plugin/src/eliminateUnreferencedIdentifiers.ts
@@ -1,3 +1,5 @@
+// TODO: DELETE THIS FILE BEFORE MERGING TO MAIN
+
 // Copied from https://github.com/pcattori/vite-env-only/blob/main/src/dce.ts
 // Adapted with some minor changes for the purpose of this project
 

--- a/packages/router-plugin/tests/code-splitter.test.ts
+++ b/packages/router-plugin/tests/code-splitter.test.ts
@@ -1,8 +1,10 @@
 import { readFile, readdir } from 'fs/promises'
 import path from 'path'
 import { describe, expect, it } from 'vitest'
-import { compileAst } from '../src/ast'
-import { compileFile, splitFile } from '../src/compilers'
+import {
+  getCodeSplitReferenceRoute,
+  getCodeSplitVirtualRoute,
+} from '../src/compilers'
 import { splitPrefix } from '../src/constants'
 
 async function getFilenames() {
@@ -20,28 +22,24 @@ describe('code-splitter works', async () => {
       )
       const code = file.toString()
 
-      const compilerResult = await compileFile({
+      const referenceRouteResult = getCodeSplitReferenceRoute({
         code,
-        compileAst: compileAst({
-          root: './code-splitter/test-files',
-        }),
+        root: './code-splitter/test-files',
         filename,
       })
 
-      await expect(compilerResult.code).toMatchFileSnapshot(
+      await expect(referenceRouteResult.code).toMatchFileSnapshot(
         `./code-splitter/snapshots/${filename}`,
-        `Compiled file for "${filename}" should match snapshot`,
+        `New Compiled file for "${filename}" should match snapshot`,
       )
 
-      const splitResult = await splitFile({
+      const splitRouteResult = getCodeSplitVirtualRoute({
         code,
-        compileAst: compileAst({
-          root: './code-splitter/test-files',
-        }),
+        root: './code-splitter/test-files',
         filename: `${filename}?${splitPrefix}`,
       })
 
-      await expect(splitResult.code).toMatchFileSnapshot(
+      await expect(splitRouteResult.code).toMatchFileSnapshot(
         `./code-splitter/snapshots/${filename.replace('.tsx', '')}@split.tsx`,
         `Split file for "${filename}" should match snapshot`,
       )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1672,6 +1672,9 @@ importers:
       '@types/babel__traverse':
         specifier: ^7.20.6
         version: 7.20.6
+      babel-dead-code-elimination:
+        specifier: ^1.0.1
+        version: 1.0.1
       unplugin:
         specifier: ^1.10.1
         version: 1.10.1
@@ -2054,11 +2057,6 @@ packages:
   '@babel/highlight@7.24.7':
     resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.24.5':
-    resolution: {integrity: sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.24.7':
     resolution: {integrity: sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==}
@@ -5070,6 +5068,9 @@ packages:
 
   b4a@1.6.6:
     resolution: {integrity: sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==}
+
+  babel-dead-code-elimination@1.0.1:
+    resolution: {integrity: sha512-QD6IAGZU/Qd7qJJPptnPVGRl9SnK9IdowcIjOcxVKbfB70chvCXRaV2BOgxpVckQud3CppYoI6QA+/cfdBGAMA==}
 
   babel-plugin-add-module-exports@0.2.1:
     resolution: {integrity: sha512-3AN/9V/rKuv90NG65m4tTHsI04XrCKsWbztIcW7a8H5iIN7WlvWucRtVV0V/rT4QvtA11n5Vmp20fLwfMWqp6g==}
@@ -9245,7 +9246,7 @@ snapshots:
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-module-transforms': 7.24.5(@babel/core@7.24.5)
       '@babel/helpers': 7.24.5
-      '@babel/parser': 7.24.5
+      '@babel/parser': 7.24.7
       '@babel/template': 7.24.7
       '@babel/traverse': 7.24.7
       '@babel/types': 7.24.7
@@ -9555,10 +9556,6 @@ snapshots:
       chalk: 2.4.2
       js-tokens: 4.0.0
       picocolors: 1.0.1
-
-  '@babel/parser@7.24.5':
-    dependencies:
-      '@babel/types': 7.24.7
 
   '@babel/parser@7.24.7':
     dependencies:
@@ -11746,7 +11743,7 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.24.5
+      '@babel/parser': 7.24.7
       '@babel/types': 7.24.7
       '@types/babel__generator': 7.6.8
       '@types/babel__template': 7.4.4
@@ -11758,7 +11755,7 @@ snapshots:
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.24.5
+      '@babel/parser': 7.24.7
       '@babel/types': 7.24.7
 
   '@types/babel__traverse@7.20.6':
@@ -12063,7 +12060,7 @@ snapshots:
 
   '@vinxi/plugin-directives@0.3.1(vinxi@0.3.11(@opentelemetry/api@1.8.0)(@types/node@20.14.7)(ioredis@5.4.1)(terser@5.31.0))':
     dependencies:
-      '@babel/parser': 7.24.5
+      '@babel/parser': 7.24.7
       acorn: 8.11.3
       acorn-jsx: 5.3.2(acorn@8.11.3)
       acorn-loose: 8.3.0
@@ -12186,7 +12183,7 @@ snapshots:
 
   '@vue/compiler-core@3.4.27':
     dependencies:
-      '@babel/parser': 7.24.5
+      '@babel/parser': 7.24.7
       '@vue/shared': 3.4.27
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -12618,6 +12615,15 @@ snapshots:
       dequal: 2.0.3
 
   b4a@1.6.6: {}
+
+  babel-dead-code-elimination@1.0.1:
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/parser': 7.24.7
+      '@babel/traverse': 7.24.7
+      '@babel/types': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
 
   babel-plugin-add-module-exports@0.2.1: {}
 
@@ -14942,7 +14948,7 @@ snapshots:
 
   magicast@0.2.11:
     dependencies:
-      '@babel/parser': 7.24.5
+      '@babel/parser': 7.24.7
       '@babel/types': 7.24.7
       recast: 0.23.4
 


### PR DESCRIPTION
🚨 Do not merge!!!

From: https://x.com/tannerlinsley/status/1806016799114424632

Currently, these issues need to be resolved before merging:
- https://github.com/pcattori/babel-dead-code-elimination/issues/9
- https://github.com/pcattori/babel-dead-code-elimination/issues/10
- https://github.com/pcattori/babel-dead-code-elimination/issues/11