### PR TITLE
fix(create-router): Specify html template used by rspack

### DIFF
--- a/packages/create-router/templates/bundler/rspack/rsbuild.config.ts
+++ b/packages/create-router/templates/bundler/rspack/rsbuild.config.ts
@@ -7,6 +7,9 @@ export default defineConfig({
   source: {
     entry: { index: './src/main.tsx' },
   },
+  html: {
+    template: './index.html',
+  },
   tools: {
     rspack: {
       plugins: [TanStackRouterRspack()],


### PR DESCRIPTION
When no template is set, rspack uses their own template for build and the dev server. rspack default template uses root as div id, and no tailwind, causes first dev load to be blank.

https://rsbuild.dev/guide/basic/html-template

mountId could be set, but then a seperate index.html template is required. with
```html
<div id="<%= mountId %>"></div>
```