### PR TITLE
perf(react-router): reduce type parameters of route definitions

### DIFF
--- a/packages/react-router/src/fileRoute.ts
+++ b/packages/react-router/src/fileRoute.ts
@@ -6,23 +6,17 @@ import { useLoaderData } from './useLoaderData'
 import { useSearch } from './useSearch'
 import { useParams } from './useParams'
 import { useNavigate } from './useNavigate'
-import type { NoInfer } from '@tanstack/react-store'
+import { type Constrain } from './utils'
 import type { ParsePathParams } from './link'
 import type {
   AnyContext,
   AnyPathParams,
   AnyRoute,
   AnySearchValidator,
-  DefaultSearchValidator,
   FileBaseRouteOptions,
-  ResolveAllParamsFromParent,
-  ResolveLoaderData,
   ResolveParams,
-  ResolveRouteContext,
   Route,
   RouteConstraints,
-  RouteContext,
-  RouteContextFn,
   RouteLoaderFn,
   UpdatableRouteOptions,
 } from './route'
@@ -73,14 +67,12 @@ export class FileRoute<
   }
 
   createRoute = <
-    TSearchValidator extends AnySearchValidator = DefaultSearchValidator,
+    TSearchValidator = undefined,
     TParams = ResolveParams<TPath>,
-    TAllParams = ResolveAllParamsFromParent<TParentRoute, TParams>,
     TRouteContextFn = AnyContext,
     TBeforeLoadFn = AnyContext,
     TLoaderDeps extends Record<string, any> = {},
-    TLoaderDataReturn = {},
-    TLoaderData = ResolveLoaderData<TLoaderDataReturn>,
+    TLoaderFn = undefined,
     TChildren = unknown,
   >(
     options?: FileBaseRouteOptions<
@@ -89,7 +81,7 @@ export class FileRoute<
       TSearchValidator,
       TParams,
       TLoaderDeps,
-      TLoaderDataReturn,
+      TLoaderFn,
       AnyContext,
       TRouteContextFn,
       TBeforeLoadFn
@@ -97,9 +89,9 @@ export class FileRoute<
       UpdatableRouteOptions<
         TParentRoute,
         TId,
-        TAllParams,
+        TParams,
         TSearchValidator,
-        TLoaderData,
+        TLoaderFn,
         TLoaderDeps,
         AnyContext,
         TRouteContextFn,
@@ -113,13 +105,11 @@ export class FileRoute<
     TId,
     TSearchValidator,
     TParams,
-    TAllParams,
     AnyContext,
     TRouteContextFn,
     TBeforeLoadFn,
     TLoaderDeps,
-    TLoaderDataReturn,
-    TLoaderData,
+    TLoaderFn,
     TChildren
   > => {
     warning(
@@ -142,30 +132,24 @@ export function FileRouteLoader<
   TRoute extends FileRoutesByPath[TFilePath]['preLoaderRoute'],
 >(
   _path: TFilePath,
-): <TLoaderData>(
-  loaderFn: RouteLoaderFn<
-    TRoute['parentRoute'],
-    TRoute['types']['params'],
-    TRoute['types']['loaderDeps'],
-    TRoute['types']['routerContext'],
-    TRoute['types']['routeContextFn'],
-    TRoute['types']['beforeLoadFn'],
-    TLoaderData
+): <TLoaderFn>(
+  loaderFn: Constrain<
+    TLoaderFn,
+    RouteLoaderFn<
+      TRoute['parentRoute'],
+      TRoute['types']['params'],
+      TRoute['types']['loaderDeps'],
+      TRoute['types']['routerContext'],
+      TRoute['types']['routeContextFn'],
+      TRoute['types']['beforeLoadFn']
+    >
   >,
-) => RouteLoaderFn<
-  TRoute['parentRoute'],
-  TRoute['types']['params'],
-  TRoute['types']['loaderDeps'],
-  TRoute['types']['routerContext'],
-  TRoute['types']['routeContextFn'],
-  TRoute['types']['beforeLoadFn'],
-  NoInfer<TLoaderData>
-> {
+) => TLoaderFn {
   warning(
     false,
     `FileRouteLoader is deprecated and will be removed in the next major version. Please place the loader function in the the main route file, inside the \`createFileRoute('/path/to/file')(options)\` options`,
   )
-  return (loaderFn) => loaderFn
+  return (loaderFn) => loaderFn as any
 }
 
 export type LazyRouteOptions = Pick<

--- a/packages/react-router/src/fileRoute.ts
+++ b/packages/react-router/src/fileRoute.ts
@@ -6,8 +6,7 @@ import { useLoaderData } from './useLoaderData'
 import { useSearch } from './useSearch'
 import { useParams } from './useParams'
 import { useNavigate } from './useNavigate'
-import { type Constrain } from './utils'
-import type { ParsePathParams } from './link'
+import type { Constrain } from './utils'
 import type {
   AnyContext,
   AnyPathParams,

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -137,7 +137,6 @@ export type InferRouterContext<TRouteTree extends AnyRoute> =
     any,
     any,
     any,
-    any,
     any
   >
     ? TRouterContext

--- a/packages/react-router/src/utils.ts
+++ b/packages/react-router/src/utils.ts
@@ -99,9 +99,9 @@ export type MergeUnion<TUnion> =
   | MergeUnionPrimitives<TUnion>
   | MergeUnionObject<TUnion>
 
-export type Constrain<T, TConstaint> =
+export type Constrain<T, TConstaint, TDefault = TConstaint> =
   | (T extends TConstaint ? T : never)
-  | TConstaint
+  | TDefault
 
 export function last<T>(arr: Array<T>) {
   return arr[arr.length - 1]


### PR DESCRIPTION
This just optimizes the types a bit after the `context` and other merges. Mainly less type parameters continuing on the tread of reducing them
