### PR TITLE
fix(react-router): set a default `transformer` during router instantiation

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -638,6 +638,10 @@ export class Router<
       ...options,
       stringifySearch: options.stringifySearch ?? defaultStringifySearch,
       parseSearch: options.parseSearch ?? defaultParseSearch,
+      transformer: options.transformer ?? {
+        parse: JSON.parse,
+        stringify: JSON.stringify,
+      },
     })
 
     if (typeof document !== 'undefined') {

--- a/packages/react-router/tests/router.test.tsx
+++ b/packages/react-router/tests/router.test.tsx
@@ -482,3 +482,14 @@ describe('router rendering stability', () => {
     expect(callerMock).toBeCalledTimes(1)
   })
 })
+
+describe.only('transformer functions are defined', () => {
+  it('should have default transformer functions', () => {
+    const rootRoute = createRootRoute({})
+    const routeTree = rootRoute.addChildren([])
+    const router = createRouter({ routeTree })
+
+    expect(router.options.transformer.parse).toBeInstanceOf(Function)
+    expect(router.options.transformer.stringify).toBeInstanceOf(Function)
+  })
+})

--- a/packages/react-router/tests/router.test.tsx
+++ b/packages/react-router/tests/router.test.tsx
@@ -483,7 +483,7 @@ describe('router rendering stability', () => {
   })
 })
 
-describe.only('transformer functions are defined', () => {
+describe('transformer functions are defined', () => {
   it('should have default transformer functions', () => {
     const rootRoute = createRootRoute({})
     const routeTree = rootRoute.addChildren([])


### PR DESCRIPTION
This affected anyone trying to use the `basic-ssr-file-based` example as a starting point.