### PR TITLE
fix(react-router): reset error boundary after the new matches are ready

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1643,11 +1643,6 @@ export class Router<
   load = async (): Promise<void> => {
     this.latestLocation = this.parseLocation(this.latestLocation)
 
-    this.__store.setState((s) => ({
-      ...s,
-      loadedAt: Date.now(),
-    }))
-
     let redirect: ResolvedRedirect | undefined
     let notFound: NotFoundError | undefined
 
@@ -1738,6 +1733,7 @@ export class Router<
                     return {
                       ...s,
                       isLoading: false,
+                      loadedAt: Date.now(),
                       matches: newMatches,
                       pendingMatches: undefined,
                       cachedMatches: [


### PR DESCRIPTION
In the current version of the router, the error boundary is reset at the beginning of the loading phase of the new matching routes. This is a problem because the currently rendered routes can re-render while the new ones ar being in the loading process. If this is the case, the re-render will trigger the error boundary again and will void the reset.

I believe the reset should happen only after the new routes have finished loading. In this way, the reset will be in sync with the matched routes.

I don't know if this fix might have some side effects, but on our project it seems to work. If you think that this fix is not ok or you have a better solution, I would be happy to try it out.

Here is the issue I am referring to: https://github.com/TanStack/router/issues/2162

fixes #2162
fixes #2043