### PR TITLE
fix(react-router) : search parameters getting overridden on page load

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1326,9 +1326,10 @@ export class Router<
         'Could not find match for from: ' + dest.from,
       )
 
-      const fromSearch = this.state.pendingMatches
-        ? last(this.state.pendingMatches)?.search
-        : last(fromMatches)?.search || this.latestLocation.search
+      const fromSearch =
+        (this.state.pendingMatches
+          ? last(this.state.pendingMatches)?.search
+          : last(fromMatches)?.search) || this.latestLocation.search
 
       const stayingMatches = matches?.filter((d) =>
         fromMatches.find((e) => e.routeId === d.routeId),


### PR DESCRIPTION
Solves [#2290 ](https://github.com/TanStack/router/issues/2290)