### PR TITLE
refactor(start): return JSON response when 'content-type' matches

### DIFF
--- a/packages/start/src/client-runtime/fetcher.tsx
+++ b/packages/start/src/client-runtime/fetcher.tsx
@@ -124,26 +124,27 @@ export async function fetcher<TPayload>(
 async function handleResponseErrors(response: Response) {
   if (!response.ok) {
     const contentType = response.headers.get('content-type')
+    const isJson = contentType && contentType.includes('application/json')
+
     const body = await (async () => {
-      if (contentType && contentType.includes('application/json')) {
+      if (isJson) {
         return await response.json()
       }
       return await response.text()
     })()
 
-    if (contentType && contentType.includes('application/json')) {
+    const message = `Request failed with status ${response.status}`
+
+    if (isJson) {
       throw new Error(
         JSON.stringify({
-          message: `Request failed with status ${response.status}`,
+          message,
           body,
         }),
       )
     } else {
       throw new Error(
-        [
-          `Request failed with status ${response.status}`,
-          `${JSON.stringify(body, null, 2)}`,
-        ].join('\n\n'),
+        [message, `${JSON.stringify(body, null, 2)}`].join('\n\n'),
       )
     }
   }

--- a/packages/start/src/client-runtime/fetcher.tsx
+++ b/packages/start/src/client-runtime/fetcher.tsx
@@ -123,20 +123,29 @@ export async function fetcher<TPayload>(
 
 async function handleResponseErrors(response: Response) {
   if (!response.ok) {
+    const contentType = response.headers.get('content-type')
     const body = await (async () => {
-      const contentType = response.headers.get('content-type')
       if (contentType && contentType.includes('application/json')) {
         return await response.json()
       }
       return await response.text()
     })()
 
-    throw new Error(
-      [
-        `Request failed with status ${response.status}`,
-        `${JSON.stringify(body, null, 2)}`,
-      ].join('\n\n'),
-    )
+    if (contentType && contentType.includes('application/json')) {
+      throw new Error(
+        JSON.stringify({
+          message: `Request failed with status ${response.status}`,
+          body,
+        }),
+      )
+    } else {
+      throw new Error(
+        [
+          `Request failed with status ${response.status}`,
+          `${JSON.stringify(body, null, 2)}`,
+        ].join('\n\n'),
+      )
+    }
   }
 
   return response


### PR DESCRIPTION
This change, has the error being thrown by the client fetcher be a JSON object instead of a plain string. This makes it so, that when its consumed on the client it'll have the error content stored in an object.

```jsonc
{
  "message": "Response failed with a status 500",
  "body": { "foo": "bar" } // this is the actual error content
}
```

closes #2238 