### PR TITLE
fix(react-router): correctly handle hashes in `redirect`

### DIFF
--- a/packages/history/tests/parseHref.test.ts
+++ b/packages/history/tests/parseHref.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from 'vitest'
+import { parseHref } from '../src'
+
+describe('parseHref', () => {
+  test('works', () => {
+    const parsed = parseHref('/foo?bar=baz#qux', {});
+    expect(parsed.pathname).toEqual('/foo')
+    expect(parsed.search).toEqual('?bar=baz')
+    expect(parsed.hash).toEqual('#qux')
+  })
+})

--- a/packages/history/tests/parseHref.test.ts
+++ b/packages/history/tests/parseHref.test.ts
@@ -3,7 +3,7 @@ import { parseHref } from '../src'
 
 describe('parseHref', () => {
   test('works', () => {
-    const parsed = parseHref('/foo?bar=baz#qux', {});
+    const parsed = parseHref('/foo?bar=baz#qux', {})
     expect(parsed.pathname).toEqual('/foo')
     expect(parsed.search).toEqual('?bar=baz')
     expect(parsed.hash).toEqual('#qux')

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1657,7 +1657,8 @@ export class Router<
       const parsed = parseHref(href, {})
       rest.to = parsed.pathname
       rest.search = this.options.parseSearch(parsed.search)
-      rest.hash = parsed.hash
+      // remove the leading `#` from the hash
+      rest.hash = parsed.hash.slice(1)
     }
 
     const location = this.buildLocation({

--- a/packages/react-router/tests/redirect.test.tsx
+++ b/packages/react-router/tests/redirect.test.tsx
@@ -122,7 +122,7 @@ describe('redirect', () => {
         path: '/about',
         loader: async () => {
           await sleep(WAIT_TIME)
-          throw redirect({ to: '/nested/foo' })
+          throw redirect({ to: '/nested/foo', hash: 'some-hash', search: { someSearch: 'hello123' } })
         },
       })
       const nestedRoute = createRoute({
@@ -134,6 +134,11 @@ describe('redirect', () => {
         },
       })
       const fooRoute = createRoute({
+        validateSearch: (search) => {
+          return {
+            someSearch : search.someSearch as string 
+          }
+        },
         getParentRoute: () => nestedRoute,
         path: '/foo',
         loader: async () => {
@@ -161,7 +166,7 @@ describe('redirect', () => {
 
       expect(fooElement).toBeInTheDocument()
 
-      expect(router.state.location.href).toBe('/nested/foo')
+      expect(router.state.location.href).toBe('/nested/foo?someSearch=hello123#some-hash')
       expect(window.location.pathname).toBe('/nested/foo')
 
       expect(nestedLoaderMock).toHaveBeenCalled()

--- a/packages/react-router/tests/redirect.test.tsx
+++ b/packages/react-router/tests/redirect.test.tsx
@@ -122,7 +122,11 @@ describe('redirect', () => {
         path: '/about',
         loader: async () => {
           await sleep(WAIT_TIME)
-          throw redirect({ to: '/nested/foo', hash: 'some-hash', search: { someSearch: 'hello123' } })
+          throw redirect({
+            to: '/nested/foo',
+            hash: 'some-hash',
+            search: { someSearch: 'hello123' },
+          })
         },
       })
       const nestedRoute = createRoute({
@@ -136,7 +140,7 @@ describe('redirect', () => {
       const fooRoute = createRoute({
         validateSearch: (search) => {
           return {
-            someSearch : search.someSearch as string 
+            someSearch: search.someSearch as string,
           }
         },
         getParentRoute: () => nestedRoute,
@@ -166,7 +170,9 @@ describe('redirect', () => {
 
       expect(fooElement).toBeInTheDocument()
 
-      expect(router.state.location.href).toBe('/nested/foo?someSearch=hello123#some-hash')
+      expect(router.state.location.href).toBe(
+        '/nested/foo?someSearch=hello123#some-hash',
+      )
       expect(window.location.pathname).toBe('/nested/foo')
 
       expect(nestedLoaderMock).toHaveBeenCalled()


### PR DESCRIPTION
fixes #2537