### PR TITLE
fix(router-valibot-adapter): support for v1 dist-tags

### DIFF
--- a/packages/router-valibot-adapter/package.json
+++ b/packages/router-valibot-adapter/package.json
@@ -71,6 +71,6 @@
   },
   "peerDependencies": {
     "@tanstack/react-router": ">=1.43.2",
-    "valibot": "^1.0.0"
+    "valibot": "^1.0.0 || ^1.0.0-beta || ^1.0.0-rc"
   }
 }


### PR DESCRIPTION
Looks like the npm install broke with the upgrade to Valibot v1. This PR should fix that.