### PR TITLE
fix(react-router): when navigating from a index the types should resolve to a valid route

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -258,7 +258,7 @@ export type ResolveRoute<
   TTo,
   TPath = ResolveRelativePath<TFrom, TTo>,
 > = TPath extends string
-  ? string extends TTo
+  ? TFrom extends TPath
     ? RouteByPath<TRouter['routeTree'], TPath>
     : RouteByToPath<TRouter, TPath>
   : never

--- a/packages/react-router/tests/link.test-d.tsx
+++ b/packages/react-router/tests/link.test-d.tsx
@@ -484,6 +484,91 @@ test('when navigating from a route with no params and no search to the current r
     .parameter(0)
     .toHaveProperty('to')
     .toEqualTypeOf<'./$postId/' | './$postId' | undefined | './'>()
+
+  expectTypeOf(Link<DefaultRouter, '/posts/', './'>)
+    .parameter(0)
+    .toHaveProperty('search')
+    .exclude<Function>()
+    .toEqualTypeOf<{ rootPage?: number } | undefined | true>()
+
+  expectTypeOf(Link<DefaultRouterObjects, '/posts/', './'>)
+    .parameter(0)
+    .toHaveProperty('search')
+    .exclude<Function>()
+    .toEqualTypeOf<{ rootPage?: number } | undefined | true>()
+
+  expectTypeOf(Link<RouterAlwaysTrailingSlashes, '/posts/', './'>)
+    .parameter(0)
+    .toHaveProperty('search')
+    .exclude<Function>()
+    .toEqualTypeOf<{ rootPage?: number } | undefined | true>()
+
+  expectTypeOf(Link<RouterNeverTrailingSlashes, '/posts/', './'>)
+    .parameter(0)
+    .toHaveProperty('search')
+    .exclude<Function>()
+    .toEqualTypeOf<{ rootPage?: number } | undefined | true>()
+
+  expectTypeOf(Link<RouterPreserveTrailingSlashes, '/posts/', './'>)
+    .parameter(0)
+    .toHaveProperty('search')
+    .exclude<Function>()
+    .toEqualTypeOf<{ rootPage?: number } | undefined | true>()
+
+  expectTypeOf(Link<DefaultRouter, '/posts/', './'>)
+    .parameter(0)
+    .toHaveProperty('search')
+    .returns.toEqualTypeOf<{ rootPage?: number }>()
+
+  expectTypeOf(Link<DefaultRouterObjects, '/posts/', './'>)
+    .parameter(0)
+    .toHaveProperty('search')
+    .returns.toEqualTypeOf<{ rootPage?: number }>()
+
+  expectTypeOf(Link<RouterAlwaysTrailingSlashes, '/posts/', './'>)
+    .parameter(0)
+    .toHaveProperty('search')
+    .returns.toEqualTypeOf<{ rootPage?: number }>()
+
+  expectTypeOf(Link<RouterNeverTrailingSlashes, '/posts/', './'>)
+    .parameter(0)
+    .toHaveProperty('search')
+    .returns.toEqualTypeOf<{ rootPage?: number }>()
+
+  expectTypeOf(Link<RouterPreserveTrailingSlashes, '/posts/', './'>)
+    .parameter(0)
+    .toHaveProperty('search')
+    .returns.toEqualTypeOf<{ rootPage?: number }>()
+
+  expectTypeOf(Link<DefaultRouter, '/posts/', './'>)
+    .parameter(0)
+    .toHaveProperty('search')
+    .parameter(0)
+    .toEqualTypeOf<{ rootPage?: number }>()
+
+  expectTypeOf(Link<DefaultRouterObjects, '/posts/', './'>)
+    .parameter(0)
+    .toHaveProperty('search')
+    .parameter(0)
+    .toEqualTypeOf<{ rootPage?: number }>()
+
+  expectTypeOf(Link<RouterAlwaysTrailingSlashes, '/posts/', './'>)
+    .parameter(0)
+    .toHaveProperty('search')
+    .parameter(0)
+    .toEqualTypeOf<{ rootPage?: number }>()
+
+  expectTypeOf(Link<RouterNeverTrailingSlashes, '/posts/', './'>)
+    .parameter(0)
+    .toHaveProperty('search')
+    .parameter(0)
+    .toEqualTypeOf<{ rootPage?: number }>()
+
+  expectTypeOf(Link<RouterPreserveTrailingSlashes, '/posts/', './'>)
+    .parameter(0)
+    .toHaveProperty('search')
+    .parameter(0)
+    .toEqualTypeOf<{ rootPage?: number }>()
 })
 
 test('when navigating from a route with no params and no search to the parent route', () => {


### PR DESCRIPTION
There is an issue in the types where `from` is an index route but there is no `to` or the resolve path is the same as `from`. It means that

`<Link from='/posts/' />` always requires a `search` param because the resolved route is incorrect and returns `never`