### PR TITLE
fix(start): fix hmr by stubbing react refresh runtime

### DIFF
--- a/packages/start/src/router-manifest/index.ts
+++ b/packages/start/src/router-manifest/index.ts
@@ -20,7 +20,12 @@ export function getFullRouterManifest() {
   if (process.env.NODE_ENV === 'development') {
     rootRoute.assets.push({
       tag: 'script',
-      children: `window.__vite_plugin_react_preamble_installed__ = true`,
+      attrs: { type: 'module' },
+      children: `import RefreshRuntime from "/_build/@react-refresh";
+RefreshRuntime.injectIntoGlobalHook(window)
+window.$RefreshReg$ = () => {}
+window.$RefreshSig$ = () => (type) => type
+window.__vite_plugin_react_preamble_installed__ = true`,
     })
   }
 


### PR DESCRIPTION
Unsure if this is a foolproof solution since it stubs variables/functions i.e. `$Refresh{Reg,Sig}$` and `__vite_plugin_react_preamble_installed`, though this has been a fix for my HMR issues with TanStack Start on a project I have in production.