### PR TITLE
fix(react-router): retain path parameters that are falsy but still valid 

### DIFF
--- a/packages/react-router/src/path.ts
+++ b/packages/react-router/src/path.ts
@@ -8,7 +8,13 @@ export interface Segment {
 }
 
 export function joinPaths(paths: Array<string | undefined>) {
-  return cleanPath(paths.filter(Boolean).join('/'))
+  return cleanPath(
+    paths
+      .filter((val) => {
+        return val !== undefined
+      })
+      .join('/'),
+  )
 }
 
 export function cleanPath(path: string) {
@@ -193,7 +199,7 @@ export function parsePathname(pathname?: string): Array<Segment> {
 
 interface InterpolatePathOptions {
   path?: string
-  params: any
+  params: Record<string, unknown>
   leaveWildcards?: boolean
   leaveParams?: boolean
 }

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -3312,6 +3312,8 @@ describe('Link', () => {
       ),
     })
 
+    const stringifyParamsMock = vi.fn()
+
     const parseParams = ({ postId }: { postId: string }) => {
       return {
         postId: parseInt(postId),
@@ -3319,6 +3321,7 @@ describe('Link', () => {
     }
 
     const stringifyParams = ({ postId }: { postId: number }) => {
+      stringifyParamsMock({ postId })
       return {
         postId: postId.toString(),
       }
@@ -3353,6 +3356,9 @@ describe('Link', () => {
 
     expect(postLink2).toHaveAttribute('href', '/2')
     expect(postLink0).toHaveAttribute('href', '/0')
+
+    expect(stringifyParamsMock).toHaveBeenCalledWith({ postId: 2 })
+    expect(stringifyParamsMock).toHaveBeenCalledWith({ postId: 0 })
   })
 })
 

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -3293,6 +3293,67 @@ describe('Link', () => {
 
     expect(parseParams).toHaveBeenCalledWith({ status: 'parsed', postId: '2' })
   })
+
+  test('when navigating to /$postId with params.parse and params.stringify handles falsey inputs', async () => {
+    const rootRoute = createRootRoute()
+
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => (
+        <>
+          <Link to="/$postId" params={{ postId: 2 }}>
+            Go to post 2
+          </Link>
+          <Link to="/$postId" params={{ postId: 0 }}>
+            Go to post 0
+          </Link>
+        </>
+      ),
+    })
+
+    const parseParams = ({ postId }: { postId: string }) => {
+      return {
+        postId: parseInt(postId),
+      }
+    }
+
+    const stringifyParams = ({ postId }: { postId: number }) => {
+      return {
+        postId: postId.toString(),
+      }
+    }
+
+    const PostComponent = () => {
+      const params = useParams({ strict: false })
+      return <div>Post: {params.postId}</div>
+    }
+
+    const postRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '$postId',
+      params: {
+        parse: parseParams,
+        stringify: stringifyParams,
+      },
+      component: PostComponent,
+    })
+
+    const routeTree = rootRoute.addChildren([indexRoute, postRoute])
+    const router = createRouter({ routeTree })
+
+    render(<RouterProvider router={router} />)
+
+    const postLink2 = await screen.findByRole('link', {
+      name: 'Go to post 2',
+    })
+    const postLink0 = await screen.findByRole('link', {
+      name: 'Go to post 0',
+    })
+
+    expect(postLink2).toHaveAttribute('href', '/2')
+    expect(postLink0).toHaveAttribute('href', '/0')
+  })
 })
 
 describe('createLink', () => {

--- a/packages/react-router/tests/path.test.ts
+++ b/packages/react-router/tests/path.test.ts
@@ -1,8 +1,7 @@
-import exp from 'node:constants'
 import { describe, expect, it } from 'vitest'
 import {
   exactPathTest,
-  matchByPath,
+  interpolatePath,
   removeBasepath,
   removeTrailingSlash,
   resolvePath,
@@ -222,6 +221,58 @@ describe('resolvePath', () => {
           }),
         ).toBe('/a/b/c/d')
       })
+    })
+  })
+})
+
+describe('interpolatePath', () => {
+  ;[
+    {
+      name: 'should interpolate the path',
+      path: '/users/$id',
+      params: { id: '123' },
+      result: '/users/123',
+    },
+    {
+      name: 'should interpolate the path with multiple params',
+      path: '/users/$id/$name',
+      params: { id: '123', name: 'tanner' },
+      result: '/users/123/tanner',
+    },
+    {
+      name: 'should interpolate the path with extra params',
+      path: '/users/$id',
+      params: { id: '123', name: 'tanner' },
+      result: '/users/123',
+    },
+    {
+      name: 'should interpolate the path with missing params',
+      path: '/users/$id/$name',
+      params: { id: '123' },
+      result: '/users/123/undefined',
+    },
+    {
+      name: 'should interpolate the path with missing params and extra params',
+      path: '/users/$id',
+      params: { name: 'john' },
+      result: '/users/undefined',
+    },
+    {
+      name: 'should interpolate the path with the param being a number',
+      path: '/users/$id',
+      params: { id: 123 },
+      result: '/users/123',
+    },
+    {
+      name: 'should interpolate the path with the param being a falsey number',
+      path: '/users/$id',
+      params: { id: 0 },
+      result: '/users/0',
+    },
+  ].forEach((exp) => {
+    it(exp.name, () => {
+      const result = interpolatePath({ path: exp.path, params: exp.params })
+      expect(result).toBe(exp.result)
     })
   })
 })


### PR DESCRIPTION
Fixes #2024 