### PR TITLE
chore: fix npm downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </a><a href="https://discord.com/invite/WrRKjPJ" target="\_parent">
   <img alt="" src="https://img.shields.io/badge/Discord-TanStack-%235865F2" />
 </a><a href="https://npmjs.com/package/@tanstack/react-router" target="\_parent">
-  <img alt="" src="https://img.shields.io/npm/dm/@tanstack/router.svg" />
+  <img alt="" src="https://img.shields.io/npm/dm/@tanstack/react-router.svg" />
 </a><a href="https://bundlephobia.com/result?p=@tanstack/react-router" target="\_parent">
   <img alt="" src="https://badgen.net/bundlephobia/minzip/@tanstack/react-router" />
 </a><a href="#badge">


### PR DESCRIPTION
It's currently showing 7k downloads per month, while it's actually 1M per month!