### PR TITLE
fix(start): fix request method check for multipart payloads

### DIFF
--- a/packages/start/src/server-handler/index.tsx
+++ b/packages/start/src/server-handler/index.tsx
@@ -58,7 +58,7 @@ export async function handleServerRequest(request: Request, _event?: H3Event) {
         ) {
           // We don't support GET requests with FormData payloads... that seems impossible
           invariant(
-            method.toLowerCase() === 'get',
+            method.toLowerCase() !== 'get',
             'GET requests with FormData payloads are not supported',
           )
 


### PR DESCRIPTION
Throw an error when the request method is GET and `Content-Type` header contains `multipart/form-data`.

Currently, it does the opposite - it throws an error for valid requests and accepts only `GET` with multipart content type.