### PR TITLE
fix(start): use configured server base for server function fetch

### DIFF
--- a/packages/start/src/client-runtime/getBaseUrl.tsx
+++ b/packages/start/src/client-runtime/getBaseUrl.tsx
@@ -1,3 +1,14 @@
+function sanitizeBase(base: string | undefined) {
+  if (!base) {
+    throw new Error(
+      '🚨 process.env.TSS_SERVER_BASE is required in start/client-runtime/getBaseUrl',
+    )
+  }
+
+  // remove the leading and trailing slash
+  return base.replace(/^\/|\/$/g, '')
+}
+
 export function getBaseUrl(base: string | undefined, id: string, name: string) {
-  return `${base}/_server/?_serverFnId=${encodeURI(id)}&_serverFnName=${encodeURI(name)}`
+  return `${base}/${sanitizeBase(process.env.TSS_SERVER_BASE)}/?_serverFnId=${encodeURI(id)}&_serverFnName=${encodeURI(name)}`
 }

--- a/packages/start/src/config/index.ts
+++ b/packages/start/src/config/index.ts
@@ -156,8 +156,12 @@ export function defineConfig(
               ...viteConfig.userConfig,
               ...clientViteConfig.userConfig,
               define: {
-                ...viteConfig.userConfig.define,
-                ...clientViteConfig.userConfig.define,
+                ...(viteConfig.userConfig.define || {}),
+                ...(clientViteConfig.userConfig.define || {}),
+                ...injectDefineEnv('TSS_PUBLIC_BASE', publicBase),
+                ...injectDefineEnv('TSS_CLIENT_BASE', clientBase),
+                ...injectDefineEnv('TSS_SERVER_BASE', serverBase),
+                ...injectDefineEnv('TSS_API_BASE', apiBase),
               },
             }),
             ...(viteConfig.plugins || []),
@@ -192,8 +196,12 @@ export function defineConfig(
               ...viteConfig.userConfig,
               ...ssrViteConfig.userConfig,
               define: {
-                ...viteConfig.userConfig.define,
-                ...ssrViteConfig.userConfig.define,
+                ...(viteConfig.userConfig.define || {}),
+                ...(ssrViteConfig.userConfig.define || {}),
+                ...injectDefineEnv('TSS_PUBLIC_BASE', publicBase),
+                ...injectDefineEnv('TSS_CLIENT_BASE', clientBase),
+                ...injectDefineEnv('TSS_SERVER_BASE', serverBase),
+                ...injectDefineEnv('TSS_API_BASE', apiBase),
               },
             }),
             tsrRoutesManifest({
@@ -236,8 +244,12 @@ export function defineConfig(
               ...viteConfig.userConfig,
               ...serverViteConfig.userConfig,
               define: {
-                ...viteConfig.userConfig.define,
-                ...serverViteConfig.userConfig.define,
+                ...(viteConfig.userConfig.define || {}),
+                ...(serverViteConfig.userConfig.define || {}),
+                ...injectDefineEnv('TSS_PUBLIC_BASE', publicBase),
+                ...injectDefineEnv('TSS_CLIENT_BASE', clientBase),
+                ...injectDefineEnv('TSS_SERVER_BASE', serverBase),
+                ...injectDefineEnv('TSS_API_BASE', apiBase),
               },
             }),
             serverFunctions.server({
@@ -298,6 +310,10 @@ export function defineConfig(
             define: {
               ...(viteConfig.userConfig.define || {}),
               ...(apiViteConfig.userConfig.define || {}),
+              ...injectDefineEnv('TSS_PUBLIC_BASE', publicBase),
+              ...injectDefineEnv('TSS_CLIENT_BASE', clientBase),
+              ...injectDefineEnv('TSS_SERVER_BASE', serverBase),
+              ...injectDefineEnv('TSS_API_BASE', apiBase),
             },
           }),
           TanStackRouterVite({
@@ -568,4 +584,14 @@ function tsrRoutesManifest(opts: {
       return
     },
   }
+}
+
+function injectDefineEnv<TKey extends string, TValue extends string>(
+  key: TKey,
+  value: TValue,
+): { [P in `process.env.${TKey}` | `import.meta.env.${TKey}`]: TValue } {
+  return {
+    [`process.env.${key}`]: JSON.stringify(value),
+    [`import.meta.env.${key}`]: JSON.stringify(value),
+  } as { [P in `process.env.${TKey}` | `import.meta.env.${TKey}`]: TValue }
 }


### PR DESCRIPTION
From https://discord.com/channels/719702312431386674/1238170697650405547/1310860918048948224

The actual server function fetch calls weren't actually respecting the configured `routers.server.base` value, instead using the hardcoded value of `/_server`.