### PR TITLE
feat(react-router): generic router history

### DIFF
--- a/examples/react/router-monorepo-react-query/packages/router/package.json
+++ b/examples/react/router-monorepo-react-query/packages/router/package.json
@@ -8,6 +8,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "dependencies": {
+    "@tanstack/history": "^1.81.9",
     "@tanstack/react-query": "^5.61.3",
     "@tanstack/react-router": "^1.84.4",
     "@tanstack/router-plugin": "^1.84.4",

--- a/examples/react/router-monorepo-simple/packages/router/package.json
+++ b/examples/react/router-monorepo-simple/packages/router/package.json
@@ -8,6 +8,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "dependencies": {
+    "@tanstack/history": "^1.81.9",
     "@tanstack/react-router": "^1.84.4",
     "@tanstack/router-plugin": "^1.84.4",
     "redaxios": "^0.5.1",

--- a/packages/react-router/src/RouterProvider.tsx
+++ b/packages/react-router/src/RouterProvider.tsx
@@ -107,6 +107,7 @@ export type RouterProps<
     TRouter['routeTree'],
     NonNullable<TRouter['options']['trailingSlash']>,
     NonNullable<TRouter['options']['defaultStructuralSharing']>,
+    TRouter['history'],
     TDehydrated
   >,
   'context'
@@ -114,13 +115,15 @@ export type RouterProps<
   router: Router<
     TRouter['routeTree'],
     NonNullable<TRouter['options']['trailingSlash']>,
-    NonNullable<TRouter['options']['defaultStructuralSharing']>
+    NonNullable<TRouter['options']['defaultStructuralSharing']>,
+    TRouter['history']
   >
   context?: Partial<
     RouterOptions<
       TRouter['routeTree'],
       NonNullable<TRouter['options']['trailingSlash']>,
       NonNullable<TRouter['options']['defaultStructuralSharing']>,
+      TRouter['history'],
       TDehydrated
     >['context']
   >

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -848,11 +848,11 @@ export class Router<
     ) {
       this.history =
         this.options.history ??
-        (this.isServer
+        ((this.isServer
           ? createMemoryHistory({
               initialEntries: [this.basepath || '/'],
             })
-          : createBrowserHistory()) as TRouterHistory
+          : createBrowserHistory()) as TRouterHistory)
       this.latestLocation = this.parseLocation()
     }
 

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -110,10 +110,11 @@ export interface Register {
   // router: Router
 }
 
-export type AnyRouter = Router<any, any, any, any, any>
+export type AnyRouter = Router<any, any, any, any, any, any>
 
 export type AnyRouterWithContext<TContext> = Router<
   AnyRouteWithContext<TContext>,
+  any,
   any,
   any,
   any
@@ -173,6 +174,7 @@ export interface RouterOptions<
   TRouteTree extends AnyRoute,
   TTrailingSlashOption extends TrailingSlashOption,
   TDefaultStructuralSharingOption extends boolean = false,
+  TRouterHistory extends RouterHistory = RouterHistory,
   TDehydrated extends Record<string, any> = Record<string, any>,
   TSerializedError extends Record<string, any> = Record<string, any>,
 > {
@@ -184,7 +186,7 @@ export interface RouterOptions<
    * @link [API Docs](https://tanstack.com/router/latest/docs/framework/react/api/router/RouterOptionsType#history-property)
    * @link [Guide](https://tanstack.com/router/latest/docs/framework/react/guide/history-types)
    */
-  history?: RouterHistory
+  history?: TRouterHistory
   /**
    * A function that will be used to stringify search params when generating links.
    *
@@ -552,6 +554,7 @@ export type RouterConstructorOptions<
   TRouteTree extends AnyRoute,
   TTrailingSlashOption extends TrailingSlashOption,
   TDefaultStructuralSharingOption extends boolean,
+  TRouterHistory extends RouterHistory,
   TDehydrated extends Record<string, any>,
   TSerializedError extends Record<string, any>,
 > = Omit<
@@ -559,6 +562,7 @@ export type RouterConstructorOptions<
     TRouteTree,
     TTrailingSlashOption,
     TDefaultStructuralSharingOption,
+    TRouterHistory,
     TDehydrated,
     TSerializedError
   >,
@@ -657,6 +661,7 @@ export function createRouter<
   TRouteTree extends AnyRoute,
   TTrailingSlashOption extends TrailingSlashOption,
   TDefaultStructuralSharingOption extends boolean,
+  TRouterHistory extends RouterHistory = RouterHistory,
   TDehydrated extends Record<string, any> = Record<string, any>,
   TSerializedError extends Record<string, any> = Record<string, any>,
 >(
@@ -666,6 +671,7 @@ export function createRouter<
         TRouteTree,
         TTrailingSlashOption,
         TDefaultStructuralSharingOption,
+        TRouterHistory,
         TDehydrated,
         TSerializedError
       >,
@@ -674,6 +680,7 @@ export function createRouter<
     TRouteTree,
     TTrailingSlashOption,
     TDefaultStructuralSharingOption,
+    TRouterHistory,
     TDehydrated,
     TSerializedError
   >(options)
@@ -690,6 +697,7 @@ export class Router<
   in out TRouteTree extends AnyRoute,
   in out TTrailingSlashOption extends TrailingSlashOption,
   in out TDefaultStructuralSharingOption extends boolean,
+  in out TRouterHistory extends RouterHistory = RouterHistory,
   in out TDehydrated extends Record<string, any> = Record<string, any>,
   in out TSerializedError extends Record<string, any> = Record<string, any>,
 > {
@@ -729,6 +737,7 @@ export class Router<
         TRouteTree,
         TTrailingSlashOption,
         TDefaultStructuralSharingOption,
+        TRouterHistory,
         TDehydrated,
         TSerializedError
       >,
@@ -738,7 +747,7 @@ export class Router<
     },
     'stringifySearch' | 'parseSearch' | 'context'
   >
-  history!: RouterHistory
+  history!: TRouterHistory
   latestLocation!: ParsedLocation<FullSearchSchema<TRouteTree>>
   basepath!: string
   routeTree!: TRouteTree
@@ -756,6 +765,7 @@ export class Router<
       TRouteTree,
       TTrailingSlashOption,
       TDefaultStructuralSharingOption,
+      TRouterHistory,
       TDehydrated,
       TSerializedError
     >,
@@ -788,6 +798,7 @@ export class Router<
       TRouteTree,
       TTrailingSlashOption,
       TDefaultStructuralSharingOption,
+      TRouterHistory,
       TDehydrated,
       TSerializedError
     >,
@@ -841,7 +852,7 @@ export class Router<
           ? createMemoryHistory({
               initialEntries: [this.basepath || '/'],
             })
-          : createBrowserHistory())
+          : createBrowserHistory()) as TRouterHistory
       this.latestLocation = this.parseLocation()
     }
 
@@ -2772,6 +2783,7 @@ export class Router<
         TRouteTree,
         TTrailingSlashOption,
         TDefaultStructuralSharingOption,
+        TRouterHistory,
         TDehydrated,
         TSerializedError
       >,
@@ -2852,6 +2864,7 @@ export class Router<
         TRouteTree,
         TTrailingSlashOption,
         TDefaultStructuralSharingOption,
+        TRouterHistory,
         TDehydrated,
         TSerializedError
       >,

--- a/packages/react-router/tests/router.test-d.tsx
+++ b/packages/react-router/tests/router.test-d.tsx
@@ -4,9 +4,9 @@ import {
   createRootRoute,
   createRootRouteWithContext,
   createRoute,
-  createRouter
+  createRouter,
 } from '../src'
-import type { RouterHistory } from '../src';
+import type { RouterHistory } from '../src'
 
 test('when creating a router without context', () => {
   // eslint-disable-next-line unused-imports/no-unused-vars
@@ -239,10 +239,16 @@ test('when creating a router with default router history', () => {
   expectTypeOf(router.history).toEqualTypeOf<RouterHistory>()
 })
 
-test('when creating a router with custom router history', () => { 
-  const customRouterHistory = { ...createMemoryHistory(), _isCustomRouterHistory: true }
+test('when creating a router with custom router history', () => {
+  const customRouterHistory = {
+    ...createMemoryHistory(),
+    _isCustomRouterHistory: true,
+  }
 
-  const router = createRouter({ routeTree: createRootRoute(), history: customRouterHistory })
+  const router = createRouter({
+    routeTree: createRootRoute(),
+    history: customRouterHistory,
+  })
 
   expectTypeOf(router.history).toMatchTypeOf<RouterHistory>()
   expectTypeOf(router.history).toEqualTypeOf<typeof customRouterHistory>()

--- a/packages/react-router/tests/router.test-d.tsx
+++ b/packages/react-router/tests/router.test-d.tsx
@@ -1,10 +1,12 @@
 import { expectTypeOf, test } from 'vitest'
 import {
+  createMemoryHistory,
   createRootRoute,
   createRootRouteWithContext,
   createRoute,
-  createRouter,
+  createRouter
 } from '../src'
+import type { RouterHistory } from '../src';
 
 test('when creating a router without context', () => {
   // eslint-disable-next-line unused-imports/no-unused-vars
@@ -229,4 +231,19 @@ test('invalidate and clearCache narrowing in filter', () => {
       return true
     },
   })
+})
+
+test('when creating a router with default router history', () => {
+  const router = createRouter({ routeTree: createRootRoute() })
+
+  expectTypeOf(router.history).toEqualTypeOf<RouterHistory>()
+})
+
+test('when creating a router with custom router history', () => { 
+  const customRouterHistory = { ...createMemoryHistory(), _isCustomRouterHistory: true }
+
+  const router = createRouter({ routeTree: createRootRoute(), history: customRouterHistory })
+
+  expectTypeOf(router.history).toMatchTypeOf<RouterHistory>()
+  expectTypeOf(router.history).toEqualTypeOf<typeof customRouterHistory>()
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2057,6 +2057,9 @@ importers:
       '@router-mono-react-query/post-query':
         specifier: workspace:*
         version: link:../post-query
+      '@tanstack/history':
+        specifier: workspace:*
+        version: link:../../../../../packages/history
       '@tanstack/react-query':
         specifier: ^5.61.3
         version: 5.61.3(react@18.3.1)
@@ -2214,6 +2217,9 @@ importers:
 
   examples/react/router-monorepo-simple/packages/router:
     dependencies:
+      '@tanstack/history':
+        specifier: workspace:*
+        version: link:../../../../../packages/history
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../../../packages/react-router


### PR DESCRIPTION
Changes type of history in router to a generic type parameter to support advanced use cases like providing an own implementation of a `RouterHistory` or to enchance a specific `RouterHistory` with additional features.