### PR TITLE
docs(router): replace deprecated preSearchFilters with search middlewares in examples

### DIFF
--- a/examples/react/kitchen-sink-file-based/src/routes/dashboard.users.tsx
+++ b/examples/react/kitchen-sink-file-based/src/routes/dashboard.users.tsx
@@ -4,6 +4,7 @@ import {
   MatchRoute,
   Outlet,
   createFileRoute,
+  retainSearchParams,
   useNavigate,
 } from '@tanstack/react-router'
 import { z } from 'zod'
@@ -21,16 +22,11 @@ export const Route = createFileRoute('/dashboard/users')({
       })
       .optional(),
   }).parse,
-  preSearchFilters: [
-    // Persist (or set as default) the usersView search param
-    // while navigating within or to this route (or it's children!)
-    (search) => ({
-      ...search,
-      usersView: {
-        ...search.usersView,
-      },
-    }),
-  ],
+  search: {
+    // Retain the usersView search param while navigating
+    // within or to this route (or it's children!)
+    middlewares: [retainSearchParams(['usersView'])],
+  },
   loaderDeps: ({ search }) => ({
     filterBy: search.usersView?.filterBy,
     sortBy: search.usersView?.sortBy,
@@ -113,10 +109,9 @@ function UsersComponent() {
             <div key={user.id}>
               <Link
                 to="/dashboard/users/user"
-                search={(d) => ({
-                  ...d,
+                search={{
                   userId: user.id,
-                })}
+                }}
                 className="block py-2 px-3 text-blue-700"
                 activeProps={{ className: `font-bold` }}
               >

--- a/examples/react/kitchen-sink-react-query-file-based/src/routes/dashboard.users.tsx
+++ b/examples/react/kitchen-sink-react-query-file-based/src/routes/dashboard.users.tsx
@@ -5,6 +5,7 @@ import {
   MatchRoute,
   Outlet,
   createFileRoute,
+  retainSearchParams,
   useNavigate,
 } from '@tanstack/react-router'
 import { useSuspenseQuery } from '@tanstack/react-query'
@@ -23,16 +24,11 @@ export const Route = createFileRoute('/dashboard/users')({
       })
       .optional(),
   }).parse,
-  preSearchFilters: [
-    // Persist (or set as default) the usersView search param
-    // while navigating within or to this route (or it's children!)
-    (search) => ({
-      ...search,
-      usersView: {
-        ...search.usersView,
-      },
-    }),
-  ],
+  search: {
+    // Retain the usersView search param while navigating
+    // within or to this route (or it's children!)
+    middlewares: [retainSearchParams(['usersView'])],
+  },
   loader: (opts) =>
     opts.context.queryClient.ensureQueryData(usersQueryOptions(opts.deps)),
   component: UsersComponent,
@@ -128,10 +124,9 @@ function UsersComponent() {
             <div key={user.id}>
               <Link
                 to="/dashboard/users/user"
-                search={(d) => ({
-                  ...d,
+                search={{
                   userId: user.id,
-                })}
+                }}
                 className="block py-2 px-3 text-blue-700"
                 activeProps={{ className: `font-bold` }}
               >

--- a/examples/react/kitchen-sink-react-query/src/main.tsx
+++ b/examples/react/kitchen-sink-react-query/src/main.tsx
@@ -12,6 +12,7 @@ import {
   createRouter,
   lazyRouteComponent,
   redirect,
+  retainSearchParams,
   useNavigate,
   useRouter,
   useRouterState,
@@ -532,16 +533,11 @@ const usersRoute = createRoute({
       })
       .optional(),
   }).parse,
-  preSearchFilters: [
-    // Persist (or set as default) the usersView search param
-    // while navigating within or to this route (or it's children!)
-    (search) => ({
-      ...search,
-      usersView: {
-        ...search.usersView,
-      },
-    }),
-  ],
+  search: {
+    // Retain the usersView search param while navigating
+    // within or to this route (or it's children!)
+    middlewares: [retainSearchParams(['usersView'])],
+  },
   loaderDeps: ({ search }) => ({
     filterBy: search.usersView?.filterBy,
     sortBy: search.usersView?.sortBy,
@@ -643,10 +639,9 @@ function UsersComponent() {
             <div key={user.id}>
               <Link
                 to="/dashboard/users/user"
-                search={(d) => ({
-                  ...d,
+                search={{
                   userId: user.id,
-                })}
+                }}
                 className="block py-2 px-3 text-blue-700"
                 activeProps={{ className: `font-bold` }}
               >

--- a/examples/react/kitchen-sink/src/main.tsx
+++ b/examples/react/kitchen-sink/src/main.tsx
@@ -12,6 +12,7 @@ import {
   createRouter,
   lazyRouteComponent,
   redirect,
+  retainSearchParams,
   useNavigate,
   useRouter,
   useRouterState,
@@ -437,16 +438,11 @@ const usersRoute = createRoute({
       })
       .optional(),
   }).parse,
-  preSearchFilters: [
-    // Persist (or set as default) the usersView search param
-    // while navigating within or to this route (or it's children!)
-    (search) => ({
-      ...search,
-      usersView: {
-        ...search.usersView,
-      },
-    }),
-  ],
+  search: {
+    // Retain the usersView search param while navigating
+    // within or to this route (or it's children!)
+    middlewares: [retainSearchParams(['usersView'])],
+  },
   loaderDeps: ({ search: { usersView } }) => ({
     filterBy: usersView?.filterBy,
     sortBy: usersView?.sortBy ?? 'name',
@@ -544,10 +540,9 @@ function UsersComponent() {
             <div key={user.id}>
               <Link
                 to="/dashboard/users/user"
-                search={(d) => ({
-                  ...d,
+                search={{
                   userId: user.id,
-                })}
+                }}
                 className="block py-2 px-3 text-blue-700"
                 activeProps={{ className: `font-bold` }}
               >


### PR DESCRIPTION
The current examples use the deprecated preSearchFilters prop for route creation.

This change would modify the examples to use the updated search middleware instead.