### PR TITLE
fix(react-router): Fix hydration SyntaxError in ScriptOnce by changing template literal to string concatenation in console.info

### DIFF
--- a/packages/react-router/src/ScriptOnce.tsx
+++ b/packages/react-router/src/ScriptOnce.tsx
@@ -16,8 +16,8 @@ export function ScriptOnce({
         __html: [
           children,
           (log ?? true) && process.env.NODE_ENV === 'development'
-          ? "console.info('Injected From Server:\\n" + children + "');"
-         : '',
+            ? "console.info('Injected From Server:\\n" + children + "');"
+            : '',
         ]
           .filter(Boolean)
           .join('\n'),

--- a/packages/react-router/src/ScriptOnce.tsx
+++ b/packages/react-router/src/ScriptOnce.tsx
@@ -16,9 +16,8 @@ export function ScriptOnce({
         __html: [
           children,
           (log ?? true) && process.env.NODE_ENV === 'development'
-            ? `console.info(\`Injected From Server:
-${children}\`)`
-            : '',
+          ? "console.info('Injected From Server:\\n" + children + "');"
+         : '',
         ]
           .filter(Boolean)
           .join('\n'),


### PR DESCRIPTION
This PR addresses an issue in ScriptOnce where console.info caused a SyntaxError due to improperly escaped special characters in the route path, particularly when using routes with splat parameters and search parameters.

**Problem**
Previously, console.info was implemented with a template literal, like so:

```ts
? `console.info(\`Injected From Server:
${children}\`)`
: ''
```

This approach led to issues when special characters (e.g., backticks or `${}`) appeared in `children`, as they were interpreted as part of the template literal, resulting in a malformed string and ultimately a `SyntaxError`.

**Solution**
The fix replaces the template literal with string concatenation using double quotes:

```ts
? "console.info('Injected From Server:\\n" + children + "');"
: ''
```

By using a standard string with concatenation, special characters inside `children `are no longer interpreted, preventing syntax issues and ensuring the output remains valid.

This change resolves the `SyntaxError` and stabilizes the client environment, as it prevents `window `from becoming `undefined `during this process.

Fixes #2725 and #2510