### PR TITLE
improve internal middleware validation typings

### DIFF
--- a/packages/start/src/client/createMiddleware.ts
+++ b/packages/start/src/client/createMiddleware.ts
@@ -235,12 +235,19 @@ export type ClientResultWithContext<TServerContext, TClientContext> = {
   headers: HeadersInit
 }
 
-export type AnyMiddleware = MiddlewareTypes<any, any, any, any, any, any>
+export type AnyMiddleware = MiddlewareTypes<
+  any,
+  any,
+  AnyValidator,
+  any,
+  any,
+  any
+>
 
 export interface MiddlewareTypes<
   TId,
   TMiddlewares,
-  TValidator,
+  TValidator extends AnyValidator,
   TServerContext,
   TClientContext,
   TClientAfterContext,
@@ -266,13 +273,13 @@ export interface MiddlewareTypes<
 export interface MiddlewareValidator<
   TId,
   TMiddlewares,
-  TValidator,
+  TValidator extends AnyValidator,
   TServerContext,
   TClientContext,
   TClientAfterContext,
 > {
-  validator: <TNewValidator>(
-    input: Constrain<TNewValidator, AnyValidator>,
+  validator: <TNewValidator extends AnyValidator>(
+    input: TNewValidator,
   ) => MiddlewareAfterMiddleware<
     TId,
     TMiddlewares,
@@ -286,7 +293,7 @@ export interface MiddlewareValidator<
 export interface MiddlewareClientAfter<
   TId,
   TMiddlewares,
-  TValidator,
+  TValidator extends AnyValidator,
   TServerContext,
   TClientContext,
   TClientAfterContext,
@@ -312,7 +319,7 @@ export interface MiddlewareClientAfter<
 export interface MiddlewareAfterServer<
   TId,
   TMiddlewares,
-  TValidator,
+  TValidator extends AnyValidator,
   TServerContext,
   TClientContext,
   TClientAfterContext,
@@ -336,7 +343,7 @@ export interface MiddlewareAfterServer<
 export interface MiddlewareServer<
   TId,
   TMiddlewares,
-  TValidator,
+  TValidator extends AnyValidator,
   TServerContext,
   TClientContext,
   TClientAfterContext,
@@ -362,7 +369,7 @@ export interface MiddlewareServer<
 export interface MiddlewareAfterClient<
   TId,
   TMiddlewares,
-  TValidator,
+  TValidator extends AnyValidator,
   TServerContext,
   TClientContext,
   TClientAfterContext,
@@ -386,7 +393,7 @@ export interface MiddlewareAfterClient<
 export interface MiddlewareClient<
   TId,
   TMiddlewares,
-  TValidator,
+  TValidator extends AnyValidator,
   TServerContext,
   TClientContext,
   TClientAfterContext,
@@ -411,7 +418,7 @@ export interface MiddlewareClient<
 export interface MiddlewareAfterMiddleware<
   TId,
   TMiddlewares,
-  TValidator,
+  TValidator extends AnyValidator,
   TServerContext,
   TClientContext,
   TClientAfterContext,
@@ -451,7 +458,7 @@ export interface MiddlewareAfterMiddleware<
 export interface Middleware<
   TId,
   TMiddlewares,
-  TValidator,
+  TValidator extends AnyValidator,
   TServerContext,
   TClientContext,
   TClientAfterContext,
@@ -478,7 +485,7 @@ export interface Middleware<
 export function createMiddleware<
   const TId,
   const TMiddlewares,
-  TValidator = undefined,
+  TValidator extends AnyValidator = undefined,
   TServerContext = undefined,
   TClientContext = undefined,
   TClientAfterContext = undefined,

--- a/packages/start/src/client/createServerFn.ts
+++ b/packages/start/src/client/createServerFn.ts
@@ -308,10 +308,13 @@ const applyMiddleware = (
 function execValidator(validator: AnyValidator, input: unknown): unknown {
   if (validator == null) return {}
 
-  if ('~validate' in validator) {
-    const result = validator['~validate']({ value: input })
+  if ('~standard' in validator) {
+    const result = validator['~standard'].validate(input)
 
     if ('value' in result) return result.value
+
+    if (result instanceof Promise)
+      throw new Error('Async validation not supported')
 
     throw new Error(JSON.stringify(result.issues, undefined, 2))
   }


### PR DESCRIPTION
Just constrains the validation generic to require it to implement AnyValidator.

This would have caught the error in https://github.com/TanStack/router/issues/2759:

<img width="907" alt="Screenshot 2024-11-14 at 4 21 54 PM" src="https://github.com/user-attachments/assets/4d24a6b0-2038-4a6e-93c5-c9f6f60a91d3">
