### PR TITLE
docs(start): update `cloudflare-pages` deployment instructions

### DIFF
--- a/docs/framework/react/start/hosting.md
+++ b/docs/framework/react/start/hosting.md
@@ -67,23 +67,39 @@ Deploy you application to Vercel using their one-click deployment process, and y
 
 ### Cloudflare Pages
 
-Set the `server.preset` value to `cloudflare-pages` in your `app.config.ts` file.
+1. Installation
+
+First you will need to install `unenv`
+
+```sh
+npm install -D unenv
+```
+
+2. Update `app.config.ts`
+
+Set the `server.preset` value to `cloudflare-pages` and `server.unenv` value to `cloudflare` in your `app.config.ts` file.
 
 ```ts
 // app.config.ts
 import { defineConfig } from '@tanstack/start/config'
+import { cloudflare } from 'unenv'
 
 export default defineConfig({
   server: {
     preset: 'cloudflare-pages',
+    unenv: cloudflare,
   },
 })
 ```
 
-Or you can use the `--preset` flag with the `build` command to specify the deployment target when building the application:
+3. Add a `wrangler.toml` config file
 
-```sh
-npm run build --preset cloudflare-pages
+```toml
+# wrangler.toml
+name = "your-cloudflare-project-name"
+pages_build_output_dir = "./dist"
+compatibility_flags = ["nodejs_compat"]
+compatibility_date = "2024-11-13"
 ```
 
 Deploy you application to Cloudflare Pages using their one-click deployment process, and you're ready to go!

--- a/docs/framework/react/start/hosting.md
+++ b/docs/framework/react/start/hosting.md
@@ -67,7 +67,7 @@ Deploy you application to Vercel using their one-click deployment process, and y
 
 ### Cloudflare Pages
 
-When deploying to Cloudflare, there are a few extra steps you'll need to complete before your users can start using your app.
+When deploying to Cloudflare Pages, you'll need to complete a few extra steps before your users can start using your app.
 
 1. Installation
 

--- a/docs/framework/react/start/hosting.md
+++ b/docs/framework/react/start/hosting.md
@@ -67,6 +67,8 @@ Deploy you application to Vercel using their one-click deployment process, and y
 
 ### Cloudflare Pages
 
+When deploying to Cloudflare, there are a few extra steps you'll need to complete before your users can start using your app.
+
 1. Installation
 
 First you will need to install `unenv`

--- a/docs/framework/react/start/hosting.md
+++ b/docs/framework/react/start/hosting.md
@@ -72,12 +72,12 @@ Deploy you application to Vercel using their one-click deployment process, and y
 First you will need to install `unenv`
 
 ```sh
-npm install -D unenv
+npm install unenv
 ```
 
 2. Update `app.config.ts`
 
-Set the `server.preset` value to `cloudflare-pages` and `server.unenv` value to `cloudflare` in your `app.config.ts` file.
+Set the `server.preset` value to `cloudflare-pages` and the `server.unenv` value to the `cloudflare` from `unenv` in your `app.config.ts` file.
 
 ```ts
 // app.config.ts


### PR DESCRIPTION
it seems like nitro and therefore vinxi rely on `node:async_context` to run. while cloudflare doesn't have support for the required API to make this work. the nitro team has started working on this on their package `unenv` in [tacked this issue](https://github.com/nitrojs/nitro/issues/1943)

until this is integrated in nitro, we need to manually point to the latest version of `unenv` in the `app.config.ts`:

```tsx
import { defineConfig } from "@tanstack/start/config";
import { cloudflare } from "unenv";

export default defineConfig({
  server: {
    preset: "cloudflare-pages",
    unenv: cloudflare,
  },
});
```

i've updated the hosting documentation to include this and also remove the build command that was attached as it's not possible to pass an unenv via the CLI

related issues:
https://github.com/nitrojs/nitro/issues/1943
https://github.com/solidjs/solid-start/issues/1527
https://github.com/TanStack/router/issues/2633#issuecomment-2473018862