### PR TITLE
fix(start): deferred `createServerFn` calls fails on the client

### DIFF
--- a/examples/react/start-basic/app/routes/deferred.tsx
+++ b/examples/react/start-basic/app/routes/deferred.tsx
@@ -2,20 +2,25 @@ import { Await, createFileRoute, defer } from '@tanstack/react-router'
 import { createServerFn } from '@tanstack/start'
 import { Suspense, useState } from 'react'
 
-const personServerFn = createServerFn('GET', async (name: string) => {
+const personServerFn = createServerFn('GET', (name: string) => {
+  return { name, randomNumber: Math.floor(Math.random() * 100) }
+})
+
+const slowServerFn = createServerFn('GET', async (name: string) => {
   await new Promise((r) => setTimeout(r, 1000))
   return { name, randomNumber: Math.floor(Math.random() * 100) }
 })
 
 export const Route = createFileRoute('/deferred')({
-  loader: () => {
+  loader: async () => {
     return {
       deferredStuff: defer(
         new Promise<string>((r) =>
-          setTimeout(() => r('Hello deferred!'), 5000),
+          setTimeout(() => r('Hello deferred!'), 2000),
         ),
       ),
-      deferredPerson: defer(personServerFn('Tanner Linsley')),
+      deferredPerson: defer(slowServerFn('Tanner Linsley')),
+      person: await personServerFn('John Doe'),
     }
   },
   component: Deferred,
@@ -23,10 +28,13 @@ export const Route = createFileRoute('/deferred')({
 
 function Deferred() {
   const [count, setCount] = useState(0)
-  const { deferredStuff, deferredPerson } = Route.useLoaderData()
+  const { deferredStuff, deferredPerson, person } = Route.useLoaderData()
 
   return (
     <div className="p-2">
+      <div data-testid="regular-person">
+        {person.name} - {person.randomNumber}
+      </div>
       <Suspense fallback={<div>Loading person...</div>}>
         <Await
           promise={deferredPerson}
@@ -38,7 +46,10 @@ function Deferred() {
         />
       </Suspense>
       <Suspense fallback={<div>Loading stuff...</div>}>
-        <Await promise={deferredStuff} children={(data) => <h3>{data}</h3>} />
+        <Await
+          promise={deferredStuff}
+          children={(data) => <h3 data-testid="deferred-stuff">{data}</h3>}
+        />
       </Suspense>
       <div>Count: {count}</div>
       <div>

--- a/examples/react/start-basic/tests/app.spec.ts
+++ b/examples/react/start-basic/tests/app.spec.ts
@@ -32,7 +32,24 @@ test('Navigating to a not-found route', async ({ page }) => {
 test('Navigating to deferred route', async ({ page }) => {
   await page.goto('/')
   await page.getByRole('link', { name: 'Deferred' }).click()
+
+  await expect(page.getByTestId('regular-person')).toContainText('John Doe')
   await expect(page.getByTestId('deferred-person')).toContainText(
     'Tanner Linsley',
+  )
+  await expect(page.getByTestId('deferred-stuff')).toContainText(
+    'Hello deferred!',
+  )
+})
+
+test('Directly visiting the deferred route', async ({ page }) => {
+  await page.goto('/deferred')
+
+  await expect(page.getByTestId('regular-person')).toContainText('John Doe')
+  await expect(page.getByTestId('deferred-person')).toContainText(
+    'Tanner Linsley',
+  )
+  await expect(page.getByTestId('deferred-stuff')).toContainText(
+    'Hello deferred!',
   )
 })

--- a/examples/react/start-basic/tests/app.spec.ts
+++ b/examples/react/start-basic/tests/app.spec.ts
@@ -28,3 +28,11 @@ test('Navigating to a not-found route', async ({ page }) => {
   await page.getByRole('link', { name: 'Start Over' }).click()
   await expect(page.getByRole('heading')).toContainText('Welcome Home!')
 })
+
+test('Navigating to deferred route', async ({ page }) => {
+  await page.goto('/')
+  await page.getByRole('link', { name: 'Deferred' }).click()
+  await expect(page.getByTestId('deferred-person')).toContainText(
+    'Tanner Linsley',
+  )
+})

--- a/packages/start/src/client/serialization.tsx
+++ b/packages/start/src/client/serialization.tsx
@@ -101,9 +101,9 @@ export function afterHydrate({ router }: { router: AnyRouter }) {
         Object.entries(extracted).forEach(([_, ex]: any) => {
           if (ex.value instanceof Promise) {
             const og = ex.value
-            ex.value = og.then((data: any) =>
-              router.options.transformer.parse(data),
-            )
+            ex.value = og.then((data: any) => {
+              return data
+            })
           }
           deepMutableSetByPath(match, ['loaderData', ...ex.path], ex.value)
         })


### PR DESCRIPTION
When wrapping a `createServerFn` call that returns something more complex than a number or string (ie: an Object or an Array), it fails on the client since the `transformer` uses `JSON.parse` which expects a string input (but can also gracefully handle a number input as well).

This fails on the client without the changes being applied in this PR.
```tsx
import { Await, createFileRoute, defer } from '@tanstack/react-router'
import { createServerFn } from '@tanstack/start'
import { Suspense, useState } from 'react'

const serverObject = createServerFn('GET', async () => {
  await new Promise((r) => setTimeout(r, 1000))
  return {
    foo: 'bar',
  }
})

export const Route = createFileRoute('/deferred')({
  loader: () => {
    return {
      deferredObject: defer(serverObject()),
    }
  },
  component: Deferred,
})

function Deferred() {
  const [count, setCount] = useState(0)
  const { deferredObject } = Route.useLoaderData()

  return (
    <div className="p-2">
      <Suspense fallback="Loading...">
        <Await
          promise={deferredObject}
          children={(data) => (
            <h3>
              {data.foo} // uh oh error happens here
            </h3>
          )}
        />
      </Suspense>
      <div>Count: {count}</div>
      <div>
        <button onClick={() => setCount(count + 1)}>Increment</button>
      </div>
    </div>
  )
}

```