### PR TITLE
fix(start): Send error messages from server functions

### DIFF
--- a/packages/start/src/client-runtime/fetcher.tsx
+++ b/packages/start/src/client-runtime/fetcher.tsx
@@ -136,16 +136,9 @@ async function handleResponseErrors(response: Response) {
     const message = `Request failed with status ${response.status}`
 
     if (isJson) {
-      throw new Error(
-        JSON.stringify({
-          message,
-          body,
-        }),
-      )
+      throw new Error(body.message || message)
     } else {
-      throw new Error(
-        [message, `${JSON.stringify(body, null, 2)}`].join('\n\n'),
-      )
+      throw new Error(body || message)
     }
   }
 

--- a/packages/start/src/client-runtime/fetcher.tsx
+++ b/packages/start/src/client-runtime/fetcher.tsx
@@ -133,13 +133,10 @@ async function handleResponseErrors(response: Response) {
       return await response.text()
     })()
 
-    const message = `Request failed with status ${response.status}`
+    const defaultMessage = `Request failed with status ${response.status}`
+    const message = body?.message || body || defaultMessage
 
-    if (isJson) {
-      throw new Error(body.message || message)
-    } else {
-      throw new Error(body || message)
-    }
+    throw new Error(message)
   }
 
   return response

--- a/packages/start/src/server-handler/index.tsx
+++ b/packages/start/src/server-handler/index.tsx
@@ -143,17 +143,20 @@ export async function handleServerRequest(request: Request, event?: H3Event) {
         return redirectOrNotFoundResponse(error)
       }
 
-      console.error('Server Fn Error!')
-      console.error(error)
-      console.info()
-
-      return new Response(JSON.stringify(error), {
-        status: 500,
-        headers: {
-          'Content-Type': 'application/json',
-          [serverFnReturnTypeHeader]: 'error',
+      return new Response(
+        error instanceof Error
+          ? error.toString()
+          : JSON.stringify({
+              message: error?.message ?? 'Internal Server Error',
+            }),
+        {
+          status: 500,
+          headers: {
+            'Content-Type': 'application/json',
+            [serverFnReturnTypeHeader]: 'error',
+          },
         },
-      })
+      )
     }
   })()
 


### PR DESCRIPTION
Removes some unnecessary logs and passes error messages from server function errors. Passes error messages directly to errors thrown from the client instead of putting a json payload in the message. 

This should align better with whats shown in the docs. It seems unsafe to send along server stack traces though. 

> Aside from special redirect and notFound errors, server functions can throw any custom error. These errors will be serialized and sent to the client as a JSON response along with a 500 status code.

```tsx

import { createServerFn } from '@tanstack/start'

export const doStuff = createServerFn('GET', async () => {
  throw new Error('Something went wrong!')
})

// Usage
function Test() {
  try {
    await doStuff()
  } catch (error) {
    console.error(error)
    // {
    //   message: "Something went wrong!",
    //   stack: "Error: Something went wrong!\n    at doStuff (file:///path/to/file.ts:3:3)"
    // }
  }
}
```

Would like to support returning other error responses without having them thrown on the client side as well. Curious how other people feel about that. 