### PR TITLE
docs(react): fix broken links in route-trees.md and routing-concepts.md

### DIFF
--- a/docs/framework/react/guide/route-trees.md
+++ b/docs/framework/react/guide/route-trees.md
@@ -61,9 +61,9 @@ The above is a valid route tree configuration that can be used with TanStack Rou
 
 Route trees can be configured using a few different ways:
 
-- [Flat Routes](./route-trees.md#flat-routes)
-- [Directories](./route-trees.md#directory-routes)
-- [Mixed Flat Routes and Directories](./route-trees.md#mixed-flat-and-directory-routes)
-- [Code-Based Routes](./route-trees.md#code-based-routes)
+- [Flat Routes](./file-based-routing#flat-routes)
+- [Directories](./file-based-routing#directory-routes)
+- [Mixed Flat Routes and Directories](./file-based-routing#mixed-flat-and-directory-routes)
+- [Code-Based Routes](./code-based-routing)
 
 For a birds-eye view, the route tree examples below showcase the [Routing Concepts](./routing-concepts.md) that are available in TanStack Router, but please be sure to check out the full documentation links above for each type of route tree, or just proceed to the next section to get started with file-based routing.

--- a/docs/framework/react/guide/routing-concepts.md
+++ b/docs/framework/react/guide/routing-concepts.md
@@ -8,7 +8,7 @@ TanStack Router supports a number of powerful routing concepts that allow you to
 - [Static Routes](./routing-concepts.md#static-routes)
 - [Index Routes](./routing-concepts.md#index-routes)
 - [Dynamic Route Segments](./routing-concepts.md#dynamic-route-segments)
-- [Splat / Catch-All Routes](./routing-concept.md#splat--catch-all-routes)
+- [Splat / Catch-All Routes](./routing-concepts.md#splat--catch-all-routes)
 - [Pathless Routes](./routing-concepts.md#pathless--layout-routes)
 - [Non-Nested Routes](./routing-concepts.md#non-nested-routes)
 - [Not-Found Routes](./routing-concepts.md#404--notfoundroutes)


### PR DESCRIPTION
This PR fixes broken hyperlinks in `docs/framework/react/guide/route-trees.md` and `docs/framework/react/guide/routing-concepts.md`.

- `route-trees.md`: route tree examples no longer exist in this page, so the hyperlinks should point to the full documentation for each route type. ([page link](https://tanstack.com/router/latest/docs/framework/react/guide/route-trees#route-tree-configuration))
- `routing-concepts.md`: there is a typo that leads to a 404 page. ([page link](https://tanstack.com/router/latest/docs/framework/react/guide/routing-concepts))