### PR TITLE
docs: remove the invalid `context` and `location` arguments from being shown as available in the `loaderDeps`

### DIFF
--- a/docs/framework/react/api/router/RouteOptionsType.md
+++ b/docs/framework/react/api/router/RouteOptionsType.md
@@ -143,18 +143,13 @@ type loader = (
 - Type:
 
 ```tsx
-type loaderDeps = (opts: {
-  search: TFullSearchSchema
-  location: ParsedLocation
-  context: TAllContext
-}) => Record<string, any>
+type loaderDeps = (opts: { search: TFullSearchSchema }) => Record<string, any>
 ```
 
 - Optional
-- [`ParsedLocation`](./ParsedLocationType.md)
 - A function that will be called before this route is matched to provide additional unique identification to the route match and serve as a dependency tracker for when the match should be reloaded. It should return any serializable value that can uniquely identify the route match from navigation to navigation.
 - By default, path params are already used to uniquely identify a route match, so it's unnecessary to return these here.
-- If your route match relies on search params or context values for unique identification, it's required that you return them here so they can be made available in the `loader`'s `deps` argument.
+- If your route match relies on search params for unique identification, it's required that you return them here so they can be made available in the `loader`'s `deps` argument.
 
 ### `staleTime` property
 


### PR DESCRIPTION
We haven't had the `context` and `location` arguments present as `loaderDeps` options, so this corrects this error in Router's documentation.

The reason we don't have `location` as an argument of `loaderDeps` is quite simple. If the `location` changes, the loader would anyways have to be refired (or retrieved from a cache using something like Query). The scenario in which this wouldn't be the case, is if you wanted to prevent this from happening when search params change. This is why only `search` is provided as its own argument.

The reason we don't have `context` as an argument of `loaderDeps` is because, when the root context has been changed, the user is expected to call `router.invalidate()`. This `invalidate` call discards all cached data and re-evaluates the entire route-tree. As such, having `context` as an argument in `loaderDeps`, makes no sense, since it wouldn't actually contribute anything towards the actual `loaderDeps` functionality.