### PR TITLE
docs: Add instructions for using Deno for install and quickstart

### DIFF
--- a/docs/framework/react/installation.md
+++ b/docs/framework/react/installation.md
@@ -12,6 +12,8 @@ pnpm add @tanstack/react-router
 yarn add @tanstack/react-router
 # or
 bun add @tanstack/react-router
+# or
+deno add npm:@tanstack/react-router
 ```
 
 TanStack Router is currently only compatible with React and ReactDOM. If you would like to contribute to the React Native adapter, please reach out to us on [Discord](https://tlinz.com/discord).

--- a/docs/framework/react/quick-start.md
+++ b/docs/framework/react/quick-start.md
@@ -18,6 +18,8 @@ pnpm create @tanstack/router
 yarn create @tanstack/router
 # or
 bun create @tanstack/router
+# or
+deno init npm:@tanstack/router
 ```
 
 Follow the prompts to setup the project.
@@ -34,6 +36,8 @@ pnpm add -D @tanstack/router-plugin @tanstack/router-devtools
 yarn add -D @tanstack/router-plugin @tanstack/router-devtools
 # or
 bun add -D @tanstack/router-plugin @tanstack/router-devtools
+# or
+deno add npm:@tanstack/router-plugin npm:@tanstack/router-devtools
 ```
 
 #### Configure the Vite Plugin

--- a/docs/framework/react/quick-start.md
+++ b/docs/framework/react/quick-start.md
@@ -19,7 +19,7 @@ yarn create @tanstack/router
 # or
 bun create @tanstack/router
 # or
-deno init npm:@tanstack/router
+deno init --npm @tanstack/router
 ```
 
 Follow the prompts to setup the project.


### PR DESCRIPTION
This PR adds information how to use Deno for package management with TanStack Router.
(All of the following have been tested and confirmed using Deno v2.1.2)

## Installation page
- Adds `deno add` command to the options for package managers (now that Deno can manage NPM packages)


## Quickstart page
- Adds `deno init` command to the options for scaffolding a new project
- Adds `deno add` commands to the options for manually creating a new project

