### PR TITLE
fix(router-plugin): normalize file path in `fileIsInRoutesDirectory` to ensure windows compatibility

### DIFF
--- a/packages/router-plugin/src/core/router-code-splitter-plugin.ts
+++ b/packages/router-plugin/src/core/router-code-splitter-plugin.ts
@@ -15,7 +15,10 @@ function capitalizeFirst(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1)
 }
 
-function fileIsInRoutesDirectory(filePath: string, routesDirectory: string) {
+function fileIsInRoutesDirectory(
+  filePath: string,
+  routesDirectory: string,
+): boolean {
   const routesDirectoryPath = isAbsolute(routesDirectory)
     ? routesDirectory
     : join(process.cwd(), routesDirectory)
@@ -62,7 +65,7 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
   const debug = Boolean(process.env.TSR_VITE_DEBUG)
 
   let ROOT: string = process.cwd()
-  let userConfig = options
+  let userConfig = options as Config
 
   const handleSplittingFile = (code: string, id: string) => {
     if (debug) console.info('Splitting route: ', id)

--- a/packages/router-plugin/src/core/router-code-splitter-plugin.ts
+++ b/packages/router-plugin/src/core/router-code-splitter-plugin.ts
@@ -16,11 +16,10 @@ function capitalizeFirst(str: string): string {
 }
 
 function fileIsInRoutesDirectory(filePath: string, routesDirectory: string) {
-  const routesDirectoryPath = normalize(
-    isAbsolute(routesDirectory)
-      ? routesDirectory
-      : join(process.cwd(), routesDirectory),
-  )
+  const routesDirectoryPath = isAbsolute(routesDirectory)
+    ? routesDirectory
+    : join(process.cwd(), routesDirectory)
+
   const path = normalize(filePath)
 
   return path.startsWith(routesDirectoryPath)

--- a/packages/router-plugin/src/core/router-code-splitter-plugin.ts
+++ b/packages/router-plugin/src/core/router-code-splitter-plugin.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, join } from 'node:path'
+import { isAbsolute, join, normalize } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
 import { getConfig } from './config'
@@ -16,11 +16,14 @@ function capitalizeFirst(str: string): string {
 }
 
 function fileIsInRoutesDirectory(filePath: string, routesDirectory: string) {
-  const routesDirectoryPath = isAbsolute(routesDirectory)
-    ? routesDirectory
-    : join(process.cwd(), routesDirectory)
+  const routesDirectoryPath = normalize(
+    isAbsolute(routesDirectory)
+      ? routesDirectory
+      : join(process.cwd(), routesDirectory),
+  )
+  const path = normalize(filePath)
 
-  return filePath.startsWith(routesDirectoryPath)
+  return path.startsWith(routesDirectoryPath)
 }
 
 type BannedBeforeExternalPlugin = {
@@ -60,7 +63,7 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
   const debug = Boolean(process.env.TSR_VITE_DEBUG)
 
   let ROOT: string = process.cwd()
-  let userConfig = options as Config
+  let userConfig = options
 
   const handleSplittingFile = (code: string, id: string) => {
     if (debug) console.info('Splitting route: ', id)


### PR DESCRIPTION
use `path.normalize` to normalize the path.

It should convert `G:/Programs/Node.js/reproduce-vite-code-splitting` to `G:\Programs\Node.js\reproduce-vite-code-splitting` in windows.

It fix #2364 and maybe fix #2167 too.

Here is a CI run log using this patch: https://github.com/greenhat616/reproduce-vite-code-splitting/actions/runs/10928570228/job/30337286182

The build in windows works as expect via this patch