### PR TITLE
feat: add `linkOptions` for re-usable props

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -105,6 +105,10 @@
               "to": "framework/react/guide/search-params"
             },
             {
+              "label": "Link Options",
+              "to": "framework/react/guide/link-options"
+            },
+            {
               "label": "Custom Links",
               "to": "framework/react/guide/custom-link"
             },

--- a/docs/framework/react/api/router.md
+++ b/docs/framework/react/api/router.md
@@ -17,6 +17,7 @@ title: Router API
   - [`isNotFound`](./router/isNotFoundFunction.md)
   - [`isRedirect`](./router/isRedirectFunction.md)
   - [`lazyRouteComponent`](./router/lazyRouteComponentFunction.md)
+  - [`linkOptions`](./router/linkOptions.md)
   - [`notFound`](./router/notFoundFunction.md)
   - [`redirect`](./router/redirectFunction.md)
 - Components

--- a/docs/framework/react/api/router/linkOptions.md
+++ b/docs/framework/react/api/router/linkOptions.md
@@ -1,0 +1,38 @@
+---
+id: linkOptions
+title: Link options
+---
+
+`linkOptions` is a function which type checks an object literal with the intention of being used for `Link`, `navigate` or `redirect`
+
+## linkOptions props
+
+The `linkOptions` accepts the following option:
+
+### `...props`
+
+- Type: `LinkProps & React.RefAttributes<HTMLAnchorElement>`
+- [`LinkProps`](./LinkPropsType.md)
+
+## `linkOptions` returns
+
+An object literal with the exact type inferred from the input
+
+## Examples
+
+```tsx
+const userLinkOptions = linkOptions({
+  to: '/dashboard/users/user',
+  search: {
+    usersView: {
+      sortBy: 'email',
+      filterBy: 'filter',
+    },
+    userId: 0,
+  },
+})
+
+function DashboardComponent() {
+  return <Link {...userLinkOptions} />
+}
+```

--- a/docs/framework/react/guide/link-options.md
+++ b/docs/framework/react/guide/link-options.md
@@ -2,7 +2,7 @@
 title: Link Options
 ---
 
-You may want to re-use options that are intended to be passed to `Link`, `redirect` or `navigate`. In which case you may decide an object literal is a good way to represent options passed to `Link`.
+You may want to reuse options that are intended to be passed to `Link`, `redirect` or `navigate`. In which case you may decide an object literal is a good way to represent options passed to `Link`.
 
 ```tsx
 const dashboardLinkOptions = {

--- a/docs/framework/react/guide/link-options.md
+++ b/docs/framework/react/guide/link-options.md
@@ -1,0 +1,117 @@
+---
+title: Link Options
+---
+
+You may want to re-use options that are intended to be passed to `Link`, `redirect` or `navigate`. In which case you may decide an object literal is a good way to represent options passed to `Link`.
+
+```tsx
+const dashboardLinkOptions = {
+  to: '/dashboard',
+  search: { search: '' },
+}
+
+function DashboardComponent() {
+  return <Link {...dashboardLinkOptions} />
+}
+```
+
+There are a few problems here. `dashboardLinkOptions.to` is inferred as `string` which by default will resolve to every route when passed to `Link`, `navigate` or `redirect` (this particular issue could be fixed by `as const`). The other issue here is we do not know `dashboardLinkOptions` even passes the type checker until it is spread into `Link`. We could very easily create incorrect navigation options and only when the options are spread into `Link` do we know there is a type error.
+
+### Using `linkOptions` function to create re-usable options
+
+`linkOptions` is a function which type checks an object literal and returns the inferred input as is. This provides type safety on options exactly like `Link` before it is used allowing for easier maintenance and re-usability. Our above example using `linkOptions` looks like this:
+
+```tsx
+const dashboardLinkOptions = linkOptions({
+  to: '/dashboard',
+  search: { search: '' },
+})
+
+function DashboardComponent() {
+  return <Link {...dashboardLinkOptions} />
+}
+```
+
+This allows eager type checking of `dashboardLinkOptions` which can then be re-used anywhere
+
+```tsx
+const dashboardLinkOptions = linkOptions({
+  to: '/dashboard',
+  search: { search: '' },
+})
+
+export const Route = createFileRoute('/dashboard')({
+  component: DashboardComponent,
+  validateSearch: (input) => ({ search: input.search }),
+  beforeLoad: () => {
+    // can used in redirect
+    throw redirect(dashboardLinkOptions)
+  },
+})
+
+function DashboardComponent() {
+  const navigate = useNavigate()
+
+  return (
+    <div>
+      {/** can be used in navigate */}
+      <button onClick={() => navigate(dashboardLinkOptions)} />
+
+      {/** can be used in Link */}
+      <Link {...dashboardLinkOptions} />
+    </div>
+  )
+}
+```
+
+### An array of `linkOptions`
+
+When creating navigation you might loop over an array to construct a navigation bar. In which case `linkOptions` can be called multiple times to construct an array which can be used to render an array of `Link`'s
+
+```tsx
+const options = [
+  linkOptions({
+    to: '/dashboard',
+    label: 'Summary',
+    activeOptions: { exact: true },
+  }),
+  linkOptions({
+    to: '/dashboard/invoices',
+    label: 'Invoices',
+  }),
+  linkOptions({
+    to: '/dashboard/users',
+    label: 'Users',
+  }),
+]
+
+function DashboardComponent() {
+  return (
+    <>
+      <div className="flex items-center border-b">
+        <h2 className="text-xl p-2">Dashboard</h2>
+      </div>
+
+      <div className="flex flex-wrap divide-x">
+        {options.map((option) => {
+          return (
+            <Link
+              {...option}
+              key={option.to}
+              activeProps={{ className: `font-bold` }}
+              className="p-2"
+            >
+              {option.label}
+            </Link>
+          )
+        })}
+      </div>
+      <hr />
+
+      <Outlet />
+    </>
+  )
+}
+```
+
+The input of `linkOptions` is inferred and returned, as shown with the use of `label` as this does not exist on `Link` props

--- a/examples/react/kitchen-sink-file-based/src/routes/dashboard.tsx
+++ b/examples/react/kitchen-sink-file-based/src/routes/dashboard.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react'
-import { Link, Outlet, createFileRoute } from '@tanstack/react-router'
+import {
+  Link,
+  Outlet,
+  createFileRoute,
+  linkOptions,
+} from '@tanstack/react-router'
 
 export const Route = createFileRoute('/dashboard')({
   component: DashboardComponent,
@@ -7,6 +12,22 @@ export const Route = createFileRoute('/dashboard')({
     crumb: 'Dashboard',
   }),
 })
+
+const options = [
+  linkOptions({
+    to: '/dashboard',
+    label: 'Summary',
+    activeOptions: { exact: true },
+  }),
+  linkOptions({
+    to: '/dashboard/invoices',
+    label: 'Invoices',
+  }),
+  linkOptions({
+    to: '/dashboard/users',
+    label: 'Users',
+  }),
+]
 
 function DashboardComponent() {
   return (
@@ -16,22 +37,15 @@ function DashboardComponent() {
       </div>
 
       <div className="flex flex-wrap divide-x">
-        {(
-          [
-            ['/dashboard', 'Summary', true],
-            ['/dashboard/invoices', 'Invoices'],
-            ['/dashboard/users', 'Users'],
-          ] as const
-        ).map(([to, label, exact]) => {
+        {options.map((option) => {
           return (
             <Link
-              key={to}
-              to={to}
-              activeOptions={{ exact }}
+              key={option.to}
+              {...option}
               activeProps={{ className: `font-bold` }}
               className="p-2"
             >
-              {label}
+              {option.label}
             </Link>
           )
         })}

--- a/examples/react/large-file-based/src/routes/linkProps.tsx
+++ b/examples/react/large-file-based/src/routes/linkProps.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react'
-import { Link, type LinkProps, createFileRoute } from '@tanstack/react-router'
+import { Link, createFileRoute, linkOptions } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/linkProps')({
   component: LinkPropsPage,
 })
 
 function LinkPropsPage() {
-  const linkProps: LinkProps = {
+  const linkProps = linkOptions({
     to: '/absolute',
-  }
+  })
 
   return <Link {...linkProps} />
 }

--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -42,7 +42,7 @@ export * from './history'
 
 export { lazyRouteComponent } from './lazyRouteComponent'
 
-export { useLinkProps, createLink, Link } from './link'
+export { useLinkProps, createLink, Link, linkOptions } from './link'
 export type {
   CleanPath,
   Split,

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -996,7 +996,7 @@ function isCtrlEvent(e: MouseEvent) {
 }
 
 export type LinkOptionsFn<TComp> = <
-  TProps,
+  const TProps,
   TRouter extends AnyRouter = RegisteredRouter,
   TFrom extends string = string,
   TTo extends string | undefined = undefined,

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -994,3 +994,21 @@ export const Link: LinkComponent<'a'> = React.forwardRef<Element, any>(
 function isCtrlEvent(e: MouseEvent) {
   return !!(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey)
 }
+
+export type LinkOptionsFn<TComp> = <
+  TProps,
+  TRouter extends AnyRouter = RegisteredRouter,
+  TFrom extends string = string,
+  TTo extends string | undefined = undefined,
+  TMaskFrom extends string = TFrom,
+  TMaskTo extends string = '',
+>(
+  options: Constrain<
+    TProps,
+    LinkProps<TComp, TRouter, TFrom, TTo, TMaskFrom, TMaskTo>
+  >,
+) => TProps
+
+export const linkOptions: LinkOptionsFn<'a'> = (options) => {
+  return options as any
+}

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -1005,7 +1005,7 @@ export type LinkOptionsFn<TComp> = <
 >(
   options: Constrain<
     TProps,
-    LinkProps<TComp, TRouter, TFrom, TTo, TMaskFrom, TMaskTo>
+    LinkComponentProps<TComp, TRouter, TFrom, TTo, TMaskFrom, TMaskTo>
   >,
 ) => TProps
 

--- a/packages/react-router/tests/link.test-d.tsx
+++ b/packages/react-router/tests/link.test-d.tsx
@@ -5,6 +5,7 @@ import {
   createRootRoute,
   createRoute,
   createRouter,
+  linkOptions,
 } from '../src'
 import type { CreateLinkProps, SearchSchemaInput } from '../src'
 
@@ -3838,4 +3839,289 @@ test('when passing a component with props to createLink and navigating to the ro
     }>()
 
   createLink((props) => expectTypeOf(props).toEqualTypeOf<CreateLinkProps>())
+})
+
+test('linkOptions', () => {
+  const defaultRouterLinkOptions = linkOptions<
+    { label: string },
+    DefaultRouter,
+    string,
+    '/'
+  >
+  const defaultRouterObjectsLinkOptions = linkOptions<
+    { label: string },
+    DefaultRouter,
+    string,
+    '/'
+  >
+
+  const routerAlwaysTrailingSlashLinkOptions = linkOptions<
+    { label: string },
+    RouterAlwaysTrailingSlashes,
+    string,
+    '/'
+  >
+
+  const routerNeverTrailingSlashLinkOptions = linkOptions<
+    { label: string },
+    RouterNeverTrailingSlashes,
+    string,
+    '/'
+  >
+  const routerPreserveTrailingSlashLinkOptions = linkOptions<
+    { label: string },
+    RouterPreserveTrailingSlashes,
+    string,
+    '/'
+  >
+
+  expectTypeOf(defaultRouterLinkOptions)
+    .parameter(0)
+    .toHaveProperty('to')
+    .toEqualTypeOf<
+      | '..'
+      | '.'
+      | '/'
+      | '/invoices'
+      | '/invoices/$invoiceId'
+      | '/invoices/$invoiceId/details/$detailId'
+      | '/invoices/$invoiceId/details'
+      | '/invoices/$invoiceId/details/$detailId/lines'
+      | '/invoices/$invoiceId/edit'
+      | '/posts'
+      | '/posts/$postId'
+      | undefined
+    >()
+
+  expectTypeOf(defaultRouterObjectsLinkOptions)
+    .parameter(0)
+    .toHaveProperty('to')
+    .toEqualTypeOf<
+      | '..'
+      | '.'
+      | '/'
+      | '/invoices'
+      | '/invoices/$invoiceId'
+      | '/invoices/$invoiceId/details/$detailId'
+      | '/invoices/$invoiceId/details/$detailId/lines'
+      | '/invoices/$invoiceId/details'
+      | '/invoices/$invoiceId/edit'
+      | '/posts'
+      | '/posts/$postId'
+      | undefined
+    >()
+
+  expectTypeOf(routerAlwaysTrailingSlashLinkOptions)
+    .parameter(0)
+    .toHaveProperty('to')
+    .toEqualTypeOf<
+      | '../'
+      | './'
+      | '/'
+      | '/invoices/'
+      | '/invoices/$invoiceId/'
+      | '/invoices/$invoiceId/details/$detailId/'
+      | '/invoices/$invoiceId/details/$detailId/lines/'
+      | '/invoices/$invoiceId/details/'
+      | '/invoices/$invoiceId/edit/'
+      | '/posts/'
+      | '/posts/$postId/'
+      | undefined
+    >()
+
+  expectTypeOf(routerNeverTrailingSlashLinkOptions)
+    .parameter(0)
+    .toHaveProperty('to')
+    .toEqualTypeOf<
+      | '..'
+      | '.'
+      | '/'
+      | '/invoices'
+      | '/invoices/$invoiceId'
+      | '/invoices/$invoiceId/details/$detailId'
+      | '/invoices/$invoiceId/details/$detailId/lines'
+      | '/invoices/$invoiceId/details'
+      | '/invoices/$invoiceId/edit'
+      | '/posts'
+      | '/posts/$postId'
+      | undefined
+    >()
+
+  expectTypeOf(routerPreserveTrailingSlashLinkOptions)
+    .parameter(0)
+    .toHaveProperty('to')
+    .toEqualTypeOf<
+      | '..'
+      | '.'
+      | './'
+      | '../'
+      | '/'
+      | '/invoices'
+      | '/invoices/'
+      | '/invoices/$invoiceId'
+      | '/invoices/$invoiceId/'
+      | '/invoices/$invoiceId/details/$detailId'
+      | '/invoices/$invoiceId/details/$detailId/'
+      | '/invoices/$invoiceId/details/$detailId/lines'
+      | '/invoices/$invoiceId/details/$detailId/lines/'
+      | '/invoices/$invoiceId/details'
+      | '/invoices/$invoiceId/details/'
+      | '/invoices/$invoiceId/edit'
+      | '/invoices/$invoiceId/edit/'
+      | '/posts'
+      | '/posts/'
+      | '/posts/$postId'
+      | '/posts/$postId/'
+      | undefined
+    >()
+
+  expectTypeOf(defaultRouterLinkOptions)
+    .parameter(0)
+    .toMatchTypeOf<{ search: unknown }>()
+
+  expectTypeOf(defaultRouterObjectsLinkOptions)
+    .parameter(0)
+    .toMatchTypeOf<{ search: unknown }>()
+
+  expectTypeOf(routerAlwaysTrailingSlashLinkOptions)
+    .parameter(0)
+    .toMatchTypeOf<{ search: unknown }>()
+
+  expectTypeOf(routerNeverTrailingSlashLinkOptions)
+    .parameter(0)
+    .toMatchTypeOf<{ search: unknown }>()
+
+  expectTypeOf(routerPreserveTrailingSlashLinkOptions)
+    .parameter(0)
+    .toMatchTypeOf<{ search: unknown }>()
+
+  expectTypeOf(defaultRouterLinkOptions)
+    .parameter(0)
+    .toHaveProperty('search')
+    .exclude<Function | boolean>()
+    .toEqualTypeOf<{ rootPage?: number; rootIndexPage: number }>()
+
+  expectTypeOf(defaultRouterObjectsLinkOptions)
+    .parameter(0)
+    .toHaveProperty('search')
+    .exclude<Function | boolean>()
+    .toEqualTypeOf<{ rootPage?: number; rootIndexPage: number }>()
+
+  expectTypeOf(routerAlwaysTrailingSlashLinkOptions)
+    .parameter(0)
+    .toHaveProperty('search')
+    .exclude<Function | boolean>()
+    .toEqualTypeOf<{ rootPage?: number; rootIndexPage: number }>()
+
+  expectTypeOf(routerNeverTrailingSlashLinkOptions)
+    .parameter(0)
+    .toHaveProperty('search')
+    .exclude<Function | boolean>()
+    .toEqualTypeOf<{ rootPage?: number; rootIndexPage: number }>()
+
+  expectTypeOf(routerPreserveTrailingSlashLinkOptions)
+    .parameter(0)
+    .toHaveProperty('search')
+    .exclude<Function | boolean>()
+    .toEqualTypeOf<{ rootPage?: number; rootIndexPage: number }>()
+
+  expectTypeOf(defaultRouterLinkOptions)
+    .parameter(0)
+    .toHaveProperty('search')
+    .parameter(0)
+    .toEqualTypeOf<{
+      page?: number
+      rootIndexPage?: number
+      rootPage?: number
+      linesPage?: number
+    }>()
+
+  expectTypeOf(defaultRouterObjectsLinkOptions)
+    .parameter(0)
+    .toHaveProperty('search')
+    .parameter(0)
+    .toEqualTypeOf<{
+      page?: number
+      rootIndexPage?: number
+      rootPage?: number
+      linesPage?: number
+    }>()
+
+  expectTypeOf(routerAlwaysTrailingSlashLinkOptions)
+    .parameter(0)
+    .toHaveProperty('search')
+    .parameter(0)
+    .toEqualTypeOf<{
+      page?: number
+      rootIndexPage?: number
+      rootPage?: number
+      linesPage?: number
+    }>()
+
+  expectTypeOf(routerNeverTrailingSlashLinkOptions)
+    .parameter(0)
+    .toHaveProperty('search')
+    .parameter(0)
+    .toEqualTypeOf<{
+      page?: number
+      rootIndexPage?: number
+      rootPage?: number
+      linesPage?: number
+    }>()
+
+  expectTypeOf(routerPreserveTrailingSlashLinkOptions)
+    .parameter(0)
+    .toHaveProperty('search')
+    .parameter(0)
+    .toEqualTypeOf<{
+      page?: number
+      rootIndexPage?: number
+      rootPage?: number
+      linesPage?: number
+    }>()
+
+  expectTypeOf(defaultRouterLinkOptions)
+    .parameter(0)
+    .toHaveProperty('search')
+    .returns.toEqualTypeOf<{ rootPage?: number; rootIndexPage: number }>()
+
+  expectTypeOf(defaultRouterObjectsLinkOptions)
+    .parameter(0)
+    .toHaveProperty('search')
+    .returns.toEqualTypeOf<{ rootPage?: number; rootIndexPage: number }>()
+
+  expectTypeOf(routerAlwaysTrailingSlashLinkOptions)
+    .parameter(0)
+    .toHaveProperty('search')
+    .returns.toEqualTypeOf<{ rootPage?: number; rootIndexPage: number }>()
+
+  expectTypeOf(routerNeverTrailingSlashLinkOptions)
+    .parameter(0)
+    .toHaveProperty('search')
+    .returns.toEqualTypeOf<{ rootPage?: number; rootIndexPage: number }>()
+
+  expectTypeOf(routerPreserveTrailingSlashLinkOptions)
+    .parameter(0)
+    .toHaveProperty('search')
+    .returns.toEqualTypeOf<{ rootPage?: number; rootIndexPage: number }>()
+
+  expectTypeOf(defaultRouterLinkOptions).returns.toEqualTypeOf<{
+    label: string
+  }>()
+
+  expectTypeOf(defaultRouterObjectsLinkOptions).returns.toEqualTypeOf<{
+    label: string
+  }>()
+
+  expectTypeOf(routerAlwaysTrailingSlashLinkOptions).returns.toEqualTypeOf<{
+    label: string
+  }>()
+
+  expectTypeOf(routerNeverTrailingSlashLinkOptions).returns.toEqualTypeOf<{
+    label: string
+  }>()
+
+  expectTypeOf(routerPreserveTrailingSlashLinkOptions).returns.toEqualTypeOf<{
+    label: string
+  }>()
 })


### PR DESCRIPTION
`linkOptions` is a new function which is similar to TanStack Query's `queryOptions` in naming. Similar to `queryOptions` it does not change the input in anyway but it provides type safety of object literals intended to be passed to `Link`, `navigate` or `redirect`.

For example, consider the following from one of our examples

```tsx

function DashboardComponent() {
  return (
    <>
      <div className="flex items-center border-b">
        <h2 className="text-xl p-2">Dashboard</h2>
      </div>

      <div className="flex flex-wrap divide-x">
        {(
          [
            ['/dashboard', 'Summary', true],
            ['/dashboard/invoices', 'Invoices'],
            ['/dashboard/users', 'Users'],
          ] as const
        ).map(([to, label, exact]) => {
          return (
            <Link
              key={to}
              to={to}
              activeOptions={{ exact }}
              activeProps={{ className: `font-bold` }}
              className="p-2"
            >
              {label}
            </Link>
          )
        })}
      </div>
      <hr />

      <Outlet />
    </>
  )
}
```


The array here allows us to loop over and render a `Link` per item. But the items in the array are not type checked and only when they are passed to `Link` TypeScript complains if something is wrong.

Instead we can now use `linkOptions` to get type checking (and all the autocompletion goodness) of options as they are defined.

```tsx
const options = [
  linkOptions({
    to: '/dashboard',
    label: 'Summary',
    activeOptions: { exact: true },
  }),
  linkOptions({
    to: '/dashboard/invoices',
    label: 'Invoices',
  }),
  linkOptions({
    to: '/dashboard/users',
    label: 'Users',
  }),
]

function DashboardComponent() {
  return (
    <>
      <div className="flex items-center border-b">
        <h2 className="text-xl p-2">Dashboard</h2>
      </div>

      <div className="flex flex-wrap divide-x">
        {options.map((option) => {
          return (
            <Link
              key={option.to}
              {...option}
              activeProps={{ className: `font-bold` }}
              className="p-2"
            >
              {option.label}
            </Link>
          )
        })}
      </div>
      <hr />

      <Outlet />
    </>
  )
}

```

`linkOptions` works very similar to `satisfies` in TypeScript. It type checks the input of `linkOptions`, providing all the great type safety of `Link`. **But it returns the type of whatever you input as is** meaning any additional props are also inferred. As you can see with `label` here