### PR TITLE
feat(devtools): align right masked path

### DIFF
--- a/packages/router-devtools/src/devtools.tsx
+++ b/packages/router-devtools/src/devtools.tsx
@@ -1023,6 +1023,7 @@ const stylesFactory = (shadowDOMTarget?: ShadowRoot) => {
       padding: ${tokens.size[1.5]} ${tokens.size[2]};
       display: flex;
       align-items: center;
+      justify-content: space-between;
       font-size: ${font.size.xs};
     `,
     routeMatchesToggle: css`


### PR DESCRIPTION
Masked path is shown right after the real path but it seems they're the same string. I suggest moving the masked path to the right.

**Current**
<img width="476" alt="image" src="https://github.com/user-attachments/assets/1bea9a64-a794-4f83-92c4-d75c9171ebb9">

**Proposed**
<img width="475" alt="image" src="https://github.com/user-attachments/assets/3e4cf2c5-bc0d-43b3-b38e-3127c7cbacf4">
