### PR TITLE
fix(react-router): remove groups when using `createLazyFileRoute`

### DIFF
--- a/packages/react-router/src/fileRoute.ts
+++ b/packages/react-router/src/fileRoute.ts
@@ -241,9 +241,16 @@ export function createLazyRoute<
   }
 }
 
+const routeGroupPatternRegex = /\(.+\)/g
+
+function removeGroups(s: string) {
+  return s.replaceAll(routeGroupPatternRegex, '').replaceAll('//', '/')
+}
+
 export function createLazyFileRoute<
   TFilePath extends keyof FileRoutesByPath,
   TRoute extends FileRoutesByPath[TFilePath]['preLoaderRoute'],
 >(id: TFilePath) {
-  return (opts: LazyRouteOptions) => new LazyRoute<TRoute>({ id, ...opts })
+  return (opts: LazyRouteOptions) =>
+    new LazyRoute<TRoute>({ id: removeGroups(id), ...opts })
 }


### PR DESCRIPTION
fixes #2219