### PR TITLE
feat(react-router): allow to explicitly check if a search prop is not set

### DIFF
--- a/docs/framework/react/guide/navigation.md
+++ b/docs/framework/react/guide/navigation.md
@@ -88,6 +88,7 @@ export type LinkOptions<
     exact?: boolean
     includeHash?: boolean
     includeSearch?: boolean
+    explicitUndefined?: boolean
   }
   // If set, will preload the linked route on hover and cache it for this many milliseconds in hopes that the user will eventually navigate there.
   preload?: false | 'intent'
@@ -282,6 +283,10 @@ export interface ActiveOptions {
   // If true, the link will only be active if the current URL search params inclusively match the `search` prop
   // Defaults to `true`
   includeSearch?: boolean
+  // This modifies the `includeSearch` behavior.
+  // If true,  properties in `search` that are explicitly `undefined` must NOT be present in the current URL search params for the link to be active.
+  // defaults to `false`
+  explicitUndefined?: boolean
 }
 ```
 

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -470,6 +470,7 @@ export interface ActiveOptions {
   exact?: boolean
   includeHash?: boolean
   includeSearch?: boolean
+  explicitUndefined?: boolean
 }
 
 export type LinkOptions<
@@ -685,11 +686,10 @@ export function useLinkProps<
       }
 
       if (activeOptions?.includeSearch ?? true) {
-        const searchTest = deepEqual(
-          s.location.search,
-          next.search,
-          !activeOptions?.exact,
-        )
+        const searchTest = deepEqual(s.location.search, next.search, {
+          partial: !activeOptions?.exact,
+          ignoreUndefined: !activeOptions?.explicitUndefined,
+        })
         if (!searchTest) {
           return false
         }

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -2725,13 +2725,15 @@ export class Router<
       return false
     }
     if (location.params) {
-      if (!deepEqual(match, location.params, true)) {
+      if (!deepEqual(match, location.params, { partial: true })) {
         return false
       }
     }
 
     if (match && (opts?.includeSearch ?? true)) {
-      return deepEqual(baseLocation.search, next.search, true) ? match : false
+      return deepEqual(baseLocation.search, next.search, { partial: true })
+        ? match
+        : false
     }
 
     return match

--- a/packages/react-router/src/utils.ts
+++ b/packages/react-router/src/utils.ts
@@ -218,7 +218,19 @@ export function isPlainArray(value: unknown): value is Array<unknown> {
   return Array.isArray(value) && value.length === Object.keys(value).length
 }
 
-export function deepEqual(a: any, b: any, partial: boolean = false): boolean {
+function getObjectKeys(obj: any, ignoreUndefined: boolean) {
+  let keys = Object.keys(obj)
+  if (ignoreUndefined) {
+    keys = keys.filter((key) => obj[key] !== undefined)
+  }
+  return keys
+}
+
+export function deepEqual(
+  a: any,
+  b: any,
+  opts?: { partial?: boolean; ignoreUndefined?: boolean },
+): boolean {
   if (a === b) {
     return true
   }
@@ -228,23 +240,22 @@ export function deepEqual(a: any, b: any, partial: boolean = false): boolean {
   }
 
   if (isPlainObject(a) && isPlainObject(b)) {
-    const aKeys = Object.keys(a).filter((key) => a[key] !== undefined)
-    const bKeys = Object.keys(b).filter((key) => b[key] !== undefined)
+    const ignoreUndefined = opts?.ignoreUndefined ?? true
+    const aKeys = getObjectKeys(a, ignoreUndefined)
+    const bKeys = getObjectKeys(b, ignoreUndefined)
 
-    if (!partial && aKeys.length !== bKeys.length) {
+    if (!opts?.partial && aKeys.length !== bKeys.length) {
       return false
     }
 
-    return !bKeys.some(
-      (key) => !(key in a) || !deepEqual(a[key], b[key], partial),
-    )
+    return !bKeys.some((key) => !(key in a) || !deepEqual(a[key], b[key], opts))
   }
 
   if (Array.isArray(a) && Array.isArray(b)) {
     if (a.length !== b.length) {
       return false
     }
-    return !a.some((item, index) => !deepEqual(item, b[index], partial))
+    return !a.some((item, index) => !deepEqual(item, b[index], opts))
   }
 
   return false

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -214,132 +214,197 @@ describe('Link', () => {
     expect(postsLink).not.toHaveAttribute('data-status', 'active')
   })
 
-  test('when the current route has a search fields with undefined values', async () => {
-    const rootRoute = createRootRoute()
-    const indexRoute = createRoute({
-      getParentRoute: () => rootRoute,
-      path: '/',
-      component: () => {
-        return (
-          <>
-            <h1>Index</h1>
-            <Link
-              to="/"
-              activeOptions={{ exact: true }}
-              inactiveProps={{ className: 'inactive' }}
-            >
-              Index exact
-            </Link>
-            <Link
-              to="/"
-              search={{ foo: undefined }}
-              inactiveProps={{ className: 'inactive' }}
-            >
-              Index foo=undefined
-            </Link>
-            <Link
-              to="/"
-              search={{ foo: undefined }}
-              activeOptions={{ exact: true }}
-              inactiveProps={{ className: 'inactive' }}
-            >
-              Index foo=undefined-exact
-            </Link>
-            <Link
-              to="/"
-              search={{ foo: 'bar' }}
-              inactiveProps={{
-                className: 'inactive',
-              }}
-            >
-              Index foo=bar
-            </Link>
-          </>
+  describe('when the current route has a search fields with undefined values', () => {
+    async function runTest(opts: { explicitUndefined: boolean | undefined }) {
+      const rootRoute = createRootRoute()
+      const indexRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/',
+        component: () => {
+          return (
+            <>
+              <h1>Index</h1>
+              <Link
+                to="/"
+                activeOptions={{ exact: true }}
+                inactiveProps={{ className: 'inactive' }}
+              >
+                Index exact
+              </Link>
+              <Link
+                to="/"
+                search={{ foo: undefined }}
+                inactiveProps={{ className: 'inactive' }}
+                activeOptions={{ explicitUndefined: opts.explicitUndefined }}
+              >
+                Index foo=undefined
+              </Link>
+              <Link
+                to="/"
+                search={{ foo: undefined }}
+                activeOptions={{
+                  exact: true,
+                  explicitUndefined: opts.explicitUndefined,
+                }}
+                inactiveProps={{ className: 'inactive' }}
+              >
+                Index foo=undefined-exact
+              </Link>
+              <Link
+                to="/"
+                search={{ foo: 'bar' }}
+                inactiveProps={{
+                  className: 'inactive',
+                }}
+              >
+                Index foo=bar
+              </Link>
+            </>
+          )
+        },
+      })
+
+      const router = createRouter({
+        routeTree: rootRoute.addChildren([indexRoute]),
+      })
+
+      render(<RouterProvider router={router} />)
+
+      // round 1
+      const indexExactLink = await screen.findByRole('link', {
+        name: 'Index exact',
+      })
+
+      const indexFooUndefinedLink = await screen.findByRole('link', {
+        name: 'Index foo=undefined',
+      })
+
+      const indexFooUndefinedExactLink = await screen.findByRole('link', {
+        name: 'Index foo=undefined-exact',
+      })
+
+      const indexFooBarLink = await screen.findByRole('link', {
+        name: 'Index foo=bar',
+      })
+
+      expect(window.location.pathname).toBe('/')
+
+      expect(indexExactLink).toHaveClass('active')
+      expect(indexExactLink).not.toHaveClass('inactive')
+      expect(indexExactLink).toHaveAttribute('href', '/')
+      expect(indexExactLink).toHaveAttribute('aria-current', 'page')
+      expect(indexExactLink).toHaveAttribute('data-status', 'active')
+
+      if (opts.explicitUndefined) {
+        expect(indexFooUndefinedLink).not.toHaveClass('active')
+        expect(indexFooUndefinedLink).toHaveClass('inactive')
+        expect(indexFooUndefinedLink).not.toHaveAttribute(
+          'aria-current',
+          'page',
         )
+        expect(indexFooUndefinedLink).not.toHaveAttribute(
+          'data-status',
+          'active',
+        )
+      } else {
+        expect(indexFooUndefinedLink).toHaveClass('active')
+        expect(indexFooUndefinedLink).not.toHaveClass('inactive')
+        expect(indexFooUndefinedLink).toHaveAttribute('aria-current', 'page')
+        expect(indexFooUndefinedLink).toHaveAttribute('data-status', 'active')
+      }
+
+      expect(indexFooUndefinedLink).toHaveAttribute('href', '/')
+
+      if (opts.explicitUndefined) {
+        expect(indexFooUndefinedExactLink).not.toHaveClass('active')
+        expect(indexFooUndefinedExactLink).toHaveClass('inactive')
+        expect(indexFooUndefinedExactLink).not.toHaveAttribute(
+          'aria-current',
+          'page',
+        )
+        expect(indexFooUndefinedExactLink).not.toHaveAttribute(
+          'data-status',
+          'active',
+        )
+      } else {
+        expect(indexFooUndefinedExactLink).toHaveClass('active')
+        expect(indexFooUndefinedExactLink).not.toHaveClass('inactive')
+        expect(indexFooUndefinedExactLink).toHaveAttribute(
+          'aria-current',
+          'page',
+        )
+        expect(indexFooUndefinedExactLink).toHaveAttribute(
+          'data-status',
+          'active',
+        )
+      }
+
+      expect(indexFooUndefinedExactLink).toHaveAttribute('href', '/')
+
+      expect(indexFooBarLink).toHaveClass('inactive')
+      expect(indexFooBarLink).not.toHaveClass('active')
+      expect(indexFooBarLink).toHaveAttribute('href', '/?foo=bar')
+      expect(indexFooBarLink).not.toHaveAttribute('aria-current', 'page')
+      expect(indexFooBarLink).not.toHaveAttribute('data-status', 'active')
+
+      // navigate to /?foo=bar
+      fireEvent.click(indexFooBarLink)
+
+      expect(indexExactLink).toHaveClass('inactive')
+      expect(indexExactLink).not.toHaveClass('active')
+      expect(indexExactLink).toHaveAttribute('href', '/')
+      expect(indexExactLink).not.toHaveAttribute('aria-current', 'page')
+      expect(indexExactLink).not.toHaveAttribute('data-status', 'active')
+
+      if (opts.explicitUndefined) {
+        expect(indexFooUndefinedLink).not.toHaveClass('active')
+        expect(indexFooUndefinedLink).toHaveClass('inactive')
+        expect(indexFooUndefinedLink).not.toHaveAttribute(
+          'aria-current',
+          'page',
+        )
+        expect(indexFooUndefinedLink).not.toHaveAttribute(
+          'data-status',
+          'active',
+        )
+      } else {
+        expect(indexFooUndefinedLink).toHaveClass('active')
+        expect(indexFooUndefinedLink).not.toHaveClass('inactive')
+        expect(indexFooUndefinedLink).toHaveAttribute('aria-current', 'page')
+        expect(indexFooUndefinedLink).toHaveAttribute('data-status', 'active')
+      }
+
+      expect(indexFooUndefinedLink).toHaveAttribute('href', '/')
+
+      expect(indexFooUndefinedExactLink).toHaveClass('inactive')
+      expect(indexFooUndefinedExactLink).not.toHaveClass('active')
+      expect(indexFooUndefinedExactLink).toHaveAttribute('href', '/')
+      expect(indexFooUndefinedExactLink).not.toHaveAttribute(
+        'aria-current',
+        'page',
+      )
+      expect(indexFooUndefinedExactLink).not.toHaveAttribute(
+        'data-status',
+        'active',
+      )
+
+      expect(indexFooBarLink).toHaveClass('active')
+      expect(indexFooBarLink).not.toHaveClass('inactive')
+      expect(indexFooBarLink).toHaveAttribute('href', '/?foo=bar')
+      expect(indexFooBarLink).toHaveAttribute('aria-current', 'page')
+      expect(indexFooBarLink).toHaveAttribute('data-status', 'active')
+    }
+
+    test.each([undefined, false])(
+      'activeOptions.explicitUndefined=%s',
+      async (explicitUndefined) => {
+        await runTest({ explicitUndefined })
       },
-    })
-
-    const router = createRouter({
-      routeTree: rootRoute.addChildren([indexRoute]),
-    })
-
-    render(<RouterProvider router={router} />)
-
-    // round 1
-    const indexExactLink = await screen.findByRole('link', {
-      name: 'Index exact',
-    })
-
-    const indexFooUndefinedLink = await screen.findByRole('link', {
-      name: 'Index foo=undefined',
-    })
-
-    const indexFooUndefinedExactLink = await screen.findByRole('link', {
-      name: 'Index foo=undefined-exact',
-    })
-
-    const indexFooBarLink = await screen.findByRole('link', {
-      name: 'Index foo=bar',
-    })
-
-    expect(window.location.pathname).toBe('/')
-
-    expect(indexExactLink).toHaveClass('active')
-    expect(indexExactLink).not.toHaveClass('inactive')
-    expect(indexExactLink).toHaveAttribute('href', '/')
-    expect(indexExactLink).toHaveAttribute('aria-current', 'page')
-    expect(indexExactLink).toHaveAttribute('data-status', 'active')
-
-    expect(indexFooUndefinedLink).toHaveClass('active')
-    expect(indexFooUndefinedLink).not.toHaveClass('inactive')
-    expect(indexFooUndefinedLink).toHaveAttribute('href', '/')
-    expect(indexFooUndefinedLink).toHaveAttribute('aria-current', 'page')
-    expect(indexFooUndefinedLink).toHaveAttribute('data-status', 'active')
-
-    expect(indexFooUndefinedExactLink).toHaveClass('active')
-    expect(indexFooUndefinedExactLink).not.toHaveClass('inactive')
-    expect(indexFooUndefinedExactLink).toHaveAttribute('href', '/')
-    expect(indexFooUndefinedExactLink).toHaveAttribute('aria-current', 'page')
-    expect(indexFooUndefinedExactLink).toHaveAttribute('data-status', 'active')
-
-    expect(indexFooBarLink).toHaveClass('inactive')
-    expect(indexFooBarLink).not.toHaveClass('active')
-    expect(indexFooBarLink).toHaveAttribute('href', '/?foo=bar')
-    expect(indexFooBarLink).not.toHaveAttribute('aria-current', 'page')
-    expect(indexFooBarLink).not.toHaveAttribute('data-status', 'active')
-
-    // navigate to /?foo=bar
-    fireEvent.click(indexFooBarLink)
-
-    expect(indexExactLink).toHaveClass('inactive')
-    expect(indexExactLink).not.toHaveClass('active')
-    expect(indexExactLink).toHaveAttribute('href', '/')
-    expect(indexExactLink).not.toHaveAttribute('aria-current', 'page')
-    expect(indexExactLink).not.toHaveAttribute('data-status', 'active')
-
-    expect(indexFooUndefinedLink).toHaveClass('active')
-    expect(indexFooUndefinedLink).not.toHaveClass('inactive')
-    expect(indexFooUndefinedLink).toHaveAttribute('href', '/')
-    expect(indexFooUndefinedLink).toHaveAttribute('aria-current', 'page')
-    expect(indexFooUndefinedLink).toHaveAttribute('data-status', 'active')
-
-    expect(indexFooUndefinedExactLink).toHaveClass('inactive')
-    expect(indexFooUndefinedExactLink).not.toHaveClass('active')
-    expect(indexFooUndefinedExactLink).toHaveAttribute('href', '/')
-    expect(indexFooUndefinedExactLink).not.toHaveAttribute(
-      'aria-current',
-      'page',
-    )
-    expect(indexFooUndefinedExactLink).not.toHaveAttribute(
-      'data-status',
-      'active',
     )
 
-    expect(indexFooBarLink).toHaveClass('active')
-    expect(indexFooBarLink).not.toHaveClass('inactive')
-    expect(indexFooBarLink).toHaveAttribute('href', '/?foo=bar')
-    expect(indexFooBarLink).toHaveAttribute('aria-current', 'page')
-    expect(indexFooBarLink).toHaveAttribute('data-status', 'active')
+    test('activeOptions.explicitUndefined=true', async () => {
+      await runTest({ explicitUndefined: true })
+    })
   })
 
   test('when the current route is the root with beforeLoad that throws', async () => {

--- a/packages/react-router/tests/utils.test.ts
+++ b/packages/react-router/tests/utils.test.ts
@@ -305,51 +305,95 @@ describe('deepEqual', () => {
     it('should return `true` for equal objects', () => {
       const a = { a: { b: 'b' }, c: 'c', d: [{ d: 'd ' }] }
       const b = { a: { b: 'b' }, c: 'c', d: [{ d: 'd ' }] }
-      expect(deepEqual(a, b, partial)).toEqual(true)
-      expect(deepEqual(b, a, partial)).toEqual(true)
+      expect(deepEqual(a, b, { partial })).toEqual(true)
+      expect(deepEqual(b, a, { partial })).toEqual(true)
     })
 
     it('should return `false` for non equal objects', () => {
       const a = { a: { b: 'b' }, c: 'c' }
       const b = { a: { b: 'c' }, c: 'c' }
-      expect(deepEqual(a, b, partial)).toEqual(false)
-      expect(deepEqual(b, a, partial)).toEqual(false)
+      expect(deepEqual(a, b, { partial })).toEqual(false)
+      expect(deepEqual(b, a, { partial })).toEqual(false)
     })
 
     it('should return `true` for equal objects and ignore `undefined` properties', () => {
       const a = { a: 'a', b: undefined, c: 'c' }
       const b = { a: 'a', c: 'c' }
-      expect(deepEqual(a, b, partial)).toEqual(true)
-      expect(deepEqual(b, a, partial)).toEqual(true)
+      expect(deepEqual(a, b, { partial })).toEqual(true)
+      expect(deepEqual(b, a, { partial })).toEqual(true)
     })
 
     it('should return `true` for equal objects and ignore `undefined` nested properties', () => {
       const a = { a: { b: 'b', x: undefined }, c: 'c' }
       const b = { a: { b: 'b' }, c: 'c', d: undefined }
-      expect(deepEqual(a, b, partial)).toEqual(true)
-      expect(deepEqual(b, a, partial)).toEqual(true)
+      expect(deepEqual(a, b, { partial })).toEqual(true)
+      expect(deepEqual(b, a, { partial })).toEqual(true)
     })
 
     it('should return `true` for equal arrays and ignore `undefined` object properties', () => {
+      const a = { a: { b: 'b' }, c: undefined }
+      const b = { a: { b: 'b' } }
+      expect(deepEqual([a], [b], { partial })).toEqual(true)
+      expect(deepEqual([b], [a], { partial })).toEqual(true)
+    })
+
+    it('should return `true` for equal arrays and ignore nested `undefined` object properties', () => {
       const a = { a: { b: 'b', x: undefined }, c: 'c' }
       const b = { a: { b: 'b' }, c: 'c' }
-      expect(deepEqual([a], [b], partial)).toEqual(true)
-      expect(deepEqual([b], [a], partial)).toEqual(true)
+      expect(deepEqual([a], [b], { partial })).toEqual(true)
+      expect(deepEqual([b], [a], { partial })).toEqual(true)
     })
   })
+
+  describe('ignoreUndefined = false', () => {
+    const ignoreUndefined = false
+    describe('partial = false', () => {
+      const partial = false
+      it('should return `false` for objects', () => {
+        const a = { a: { b: 'b', x: undefined }, c: 'c' }
+        const b = { a: { b: 'b' }, c: 'c', d: undefined }
+        expect(deepEqual(a, b, { partial, ignoreUndefined })).toEqual(false)
+        expect(deepEqual(b, a, { partial, ignoreUndefined })).toEqual(false)
+      })
+
+      it('should return `false` for arrays', () => {
+        const a = { a: { b: 'b', x: undefined }, c: 'c' }
+        const b = { a: { b: 'b' }, c: 'c' }
+        expect(deepEqual([a], [b], { partial, ignoreUndefined })).toEqual(false)
+        expect(deepEqual([b], [a], { partial, ignoreUndefined })).toEqual(false)
+      })
+    })
+    describe('partial = true', () => {
+      const partial = true
+      it('should return `true` for objects', () => {
+        const a = { a: { b: 'b' }, c: 'c' }
+        const b = { a: { b: 'b' }, c: 'c', d: undefined }
+        expect(deepEqual(a, b, { partial, ignoreUndefined })).toEqual(false)
+        expect(deepEqual(b, a, { partial, ignoreUndefined })).toEqual(true)
+      })
+
+      it('should return `true` for arrays', () => {
+        const a = { a: { b: 'b', x: undefined }, c: 'c' }
+        const b = { a: { b: 'b' }, c: 'c' }
+        expect(deepEqual([a], [b], { partial, ignoreUndefined })).toEqual(true)
+        expect(deepEqual([b], [a], { partial, ignoreUndefined })).toEqual(false)
+      })
+    })
+  })
+
   describe('partial comparison', () => {
     it('correctly compares partially equal objects', () => {
       const a = { a: { b: 'b' }, c: 'c', d: [{ d: 'd ' }] }
       const b = { a: { b: 'b' }, c: 'c' }
-      expect(deepEqual(a, b, true)).toEqual(true)
-      expect(deepEqual(b, a, true)).toEqual(false)
+      expect(deepEqual(a, b, { partial: true })).toEqual(true)
+      expect(deepEqual(b, a, { partial: true })).toEqual(false)
     })
 
     it('correctly compares partially equal objects and ignores `undefined` object properties', () => {
       const a = { a: { b: 'b' }, c: 'c', d: [{ d: 'd ' }], e: undefined }
       const b = { a: { b: 'b' }, c: 'c', d: undefined }
-      expect(deepEqual(a, b, true)).toEqual(true)
-      expect(deepEqual(b, a, true)).toEqual(false)
+      expect(deepEqual(a, b, { partial: true })).toEqual(true)
+      expect(deepEqual(b, a, { partial: true })).toEqual(false)
     })
   })
 })


### PR DESCRIPTION
implements the feature requested in #2566