### PR TITLE
ci: fix the workflow for running the e2e test on the "start-basic" example

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           main-branch-name: 'main'
       - name: Build dependecies
-        run: pnpm run build
+        run: pnpm run build:all
       - name: Get Replay Chromium
         run: npx replayio install
       - name: Run Playwright tests

--- a/examples/react/start-basic/package.json
+++ b/examples/react/start-basic/package.json
@@ -11,7 +11,7 @@
     "lint": "prettier --check '**/*' --ignore-unknown && eslint --ext .ts,.tsx ./app",
     "format": "prettier --write '**/*' --ignore-unknown",
     "test:e2e": "playwright test --project=chromium",
-    "test:e2e:replay": "DEBUG='*' playwright test --project=replay-chromium"
+    "test:e2e:replay": "playwright test --project=replay-chromium"
   },
   "dependencies": {
     "@tanstack/react-router": "^1.40.0",

--- a/examples/react/start-basic/package.json
+++ b/examples/react/start-basic/package.json
@@ -11,7 +11,7 @@
     "lint": "prettier --check '**/*' --ignore-unknown && eslint --ext .ts,.tsx ./app",
     "format": "prettier --write '**/*' --ignore-unknown",
     "test:e2e": "playwright test --project=chromium",
-    "test:e2e:replay": "playwright test --project=replay-chromium"
+    "test:e2e:replay": "DEBUG='*' playwright test --project=replay-chromium"
   },
   "dependencies": {
     "@tanstack/react-router": "^1.40.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "test:e2e:replay": "nx run-many --target=test:e2e:replay",
     "build": "nx affected --target=build --exclude=examples/**",
     "build:all": "nx run-many --target=build --exclude=examples/**",
-    "build:examples": "nx run-many --target=build",
     "watch": "pnpm run build:all && nx watch --all -- pnpm run build:all",
     "dev": "pnpm run watch",
     "prettier": "prettier --ignore-unknown '**/*'",


### PR DESCRIPTION
`build:example` wasn't building right dep. This PR builds all of the packages before starting the tests.