### PR TITLE
Specify context with routerWithQueryClient

### DIFF
--- a/examples/react/start-basic-react-query/app/router.tsx
+++ b/examples/react/start-basic-react-query/app/router.tsx
@@ -18,6 +18,7 @@ export function createRouter() {
       defaultPreload: 'intent',
       defaultErrorComponent: DefaultCatchBoundary,
       defaultNotFoundComponent: () => <NotFound />,
+      context: { queryClient },
     }),
     queryClient,
   )

--- a/examples/react/start-trellaux/app/router.tsx
+++ b/examples/react/start-trellaux/app/router.tsx
@@ -39,6 +39,7 @@ export function createRouter() {
       defaultPreload: 'intent',
       defaultErrorComponent: DefaultCatchBoundary,
       defaultNotFoundComponent: () => <NotFound />,
+      context: { queryClient },
     }),
     queryClient,
   )


### PR DESCRIPTION
https://github.com/TanStack/router/pull/1946 broke these types as they're used, for now just specify the query client explicitly.