### PR TITLE
docs: revise wording in TanStack Router documentation

### DIFF
--- a/docs/framework/react/guide/file-based-routing.md
+++ b/docs/framework/react/guide/file-based-routing.md
@@ -350,7 +350,7 @@ export default defineConfig({
 
 ### Ignoring the generated route tree file
 
-If your project is configured to use a linter and/or formatter, you may want to ignore the generated route tree file. This is this file is managed by TanStack Router and shouldn't and therefore shouldn't be changed by your linter or formatter.
+If your project is configured to use a linter and/or formatter, you may want to ignore the generated route tree file. This file is managed by TanStack Router and therefore shouldn't be changed by your linter or formatter.
 
 Here are some resources to help you ignore the generated route tree file:
 


### PR DESCRIPTION
Updated the wording in the TanStack Router documentation to improve clarity by removing redundant text.