### PR TITLE
feat: expose unmaskOnReload on createRouteMask

### DIFF
--- a/packages/react-router/src/route.ts
+++ b/packages/react-router/src/route.ts
@@ -12,7 +12,7 @@ import type * as React from 'react'
 import type { RootRouteId } from './root'
 import type { UseNavigateResult } from './useNavigate'
 import type { MakeRouteMatch, RouteMatch } from './Matches'
-import type { NavigateOptions, ParsePathParams, ToSubOptions } from './link'
+import type { NavigateOptions, ParsePathParams, ToMaskOptions } from './link'
 import type { ParsedLocation } from './location'
 import type { RouteById, RouteIds, RoutePaths } from './routeInfo'
 import type { AnyRouter, RegisteredRouter, Router } from './router'
@@ -1233,7 +1233,7 @@ export function createRouteMask<
 >(
   opts: {
     routeTree: TRouteTree
-  } & ToSubOptions<Router<TRouteTree, 'never'>, TFrom, TTo>,
+  } & ToMaskOptions<Router<TRouteTree, 'never'>, TFrom, TTo>,
 ): RouteMask<TRouteTree> {
   return opts as any
 }


### PR DESCRIPTION
The flag `unmaskOnReload` is already handled in `createRouter({routeMasks})` but wasn't exposed from `createRouteMask`.