### PR TITLE
refactor(start): supply `links()` with same context signature as `meta()`

### DIFF
--- a/examples/react/start-basic/app/routes/index.tsx
+++ b/examples/react/start-basic/app/routes/index.tsx
@@ -2,6 +2,16 @@ import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/')({
   component: Home,
+  loader: () => Promise.resolve({ num: 20 }),
+  links: () => {
+    // console.log({ loaderData })
+    return [
+      {
+        rel: 'stylesheet',
+        href: 'https://fonts.googleapis.com/css2?family=Roboto:wght@300&display=swap',
+      },
+    ]
+  },
 })
 
 function Home() {

--- a/examples/react/start-basic/app/routes/index.tsx
+++ b/examples/react/start-basic/app/routes/index.tsx
@@ -2,16 +2,6 @@ import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/')({
   component: Home,
-  loader: () => Promise.resolve({ num: 20 }),
-  links: () => {
-    // console.log({ loaderData })
-    return [
-      {
-        rel: 'stylesheet',
-        href: 'https://fonts.googleapis.com/css2?family=Roboto:wght@300&display=swap',
-      },
-    ]
-  },
 })
 
 function Home() {

--- a/packages/react-router/src/route.ts
+++ b/packages/react-router/src/route.ts
@@ -435,6 +435,36 @@ export interface UpdatableRouteOptions<
     loaderData: ResolveLoaderData<TLoaderFn>
   }) => Array<React.JSX.IntrinsicElements['meta']>
   links?: (ctx: {
+    matches: Array<
+      RouteMatch<
+        TRouteId,
+        TFullPath,
+        ResolveAllParamsFromParent<TParentRoute, TParams>,
+        ResolveFullSearchSchema<TParentRoute, TSearchValidator>,
+        ResolveLoaderData<TLoaderFn>,
+        ResolveAllContext<
+          TParentRoute,
+          TRouterContext,
+          TRouteContextFn,
+          TBeforeLoadFn
+        >,
+        TLoaderDeps
+      >
+    >
+    match: RouteMatch<
+      TRouteId,
+      TFullPath,
+      ResolveAllParamsFromParent<TParentRoute, TParams>,
+      ResolveFullSearchSchema<TParentRoute, TSearchValidator>,
+      ResolveLoaderData<TLoaderFn>,
+      ResolveAllContext<
+        TParentRoute,
+        TRouterContext,
+        TRouteContextFn,
+        TBeforeLoadFn
+      >,
+      TLoaderDeps
+    >
     params: ResolveAllParamsFromParent<TParentRoute, TParams>
     loaderData: ResolveLoaderData<TLoaderFn>
   }) => Array<React.JSX.IntrinsicElements['link']>

--- a/packages/react-router/src/route.ts
+++ b/packages/react-router/src/route.ts
@@ -434,7 +434,10 @@ export interface UpdatableRouteOptions<
     params: ResolveAllParamsFromParent<TParentRoute, TParams>
     loaderData: ResolveLoaderData<TLoaderFn>
   }) => Array<React.JSX.IntrinsicElements['meta']>
-  links?: () => Array<React.JSX.IntrinsicElements['link']>
+  links?: (ctx: {
+    params: ResolveAllParamsFromParent<TParentRoute, TParams>
+    loaderData: ResolveLoaderData<TLoaderFn>
+  }) => Array<React.JSX.IntrinsicElements['link']>
   scripts?: () => Array<React.JSX.IntrinsicElements['script']>
   headers?: (ctx: {
     loaderData: ResolveLoaderData<TLoaderFn>

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1236,6 +1236,8 @@ export class Router<
         })
 
         match.links = route.options.links?.({
+          matches,
+          match,
           params: match.params,
           loaderData: match.loaderData,
         })

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1217,7 +1217,6 @@ export class Router<
           loaderDeps,
           invalid: false,
           preload: false,
-          links: route.options.links?.(),
           scripts: route.options.scripts?.(),
           staticData: route.options.staticData || {},
           loadPromise: createControlledPromise(),
@@ -1225,13 +1224,18 @@ export class Router<
         }
       }
 
-      // If it's already a success, update the meta and headers
+      // If it's already a success, update the meta, links, and headers
       // These may get updated again if the match is refreshed
       // due to being stale
       if (match.status === 'success') {
         match.meta = route.options.meta?.({
           matches,
           match,
+          params: match.params,
+          loaderData: match.loaderData,
+        })
+
+        match.links = route.options.links?.({
           params: match.params,
           loaderData: match.loaderData,
         })

--- a/packages/start/src/client/serialization.tsx
+++ b/packages/start/src/client/serialization.tsx
@@ -120,9 +120,17 @@ export function afterHydrate({ router }: { router: AnyRouter }) {
           })
         : undefined
 
+    const links =
+      match.status === 'success'
+        ? route.options.links?.({
+            params: match.params,
+            loaderData: match.loaderData,
+          })
+        : undefined
+
     Object.assign(match, {
       meta,
-      links: route.options.links?.(),
+      links,
       scripts: route.options.scripts?.(),
     })
   })

--- a/packages/start/src/client/serialization.tsx
+++ b/packages/start/src/client/serialization.tsx
@@ -123,6 +123,8 @@ export function afterHydrate({ router }: { router: AnyRouter }) {
     const links =
       match.status === 'success'
         ? route.options.links?.({
+            matches: router.state.matches,
+            match,
             params: match.params,
             loaderData: match.loaderData,
           })


### PR DESCRIPTION
Closes #2426 