### PR TITLE
fix: router should have 'pending' when loaders in progress (draft)

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -2113,7 +2113,11 @@ export class Router<
       }
     }
 
-    if (!this.isServer && !this.state.matches.length) {
+    if (
+      !this.isServer &&
+      !this.state.matches.length &&
+      !this.state.pendingMatches?.length
+    ) {
       triggerOnReady()
     }
 

--- a/packages/react-router/tests/router.test.tsx
+++ b/packages/react-router/tests/router.test.tsx
@@ -1126,7 +1126,10 @@ describe('router state', () => {
     })
 
     // ensure the router is stable once idle and do not update its state
-    expect(stateHistory.slice(-2).map(s => s.status)).toStrictEqual(['pending', 'idle']);
+    expect(stateHistory.slice(-2).map((s) => s.status)).toStrictEqual([
+      'pending',
+      'idle',
+    ])
 
     // if the router is idle, all promises should be settled
     expect(

--- a/packages/react-router/tests/router.test.tsx
+++ b/packages/react-router/tests/router.test.tsx
@@ -21,6 +21,8 @@ import {
 import type { AnyRoute, AnyRouter, RouterOptions } from '../src'
 
 afterEach(() => {
+  // @ts-ignore
+  window.__TSR__ROUTER__.history.destroy()
   vi.resetAllMocks()
   window.history.replaceState(null, 'root', '/')
   cleanup()
@@ -1125,7 +1127,7 @@ describe('router state', () => {
       expect(router.state.status).toBe('idle')
     })
 
-    // ensure the router is stable once idle and do not update its state
+    // ensure the router is stable once idle and do not update its state since then
     expect(stateHistory.slice(-2).map((s) => s.status)).toStrictEqual([
       'pending',
       'idle',

--- a/packages/react-router/tests/router.test.tsx
+++ b/packages/react-router/tests/router.test.tsx
@@ -19,8 +19,10 @@ import {
   RouterState,
 } from '../src'
 import type { AnyRoute, AnyRouter, RouterOptions } from '../src'
+import React from 'react'
 
 afterEach(() => {
+  // TODO: should we use same approach like in routeContext.test.tsx and specify history explicitly to all tests?
   // @ts-ignore
   window.__TSR__ROUTER__.history.destroy()
   vi.resetAllMocks()


### PR DESCRIPTION
The `router` had a state `idle`, while the `load` and `beforeLoad` was not resolved. 

I noticed this in tests, when I attempted to fix the warning
```
Warning: An update to Transitioner inside a test was not wrapped in act(...).
```
by waiting for `state = idle`. 

I also noticed that `Transitionier` warning happens in `afterEach`, so I've added a unsubscribe method for history:

```ts
afterEach(() => {
  vi.resetAllMocks()
  window.history.replaceState(null, 'root', '/') <-- also causes 'Warning: An update to Transitioner inside a test was not wrapped in act(...).'
```

Should I expand this approach for other tests?