### PR TITLE
fix(start): expose "netlify" and "vercel" as target deployment presets

### DIFF
--- a/packages/start/src/config/index.ts
+++ b/packages/start/src/config/index.ts
@@ -30,6 +30,19 @@ const deploymentSchema = z.object({
     ])
     .optional(),
   static: z.boolean().optional(),
+  prerender: z
+    .object({
+      routes: z.array(z.string()),
+      ignore: z
+        .array(
+          z.custom<
+            string | RegExp | ((path: string) => undefined | null | boolean)
+          >(),
+        )
+        .optional(),
+      crawlLinks: z.boolean().optional(),
+    })
+    .optional(),
 })
 
 const viteSchema = z.object({

--- a/packages/start/src/config/index.ts
+++ b/packages/start/src/config/index.ts
@@ -27,7 +27,7 @@ const deploymentSchema = z.object({
       'netlify', // working
       'cloudflare-pages', // not working
       'static', // partially working
-      'node', // working
+      'node', // partially working
     ])
     .optional(),
   static: z.boolean().optional(),

--- a/packages/start/src/config/index.ts
+++ b/packages/start/src/config/index.ts
@@ -27,6 +27,7 @@ const deploymentSchema = z.object({
       'netlify', // working
       'cloudflare-pages', // not working
       'static', // partially working
+      'node', // working
     ])
     .optional(),
   static: z.boolean().optional(),
@@ -137,7 +138,7 @@ export function defineConfig(
     server: {
       ...deploymentOptions,
       static: isStaticDeployment,
-      preset: deploymentPreset,
+      preset: 'node',
       experimental: {
         asyncContext: true,
       },

--- a/packages/start/src/config/index.ts
+++ b/packages/start/src/config/index.ts
@@ -138,7 +138,7 @@ export function defineConfig(
     server: {
       ...deploymentOptions,
       static: isStaticDeployment,
-      preset: 'node',
+      preset: deploymentPreset,
       experimental: {
         asyncContext: true,
       },

--- a/packages/start/src/config/index.ts
+++ b/packages/start/src/config/index.ts
@@ -21,7 +21,7 @@ import type { Manifest } from '@tanstack/react-router'
 import type * as vite from 'vite'
 
 const deploymentSchema = z.object({
-  preset: z.enum(['vercel', 'netlify']).optional(),
+  preset: z.enum(['vercel', 'netlify', 'cloudflare-pages']).optional(),
 })
 
 const viteSchema = z.object({


### PR DESCRIPTION
## ✅ Working:

<details><summary>Vercel</summary>
<p>
😊 We already know this works since tanstack.com is deployed on Vercel.
</p>
</details> 

<details><summary>Netlify</summary>
https://start-basic-netlify.netlify.app
</details> 

## ⚠️ Partially working

<details><summary>Static</summary>
<p>
The build output is correct.
<img width="766" alt="image" src="https://github.com/user-attachments/assets/a0b5cc55-a2fd-4321-a46d-0ded079b6bcb">
Also, directly visiting URLs (initial load) that use a `createServerFn` call works, like going to `/posts/1`.

However, you cannot navigate to a that uses a `createServerFn` call, after the page has loaded. Then an exception is thrown in the UI.
<img width="999" alt="image" src="https://github.com/user-attachments/assets/36a1794b-3af5-40b4-adbf-495c38d67b74">
</p>
</details> 

<details><summary>Node</summary>
<p>
Functionally, everything in the Router and the `createServerFn` calls seem to be working.

You'll need to create a node server that uses the listener from the build output. Snippet below.

```js
// examples/react/start-basic/index.mjs
import { createServer } from 'node:http'
import { listener } from './.output/server/index.mjs'

const server = createServer(listener)
server.listen(8080)
```

I'm listing this as partial since the tailwindcss style seems to be broken on the built version.

<img width="929" alt="image" src="https://github.com/user-attachments/assets/1a502797-2f93-4d40-a188-07acd930bebf">

</p>
</details> 

## 🚨 Borked:

<details><summary>Cloudflare pages</summary>
<p>

[https://start-basic-cf-pages.pages.dev](https://start-basic-cf-pages.pages.dev)

<img width="844" alt="image" src="https://github.com/user-attachments/assets/57b21812-9277-4520-b8af-6ae8925c7d79">

@tannerlinsley mentioned that we could probably fix this deployment bug by switching the node imports over to what's provided by Vinxi, Nitro, and/or h3.
</p>
</details> 