### PR TITLE
fix(react-router): populate result of `validateSearch` into URL when navigating

### DIFF
--- a/packages/react-router/src/RouterProvider.tsx
+++ b/packages/react-router/src/RouterProvider.tsx
@@ -48,6 +48,7 @@ export type BuildLocationFn = <
 >(
   opts: ToOptions<TRouter, TFrom, TTo, TMaskFrom, TMaskTo> & {
     leaveParams?: boolean
+    _includeValidateSearch?: boolean
   },
 ) => ParsedLocation
 

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -757,8 +757,9 @@ export function useLinkProps<
       })
 
       // All is well? Navigate!
-      router.commitLocation({
-        ...next,
+      // N.B. we don't call `router.commitLocation(next) here because we want to run `validateSearch` before committing
+      router.buildAndCommitLocation({
+        ...options,
         replace,
         resetScroll,
         startTransition,


### PR DESCRIPTION
fixes #2496
fixes #1184 