### PR TITLE
docs: fix typo w/ guarantee

### DIFF
--- a/docs/framework/react/overview.md
+++ b/docs/framework/react/overview.md
@@ -118,7 +118,7 @@ TanStack Router solves these problems with a two-prong approach to caching and d
 
 ### Built-in Cache
 
-TanStack Router provides a light-weight built-in caching layer that works seamlessly with the Router. This caching layer is loosely based on TanStack Query, but with fewer features and a much smaller API surface area. Like TanStack Query, sane but powerful defaults guaranty that your data is cached for reuse, invalidated when necessary, and garbage collected when not in use. It also provides a simple API for invalidating the cache manually when needed.
+TanStack Router provides a light-weight built-in caching layer that works seamlessly with the Router. This caching layer is loosely based on TanStack Query, but with fewer features and a much smaller API surface area. Like TanStack Query, sane but powerful defaults guarantee that your data is cached for reuse, invalidated when necessary, and garbage collected when not in use. It also provides a simple API for invalidating the cache manually when needed.
 
 ### Flexible & Powerful Data Lifecycle APIs
 


### PR DESCRIPTION
Fixes a typo: `guaranty` to `guarantee`.