### PR TITLE
start: allow disabling server functions logs

### DIFF
--- a/packages/start/src/server-handler/index.tsx
+++ b/packages/start/src/server-handler/index.tsx
@@ -44,9 +44,12 @@ export async function handleServerRequest(request: Request, event?: H3Event) {
 
   invariant(typeof serverFnId === 'string', 'Invalid server action')
 
-  if (process.env.NODE_ENV === 'development')
-    console.info(`ServerFn Request: ${serverFnId} - ${serverFnName}`)
-  if (process.env.NODE_ENV === 'development') console.info()
+  const shouldLogServerFn =
+    process.env.NODE_ENV === 'development' &&
+    process.env.TANSTACK_START_LOG_SERVER_FN_ENABLED !== 'false'
+
+  if (shouldLogServerFn)
+    console.info(`ServerFn Request: ${serverFnId} - ${serverFnName}\n`)
 
   const action = (await getManifest('server').chunks[serverFnId]?.import())?.[
     serverFnName
@@ -157,20 +160,18 @@ export async function handleServerRequest(request: Request, event?: H3Event) {
     }
   })()
 
-  if (process.env.NODE_ENV === 'development')
-    console.info(`ServerFn Response: ${response.status}`)
+  if (shouldLogServerFn) console.info(`ServerFn Response: ${response.status}`)
 
   if (response.headers.get('Content-Type') === 'application/json') {
     const cloned = response.clone()
     const text = await cloned.text()
     const payload = text ? JSON.stringify(JSON.parse(text)) : 'undefined'
 
-    if (process.env.NODE_ENV === 'development')
+    if (shouldLogServerFn)
       console.info(
-        ` - Payload: ${payload.length > 100 ? payload.substring(0, 100) + '...' : payload}`,
+        ` - Payload: ${payload.length > 100 ? payload.substring(0, 100) + '...' : payload}\n`,
       )
   }
-  if (process.env.NODE_ENV === 'development') console.info()
 
   return response
 }


### PR DESCRIPTION
Allow disabling serverFn logs in development as requested in https://discord.com/channels/719702312431386674/1304470693970444318

I would like to also make this configurable in `app.config.ts` but I'm not sure what is the vinxi/nitro way to read configs in places like `packages/start/src/server-runtime/index.tsx`