### PR TITLE
fix: export FetchFnCtx type for library usage

### DIFF
--- a/packages/start/src/client/index.tsx
+++ b/packages/start/src/client/index.tsx
@@ -6,6 +6,7 @@ export {
   type FetcherOptionsBase,
   type FetcherOptions,
   type FetchFn,
+  type FetchFnCtx,
   type CompiledFetcherFnOptions,
   type CompiledFetcherFn,
   type Fetcher,


### PR DESCRIPTION
In TanStack Form, it would be helpful to have this type exported in a way that's easier to access so that I can move our `createServerFn` into userland.