### PR TITLE
fix(router-generator): initial route template should return JSX

### DIFF
--- a/packages/router-generator/src/config.ts
+++ b/packages/router-generator/src/config.ts
@@ -9,7 +9,7 @@ const defaultTemplate = {
     '%%tsrImports%%',
     '\n\n',
     '%%tsrExportStart%%{\n component: RouteComponent\n }%%tsrExportEnd%%\n\n',
-    'function RouteComponent() { return <div>Hello %%tsrPath%%!</div> };\n',
+    'function RouteComponent() { return <div>Hello "%%tsrPath%%"!</div> };\n',
   ].join(''),
   apiTemplate: [
     'import { json } from "@tanstack/start";\n',

--- a/packages/router-generator/src/config.ts
+++ b/packages/router-generator/src/config.ts
@@ -9,7 +9,7 @@ const defaultTemplate = {
     '%%tsrImports%%',
     '\n\n',
     '%%tsrExportStart%%{\n component: RouteComponent\n }%%tsrExportEnd%%\n\n',
-    'function RouteComponent() { return "Hello %%tsrPath%%!" };\n',
+    'function RouteComponent() { return <div>Hello %%tsrPath%%!</div> };\n',
   ].join(''),
   apiTemplate: [
     'import { json } from "@tanstack/start";\n',


### PR DESCRIPTION
Closes #2814 

Changes the route template in the generator from returning:

```
return 'Hello /foo/!'
```

To now return valid JSX:

```
return <div>Hello "/foo/"!</div>
```