### PR TITLE
fix(start): allow specifying vinxi experimental options

### DIFF
--- a/packages/start/src/config/index.ts
+++ b/packages/start/src/config/index.ts
@@ -257,6 +257,7 @@ export function defineConfig(
       ...serverOptions,
       preset: deploymentPreset,
       experimental: {
+        ...serverOptions.experimental,
         asyncContext: true,
       },
     },


### PR DESCRIPTION
Specifying experimental options for Vinxi get overridden by the `asyncContext: true` option.

This PR lets the experimental options such as Web Sockets be enabled.