### PR TITLE
fix(router-devtools): remove date-fns

### DIFF
--- a/packages/router-devtools/package.json
+++ b/packages/router-devtools/package.json
@@ -63,7 +63,6 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
-    "date-fns": "^2.30.0",
     "goober": "^2.1.14"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1780,9 +1780,6 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      date-fns:
-        specifier: ^2.30.0
-        version: 2.30.0
       goober:
         specifier: ^2.1.14
         version: 2.1.14(csstype@3.1.3)


### PR DESCRIPTION
`date-fns` is specified in dependencies, but not used