### PR TITLE
test(react-router): reducing the `React.act` warnings during unit tests

### DIFF
--- a/packages/react-router/tests/createLazyRoute.test.tsx
+++ b/packages/react-router/tests/createLazyRoute.test.tsx
@@ -1,7 +1,13 @@
 import React, { act } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import '@testing-library/jest-dom/vitest'
-import { cleanup, configure, render, screen } from '@testing-library/react'
+import {
+  cleanup,
+  configure,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
 import {
   Link,
   RouterProvider,
@@ -79,9 +85,9 @@ describe('preload: matched routes', { timeout: 20000 }, () => {
   it('should render the heavy/lazy component', async () => {
     const { router } = createTestRouter(createBrowserHistory())
 
-    await act(() => render(<RouterProvider router={router} />))
+    render(<RouterProvider router={router} />)
 
-    const linkToHeavy = await screen.findByText('Link to heavy')
+    const linkToHeavy = await waitFor(() => screen.findByText('Link to heavy'))
     expect(linkToHeavy).toBeInTheDocument()
 
     expect(router.state.location.pathname).toBe('/')
@@ -90,7 +96,9 @@ describe('preload: matched routes', { timeout: 20000 }, () => {
     // click the link to navigate to the heavy route
     act(() => linkToHeavy.click())
 
-    const heavyElement = await screen.findByText('I am sooo heavy')
+    const heavyElement = await waitFor(() =>
+      screen.findByText('I am sooo heavy'),
+    )
     expect(heavyElement).toBeInTheDocument()
 
     expect(router.state.location.pathname).toBe('/heavy')

--- a/packages/react-router/tests/loaders.test.tsx
+++ b/packages/react-router/tests/loaders.test.tsx
@@ -104,7 +104,7 @@ describe('loaders are being called', () => {
     render(<RouterProvider router={router} />)
 
     const linkToAbout = await waitFor(() => screen.findByText('link to foo'))
-    await act(() => fireEvent.click(linkToAbout))
+    act(() => fireEvent.click(linkToAbout))
 
     const fooElement = await waitFor(() => screen.findByText('Nested Foo page'))
     expect(fooElement).toBeInTheDocument()
@@ -161,7 +161,7 @@ describe('loaders parentMatchPromise', () => {
     )
     expect(linkToFoo).toBeInTheDocument()
 
-    await act(() => fireEvent.click(linkToFoo))
+    act(() => fireEvent.click(linkToFoo))
 
     const fooElement = await waitFor(() => screen.findByText('Nested Foo page'))
     expect(fooElement).toBeInTheDocument()

--- a/packages/react-router/tests/loaders.test.tsx
+++ b/packages/react-router/tests/loaders.test.tsx
@@ -6,6 +6,7 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
 } from '@testing-library/react'
 
 import { afterEach, describe, expect, test, vi } from 'vitest'
@@ -49,9 +50,9 @@ describe('loaders are being called', () => {
     const routeTree = rootRoute.addChildren([indexRoute])
     const router = await act(() => createRouter({ routeTree }))
 
-    await act(() => render(<RouterProvider router={router} />))
+    render(<RouterProvider router={router} />)
 
-    const indexElement = await screen.findByText('Index page')
+    const indexElement = await waitFor(() => screen.findByText('Index page'))
     expect(indexElement).toBeInTheDocument()
 
     expect(router.state.location.href).toBe('/')
@@ -98,14 +99,14 @@ describe('loaders are being called', () => {
       nestedRoute.addChildren([fooRoute]),
       indexRoute,
     ])
-    const router = await act(() => createRouter({ routeTree }))
+    const router = createRouter({ routeTree })
 
-    await act(() => render(<RouterProvider router={router} />))
+    render(<RouterProvider router={router} />)
 
-    const linkToAbout = await screen.findByText('link to foo')
+    const linkToAbout = await waitFor(() => screen.findByText('link to foo'))
     await act(() => fireEvent.click(linkToAbout))
 
-    const fooElement = await screen.findByText('Nested Foo page')
+    const fooElement = await waitFor(() => screen.findByText('Nested Foo page'))
     expect(fooElement).toBeInTheDocument()
 
     expect(router.state.location.href).toBe('/nested/foo')
@@ -151,16 +152,18 @@ describe('loaders parentMatchPromise', () => {
       nestedRoute.addChildren([fooRoute]),
       indexRoute,
     ])
-    const router = await act(() => createRouter({ routeTree }))
+    const router = createRouter({ routeTree })
 
-    await act(() => render(<RouterProvider router={router} />))
+    render(<RouterProvider router={router} />)
 
-    const linkToFoo = await screen.findByRole('link', { name: 'link to foo' })
+    const linkToFoo = await waitFor(() =>
+      screen.findByRole('link', { name: 'link to foo' }),
+    )
     expect(linkToFoo).toBeInTheDocument()
 
     await act(() => fireEvent.click(linkToFoo))
 
-    const fooElement = await screen.findByText('Nested Foo page')
+    const fooElement = await waitFor(() => screen.findByText('Nested Foo page'))
     expect(fooElement).toBeInTheDocument()
 
     expect(nestedLoaderMock).toHaveBeenCalled()

--- a/packages/react-router/tests/redirect.test.tsx
+++ b/packages/react-router/tests/redirect.test.tsx
@@ -6,6 +6,7 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
 } from '@testing-library/react'
 
 import { afterEach, describe, expect, test, vi } from 'vitest'
@@ -81,14 +82,20 @@ describe('redirect', () => {
         aboutRoute,
         indexRoute,
       ])
-      const router = await act(() => createRouter({ routeTree }))
+      const router = createRouter({ routeTree })
 
-      await act(() => render(<RouterProvider router={router} />))
+      render(<RouterProvider router={router} />)
 
-      const linkToAbout = await screen.findByText('link to about')
+      const linkToAbout = await waitFor(() =>
+        screen.findByText('link to about'),
+      )
+      expect(linkToAbout).toBeInTheDocument()
+
       await act(() => fireEvent.click(linkToAbout))
 
-      const fooElement = await screen.findByText('Nested Foo page')
+      const fooElement = await waitFor(() =>
+        screen.findByText('Nested Foo page'),
+      )
       expect(fooElement).toBeInTheDocument()
 
       expect(router.state.location.href).toBe('/nested/foo')
@@ -145,14 +152,20 @@ describe('redirect', () => {
         aboutRoute,
         indexRoute,
       ])
-      const router = await act(() => createRouter({ routeTree }))
+      const router = createRouter({ routeTree })
 
-      await act(() => render(<RouterProvider router={router} />))
+      render(<RouterProvider router={router} />)
 
-      const linkToAbout = await screen.findByText('link to about')
+      const linkToAbout = await waitFor(() =>
+        screen.findByText('link to about'),
+      )
+      expect(linkToAbout).toBeInTheDocument()
+
       await act(() => fireEvent.click(linkToAbout))
 
-      const fooElement = await screen.findByText('Nested Foo page')
+      const fooElement = await waitFor(() =>
+        screen.findByText('Nested Foo page'),
+      )
       expect(fooElement).toBeInTheDocument()
 
       expect(router.state.location.href).toBe('/nested/foo')

--- a/packages/react-router/tests/router.test.tsx
+++ b/packages/react-router/tests/router.test.tsx
@@ -1,4 +1,4 @@
-import React, { act } from 'react'
+import { act } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, render, waitFor } from '@testing-library/react'
 import {
@@ -73,307 +73,307 @@ function createTestRouter(initialHistory?: RouterHistory) {
   }
 }
 
-describe('encoding: URL param segment for /posts/$slug', () => {
-  it('state.location.pathname, should have the params.slug value of "tanner"', async () => {
-    const { router } = createTestRouter(
-      createMemoryHistory({ initialEntries: ['/posts/tanner'] }),
-    )
+// describe('encoding: URL param segment for /posts/$slug', () => {
+//   it('state.location.pathname, should have the params.slug value of "tanner"', async () => {
+//     const { router } = createTestRouter(
+//       createMemoryHistory({ initialEntries: ['/posts/tanner'] }),
+//     )
 
-    await act(() => router.load())
+//     await act(() => router.load())
 
-    expect(router.state.location.pathname).toBe('/posts/tanner')
-  })
+//     expect(router.state.location.pathname).toBe('/posts/tanner')
+//   })
 
-  it('state.location.pathname, should have the params.slug value of "🚀"', async () => {
-    const { router } = createTestRouter(
-      createMemoryHistory({ initialEntries: ['/posts/🚀'] }),
-    )
+//   it('state.location.pathname, should have the params.slug value of "🚀"', async () => {
+//     const { router } = createTestRouter(
+//       createMemoryHistory({ initialEntries: ['/posts/🚀'] }),
+//     )
 
-    await act(() => router.load())
+//     await act(() => router.load())
 
-    expect(router.state.location.pathname).toBe('/posts/🚀')
-  })
+//     expect(router.state.location.pathname).toBe('/posts/🚀')
+//   })
 
-  it('state.location.pathname, should have the params.slug value of "%F0%9F%9A%80"', async () => {
-    const { router } = createTestRouter(
-      createMemoryHistory({ initialEntries: ['/posts/%F0%9F%9A%80'] }),
-    )
-
-    await act(() => router.load())
+//   it('state.location.pathname, should have the params.slug value of "%F0%9F%9A%80"', async () => {
+//     const { router } = createTestRouter(
+//       createMemoryHistory({ initialEntries: ['/posts/%F0%9F%9A%80'] }),
+//     )
+
+//     await act(() => router.load())
 
-    expect(router.state.location.pathname).toBe('/posts/%F0%9F%9A%80')
-  })
-
-  it('state.location.pathname, should have the params.slug value of "framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack"', async () => {
-    const { router } = createTestRouter(
-      createMemoryHistory({
-        initialEntries: [
-          '/posts/framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack',
-        ],
-      }),
-    )
+//     expect(router.state.location.pathname).toBe('/posts/%F0%9F%9A%80')
+//   })
+
+//   it('state.location.pathname, should have the params.slug value of "framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack"', async () => {
+//     const { router } = createTestRouter(
+//       createMemoryHistory({
+//         initialEntries: [
+//           '/posts/framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack',
+//         ],
+//       }),
+//     )
 
-    await act(() => router.load())
-
-    expect(router.state.location.pathname).toBe(
-      '/posts/framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack',
-    )
-  })
+//     await act(() => router.load())
+
+//     expect(router.state.location.pathname).toBe(
+//       '/posts/framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack',
+//     )
+//   })
 
-  it('params.slug for the matched route, should be "tanner"', async () => {
-    const { router, routes } = createTestRouter(
-      createMemoryHistory({ initialEntries: ['/posts/tanner'] }),
-    )
+//   it('params.slug for the matched route, should be "tanner"', async () => {
+//     const { router, routes } = createTestRouter(
+//       createMemoryHistory({ initialEntries: ['/posts/tanner'] }),
+//     )
 
-    await act(() => router.load())
+//     await act(() => router.load())
 
-    const match = router.state.matches.find(
-      (r) => r.routeId === routes.postIdRoute.id,
-    )
+//     const match = router.state.matches.find(
+//       (r) => r.routeId === routes.postIdRoute.id,
+//     )
 
-    if (!match) {
-      throw new Error('No match found')
-    }
+//     if (!match) {
+//       throw new Error('No match found')
+//     }
 
-    expect((match.params as unknown as any).slug).toBe('tanner')
-  })
+//     expect((match.params as unknown as any).slug).toBe('tanner')
+//   })
 
-  it('params.slug for the matched route, should be "🚀"', async () => {
-    const { router, routes } = createTestRouter(
-      createMemoryHistory({ initialEntries: ['/posts/🚀'] }),
-    )
+//   it('params.slug for the matched route, should be "🚀"', async () => {
+//     const { router, routes } = createTestRouter(
+//       createMemoryHistory({ initialEntries: ['/posts/🚀'] }),
+//     )
 
-    await act(() => router.load())
+//     await act(() => router.load())
 
-    const match = router.state.matches.find(
-      (r) => r.routeId === routes.postIdRoute.id,
-    )
+//     const match = router.state.matches.find(
+//       (r) => r.routeId === routes.postIdRoute.id,
+//     )
 
-    if (!match) {
-      throw new Error('No match found')
-    }
-
-    expect((match.params as unknown as any).slug).toBe('🚀')
-  })
+//     if (!match) {
+//       throw new Error('No match found')
+//     }
+
+//     expect((match.params as unknown as any).slug).toBe('🚀')
+//   })
 
-  it('params.slug for the matched route, should be "🚀" instead of it being "%F0%9F%9A%80"', async () => {
-    const { router, routes } = createTestRouter(
-      createMemoryHistory({ initialEntries: ['/posts/%F0%9F%9A%80'] }),
-    )
+//   it('params.slug for the matched route, should be "🚀" instead of it being "%F0%9F%9A%80"', async () => {
+//     const { router, routes } = createTestRouter(
+//       createMemoryHistory({ initialEntries: ['/posts/%F0%9F%9A%80'] }),
+//     )
 
-    await act(() => router.load())
-
-    const match = router.state.matches.find(
-      (r) => r.routeId === routes.postIdRoute.id,
-    )
-
-    if (!match) {
-      throw new Error('No match found')
-    }
-
-    expect((match.params as unknown as any).slug).toBe('🚀')
-  })
+//     await act(() => router.load())
+
+//     const match = router.state.matches.find(
+//       (r) => r.routeId === routes.postIdRoute.id,
+//     )
+
+//     if (!match) {
+//       throw new Error('No match found')
+//     }
+
+//     expect((match.params as unknown as any).slug).toBe('🚀')
+//   })
 
-  it('params.slug for the matched route, should be "framework/react/guide/file-based-routing tanstack" instead of it being "framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack"', async () => {
-    const { router, routes } = createTestRouter(
-      createMemoryHistory({
-        initialEntries: [
-          '/posts/framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack',
-        ],
-      }),
-    )
-
-    await act(() => router.load())
-
-    const match = router.state.matches.find(
-      (r) => r.routeId === routes.postIdRoute.id,
-    )
-
-    if (!match) {
-      throw new Error('No match found')
-    }
-
-    expect((match.params as unknown as any).slug).toBe(
-      'framework/react/guide/file-based-routing tanstack',
-    )
-  })
-})
-
-describe('encoding: URL splat segment for /$', () => {
-  it('state.location.pathname, should have the params._splat value of "tanner"', async () => {
-    const { router } = createTestRouter(
-      createMemoryHistory({ initialEntries: ['/tanner'] }),
-    )
+//   it('params.slug for the matched route, should be "framework/react/guide/file-based-routing tanstack" instead of it being "framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack"', async () => {
+//     const { router, routes } = createTestRouter(
+//       createMemoryHistory({
+//         initialEntries: [
+//           '/posts/framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack',
+//         ],
+//       }),
+//     )
+
+//     await act(() => router.load())
+
+//     const match = router.state.matches.find(
+//       (r) => r.routeId === routes.postIdRoute.id,
+//     )
+
+//     if (!match) {
+//       throw new Error('No match found')
+//     }
+
+//     expect((match.params as unknown as any).slug).toBe(
+//       'framework/react/guide/file-based-routing tanstack',
+//     )
+//   })
+// })
+
+// describe('encoding: URL splat segment for /$', () => {
+//   it('state.location.pathname, should have the params._splat value of "tanner"', async () => {
+//     const { router } = createTestRouter(
+//       createMemoryHistory({ initialEntries: ['/tanner'] }),
+//     )
 
-    await act(() => router.load())
-
-    expect(router.state.location.pathname).toBe('/tanner')
-  })
+//     await act(() => router.load())
+
+//     expect(router.state.location.pathname).toBe('/tanner')
+//   })
 
-  it('state.location.pathname, should have the params._splat value of "🚀"', async () => {
-    const { router } = createTestRouter(
-      createMemoryHistory({ initialEntries: ['/🚀'] }),
-    )
+//   it('state.location.pathname, should have the params._splat value of "🚀"', async () => {
+//     const { router } = createTestRouter(
+//       createMemoryHistory({ initialEntries: ['/🚀'] }),
+//     )
 
-    await act(() => router.load())
+//     await act(() => router.load())
 
-    expect(router.state.location.pathname).toBe('/🚀')
-  })
-
-  it('state.location.pathname, should have the params._splat value of "%F0%9F%9A%80"', async () => {
-    const { router } = createTestRouter(
-      createMemoryHistory({ initialEntries: ['/%F0%9F%9A%80'] }),
-    )
+//     expect(router.state.location.pathname).toBe('/🚀')
+//   })
+
+//   it('state.location.pathname, should have the params._splat value of "%F0%9F%9A%80"', async () => {
+//     const { router } = createTestRouter(
+//       createMemoryHistory({ initialEntries: ['/%F0%9F%9A%80'] }),
+//     )
 
-    await act(() => router.load())
-
-    expect(router.state.location.pathname).toBe('/%F0%9F%9A%80')
-  })
+//     await act(() => router.load())
+
+//     expect(router.state.location.pathname).toBe('/%F0%9F%9A%80')
+//   })
 
-  it('state.location.pathname, should have the params._splat value of "framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack"', async () => {
-    const { router } = createTestRouter(
-      createMemoryHistory({
-        initialEntries: [
-          '/framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack',
-        ],
-      }),
-    )
-
-    await act(() => router.load())
-
-    expect(router.state.location.pathname).toBe(
-      '/framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack',
-    )
-  })
-
-  it('state.location.pathname, should have the params._splat value of "framework/react/guide/file-based-routing tanstack"', async () => {
-    const { router } = createTestRouter(
-      createMemoryHistory({
-        initialEntries: ['/framework/react/guide/file-based-routing tanstack'],
-      }),
-    )
-
-    await act(() => router.load())
-
-    expect(router.state.location.pathname).toBe(
-      '/framework/react/guide/file-based-routing tanstack',
-    )
-  })
-
-  it('params._splat for the matched route, should be "tanner"', async () => {
-    const { router, routes } = createTestRouter(
-      createMemoryHistory({ initialEntries: ['/tanner'] }),
-    )
-
-    await act(() => router.load())
-
-    const match = router.state.matches.find(
-      (r) => r.routeId === routes.topLevelSplatRoute.id,
-    )
-
-    if (!match) {
-      throw new Error('No match found')
-    }
-
-    expect((match.params as unknown as any)._splat).toBe('tanner')
-  })
-
-  it('params._splat for the matched route, should be "🚀"', async () => {
-    const { router, routes } = createTestRouter(
-      createMemoryHistory({ initialEntries: ['/🚀'] }),
-    )
-
-    await act(() => router.load())
-
-    const match = router.state.matches.find(
-      (r) => r.routeId === routes.topLevelSplatRoute.id,
-    )
-
-    if (!match) {
-      throw new Error('No match found')
-    }
-
-    expect((match.params as unknown as any)._splat).toBe('🚀')
-  })
-
-  it('params._splat for the matched route, should be "🚀" instead of it being "%F0%9F%9A%80"', async () => {
-    const { router, routes } = createTestRouter(
-      createMemoryHistory({ initialEntries: ['/%F0%9F%9A%80'] }),
-    )
-
-    await act(() => router.load())
-
-    const match = router.state.matches.find(
-      (r) => r.routeId === routes.topLevelSplatRoute.id,
-    )
-
-    if (!match) {
-      throw new Error('No match found')
-    }
-
-    expect((match.params as unknown as any)._splat).toBe('🚀')
-  })
-
-  it('params._splat for the matched route, should be "framework/react/guide/file-based-routing tanstack"', async () => {
-    const { router, routes } = createTestRouter(
-      createMemoryHistory({
-        initialEntries: ['/framework/react/guide/file-based-routing tanstack'],
-      }),
-    )
-
-    await act(() => router.load())
-
-    const match = router.state.matches.find(
-      (r) => r.routeId === routes.topLevelSplatRoute.id,
-    )
-
-    if (!match) {
-      throw new Error('No match found')
-    }
-
-    expect((match.params as unknown as any)._splat).toBe(
-      'framework/react/guide/file-based-routing tanstack',
-    )
-  })
-})
-
-describe('encoding: URL path segment', () => {
-  // TODO: Find out why this wasn't working with createMemoryHistory
-  it.each([
-    {
-      input: '/path-segment/%C3%A9',
-      output: '/path-segment/é',
-      type: 'encoded',
-    },
-    {
-      input: '/path-segment/é',
-      output: '/path-segment/é',
-      type: 'not encoded',
-    },
-    {
-      input: '/path-segment/%F0%9F%9A%80',
-      output: '/path-segment/🚀',
-      type: 'encoded',
-    },
-    {
-      input: '/path-segment/🚀',
-      output: '/path-segment/🚀',
-      type: 'not encoded',
-    },
-  ])(
-    'should resolve $input to $output when the path segment is $type',
-    async ({ input, output }) => {
-      const { router } = createTestRouter()
-
-      window.history.pushState({}, '', input)
-
-      await act(() => render(<RouterProvider router={router} />))
-      await act(() => router.load())
-
-      expect(router.state.location.pathname).toBe(output)
-    },
-  )
-})
+//   it('state.location.pathname, should have the params._splat value of "framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack"', async () => {
+//     const { router } = createTestRouter(
+//       createMemoryHistory({
+//         initialEntries: [
+//           '/framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack',
+//         ],
+//       }),
+//     )
+
+//     await act(() => router.load())
+
+//     expect(router.state.location.pathname).toBe(
+//       '/framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack',
+//     )
+//   })
+
+//   it('state.location.pathname, should have the params._splat value of "framework/react/guide/file-based-routing tanstack"', async () => {
+//     const { router } = createTestRouter(
+//       createMemoryHistory({
+//         initialEntries: ['/framework/react/guide/file-based-routing tanstack'],
+//       }),
+//     )
+
+//     await act(() => router.load())
+
+//     expect(router.state.location.pathname).toBe(
+//       '/framework/react/guide/file-based-routing tanstack',
+//     )
+//   })
+
+//   it('params._splat for the matched route, should be "tanner"', async () => {
+//     const { router, routes } = createTestRouter(
+//       createMemoryHistory({ initialEntries: ['/tanner'] }),
+//     )
+
+//     await act(() => router.load())
+
+//     const match = router.state.matches.find(
+//       (r) => r.routeId === routes.topLevelSplatRoute.id,
+//     )
+
+//     if (!match) {
+//       throw new Error('No match found')
+//     }
+
+//     expect((match.params as unknown as any)._splat).toBe('tanner')
+//   })
+
+//   it('params._splat for the matched route, should be "🚀"', async () => {
+//     const { router, routes } = createTestRouter(
+//       createMemoryHistory({ initialEntries: ['/🚀'] }),
+//     )
+
+//     await act(() => router.load())
+
+//     const match = router.state.matches.find(
+//       (r) => r.routeId === routes.topLevelSplatRoute.id,
+//     )
+
+//     if (!match) {
+//       throw new Error('No match found')
+//     }
+
+//     expect((match.params as unknown as any)._splat).toBe('🚀')
+//   })
+
+//   it('params._splat for the matched route, should be "🚀" instead of it being "%F0%9F%9A%80"', async () => {
+//     const { router, routes } = createTestRouter(
+//       createMemoryHistory({ initialEntries: ['/%F0%9F%9A%80'] }),
+//     )
+
+//     await act(() => router.load())
+
+//     const match = router.state.matches.find(
+//       (r) => r.routeId === routes.topLevelSplatRoute.id,
+//     )
+
+//     if (!match) {
+//       throw new Error('No match found')
+//     }
+
+//     expect((match.params as unknown as any)._splat).toBe('🚀')
+//   })
+
+//   it('params._splat for the matched route, should be "framework/react/guide/file-based-routing tanstack"', async () => {
+//     const { router, routes } = createTestRouter(
+//       createMemoryHistory({
+//         initialEntries: ['/framework/react/guide/file-based-routing tanstack'],
+//       }),
+//     )
+
+//     await act(() => router.load())
+
+//     const match = router.state.matches.find(
+//       (r) => r.routeId === routes.topLevelSplatRoute.id,
+//     )
+
+//     if (!match) {
+//       throw new Error('No match found')
+//     }
+
+//     expect((match.params as unknown as any)._splat).toBe(
+//       'framework/react/guide/file-based-routing tanstack',
+//     )
+//   })
+// })
+
+// describe('encoding: URL path segment', () => {
+//   // TODO: Find out why this wasn't working with createMemoryHistory
+//   it.each([
+//     {
+//       input: '/path-segment/%C3%A9',
+//       output: '/path-segment/é',
+//       type: 'encoded',
+//     },
+//     {
+//       input: '/path-segment/é',
+//       output: '/path-segment/é',
+//       type: 'not encoded',
+//     },
+//     {
+//       input: '/path-segment/%F0%9F%9A%80',
+//       output: '/path-segment/🚀',
+//       type: 'encoded',
+//     },
+//     {
+//       input: '/path-segment/🚀',
+//       output: '/path-segment/🚀',
+//       type: 'not encoded',
+//     },
+//   ])(
+//     'should resolve $input to $output when the path segment is $type',
+//     async ({ input, output }) => {
+//       const { router } = createTestRouter()
+
+//       window.history.pushState({}, '', input)
+
+//       render(<RouterProvider router={router} />)
+//       await router.load()
+
+//       expect(router.state.location.pathname).toBe(output)
+//     },
+//   )
+// })
 
 describe('router emits events during rendering', () => {
   it('during initial load, should emit the "onResolved" event', async () => {
@@ -382,8 +382,8 @@ describe('router emits events during rendering', () => {
     )
 
     const unsub = router.subscribe('onResolved', mockFn1)
-    await act(() => router.load())
-    await act(() => render(<RouterProvider router={router} />))
+    await router.load()
+    render(<RouterProvider router={router} />)
 
     await waitFor(() => expect(mockFn1).toBeCalled())
     unsub()
@@ -395,8 +395,8 @@ describe('router emits events during rendering', () => {
     )
 
     const unsub = router.subscribe('onResolved', mockFn1)
-    await act(() => router.load())
-    await act(() => render(<RouterProvider router={router} />))
+    await router.load()
+    render(<RouterProvider router={router} />)
 
     await act(() => router.navigate({ to: '/$', params: { _splat: 'tanner' } }))
 

--- a/packages/react-router/tests/router.test.tsx
+++ b/packages/react-router/tests/router.test.tsx
@@ -73,307 +73,306 @@ function createTestRouter(initialHistory?: RouterHistory) {
   }
 }
 
-// describe('encoding: URL param segment for /posts/$slug', () => {
-//   it('state.location.pathname, should have the params.slug value of "tanner"', async () => {
-//     const { router } = createTestRouter(
-//       createMemoryHistory({ initialEntries: ['/posts/tanner'] }),
-//     )
+describe('encoding: URL param segment for /posts/$slug', () => {
+  it('state.location.pathname, should have the params.slug value of "tanner"', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/posts/tanner'] }),
+    )
 
-//     await act(() => router.load())
+    await act(() => router.load())
 
-//     expect(router.state.location.pathname).toBe('/posts/tanner')
-//   })
+    expect(router.state.location.pathname).toBe('/posts/tanner')
+  })
 
-//   it('state.location.pathname, should have the params.slug value of "🚀"', async () => {
-//     const { router } = createTestRouter(
-//       createMemoryHistory({ initialEntries: ['/posts/🚀'] }),
-//     )
+  it('state.location.pathname, should have the params.slug value of "🚀"', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/posts/🚀'] }),
+    )
 
-//     await act(() => router.load())
+    await act(() => router.load())
 
-//     expect(router.state.location.pathname).toBe('/posts/🚀')
-//   })
+    expect(router.state.location.pathname).toBe('/posts/🚀')
+  })
 
-//   it('state.location.pathname, should have the params.slug value of "%F0%9F%9A%80"', async () => {
-//     const { router } = createTestRouter(
-//       createMemoryHistory({ initialEntries: ['/posts/%F0%9F%9A%80'] }),
-//     )
-
-//     await act(() => router.load())
+  it('state.location.pathname, should have the params.slug value of "%F0%9F%9A%80"', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/posts/%F0%9F%9A%80'] }),
+    )
+
+    await act(() => router.load())
 
-//     expect(router.state.location.pathname).toBe('/posts/%F0%9F%9A%80')
-//   })
-
-//   it('state.location.pathname, should have the params.slug value of "framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack"', async () => {
-//     const { router } = createTestRouter(
-//       createMemoryHistory({
-//         initialEntries: [
-//           '/posts/framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack',
-//         ],
-//       }),
-//     )
+    expect(router.state.location.pathname).toBe('/posts/%F0%9F%9A%80')
+  })
+
+  it('state.location.pathname, should have the params.slug value of "framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack"', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({
+        initialEntries: [
+          '/posts/framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack',
+        ],
+      }),
+    )
 
-//     await act(() => router.load())
-
-//     expect(router.state.location.pathname).toBe(
-//       '/posts/framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack',
-//     )
-//   })
+    await act(() => router.load())
+
+    expect(router.state.location.pathname).toBe(
+      '/posts/framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack',
+    )
+  })
 
-//   it('params.slug for the matched route, should be "tanner"', async () => {
-//     const { router, routes } = createTestRouter(
-//       createMemoryHistory({ initialEntries: ['/posts/tanner'] }),
-//     )
+  it('params.slug for the matched route, should be "tanner"', async () => {
+    const { router, routes } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/posts/tanner'] }),
+    )
 
-//     await act(() => router.load())
+    await act(() => router.load())
 
-//     const match = router.state.matches.find(
-//       (r) => r.routeId === routes.postIdRoute.id,
-//     )
+    const match = router.state.matches.find(
+      (r) => r.routeId === routes.postIdRoute.id,
+    )
 
-//     if (!match) {
-//       throw new Error('No match found')
-//     }
+    if (!match) {
+      throw new Error('No match found')
+    }
 
-//     expect((match.params as unknown as any).slug).toBe('tanner')
-//   })
+    expect((match.params as unknown as any).slug).toBe('tanner')
+  })
 
-//   it('params.slug for the matched route, should be "🚀"', async () => {
-//     const { router, routes } = createTestRouter(
-//       createMemoryHistory({ initialEntries: ['/posts/🚀'] }),
-//     )
+  it('params.slug for the matched route, should be "🚀"', async () => {
+    const { router, routes } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/posts/🚀'] }),
+    )
 
-//     await act(() => router.load())
+    await act(() => router.load())
 
-//     const match = router.state.matches.find(
-//       (r) => r.routeId === routes.postIdRoute.id,
-//     )
+    const match = router.state.matches.find(
+      (r) => r.routeId === routes.postIdRoute.id,
+    )
 
-//     if (!match) {
-//       throw new Error('No match found')
-//     }
-
-//     expect((match.params as unknown as any).slug).toBe('🚀')
-//   })
+    if (!match) {
+      throw new Error('No match found')
+    }
+
+    expect((match.params as unknown as any).slug).toBe('🚀')
+  })
 
-//   it('params.slug for the matched route, should be "🚀" instead of it being "%F0%9F%9A%80"', async () => {
-//     const { router, routes } = createTestRouter(
-//       createMemoryHistory({ initialEntries: ['/posts/%F0%9F%9A%80'] }),
-//     )
+  it('params.slug for the matched route, should be "🚀" instead of it being "%F0%9F%9A%80"', async () => {
+    const { router, routes } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/posts/%F0%9F%9A%80'] }),
+    )
 
-//     await act(() => router.load())
-
-//     const match = router.state.matches.find(
-//       (r) => r.routeId === routes.postIdRoute.id,
-//     )
-
-//     if (!match) {
-//       throw new Error('No match found')
-//     }
-
-//     expect((match.params as unknown as any).slug).toBe('🚀')
-//   })
+    await act(() => router.load())
+
+    const match = router.state.matches.find(
+      (r) => r.routeId === routes.postIdRoute.id,
+    )
+
+    if (!match) {
+      throw new Error('No match found')
+    }
+
+    expect((match.params as unknown as any).slug).toBe('🚀')
+  })
 
-//   it('params.slug for the matched route, should be "framework/react/guide/file-based-routing tanstack" instead of it being "framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack"', async () => {
-//     const { router, routes } = createTestRouter(
-//       createMemoryHistory({
-//         initialEntries: [
-//           '/posts/framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack',
-//         ],
-//       }),
-//     )
-
-//     await act(() => router.load())
-
-//     const match = router.state.matches.find(
-//       (r) => r.routeId === routes.postIdRoute.id,
-//     )
-
-//     if (!match) {
-//       throw new Error('No match found')
-//     }
-
-//     expect((match.params as unknown as any).slug).toBe(
-//       'framework/react/guide/file-based-routing tanstack',
-//     )
-//   })
-// })
-
-// describe('encoding: URL splat segment for /$', () => {
-//   it('state.location.pathname, should have the params._splat value of "tanner"', async () => {
-//     const { router } = createTestRouter(
-//       createMemoryHistory({ initialEntries: ['/tanner'] }),
-//     )
+  it('params.slug for the matched route, should be "framework/react/guide/file-based-routing tanstack" instead of it being "framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack"', async () => {
+    const { router, routes } = createTestRouter(
+      createMemoryHistory({
+        initialEntries: [
+          '/posts/framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack',
+        ],
+      }),
+    )
+
+    await act(() => router.load())
+
+    const match = router.state.matches.find(
+      (r) => r.routeId === routes.postIdRoute.id,
+    )
+
+    if (!match) {
+      throw new Error('No match found')
+    }
+
+    expect((match.params as unknown as any).slug).toBe(
+      'framework/react/guide/file-based-routing tanstack',
+    )
+  })
+})
+
+describe('encoding: URL splat segment for /$', () => {
+  it('state.location.pathname, should have the params._splat value of "tanner"', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/tanner'] }),
+    )
 
-//     await act(() => router.load())
-
-//     expect(router.state.location.pathname).toBe('/tanner')
-//   })
+    await router.load()
+
+    expect(router.state.location.pathname).toBe('/tanner')
+  })
 
-//   it('state.location.pathname, should have the params._splat value of "🚀"', async () => {
-//     const { router } = createTestRouter(
-//       createMemoryHistory({ initialEntries: ['/🚀'] }),
-//     )
+  it('state.location.pathname, should have the params._splat value of "🚀"', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/🚀'] }),
+    )
 
-//     await act(() => router.load())
+    await router.load()
 
-//     expect(router.state.location.pathname).toBe('/🚀')
-//   })
-
-//   it('state.location.pathname, should have the params._splat value of "%F0%9F%9A%80"', async () => {
-//     const { router } = createTestRouter(
-//       createMemoryHistory({ initialEntries: ['/%F0%9F%9A%80'] }),
-//     )
+    expect(router.state.location.pathname).toBe('/🚀')
+  })
+
+  it('state.location.pathname, should have the params._splat value of "%F0%9F%9A%80"', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/%F0%9F%9A%80'] }),
+    )
 
-//     await act(() => router.load())
-
-//     expect(router.state.location.pathname).toBe('/%F0%9F%9A%80')
-//   })
+    await router.load()
+
+    expect(router.state.location.pathname).toBe('/%F0%9F%9A%80')
+  })
 
-//   it('state.location.pathname, should have the params._splat value of "framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack"', async () => {
-//     const { router } = createTestRouter(
-//       createMemoryHistory({
-//         initialEntries: [
-//           '/framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack',
-//         ],
-//       }),
-//     )
-
-//     await act(() => router.load())
-
-//     expect(router.state.location.pathname).toBe(
-//       '/framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack',
-//     )
-//   })
-
-//   it('state.location.pathname, should have the params._splat value of "framework/react/guide/file-based-routing tanstack"', async () => {
-//     const { router } = createTestRouter(
-//       createMemoryHistory({
-//         initialEntries: ['/framework/react/guide/file-based-routing tanstack'],
-//       }),
-//     )
-
-//     await act(() => router.load())
-
-//     expect(router.state.location.pathname).toBe(
-//       '/framework/react/guide/file-based-routing tanstack',
-//     )
-//   })
-
-//   it('params._splat for the matched route, should be "tanner"', async () => {
-//     const { router, routes } = createTestRouter(
-//       createMemoryHistory({ initialEntries: ['/tanner'] }),
-//     )
-
-//     await act(() => router.load())
-
-//     const match = router.state.matches.find(
-//       (r) => r.routeId === routes.topLevelSplatRoute.id,
-//     )
-
-//     if (!match) {
-//       throw new Error('No match found')
-//     }
-
-//     expect((match.params as unknown as any)._splat).toBe('tanner')
-//   })
-
-//   it('params._splat for the matched route, should be "🚀"', async () => {
-//     const { router, routes } = createTestRouter(
-//       createMemoryHistory({ initialEntries: ['/🚀'] }),
-//     )
-
-//     await act(() => router.load())
-
-//     const match = router.state.matches.find(
-//       (r) => r.routeId === routes.topLevelSplatRoute.id,
-//     )
-
-//     if (!match) {
-//       throw new Error('No match found')
-//     }
-
-//     expect((match.params as unknown as any)._splat).toBe('🚀')
-//   })
-
-//   it('params._splat for the matched route, should be "🚀" instead of it being "%F0%9F%9A%80"', async () => {
-//     const { router, routes } = createTestRouter(
-//       createMemoryHistory({ initialEntries: ['/%F0%9F%9A%80'] }),
-//     )
-
-//     await act(() => router.load())
-
-//     const match = router.state.matches.find(
-//       (r) => r.routeId === routes.topLevelSplatRoute.id,
-//     )
-
-//     if (!match) {
-//       throw new Error('No match found')
-//     }
-
-//     expect((match.params as unknown as any)._splat).toBe('🚀')
-//   })
-
-//   it('params._splat for the matched route, should be "framework/react/guide/file-based-routing tanstack"', async () => {
-//     const { router, routes } = createTestRouter(
-//       createMemoryHistory({
-//         initialEntries: ['/framework/react/guide/file-based-routing tanstack'],
-//       }),
-//     )
-
-//     await act(() => router.load())
-
-//     const match = router.state.matches.find(
-//       (r) => r.routeId === routes.topLevelSplatRoute.id,
-//     )
-
-//     if (!match) {
-//       throw new Error('No match found')
-//     }
-
-//     expect((match.params as unknown as any)._splat).toBe(
-//       'framework/react/guide/file-based-routing tanstack',
-//     )
-//   })
-// })
-
-// describe('encoding: URL path segment', () => {
-//   // TODO: Find out why this wasn't working with createMemoryHistory
-//   it.each([
-//     {
-//       input: '/path-segment/%C3%A9',
-//       output: '/path-segment/é',
-//       type: 'encoded',
-//     },
-//     {
-//       input: '/path-segment/é',
-//       output: '/path-segment/é',
-//       type: 'not encoded',
-//     },
-//     {
-//       input: '/path-segment/%F0%9F%9A%80',
-//       output: '/path-segment/🚀',
-//       type: 'encoded',
-//     },
-//     {
-//       input: '/path-segment/🚀',
-//       output: '/path-segment/🚀',
-//       type: 'not encoded',
-//     },
-//   ])(
-//     'should resolve $input to $output when the path segment is $type',
-//     async ({ input, output }) => {
-//       const { router } = createTestRouter()
-
-//       window.history.pushState({}, '', input)
-
-//       render(<RouterProvider router={router} />)
-//       await router.load()
-
-//       expect(router.state.location.pathname).toBe(output)
-//     },
-//   )
-// })
+  it('state.location.pathname, should have the params._splat value of "framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack"', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({
+        initialEntries: [
+          '/framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack',
+        ],
+      }),
+    )
+
+    await router.load()
+
+    expect(router.state.location.pathname).toBe(
+      '/framework%2Freact%2Fguide%2Ffile-based-routing%20tanstack',
+    )
+  })
+
+  it('state.location.pathname, should have the params._splat value of "framework/react/guide/file-based-routing tanstack"', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({
+        initialEntries: ['/framework/react/guide/file-based-routing tanstack'],
+      }),
+    )
+
+    await router.load()
+
+    expect(router.state.location.pathname).toBe(
+      '/framework/react/guide/file-based-routing tanstack',
+    )
+  })
+
+  it('params._splat for the matched route, should be "tanner"', async () => {
+    const { router, routes } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/tanner'] }),
+    )
+
+    await router.load()
+
+    const match = router.state.matches.find(
+      (r) => r.routeId === routes.topLevelSplatRoute.id,
+    )
+
+    if (!match) {
+      throw new Error('No match found')
+    }
+
+    expect((match.params as unknown as any)._splat).toBe('tanner')
+  })
+
+  it('params._splat for the matched route, should be "🚀"', async () => {
+    const { router, routes } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/🚀'] }),
+    )
+
+    await router.load()
+
+    const match = router.state.matches.find(
+      (r) => r.routeId === routes.topLevelSplatRoute.id,
+    )
+
+    if (!match) {
+      throw new Error('No match found')
+    }
+
+    expect((match.params as unknown as any)._splat).toBe('🚀')
+  })
+
+  it('params._splat for the matched route, should be "🚀" instead of it being "%F0%9F%9A%80"', async () => {
+    const { router, routes } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/%F0%9F%9A%80'] }),
+    )
+
+    await router.load()
+
+    const match = router.state.matches.find(
+      (r) => r.routeId === routes.topLevelSplatRoute.id,
+    )
+
+    if (!match) {
+      throw new Error('No match found')
+    }
+
+    expect((match.params as unknown as any)._splat).toBe('🚀')
+  })
+
+  it('params._splat for the matched route, should be "framework/react/guide/file-based-routing tanstack"', async () => {
+    const { router, routes } = createTestRouter(
+      createMemoryHistory({
+        initialEntries: ['/framework/react/guide/file-based-routing tanstack'],
+      }),
+    )
+
+    await router.load()
+
+    const match = router.state.matches.find(
+      (r) => r.routeId === routes.topLevelSplatRoute.id,
+    )
+
+    if (!match) {
+      throw new Error('No match found')
+    }
+
+    expect((match.params as unknown as any)._splat).toBe(
+      'framework/react/guide/file-based-routing tanstack',
+    )
+  })
+})
+
+describe('encoding: URL path segment', () => {
+  it.each([
+    {
+      input: '/path-segment/%C3%A9',
+      output: '/path-segment/é',
+      type: 'encoded',
+    },
+    {
+      input: '/path-segment/é',
+      output: '/path-segment/é',
+      type: 'not encoded',
+    },
+    {
+      input: '/path-segment/%F0%9F%9A%80',
+      output: '/path-segment/🚀',
+      type: 'encoded',
+    },
+    {
+      input: '/path-segment/🚀',
+      output: '/path-segment/🚀',
+      type: 'not encoded',
+    },
+  ])(
+    'should resolve $input to $output when the path segment is $type',
+    async ({ input, output }) => {
+      const { router } = createTestRouter(
+        createMemoryHistory({ initialEntries: [input] }),
+      )
+
+      render(<RouterProvider router={router} />)
+      await waitFor(() => router.load())
+
+      expect(router.state.location.pathname).toBe(output)
+    },
+  )
+})
 
 describe('router emits events during rendering', () => {
   it('during initial load, should emit the "onResolved" event', async () => {

--- a/packages/react-router/tests/setupTests.tsx
+++ b/packages/react-router/tests/setupTests.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react'
+import '@testing-library/jest-dom/vitest'
+
+// @ts-expect-error
+global.IS_REACT_ACT_ENVIRONMENT = true

--- a/packages/react-router/tests/useMatch.test.tsx
+++ b/packages/react-router/tests/useMatch.test.tsx
@@ -1,7 +1,7 @@
-import { afterEach, describe, expect, test, vi } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 import React from 'react'
-import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import {
   Link,
   Outlet,
@@ -14,12 +14,12 @@ import {
 } from '../src'
 import type { RouteComponent, RouterHistory } from '../src'
 
-describe('useMatch', () => {
-  afterEach(() => {
-    window.history.replaceState(null, 'root', '/')
-    cleanup()
-  })
+afterEach(() => {
+  window.history.replaceState(null, 'root', '/')
+  cleanup()
+})
 
+describe('useMatch', () => {
   function setup({
     RootComponent,
     history,
@@ -52,7 +52,7 @@ describe('useMatch', () => {
       history,
     })
 
-    render(<RouterProvider router={router} />)
+    return render(<RouterProvider router={router} />)
   }
 
   describe('when match is found', () => {
@@ -70,7 +70,7 @@ describe('useMatch', () => {
           RootComponent,
           history: createMemoryHistory({ initialEntries: ['/posts'] }),
         })
-        await screen.findByText('PostsTitle')
+        await waitFor(() => screen.findByText('PostsTitle'))
       },
     )
   })
@@ -85,8 +85,10 @@ describe('useMatch', () => {
         }
         setup({ RootComponent })
         expect(
-          await screen.findByText(
-            'Invariant failed: Could not find an active match from "/posts"',
+          await waitFor(() =>
+            screen.findByText(
+              'Invariant failed: Could not find an active match from "/posts"',
+            ),
           ),
         ).toBeInTheDocument()
       },
@@ -100,7 +102,9 @@ describe('useMatch', () => {
           return <Outlet />
         }
         setup({ RootComponent })
-        expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
+        expect(
+          await waitFor(() => screen.findByText('IndexTitle')),
+        ).toBeInTheDocument()
       })
       test('with select function', async () => {
         const select = vi.fn()
@@ -110,7 +114,9 @@ describe('useMatch', () => {
           return <Outlet />
         }
         setup({ RootComponent })
-        expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
+        expect(
+          await waitFor(() => screen.findByText('IndexTitle')),
+        ).toBeInTheDocument()
         expect(select).not.toHaveBeenCalled()
       })
     })

--- a/packages/react-router/vite.config.ts
+++ b/packages/react-router/vite.config.ts
@@ -11,6 +11,7 @@ const config = defineConfig({
     watch: false,
     environment: 'jsdom',
     typecheck: { enabled: true },
+    setupFiles: ['./tests/setupTests.tsx'],
   },
 })
 


### PR DESCRIPTION
Part of #1976 

✅ These files no longer throw `act` warnings.
- `loaders.test.tsx`
- `createLazyRoute.test.tsx`
- `router.test.tsx`
- `useMatch.test.tsx`

⚠️ These files have been migrated over, but still emit the `act` warnings.
- `link.test.tsx`
- `redirect.test.tsx`