### PR TITLE
fix(router-generator): scaffolding the initial content for the root route

### DIFF
--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -413,6 +413,33 @@ export async function generator(config: Config) {
     routeNodes.push(node)
   }
 
+  const handleRootNode = (node: RouteNode) => {
+    const routeCode = fs.readFileSync(node.fullPath, 'utf-8')
+
+    if (!routeCode) {
+      const replaced = [
+        `import * as React from 'react'`,
+        `import { Outlet, createRootRoute } from '@tanstack/react-router'`,
+        `export const Route = createRootRoute({
+  component: () => (
+    <React.Fragment>
+      <div>Hello World!</div>
+      <Outlet />
+    </React.Fragment>
+  ),
+})`,
+      ].join('\n\n')
+
+      logger.log(`🟡 Creating ${node.fullPath}`)
+
+      fs.writeFileSync(node.fullPath, replaced)
+    }
+  }
+
+  if (rootRouteNode) {
+    handleRootNode(rootRouteNode)
+  }
+
   for (const node of preRouteNodes) {
     await handleNode(node)
   }

--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -226,6 +226,9 @@ export async function generator(config: Config) {
   // build up a tree based on the routeNodes' routePath
   const routeNodes: Array<RouteNode> = []
 
+  // the handleRootNode function is not being collapsed into the handleNode function
+  // because it requires only a subset of the logic that the handleNode function requires
+  // and it's easier to read and maintain this way
   const handleRootNode = (node?: RouteNode) => {
     if (!node) {
       // currently this is not being handled, but it could be in the future


### PR DESCRIPTION
We handled the scaffolding of "routes" and "lazy routes", but never the "root route". This change adds that functionality with the option to handle having virtual root routes in future if need be.