### PR TITLE
fix: enforce trailing slashes better and general relative pathing imrovements

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -16,12 +16,15 @@ import type { HistoryState } from '@tanstack/history'
 import type {
   AllParams,
   CatchAllPaths,
+  CurrentPath,
   FullSearchSchema,
   FullSearchSchemaInput,
+  ParentPath,
   RouteByPath,
   RouteByToPath,
   RoutePaths,
   RouteToPath,
+  TrailingSlashOptionByRouter,
 } from './routeInfo'
 import type { RegisteredRouter } from './router'
 import type {
@@ -121,7 +124,7 @@ export type SearchRelativePathAutoComplete<
   TRouter extends AnyRouter,
   TTo extends string,
   TSearchPath extends string,
-> = `${TTo}/${RemoveLeadingSlashes<SearchPaths<TRouter, TSearchPath>>}`
+> = `${TTo}${SearchPaths<TRouter, TSearchPath>}`
 
 export type RelativeToParentPathAutoComplete<
   TRouter extends AnyRouter,
@@ -132,15 +135,15 @@ export type RelativeToParentPathAutoComplete<
   >,
 > =
   | SearchRelativePathAutoComplete<TRouter, TTo, TResolvedPath>
-  | (TResolvedPath extends '' ? never : `${TTo}/../`)
+  | (TResolvedPath extends ''
+      ? never
+      : `${TTo}/${ParentPath<TrailingSlashOptionByRouter<TRouter>>}`)
 
 export type RelativeToCurrentPathAutoComplete<
   TRouter extends AnyRouter,
   TFrom extends string,
   TTo extends string,
-  TRestTo extends string,
-  TResolvedPath extends
-    string = RemoveTrailingSlashes<`${RemoveTrailingSlashes<TFrom>}/${RemoveLeadingSlashes<TRestTo>}`>,
+  TResolvedPath extends string = ResolveRelativePath<TFrom, TTo>,
 > = SearchRelativePathAutoComplete<TRouter, TTo, TResolvedPath>
 
 export type AbsolutePathAutoComplete<
@@ -148,13 +151,17 @@ export type AbsolutePathAutoComplete<
   TFrom extends string,
 > =
   | (string extends TFrom
-      ? './'
+      ? CurrentPath<TrailingSlashOptionByRouter<TRouter>>
       : TFrom extends `/`
         ? never
         : SearchPaths<TRouter, TFrom> extends ''
           ? never
-          : './')
-  | (string extends TFrom ? '../' : TFrom extends `/` ? never : '../')
+          : CurrentPath<TrailingSlashOptionByRouter<TRouter>>)
+  | (string extends TFrom
+      ? ParentPath<TrailingSlashOptionByRouter<TRouter>>
+      : TFrom extends `/`
+        ? never
+        : ParentPath<TrailingSlashOptionByRouter<TRouter>>)
   | RouteToPath<TRouter, TRouter['routeTree']>
   | (TFrom extends '/'
       ? never
@@ -168,12 +175,11 @@ export type RelativeToPathAutoComplete<
   TTo extends string,
 > = TTo extends `..${string}`
   ? RelativeToParentPathAutoComplete<TRouter, TFrom, RemoveTrailingSlashes<TTo>>
-  : TTo extends `./${infer TRestTTo}`
+  : TTo extends `.${string}`
     ? RelativeToCurrentPathAutoComplete<
         TRouter,
         TFrom,
-        RemoveTrailingSlashes<TTo>,
-        TRestTTo
+        RemoveTrailingSlashes<TTo>
       >
     : AbsolutePathAutoComplete<TRouter, TFrom>
 
@@ -312,7 +318,7 @@ export type ResolveToParams<
   ResolveRelativePath<TFrom, TTo> extends infer TPath
     ? string extends TPath
       ? ResolveAllToParams<TRouter, TParamVariant>
-      : TPath extends CatchAllPaths
+      : TPath extends CatchAllPaths<TrailingSlashOptionByRouter<TRouter>>
         ? ResolveAllToParams<TRouter, TParamVariant>
         : ResolveRoute<
             TRouter,
@@ -397,7 +403,7 @@ export type IsRequired<
   ResolveRelativePath<TFrom, TTo> extends infer TPath
     ? string extends TPath
       ? never
-      : TPath extends CatchAllPaths
+      : TPath extends CatchAllPaths<TrailingSlashOptionByRouter<TRouter>>
         ? never
         : IsRequiredParams<
             ResolveRelativeToParams<TRouter, TParamVariant, TFrom, TTo>
@@ -501,7 +507,9 @@ export interface LinkOptionsProps {
 export type CheckPath<TRouter extends AnyRouter, TPass, TFail, TFrom, TTo> =
   string extends ResolveRelativePath<TFrom, TTo>
     ? TPass
-    : ResolveRelativePath<TFrom, TTo> extends CatchAllPaths
+    : ResolveRelativePath<TFrom, TTo> extends CatchAllPaths<
+          TrailingSlashOptionByRouter<TRouter>
+        >
       ? TPass
       : ResolveRoute<TRouter, TFrom, TTo> extends never
         ? TFail

--- a/packages/react-router/src/routeInfo.ts
+++ b/packages/react-router/src/routeInfo.ts
@@ -41,7 +41,22 @@ export type RouteById<TRouteTree extends AnyRoute, TId> = Extract<
 
 export type RouteIds<TRouteTree extends AnyRoute> = ParseRoute<TRouteTree>['id']
 
-export type CatchAllPaths = '.' | '..' | ''
+export type ParentPath<TOption> = 'always' extends TOption
+  ? '../'
+  : 'never' extends TOption
+    ? '..'
+    : '../' | '..'
+
+export type CurrentPath<TOption> = 'always' extends TOption
+  ? './'
+  : 'never' extends TOption
+    ? '.'
+    : './' | '.'
+
+export type CatchAllPaths<TOption> =
+  | CurrentPath<TOption>
+  | ParentPath<TOption>
+  | ''
 
 export type RoutesByPath<TRouteTree extends AnyRoute> = {
   [K in ParseRoute<TRouteTree> as K['fullPath']]: K

--- a/packages/react-router/tests/Matches.test-d.tsx
+++ b/packages/react-router/tests/Matches.test-d.tsx
@@ -158,8 +158,8 @@ test('when matching a route with params', () => {
     .toHaveProperty('to')
     .toEqualTypeOf<
       | '/'
-      | './'
-      | '../'
+      | '.'
+      | '..'
       | '/invoices'
       | '/invoices/$invoiceId'
       | '/comments/$id'
@@ -171,8 +171,8 @@ test('when matching a route with params', () => {
     .toHaveProperty('to')
     .toEqualTypeOf<
       | '/'
-      | './'
-      | '../'
+      | '.'
+      | '..'
       | '/invoices'
       | '/invoices/$invoiceId'
       | '/comments/$id'

--- a/packages/react-router/tests/link.test-d.tsx
+++ b/packages/react-router/tests/link.test-d.tsx
@@ -158,8 +158,8 @@ test('when navigating to the root', () => {
     .parameter(0)
     .toHaveProperty('to')
     .toEqualTypeOf<
-      | '../'
-      | './'
+      | '..'
+      | '.'
       | '/'
       | '/invoices'
       | '/invoices/$invoiceId'
@@ -176,8 +176,8 @@ test('when navigating to the root', () => {
     .parameter(0)
     .toHaveProperty('to')
     .toEqualTypeOf<
-      | '../'
-      | './'
+      | '..'
+      | '.'
       | '/'
       | '/invoices'
       | '/invoices/$invoiceId'
@@ -212,8 +212,8 @@ test('when navigating to the root', () => {
     .parameter(0)
     .toHaveProperty('to')
     .toEqualTypeOf<
-      | '../'
-      | './'
+      | '..'
+      | '.'
       | '/'
       | '/invoices'
       | '/invoices/$invoiceId'
@@ -230,8 +230,10 @@ test('when navigating to the root', () => {
     .parameter(0)
     .toHaveProperty('to')
     .toEqualTypeOf<
-      | '../'
+      | '..'
+      | '.'
       | './'
+      | '../'
       | '/'
       | '/invoices'
       | '/invoices/'
@@ -388,8 +390,8 @@ test('when navigating from a route with no params and no search to the root', ()
     .parameter(0)
     .toHaveProperty('to')
     .toEqualTypeOf<
-      | '../'
-      | './'
+      | '..'
+      | '.'
       | '/'
       | ''
       | '/invoices'
@@ -408,8 +410,8 @@ test('when navigating from a route with no params and no search to the root', ()
     .parameter(0)
     .toHaveProperty('to')
     .toEqualTypeOf<
-      | '../'
-      | './'
+      | '..'
+      | '.'
       | '/'
       | ''
       | '/invoices'
@@ -448,8 +450,8 @@ test('when navigating from a route with no params and no search to the root', ()
     .parameter(0)
     .toHaveProperty('to')
     .toEqualTypeOf<
-      | '../'
-      | './'
+      | '..'
+      | '.'
       | '/'
       | ''
       | '/invoices'
@@ -468,6 +470,8 @@ test('when navigating from a route with no params and no search to the root', ()
     .parameter(0)
     .toHaveProperty('to')
     .toEqualTypeOf<
+      | '.'
+      | '..'
       | '../'
       | '../'
       | './'
@@ -609,12 +613,12 @@ test('when navigating from a route with no params and no search to the current r
   expectTypeOf(Link<DefaultRouter, '/posts/', './'>)
     .parameter(0)
     .toHaveProperty('to')
-    .toEqualTypeOf<'./$postId' | undefined | './'>()
+    .toEqualTypeOf<'./$postId' | undefined | './' | '.'>()
 
   expectTypeOf(Link<DefaultRouterObjects, '/posts/', './'>)
     .parameter(0)
     .toHaveProperty('to')
-    .toEqualTypeOf<'./$postId' | undefined | './'>()
+    .toEqualTypeOf<'./$postId' | undefined | './' | '.'>()
 
   expectTypeOf(Link<RouterAlwaysTrailingSlashes, '/posts/', './'>)
     .parameter(0)
@@ -624,20 +628,20 @@ test('when navigating from a route with no params and no search to the current r
   expectTypeOf(Link<RouterNeverTrailingSlashes, '/posts/', './'>)
     .parameter(0)
     .toHaveProperty('to')
-    .toEqualTypeOf<'./$postId' | undefined | './'>()
+    .toEqualTypeOf<'./$postId' | undefined | './' | '.'>()
 
   expectTypeOf(Link<RouterPreserveTrailingSlashes, '/posts/', './'>)
     .parameter(0)
     .toHaveProperty('to')
-    .toEqualTypeOf<'./$postId/' | './$postId' | undefined | './'>()
+    .toEqualTypeOf<'./$postId/' | './$postId' | undefined | './' | '.'>()
 
-  expectTypeOf(Link<DefaultRouter, '/posts/', './'>)
+  expectTypeOf(Link<DefaultRouter, '/posts/', '.'>)
     .parameter(0)
     .toHaveProperty('search')
     .exclude<Function>()
     .toEqualTypeOf<{ rootPage?: number } | undefined | true>()
 
-  expectTypeOf(Link<DefaultRouterObjects, '/posts/', './'>)
+  expectTypeOf(Link<DefaultRouterObjects, '/posts/', '.'>)
     .parameter(0)
     .toHaveProperty('search')
     .exclude<Function>()
@@ -649,7 +653,7 @@ test('when navigating from a route with no params and no search to the current r
     .exclude<Function>()
     .toEqualTypeOf<{ rootPage?: number } | undefined | true>()
 
-  expectTypeOf(Link<RouterNeverTrailingSlashes, '/posts/', './'>)
+  expectTypeOf(Link<RouterNeverTrailingSlashes, '/posts/', '.'>)
     .parameter(0)
     .toHaveProperty('search')
     .exclude<Function>()
@@ -661,7 +665,7 @@ test('when navigating from a route with no params and no search to the current r
     .exclude<Function>()
     .toEqualTypeOf<{ rootPage?: number } | undefined | true>()
 
-  expectTypeOf(Link<DefaultRouter, '/posts/', './'>)
+  expectTypeOf(Link<DefaultRouter, '/posts/', '.'>)
     .parameter(0)
     .toHaveProperty('search')
     .returns.toEqualTypeOf<{ rootPage?: number }>()
@@ -821,8 +825,8 @@ test('cannot navigate to a branch with an index', () => {
       | '/invoices/$invoiceId/details'
       | '/invoices/$invoiceId/details/$detailId'
       | '/invoices/$invoiceId/details/$detailId/lines'
-      | './'
-      | '../'
+      | '.'
+      | '..'
       | undefined
     >()
 
@@ -839,8 +843,8 @@ test('cannot navigate to a branch with an index', () => {
       | '/invoices/$invoiceId/details'
       | '/invoices/$invoiceId/details/$detailId'
       | '/invoices/$invoiceId/details/$detailId/lines'
-      | './'
-      | '../'
+      | '.'
+      | '..'
       | undefined
     >()
 
@@ -877,8 +881,8 @@ test('cannot navigate to a branch with an index', () => {
       | '/invoices/$invoiceId/details'
       | '/invoices/$invoiceId/details/$detailId'
       | '/invoices/$invoiceId/details/$detailId/lines'
-      | './'
-      | '../'
+      | '.'
+      | '..'
       | undefined
     >()
 
@@ -905,6 +909,8 @@ test('cannot navigate to a branch with an index', () => {
       | '/invoices/$invoiceId/details/$detailId/'
       | '/invoices/$invoiceId/details/$detailId/lines'
       | '/invoices/$invoiceId/details/$detailId/lines/'
+      | '.'
+      | '..'
       | './'
       | '../'
       | undefined
@@ -1120,7 +1126,7 @@ test('when navigating to the parent route', () => {
   const RouterAlwaysTrailingSlashesLink = Link<
     RouterAlwaysTrailingSlashes,
     string,
-    '..'
+    '../'
   >
   const RouterNeverTrailingSlashesLink = Link<
     RouterNeverTrailingSlashes,

--- a/packages/react-router/tests/redirects.test-d.tsx
+++ b/packages/react-router/tests/redirects.test-d.tsx
@@ -40,6 +40,6 @@ test('can redirect to valid route', () => {
     .parameter(0)
     .toHaveProperty('to')
     .toEqualTypeOf<
-      '/' | '/invoices' | '/invoices/$invoiceId' | './' | '../' | undefined
+      '/' | '/invoices' | '/invoices/$invoiceId' | '.' | '..' | undefined
     >()
 })

--- a/packages/react-router/tests/route.test-d.tsx
+++ b/packages/react-router/tests/route.test-d.tsx
@@ -1039,8 +1039,8 @@ test('when creating a child route with context, search, params and beforeLoad', 
           | '/invoices/$invoiceId'
           | '/invoices/$invoiceId/details'
           | '/invoices/$invoiceId/details/$detailId'
-          | './'
-          | '../'
+          | '.'
+          | '..'
           | undefined
         >()
     },

--- a/packages/react-router/tests/useNavigate.test-d.tsx
+++ b/packages/react-router/tests/useNavigate.test-d.tsx
@@ -42,7 +42,7 @@ test('when navigating to a route', () => {
     .parameter(0)
     .toHaveProperty('to')
     .toEqualTypeOf<
-      '/' | '/invoices' | '/invoices/$invoiceId' | './' | '../' | undefined
+      '/' | '/invoices' | '/invoices/$invoiceId' | '.' | '..' | undefined
     >()
 })
 


### PR DESCRIPTION
Due to the trailing slashes setting there were some left over annoyances with relative pathing.

Firstly was possible to use `./` or `../` when trailing slashes was set to `never` but the route resolved to `never` because we handled this properly.

Secondly suggestions for relative routing were triggered when the user typed `..` for parent paths but triggered for './` for current paths

fixes #1838