### PR TITLE
fix(start): fix server function handling of standard schemas

### DIFF
--- a/packages/start/src/client/createServerFn.ts
+++ b/packages/start/src/client/createServerFn.ts
@@ -17,8 +17,6 @@ import type {
   ResolveAllValidators,
 } from './createMiddleware'
 
-//
-
 export interface JsonResponse<TData> extends Response {
   json: () => Promise<TData>
 }
@@ -353,12 +351,13 @@ function execValidator(validator: AnyValidator, input: unknown): unknown {
   if ('~standard' in validator) {
     const result = validator['~standard'].validate(input)
 
-    if ('value' in result) return result.value
-
     if (result instanceof Promise)
       throw new Error('Async validation not supported')
 
-    throw new Error(JSON.stringify(result.issues, undefined, 2))
+    if (result.issues)
+      throw new Error(JSON.stringify(result.issues, undefined, 2))
+
+    return result.value
   }
 
   if ('parse' in validator) {


### PR DESCRIPTION
Some implementations (namely Valibot) still include the value key for failure results, which is technically still correct in structural typing (since an object type is a *minimum* requirement). What can actually be relied on is that `result.issues` is undefined if the result is valid, as this is in the spec.

Currently failure results from Valibot are still treated as success - this PR flips to checking for `result.issues` instead of `result.value`.