### PR TITLE
ci: Improve Nx inputs

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -7,7 +7,6 @@
   "namedInputs": {
     "sharedGlobals": [
       "{workspaceRoot}/.nvmrc",
-      "{workspaceRoot}/eslint.config.js",
       "{workspaceRoot}/package.json",
       "{workspaceRoot}/tsconfig.json"
     ],
@@ -16,44 +15,43 @@
       "{projectRoot}/**/*",
       "!{projectRoot}/**/*.md"
     ],
-    "public": [
+    "production": [
       "default",
-      "{projectRoot}/build",
-      "{projectRoot}/dist",
+      "!{projectRoot}/tests/**/*",
       "!{projectRoot}/eslint.config.js"
     ]
   },
   "targetDefaults": {
-    "test:unit": {
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^public"],
-      "outputs": ["{projectRoot}/coverage"],
-      "cache": true
-    },
-    "test:eslint": {
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^public"],
-      "cache": true
-    },
-    "test:types": {
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^public"],
-      "cache": true
-    },
-    "test:build": {
-      "dependsOn": ["build"],
-      "inputs": ["default", "^public"],
-      "cache": true
-    },
-    "build": {
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^public"],
-      "outputs": ["{projectRoot}/build", "{projectRoot}/dist"],
-      "cache": true
-    },
     "test:format": {
       "cache": true,
       "inputs": ["{workspaceRoot}/**/*"]
+    },
+    "test:eslint": {
+      "cache": true,
+      "dependsOn": ["^build"],
+      "inputs": ["default", "^production", "{workspaceRoot}/eslint.config.js"]
+    },
+    "test:unit": {
+      "cache": true,
+      "dependsOn": ["^build"],
+      "inputs": ["default", "^production"],
+      "outputs": ["{projectRoot}/coverage"]
+    },
+    "test:types": {
+      "cache": true,
+      "dependsOn": ["^build"],
+      "inputs": ["default", "^production"]
+    },
+    "build": {
+      "cache": true,
+      "dependsOn": ["^build"],
+      "inputs": ["production", "^production"],
+      "outputs": ["{projectRoot}/build", "{projectRoot}/dist"]
+    },
+    "test:build": {
+      "cache": true,
+      "dependsOn": ["build"],
+      "inputs": ["production"]
     }
   }
 }

--- a/packages/history/vite.config.ts
+++ b/packages/history/vite.config.ts
@@ -1,7 +1,16 @@
 import { defineConfig, mergeConfig } from 'vitest/config'
 import { tanstackViteConfig } from '@tanstack/config/vite'
+import packageJson from './package.json'
 
-const config = defineConfig({})
+const config = defineConfig({
+  test: {
+    name: packageJson.name,
+    dir: './tests',
+    watch: false,
+    environment: 'jsdom',
+    typecheck: { enabled: true },
+  },
+})
 
 export default mergeConfig(
   config,


### PR DESCRIPTION
- Renamed `public` to `production` to match [Nx docs](https://nx.dev/reference/inputs)
- `build` will not be invalidated when only tests change
- `test:build` now has the right cache inputs
- `test:sherif` only depends on `package.json` files