### PR TITLE
fix(start): load meta only on successful hydration

### DIFF
--- a/packages/start/src/client/serialization.tsx
+++ b/packages/start/src/client/serialization.tsx
@@ -110,13 +110,18 @@ export function afterHydrate({ router }: { router: AnyRouter }) {
       }
     }
 
+    const meta =
+      match.status === 'success'
+        ? route.options.meta?.({
+            matches: router.state.matches,
+            match,
+            params: match.params,
+            loaderData: match.loaderData,
+          })
+        : undefined
+
     Object.assign(match, {
-      meta: route.options.meta?.({
-        matches: router.state.matches,
-        match,
-        params: match.params,
-        loaderData: match.loaderData,
-      }),
+      meta,
       links: route.options.links?.(),
       scripts: route.options.scripts?.(),
     })


### PR DESCRIPTION
When a route is matched to be unsuccessful such that no loader data is available, the meta function still gets called with undefined loader data. Given that the type signature of the meta function assumes that loader data is always to be defined, a change was made to only call the meta function when a match is successful.