### PR TITLE
docs: add missing spaces for comments in the installation guide

### DIFF
--- a/docs/framework/react/installation.md
+++ b/docs/framework/react/installation.md
@@ -8,9 +8,9 @@ You can install TanStack Router with any [NPM](https://npmjs.com) package manage
 npm install @tanstack/react-router
 # or
 pnpm add @tanstack/react-router
-#or
+# or
 yarn add @tanstack/react-router
-#or
+# or
 bun add @tanstack/react-router
 ```
 


### PR DESCRIPTION
From `#or` to `# or`

![CleanShot 2024-10-10 at 00 24 33@2x](https://github.com/user-attachments/assets/f8aea98e-680f-4899-a853-ec5f3caeb63a)
