### PR TITLE
feat(react-router): expose 'key' for search param serialization

### DIFF
--- a/docs/framework/react/guide/custom-search-param-serialization.md
+++ b/docs/framework/react/guide/custom-search-param-serialization.md
@@ -31,8 +31,8 @@ import {
 
 const router = createRouter({
   // ...
-  parseSearch: parseSearchWith(JSON.parse),
-  stringifySearch: stringifySearchWith(JSON.stringify),
+  parseSearch: parseSearchWith((value) => JSON.parse(value)),
+  stringifySearch: stringifySearchWith((value) => JSON.stringify(value)),
 })
 ```
 
@@ -135,8 +135,8 @@ import { parse, stringify } from 'jsurl2'
 
 const router = createRouter({
   // ...
-  parseSearch: parseSearchWith(parse),
-  stringifySearch: stringifySearchWith(stringify),
+  parseSearch: parseSearchWith((value) => parse(value)),
+  stringifySearch: stringifySearchWith((value) => stringify(value)),
 })
 ```
 


### PR DESCRIPTION
Hi, 

I would like to expose the JSON key for serialization. 

I have a use-case where I want to serialize a `Date`, but I have query params (`fromDate`, `toDate`) that should be serialized to `2024-10-19` and others with a different key that should also include minutes, seconds, etc.

So the type is the same for both cases, so I have to make the distinction based on the `key`.

This PR exposes the `key` in addition to the `value`.
