### PR TITLE
Add @vitejs/plugin-react to counter example

### DIFF
--- a/examples/react/start-counter/package.json
+++ b/examples/react/start-counter/package.json
@@ -19,6 +19,7 @@
     "@types/node": "^22.5.4",
     "@types/react": "^18.2.65",
     "@types/react-dom": "^18.2.21",
+    "@vitejs/plugin-react": "^4.3.3",
     "typescript": "^5.6.2"
   }
 }


### PR DESCRIPTION
Fixes issue when trying to run counter example due to missing dependency

<img width="965" alt="image" src="https://github.com/user-attachments/assets/f69f58f2-e12e-4917-bde3-d0cd267e2b9c">
