### PR TITLE
fix: AnyMiddleware typings (createServerFn, with middleware)

### DIFF
--- a/packages/start/src/client/createMiddleware.ts
+++ b/packages/start/src/client/createMiddleware.ts
@@ -1,4 +1,3 @@
-import type { Method } from './createServerFn'
 import type {
   AnyValidator,
   Constrain,
@@ -7,6 +6,7 @@ import type {
   ResolveValidatorInput,
   ResolveValidatorOutput,
 } from '@tanstack/react-router'
+import type { Method } from './createServerFn'
 
 /**
  * Turns all middleware into a union
@@ -235,14 +235,7 @@ export type ClientResultWithContext<TServerContext, TClientContext> = {
   headers: HeadersInit
 }
 
-export type AnyMiddleware = MiddlewareTypes<
-  any,
-  any,
-  AnyValidator,
-  any,
-  any,
-  any
->
+export type AnyMiddleware = MiddlewareTypes<any, any, any, any, any, any>
 
 export interface MiddlewareTypes<
   TId,

--- a/packages/start/src/client/createMiddleware.ts
+++ b/packages/start/src/client/createMiddleware.ts
@@ -1,3 +1,4 @@
+import type { Method } from './createServerFn'
 import type {
   AnyValidator,
   Constrain,
@@ -6,7 +7,6 @@ import type {
   ResolveValidatorInput,
   ResolveValidatorOutput,
 } from '@tanstack/react-router'
-import type { Method } from './createServerFn'
 
 /**
  * Turns all middleware into a union


### PR DESCRIPTION
AnyMiddleware had a strict requirement on AnyValidator that broke middleware types with serverFn.

Was introduced in: [4d7c669](https://github.com/TanStack/router/commit/4d7c6697f444e5547cb5adae987cdd98c0da0a83)

closes: https://github.com/TanStack/router/issues/2769