### PR TITLE
fix(router-generator): fix path for virtual file routes on Windows

### DIFF
--- a/packages/router-generator/src/filesystem/physical/getRouteNodes.ts
+++ b/packages/router-generator/src/filesystem/physical/getRouteNodes.ts
@@ -95,8 +95,8 @@ export async function getRouteNodes(
 
     await Promise.all(
       dirList.map(async (dirent) => {
-        const fullPath = path.join(fullDir, dirent.name)
-        const relativePath = path.join(dir, dirent.name)
+        const fullPath = path.posix.join(fullDir, dirent.name)
+        const relativePath = path.posix.join(dir, dirent.name)
 
         if (dirent.isDirectory()) {
           await recurse(relativePath)

--- a/packages/router-generator/src/filesystem/virtual/getRouteNodes.ts
+++ b/packages/router-generator/src/filesystem/virtual/getRouteNodes.ts
@@ -84,7 +84,7 @@ export async function getRouteNodesRecursive(
       }
 
       function getFile(file: string) {
-        const filePath = file.split('/').join(path.sep)
+        const filePath = file
         const variableName = routePathToVariable(removeExt(filePath))
         const fullPath = join(fullDir, filePath)
         return { filePath, variableName, fullPath }


### PR DESCRIPTION
The issues:
![image](https://github.com/user-attachments/assets/31d0a994-a250-4ee9-aeee-e5d53058be8e)

This also fix: https://github.com/TanStack/router/pull/2694