### PR TITLE
fix(router-generator): resolving the `routesDirectory` and `generatedRouteTree` when the `configDirectory` is set

### DIFF
--- a/packages/router-generator/src/config.ts
+++ b/packages/router-generator/src/config.ts
@@ -65,5 +65,31 @@ export function getConfig(
     )
   }
 
+  // if a configDirectory is used, paths should be relative to that directory
+  if (configDirectory) {
+    // if absolute configDirectory is provided, use it as the root
+    if (path.isAbsolute(configDirectory)) {
+      config.routesDirectory = path.resolve(
+        configDirectory,
+        config.routesDirectory,
+      )
+      config.generatedRouteTree = path.resolve(
+        configDirectory,
+        config.generatedRouteTree,
+      )
+    } else {
+      config.routesDirectory = path.resolve(
+        process.cwd(),
+        configDirectory,
+        config.routesDirectory,
+      )
+      config.generatedRouteTree = path.resolve(
+        process.cwd(),
+        configDirectory,
+        config.generatedRouteTree,
+      )
+    }
+  }
+
   return config
 }

--- a/packages/router-plugin/src/router-generator.ts
+++ b/packages/router-plugin/src/router-generator.ts
@@ -34,10 +34,7 @@ export const unpluginRouterGeneratorFactory: UnpluginFactory<
     setLock(true)
 
     try {
-      await generator({
-        ...userConfig,
-        routesDirectory: getRoutesDirectoryPath(),
-      })
+      await generator(userConfig)
     } catch (err) {
       console.error(err)
       console.info()

--- a/packages/router-plugin/src/router-generator.ts
+++ b/packages/router-plugin/src/router-generator.ts
@@ -34,7 +34,10 @@ export const unpluginRouterGeneratorFactory: UnpluginFactory<
     setLock(true)
 
     try {
-      await generator(userConfig)
+      await generator({
+        ...userConfig,
+        routesDirectory: getRoutesDirectoryPath(),
+      })
     } catch (err) {
       console.error(err)
       console.info()

--- a/packages/router-plugin/src/router-generator.ts
+++ b/packages/router-plugin/src/router-generator.ts
@@ -85,7 +85,6 @@ export const unpluginRouterGeneratorFactory: UnpluginFactory<
       async configResolved(config) {
         ROOT = config.root
         userConfig = getConfig(options, ROOT)
-        console.log('userConfig', userConfig)
 
         await run(generate)
       },

--- a/packages/router-plugin/src/router-generator.ts
+++ b/packages/router-plugin/src/router-generator.ts
@@ -88,6 +88,7 @@ export const unpluginRouterGeneratorFactory: UnpluginFactory<
       async configResolved(config) {
         ROOT = config.root
         userConfig = getConfig(options, ROOT)
+        console.log('userConfig', userConfig)
 
         await run(generate)
       },


### PR DESCRIPTION
This affects users that have their `root` set to something other than the default, whereby the plugin's watcher functionality stops working.

Fixes #2030 