### PR TITLE
build(react-router-with-query): add `@tanstack/react-router-with-query` to the publish list

### DIFF
--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -17,6 +17,10 @@ await publish({
       packageDir: 'packages/react-router',
     },
     {
+      name: '@tanstack/react-router-with-query',
+      packageDir: 'packages/react-router-with-query',
+    },
+    {
       name: '@tanstack/router-devtools',
       packageDir: 'packages/router-devtools',
     },


### PR DESCRIPTION
For whatever reason, https://github.com/TanStack/router/commit/2c94fa0ee8f54f7039649f5e7e2c3e74087df5f1 did not trigger a package to be published.

Looking at our `publish` script, we don't seem to have the `@tanstack/react-router-with-query` as a package to be published.