### PR TITLE
fix(react-router): resolve staticData in createFileRoute

### DIFF
--- a/packages/react-router/src/fileRoute.ts
+++ b/packages/react-router/src/fileRoute.ts
@@ -45,7 +45,9 @@ export function createFileRoute<
   TPath extends RouteConstraints['TPath'] = FileRoutesByPath[TFilePath]['path'],
   TFullPath extends
     RouteConstraints['TFullPath'] = FileRoutesByPath[TFilePath]['fullPath'],
->(path: TFilePath) {
+>(
+  path: TFilePath,
+): FileRoute<TFilePath, TParentRoute, TId, TPath, TFullPath>['createRoute'] {
   return new FileRoute<TFilePath, TParentRoute, TId, TPath, TFullPath>(path, {
     silent: true,
   }).createRoute


### PR DESCRIPTION
Resolves #1978 
`createFileRoute` didn't correctly resolve and enforce `staticData` even when it should. The return type for this function was always compiled down with typescript instead of using the "live" types. During the library build, the `StaticDataRouteOption` was empty, and it resulted in the `staticData` being always optional.

<img width="510" alt="Screenshot 2024-08-02 at 15 04 59" src="https://github.com/user-attachments/assets/434321f8-284b-45c4-beb9-c8a08f42f8cf">
<img width="622" alt="Screenshot 2024-08-02 at 15 05 29" src="https://github.com/user-attachments/assets/e6d091b5-fef2-4fa3-ad77-c2998bd18f14">
<img width="716" alt="Screenshot 2024-08-02 at 15 06 29" src="https://github.com/user-attachments/assets/75a7c082-5256-4abb-b4b6-86ff40974990">
