### PR TITLE
feat: Add this route's match to route `meta()` params

### DIFF
--- a/packages/react-router/src/route.ts
+++ b/packages/react-router/src/route.ts
@@ -254,6 +254,7 @@ export type UpdatableRouteOptions<
   onLeave?: (match: TRouteMatch) => void
   meta?: (ctx: {
     matches: Array<TRouteMatch>
+    match: TRouteMatch
     params: TAllParams
     loaderData: TLoaderData
   }) => Array<React.JSX.IntrinsicElements['meta']>

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1104,6 +1104,7 @@ export class Router<
       if (match.status === 'success') {
         match.meta = route.options.meta?.({
           matches,
+          match,
           params: match.params,
           loaderData: match.loaderData,
         })
@@ -2009,6 +2010,7 @@ export class Router<
 
                     const meta = route.options.meta?.({
                       matches,
+                      match,
                       params: match.params,
                       loaderData,
                     })

--- a/packages/start/src/client/serialization.tsx
+++ b/packages/start/src/client/serialization.tsx
@@ -104,6 +104,7 @@ export function afterHydrate({ router }: { router: AnyRouter }) {
     Object.assign(match, {
       meta: route.options.meta?.({
         matches: router.state.matches,
+        match,
         params: match.params,
         loaderData: match.loaderData,
       }),


### PR DESCRIPTION
The route `meta()` callback currently receives _all_ matches, _this route's_ path params, and _this route's_ loader data. Although you can of course write a given route's meta callback to retrieve its own full match object from the array using a hardcoded `id`, you can't bootstrap that in a helper for arbitrary routes using the params given to the callback.

This PR adds the given route's own match to the parameter object, separate from the list of all matches. My own situation involves using a search param in the page title.