### PR TITLE
style(workspace): more patterns for prettier to ignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,9 @@
 pnpm-lock.yaml
 **/snapshots
 **/.vercel
-
+**/.vinxi
+**/.output
+**/node_modules
+node_modules
 
 **/tests/generator/file-modification/routes/(test)/*


### PR DESCRIPTION
Since we cache our builds, running our `pnpm test:format` command in `test:ci` and `test:pr` tends to sometimes fail.