### PR TITLE
test(react-router): set up performance testing for Link

### DIFF
--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -35,6 +35,8 @@
     "test:types:ts56": "tsc -p tsconfig.legacy.json",
     "test:unit": "vitest",
     "test:unit:dev": "pnpm run test:unit --watch --hideSkippedTests",
+    "test:perf": "vitest bench",
+    "test:perf:dev": "pnpm run test:perf --watch --hideSkippedTests",
     "test:build": "publint --strict && attw --ignore-rules no-resolution --pack .",
     "build": "vite build"
   },

--- a/packages/react-router/tests/link.bench.tsx
+++ b/packages/react-router/tests/link.bench.tsx
@@ -50,17 +50,23 @@ type LinkProps = React.PropsWithChildren<{
 
 describe.each([
   {
-    name: 'small router (1 route with params)',
+    name: 'small router',
     numberOfRoutes: 1,
     matchedParamId: 0, // range from 0 to numberOfRoutes-1
     numberOfLinks: 5000,
   },
   {
-    name: 'large router (1000 routes with params)',
+    name: 'medium router',
     numberOfRoutes: 1000,
     matchedParamId: 500, // range from 0 to numberOfRoutes-1
     numberOfLinks: 5000,
   },
+  // {
+  //   name: 'large router',
+  //   numberOfRoutes: 10000,
+  //   matchedParamId: 9999, // range from 0 to numberOfRoutes-1
+  //   numberOfLinks: 15000,
+  // },
 ])('$name', ({ numberOfRoutes, numberOfLinks, matchedParamId }) => {
   const renderRouter = createRouterRenderer(numberOfRoutes)
 
@@ -86,8 +92,8 @@ describe.each([
         Array.from({ length: numberOfLinks }).map((_, i) => (
           <InterpolatePathLink
             key={i}
-            to={`/params/$param${matchedParamId}`}
-            params={{ [`param${matchedParamId}`]: i }}
+            to={`/params/$param${Math.min(i, matchedParamId)}`}
+            params={{ [`param${Math.min(i, matchedParamId)}`]: i }}
           >
             {i}
           </InterpolatePathLink>
@@ -105,8 +111,8 @@ describe.each([
         Array.from({ length: numberOfLinks }).map((_, i) => (
           <BuildLocationLink
             key={i}
-            to={`/params/$param${matchedParamId}`}
-            params={{ [`param${matchedParamId}`]: i }}
+            to={`/params/$param${Math.min(i, matchedParamId)}`}
+            params={{ [`param${Math.min(i, matchedParamId)}`]: i }}
           >
             {i}
           </BuildLocationLink>
@@ -124,8 +130,8 @@ describe.each([
         Array.from({ length: numberOfLinks }).map((_, i) => (
           <Link
             key={i}
-            to={`/params/$param${matchedParamId}`}
-            params={{ [`param${matchedParamId}`]: i }}
+            to={`/params/$param${Math.min(i, matchedParamId)}`}
+            params={{ [`param${Math.min(i, matchedParamId)}`]: i }}
           >
             {i}
           </Link>

--- a/packages/react-router/tests/link.bench.tsx
+++ b/packages/react-router/tests/link.bench.tsx
@@ -2,16 +2,15 @@ import { render } from '@testing-library/react'
 import { bench, describe } from 'vitest'
 import {
   Link,
-  
   RouterProvider,
   createMemoryHistory,
   createRootRoute,
   createRoute,
   createRouter,
   interpolatePath,
-  useRouter
+  useRouter,
 } from '../src'
-import type {LinkProps} from '../src';
+import type { LinkProps } from '../src'
 
 const createRouterRenderer =
   (routesCount: number) => (children: React.ReactNode) => {

--- a/packages/react-router/tests/link.bench.tsx
+++ b/packages/react-router/tests/link.bench.tsx
@@ -1,0 +1,137 @@
+import { render } from '@testing-library/react'
+import { bench, describe } from 'vitest'
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  interpolatePath,
+  Link,
+  RouterContextProvider,
+  useRouter,
+} from '../src'
+
+const createTestRouter = (routesCount: number) => {
+  const rootRoute = createRootRoute()
+  const indexRoute = createRoute({ getParentRoute: () => rootRoute, path: '/' })
+  const paramRoutes = Array.from({ length: routesCount }).map((_, i) =>
+    createRoute({
+      getParentRoute: () => indexRoute,
+      path: `/params/$param${i}`,
+    }),
+  )
+  const routeTree = rootRoute.addChildren([indexRoute, ...paramRoutes])
+  return createRouter({
+    routeTree,
+    history: createMemoryHistory(),
+  })
+}
+
+const InterpolatePathLink = ({ to, params, children }: LinkProps) => {
+  const href = interpolatePath({ path: to, params })
+  return <a href={href}>{children}</a>
+}
+
+const BuildLocationLink = ({ to, params, children }: LinkProps) => {
+  const router = useRouter()
+  const { href } = router.buildLocation({ to, params })
+  return <a href={href}>{children}</a>
+}
+
+type LinkProps = React.PropsWithChildren<{
+  to: string
+  params: Record<string, string | number>
+}>
+
+describe.each([
+  {
+    name: 'small router (1 route with params)',
+    numberOfRoutes: 1,
+    matchedParamId: 0, // range from 0 to numberOfRoutes-1
+    numberOfLinks: 5000,
+  },
+  {
+    name: 'large router (1000 routes with params)',
+    numberOfRoutes: 1000,
+    matchedParamId: 500, // range from 0 to numberOfRoutes-1
+    numberOfLinks: 5000,
+  },
+])('$name', ({ numberOfRoutes, numberOfLinks, matchedParamId }) => {
+  const router = createTestRouter(numberOfRoutes)
+
+  bench(
+    'hardcoded href',
+    () => {
+      render(
+        <RouterContextProvider router={router}>
+          {Array.from({ length: numberOfLinks }).map((_, i) => (
+            <a key={i} href={`/params/${i}`}>
+              {i}
+            </a>
+          ))}
+        </RouterContextProvider>,
+      )
+    },
+    { warmupIterations: 0 },
+  )
+
+  bench(
+    'interpolate path',
+    () => {
+      render(
+        <RouterContextProvider router={router}>
+          {Array.from({ length: numberOfLinks }).map((_, i) => (
+            <InterpolatePathLink
+              key={i}
+              to={`/params/$param${matchedParamId}`}
+              params={{ [`param${matchedParamId}`]: i }}
+            >
+              {i}
+            </InterpolatePathLink>
+          ))}
+        </RouterContextProvider>,
+      )
+    },
+    { warmupIterations: 0 },
+  )
+
+  bench(
+    'build location',
+    () => {
+      render(
+        <RouterContextProvider router={router}>
+          {Array.from({ length: numberOfLinks }).map((_, i) => (
+            <BuildLocationLink
+              key={i}
+              to={`/params/$param${matchedParamId}`}
+              params={{ [`param${matchedParamId}`]: i }}
+            >
+              {i}
+            </BuildLocationLink>
+          ))}
+        </RouterContextProvider>,
+      )
+    },
+    { warmupIterations: 0 },
+  )
+
+  bench(
+    'link component',
+    () => {
+      render(
+        <RouterContextProvider router={router}>
+          {Array.from({ length: numberOfLinks }).map((_, i) => (
+            <Link
+              key={i}
+              to={`/params/$param${matchedParamId}`}
+              params={{ [`param${matchedParamId}`]: i }}
+            >
+              {i}
+            </Link>
+          ))}
+        </RouterContextProvider>,
+      )
+    },
+    { warmupIterations: 0 },
+  )
+})

--- a/packages/react-router/tests/link.bench.tsx
+++ b/packages/react-router/tests/link.bench.tsx
@@ -1,13 +1,13 @@
-import { render, act } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import { bench, describe } from 'vitest'
 import {
+  Link,
+  RouterProvider,
   createMemoryHistory,
   createRootRoute,
   createRoute,
   createRouter,
   interpolatePath,
-  Link,
-  RouterProvider,
   useRouter,
 } from '../src'
 

--- a/packages/react-router/tests/link.bench.tsx
+++ b/packages/react-router/tests/link.bench.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react'
 import { bench, describe } from 'vitest'
 import {
   Link,
-  LinkProps,
+  type LinkProps,
   RouterProvider,
   createMemoryHistory,
   createRootRoute,

--- a/packages/react-router/tests/link.bench.tsx
+++ b/packages/react-router/tests/link.bench.tsx
@@ -2,15 +2,16 @@ import { render } from '@testing-library/react'
 import { bench, describe } from 'vitest'
 import {
   Link,
-  type LinkProps,
+  
   RouterProvider,
   createMemoryHistory,
   createRootRoute,
   createRoute,
   createRouter,
   interpolatePath,
-  useRouter,
+  useRouter
 } from '../src'
+import type {LinkProps} from '../src';
 
 const createRouterRenderer =
   (routesCount: number) => (children: React.ReactNode) => {


### PR DESCRIPTION
Related to #2359, I set up a basic performance testing of the Link component and its simplified versions, using vitest `bench` functionality.

<img width="100%" alt="link perf" src="https://github.com/user-attachments/assets/a04dab44-7c1f-4ca5-a81a-a3456498b92a">
