### PR TITLE
fix(react-router): Correct typo in optional peerDependenciesMeta

### DIFF
--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -84,7 +84,7 @@
     "@tanstack/router-generator": "workspace:*"
   },
   "peerDependenciesMeta": {
-    "@tanstack/react-generator": {
+    "@tanstack/router-generator": {
       "optional": true
     }
   }


### PR DESCRIPTION
There is no package called `@tanstack/react-generator` so I guess it is meant to be `@tanstack/router-generator`.