### PR TITLE
docs(start): `FormData` to use `e.currentTarget` instead of `e.target`

### DIFF
--- a/docs/framework/react/start/server-functions.md
+++ b/docs/framework/react/start/server-functions.md
@@ -306,7 +306,7 @@ function Test() {
     <form
       onSubmit={async (event) => {
         event.preventDefault()
-        const formData = new FormData(event.target)
+        const formData = new FormData(event.currentTarget)
         const response = await greetUser({ data: formData })
         console.log(response)
       }}


### PR DESCRIPTION
Currently [this example](https://tanstack.com/router/latest/docs/framework/react/start/server-functions#formdata-parameters) has a type error:

<img width="471" alt="Screenshot 2024-11-24 at 09 29 16" src="https://github.com/user-attachments/assets/89af4a3f-9d4f-414e-aa4d-c1ff4ba71aa8">

because:

<img width="557" alt="Screenshot 2024-11-24 at 09 29 45" src="https://github.com/user-attachments/assets/83ff68ad-44ca-483a-b0f9-86e44ffe1b54">

At first I ended up type casting `event.target` but there's a better solution: use `event.currentTarget`.

<img width="441" alt="Screenshot 2024-11-24 at 09 31 45" src="https://github.com/user-attachments/assets/0e1da1ee-79d5-4934-b765-15cf006c132b">

For context: `event.currentTarget` refers to the element the event handler is attached to, while `event.target` refers to the element that fired the event. [Src](https://developer.mozilla.org/en-US/docs/Web/API/Event/currentTarget)