### PR TITLE
refactor(react-router): export `LinkComponentProps` type

### DIFF
--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -73,6 +73,7 @@ export type {
   ActiveLinkOptions,
   LinkProps,
   LinkComponent,
+  LinkComponentProps,
   CreateLinkProps,
   MakeOptionalPathParams,
 } from './link'


### PR DESCRIPTION
`React.ComponentProps<LinkComponent<'a'>>` was not bringing in the generated types for props.params, but `LinkComponentProps` does.

FWIW: My specific user case is I'm creating a wrapper component around `<Link />` that supports `href` as an alias for `to` to support some existing code. Using `createLink` was not working properly in this case.