### PR TITLE
Fix hydration of server functions that return strings with backticks in them (in development)

### DIFF
--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -68,10 +68,12 @@
   "dependencies": {
     "@tanstack/history": "workspace:*",
     "@tanstack/react-store": "^0.5.6",
+    "jsesc": "^3.0.2",
     "tiny-invariant": "^1.3.3",
     "tiny-warning": "^1.0.3"
   },
   "devDependencies": {
+    "@types/jsesc": "^3.0.3",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",
     "@vitejs/plugin-react": "^4.3.3",

--- a/packages/react-router/src/ScriptOnce.tsx
+++ b/packages/react-router/src/ScriptOnce.tsx
@@ -1,3 +1,5 @@
+import jsesc from 'jsesc'
+
 export function ScriptOnce({
   className,
   children,
@@ -17,7 +19,7 @@ export function ScriptOnce({
           children,
           (log ?? true) && process.env.NODE_ENV === 'development'
             ? `console.info(\`Injected From Server:
-${children}\`)`
+${jsesc(children.toString(), {quotes: 'backtick'})}\`)`
             : '',
         ]
           .filter(Boolean)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3039,6 +3039,9 @@ importers:
       '@tanstack/router-generator':
         specifier: workspace:*
         version: link:../router-generator
+      jsesc:
+        specifier: ^3.0.2
+        version: 3.0.2
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3
@@ -3052,6 +3055,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.0.1
         version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/jsesc':
+        specifier: ^3.0.3
+        version: 3.0.3
       '@vitejs/plugin-react':
         specifier: ^4.3.3
         version: 4.3.3(vite@5.4.10(@types/node@22.8.6)(terser@5.36.0))


### PR DESCRIPTION
If a server function returns a string with a backtick in it, or an object that contains such a string, hydration will fail due to the backtick not being escaped in a console.info that only gets logged in development.

Fixes #2510 