### PR TITLE
refactor(start): export the `MiddlewareAfterServer` type

### DIFF
--- a/packages/start/src/client/index.tsx
+++ b/packages/start/src/client/index.tsx
@@ -28,6 +28,7 @@ export {
   type MiddlewareServer,
   type MiddlewareAfterClient,
   type MiddlewareAfterMiddleware,
+  type MiddlewareAfterServer,
   type Middleware,
 } from './createMiddleware'
 export { serverOnly } from './serverOnly'


### PR DESCRIPTION
In a monorepo setup where middlewares and serverFn are declared in different packages. Some types have issues with inference.

Example:

```
export const authenticated = createMiddleware().server(async ({ next }) => {
  const session = await getSession();

  if (!session) {
    throw redirect({
      to: "/sign-in/$",
    });
  }

  return await next({
    context: {
      session,
    },
  });
});
```

Reports:

```
The inferred type of 'authenticated' cannot be named without a reference to '../../../../node_modules/@tanstack/start/dist/esm/client/createMiddleware'. This is likely not portable. A type annotation is necessary.ts(2742)
```

Workaround:

```
// TODO: temporary fixes inferred types
export { type MiddlewareAfterServer } from "../../../../node_modules/@tanstack/start/dist/esm/client/createMiddleware";

export const authenticated = createMiddleware().server(async ({ next }) => {
...
```

exporting `MiddlewareAfterServer` resolves this. This may have been a missed export.