### PR TITLE
feat(react-router): added router option `search.strict`

### DIFF
--- a/docs/framework/react/api/router/RouterOptionsType.md
+++ b/docs/framework/react/api/router/RouterOptionsType.md
@@ -35,6 +35,15 @@ The `RouterOptions` type accepts an object with the following properties and met
 - A function that will be used to parse search params when parsing the current location.
 - Defaults to `defaultParseSearch`.
 
+### `search.strict` property
+
+- Type: `boolean`
+- Optional
+- Defaults to `false`
+- Configures how unknown search params (= not returned by any `validateSearch`) are treated.
+- If `false`, unknown search params will be kept.
+- If `true`, unknown search params will be removed.
+
 ### `defaultPreload` property
 
 - Type: `undefined | false | 'intent' | 'viewport'`

--- a/packages/react-router/src/Transitioner.tsx
+++ b/packages/react-router/src/Transitioner.tsx
@@ -39,6 +39,7 @@ export function Transitioner() {
       params: true,
       hash: true,
       state: true,
+      _includeValidateSearch: true,
     })
 
     if (

--- a/packages/react-router/tests/useNavigate.test.tsx
+++ b/packages/react-router/tests/useNavigate.test.tsx
@@ -1238,9 +1238,12 @@ test('when setting search params with 2 parallel navigate calls', async () => {
 
   const IndexComponent = () => {
     const navigate = useNavigate()
+    const search = indexRoute.useSearch()
     return (
       <React.Fragment>
         <h1>Index</h1>
+        <div data-testid="param1">{search.param1}</div>
+        <div data-testid="param2">{search.param2}</div>
         <button
           onClick={() => {
             navigate({
@@ -1284,5 +1287,10 @@ test('when setting search params with 2 parallel navigate calls', async () => {
 
   fireEvent.click(postsButton)
 
+  expect(await screen.findByTestId('param1')).toHaveTextContent('foo')
+  expect(await screen.findByTestId('param2')).toHaveTextContent('bar')
   expect(router.state.location.search).toEqual({ param1: 'foo', param2: 'bar' })
+  const search = new URLSearchParams(window.location.search)
+  expect(search.get('param1')).toEqual('foo')
+  expect(search.get('param2')).toEqual('bar')
 })


### PR DESCRIPTION
Configures how unknown search params (= not returned by any `validateSearch`) are treated.