### PR TITLE
fix: use chunk compiler directly to add module transform loader

### DIFF
--- a/packages/router-plugin/src/demo-rspack-code-splitter.ts
+++ b/packages/router-plugin/src/demo-rspack-code-splitter.ts
@@ -123,6 +123,14 @@ export const unpluginRsPackRouterCodeSplitterFactory: UnpluginFactory<
           },
         )
       })
+      compiler.options.module.rules.push({
+        test: (id) => fileIsInRoutesDirectory(id, userConfig.routesDirectory),
+        //@ts-ignore
+        use(data) {
+          // console.log(data)
+          return 'module.exports = "your code here"'
+        },
+      })
       // TODO: explore replacing the above hook with https://webpack.js.org/plugins/normal-module-replacement-plugin/
     },
 

--- a/packages/router-plugin/src/rspack.ts
+++ b/packages/router-plugin/src/rspack.ts
@@ -1,5 +1,5 @@
 import { createRspackPlugin } from 'unplugin'
-// import { unpluginRouterCodeSplitterFactory } from './code-splitter'
+import { unpluginRouterCodeSplitterFactory } from './code-splitter'
 import { configSchema } from './config'
 import { unpluginRouterGeneratorFactory } from './router-generator'
 import { unpluginRouterComposedFactory } from './composed'
@@ -45,8 +45,8 @@ const TanStackRouterGeneratorRspack = /* #__PURE__ */ createRspackPlugin(
  * })
  * ```
  */
-// const unstable_TanStackRouterCodeSplitterRspack =
-//   /* #__PURE__ */ createRspackPlugin(unpluginRouterCodeSplitterFactory)
+const unstable_TanStackRouterCodeSplitterRspack =
+  /* #__PURE__ */ createRspackPlugin(unpluginRouterCodeSplitterFactory)
 
 const unstable_TanStackRouterCodeSplitterRspackTest =
   /* #__PURE__ */ createRspackPlugin(unpluginRsPackRouterCodeSplitterFactory)
@@ -73,7 +73,7 @@ export {
   configSchema,
   TanStackRouterRspack,
   TanStackRouterGeneratorRspack,
-  // unstable_TanStackRouterCodeSplitterRspack,
+  unstable_TanStackRouterCodeSplitterRspack,
   unstable_TanStackRouterCodeSplitterRspackTest,
 }
 export type { Config }


### PR DESCRIPTION
Since unplugin takes away too much control over child compilers transform, the easiest solution is to just add the loader directly through rspack compiler and skip unplugin apis for the time bring

The transform hook doesn't implement the test regex. So using transform has an impact on other compilation targets and there's no way to scope it down that I could see at a glance. 