### PR TITLE
fix(start): Fix `FormData` handling in server functions

### DIFF
--- a/e2e/start/basic/app/routes/server-fns.tsx
+++ b/e2e/start/basic/app/routes/server-fns.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 import { createServerFn } from '@tanstack/start'
+import { useRef } from 'react'
 
 export const Route = createFileRoute('/server-fns')({
   component: RouteComponent,
@@ -10,6 +11,7 @@ function RouteComponent() {
   return (
     <>
       <ConsistentServerFnCalls />
+      <MultipartServerFnCall />
     </>
   )
 }
@@ -122,3 +124,106 @@ function ConsistentServerFnCalls() {
 }
 
 // END CONSISTENT_SERVER_FN_CALLS
+
+// START MULTIPART_FORMDATA_SERVER_FN_CALLS
+const multipartFormDataServerFn = createServerFn({ method: 'POST' })
+  .validator((x: unknown) => {
+    if (!(x instanceof FormData)) {
+      throw new Error('Invalid form data')
+    }
+
+    const value = x.get('input_field')
+    const file = x.get('input_file')
+
+    if (typeof value !== 'string') {
+      throw new Error('Submitted value is not a string')
+    }
+
+    if (!(file instanceof File)) {
+      throw new Error('File is required')
+    }
+
+    return {
+      submittedValue: value,
+      file,
+    }
+  })
+  .handler(async ({ data }) => {
+    const contents = await data.file.text()
+    return {
+      value: data.submittedValue,
+      file: {
+        name: data.file.name,
+        size: data.file.size,
+        contents: contents,
+      },
+    }
+  })
+
+function MultipartServerFnCall() {
+  const formRef = useRef<HTMLFormElement | null>(null)
+  const [multipartResult, setMultipartResult] = React.useState({})
+
+  const handleSubmit = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+
+    if (!formRef.current) {
+      return
+    }
+
+    const formData = new FormData(formRef.current)
+    multipartFormDataServerFn({ data: formData }).then(setMultipartResult)
+  }
+
+  return (
+    <div className="p-2 border m-2 grid gap-2">
+      <h3>Multipart Server Fn POST Call</h3>
+      <div>
+        It should return{' '}
+        <code>
+          <pre data-testid="expected-multipart-server-fn-result">
+            {JSON.stringify({
+              value: 'test field value',
+              file: { name: 'my_file.txt', size: 9, contents: 'test data' },
+            })}
+          </pre>
+        </code>
+      </div>
+      <form
+        className="flex flex-col gap-2"
+        action={multipartFormDataServerFn.url}
+        method="POST"
+        encType="multipart/form-data"
+        ref={formRef}
+        data-testid="multipart-form"
+      >
+        <input type="text" name="input_field" defaultValue="test field value" />
+        <input
+          type="file"
+          name="input_file"
+          data-testid="multipart-form-file-input"
+        />
+        <button
+          type="submit"
+          className="rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+        >
+          Submit (native)
+        </button>
+        <button
+          type="button"
+          onClick={handleSubmit}
+          className="rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+        >
+          Submit (onClick)
+        </button>
+      </form>
+      <div>
+        <pre data-testid="multipart-form-response">
+          {JSON.stringify(multipartResult)}
+        </pre>
+      </div>
+    </div>
+  )
+}
+
+// END MULTIPART_FORMDATA_SERVER_FN_CALLS

--- a/e2e/start/basic/tests/app.spec.ts
+++ b/e2e/start/basic/tests/app.spec.ts
@@ -131,3 +131,31 @@ test('Consistent server function returns both on client and server for GET and P
     expected,
   )
 })
+
+test('submitting multipart/form-data as server function input', async ({
+  page,
+}) => {
+  await page.goto('/server-fns')
+
+  await page.waitForLoadState('networkidle')
+  const expected =
+    (await page
+      .getByTestId('expected-multipart-server-fn-result')
+      .textContent()) || ''
+  expect(expected).not.toBe('')
+
+  const fileChooserPromise = page.waitForEvent('filechooser')
+  await page.getByTestId('multipart-form-file-input').click()
+  const fileChooser = await fileChooserPromise
+  await fileChooser.setFiles({
+    name: 'my_file.txt',
+    mimeType: 'text/plain',
+    buffer: Buffer.from('test data', 'utf-8'),
+  })
+  await page.getByText('Submit (onClick)').click()
+  await page.waitForLoadState('networkidle')
+
+  await expect(page.getByTestId('multipart-form-response')).toContainText(
+    expected,
+  )
+})


### PR DESCRIPTION
- Ensure context is included when serializing `FormData` on the client (serialized using default transformer and added to the `__TSR_CONTEXT` field in the payload)
- Add input type check on the server and, if it's `FormData`, extract context value from the `__TSR_CONTEXT` field before passing the actual payload to the middleware
- Add E2E test for `multipart/form-data` form submission
