### PR TITLE
fix(router-plugin): ignore initial files

### DIFF
--- a/packages/router-plugin/src/core/router-generator-plugin.ts
+++ b/packages/router-plugin/src/core/router-generator-plugin.ts
@@ -103,6 +103,14 @@ export const unpluginRouterGeneratorFactory: UnpluginFactory<
           .on('add', async () => {
             await run(generate)
           })
+
+        let generated = false
+        compiler.hooks.watchRun.tapPromise(PLUGIN_NAME, async () => {
+          if (!generated) {
+            generated = true
+            return run(generate)
+          }
+        })
       }
     },
     async webpack(compiler) {
@@ -119,6 +127,14 @@ export const unpluginRouterGeneratorFactory: UnpluginFactory<
           .on('add', async () => {
             await run(generate)
           })
+
+        let generated = false
+        compiler.hooks.watchRun.tapPromise(PLUGIN_NAME, async () => {
+          if (!generated) {
+            generated = true
+            return run(generate)
+          }
+        })
       }
 
       if (compiler.options.mode === 'production') {

--- a/packages/router-plugin/src/core/router-generator-plugin.ts
+++ b/packages/router-plugin/src/core/router-generator-plugin.ts
@@ -92,29 +92,33 @@ export const unpluginRouterGeneratorFactory: UnpluginFactory<
     async rspack(compiler) {
       userConfig = getConfig(options, ROOT)
 
-      // rspack watcher doesn't register newly created files
       if (compiler.options.mode === 'production') {
         await run(generate)
       } else {
+        // rspack watcher doesn't register newly created files
         const routesDirectoryPath = getRoutesDirectoryPath()
         const chokidar = await import('chokidar')
-        chokidar.watch(routesDirectoryPath).on('add', async () => {
-          await run(generate)
-        })
+        chokidar
+          .watch(routesDirectoryPath, { ignoreInitial: true })
+          .on('add', async () => {
+            await run(generate)
+          })
       }
     },
     async webpack(compiler) {
       userConfig = getConfig(options, ROOT)
 
-      // webpack watcher doesn't register newly created files
       if (compiler.options.mode === 'production') {
         await run(generate)
       } else {
+        // webpack watcher doesn't register newly created files
         const routesDirectoryPath = getRoutesDirectoryPath()
         const chokidar = await import('chokidar')
-        chokidar.watch(routesDirectoryPath).on('add', async () => {
-          await run(generate)
-        })
+        chokidar
+          .watch(routesDirectoryPath, { ignoreInitial: true })
+          .on('add', async () => {
+            await run(generate)
+          })
       }
 
       if (compiler.options.mode === 'production') {


### PR DESCRIPTION
The chokidar watcher in `router-plugin` is supposed to be looking only for newly created files in webpack/rspack apps. By default, it considers all files as "new" when starting the dev server, causing the generator to run multiple times, and slowing down the actual startup of the app.

There's a question if we want to always run the generator at least once when starting the dev server 🤔 

<img width="650" alt="Screenshot 2024-09-24 at 12 22 23" src="https://github.com/user-attachments/assets/5c2929f7-2861-4bea-8404-c742f22c1205">
