### PR TITLE
docs: correcting a variable reference in external-data-loading.md

### DIFF
--- a/docs/framework/react/guide/external-data-loading.md
+++ b/docs/framework/react/guide/external-data-loading.md
@@ -175,7 +175,7 @@ export function createRouter() {
     // On the client, hydrate the loader client with the data
     // we dehydrated on the server
     hydrate: (dehydrated) => {
-      hydrate(client, dehydrated.queryClientState)
+      hydrate(queryClient, dehydrated.queryClientState)
     },
     // Optionally, we can use `Wrap` to wrap our router in the loader client provider
     Wrap: ({ children }) => {


### PR DESCRIPTION
"client" should have been "queryClient"