### PR TITLE
docs: ypdate RouterEventsType.md missing onBeforeNavigate

### DIFF
--- a/docs/framework/react/api/router/RouterEventsType.md
+++ b/docs/framework/react/api/router/RouterEventsType.md
@@ -7,6 +7,12 @@ The `RouterEvents` type contains all of the events that the router can emit. Eac
 
 ```tsx
 type RouterEvents = {
+  onBeforeNavigate: {
+    type: 'onBeforeNavigate'
+    fromLocation: ParsedLocation
+    toLocation: ParsedLocation
+    pathChanged: boolean
+  }
   onBeforeLoad: {
     type: 'onBeforeLoad'
     fromLocation: ParsedLocation


### PR DESCRIPTION
Hi, was needing something just like the function `onBeforeNavigate` took me some time to figure out how to do it as it wasn't documented yet.

As a reminder:
`onBeforeNavigate` was added there: https://github.com/TanStack/router/commit/2b0135bc7ed8dd5f85959c4642d09c04bafde9b4

So I just added:

```tsx
onBeforeNavigate: {
    type: 'onBeforeNavigate'
    fromLocation: ParsedLocation
    toLocation: ParsedLocation
    pathChanged: boolean
}
```

to the RouterEvents specified in the documentation.

Might help someone in the future 😄