### PR TITLE
Add details to getting started with Start.

### DIFF
--- a/docs/framework/react/guide/tanstack-start.md
+++ b/docs/framework/react/guide/tanstack-start.md
@@ -36,8 +36,8 @@ Create a `tsconfig.json` file with at least the following settings:
     "moduleResolution": "Bundler",
     "module": "Preserve",
     "target": "ES2022",
-    "skipLibCheck": true
-  }
+    "skipLibCheck": true,
+  },
 }
 ```
 
@@ -58,6 +58,7 @@ npm i react react-dom @vitejs/plugin-react
 ```
 
 and some TypeScript:
+
 ```shell
 npm i -D typescript @types/react @types/react-dom
 ```

--- a/docs/framework/react/guide/tanstack-start.md
+++ b/docs/framework/react/guide/tanstack-start.md
@@ -19,6 +19,28 @@ Follow this guide to build a basic TanStack Start web application. Together, we 
 
 [Here is what that will look like](https://stackblitz.com/github/tanstack/router/tree/main/examples/react/start-basic-counter)
 
+Create a new project if you're starting fresh.
+
+```shell
+mkdir myApp
+cd myApp
+npm init -y
+```
+
+Create a `tsconfig.json` file with at least the following settings:
+
+```jsonc
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "moduleResolution": "Bundler",
+    "module": "Preserve",
+    "target": "ES2022",
+    "skipLibCheck": true
+  }
+}
+```
+
 # Install Dependencies
 
 TanStack Start is powered by [Vinxi](https://vinxi.vercel.app/) and [TanStack Router](https://tanstack.com/router) and requires them as dependencies.
@@ -29,13 +51,25 @@ To install them, run:
 npm i @tanstack/start @tanstack/react-router vinxi
 ```
 
+You'll also need React and the Vite React plugin, so install them too:
+
+```shell
+npm i react react-dom @vitejs/plugin-react
+```
+
+and some TypeScript:
+```shell
+npm i -D typescript @types/react @types/react-dom
+```
+
 # Update Configuration Files
 
-We'll then update our `package.json` to reference the new Vinxi entry point:
+We'll then update our `package.json` to reference the new Vinxi entry point and set `"type": "module"`:
 
 ```json
 {
   "//": "...",
+  "type": "module"
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",


### PR DESCRIPTION
This is the minimum I found I needed to get to teh page rendering, the server actions working, and a `tsc --noEmit` passing.

There's still a `[plugin:vite:resolve] Module "fs" has been externalized...` warning and visiting the page causes
```
Warning: A notFoundError was encountered on the route with ID "__root__", but a notFoundComponent option was not configured, nor was a router level defaultNotFoundComponent configured. Consider configuring at least one of these to avoid TanStack Router's overly generic defaultNotFoundComponent (<div>Not Found<div>)
```