### PR TITLE
fix outdated navigation hint inside the docs

### DIFF
--- a/docs/framework/react/guide/navigation.md
+++ b/docs/framework/react/guide/navigation.md
@@ -217,8 +217,6 @@ const link = (
 )
 ```
 
-> 🧠 Did you notice that how we didn't even need to supply a `to` prop? By default, all navigations are relative to the current route, so if you don't supply a `to` prop, it will just update the current route's search params.
-
 ### Search Param Type Safety
 
 Search params are a highly dynamic state management mechanism, so it's important to ensure that you are passing the correct types to your search params. We'll see in a later section in detail how to validate and ensure search params typesafety, among other great features!


### PR DESCRIPTION
remove outdated hint for omitting `to` prop.