### PR TITLE
refactor(react-router): `never` return type for `notFound`

### DIFF
--- a/packages/router-core/src/not-found.ts
+++ b/packages/router-core/src/not-found.ts
@@ -18,8 +18,8 @@ export type NotFoundError = {
   headers?: HeadersInit
 }
 
-export function notFound(options: { throw: true }): never
-export function notFound(options: { throw?: false }): NotFoundError
+export function notFound(options: NotFoundError & { throw: true }): never
+export function notFound(options?: NotFoundError): NotFoundError
 export function notFound(options: NotFoundError = {}): NotFoundError | never {
   ;(options as any).isNotFound = true
   if (options.throw) throw options

--- a/packages/router-core/src/not-found.ts
+++ b/packages/router-core/src/not-found.ts
@@ -18,7 +18,9 @@ export type NotFoundError = {
   headers?: HeadersInit
 }
 
-export function notFound(options: NotFoundError = {}) {
+export function notFound(options: { throw: true }): never
+export function notFound(options: { throw?: false }): NotFoundError
+export function notFound(options: NotFoundError = {}): NotFoundError | never {
   ;(options as any).isNotFound = true
   if (options.throw) throw options
   return options


### PR DESCRIPTION
Currently, when you call `notFound({ throw: true })` Typescript does not identify it as never returning.

A discussion of this issue: https://github.com/TanStack/router/discussions/2168

Here is an example:

```ts
export const Route = createFileRoute('/$tenantId')({
  loader: async ({ context, params: { tenantId } }) => {
    const result = await context.getTenantInfo()
    if (!result) {
      throw new Error('Got no result')
    }
    if (result.error) {
      throw result.error
    }
    if (!result.data.tenant) {
      notFound({ throw: true })
    }
    return result.data.tenant
  },
  component: TenantLayout,
})

function TenantLayout() {
  const tenant = Route.useLoaderData() // tenant is possibly null or undefined
}
```

Typescript infers the return type of the `loader` function in this case to be either a data structure or `undefined` or `null`. Since the type being returned is a subset of another object, defining an explicit type is not very efficient.

Fortunately Typescript can be given a hint that the `notFound` function will never return, and in that case will infer a non-nullable return type.

Because the `notFound` function only raises an exception when the `throws` option is true, this is expressed as an overload of the function. The overloads tell Typescript the concrete return types depending on options passed, returning `never` when `throws` is true, and returning a `NotFoundError` in other cases.

With this in place, the result of `Route.useLoaderData()` is a non-nullable data structure.

(The `throws: true` implementation is desired when using eslint, since it will complain about throwing a `NotFoundError` because it does not inherit from `Error`. By asking the function to throw instead, we can bypass the eslint complaint. The complaint is otherwise desirable, but the internal implementation of the router throws and catches these specific `NotFoundError` objects, and our application should not catch one, so the eslint complaint is not applicable.)
