### PR TITLE
chore: move Prettier to devDependencies

### DIFF
--- a/packages/router-generator/package.json
+++ b/packages/router-generator/package.json
@@ -66,7 +66,9 @@
   "dependencies": {
     "@tanstack/virtual-file-routes": "workspace:^",
     "tsx": "^4.19.1",
-    "prettier": "^3.3.3",
     "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "prettier": "^3.3.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2587,15 +2587,16 @@ importers:
       '@tanstack/virtual-file-routes':
         specifier: workspace:*
         version: link:../virtual-file-routes
-      prettier:
-        specifier: ^3.3.3
-        version: 3.3.3
       tsx:
         specifier: ^4.19.1
         version: 4.19.1
       zod:
         specifier: ^3.23.8
         version: 3.23.8
+    devDependencies:
+      prettier:
+        specifier: ^3.3.3
+        version: 3.3.3
 
   packages/router-plugin:
     dependencies:


### PR DESCRIPTION
This reduce node_modules size on projects using tanstack_router