### PR TITLE
fix(router-generator): fix variableName for virtual file routes on Windows

### DIFF
--- a/packages/router-generator/src/utils.ts
+++ b/packages/router-generator/src/utils.ts
@@ -98,7 +98,7 @@ export function routePathToVariable(routePath: string): string {
       ?.replace(/\/\$\//g, '/splat/')
       .replace(/\$$/g, 'splat')
       .replace(/\$/g, '')
-      .split(/[/-]/g)
+      .split(/[\\/\\-]/g)
       .map((d, i) => (i > 0 ? capitalize(d) : d))
       .join('')
       .replace(/([^a-zA-Z0-9]|[.])/gm, '')


### PR DESCRIPTION
the issue:

![image](https://github.com/user-attachments/assets/df535d2d-4c1a-45b1-bb4f-8c96ddd0e385)

the `postspostsImport` should be `postsPostsImport` etc...