### PR TITLE
examples: use a shared Convex backend for StackBlitz

### DIFF
--- a/examples/react/start-convex-trellaux/.env.local.example
+++ b/examples/react/start-convex-trellaux/.env.local.example
@@ -1,0 +1,3 @@
+# This is a shared default backend you can't modify the code for.
+# In order to create your own backend, run `npx convex dev`.
+VITE_CONVEX_URL=https://laudable-anaconda-558.convex.cloud

--- a/examples/react/start-convex-trellaux/.stackblitzrc
+++ b/examples/react/start-convex-trellaux/.stackblitzrc
@@ -1,0 +1,3 @@
+{
+  "startCommand": "cp .env.local.example .env.local && npx vinxi dev",
+}

--- a/examples/react/start-convex-trellaux/app/routeTree.gen.ts
+++ b/examples/react/start-convex-trellaux/app/routeTree.gen.ts
@@ -17,13 +17,11 @@ import { Route as BoardsBoardIdImport } from './routes/boards.$boardId'
 // Create/Update Routes
 
 const IndexRoute = IndexImport.update({
-  id: '/',
   path: '/',
   getParentRoute: () => rootRoute,
 } as any)
 
 const BoardsBoardIdRoute = BoardsBoardIdImport.update({
-  id: '/boards/$boardId',
   path: '/boards/$boardId',
   getParentRoute: () => rootRoute,
 } as any)

--- a/examples/react/start-convex-trellaux/convex/crons.ts
+++ b/examples/react/start-convex-trellaux/convex/crons.ts
@@ -1,14 +1,8 @@
-import { cronJobs } from "convex/server";
-import { internal } from "./_generated/api";
+import { cronJobs } from 'convex/server'
+import { internal } from './_generated/api'
 
-const crons = cronJobs();
+const crons = cronJobs()
 
-crons.cron(
-  "clear messages table",
-  "0,20,40 * * * *",
-  internal.board.clear,
-);
+crons.cron('clear messages table', '0,20,40 * * * *', internal.board.clear)
 
-
-
-export default crons;
+export default crons

--- a/examples/react/start-convex-trellaux/convex/crons.ts
+++ b/examples/react/start-convex-trellaux/convex/crons.ts
@@ -1,0 +1,14 @@
+import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
+
+const crons = cronJobs();
+
+crons.cron(
+  "clear messages table",
+  "0,20,40 * * * *",
+  internal.board.clear,
+);
+
+
+
+export default crons;


### PR DESCRIPTION
Custom StackBlitz dev command that uses a shared backend. This makes https://tanstack.com/router/v1/docs/framework/react/examples/start-convex-trellaux usable.

Clear this shared table every 20 minutes.