### PR TITLE
fix(react-router,start): ensure document is only used when available

### DIFF
--- a/packages/react-router/src/Transitioner.tsx
+++ b/packages/react-router/src/Transitioner.tsx
@@ -111,13 +111,11 @@ export function Transitioner() {
         resolvedLocation: s.location,
       }))
 
-      if (!router.isServer) {
-        if (tyepof document !== 'undefined' && (document as any).querySelector) {
-          if (router.state.location.hash !== '') {
-            const el = document.getElementById(router.state.location.hash)
-            if (el) {
-              el.scrollIntoView()
-            }
+      if (typeof document !== 'undefined' && (document as any).querySelector) {
+        if (router.state.location.hash !== '') {
+          const el = document.getElementById(router.state.location.hash)
+          if (el) {
+            el.scrollIntoView()
           }
         }
       }

--- a/packages/react-router/src/Transitioner.tsx
+++ b/packages/react-router/src/Transitioner.tsx
@@ -56,7 +56,7 @@ export function Transitioner() {
   // Try to load the initial location
   useLayoutEffect(() => {
     if (
-      window.__TSR__?.dehydrated ||
+      (typeof window !== 'undefined' && window.__TSR__?.dehydrated) ||
       (mountLoadForRouter.current.router === router &&
         mountLoadForRouter.current.mounted)
     ) {
@@ -111,11 +111,13 @@ export function Transitioner() {
         resolvedLocation: s.location,
       }))
 
-      if ((document as any).querySelector) {
-        if (router.state.location.hash !== '') {
-          const el = document.getElementById(router.state.location.hash)
-          if (el) {
-            el.scrollIntoView()
+      if (!router.isServer) {
+        if ((document as any).querySelector) {
+          if (router.state.location.hash !== '') {
+            const el = document.getElementById(router.state.location.hash)
+            if (el) {
+              el.scrollIntoView()
+            }
           }
         }
       }

--- a/packages/react-router/src/Transitioner.tsx
+++ b/packages/react-router/src/Transitioner.tsx
@@ -112,7 +112,7 @@ export function Transitioner() {
       }))
 
       if (!router.isServer) {
-        if ((document as any).querySelector) {
+        if (tyepof document !== 'undefined' && (document as any).querySelector) {
           if (router.state.location.hash !== '') {
             const el = document.getElementById(router.state.location.hash)
             if (el) {

--- a/packages/start/src/client/Meta.tsx
+++ b/packages/start/src/client/Meta.tsx
@@ -173,6 +173,10 @@ export const Meta = ({ children }: { children?: React.ReactNode }) => {
   React[
     typeof document !== 'undefined' ? 'useLayoutEffect' : 'useEffect'
   ](() => {
+    if (typeof document !== 'undefined') {
+      return
+    }
+
     // Remove all meta between the tsr meta tags
     const start = document.head.querySelector('meta[name="tsr-meta"]')
     const end = document.head.querySelector('meta[name="/tsr-meta"]')

--- a/packages/start/src/client/Meta.tsx
+++ b/packages/start/src/client/Meta.tsx
@@ -173,7 +173,7 @@ export const Meta = ({ children }: { children?: React.ReactNode }) => {
   React[
     typeof document !== 'undefined' ? 'useLayoutEffect' : 'useEffect'
   ](() => {
-    if (typeof document !== 'undefined') {
+    if (typeof document === 'undefined') {
       return
     }
 


### PR DESCRIPTION
I’m trying to use `react-test-renderer` to render a component that uses router hooks or components like `Meta`. It seems like `react-test-renderer` is always executing `useLayoutEffect` and `useEffect`. Since I don’t have a global `window` or `document` object during my test run, some components fail when using `document` without checking if it exist.

See also discussion https://github.com/TanStack/router/discussions/2109. 