### PR TITLE
fix(react-router): `activeProps` and `inactiveProps` on `Link` to accept data-attributes

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -846,21 +846,24 @@ export type ActiveLinkOptions<
   TMaskTo extends string = '',
 > = LinkOptions<TRouter, TFrom, TTo, TMaskFrom, TMaskTo> & ActiveLinkOptionProps
 
+type ActiveLinkAnchorProps = Omit<
+  React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    [key: `data-${string}`]: unknown
+  },
+  'children'
+>
+
 export interface ActiveLinkOptionProps {
   /**
    * A function that returns additional props for the `active` state of this link.
    * These props override other props passed to the link (`style`'s are merged, `className`'s are concatenated)
    */
-  activeProps?:
-    | React.AnchorHTMLAttributes<HTMLAnchorElement>
-    | (() => React.AnchorHTMLAttributes<HTMLAnchorElement>)
+  activeProps?: ActiveLinkAnchorProps | (() => ActiveLinkAnchorProps)
   /**
    * A function that returns additional props for the `inactive` state of this link.
    * These props override other props passed to the link (`style`'s are merged, `className`'s are concatenated)
    */
-  inactiveProps?:
-    | React.AnchorHTMLAttributes<HTMLAnchorElement>
-    | (() => React.AnchorHTMLAttributes<HTMLAnchorElement>)
+  inactiveProps?: ActiveLinkAnchorProps | (() => ActiveLinkAnchorProps)
 }
 
 export type LinkProps<

--- a/packages/react-router/tests/link.test-d.tsx
+++ b/packages/react-router/tests/link.test-d.tsx
@@ -1,6 +1,6 @@
-import { expectTypeOf, test } from 'vitest'
-import { Link, createRoute, createRouter } from '../src'
-import { createRootRoute } from '../src'
+import { expect, expectTypeOf, test } from 'vitest'
+
+import { Link, createRootRoute, createRoute, createRouter } from '../src'
 
 const rootRoute = createRootRoute({
   validateSearch: (): { rootPage?: number } => ({ rootPage: 0 }),


### PR DESCRIPTION
Fixes #2087
