### PR TITLE
fix(router-generator): parse the experimental flags at the generator

### DIFF
--- a/packages/router-cli/src/index.ts
+++ b/packages/router-cli/src/index.ts
@@ -11,13 +11,13 @@ export function main() {
     .scriptName('tsr')
     .usage('$0 <cmd> [args]')
     .command('generate', 'Generate the routes for a project', async () => {
-      const config = await getConfig()
+      const config = getConfig()
       await generate(config)
     })
     .command(
       'watch',
       'Continuously watch and generate the routes for a project',
-      async () => {
+      () => {
         watch()
       },
     )

--- a/packages/router-cli/src/watch.ts
+++ b/packages/router-cli/src/watch.ts
@@ -2,15 +2,15 @@ import path from 'node:path'
 import chokidar from 'chokidar'
 import { generator, getConfig } from '@tanstack/router-generator'
 
-export async function watch() {
+export function watch() {
   const configWatcher = chokidar.watch(
     path.resolve(process.cwd(), 'tsr.config.json'),
   )
 
   let watcher = new chokidar.FSWatcher({})
 
-  const generatorWatcher = async () => {
-    const config = await getConfig()
+  const generatorWatcher = () => {
+    const config = getConfig()
 
     watcher.close()
 

--- a/packages/router-generator/src/config.ts
+++ b/packages/router-generator/src/config.ts
@@ -26,14 +26,19 @@ export const configSchema = z.object({
     .array(z.string())
     .optional()
     .default(['/* prettier-ignore-end */']),
+  experimental: z
+    .object({
+      enableCodeSplitting: z.boolean().optional(),
+    })
+    .optional(),
 })
 
 export type Config = z.infer<typeof configSchema>
 
-export async function getConfig(
+export function getConfig(
   inlineConfig: Partial<Config> = {},
   configDirectory?: string,
-): Promise<Config> {
+): Config {
   if (configDirectory === undefined) {
     configDirectory = process.cwd()
   }

--- a/packages/router-plugin/src/code-splitter.ts
+++ b/packages/router-plugin/src/code-splitter.ts
@@ -62,7 +62,7 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
   let ROOT: string = process.cwd()
   let userConfig = options as Config
 
-  const handleSplittingFile = async (code: string, id: string) => {
+  const handleSplittingFile = (code: string, id: string) => {
     if (debug) console.info('Splitting route: ', id)
 
     const compiledVirtualRoute = compileCodeSplitVirtualRoute({
@@ -82,7 +82,7 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
     return compiledVirtualRoute
   }
 
-  const handleCompilingFile = async (code: string, id: string) => {
+  const handleCompilingFile = (code: string, id: string) => {
     if (debug) console.info('Handling createRoute: ', id)
 
     const compiledReferenceRoute = compileCodeSplitReferenceRoute({
@@ -169,13 +169,13 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
     },
 
     vite: {
-      async configResolved(config) {
+      configResolved(config) {
         ROOT = config.root
-        userConfig = await getConfig(options, ROOT)
+        userConfig = getConfig(options, ROOT)
       },
     },
 
-    async rspack(compiler) {
+    rspack(compiler) {
       ROOT = process.cwd()
 
       compiler.hooks.beforeCompile.tap(PLUGIN_NAME, (self) => {
@@ -192,10 +192,10 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
         )
       })
 
-      userConfig = await getConfig(options, ROOT)
+      userConfig = getConfig(options, ROOT)
     },
 
-    async webpack(compiler) {
+    webpack(compiler) {
       ROOT = process.cwd()
 
       compiler.hooks.beforeCompile.tap(PLUGIN_NAME, (self) => {
@@ -212,7 +212,7 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
         )
       })
 
-      userConfig = await getConfig(options, ROOT)
+      userConfig = getConfig(options, ROOT)
 
       if (
         userConfig.experimental?.enableCodeSplitting &&

--- a/packages/router-plugin/src/config.ts
+++ b/packages/router-plugin/src/config.ts
@@ -6,18 +6,10 @@ import {
 
 export const configSchema = generatorConfigSchema.extend({
   enableRouteGeneration: z.boolean().optional(),
-  experimental: z
-    .object({
-      enableCodeSplitting: z.boolean().optional(),
-    })
-    .optional(),
 })
 
-export const getConfig = async (
-  inlineConfig: Partial<Config>,
-  root: string,
-) => {
-  const config = await getGeneratorConfig(inlineConfig, root)
+export const getConfig = (inlineConfig: Partial<Config>, root: string) => {
+  const config = getGeneratorConfig(inlineConfig, root)
 
   return configSchema.parse({ ...config, ...inlineConfig })
 }

--- a/packages/router-plugin/src/router-generator.ts
+++ b/packages/router-plugin/src/router-generator.ts
@@ -50,7 +50,7 @@ export const unpluginRouterGeneratorFactory: UnpluginFactory<
     const filePath = normalize(file)
 
     if (filePath === join(ROOT, CONFIG_FILE_NAME)) {
-      userConfig = await getConfig(options, ROOT)
+      userConfig = getConfig(options, ROOT)
       return
     }
 
@@ -84,13 +84,13 @@ export const unpluginRouterGeneratorFactory: UnpluginFactory<
     vite: {
       async configResolved(config) {
         ROOT = config.root
-        userConfig = await getConfig(options, ROOT)
+        userConfig = getConfig(options, ROOT)
 
         await run(generate)
       },
     },
     async rspack(compiler) {
-      userConfig = await getConfig(options, ROOT)
+      userConfig = getConfig(options, ROOT)
 
       // rspack watcher doesn't register newly created files
       if (compiler.options.mode === 'production') {
@@ -104,7 +104,7 @@ export const unpluginRouterGeneratorFactory: UnpluginFactory<
       }
     },
     async webpack(compiler) {
-      userConfig = await getConfig(options, ROOT)
+      userConfig = getConfig(options, ROOT)
 
       // webpack watcher doesn't register newly created files
       if (compiler.options.mode === 'production') {

--- a/packages/start/src/config/index.ts
+++ b/packages/start/src/config/index.ts
@@ -88,12 +88,12 @@ function setTsrDefaults(
   }
 }
 
-export async function defineConfig(
+export function defineConfig(
   inlineConfig: TanStackStartDefineConfigOptions = {},
 ) {
   const opts = inlineConfigSchema.parse(inlineConfig)
 
-  const tsrConfig = await getConfig(setTsrDefaults(opts.tsr))
+  const tsrConfig = getConfig(setTsrDefaults(opts.tsr))
 
   const clientBase = opts.routers?.client?.base || '/_build'
 


### PR DESCRIPTION
The flags under the key of `experimental` need to be parsed by the router-generator, for it to work when using a `tsr.config.json` file instead of having to inline the config with the bundler plugin.