### PR TITLE
chore(examples): move from `@tanstack/router-vite-plugin` to `@tanstack/router-plugin`

### DIFF
--- a/examples/react/authenticated-routes/package.json
+++ b/examples/react/authenticated-routes/package.json
@@ -11,11 +11,11 @@
   "dependencies": {
     "@tanstack/react-router": "^1.43.10",
     "@tanstack/router-devtools": "^1.43.10",
-    "@tanstack/router-vite-plugin": "^1.43.9",
-    "redaxios": "^0.5.0",
+    "@tanstack/router-plugin": "^1.43.9",
     "immer": "^10.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "redaxios": "^0.5.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/examples/react/authenticated-routes/vite.config.js
+++ b/examples/react/authenticated-routes/vite.config.js
@@ -1,8 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { TanStackRouterVite } from '@tanstack/router-vite-plugin'
+import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), TanStackRouterVite()],
+  plugins: [TanStackRouterVite(), react()],
 })

--- a/examples/react/basic-file-based-codesplitting/package.json
+++ b/examples/react/basic-file-based-codesplitting/package.json
@@ -11,11 +11,11 @@
   "dependencies": {
     "@tanstack/react-router": "^1.43.10",
     "@tanstack/router-devtools": "^1.43.10",
-    "@tanstack/router-vite-plugin": "^1.43.9",
-    "redaxios": "^0.5.0",
+    "@tanstack/router-plugin": "^1.43.9",
     "immer": "^10.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "redaxios": "^0.5.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/examples/react/basic-file-based-codesplitting/vite.config.js
+++ b/examples/react/basic-file-based-codesplitting/vite.config.js
@@ -1,8 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { TanStackRouterVite } from '@tanstack/router-vite-plugin'
+import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), TanStackRouterVite()],
+  plugins: [TanStackRouterVite(), react()],
 })

--- a/examples/react/basic-file-based/package.json
+++ b/examples/react/basic-file-based/package.json
@@ -11,11 +11,11 @@
   "dependencies": {
     "@tanstack/react-router": "^1.43.10",
     "@tanstack/router-devtools": "^1.43.10",
-    "@tanstack/router-vite-plugin": "^1.43.9",
-    "redaxios": "^0.5.0",
+    "@tanstack/router-plugin": "^1.43.9",
     "immer": "^10.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "redaxios": "^0.5.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/examples/react/basic-file-based/vite.config.js
+++ b/examples/react/basic-file-based/vite.config.js
@@ -1,15 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { TanStackRouterVite } from '@tanstack/router-vite-plugin'
+import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [
-    TanStackRouterVite({
-      experimental: {
-        enableCodeSplitting: true,
-      },
-    }),
-    react(),
-  ],
+  plugins: [TanStackRouterVite(), react()],
 })

--- a/examples/react/basic-react-query-file-based/package.json
+++ b/examples/react/basic-react-query-file-based/package.json
@@ -13,11 +13,11 @@
     "@tanstack/react-query-devtools": "^5.17.8",
     "@tanstack/react-router": "^1.43.10",
     "@tanstack/router-devtools": "^1.43.10",
-    "@tanstack/router-vite-plugin": "^1.43.9",
-    "redaxios": "^0.5.0",
+    "@tanstack/router-plugin": "^1.43.9",
     "immer": "^10.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "redaxios": "^0.5.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/examples/react/basic-react-query-file-based/vite.config.js
+++ b/examples/react/basic-react-query-file-based/vite.config.js
@@ -1,8 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { TanStackRouterVite } from '@tanstack/router-vite-plugin'
+import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), TanStackRouterVite()],
+  plugins: [TanStackRouterVite(), react()],
 })

--- a/examples/react/basic-ssr-file-based/package.json
+++ b/examples/react/basic-ssr-file-based/package.json
@@ -12,13 +12,13 @@
   },
   "dependencies": {
     "@tanstack/react-router": "^1.43.10",
-    "@tanstack/start": "^1.43.11",
     "@tanstack/router-devtools": "^1.43.10",
-    "@tanstack/router-vite-plugin": "^1.43.9",
-    "redaxios": "^0.5.0",
+    "@tanstack/router-plugin": "^1.43.9",
+    "@tanstack/start": "^1.43.11",
     "get-port": "^7.0.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "redaxios": "^0.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.23.7",

--- a/examples/react/basic-ssr-file-based/vite.config.js
+++ b/examples/react/basic-ssr-file-based/vite.config.js
@@ -1,8 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { TanStackRouterVite } from '@tanstack/router-vite-plugin'
+import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), TanStackRouterVite()],
+  plugins: [TanStackRouterVite(), react()],
 })

--- a/examples/react/basic-ssr-streaming-file-based/package.json
+++ b/examples/react/basic-ssr-streaming-file-based/package.json
@@ -12,13 +12,13 @@
   },
   "dependencies": {
     "@tanstack/react-router": "^1.43.10",
-    "@tanstack/start": "^1.43.11",
     "@tanstack/router-devtools": "^1.43.10",
-    "@tanstack/router-vite-plugin": "^1.43.9",
-    "redaxios": "^0.5.0",
+    "@tanstack/router-plugin": "^1.43.9",
+    "@tanstack/start": "^1.43.11",
     "get-port": "^7.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "redaxios": "^0.5.0",
     "superjson": "^2.2.1"
   },
   "devDependencies": {

--- a/examples/react/basic-ssr-streaming-file-based/vite.config.js
+++ b/examples/react/basic-ssr-streaming-file-based/vite.config.js
@@ -1,8 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { TanStackRouterVite } from '@tanstack/router-vite-plugin'
+import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), TanStackRouterVite()],
+  plugins: [TanStackRouterVite(), react()],
 })

--- a/examples/react/kitchen-sink-file-based/package.json
+++ b/examples/react/kitchen-sink-file-based/package.json
@@ -11,11 +11,11 @@
   "dependencies": {
     "@tanstack/react-router": "^1.43.10",
     "@tanstack/router-devtools": "^1.43.10",
-    "@tanstack/router-vite-plugin": "^1.43.9",
-    "redaxios": "^0.5.0",
+    "@tanstack/router-plugin": "^1.43.9",
     "immer": "^10.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "redaxios": "^0.5.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/examples/react/kitchen-sink-file-based/vite.config.js
+++ b/examples/react/kitchen-sink-file-based/vite.config.js
@@ -1,8 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { TanStackRouterVite } from '@tanstack/router-vite-plugin'
+import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), TanStackRouterVite()],
+  plugins: [TanStackRouterVite(), react()],
 })

--- a/examples/react/kitchen-sink-react-query-file-based/package.json
+++ b/examples/react/kitchen-sink-react-query-file-based/package.json
@@ -13,11 +13,11 @@
     "@tanstack/react-query-devtools": "^5.17.8",
     "@tanstack/react-router": "^1.43.10",
     "@tanstack/router-devtools": "^1.43.10",
-    "@tanstack/router-vite-plugin": "^1.43.9",
-    "redaxios": "^0.5.0",
+    "@tanstack/router-plugin": "^1.43.9",
     "immer": "^10.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "redaxios": "^0.5.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/examples/react/kitchen-sink-react-query-file-based/vite.config.js
+++ b/examples/react/kitchen-sink-react-query-file-based/vite.config.js
@@ -1,8 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { TanStackRouterVite } from '@tanstack/router-vite-plugin'
+import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), TanStackRouterVite()],
+  plugins: [TanStackRouterVite(), react()],
 })

--- a/examples/react/large-file-based/package.json
+++ b/examples/react/large-file-based/package.json
@@ -14,11 +14,11 @@
     "@tanstack/react-query": "^5.17.8",
     "@tanstack/react-router": "^1.43.10",
     "@tanstack/router-devtools": "^1.43.10",
-    "@tanstack/router-vite-plugin": "^1.43.9",
-    "redaxios": "^0.5.0",
+    "@tanstack/router-plugin": "^1.43.9",
     "immer": "^10.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "redaxios": "^0.5.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/examples/react/large-file-based/vite.config.js
+++ b/examples/react/large-file-based/vite.config.js
@@ -1,8 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { TanStackRouterVite } from '@tanstack/router-vite-plugin'
+import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), TanStackRouterVite()],
+  plugins: [TanStackRouterVite(), react()],
 })

--- a/examples/react/quickstart-file-based/package.json
+++ b/examples/react/quickstart-file-based/package.json
@@ -11,11 +11,11 @@
   "dependencies": {
     "@tanstack/react-router": "^1.43.10",
     "@tanstack/router-devtools": "^1.43.10",
-    "@tanstack/router-vite-plugin": "^1.43.9",
-    "redaxios": "^0.5.0",
+    "@tanstack/router-plugin": "^1.43.9",
     "immer": "^10.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "redaxios": "^0.5.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/examples/react/quickstart-file-based/vite.config.js
+++ b/examples/react/quickstart-file-based/vite.config.js
@@ -1,8 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { TanStackRouterVite } from '@tanstack/router-vite-plugin'
+import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), TanStackRouterVite()],
+  plugins: [TanStackRouterVite(), react()],
 })

--- a/examples/react/start-basic-react-query/package.json
+++ b/examples/react/start-basic-react-query/package.json
@@ -19,7 +19,7 @@
     "@tanstack/react-router": "^1.43.10",
     "@tanstack/react-router-with-query": "^1.43.2",
     "@tanstack/router-devtools": "^1.43.10",
-    "@tanstack/router-vite-plugin": "^1.43.9",
+    "@tanstack/router-plugin": "^1.43.9",
     "@tanstack/start": "^1.43.11",
     "@typescript-eslint/parser": "^7.2.0",
     "@vitejs/plugin-react": "^4",

--- a/examples/react/start-basic-rsc/package.json
+++ b/examples/react/start-basic-rsc/package.json
@@ -15,7 +15,7 @@
     "@babel/plugin-syntax-typescript": "^7.24.1",
     "@tanstack/react-router": "^1.43.10",
     "@tanstack/router-devtools": "^1.43.10",
-    "@tanstack/router-vite-plugin": "^1.43.9",
+    "@tanstack/router-plugin": "^1.43.9",
     "@tanstack/start": "^1.43.11",
     "redaxios": "^0.5.0",
     "tailwind-merge": "^1.14.0",

--- a/examples/react/start-basic/package.json
+++ b/examples/react/start-basic/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@tanstack/react-router": "^1.43.10",
     "@tanstack/router-devtools": "^1.43.10",
-    "@tanstack/router-vite-plugin": "^1.43.9",
+    "@tanstack/router-plugin": "^1.43.9",
     "@tanstack/start": "^1.43.11",
     "@typescript-eslint/parser": "^7.2.0",
     "@vitejs/plugin-react": "^4",

--- a/examples/react/start-trellaux/package.json
+++ b/examples/react/start-trellaux/package.json
@@ -17,7 +17,7 @@
     "@tanstack/react-router": "^1.43.10",
     "@tanstack/react-router-with-query": "^1.43.2",
     "@tanstack/router-devtools": "^1.43.10",
-    "@tanstack/router-vite-plugin": "^1.43.9",
+    "@tanstack/router-plugin": "^1.43.9",
     "@tanstack/start": "^1.43.11",
     "@typescript-eslint/parser": "^7.2.0",
     "@vitejs/plugin-react": "^4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,9 +91,9 @@ importers:
       '@tanstack/router-devtools':
         specifier: workspace:*
         version: link:../../../packages/router-devtools
-      '@tanstack/router-vite-plugin':
+      '@tanstack/router-plugin':
         specifier: workspace:*
-        version: link:../../../packages/router-vite-plugin
+        version: link:../../../packages/router-plugin
       immer:
         specifier: ^10.0.3
         version: 10.0.3
@@ -202,9 +202,9 @@ importers:
       '@tanstack/router-devtools':
         specifier: workspace:*
         version: link:../../../packages/router-devtools
-      '@tanstack/router-vite-plugin':
+      '@tanstack/router-plugin':
         specifier: workspace:*
-        version: link:../../../packages/router-vite-plugin
+        version: link:../../../packages/router-plugin
       immer:
         specifier: ^10.0.3
         version: 10.0.3
@@ -242,9 +242,9 @@ importers:
       '@tanstack/router-devtools':
         specifier: workspace:*
         version: link:../../../packages/router-devtools
-      '@tanstack/router-vite-plugin':
+      '@tanstack/router-plugin':
         specifier: workspace:*
-        version: link:../../../packages/router-vite-plugin
+        version: link:../../../packages/router-plugin
       immer:
         specifier: ^10.0.3
         version: 10.0.3
@@ -325,9 +325,9 @@ importers:
       '@tanstack/router-devtools':
         specifier: workspace:*
         version: link:../../../packages/router-devtools
-      '@tanstack/router-vite-plugin':
+      '@tanstack/router-plugin':
         specifier: workspace:*
-        version: link:../../../packages/router-vite-plugin
+        version: link:../../../packages/router-plugin
       immer:
         specifier: ^10.0.3
         version: 10.0.3
@@ -365,9 +365,9 @@ importers:
       '@tanstack/router-devtools':
         specifier: workspace:*
         version: link:../../../packages/router-devtools
-      '@tanstack/router-vite-plugin':
+      '@tanstack/router-plugin':
         specifier: workspace:*
-        version: link:../../../packages/router-vite-plugin
+        version: link:../../../packages/router-plugin
       '@tanstack/start':
         specifier: workspace:*
         version: link:../../../packages/start
@@ -429,9 +429,9 @@ importers:
       '@tanstack/router-devtools':
         specifier: workspace:*
         version: link:../../../packages/router-devtools
-      '@tanstack/router-vite-plugin':
+      '@tanstack/router-plugin':
         specifier: workspace:*
-        version: link:../../../packages/router-vite-plugin
+        version: link:../../../packages/router-plugin
       '@tanstack/start':
         specifier: workspace:*
         version: link:../../../packages/start
@@ -570,9 +570,9 @@ importers:
       '@tanstack/router-devtools':
         specifier: workspace:*
         version: link:../../../packages/router-devtools
-      '@tanstack/router-vite-plugin':
+      '@tanstack/router-plugin':
         specifier: workspace:*
-        version: link:../../../packages/router-vite-plugin
+        version: link:../../../packages/router-plugin
       immer:
         specifier: ^10.0.3
         version: 10.0.3
@@ -659,9 +659,9 @@ importers:
       '@tanstack/router-devtools':
         specifier: workspace:*
         version: link:../../../packages/router-devtools
-      '@tanstack/router-vite-plugin':
+      '@tanstack/router-plugin':
         specifier: workspace:*
-        version: link:../../../packages/router-vite-plugin
+        version: link:../../../packages/router-plugin
       immer:
         specifier: ^10.0.3
         version: 10.0.3
@@ -702,9 +702,9 @@ importers:
       '@tanstack/router-devtools':
         specifier: workspace:*
         version: link:../../../packages/router-devtools
-      '@tanstack/router-vite-plugin':
+      '@tanstack/router-plugin':
         specifier: workspace:*
-        version: link:../../../packages/router-vite-plugin
+        version: link:../../../packages/router-plugin
       immer:
         specifier: ^10.0.3
         version: 10.0.3
@@ -841,9 +841,9 @@ importers:
       '@tanstack/router-devtools':
         specifier: workspace:*
         version: link:../../../packages/router-devtools
-      '@tanstack/router-vite-plugin':
+      '@tanstack/router-plugin':
         specifier: workspace:*
-        version: link:../../../packages/router-vite-plugin
+        version: link:../../../packages/router-plugin
       immer:
         specifier: ^10.0.3
         version: 10.0.3
@@ -992,9 +992,9 @@ importers:
       '@tanstack/router-devtools':
         specifier: workspace:*
         version: link:../../../packages/router-devtools
-      '@tanstack/router-vite-plugin':
+      '@tanstack/router-plugin':
         specifier: workspace:*
-        version: link:../../../packages/router-vite-plugin
+        version: link:../../../packages/router-plugin
       '@tanstack/start':
         specifier: workspace:*
         version: link:../../../packages/start
@@ -1092,9 +1092,9 @@ importers:
       '@tanstack/router-devtools':
         specifier: workspace:*
         version: link:../../../packages/router-devtools
-      '@tanstack/router-vite-plugin':
+      '@tanstack/router-plugin':
         specifier: workspace:*
-        version: link:../../../packages/router-vite-plugin
+        version: link:../../../packages/router-plugin
       '@tanstack/start':
         specifier: workspace:*
         version: link:../../../packages/start
@@ -1186,9 +1186,9 @@ importers:
       '@tanstack/router-devtools':
         specifier: workspace:*
         version: link:../../../packages/router-devtools
-      '@tanstack/router-vite-plugin':
+      '@tanstack/router-plugin':
         specifier: workspace:*
-        version: link:../../../packages/router-vite-plugin
+        version: link:../../../packages/router-plugin
       '@tanstack/start':
         specifier: workspace:*
         version: link:../../../packages/start
@@ -1262,9 +1262,9 @@ importers:
       '@tanstack/router-devtools':
         specifier: workspace:*
         version: link:../../../packages/router-devtools
-      '@tanstack/router-vite-plugin':
+      '@tanstack/router-plugin':
         specifier: workspace:*
-        version: link:../../../packages/router-vite-plugin
+        version: link:../../../packages/router-plugin
       '@tanstack/start':
         specifier: workspace:*
         version: link:../../../packages/start


### PR DESCRIPTION
Should have done this when I released the unplugin version of the Router plugin.