### PR TITLE
fix(react-router): when children are added to the route tree, the inference of RouterContext is lost

### DIFF
--- a/packages/react-router/src/route.ts
+++ b/packages/react-router/src/route.ts
@@ -765,7 +765,7 @@ export class Route<
     this.to = fullPath as TrimPathRight<TFullPath>
   }
 
-  addChildren = <
+  addChildren<
     const TNewChildren extends
       | Record<string, AnyRoute>
       | ReadonlyArray<AnyRoute>,
@@ -791,7 +791,7 @@ export class Route<
     TLoaderDataReturn,
     TLoaderData,
     TNewChildren
-  > => {
+  > {
     this.children = (
       Array.isArray(children) ? children : Object.values(children)
     ) as any
@@ -1061,6 +1061,7 @@ export class RootRoute<
   TLoaderDeps extends Record<string, any> = {},
   TLoaderDataReturn = {},
   in out TLoaderData = ResolveLoaderData<TLoaderDataReturn>,
+  TChildren = unknown,
 > extends Route<
   any, // TParentRoute
   '/', // TPath
@@ -1080,7 +1081,7 @@ export class RootRoute<
   TLoaderDeps,
   TLoaderDataReturn,
   TLoaderData,
-  any // TChildren
+  TChildren // TChildren
 > {
   /**
    * @deprecated `RootRoute` is now an internal implementation detail. Use `createRootRoute()` instead.
@@ -1098,6 +1099,27 @@ export class RootRoute<
     >,
   ) {
     super(options as any)
+  }
+
+  addChildren<
+    const TNewChildren extends
+      | Record<string, AnyRoute>
+      | ReadonlyArray<AnyRoute>,
+  >(
+    children: TNewChildren,
+  ): RootRoute<
+    TSearchSchemaInput,
+    TSearchSchema,
+    TSearchSchemaUsed,
+    TRouteContextReturn,
+    TRouteContext,
+    TRouterContext,
+    TLoaderDeps,
+    TLoaderDataReturn,
+    TLoaderData,
+    TNewChildren
+  > {
+    return super.addChildren(children)
   }
 }
 

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -104,6 +104,7 @@ export interface Register {
 }
 
 export type AnyRouter = Router<any, any, any, any>
+
 export type AnyRouterWithContext<TContext> = Router<
   AnyRouteWithContext<TContext>,
   any,
@@ -130,6 +131,7 @@ export type InferRouterContext<TRouteTree extends AnyRoute> =
     any,
     any,
     infer TRouterContext extends AnyContext,
+    any,
     any,
     any,
     any

--- a/packages/react-router/tests/route.test-d.tsx
+++ b/packages/react-router/tests/route.test-d.tsx
@@ -567,6 +567,7 @@ test('when creating a child route with context, search, params and beforeLoad', 
 
   const router = createRouter({
     routeTree,
+    context: { userId: 'userId' },
   })
 
   type Router = typeof router

--- a/packages/react-router/tests/router.test-d.tsx
+++ b/packages/react-router/tests/router.test-d.tsx
@@ -2,6 +2,7 @@ import { expectTypeOf, test } from 'vitest'
 import {
   createRootRoute,
   createRootRouteWithContext,
+  createRoute,
   createRouter,
 } from '../src'
 
@@ -31,6 +32,35 @@ test('when creating a router with context', () => {
   const rootRoute = createRootRouteWithContext<{ userId: string }>()()
 
   type RouteTree = typeof rootRoute
+
+  expectTypeOf(createRouter<RouteTree, 'never'>)
+    .parameter(0)
+    .toHaveProperty('routeTree')
+    .toEqualTypeOf<RouteTree | undefined>()
+
+  expectTypeOf(createRouter<RouteTree, 'never'>)
+    .parameter(0)
+    .toHaveProperty('context')
+    .toEqualTypeOf<{ userId: string }>()
+
+  expectTypeOf(createRouter<RouteTree, 'never'>)
+    .parameter(0)
+    .toMatchTypeOf<{
+      context: { userId: string }
+    }>()
+})
+
+test('when creating a router with context and children', () => {
+  const rootRoute = createRootRouteWithContext<{ userId: string }>()()
+
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+  })
+
+  const routeTree = rootRoute.addChildren([indexRoute])
+
+  type RouteTree = typeof routeTree
 
   expectTypeOf(createRouter<RouteTree, 'never'>)
     .parameter(0)


### PR DESCRIPTION
When `addChildren` was called, we lost the type of `RootRoute` and there could no longer infer `RouterContext`.

Fixes #1943 
Fixes #1926
