### PR TITLE
examples: upgrade framer-motion

### DIFF
--- a/examples/react/with-framer-motion/package.json
+++ b/examples/react/with-framer-motion/package.json
@@ -12,7 +12,7 @@
     "@tanstack/react-router": "^1.59.0",
     "@tanstack/router-devtools": "^1.59.0",
     "redaxios": "^0.5.1",
-    "framer-motion": "^11.5.4",
+    "framer-motion": "^11.11.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "zod": "^3.23.8"

--- a/examples/react/with-framer-motion/tsconfig.json
+++ b/examples/react/with-framer-motion/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "esModuleInterop": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "skipLibCheck": true
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2230,8 +2230,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/router-devtools
       framer-motion:
-        specifier: ^11.5.4
-        version: 11.5.4(@emotion/is-prop-valid@0.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^11.11.1
+        version: 11.11.1(@emotion/is-prop-valid@0.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -6751,8 +6751,8 @@ packages:
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
-  framer-motion@11.5.4:
-    resolution: {integrity: sha512-E+tb3/G6SO69POkdJT+3EpdMuhmtCh9EWuK4I1DnIC23L7tFPrl8vxP+LSovwaw6uUr73rUbpb4FgK011wbRJQ==}
+  framer-motion@11.11.1:
+    resolution: {integrity: sha512-Ucr9eHSrk0d+l6vyl9fvq6omh/PAWHjS+PlczpsoUdhJo1TuF3ULWJNuAMnpWQ1dGyPOyoUVuYlUKjE/s8dyCA==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0
@@ -14108,7 +14108,7 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
-  framer-motion@11.5.4(@emotion/is-prop-valid@0.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  framer-motion@11.11.1(@emotion/is-prop-valid@0.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       tslib: 2.7.0
     optionalDependencies:


### PR DESCRIPTION
set `skipLibCheck: true` to get rid of the following error:

```
../../../node_modules/.pnpm/framer-motion@11.11.1_@emotion+is-prop-valid@0.8.8_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/framer-motion/dist/index.d.ts:3844:5 - error TS2416: Property 'attachTimeline' in type 'GroupPlaybackControls' is not assignable to the same property in base type 'AnimationPlaybackControls'.
  Type '(timeline: any, fallback: (animation: AnimationPlaybackControls) => VoidFunction) => () => void' is not assignable to type '(timeline: ProgressTimeline, fallback?: ((animation: AnimationPlaybackControls) => VoidFunction) | undefined) => VoidFunction'.
    Types of parameters 'fallback' and 'fallback' are incompatible.
      Type '((animation: AnimationPlaybackControls) => VoidFunction) | undefined' is not assignable to type '(animation: AnimationPlaybackControls) => VoidFunction'.
        Type 'undefined' is not assignable to type '(animation: AnimationPlaybackControls) => VoidFunction'.

3844     attachTimeline(timeline: any, fallback: (animation: AnimationPlaybackControls) => VoidFunction): () => void;
         ~~~~~~~~~~~~~~

Found 1 error in ../../../node_modules/.pnpm/framer-motion@11.11.1_@emotion+is-prop-valid@0.8.8_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/framer-motion/dist/index.d.ts:3844
```