### PR TITLE
refactor: better API surface for the internal `useIntersectionObserver` hook

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -665,7 +665,7 @@ export function useLinkProps<
     })
   }, [options, router])
 
-  const viewportIntersectionCallback = React.useCallback(
+  const preloadViewportIoCallback = React.useCallback(
     (entry: IntersectionObserverEntry | undefined) => {
       if (entry?.isIntersecting) {
         doPreload()
@@ -676,13 +676,9 @@ export function useLinkProps<
 
   useIntersectionObserver(
     innerRef,
-    {
-      rootMargin: '100px',
-    },
-    {
-      disabled: !!disabled || preload !== 'viewport',
-    },
-    viewportIntersectionCallback,
+    preloadViewportIoCallback,
+    { rootMargin: '100px' },
+    { disabled: !!disabled || preload !== 'viewport' },
   )
 
   if (type === 'external') {

--- a/packages/react-router/src/utils.ts
+++ b/packages/react-router/src/utils.ts
@@ -389,16 +389,20 @@ export function usePrevious<T>(value: T): T | null {
  * ```tsx
  * const MyComponent = () => {
  * const ref = React.useRef<HTMLDivElement>(null)
- * useIntersectionObserver(ref, { rootMargin: '10px' }, {}, (entry) => {
+ * useIntersectionObserver(
+ *  ref,
+ *  (entry) => { doSomething(entry) },
+ *  { rootMargin: '10px' },
+ *  { disabled: false }
+ * )
  * return <div ref={ref} />
- * })
  * ```
  */
 export function useIntersectionObserver<T extends Element>(
   ref: React.RefObject<T>,
+  callback: (entry: IntersectionObserverEntry | undefined) => void,
   intersectionObserverOptions: IntersectionObserverInit = {},
   options: { disabled?: boolean } = {},
-  callback: (entry: IntersectionObserverEntry | undefined) => void,
 ): IntersectionObserver | null {
   const isIntersectionObserverAvailable = React.useRef(
     typeof IntersectionObserver === 'function',
@@ -424,7 +428,7 @@ export function useIntersectionObserver<T extends Element>(
     return () => {
       observerRef.current?.disconnect()
     }
-  }, [intersectionObserverOptions, options, ref, callback])
+  }, [callback, intersectionObserverOptions, options.disabled, ref])
 
   return observerRef.current
 }


### PR DESCRIPTION
The previous interface for the internal `useIntersectionObserver` hook didn't account for the fact that the two important parts of the hook was to accept a `ref` and a `callback`. This also lets the `intersectionObserverOptions` and `options` truly be _optional_.