### PR TITLE
docs: fix pathless route link

### DIFF
--- a/docs/framework/react/guide/routing-concepts.md
+++ b/docs/framework/react/guide/routing-concepts.md
@@ -9,7 +9,7 @@ TanStack Router supports a number of powerful routing concepts that allow you to
 - [Index Routes](./routing-concepts.md#index-routes)
 - [Dynamic Route Segments](./routing-concepts.md#dynamic-route-segments)
 - [Splat / Catch-All Routes](./routing-concepts.md#splat--catch-all-routes)
-- [Pathless Routes](./routing-concepts.md#pathless--layout-routes)
+- [Pathless Routes](./routing-concepts.md#pathless-routes)
 - [Non-Nested Routes](./routing-concepts.md#non-nested-routes)
 - [Not-Found Routes](./routing-concepts.md#404--notfoundroutes)
 


### PR DESCRIPTION
Fixes `Pathless Routes` link on the table-of-contents.