### PR TITLE
fix(react-router): do not copy `id` from lazy route over to non-lazy route

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -2254,10 +2254,8 @@ export class Router<
                             route._lazyPromise ||
                             (route.lazyFn
                               ? route.lazyFn().then((lazyRoute) => {
-                                  Object.assign(
-                                    route.options,
-                                    lazyRoute.options,
-                                  )
+                                  const { id, ...options } = lazyRoute.options
+                                  Object.assign(route.options, options)
                                 })
                               : Promise.resolve())
 


### PR DESCRIPTION
fixes #2400