### PR TITLE
Use different port on example apps

### DIFF
--- a/examples/react/start-basic-react-query/package.json
+++ b/examples/react/start-basic-react-query/package.json
@@ -5,13 +5,13 @@
   "packageManager": "pnpm@8.10.2",
   "type": "module",
   "scripts": {
-    "dev": "vinxi dev",
+    "dev": "vinxi dev --port=3001",
     "build": "vinxi build",
     "start": "vinxi start",
     "lint": "prettier --check '**/*' --ignore-unknown && eslint --ext .ts,.tsx ./app",
     "format": "prettier --write '**/*' --ignore-unknown",
     "test:e2e": "playwright test --project=chromium",
-    "test:e2e:replay": "playwright test --project=replay-chromium"
+    "test:e2e:replay": "REPLAY_PLAYWRIGHT_PLUGIN_SERVER_PORT=52026 playwright test --project=replay-chromium"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.48.0",

--- a/examples/react/start-basic-react-query/playwright.config.ts
+++ b/examples/react/start-basic-react-query/playwright.config.ts
@@ -21,13 +21,13 @@ export default defineConfig({
 
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:3000/',
+    baseURL: 'http://localhost:3001/',
   },
 
   webServer: {
     // TODO: build && start seems broken, use that if it's working
     command: 'pnpm run dev',
-    url: 'http://localhost:3000',
+    url: 'http://localhost:3001',
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',
   },


### PR DESCRIPTION
Targetting `rsc` branch.

@tannerlinsley There were two port conflicts. One was dev server itself between two example projects. Another was the internal playwright plugin server. I'm filing an issue internally, so we don't need env workaround I added.

Tests are still failing on an unrelated error. Here's an example run: https://cloud.nx.app/runs/Cv51FZLMhi 

I guess `createStartHandler` has been changed to something else?