### PR TITLE
fix(start): Could not auto-determine entry point

### DIFF
--- a/packages/start/src/config/index.ts
+++ b/packages/start/src/config/index.ts
@@ -321,6 +321,11 @@ export function defineConfig(
                     {}),
                   noExternal: ['@tanstack/start', 'tsr:routes-manifest'],
                 },
+                optimizeDeps: {
+                  ...(getUserConfig(opts.vite).userConfig.optimizeDeps || {}),
+                  ...(getUserConfig(opts.routers?.api?.vite).userConfig.optimizeDeps || {}),
+                  entries: [],
+                }
               }),
               TanStackRouterVite({
                 ...tsrConfig,
@@ -471,9 +476,12 @@ function withStartPlugins(
           ...(routerUserConfig.ssr || {}),
           noExternal: ['@tanstack/start', 'tsr:routes-manifest'],
         },
-        // optimizeDeps: {
-        //   include: ['@tanstack/start/server-runtime'],
-        // },
+        optimizeDeps: {
+          ...(userConfig.optimizeDeps || {}),
+          ...(routerUserConfig.optimizeDeps || {}),
+          entries: [],
+          // include: ['@tanstack/start/server-runtime'],
+        },
       }),
       TanStackRouterVite({
         ...tsrConfig,
@@ -650,7 +658,8 @@ function tsrRoutesManifest(opts: {
           }
         }
 
-        recurseRoute(routes.__root__!)
+        // @ts-expect-error
+        recurseRoute(routes.__root__)
 
         const routesManifest = {
           routes,

--- a/packages/start/src/config/index.ts
+++ b/packages/start/src/config/index.ts
@@ -323,9 +323,10 @@ export function defineConfig(
                 },
                 optimizeDeps: {
                   ...(getUserConfig(opts.vite).userConfig.optimizeDeps || {}),
-                  ...(getUserConfig(opts.routers?.api?.vite).userConfig.optimizeDeps || {}),
+                  ...(getUserConfig(opts.routers?.api?.vite).userConfig
+                    .optimizeDeps || {}),
                   entries: [],
-                }
+                },
               }),
               TanStackRouterVite({
                 ...tsrConfig,

--- a/packages/start/src/config/index.ts
+++ b/packages/start/src/config/index.ts
@@ -322,10 +322,10 @@ export function defineConfig(
                   noExternal: ['@tanstack/start', 'tsr:routes-manifest'],
                 },
                 optimizeDeps: {
+                  entries: [],
                   ...(getUserConfig(opts.vite).userConfig.optimizeDeps || {}),
                   ...(getUserConfig(opts.routers?.api?.vite).userConfig
                     .optimizeDeps || {}),
-                  entries: [],
                 },
               }),
               TanStackRouterVite({
@@ -478,9 +478,9 @@ function withStartPlugins(
           noExternal: ['@tanstack/start', 'tsr:routes-manifest'],
         },
         optimizeDeps: {
+          entries: [],
           ...(userConfig.optimizeDeps || {}),
           ...(routerUserConfig.optimizeDeps || {}),
-          entries: [],
           // include: ['@tanstack/start/server-runtime'],
         },
       }),


### PR DESCRIPTION
This PR fixes the `Could not auto-determine entry point from rollupOptions or HTML files, and there are no explicit optimizeDeps.include patterns. Skipping dependency pre-bundling.` warning.
