### PR TITLE
fix(react-router): scroll-restoration not being persisted on initial load

### DIFF
--- a/packages/react-router/src/scroll-restoration.tsx
+++ b/packages/react-router/src/scroll-restoration.tsx
@@ -47,7 +47,15 @@ export type ScrollRestorationOptions = {
   getKey?: (location: ParsedLocation) => string
 }
 
-const defaultGetKey = (location: ParsedLocation) => location.state.key!
+/**
+ * The default `getKey` function for `useScrollRestoration`.
+ * It returns the `key` from the location state or the `href` of the location.
+ *
+ * The `location.href` is used as a fallback to support the use case where the location state is not available like the initial render.
+ */
+const defaultGetKey = (location: ParsedLocation) => {
+  return location.state.key! || location.href
+}
 
 export function useScrollRestoration(options?: ScrollRestorationOptions) {
   const router = useRouter()


### PR DESCRIPTION
From #1944.

The default `getKey` returns `undefined` on the initial load since `location.state.key` wouldn't have been set.

Fixes #1944 