### PR TITLE
docs(start): markdown to follow the website flow

### DIFF
--- a/docs/framework/react/start/authentication.md
+++ b/docs/framework/react/start/authentication.md
@@ -3,9 +3,7 @@ id: authentication
 title: Authentication
 ---
 
-// We need some placeholder content here for authentication. One of our partners, Clerk, should get preferential treatment as the "preferred" way of doing auth with TanStack, but we'll support any and all other authentication providers and strategies. Write some general authentication content here until we have docs for both Clerk and other auth providers:
-
-# Authentication
+<!-- We need some placeholder content here for authentication. One of our partners, Clerk, should get preferential treatment as the "preferred" way of doing auth with TanStack, but we'll support any and all other authentication providers and strategies. Write some general authentication content here until we have docs for both Clerk and other auth providers: -->
 
 Authentication is the process of verifying the identity of a user. This is a critical part of any application that requires users to log in or access protected resources. TanStack Start provides the necessary full-stack APIs to implement authentication in your application.
 

--- a/docs/framework/react/start/databases.md
+++ b/docs/framework/react/start/databases.md
@@ -3,8 +3,6 @@ id: databases
 title: Databases
 ---
 
-# Databases
-
 Databases are at the core of any dynamic application, providing the necessary infrastructure to store, retrieve, and manage data. TanStack Start makes it easy to integrate with a variety of databases, offering a flexible approach to managing your application's data layer.
 
 ## What should I use?

--- a/docs/framework/react/start/getting-started.md
+++ b/docs/framework/react/start/getting-started.md
@@ -1,6 +1,6 @@
 ---
-id: installation
-title: Installation
+id: getting-started
+title: Getting Started
 ---
 
 To set up a TanStack Start project, you'll need to:
@@ -39,7 +39,7 @@ Create a `tsconfig.json` file with at least the following settings:
 }
 ```
 
-# Install Dependencies
+## Install Dependencies
 
 TanStack Start is powered by [Vinxi](https://vinxi.vercel.app/) and [TanStack Router](https://tanstack.com/router) and requires them as dependencies.
 
@@ -61,7 +61,7 @@ and some TypeScript:
 npm i -D typescript @types/react @types/react-dom
 ```
 
-# Update Configuration Files
+## Update Configuration Files
 
 We'll then update our `package.json` to reference the new Vinxi entry point and set `"type": "module"`:
 
@@ -86,7 +86,7 @@ import { defineConfig } from '@tanstack/start/config'
 export default defineConfig({})
 ```
 
-# Add the Basic Templating
+## Add the Basic Templating
 
 There are four required files for TanStack Start usage:
 
@@ -232,7 +232,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
 }
 ```
 
-# Writing Your First Route
+## Writing Your First Route
 
 Now that we have the basic templating setup, we can write our first route. This is done by creating a new file in the `app/routes` directory.
 

--- a/docs/framework/react/start/hosting.md
+++ b/docs/framework/react/start/hosting.md
@@ -3,8 +3,6 @@ id: hosting
 title: Hosting
 ---
 
-# Hosting
-
 Hosting is the process of deploying your application to the internet so that users can access it. This is a critical part of any web development project, ensuring your application is available to the world. TanStack Start is built on [Nitro](https://nitro.unjs.io/), a powerful server toolkit for deploying web applications anywhere. Nitro allows TanStack Start to provide a unified API for SSR, streaming, and hydration on any hosting provider.
 
 ## What should I use?

--- a/docs/framework/react/start/observability.md
+++ b/docs/framework/react/start/observability.md
@@ -3,8 +3,6 @@ id: observability
 title: Observability
 ---
 
-# Observability
-
 Observability is a critical aspect of modern web development, enabling you to monitor, trace, and debug your application’s performance and errors. TanStack Start integrates seamlessly with observability tools to provide comprehensive insights into how your application behaves in production, helping you ensure that everything runs smoothly.
 
 ## What should I use?


### PR DESCRIPTION
The Start documentation had some comments which weren't properly commented out and it had top-level headings that conflicted with what the website generated.