### PR TITLE
docs(useBlockerHook) fix minor typo in useBlockerHook docs

### DIFF
--- a/docs/framework/react/api/router/useBlockerHook.md
+++ b/docs/framework/react/api/router/useBlockerHook.md
@@ -42,7 +42,7 @@ function MyComponent() {
   const [formIsDirty, setFormIsDirty] = useState(false)
 
   useBlocker({
-    blockerfn: () => window.confirm('Are you sure you want to leave?'),
+    blockerFn: () => window.confirm('Are you sure you want to leave?'),
     condition: formIsDirty,
   })
 


### PR DESCRIPTION
Fixing only minor typos in the router useBlockerHook basic usage `BlockerFn`
[Basic usage](https://tanstack.com/router/latest/docs/framework/react/api/router/useBlockerHook#basic-usage)