### PR TITLE
docs: remove the unnecessary encode and decode `URIComponent` calls in the zipson example of the "custom search param serialization" guide

### DIFF
--- a/docs/framework/react/guide/custom-search-param-serialization.md
+++ b/docs/framework/react/guide/custom-search-param-serialization.md
@@ -158,12 +158,8 @@ import {
 import { stringify, parse } from 'zipson'
 
 const router = createRouter({
-  parseSearch: parseSearchWith((value) =>
-    parse(decodeURIComponent(decodeFromBinary(value))),
-  ),
-  stringifySearch: stringifySearchWith((value) =>
-    encodeToBinary(encodeURIComponent(stringify(value))),
-  ),
+  parseSearch: parseSearchWith((value) => parse(decodeFromBinary(value))),
+  stringifySearch: stringifySearchWith((value) => encodeToBinary(stringify(value))),
 })
 
 function decodeFromBinary(str: string): string {


### PR DESCRIPTION
Howdy! 

When using Zipson per this original example I had unexpected results. The URL produced was actually larger than the base-64 encoding example. I believe it was because `decodeURIComponent` and `encodeURIComponent` were being ran twice (ie: once in the lambda passed to `parseSearchWith` and once inside `decodeFromBinary`). Removing the duplicate function call seemed to do the trick. 

If anyone wants to try to reproduce it, copy-pasting from this change should be enough. 

Thanks!