### PR TITLE
docs: add missing import for `retainSearchParams`

### DIFF
--- a/docs/framework/react/guide/search-params.md
+++ b/docs/framework/react/guide/search-params.md
@@ -563,7 +563,7 @@ Since this specific use case is quite common, TanStack Router provides a generic
 
 ```tsx
 import { z } from 'zod'
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, retainSearchParams } from '@tanstack/react-router'
 import { zodSearchValidator } from '@tanstack/router-zod-adapter'
 
 const searchSchema = z.object({


### PR DESCRIPTION
I noticed that there's an import missing for "retainSearchParams" inside the Search Params documentation page. 

**Before:** 

```ts
import { createFileRoute } from '@tanstack/react-router'
```

**After:**

```ts
import { createFileRoute, retainSearchParams } from '@tanstack/react-router'
```