### PR TITLE
fix(react-router): `pendingComponent` not rendering with preload='intent'

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1997,12 +1997,8 @@ export class Router<
                 existingMatch.beforeLoadPromise ||
                 existingMatch.loaderPromise
               ) {
-                let pendingTimeout: ReturnType<typeof setTimeout>
-
                 if (shouldPending) {
-                  // If we might show a pending component, we need to wait for the
-                  // pending promise to resolve before we start showing that state
-                  pendingTimeout = setTimeout(() => {
+                  setTimeout(() => {
                     try {
                       // Update the match and prematurely resolve the loadMatches promise so that
                       // the pending component can start rendering


### PR DESCRIPTION
Hi, I tried fixing this issue #2008. If route had preload: 'intent' enabled, the pendingComponent would not show, UI just waited for promise to end, and then it would switch route. I found out, that triggerOnReady() in router.ts weren't used if route had beforeLoadPromise or loaderPromise to await for.

https://github.com/user-attachments/assets/960609ad-1e4f-4cf9-a376-ad32f16e3e2a


https://github.com/user-attachments/assets/7701b0ba-4def-42a9-b543-89f26e9003bb

