### PR TITLE
feat(react-router): add `preload='render'` support

### DIFF
--- a/docs/framework/react/api/router/LinkOptionsType.md
+++ b/docs/framework/react/api/router/LinkOptionsType.md
@@ -33,7 +33,7 @@ The `LinkOptions` object accepts/contains the following properties:
 
 ### `preload`
 
-- Type: `false | 'intent' | 'viewport'`
+- Type: `false | 'intent' | 'viewport' | 'render'`
 - Optional
 - If set, the link's preloading strategy will be set to this value.
 - See the [Preloading guide](../../guide/preloading.md) for more information.

--- a/docs/framework/react/api/router/RouterOptionsType.md
+++ b/docs/framework/react/api/router/RouterOptionsType.md
@@ -52,7 +52,7 @@ The `RouterOptions` type accepts an object with the following properties and met
 - If `false`, routes will not be preloaded by default in any way.
 - If `'intent'`, routes will be preloaded by default when the user hovers over a link or a `touchstart` event is detected on a `<Link>`.
 - If `'viewport'`, routes will be preloaded by default when they are within the viewport of the browser.
-- If `'render'`, routes will be preloaded by default when as soon as they are rendered on in the DOM.
+- If `'render'`, routes will be preloaded by default as soon as they are rendered in the DOM.
 
 ### `defaultPreloadDelay` property
 

--- a/docs/framework/react/api/router/RouterOptionsType.md
+++ b/docs/framework/react/api/router/RouterOptionsType.md
@@ -46,12 +46,13 @@ The `RouterOptions` type accepts an object with the following properties and met
 
 ### `defaultPreload` property
 
-- Type: `undefined | false | 'intent' | 'viewport'`
+- Type: `undefined | false | 'intent' | 'viewport' | 'render'`
 - Optional
 - Defaults to `false`
 - If `false`, routes will not be preloaded by default in any way.
 - If `'intent'`, routes will be preloaded by default when the user hovers over a link or a `touchstart` event is detected on a `<Link>`.
 - If `'viewport'`, routes will be preloaded by default when they are within the viewport of the browser.
+- If `'render'`, routes will be preloaded by default when as soon as they are rendered on in the DOM.
 
 ### `defaultPreloadDelay` property
 

--- a/docs/framework/react/guide/preloading.md
+++ b/docs/framework/react/guide/preloading.md
@@ -13,7 +13,8 @@ Preloading in TanStack Router is a way to load a route before the user actually 
   - Preloading by **"viewport**" works by using the Intersection Observer API to preload the dependencies for the destination route when the `<Link>` component is in the viewport.
   - This strategy is useful for preloading routes that are below the fold or off-screen.
 - Render
-  - **Coming soon!**
+  - Preloading by **"render"** works by preloading the dependencies for the destination route as soon as the `<Link>` component is rendered in the DOM.
+  - This strategy is useful for preloading routes that are always needed.
 
 ## How long does preloaded data stay in memory?
 

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -211,7 +211,7 @@ export interface RouterOptions<
    * @link [API Docs](https://tanstack.com/router/latest/docs/framework/react/api/router/RouterOptionsType#defaultpreload-property)
    * @link [Guide](https://tanstack.com/router/latest/docs/framework/react/guide/preloading)
    */
-  defaultPreload?: false | 'intent' | 'viewport'
+  defaultPreload?: false | 'intent' | 'viewport' | 'render'
   /**
    * The delay in milliseconds that a route must be hovered over or touched before it is preloaded.
    *
@@ -1622,7 +1622,7 @@ export class Router<
         })
 
         if (foundMask) {
-          const { from, ...maskProps } = foundMask
+          const { from: _from, ...maskProps } = foundMask
           maskedDest = {
             ...pick(opts, ['from']),
             ...maskProps,

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -3643,6 +3643,37 @@ describe('Link', () => {
     },
   )
 
+  test.each([false, 'intent', 'viewport', 'render'] as const)(
+    'Router.preload="%s" with Link.preload="false", should not trigger the IntersectionObserver\'s observe method',
+    async (preload) => {
+      const rootRoute = createRootRoute()
+      const indexRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/',
+        component: () => (
+          <>
+            <h1>Index Heading</h1>
+            <Link to="/" preload={false}>
+              Index Link
+            </Link>
+          </>
+        ),
+      })
+
+      const router = createRouter({
+        routeTree: rootRoute.addChildren([indexRoute]),
+        defaultPreload: preload,
+      })
+
+      render(<RouterProvider router={router} />)
+
+      const indexLink = await screen.findByRole('link', { name: 'Index Link' })
+      expect(indexLink).toBeInTheDocument()
+
+      expect(ioObserveMock).not.toBeCalled()
+    },
+  )
+
   test('Router.preload="viewport", should trigger the IntersectionObserver\'s observe and disconnect methods', async () => {
     const rootRoute = createRootRoute()
     const indexRoute = createRoute({
@@ -3671,62 +3702,6 @@ describe('Link', () => {
 
     expect(ioDisconnectMock).toBeCalled()
     expect(ioDisconnectMock).toBeCalledTimes(1) // since React.StrictMode is enabled it should have disconnected
-  })
-
-  test('Router.preload="viewport" with Link.preload="false", should not trigger the IntersectionObserver\'s observe method', async () => {
-    const rootRoute = createRootRoute()
-    const indexRoute = createRoute({
-      getParentRoute: () => rootRoute,
-      path: '/',
-      component: () => (
-        <>
-          <h1>Index Heading</h1>
-          <Link to="/" preload={false}>
-            Index Link
-          </Link>
-        </>
-      ),
-    })
-
-    const router = createRouter({
-      routeTree: rootRoute.addChildren([indexRoute]),
-      defaultPreload: 'viewport',
-    })
-
-    render(<RouterProvider router={router} />)
-
-    const indexLink = await screen.findByRole('link', { name: 'Index Link' })
-    expect(indexLink).toBeInTheDocument()
-
-    expect(ioObserveMock).not.toBeCalled()
-  })
-
-  test('Router.preload="render" with Link.preload="false", should not trigger the IntersectionObserver\'s observe method', async () => {
-    const rootRoute = createRootRoute()
-    const indexRoute = createRoute({
-      getParentRoute: () => rootRoute,
-      path: '/',
-      component: () => (
-        <>
-          <h1>Index Heading</h1>
-          <Link to="/" preload={false}>
-            Index Link
-          </Link>
-        </>
-      ),
-    })
-
-    const router = createRouter({
-      routeTree: rootRoute.addChildren([indexRoute]),
-      defaultPreload: 'viewport',
-    })
-
-    render(<RouterProvider router={router} />)
-
-    const indexLink = await screen.findByRole('link', { name: 'Index Link' })
-    expect(indexLink).toBeInTheDocument()
-
-    expect(ioObserveMock).not.toBeCalled()
   })
 
   test("Router.preload='render', should trigger the route loader on render", async () => {


### PR DESCRIPTION
This is the last preloading strategy which was left to implement.

This option makes it so that a preload will be fired off as soon as the Link component is rendered into the DOM. Once fired, it won't ever fire again unless the component is destroyed.