### PR TITLE
fix:  mistake in search-params.md about `catch` with `fallback` usage

### DIFF
--- a/docs/framework/react/guide/search-params.md
+++ b/docs/framework/react/guide/search-params.md
@@ -233,9 +233,9 @@ import { fallback, zodSearchValidator } from '@tanstack/router-zod-adapter'
 import { z } from 'zod'
 
 const productSearchSchema = z.object({
-  page: fallback(z.number(), 1).default(1),
-  filter: fallback(z.string(), '').default(''),
-  sort: fallback(z.enum(['newest', 'oldest', 'price']), 'newest').default(
+  page: fallback(z.number(), 1).catch(1),
+  filter: fallback(z.string(), '').catch(''),
+  sort: fallback(z.enum(['newest', 'oldest', 'price']), 'newest').catch(
     'newest',
   ),
 })


### PR DESCRIPTION
I think this is a mistake. You are talking about the use of zod `catch` with `fallback`, but the example uses `default` instead of `catch`.  