### PR TITLE
docs(start): explicitly set POST method `updateCount` server function examples

### DIFF
--- a/docs/framework/react/guide/tanstack-start.md
+++ b/docs/framework/react/guide/tanstack-start.md
@@ -258,7 +258,7 @@ const getCount = createServerFn({
   return readCount()
 })
 
-const updateCount = createServerFn()
+const updateCount = createServerFn({ method: 'POST' })
   .validator((d: number) => d)
   .handler(async ({ data }) => {
     const count = await readCount()

--- a/docs/framework/react/start/getting-started.md
+++ b/docs/framework/react/start/getting-started.md
@@ -264,7 +264,7 @@ const getCount = createServerFn({
   return readCount()
 })
 
-const updateCount = createServerFn()
+const updateCount = createServerFn({ method: 'POST' })
   .validator((d: number) => d)
   .handler(async ({ data }) => {
     const count = await readCount()

--- a/docs/framework/react/start/server-functions.md
+++ b/docs/framework/react/start/server-functions.md
@@ -798,7 +798,7 @@ const getCount = createServerFn({
   return readCount()
 })
 
-const updateCount = createServerFn()
+const updateCount = createServerFn({ method: 'POST' })
   .validator((formData) => {
     if (!(formData instanceof FormData)) {
       throw new Error('Invalid form data')

--- a/examples/react/start-counter/app/routes/index.tsx
+++ b/examples/react/start-counter/app/routes/index.tsx
@@ -14,7 +14,7 @@ const getCount = createServerFn({ method: 'GET' }).handler(() => {
   return readCount()
 })
 
-const updateCount = createServerFn()
+const updateCount = createServerFn({ method: 'POST' })
   .validator((addBy: number) => addBy)
   .handler(async ({ data }) => {
     const count = await readCount()


### PR DESCRIPTION
Since the default method is GET I think it's correct to explicitly set these examples to POST