### PR TITLE
Examples: remove unnecessary <Suspense>

### DIFF
--- a/docs/framework/react/guide/deferred-data-loading.md
+++ b/docs/framework/react/guide/deferred-data-loading.md
@@ -53,14 +53,12 @@ function PostIdComponent() {
   const { deferredSlowData } = Route.useLoaderData()
 
   return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <Await promise={deferredSlowData}>
-        {(data) => {
-          return <div>{data}</div>
-        }}
-      </Await>
-    </Suspense>
-  )
+    <Await promise={deferredSlowData} fallback={<div>Loading...</div>}>
+      {(data) => {
+        return <div>{data}</div>;
+      }}
+    </Await>
+  );
 }
 ```
 

--- a/docs/framework/react/guide/deferred-data-loading.md
+++ b/docs/framework/react/guide/deferred-data-loading.md
@@ -55,10 +55,10 @@ function PostIdComponent() {
   return (
     <Await promise={deferredSlowData} fallback={<div>Loading...</div>}>
       {(data) => {
-        return <div>{data}</div>;
+        return <div>{data}</div>
       }}
     </Await>
-  );
+  )
 }
 ```
 


### PR DESCRIPTION
As Tanner [mentioned](https://x.com/tannerlinsley/status/1841844004755013994), Suspense is unnecessary, as Await has a built in suspense boundary