### PR TITLE
examples: no trailing comma in stackblitzrc

### DIFF
--- a/examples/react/start-convex-trellaux/.stackblitzrc
+++ b/examples/react/start-convex-trellaux/.stackblitzrc
@@ -1,3 +1,3 @@
 {
-  "startCommand": "cp .env.local.example .env.local && npx vinxi dev",
+  "startCommand": "cp .env.local.example .env.local && npx vinxi dev"
 }


### PR DESCRIPTION
https://github.com/TanStack/router/pull/2606 didn't work, maybe the problem was the trailing comma? I'll try to test this first.