### PR TITLE
fix: add option to include and exclude properties from React plugin

### DIFF
--- a/packages/start/src/config/index.ts
+++ b/packages/start/src/config/index.ts
@@ -38,6 +38,8 @@ const babelSchema = z
 const reactSchema = z
   .object({
     babel: babelSchema,
+    exclude: z.array(z.instanceof(RegExp)).optional(),
+    include: z.array(z.instanceof(RegExp)).optional(),
   })
   .optional()
   .default({})
@@ -171,6 +173,8 @@ export async function defineConfig(opts_?: z.infer<typeof optsSchema>) {
           }),
           reactRefresh({
             babel: opts.react.babel,
+            exclude: opts.react.exclude,
+            include: opts.react.include,
           }),
           // serverComponents.client(),
         ],


### PR DESCRIPTION
In TanStack Form, I need a way to disable the React dev refresh transform for internal packages in the monorepo.

This allows us to have a configuration file like so:

```tsx
import { defineConfig } from '@tanstack/start/config'
import tsConfigPaths from 'vite-tsconfig-paths'

export default defineConfig({
  vite: {
    plugins: () => [
      tsConfigPaths({
        projects: ['./tsconfig.json'],
      }),
    ],
  },
  react: {
    exclude: [/packages/],
  }
})
```

Which solves my issue in the monorepo.