### PR TITLE
Add file extensions to generated imports

### DIFF
--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -488,13 +488,13 @@ export const Route = createAPIFileRoute('${escapedRoutePath}')({
       : '',
     '// Import Routes',
     [
-      `import { Route as rootRoute } from './${getImportPath(rootRouteNode)}'`,
+      `import { Route as rootRoute } from './${getImportPath(rootRouteNode)}.${config.disableTypes ? 'js' : 'tsx'}'`,
       ...sortedRouteNodes
         .filter((d) => !d.isVirtual)
         .map((node) => {
           return `import { Route as ${
             node.variableName
-          }Import } from './${getImportPath(node)}'`
+          }Import } from './${getImportPath(node)}.${config.disableTypes ? 'js' : 'tsx'}'`
         }),
     ].join('\n'),
     virtualRouteNodes.length ? '// Create Virtual Routes' : '',


### PR DESCRIPTION
Adds file extensions to auto-generated imports so user's can use Tanstack's file-based router with **Deno** (v2+)
(and other tools that enforce strict ECMAScript module compatibility.)

To test: 
- Have Deno v2 installed
- Build and run the project as outlined in `CONTRIBUTING.md`
- Navigate to an example project
- Delete `tsconfig.json` file
- Run : `deno task dev`

The example project should start without errors.
