### PR TITLE
fix(react-router): fix explicitUndefined links never matching

### DIFF
--- a/packages/react-router/src/utils.ts
+++ b/packages/react-router/src/utils.ts
@@ -248,7 +248,7 @@ export function deepEqual(
       return false
     }
 
-    return !bKeys.some((key) => !(key in a) || !deepEqual(a[key], b[key], opts))
+    return bKeys.every((key) => deepEqual(a[key], b[key], opts))
   }
 
   if (Array.isArray(a) && Array.isArray(b)) {

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -298,14 +298,8 @@ describe('Link', () => {
       if (opts.explicitUndefined) {
         expect(indexFooUndefinedLink).toHaveClass('active')
         expect(indexFooUndefinedLink).not.toHaveClass('inactive')
-        expect(indexFooUndefinedLink).toHaveAttribute(
-          'aria-current',
-          'page',
-        )
-        expect(indexFooUndefinedLink).toHaveAttribute(
-          'data-status',
-          'active',
-        )
+        expect(indexFooUndefinedLink).toHaveAttribute('aria-current', 'page')
+        expect(indexFooUndefinedLink).toHaveAttribute('data-status', 'active')
       } else {
         expect(indexFooUndefinedLink).toHaveClass('active')
         expect(indexFooUndefinedLink).not.toHaveClass('inactive')

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -296,13 +296,13 @@ describe('Link', () => {
       expect(indexExactLink).toHaveAttribute('data-status', 'active')
 
       if (opts.explicitUndefined) {
-        expect(indexFooUndefinedLink).not.toHaveClass('active')
-        expect(indexFooUndefinedLink).toHaveClass('inactive')
-        expect(indexFooUndefinedLink).not.toHaveAttribute(
+        expect(indexFooUndefinedLink).toHaveClass('active')
+        expect(indexFooUndefinedLink).not.toHaveClass('inactive')
+        expect(indexFooUndefinedLink).toHaveAttribute(
           'aria-current',
           'page',
         )
-        expect(indexFooUndefinedLink).not.toHaveAttribute(
+        expect(indexFooUndefinedLink).toHaveAttribute(
           'data-status',
           'active',
         )

--- a/packages/react-router/tests/utils.test.ts
+++ b/packages/react-router/tests/utils.test.ts
@@ -368,7 +368,7 @@ describe('deepEqual', () => {
       it('should return `true` for objects', () => {
         const a = { a: { b: 'b' }, c: 'c' }
         const b = { a: { b: 'b' }, c: 'c', d: undefined }
-        expect(deepEqual(a, b, { partial, ignoreUndefined })).toEqual(false)
+        expect(deepEqual(a, b, { partial, ignoreUndefined })).toEqual(true)
         expect(deepEqual(b, a, { partial, ignoreUndefined })).toEqual(true)
       })
 
@@ -376,7 +376,7 @@ describe('deepEqual', () => {
         const a = { a: { b: 'b', x: undefined }, c: 'c' }
         const b = { a: { b: 'b' }, c: 'c' }
         expect(deepEqual([a], [b], { partial, ignoreUndefined })).toEqual(true)
-        expect(deepEqual([b], [a], { partial, ignoreUndefined })).toEqual(false)
+        expect(deepEqual([b], [a], { partial, ignoreUndefined })).toEqual(true)
       })
     })
   })


### PR DESCRIPTION
Small follow-up to #2592, as I noticed that it doesn't quite seem to work as I think would be expected - it does correctly _exclude_ the route when the parameter exists, however it doesn't _match_ the route when it doesn't. In other words, there's currently no way for `explicitUndefined` links to ever match a route. This PR fixes that.