### PR TITLE
fix(start): remove debug log that causes dehydration errors

### DIFF
--- a/packages/react-router/src/ScriptOnce.tsx
+++ b/packages/react-router/src/ScriptOnce.tsx
@@ -2,9 +2,8 @@
 export function ScriptOnce({
   className,
   children,
-  log,
   ...rest
-}: { children: string; log?: boolean } & React.HTMLProps<HTMLScriptElement>) {
+}: { children: string } & React.HTMLProps<HTMLScriptElement>) {
   if (typeof document !== 'undefined') {
     return null
   }
@@ -12,17 +11,9 @@ export function ScriptOnce({
   return (
     <script
       {...rest}
-      className={`tsr-once ${className || ''}`}
+      className={['tsr-once', className].filter(Boolean).join(' ')}
       dangerouslySetInnerHTML={{
-        __html: [
-          children,
-          (log ?? true) && process.env.NODE_ENV === 'development'
-            ? `console.info(\`Injected From Server:
-${children}\`)`
-            : '',
-        ]
-          .filter(Boolean)
-          .join('\n'),
+        __html: [children].filter(Boolean).join('\n'),
       }}
     />
   )

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -2558,15 +2558,10 @@ export class Router<
     )
 
     this.streamedKeys.add(key)
-    const children = `__TSR__.streamedValues['${key}'] = { value: ${this.serializer?.(this.options.transformer.stringify(value))}}`
+    const children = `__TSR__.streamedValues['${key}'] = { value: ${this.serializer?.(this.options.transformer.stringify(value))} }`
 
     this.injectHtml(
-      `<script class='tsr-once'>${children}${
-        process.env.NODE_ENV === 'development'
-          ? `; console.info(\`Injected From Server:
-        ${children}\`)`
-          : ''
-      }; __TSR__.cleanScripts()</script>`,
+      `<script class='tsr-once'>${children}; __TSR__.cleanScripts()</script>`,
     )
   }
 

--- a/packages/start/src/client/Meta.tsx
+++ b/packages/start/src/client/Meta.tsx
@@ -118,7 +118,6 @@ export const useMetaElements = () => {
       ))}
       <>
         <ScriptOnce
-          log={false}
           children={`
 __TSR__ = {
   matches: [],


### PR DESCRIPTION
The debug 'Injected from Server: ' logs are not properly escaped, causing dehydration to fail. These logs have been removed.

`<ScriptOnce/>` debug logs are removed, and the 'tsr-once' class name set on <ScriptOnce/> elements has an extraneous space suffixed to it which has been removed as well.

<img width="459" alt="image" src="https://github.com/user-attachments/assets/2c8b0902-ecea-4603-be93-552136c8ee2c">
