### PR TITLE
fix(react-router): use `routeId` to stabilize the memoized route component to prevent from remounting when on the same route

### DIFF
--- a/packages/react-router/src/Match.tsx
+++ b/packages/react-router/src/Match.tsx
@@ -138,8 +138,8 @@ export const MatchInner = React.memo(function MatchInnerImpl({
 
   const out = React.useMemo(() => {
     const Comp = route.options.component ?? router.options.defaultComponent
-    return Comp ? <Comp key={matchId} /> : <Outlet />
-  }, [matchId, route.options.component, router.options.defaultComponent])
+    return Comp ? <Comp key={routeId} /> : <Outlet />
+  }, [routeId, route.options.component, router.options.defaultComponent])
 
   React.useEffect(() => {
     if (match.status === 'pending') {

--- a/packages/react-router/tests/router.test.tsx
+++ b/packages/react-router/tests/router.test.tsx
@@ -10,13 +10,13 @@ import {
 import {
   Link,
   Outlet,
-  type RouterHistory,
   RouterProvider,
   createMemoryHistory,
   createRootRoute,
   createRoute,
   createRouter,
 } from '../src'
+import type { RouterHistory } from '../src'
 
 afterEach(() => {
   vi.resetAllMocks()


### PR DESCRIPTION
Resolves #2085 

Since the `matchId` is a unique string formed to represent the current match, when using it as a key to stabilize the route component, the `matchId` caused the page component to be remounted even on the smallest changes to a route. Whilst, rendering is expected, remounting certainly is not.

Using the `routeId` here stabilizes the component across many more renders, since it remains static.