### PR TITLE
perf(react-router): reduce instantiations for relative routing after language service performance

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -119,7 +119,8 @@ export type SearchPaths<
   TSearchPath extends string,
   TPaths = ResolvePaths<TRouter, TSearchPath>,
   TPrefix extends string = `${RemoveTrailingSlashes<TSearchPath>}/`,
-> = TPaths extends `${TPrefix}${infer TRest}` ? TRest : never
+  TFilteredPaths = TPaths & `${TPrefix}${string}`,
+> = TFilteredPaths extends `${TPrefix}${infer TRest}` ? TRest : never
 
 export type SearchRelativePathAutoComplete<
   TRouter extends AnyRouter,


### PR DESCRIPTION
There was a regression in instantiations which affected overall check time with the new language service improvements. This PR reduces it back down.

Before

```
> tsc --extendedDiagnostics

Files:                         683
Lines of Library:            41276
Lines of Definitions:        86370
Lines of TypeScript:         24510
Lines of JavaScript:             0
Lines of JSON:                   0
Lines of Other:                  0
Identifiers:                144216
Symbols:                    338892
Types:                      113449
Instantiations:            1040616
Memory used:               368084K
Assignability cache size:    86626
Identity cache size:          8937
Subtype cache size:           2830
Strict subtype cache size:      10
I/O Read time:               0.09s
Parse time:                  0.57s
ResolveModule time:          0.19s
ResolveTypeReference time:   0.00s
ResolveLibrary time:         0.03s
Program time:                1.00s
Bind time:                   0.30s
Check time:                  6.20s
printTime time:              0.00s
Emit time:                   0.00s
Total time:                  7.51s
```

After

```
> tsc --extendedDiagnostics

Files:                         683
Lines of Library:            41276
Lines of Definitions:        86370
Lines of TypeScript:         24510
Lines of JavaScript:             0
Lines of JSON:                   0
Lines of Other:                  0
Identifiers:                144219
Symbols:                    339108
Types:                      111645
Instantiations:             737362
Memory used:               368396K
Assignability cache size:    45486
Identity cache size:          8937
Subtype cache size:          44038
Strict subtype cache size:      10
I/O Read time:               0.09s
Parse time:                  0.57s
ResolveModule time:          0.19s
ResolveTypeReference time:   0.00s
ResolveLibrary time:         0.03s
Program time:                1.00s
Bind time:                   0.29s
Check time:                  5.85s
printTime time:              0.00s
Emit time:                   0.00s
Total time:                  7.14s
```