### PR TITLE
Update Convex codegen

### DIFF
--- a/examples/react/start-convex-trellaux/convex/_generated/api.d.ts
+++ b/examples/react/start-convex-trellaux/convex/_generated/api.d.ts
@@ -1,3 +1,5 @@
+/* prettier-ignore-start */
+
 /* eslint-disable */
 /**
  * Generated `api` utility.
@@ -12,8 +14,8 @@ import type {
   ApiFromModules,
   FilterApi,
   FunctionReference,
-} from 'convex/server'
-import type * as board from '../board.js'
+} from "convex/server";
+import type * as board from "../board.js";
 
 /**
  * A utility for referencing Convex functions in your app's API.
@@ -24,13 +26,15 @@ import type * as board from '../board.js'
  * ```
  */
 declare const fullApi: ApiFromModules<{
-  board: typeof board
-}>
+  board: typeof board;
+}>;
 export declare const api: FilterApi<
   typeof fullApi,
-  FunctionReference<any, 'public'>
->
+  FunctionReference<any, "public">
+>;
 export declare const internal: FilterApi<
   typeof fullApi,
-  FunctionReference<any, 'internal'>
->
+  FunctionReference<any, "internal">
+>;
+
+/* prettier-ignore-end */

--- a/examples/react/start-convex-trellaux/convex/_generated/api.d.ts
+++ b/examples/react/start-convex-trellaux/convex/_generated/api.d.ts
@@ -14,8 +14,8 @@ import type {
   ApiFromModules,
   FilterApi,
   FunctionReference,
-} from "convex/server";
-import type * as board from "../board.js";
+} from 'convex/server'
+import type * as board from '../board.js'
 
 /**
  * A utility for referencing Convex functions in your app's API.
@@ -26,15 +26,15 @@ import type * as board from "../board.js";
  * ```
  */
 declare const fullApi: ApiFromModules<{
-  board: typeof board;
-}>;
+  board: typeof board
+}>
 export declare const api: FilterApi<
   typeof fullApi,
-  FunctionReference<any, "public">
->;
+  FunctionReference<any, 'public'>
+>
 export declare const internal: FilterApi<
   typeof fullApi,
-  FunctionReference<any, "internal">
->;
+  FunctionReference<any, 'internal'>
+>
 
 /* prettier-ignore-end */

--- a/examples/react/start-convex-trellaux/convex/_generated/api.js
+++ b/examples/react/start-convex-trellaux/convex/_generated/api.js
@@ -1,3 +1,5 @@
+/* prettier-ignore-start */
+
 /* eslint-disable */
 /**
  * Generated `api` utility.
@@ -8,7 +10,7 @@
  * @module
  */
 
-import { anyApi } from 'convex/server'
+import { anyApi } from "convex/server";
 
 /**
  * A utility for referencing Convex functions in your app's API.
@@ -18,5 +20,7 @@ import { anyApi } from 'convex/server'
  * const myFunctionReference = api.myModule.myFunction;
  * ```
  */
-export const api = anyApi
-export const internal = anyApi
+export const api = anyApi;
+export const internal = anyApi;
+
+/* prettier-ignore-end */

--- a/examples/react/start-convex-trellaux/convex/_generated/api.js
+++ b/examples/react/start-convex-trellaux/convex/_generated/api.js
@@ -10,7 +10,7 @@
  * @module
  */
 
-import { anyApi } from "convex/server";
+import { anyApi } from 'convex/server'
 
 /**
  * A utility for referencing Convex functions in your app's API.
@@ -20,7 +20,7 @@ import { anyApi } from "convex/server";
  * const myFunctionReference = api.myModule.myFunction;
  * ```
  */
-export const api = anyApi;
-export const internal = anyApi;
+export const api = anyApi
+export const internal = anyApi
 
 /* prettier-ignore-end */

--- a/examples/react/start-convex-trellaux/convex/_generated/dataModel.d.ts
+++ b/examples/react/start-convex-trellaux/convex/_generated/dataModel.d.ts
@@ -1,3 +1,5 @@
+/* prettier-ignore-start */
+
 /* eslint-disable */
 /**
  * Generated data model types.
@@ -13,14 +15,14 @@ import type {
   DocumentByName,
   TableNamesInDataModel,
   SystemTableNames,
-} from 'convex/server'
-import type { GenericId } from 'convex/values'
-import schema from '../schema.js'
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
 
 /**
  * The names of all of your Convex tables.
  */
-export type TableNames = TableNamesInDataModel<DataModel>
+export type TableNames = TableNamesInDataModel<DataModel>;
 
 /**
  * The type of a document stored in Convex.
@@ -30,7 +32,7 @@ export type TableNames = TableNamesInDataModel<DataModel>
 export type Doc<TableName extends TableNames> = DocumentByName<
   DataModel,
   TableName
->
+>;
 
 /**
  * An identifier for a document in Convex.
@@ -46,7 +48,7 @@ export type Doc<TableName extends TableNames> = DocumentByName<
  * @typeParam TableName - A string literal type of the table name (like "users").
  */
 export type Id<TableName extends TableNames | SystemTableNames> =
-  GenericId<TableName>
+  GenericId<TableName>;
 
 /**
  * A type describing your Convex data model.
@@ -57,4 +59,6 @@ export type Id<TableName extends TableNames | SystemTableNames> =
  * This type is used to parameterize methods like `queryGeneric` and
  * `mutationGeneric` to make them type-safe.
  */
-export type DataModel = DataModelFromSchemaDefinition<typeof schema>
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;
+
+/* prettier-ignore-end */

--- a/examples/react/start-convex-trellaux/convex/_generated/dataModel.d.ts
+++ b/examples/react/start-convex-trellaux/convex/_generated/dataModel.d.ts
@@ -15,14 +15,14 @@ import type {
   DocumentByName,
   TableNamesInDataModel,
   SystemTableNames,
-} from "convex/server";
-import type { GenericId } from "convex/values";
-import schema from "../schema.js";
+} from 'convex/server'
+import type { GenericId } from 'convex/values'
+import schema from '../schema.js'
 
 /**
  * The names of all of your Convex tables.
  */
-export type TableNames = TableNamesInDataModel<DataModel>;
+export type TableNames = TableNamesInDataModel<DataModel>
 
 /**
  * The type of a document stored in Convex.
@@ -32,7 +32,7 @@ export type TableNames = TableNamesInDataModel<DataModel>;
 export type Doc<TableName extends TableNames> = DocumentByName<
   DataModel,
   TableName
->;
+>
 
 /**
  * An identifier for a document in Convex.
@@ -48,7 +48,7 @@ export type Doc<TableName extends TableNames> = DocumentByName<
  * @typeParam TableName - A string literal type of the table name (like "users").
  */
 export type Id<TableName extends TableNames | SystemTableNames> =
-  GenericId<TableName>;
+  GenericId<TableName>
 
 /**
  * A type describing your Convex data model.
@@ -59,6 +59,6 @@ export type Id<TableName extends TableNames | SystemTableNames> =
  * This type is used to parameterize methods like `queryGeneric` and
  * `mutationGeneric` to make them type-safe.
  */
-export type DataModel = DataModelFromSchemaDefinition<typeof schema>;
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>
 
 /* prettier-ignore-end */

--- a/examples/react/start-convex-trellaux/convex/_generated/server.d.ts
+++ b/examples/react/start-convex-trellaux/convex/_generated/server.d.ts
@@ -1,3 +1,5 @@
+/* prettier-ignore-start */
+
 /* eslint-disable */
 /**
  * Generated utilities for implementing server-side Convex query and mutation functions.
@@ -18,8 +20,8 @@ import {
   GenericQueryCtx,
   GenericDatabaseReader,
   GenericDatabaseWriter,
-} from 'convex/server'
-import type { DataModel } from './dataModel.js'
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
 
 /**
  * Define a query in this Convex app's public API.
@@ -29,7 +31,7 @@ import type { DataModel } from './dataModel.js'
  * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
  * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
  */
-export declare const query: QueryBuilder<DataModel, 'public'>
+export declare const query: QueryBuilder<DataModel, "public">;
 
 /**
  * Define a query that is only accessible from other Convex functions (but not from the client).
@@ -39,7 +41,7 @@ export declare const query: QueryBuilder<DataModel, 'public'>
  * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
  * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
  */
-export declare const internalQuery: QueryBuilder<DataModel, 'internal'>
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
 
 /**
  * Define a mutation in this Convex app's public API.
@@ -49,7 +51,7 @@ export declare const internalQuery: QueryBuilder<DataModel, 'internal'>
  * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
  * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
  */
-export declare const mutation: MutationBuilder<DataModel, 'public'>
+export declare const mutation: MutationBuilder<DataModel, "public">;
 
 /**
  * Define a mutation that is only accessible from other Convex functions (but not from the client).
@@ -59,7 +61,7 @@ export declare const mutation: MutationBuilder<DataModel, 'public'>
  * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
  * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
  */
-export declare const internalMutation: MutationBuilder<DataModel, 'internal'>
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
 
 /**
  * Define an action in this Convex app's public API.
@@ -72,7 +74,7 @@ export declare const internalMutation: MutationBuilder<DataModel, 'internal'>
  * @param func - The action. It receives an {@link ActionCtx} as its first argument.
  * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
  */
-export declare const action: ActionBuilder<DataModel, 'public'>
+export declare const action: ActionBuilder<DataModel, "public">;
 
 /**
  * Define an action that is only accessible from other Convex functions (but not from the client).
@@ -80,7 +82,7 @@ export declare const action: ActionBuilder<DataModel, 'public'>
  * @param func - The function. It receives an {@link ActionCtx} as its first argument.
  * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
  */
-export declare const internalAction: ActionBuilder<DataModel, 'internal'>
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
 
 /**
  * Define an HTTP action.
@@ -92,7 +94,7 @@ export declare const internalAction: ActionBuilder<DataModel, 'internal'>
  * @param func - The function. It receives an {@link ActionCtx} as its first argument.
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
-export declare const httpAction: HttpActionBuilder
+export declare const httpAction: HttpActionBuilder;
 
 /**
  * A set of services for use within Convex query functions.
@@ -103,7 +105,7 @@ export declare const httpAction: HttpActionBuilder
  * This differs from the {@link MutationCtx} because all of the services are
  * read-only.
  */
-export type QueryCtx = GenericQueryCtx<DataModel>
+export type QueryCtx = GenericQueryCtx<DataModel>;
 
 /**
  * A set of services for use within Convex mutation functions.
@@ -111,7 +113,7 @@ export type QueryCtx = GenericQueryCtx<DataModel>
  * The mutation context is passed as the first argument to any Convex mutation
  * function run on the server.
  */
-export type MutationCtx = GenericMutationCtx<DataModel>
+export type MutationCtx = GenericMutationCtx<DataModel>;
 
 /**
  * A set of services for use within Convex action functions.
@@ -119,7 +121,7 @@ export type MutationCtx = GenericMutationCtx<DataModel>
  * The action context is passed as the first argument to any Convex action
  * function run on the server.
  */
-export type ActionCtx = GenericActionCtx<DataModel>
+export type ActionCtx = GenericActionCtx<DataModel>;
 
 /**
  * An interface to read from the database within Convex query functions.
@@ -128,7 +130,7 @@ export type ActionCtx = GenericActionCtx<DataModel>
  * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
  * building a query.
  */
-export type DatabaseReader = GenericDatabaseReader<DataModel>
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
 
 /**
  * An interface to read from and write to the database within Convex mutation
@@ -139,4 +141,6 @@ export type DatabaseReader = GenericDatabaseReader<DataModel>
  * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
  * for the guarantees Convex provides your functions.
  */
-export type DatabaseWriter = GenericDatabaseWriter<DataModel>
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;
+
+/* prettier-ignore-end */

--- a/examples/react/start-convex-trellaux/convex/_generated/server.d.ts
+++ b/examples/react/start-convex-trellaux/convex/_generated/server.d.ts
@@ -20,8 +20,8 @@ import {
   GenericQueryCtx,
   GenericDatabaseReader,
   GenericDatabaseWriter,
-} from "convex/server";
-import type { DataModel } from "./dataModel.js";
+} from 'convex/server'
+import type { DataModel } from './dataModel.js'
 
 /**
  * Define a query in this Convex app's public API.
@@ -31,7 +31,7 @@ import type { DataModel } from "./dataModel.js";
  * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
  * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
  */
-export declare const query: QueryBuilder<DataModel, "public">;
+export declare const query: QueryBuilder<DataModel, 'public'>
 
 /**
  * Define a query that is only accessible from other Convex functions (but not from the client).
@@ -41,7 +41,7 @@ export declare const query: QueryBuilder<DataModel, "public">;
  * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
  * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
  */
-export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+export declare const internalQuery: QueryBuilder<DataModel, 'internal'>
 
 /**
  * Define a mutation in this Convex app's public API.
@@ -51,7 +51,7 @@ export declare const internalQuery: QueryBuilder<DataModel, "internal">;
  * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
  * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
  */
-export declare const mutation: MutationBuilder<DataModel, "public">;
+export declare const mutation: MutationBuilder<DataModel, 'public'>
 
 /**
  * Define a mutation that is only accessible from other Convex functions (but not from the client).
@@ -61,7 +61,7 @@ export declare const mutation: MutationBuilder<DataModel, "public">;
  * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
  * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
  */
-export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+export declare const internalMutation: MutationBuilder<DataModel, 'internal'>
 
 /**
  * Define an action in this Convex app's public API.
@@ -74,7 +74,7 @@ export declare const internalMutation: MutationBuilder<DataModel, "internal">;
  * @param func - The action. It receives an {@link ActionCtx} as its first argument.
  * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
  */
-export declare const action: ActionBuilder<DataModel, "public">;
+export declare const action: ActionBuilder<DataModel, 'public'>
 
 /**
  * Define an action that is only accessible from other Convex functions (but not from the client).
@@ -82,7 +82,7 @@ export declare const action: ActionBuilder<DataModel, "public">;
  * @param func - The function. It receives an {@link ActionCtx} as its first argument.
  * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
  */
-export declare const internalAction: ActionBuilder<DataModel, "internal">;
+export declare const internalAction: ActionBuilder<DataModel, 'internal'>
 
 /**
  * Define an HTTP action.
@@ -94,7 +94,7 @@ export declare const internalAction: ActionBuilder<DataModel, "internal">;
  * @param func - The function. It receives an {@link ActionCtx} as its first argument.
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
-export declare const httpAction: HttpActionBuilder;
+export declare const httpAction: HttpActionBuilder
 
 /**
  * A set of services for use within Convex query functions.
@@ -105,7 +105,7 @@ export declare const httpAction: HttpActionBuilder;
  * This differs from the {@link MutationCtx} because all of the services are
  * read-only.
  */
-export type QueryCtx = GenericQueryCtx<DataModel>;
+export type QueryCtx = GenericQueryCtx<DataModel>
 
 /**
  * A set of services for use within Convex mutation functions.
@@ -113,7 +113,7 @@ export type QueryCtx = GenericQueryCtx<DataModel>;
  * The mutation context is passed as the first argument to any Convex mutation
  * function run on the server.
  */
-export type MutationCtx = GenericMutationCtx<DataModel>;
+export type MutationCtx = GenericMutationCtx<DataModel>
 
 /**
  * A set of services for use within Convex action functions.
@@ -121,7 +121,7 @@ export type MutationCtx = GenericMutationCtx<DataModel>;
  * The action context is passed as the first argument to any Convex action
  * function run on the server.
  */
-export type ActionCtx = GenericActionCtx<DataModel>;
+export type ActionCtx = GenericActionCtx<DataModel>
 
 /**
  * An interface to read from the database within Convex query functions.
@@ -130,7 +130,7 @@ export type ActionCtx = GenericActionCtx<DataModel>;
  * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
  * building a query.
  */
-export type DatabaseReader = GenericDatabaseReader<DataModel>;
+export type DatabaseReader = GenericDatabaseReader<DataModel>
 
 /**
  * An interface to read from and write to the database within Convex mutation
@@ -141,6 +141,6 @@ export type DatabaseReader = GenericDatabaseReader<DataModel>;
  * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
  * for the guarantees Convex provides your functions.
  */
-export type DatabaseWriter = GenericDatabaseWriter<DataModel>;
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>
 
 /* prettier-ignore-end */

--- a/examples/react/start-convex-trellaux/convex/_generated/server.js
+++ b/examples/react/start-convex-trellaux/convex/_generated/server.js
@@ -1,3 +1,5 @@
+/* prettier-ignore-start */
+
 /* eslint-disable */
 /**
  * Generated utilities for implementing server-side Convex query and mutation functions.
@@ -16,7 +18,7 @@ import {
   internalActionGeneric,
   internalMutationGeneric,
   internalQueryGeneric,
-} from 'convex/server'
+} from "convex/server";
 
 /**
  * Define a query in this Convex app's public API.
@@ -26,7 +28,7 @@ import {
  * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
  * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
  */
-export const query = queryGeneric
+export const query = queryGeneric;
 
 /**
  * Define a query that is only accessible from other Convex functions (but not from the client).
@@ -36,7 +38,7 @@ export const query = queryGeneric
  * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
  * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
  */
-export const internalQuery = internalQueryGeneric
+export const internalQuery = internalQueryGeneric;
 
 /**
  * Define a mutation in this Convex app's public API.
@@ -46,7 +48,7 @@ export const internalQuery = internalQueryGeneric
  * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
  * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
  */
-export const mutation = mutationGeneric
+export const mutation = mutationGeneric;
 
 /**
  * Define a mutation that is only accessible from other Convex functions (but not from the client).
@@ -56,7 +58,7 @@ export const mutation = mutationGeneric
  * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
  * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
  */
-export const internalMutation = internalMutationGeneric
+export const internalMutation = internalMutationGeneric;
 
 /**
  * Define an action in this Convex app's public API.
@@ -69,7 +71,7 @@ export const internalMutation = internalMutationGeneric
  * @param func - The action. It receives an {@link ActionCtx} as its first argument.
  * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
  */
-export const action = actionGeneric
+export const action = actionGeneric;
 
 /**
  * Define an action that is only accessible from other Convex functions (but not from the client).
@@ -77,7 +79,7 @@ export const action = actionGeneric
  * @param func - The function. It receives an {@link ActionCtx} as its first argument.
  * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
  */
-export const internalAction = internalActionGeneric
+export const internalAction = internalActionGeneric;
 
 /**
  * Define a Convex HTTP action.
@@ -86,4 +88,6 @@ export const internalAction = internalActionGeneric
  * as its second.
  * @returns The wrapped endpoint function. Route a URL path to this function in `convex/http.js`.
  */
-export const httpAction = httpActionGeneric
+export const httpAction = httpActionGeneric;
+
+/* prettier-ignore-end */

--- a/examples/react/start-convex-trellaux/convex/_generated/server.js
+++ b/examples/react/start-convex-trellaux/convex/_generated/server.js
@@ -18,7 +18,7 @@ import {
   internalActionGeneric,
   internalMutationGeneric,
   internalQueryGeneric,
-} from "convex/server";
+} from 'convex/server'
 
 /**
  * Define a query in this Convex app's public API.
@@ -28,7 +28,7 @@ import {
  * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
  * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
  */
-export const query = queryGeneric;
+export const query = queryGeneric
 
 /**
  * Define a query that is only accessible from other Convex functions (but not from the client).
@@ -38,7 +38,7 @@ export const query = queryGeneric;
  * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
  * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
  */
-export const internalQuery = internalQueryGeneric;
+export const internalQuery = internalQueryGeneric
 
 /**
  * Define a mutation in this Convex app's public API.
@@ -48,7 +48,7 @@ export const internalQuery = internalQueryGeneric;
  * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
  * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
  */
-export const mutation = mutationGeneric;
+export const mutation = mutationGeneric
 
 /**
  * Define a mutation that is only accessible from other Convex functions (but not from the client).
@@ -58,7 +58,7 @@ export const mutation = mutationGeneric;
  * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
  * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
  */
-export const internalMutation = internalMutationGeneric;
+export const internalMutation = internalMutationGeneric
 
 /**
  * Define an action in this Convex app's public API.
@@ -71,7 +71,7 @@ export const internalMutation = internalMutationGeneric;
  * @param func - The action. It receives an {@link ActionCtx} as its first argument.
  * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
  */
-export const action = actionGeneric;
+export const action = actionGeneric
 
 /**
  * Define an action that is only accessible from other Convex functions (but not from the client).
@@ -79,7 +79,7 @@ export const action = actionGeneric;
  * @param func - The function. It receives an {@link ActionCtx} as its first argument.
  * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
  */
-export const internalAction = internalActionGeneric;
+export const internalAction = internalActionGeneric
 
 /**
  * Define a Convex HTTP action.
@@ -88,6 +88,6 @@ export const internalAction = internalActionGeneric;
  * as its second.
  * @returns The wrapped endpoint function. Route a URL path to this function in `convex/http.js`.
  */
-export const httpAction = httpActionGeneric;
+export const httpAction = httpActionGeneric
 
 /* prettier-ignore-end */


### PR DESCRIPTION
Convex now uses prettierignore directives for generated files, update this so anyone running this locally isn't confused.