### PR TITLE
perf(start): improve typescript performance of start types

### DIFF
--- a/packages/react-router/src/Matches.tsx
+++ b/packages/react-router/src/Matches.tsx
@@ -136,13 +136,13 @@ export type MakeRouteMatchFromRoute<TRoute extends AnyRoute> = RouteMatch<
 >
 
 export interface RouteMatch<
-  TRouteId,
-  TFullPath,
-  TAllParams,
-  TFullSearchSchema,
-  TLoaderData,
-  TAllContext,
-  TLoaderDeps,
+  out TRouteId,
+  out TFullPath,
+  out TAllParams,
+  out TFullSearchSchema,
+  out TLoaderData,
+  out TAllContext,
+  out TLoaderDeps,
 > {
   id: string
   routeId: TRouteId

--- a/packages/react-router/src/route.ts
+++ b/packages/react-router/src/route.ts
@@ -127,17 +127,17 @@ export type ResolveParams<TPath extends string> =
     ? Record<ParsePathParams<TPath>, string>
     : Record<ParsePathParams<TPath>, string> & SplatParams
 
-export type ParseParamsFn<TPath extends string, TParams> = (
+export type ParseParamsFn<in out TPath extends string, in out TParams> = (
   rawParams: ResolveParams<TPath>,
 ) => TParams extends Record<ParsePathParams<TPath>, any>
   ? TParams
   : Record<ParsePathParams<TPath>, any>
 
-export type StringifyParamsFn<TPath extends string, TParams> = (
+export type StringifyParamsFn<in out TPath extends string, in out TParams> = (
   params: TParams,
 ) => ResolveParams<TPath>
 
-export type ParamsOptions<TPath extends string, TParams> = {
+export type ParamsOptions<in out TPath extends string, in out TParams> = {
   params?: {
     parse?: ParseParamsFn<TPath, TParams>
     stringify?: StringifyParamsFn<TPath, TParams>
@@ -1083,12 +1083,11 @@ export class Route<
     this._ssr = options?.ssr ?? opts.defaultSsr ?? true
   }
 
-  addChildren<
-    const TNewChildren extends
-      | Record<string, AnyRoute>
-      | ReadonlyArray<AnyRoute>,
-  >(
-    children: TNewChildren,
+  addChildren<const TNewChildren>(
+    children: Constrain<
+      TNewChildren,
+      ReadonlyArray<AnyRoute> | Record<string, AnyRoute>
+    >,
   ): Route<
     TParentRoute,
     TPath,
@@ -1104,7 +1103,21 @@ export class Route<
     TLoaderFn,
     TNewChildren
   > {
-    return this._addFileChildren(children)
+    return this._addFileChildren(children) as Route<
+      TParentRoute,
+      TPath,
+      TFullPath,
+      TCustomId,
+      TId,
+      TSearchValidator,
+      TParams,
+      TRouterContext,
+      TRouteContextFn,
+      TBeforeLoadFn,
+      TLoaderDeps,
+      TLoaderFn,
+      TNewChildren
+    >
   }
 
   _addFileChildren<const TNewChildren>(
@@ -1302,7 +1315,7 @@ export function createRoute<
   >(options)
 }
 
-export type AnyRootRoute = RootRoute<any, any, any, any, any, any, any>
+export type AnyRootRoute = RootRoute<any, any, any, any, any, any, any, any>
 
 export type RootRouteOptions<
   TSearchValidator = undefined,
@@ -1408,12 +1421,11 @@ export class RootRoute<
     super(options as any)
   }
 
-  addChildren<
-    const TNewChildren extends
-      | Record<string, AnyRoute>
-      | ReadonlyArray<AnyRoute>,
-  >(
-    children: TNewChildren,
+  addChildren<const TNewChildren>(
+    children: Constrain<
+      TNewChildren,
+      ReadonlyArray<AnyRoute> | Record<string, AnyRoute>
+    >,
   ): RootRoute<
     TSearchValidator,
     TRouterContext,

--- a/packages/start/src/client/createServerFn.ts
+++ b/packages/start/src/client/createServerFn.ts
@@ -15,7 +15,6 @@ import type {
   MergeAllServerContext,
   MergeAllValidatorInputs,
   MergeAllValidatorOutputs,
-  ResolveAllValidators,
 } from './createMiddleware'
 
 export interface JsonResponse<TData> extends Response {
@@ -36,11 +35,6 @@ export type Fetcher<TMiddlewares, TValidator, TResponse> = {
     headers?: HeadersInit
   }) => Promise<unknown>
 } & FetcherImpl<TMiddlewares, TValidator, TResponse>
-
-export type IsDataOptional<TMiddlewares, TValidator> = ResolveAllValidators<
-  TMiddlewares,
-  TValidator
->
 
 export type FetcherImpl<TMiddlewares, TValidator, TResponse> =
   undefined extends MergeAllValidatorInputs<TMiddlewares, TValidator>
@@ -83,7 +77,7 @@ export type ServerFn<TMethod, TMiddlewares, TValidator, TResponse> = (
   | Promise<DefaultTransformerStringify<TResponse>>
   | DefaultTransformerStringify<TResponse>
 
-export type ServerFnCtx<TMethod, TMiddlewares, TValidator> = {
+export interface ServerFnCtx<TMethod, TMiddlewares, TValidator> {
   method: TMethod
   data: MergeAllValidatorOutputs<TMiddlewares, TValidator>
   context: MergeAllServerContext<TMiddlewares>
@@ -123,28 +117,51 @@ export type ConstrainValidator<TValidator> = unknown extends TValidator
       >
     >
 
-type ServerFnBase<
+export interface ServerFnMiddleware<TMethod extends Method, TValidator> {
+  middleware: <const TNewMiddlewares>(
+    middlewares: Constrain<TNewMiddlewares, ReadonlyArray<AnyMiddleware>>,
+  ) => ServerFnAfterMiddleware<TMethod, TNewMiddlewares, TValidator>
+}
+
+export interface ServerFnAfterMiddleware<
+  TMethod extends Method,
+  TMiddlewares,
+  TValidator,
+> extends ServerFnValidator<TMethod, TMiddlewares>,
+    ServerFnHandler<TMethod, TMiddlewares, TValidator> {}
+
+export interface ServerFnValidator<TMethod extends Method, TMiddlewares> {
+  validator: <TValidator>(
+    validator: ConstrainValidator<TValidator>,
+  ) => ServerFnAfterValidator<TMethod, TMiddlewares, TValidator>
+}
+
+export interface ServerFnAfterValidator<
+  TMethod extends Method,
+  TMiddlewares,
+  TValidator,
+> extends ServerFnMiddleware<TMethod, TValidator>,
+    ServerFnHandler<TMethod, TMiddlewares, TValidator> {}
+
+export interface ServerFnHandler<
+  TMethod extends Method,
+  TMiddlewares,
+  TValidator,
+> {
+  handler: <TNewResponse>(
+    fn?: ServerFn<TMethod, TMiddlewares, TValidator, TNewResponse>,
+  ) => Fetcher<TMiddlewares, TValidator, TNewResponse>
+}
+
+export interface ServerFnBuilder<
   TMethod extends Method = 'GET',
   TResponse = unknown,
   TMiddlewares = unknown,
   TValidator = unknown,
-> = {
+> extends ServerFnMiddleware<TMethod, TValidator>,
+    ServerFnValidator<TMethod, TMiddlewares>,
+    ServerFnHandler<TMethod, TMiddlewares, TValidator> {
   options: ServerFnBaseOptions<TMethod, TResponse, TMiddlewares, TValidator>
-  middleware: <const TNewMiddlewares>(
-    middlewares: Constrain<TNewMiddlewares, ReadonlyArray<AnyMiddleware>>,
-  ) => Pick<
-    ServerFnBase<TMethod, TResponse, TNewMiddlewares, TValidator>,
-    'validator' | 'handler'
-  >
-  validator: <TValidator>(
-    validator: ConstrainValidator<TValidator>,
-  ) => Pick<
-    ServerFnBase<TMethod, TResponse, TMiddlewares, TValidator>,
-    'handler' | 'middleware'
-  >
-  handler: <TNewResponse>(
-    fn?: ServerFn<TMethod, TMiddlewares, TValidator, TNewResponse>,
-  ) => Fetcher<TMiddlewares, TValidator, TNewResponse>
 }
 
 export function createServerFn<
@@ -157,7 +174,7 @@ export function createServerFn<
     method: TMethod
   },
   __opts?: ServerFnBaseOptions<TMethod, TResponse, TMiddlewares, TValidator>,
-): ServerFnBase<TMethod, TResponse, TMiddlewares, TValidator> {
+): ServerFnBuilder<TMethod, TResponse, TMiddlewares, TValidator> {
   const resolvedOptions = (__opts || options || {}) as ServerFnBaseOptions<
     TMethod,
     TResponse,


### PR DESCRIPTION
This reduces instantiations of start types and some router types. Mostly middleware/server fns should type check faster after caching but also sprinkled in some variance annotations to help the language service for middleware

Before
```> tsc --extendedDiagnostics

Files:                        1175
Lines of Library:            40097
Lines of Definitions:       198118
Lines of TypeScript:         32262
Lines of JavaScript:             0
Lines of JSON:                   0
Lines of Other:                  0
Identifiers:                314481
Symbols:                    508239
Types:                      156072
Instantiations:            2714633
Memory used:               587444K
Assignability cache size:    67144
Identity cache size:         15480
Subtype cache size:          44949
Strict subtype cache size:      10
I/O Read time:               0.16s
Parse time:                  0.96s
ResolveModule time:          0.54s
ResolveTypeReference time:   0.02s
ResolveLibrary time:         0.02s
Program time:                1.93s
Bind time:                   0.42s
Check time:                  7.66s
printTime time:              0.00s
Emit time:                   0.00s
Total time:                 10.00s
```

After
```
> tsc --extendedDiagnostics

Files:                        1175
Lines of Library:            40097
Lines of Definitions:       198133
Lines of TypeScript:         32262
Lines of JavaScript:             0
Lines of JSON:                   0
Lines of Other:                  0
Identifiers:                314567
Symbols:                    502683
Types:                      148047
Instantiations:            2145246
Memory used:               572880K
Assignability cache size:    60557
Identity cache size:         15475
Subtype cache size:          44949
Strict subtype cache size:       9
I/O Read time:               0.16s
Parse time:                  0.91s
ResolveModule time:          0.54s
ResolveTypeReference time:   0.02s
ResolveLibrary time:         0.02s
Program time:                1.96s
Bind time:                   0.41s
Check time:                  6.91s
printTime time:              0.00s
Emit time:                   0.00s
Total time:                  9.27s
```