### PR TITLE
fix: ensure context is consistent on concurrent match loads

### DIFF
--- a/packages/react-router/src/Matches.tsx
+++ b/packages/react-router/src/Matches.tsx
@@ -48,6 +48,7 @@ export interface RouteMatch<
   searchError: unknown
   updatedAt: number
   loadPromise: ControlledPromise<void>
+  beforeLoadPromise: ControlledPromise<void>
   loaderPromise: Promise<TLoaderData>
   loaderData?: TLoaderData
   routeContext: TRouteContext

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1996,11 +1996,14 @@ export class Router<
                       checkLatest()
 
                       // Kick off the loader!
+                      const loaderPromise =
+                        route.options.loader?.(loaderContext)
+
                       matches[index] = match = updateMatch(
                         match.id,
                         (prev) => ({
                           ...prev,
-                          loaderPromise: route.options.loader?.(loaderContext),
+                          loaderPromise,
                         }),
                       )
                     }


### PR DESCRIPTION
If a match has multiple load routines running (such as navigation happening while preload isn't finished yet), we might start the `loader` function too early when the context isn't ready for consumption yet.

This happens because [execution flow is skipped](https://github.com/TanStack/router/blob/main/packages/react-router/src/router.ts#L1772) when a route already in beforeLoad fetching state is re-loaded.

This patch adds beforeLoad tracking to matched routes, so that we can eventually await any pending beforeLoad function and ensure we have up to date context to feed into the `loader` function.

Fixes https://github.com/TanStack/router/issues/1886