### PR TITLE
fix: allow composite and `createLink`

### DIFF
--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -74,6 +74,7 @@ export type {
   LinkProps,
   LinkComponent,
   CreateLinkProps,
+  MakeOptionalPathParams,
 } from './link'
 
 export type { ParsedLocation } from './location'

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -356,7 +356,7 @@ type ResolveRelativeToParams<
         TToParams
       >
 
-interface MakeOptionalSearchParams<
+export interface MakeOptionalSearchParams<
   in out TRouter extends AnyRouter,
   in out TFrom,
   in out TTo,
@@ -364,7 +364,7 @@ interface MakeOptionalSearchParams<
   search?: true | (ParamsReducer<TRouter, 'SEARCH', TFrom, TTo> & {})
 }
 
-interface MakeOptionalPathParams<
+export interface MakeOptionalPathParams<
   in out TRouter extends AnyRouter,
   in out TFrom,
   in out TTo,


### PR DESCRIPTION
Fixes #2449 