### PR TITLE
fix(router-generator): fix virtual file routes on windows

### DIFF
--- a/packages/router-generator/src/filesystem/virtual/loadConfigFile.ts
+++ b/packages/router-generator/src/filesystem/virtual/loadConfigFile.ts
@@ -1,6 +1,8 @@
+import { pathToFileURL } from 'node:url'
 import { tsImport } from 'tsx/esm/api'
 
 export async function loadConfigFile(filePath: string) {
-  const loaded = await tsImport(filePath, './')
+  const fileURL = pathToFileURL(filePath).href
+  const loaded = await tsImport(fileURL, './')
   return loaded
 }


### PR DESCRIPTION
```
♻️  Generating routes...
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
```