### PR TITLE
fix(react-router): only execute context when params or loader deps change

### DIFF
--- a/docs/eslint/create-route-property-order.md
+++ b/docs/eslint/create-route-property-order.md
@@ -14,9 +14,9 @@ The correct property order is as follows:
 
 - `params`
 - `validateSearch`
+- `loaderDeps`
 - `context`
 - `beforeLoad`
-- `loaderDeps`
 - `loader`
 
 All other properties are insensitive to the order as they do not depend on type inference.

--- a/packages/eslint-plugin-router/src/rules/create-route-property-order/constants.ts
+++ b/packages/eslint-plugin-router/src/rules/create-route-property-order/constants.ts
@@ -17,15 +17,15 @@ export type CreateRouteFunction = (typeof createRouteFunctions)[number]
 export const checkedProperties = [
   'params',
   'validateSearch',
+  'loaderDeps',
   'context',
   'beforeLoad',
-  'loaderDeps',
   'loader',
 ] as const
 
 export const sortRules = [
-  [['params', 'validateSearch'], ['context']],
+  [['params', 'validateSearch'], ['loaderDeps']],
+  [['loaderDeps'], ['context']],
   [['context'], ['beforeLoad']],
-  [['beforeLoad'], ['loaderDeps']],
-  [['loaderDeps'], ['loader']],
+  [['beforeLoad'], ['loader']],
 ] as const

--- a/packages/react-router/src/route.ts
+++ b/packages/react-router/src/route.ts
@@ -201,9 +201,9 @@ export type FileBaseRouteOptions<
     (
       ctx: RouteContextOptions<
         TParentRoute,
-        TSearchValidator,
         TParams,
-        TRouterContext
+        TRouterContext,
+        TLoaderDeps
       >,
     ) => any
   >
@@ -272,9 +272,8 @@ export type BaseRouteOptions<
 
 export interface ContextOptions<
   in out TParentRoute extends AnyRoute,
-  in out TSearchValidator,
   in out TParams,
-> extends FullSearchSchemaOption<TParentRoute, TSearchValidator> {
+> {
   abortController: AbortController
   preload: boolean
   params: Expand<ResolveAllParamsFromParent<TParentRoute, TParams>>
@@ -290,10 +289,11 @@ export interface ContextOptions<
 
 export interface RouteContextOptions<
   in out TParentRoute extends AnyRoute,
-  in out TSearchValidator,
   in out TParams,
   in out TRouterContext,
-> extends ContextOptions<TParentRoute, TSearchValidator, TParams> {
+  in out TLoaderDeps,
+> extends ContextOptions<TParentRoute, TParams> {
+  deps: TLoaderDeps
   context: Expand<RouteContextParameter<TParentRoute, TRouterContext>>
 }
 
@@ -303,7 +303,8 @@ export interface BeforeLoadContextOptions<
   in out TParams,
   in out TRouterContext,
   in out TRouteContextFn,
-> extends ContextOptions<TParentRoute, TSearchValidator, TParams> {
+> extends ContextOptions<TParentRoute, TParams>,
+    FullSearchSchemaOption<TParentRoute, TSearchValidator> {
   context: Expand<
     BeforeLoadContextParameter<TParentRoute, TRouterContext, TRouteContextFn>
   >

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1274,28 +1274,30 @@ export class Router<
         ...match.__beforeLoadContext,
       }
 
-      // Update the match's context
-      const contextFnContext: RouteContextOptions<any, any, any, any> = {
-        search: match.search,
-        params: match.params,
-        context: match.context,
-        location: next,
-        navigate: (opts: any) =>
-          this.navigate({ ...opts, _fromLocation: next }),
-        buildLocation: this.buildLocation,
-        cause: match.cause,
-        abortController: match.abortController,
-        preload: !!match.preload,
-        matches,
-      }
+      if (!existingMatch) {
+        // Update the match's context
+        const contextFnContext: RouteContextOptions<any, any, any, any> = {
+          deps: loaderDeps,
+          params: match.params,
+          context: match.context,
+          location: next,
+          navigate: (opts: any) =>
+            this.navigate({ ...opts, _fromLocation: next }),
+          buildLocation: this.buildLocation,
+          cause: match.cause,
+          abortController: match.abortController,
+          preload: !!match.preload,
+          matches,
+        }
 
-      // Get the route context
-      match.__routeContext = route.options.context?.(contextFnContext) ?? {}
+        // Get the route context
+        match.__routeContext = route.options.context?.(contextFnContext) ?? {}
 
-      match.context = {
-        ...parentContext,
-        ...match.__routeContext,
-        ...match.__beforeLoadContext,
+        match.context = {
+          ...parentContext,
+          ...match.__routeContext,
+          ...match.__beforeLoadContext,
+        }
       }
 
       matches.push(match)

--- a/packages/react-router/tests/route.test-d.tsx
+++ b/packages/react-router/tests/route.test-d.tsx
@@ -38,7 +38,7 @@ test('when creating the root with routeContext', () => {
         buildLocation: BuildLocationFn
         cause: 'preload' | 'enter' | 'stay'
         context: {}
-        search: {}
+        deps: {}
         matches: Array<MakeRouteMatchUnion>
       }>()
     },
@@ -109,7 +109,7 @@ test('when creating the root route with context and routeContext', () => {
         buildLocation: BuildLocationFn
         cause: 'preload' | 'enter' | 'stay'
         context: { userId: string }
-        search: {}
+        deps: {}
         matches: Array<MakeRouteMatchUnion>
       }>()
     },
@@ -214,7 +214,7 @@ test('when creating the root route with context, routeContext, beforeLoad and a 
         buildLocation: BuildLocationFn
         cause: 'preload' | 'enter' | 'stay'
         context: { userId: string }
-        search: {}
+        deps: {}
         matches: Array<MakeRouteMatchUnion>
       }>()
 
@@ -325,7 +325,7 @@ test('when creating a child route with routeContext from the root route with con
         buildLocation: BuildLocationFn
         cause: 'preload' | 'enter' | 'stay'
         context: { userId: string }
-        search: {}
+        deps: {}
         matches: Array<MakeRouteMatchUnion>
       }>()
 
@@ -622,7 +622,7 @@ test('when creating a child route with params, search with routeContext from the
         buildLocation: BuildLocationFn
         cause: 'preload' | 'enter' | 'stay'
         context: { userId: string }
-        search: { page: number }
+        deps: {}
         matches: Array<MakeRouteMatchUnion>
       }>()
     },
@@ -670,7 +670,7 @@ test('when creating a child route with params, search with routeContext, beforeL
         buildLocation: BuildLocationFn
         cause: 'preload' | 'enter' | 'stay'
         context: { userId: string }
-        search: { page: number }
+        deps: {}
         matches: Array<MakeRouteMatchUnion>
       }>()
       return {
@@ -786,7 +786,7 @@ test('when creating a child route with routeContext from a parent with routeCont
         buildLocation: BuildLocationFn
         cause: 'preload' | 'enter' | 'stay'
         context: { userId: string }
-        search: {}
+        deps: {}
         matches: Array<MakeRouteMatchUnion>
       }>()
 
@@ -807,7 +807,7 @@ test('when creating a child route with routeContext from a parent with routeCont
         buildLocation: BuildLocationFn
         cause: 'preload' | 'enter' | 'stay'
         context: { userId: string; invoiceId: string }
-        search: {}
+        deps: {}
         matches: Array<MakeRouteMatchUnion>
       }>()
 
@@ -915,7 +915,7 @@ test('when creating a child route with routeContext, beforeLoad, search, params,
         buildLocation: BuildLocationFn
         cause: 'preload' | 'enter' | 'stay'
         context: { userId: string }
-        search: { page: number }
+        deps: {}
         matches: Array<MakeRouteMatchUnion>
       }>()
       return { env: 'env1' }
@@ -960,7 +960,7 @@ test('when creating a child route with routeContext, beforeLoad, search, params,
           env: string
           invoicePermissions: readonly ['view']
         }
-        search: { page: number; detailPage: number }
+        deps: {}
         matches: Array<MakeRouteMatchUnion>
       }>()
       return { detailEnv: 'detailEnv' }
@@ -994,6 +994,27 @@ test('when creating a child route with routeContext, beforeLoad, search, params,
       detailPage: deps.search.detailPage,
       invoicePage: deps.search.page,
     }),
+    context: (opt) => {
+      expectTypeOf(opt).toEqualTypeOf<{
+        abortController: AbortController
+        preload: boolean
+        params: { invoiceId: string; detailId: string }
+        location: ParsedLocation
+        navigate: NavigateFn
+        buildLocation: BuildLocationFn
+        cause: 'preload' | 'enter' | 'stay'
+        context: {
+          userId: string
+          env: string
+          invoicePermissions: readonly ['view']
+          detailEnv: string
+          detailsPermissions: readonly ['view']
+        }
+        deps: { detailPage: number; invoicePage: number }
+        matches: Array<MakeRouteMatchUnion>
+      }>()
+      return { detailEnv: 'detailEnv' }
+    },
     loader: (opts) =>
       expectTypeOf(opts).toEqualTypeOf<{
         abortController: AbortController

--- a/packages/react-router/tests/routeContext.test.tsx
+++ b/packages/react-router/tests/routeContext.test.tsx
@@ -1,4 +1,5 @@
 import {
+  act,
   cleanup,
   configure,
   fireEvent,
@@ -6,6 +7,7 @@ import {
   screen,
 } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { z } from 'zod'
 
 import {
   Link,
@@ -39,6 +41,213 @@ const WAIT_TIME = 150
 
 describe('context function', () => {
   configure({ reactStrictMode: true })
+
+  describe('context is executed', () => {
+    async function findByText(text: string) {
+      const element = await screen.findByText(text)
+      expect(element).toBeInTheDocument()
+    }
+
+    async function clickButton(name: string) {
+      const button = await screen.findByRole('button', {
+        name,
+      })
+      expect(button).toBeInTheDocument()
+      fireEvent.click(button)
+    }
+
+    test('when the path params change', async () => {
+      const mockContextFn = vi.fn()
+
+      const rootRoute = createRootRoute()
+      const indexRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/',
+        component: () => {
+          const navigate = indexRoute.useNavigate()
+          return (
+            <div>
+              <h1>Index page</h1>
+
+              <button
+                onClick={() =>
+                  navigate({ to: '/detail/$id', params: { id: 1 } })
+                }
+              >
+                detail-1
+              </button>
+            </div>
+          )
+        },
+      })
+      const detailRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/detail/$id',
+        params: {
+          parse: (p) => z.object({ id: z.coerce.number() }).parse(p),
+          stringify: (p) => ({ id: `${p.id}` }),
+        },
+        context: (args) => {
+          mockContextFn(args.params)
+        },
+        component: () => {
+          const id = detailRoute.useParams({ select: (params) => params.id })
+          const navigate = detailRoute.useNavigate()
+          return (
+            <div>
+              <h1>Detail page: {id}</h1>
+              <button
+                onClick={() =>
+                  navigate({
+                    to: '/detail/$id',
+                    params: (p: any) => ({ ...p, id: p.id + 1 }),
+                  })
+                }
+              >
+                next
+              </button>
+            </div>
+          )
+        },
+      })
+
+      const routeTree = rootRoute.addChildren([indexRoute, detailRoute])
+      const router = createRouter({ routeTree, history })
+
+      await act(() => render(<RouterProvider router={router} />))
+
+      await findByText('Index page')
+      expect(mockContextFn).not.toHaveBeenCalled()
+
+      await clickButton('detail-1')
+
+      await findByText('Detail page: 1')
+      console.log(mockContextFn.mock.calls)
+      expect(mockContextFn).toHaveBeenCalledOnce()
+      expect(mockContextFn).toHaveBeenCalledWith({ id: 1 })
+      mockContextFn.mockClear()
+      await clickButton('next')
+
+      await findByText('Detail page: 2')
+      expect(mockContextFn).toHaveBeenCalledOnce()
+      expect(mockContextFn).toHaveBeenCalledWith({ id: 2 })
+      mockContextFn.mockClear()
+      await clickButton('next')
+
+      await findByText('Detail page: 3')
+      expect(mockContextFn).toHaveBeenCalledOnce()
+      expect(mockContextFn).toHaveBeenCalledWith({ id: 3 })
+      mockContextFn.mockClear()
+    })
+
+    test('when loader deps change', async () => {
+      const mockContextFn = vi.fn()
+
+      const rootRoute = createRootRoute()
+      const indexRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        validateSearch: z.object({
+          foo: z.string().optional(),
+          bar: z.string().optional(),
+        }),
+        path: '/',
+        loaderDeps: ({ search }) => ({ foo: search.foo }),
+        context: ({ deps }) => {
+          mockContextFn(deps)
+        },
+        component: () => {
+          const navigate = indexRoute.useNavigate()
+          return (
+            <div>
+              <h1>Index page</h1>
+              <h2>search: {JSON.stringify(indexRoute.useSearch())}</h2>
+              <button
+                onClick={() => {
+                  navigate({ search: (p: any) => ({ ...p, foo: 'foo-1' }) })
+                }}
+              >
+                foo-1
+              </button>
+              <button
+                onClick={() => {
+                  navigate({ search: (p: any) => ({ ...p, foo: 'foo-2' }) })
+                }}
+              >
+                foo-2
+              </button>
+              <button
+                onClick={() => {
+                  navigate({ search: (p: any) => ({ ...p, bar: 'bar-1' }) })
+                }}
+              >
+                bar-1
+              </button>
+              <button
+                onClick={() => {
+                  navigate({ search: (p: any) => ({ ...p, bar: 'bar-2' }) })
+                }}
+              >
+                bar-2
+              </button>
+              <button
+                onClick={() => {
+                  navigate({ search: {} })
+                }}
+              >
+                clear
+              </button>
+            </div>
+          )
+        },
+      })
+
+      const routeTree = rootRoute.addChildren([indexRoute])
+      const router = createRouter({ routeTree, history })
+
+      render(<RouterProvider router={router} />)
+
+      await findByText('Index page')
+      await findByText(`search: ${JSON.stringify({})}`)
+
+      expect(mockContextFn).toHaveBeenCalledOnce()
+      expect(mockContextFn).toHaveBeenCalledWith({})
+      mockContextFn.mockClear()
+
+      await clickButton('foo-1')
+      await findByText(`search: ${JSON.stringify({ foo: 'foo-1' })}`)
+      expect(mockContextFn).toHaveBeenCalledOnce()
+      expect(mockContextFn).toHaveBeenCalledWith({ foo: 'foo-1' })
+
+      mockContextFn.mockClear()
+      await clickButton('foo-1')
+      await findByText(`search: ${JSON.stringify({ foo: 'foo-1' })}`)
+      expect(mockContextFn).not.toHaveBeenCalled()
+
+      await clickButton('bar-1')
+      await findByText(
+        `search: ${JSON.stringify({ foo: 'foo-1', bar: 'bar-1' })}`,
+      )
+      expect(mockContextFn).not.toHaveBeenCalled()
+
+      await clickButton('foo-2')
+      await findByText(
+        `search: ${JSON.stringify({ foo: 'foo-2', bar: 'bar-1' })}`,
+      )
+      expect(mockContextFn).toHaveBeenCalledWith({ foo: 'foo-2' })
+      mockContextFn.mockClear()
+
+      await clickButton('bar-2')
+      await findByText(
+        `search: ${JSON.stringify({ foo: 'foo-2', bar: 'bar-2' })}`,
+      )
+      expect(mockContextFn).not.toHaveBeenCalled()
+
+      await clickButton('clear')
+      await findByText(`search: ${JSON.stringify({})}`)
+      expect(mockContextFn).toHaveBeenCalledOnce()
+      expect(mockContextFn).toHaveBeenCalledWith({})
+    })
+  })
 
   describe('accessing values in the context function', () => {
     test('receives an empty object', async () => {


### PR DESCRIPTION
also do not pass search params into `context`, only `loaderDeps` (in analogy to `loader`)