### PR TITLE
docs: hide the `start-basic-rsc` example from the website

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -203,6 +203,10 @@
               "to": "framework/react/examples/start-basic"
             },
             {
+              "label": "Start Basic + React Query",
+              "to": "framework/react/examples/start-basic-react-query"
+            },
+            {
               "label": "Basic (file-based)",
               "to": "framework/react/examples/basic-file-based"
             },

--- a/docs/config.json
+++ b/docs/config.json
@@ -203,10 +203,6 @@
               "to": "framework/react/examples/start-basic"
             },
             {
-              "label": "Start Basic (RSC)",
-              "to": "framework/react/examples/start-basic-rsc"
-            },
-            {
               "label": "Basic (file-based)",
               "to": "framework/react/examples/basic-file-based"
             },


### PR DESCRIPTION
The `start-basic-rsc` example is in a working condition since TSR's RSC story hasn't been flushed out yet. For the time being, we'll be hiding this option from the website.

Closes #2126 