### PR TITLE
examples: Use ensureQuery in start-basic-react-query

### DIFF
--- a/examples/react/start-basic-react-query/app/routes/deferred.tsx
+++ b/examples/react/start-basic-react-query/app/routes/deferred.tsx
@@ -1,4 +1,4 @@
-import { queryOptions, useQuery, useSuspenseQuery } from '@tanstack/react-query'
+import { queryOptions, useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import { Suspense, useState } from 'react'
 

--- a/examples/react/start-basic-react-query/app/routes/posts.$postId.tsx
+++ b/examples/react/start-basic-react-query/app/routes/posts.$postId.tsx
@@ -6,7 +6,9 @@ import { NotFound } from '~/components/NotFound'
 
 export const Route = createFileRoute('/posts/$postId')({
   loader: async ({ params: { postId }, context }) => {
-    const data = await context.queryClient.fetchQuery(postQueryOptions(postId))
+    const data = await context.queryClient.ensureQueryData(
+      postQueryOptions(postId),
+    )
 
     return {
       title: data.title,

--- a/examples/react/start-basic-react-query/app/routes/posts.tsx
+++ b/examples/react/start-basic-react-query/app/routes/posts.tsx
@@ -4,7 +4,7 @@ import { postsQueryOptions } from '../utils/posts'
 
 export const Route = createFileRoute('/posts')({
   loader: async ({ context }) => {
-    await context.queryClient.prefetchQuery(postsQueryOptions())
+    await context.queryClient.ensureQueryData(postsQueryOptions())
   },
   meta: () => [{ title: 'Posts' }],
   component: PostsComponent,

--- a/examples/react/start-basic-react-query/app/routes/posts_.$postId.deep.tsx
+++ b/examples/react/start-basic-react-query/app/routes/posts_.$postId.deep.tsx
@@ -5,7 +5,9 @@ import { PostErrorComponent } from './posts.$postId'
 
 export const Route = createFileRoute('/posts/$postId/deep')({
   loader: async ({ params: { postId }, context }) => {
-    const data = await context.queryClient.fetchQuery(postQueryOptions(postId))
+    const data = await context.queryClient.ensureQueryData(
+      postQueryOptions(postId),
+    )
 
     return {
       title: data.title,


### PR DESCRIPTION
Use ensureQuery for loaders so that if the data is not stale it won't need to be refetched.

As suggested in https://github.com/TanStack/router/pull/1883/files#r1667101376