### PR TITLE
fix(start): extend `defineConfig` server options with VinxiAppOptions.server

### DIFF
--- a/packages/start/src/config/index.ts
+++ b/packages/start/src/config/index.ts
@@ -114,24 +114,41 @@ function checkDeploymentPresetInput(preset: string): DeploymentPreset {
   return preset
 }
 
-const serverSchema = z.object({
-  routeRules: z.custom<NitroOptions['routeRules']>().optional(),
-  preset: z.custom<DeploymentPreset>().optional(),
-  static: z.boolean().optional(),
-  prerender: z
-    .object({
-      routes: z.array(z.string()),
-      ignore: z
-        .array(
-          z.custom<
-            string | RegExp | ((path: string) => undefined | null | boolean)
-          >(),
-        )
-        .optional(),
-      crawlLinks: z.boolean().optional(),
-    })
-    .optional(),
-})
+type HTTPSOptions = {
+  cert?: string
+  key?: string
+  pfx?: string
+  passphrase?: string
+  validityDays?: number
+  domains?: Array<string>
+}
+type ServerOptions_ = VinxiAppOptions['server'] & {
+  https?: boolean | HTTPSOptions
+}
+type ServerOptions = {
+  [K in keyof ServerOptions_]: ServerOptions_[K]
+}
+
+const serverSchema = z
+  .object({
+    routeRules: z.custom<NitroOptions['routeRules']>().optional(),
+    preset: z.custom<DeploymentPreset>().optional(),
+    static: z.boolean().optional(),
+    prerender: z
+      .object({
+        routes: z.array(z.string()),
+        ignore: z
+          .array(
+            z.custom<
+              string | RegExp | ((path: string) => undefined | null | boolean)
+            >(),
+          )
+          .optional(),
+        crawlLinks: z.boolean().optional(),
+      })
+      .optional(),
+  })
+  .and(z.custom<ServerOptions>())
 
 const viteSchema = z.object({
   plugins: z


### PR DESCRIPTION
Ok so this PR follows some discussions from the Tanstack discord. For deploying Tanstack start to cloudflare, one must add some additional configs, which were not available in the config.

Current implementation copies `HTTPSOptions` from `@vinxi/listhen` because the type is not portable and the build fails. Ideally the implementation shouldn't do such things, so I'm open to suggestions.

With this change, the Tanstack start config is more aligned with the Solid start one:))

(P.S. this is my first OSS contribution, hello to everyone)