### PR TITLE
docs(start): enable strictNullChecks

### DIFF
--- a/docs/framework/react/start/getting-started.md
+++ b/docs/framework/react/start/getting-started.md
@@ -35,6 +35,7 @@ Create a `tsconfig.json` file with at least the following settings:
     "module": "ESNext",
     "target": "ES2022",
     "skipLibCheck": true,
+    "strictNullChecks": true,
   },
 }
 ```


### PR DESCRIPTION
Must be enabled for app/router.tsx->createRouter()

_app/router.tsx line: 7_
```
Argument of type 
'{ routeTree: RootRoute<undefined, {}, AnyContext, AnyContext, {}, undefined, RootRouteChildren, FileRouteTypes>; }'
 is not assignable to parameter of type '"strictNullChecks must be enabled in tsconfig.json"'.ts(2345)
```