### PR TITLE
fix(start): allow types to override for input and context

### DIFF
--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -344,7 +344,13 @@ export type { NotFoundError } from './not-found'
 export type { Manifest, RouterManagedTag } from './manifest'
 
 export { createControlledPromise } from './utils'
-export type { ControlledPromise, Constrain, Expand, MergeAll } from './utils'
+export type {
+  ControlledPromise,
+  Constrain,
+  Expand,
+  MergeAll,
+  Assign,
+} from './utils'
 
 export type {
   ResolveValidatorInput,

--- a/packages/react-router/src/validators.ts
+++ b/packages/react-router/src/validators.ts
@@ -112,10 +112,12 @@ export type ResolveValidatorOutputFn<TValidator> = TValidator extends (
 
 export type ResolveValidatorOutput<TValidator> = unknown extends TValidator
   ? TValidator
-  : TValidator extends AnyStandardSchemaValidator
-    ? NonNullable<TValidator['~standard']['types']>['output']
-    : TValidator extends AnyValidatorAdapter
-      ? TValidator['types']['output']
-      : TValidator extends AnyValidatorObj
-        ? ResolveValidatorOutputFn<TValidator['parse']>
-        : ResolveValidatorOutputFn<TValidator>
+  : undefined extends TValidator
+    ? TValidator
+    : TValidator extends AnyStandardSchemaValidator
+      ? NonNullable<TValidator['~standard']['types']>['output']
+      : TValidator extends AnyValidatorAdapter
+        ? TValidator['types']['output']
+        : TValidator extends AnyValidatorObj
+          ? ResolveValidatorOutputFn<TValidator['parse']>
+          : ResolveValidatorOutputFn<TValidator>

--- a/packages/react-router/src/validators.ts
+++ b/packages/react-router/src/validators.ts
@@ -112,12 +112,10 @@ export type ResolveValidatorOutputFn<TValidator> = TValidator extends (
 
 export type ResolveValidatorOutput<TValidator> = unknown extends TValidator
   ? TValidator
-  : undefined extends TValidator
-    ? TValidator
-    : TValidator extends AnyStandardSchemaValidator
-      ? NonNullable<TValidator['~standard']['types']>['output']
-      : TValidator extends AnyValidatorAdapter
-        ? TValidator['types']['output']
-        : TValidator extends AnyValidatorObj
-          ? ResolveValidatorOutputFn<TValidator['parse']>
-          : ResolveValidatorOutputFn<TValidator>
+  : TValidator extends AnyStandardSchemaValidator
+    ? NonNullable<TValidator['~standard']['types']>['output']
+    : TValidator extends AnyValidatorAdapter
+      ? TValidator['types']['output']
+      : TValidator extends AnyValidatorObj
+        ? ResolveValidatorOutputFn<TValidator['parse']>
+        : ResolveValidatorOutputFn<TValidator>

--- a/packages/start/src/client/createMiddleware.ts
+++ b/packages/start/src/client/createMiddleware.ts
@@ -1,125 +1,75 @@
 import type { ConstrainValidator, Method } from './createServerFn'
 import type {
+  Assign,
   Constrain,
   DefaultTransformerStringify,
   Expand,
-  MergeAll,
   ResolveValidatorInput,
   ResolveValidatorOutput,
 } from '@tanstack/react-router'
 
-/**
- * Turns all middleware into a union
- */
-export type ParseMiddlewares<
+export type MergeAllMiddleware<
   TMiddlewares,
-  TAcc = never,
-> = unknown extends TMiddlewares
-  ? TAcc
-  : [] extends TMiddlewares
-    ? TAcc
-    : TMiddlewares extends ReadonlyArray<AnyMiddleware>
-      ? TMiddlewares[number] extends infer TMiddleware extends AnyMiddleware
-        ? TMiddleware extends any
-          ? ParseMiddlewares<
-              TMiddleware['_types']['middlewares'],
-              TAcc | TMiddleware
-            >
-          : TAcc
-        : TAcc
-      : TAcc
-
-export type ResolveAllMiddlewareServerContext<
-  TMiddlewares,
-  TContext = undefined,
-> = ParseMiddlewares<TMiddlewares>['_types']['serverContext'] | TContext
-
-/**
- * Recursively resolve the server context type produced by a sequence of middleware
- */
-export type MergeAllServerContext<TMiddlewares, TContext = undefined> = Expand<
-  MergeAll<
-    ResolveAllMiddlewareServerContext<TMiddlewares, TContext> extends undefined
-      ? undefined
-      : NonNullable<ResolveAllMiddlewareServerContext<TMiddlewares, TContext>>
-  >
->
-
-export type ResolveAllMiddlewareClientContext<
-  TMiddlewares,
-  TContext = undefined,
-> = ParseMiddlewares<TMiddlewares>['_types']['clientContext'] | TContext
-
-/**
- * Recursively resolve the client context type produced by a sequence of middleware
- */
-export type MergeAllClientContext<TMiddlewares, TContext = undefined> = Expand<
-  MergeAll<
-    ResolveAllMiddlewareClientContext<TMiddlewares, TContext> extends undefined
-      ? undefined
-      : NonNullable<ResolveAllMiddlewareClientContext<TMiddlewares, TContext>>
-  >
->
-
-export type ResolveAllMiddlewareClientAfterContext<
-  TMiddlewares,
-  TContext = undefined,
-> =
-  | ParseMiddlewares<TMiddlewares>['_types']['clientContext']
-  | ParseMiddlewares<TMiddlewares>['_types']['clientAfterContext']
-  | TContext
+  TType extends keyof AnyMiddleware['_types'],
+  TAcc = undefined,
+> = TMiddlewares extends readonly [
+  infer TMiddleware extends AnyMiddleware,
+  ...infer TRest,
+]
+  ? MergeAllMiddleware<TRest, TType, Assign<TAcc, TMiddleware['_types'][TType]>>
+  : TAcc
 
 export type MergeAllClientAfterContext<
   TMiddlewares,
   TClientContext = undefined,
   TClientAfterContext = undefined,
-> = Expand<
-  MergeAll<
-    ResolveAllMiddlewareClientAfterContext<
-      TMiddlewares,
-      TClientContext | TClientAfterContext
-    > extends undefined
-      ? undefined
-      : NonNullable<
-          ResolveAllMiddlewareClientAfterContext<
-            TMiddlewares,
-            TClientContext | TClientAfterContext
-          >
-        >
-  >
->
+> = unknown extends TClientContext
+  ? TClientContext
+  : Assign<
+      MergeAllMiddleware<TMiddlewares, 'allClientAfterContext'>,
+      Assign<TClientContext, TClientAfterContext>
+    >
 
-export type ResolveAllValidators<TMiddlewares, TValidator> =
-  | ParseMiddlewares<TMiddlewares>['_types']['validator']
-  | TValidator
+/**
+ * Recursively resolve the client context type produced by a sequence of middleware
+ */
+export type MergeAllClientContext<
+  TMiddlewares,
+  TContext = undefined,
+> = unknown extends TContext
+  ? TContext
+  : Assign<MergeAllMiddleware<TMiddlewares, 'allClientContext'>, TContext>
 
-export type ResolveAllValidatorInputs<TMiddlewares, TValidator> =
-  ResolveAllValidators<TMiddlewares, TValidator> extends undefined
-    ? undefined
-    : ResolveValidatorInput<
-        NonNullable<ResolveAllValidators<TMiddlewares, TValidator>>
-      >
+/**
+ * Recursively resolve the server context type produced by a sequence of middleware
+ */
+export type MergeAllServerContext<
+  TMiddlewares,
+  TContext = undefined,
+> = unknown extends TContext
+  ? TContext
+  : Assign<MergeAllMiddleware<TMiddlewares, 'allServerContext'>, TContext>
 
 /**
  * Recursively resolve the input type produced by a sequence of middleware
  */
-export type MergeAllValidatorInputs<TMiddlewares, TValidator> = Expand<
-  MergeAll<ResolveAllValidatorInputs<TMiddlewares, TValidator>>
->
-
-export type ResolveAllValidatorOutputs<TMiddlewares, TValidator> =
-  ResolveAllValidators<TMiddlewares, TValidator> extends undefined
-    ? undefined
-    : ResolveValidatorOutput<
-        NonNullable<ResolveAllValidators<TMiddlewares, TValidator>>
+export type MergeAllValidatorInputs<TMiddlewares, TValidator> =
+  unknown extends TValidator
+    ? TValidator
+    : Assign<
+        MergeAllMiddleware<TMiddlewares, 'allInput'>,
+        ResolveValidatorInput<TValidator>
       >
-
 /**
  * Recursively merge the output type produced by a sequence of middleware
  */
-export type MergeAllValidatorOutputs<TMiddlewares, TValidator> = Expand<
-  MergeAll<ResolveAllValidatorOutputs<TMiddlewares, TValidator>>
->
+export type MergeAllValidatorOutputs<TMiddlewares, TValidator> =
+  unknown extends TValidator
+    ? TValidator
+    : Assign<
+        MergeAllMiddleware<TMiddlewares, 'allOutput'>,
+        ResolveValidatorOutput<TValidator>
+      >
 
 export interface MiddlewareOptions<
   in out TMiddlewares,
@@ -167,8 +117,8 @@ export interface MiddlewareServerFnOptions<
   in out TValidator,
   in out TServerContext,
 > {
-  data: MergeAllValidatorOutputs<TMiddlewares, NonNullable<TValidator>>
-  context: MergeAllServerContext<TMiddlewares, NonNullable<TServerContext>>
+  data: Expand<MergeAllValidatorOutputs<TMiddlewares, TValidator>>
+  context: Expand<MergeAllServerContext<TMiddlewares, TServerContext>>
   next: MiddlewareServerNextFn
 }
 
@@ -197,8 +147,8 @@ export interface MiddlewareClientFnOptions<
   in out TMiddlewares,
   in out TValidator,
 > {
-  data: MergeAllValidatorInputs<TMiddlewares, NonNullable<TValidator>>
-  context: MergeAllClientContext<TMiddlewares>
+  data: Expand<MergeAllValidatorInputs<TMiddlewares, TValidator>>
+  context: Expand<MergeAllClientContext<TMiddlewares>>
   sendContext?: unknown // cc Chris Horobin
   method: Method
   next: MiddlewareClientNextFn
@@ -229,11 +179,13 @@ export interface MiddlewareClientAfterFnOptions<
   in out TClientContext,
   in out TClientAfterContext,
 > {
-  data: MergeAllValidatorInputs<TMiddlewares, NonNullable<TValidator>>
-  context: MergeAllClientAfterContext<
-    TMiddlewares,
-    TClientContext,
-    TClientAfterContext
+  data: Expand<MergeAllValidatorInputs<TMiddlewares, TValidator>>
+  context: Expand<
+    MergeAllClientAfterContext<
+      TMiddlewares,
+      TClientContext,
+      TClientAfterContext
+    >
   >
   method: Method
   next: MiddlewareClientAfterNextFn
@@ -289,10 +241,19 @@ export interface MiddlewareTypes<
     id: TId
     middlewares: TMiddlewares
     input: ResolveValidatorInput<TValidator>
+    allInput: MergeAllValidatorInputs<TMiddlewares, TValidator>
     output: ResolveValidatorOutput<TValidator>
+    allOutput: MergeAllValidatorOutputs<TMiddlewares, TValidator>
     clientContext: TClientContext
+    allClientContext: MergeAllClientContext<TMiddlewares, TClientContext>
     serverContext: TServerContext
+    allServerContext: MergeAllServerContext<TMiddlewares, TServerContext>
     clientAfterContext: TClientAfterContext
+    allClientAfterContext: MergeAllClientAfterContext<
+      TMiddlewares,
+      TClientContext,
+      TClientAfterContext
+    >
     validator: TValidator
   }
   options: MiddlewareOptions<
@@ -345,7 +306,7 @@ export interface MiddlewareClientAfter<
     TValidator,
     TServerContext,
     TClientContext,
-    TClientAfterContext | TNewClientAfterContext
+    Assign<TClientAfterContext, TNewClientAfterContext>
   >
 }
 
@@ -393,9 +354,9 @@ export interface MiddlewareServer<
     TId,
     TMiddlewares,
     TValidator,
-    TServerContext | TNewServerContext,
+    Assign<TServerContext, TNewServerContext>,
     TClientContext,
-    TClientAfterContext | TNewClientAfterContext
+    Assign<TClientAfterContext, TNewClientAfterContext>
   >
 }
 
@@ -442,8 +403,8 @@ export interface MiddlewareClient<
     TId,
     TMiddlewares,
     TValidator,
-    TServerContext | TNewServerContext,
-    TClientContext | TNewClientContext,
+    Assign<TServerContext, TNewServerContext>,
+    Assign<TClientContext, TNewClientContext>,
     TClientAfterContext
   >
 }
@@ -503,7 +464,7 @@ export interface Middleware<
     TClientContext,
     TClientAfterContext
   > {
-  middleware: <const TNewMiddlewares>(
+  middleware: <const TNewMiddlewares = undefined>(
     middlewares: Constrain<TNewMiddlewares, ReadonlyArray<AnyMiddleware>>,
   ) => MiddlewareAfterMiddleware<
     TId,

--- a/packages/start/src/client/createMiddleware.ts
+++ b/packages/start/src/client/createMiddleware.ts
@@ -58,7 +58,9 @@ export type MergeAllValidatorInputs<TMiddlewares, TValidator> =
     ? TValidator
     : Assign<
         MergeAllMiddleware<TMiddlewares, 'allInput'>,
-        ResolveValidatorInput<TValidator>
+        TValidator extends undefined
+          ? undefined
+          : ResolveValidatorInput<TValidator>
       >
 /**
  * Recursively merge the output type produced by a sequence of middleware
@@ -68,7 +70,9 @@ export type MergeAllValidatorOutputs<TMiddlewares, TValidator> =
     ? TValidator
     : Assign<
         MergeAllMiddleware<TMiddlewares, 'allOutput'>,
-        ResolveValidatorOutput<TValidator>
+        TValidator extends undefined
+          ? undefined
+          : ResolveValidatorOutput<TValidator>
       >
 
 export interface MiddlewareOptions<

--- a/packages/start/src/client/createServerFn.ts
+++ b/packages/start/src/client/createServerFn.ts
@@ -6,6 +6,7 @@ import type {
   Constrain,
   DefaultTransformerParse,
   DefaultTransformerStringify,
+  Expand,
   ResolveValidatorInput,
   TransformerStringify,
   Validator,
@@ -40,12 +41,12 @@ export type FetcherImpl<TMiddlewares, TValidator, TResponse> =
   undefined extends MergeAllValidatorInputs<TMiddlewares, TValidator>
     ? (
         opts?: OptionalFetcherDataOptions<
-          MergeAllValidatorInputs<TMiddlewares, TValidator>
+          Expand<MergeAllValidatorInputs<TMiddlewares, TValidator>>
         >,
       ) => Promise<FetcherData<TResponse>>
     : (
         opts: RequiredFetcherDataOptions<
-          MergeAllValidatorInputs<TMiddlewares, TValidator>
+          Expand<MergeAllValidatorInputs<TMiddlewares, TValidator>>
         >,
       ) => Promise<FetcherData<TResponse>>
 
@@ -79,8 +80,8 @@ export type ServerFn<TMethod, TMiddlewares, TValidator, TResponse> = (
 
 export interface ServerFnCtx<TMethod, TMiddlewares, TValidator> {
   method: TMethod
-  data: MergeAllValidatorOutputs<TMiddlewares, TValidator>
-  context: MergeAllServerContext<TMiddlewares>
+  data: Expand<MergeAllValidatorOutputs<TMiddlewares, TValidator>>
+  context: Expand<MergeAllServerContext<TMiddlewares>>
 }
 
 export type CompiledFetcherFn<TResponse> = {
@@ -118,7 +119,7 @@ export type ConstrainValidator<TValidator> = unknown extends TValidator
     >
 
 export interface ServerFnMiddleware<TMethod extends Method, TValidator> {
-  middleware: <const TNewMiddlewares>(
+  middleware: <const TNewMiddlewares = undefined>(
     middlewares: Constrain<TNewMiddlewares, ReadonlyArray<AnyMiddleware>>,
   ) => ServerFnAfterMiddleware<TMethod, TNewMiddlewares, TValidator>
 }

--- a/packages/start/src/client/index.tsx
+++ b/packages/start/src/client/index.tsx
@@ -17,7 +17,6 @@ export {
 } from './createServerFn'
 export {
   createMiddleware,
-  type ParseMiddlewares,
   type MergeAllValidatorInputs,
   type MergeAllValidatorOutputs,
   type MiddlewareServerFn,


### PR DESCRIPTION
Fixes #2780 

I had an idea how to fix this while making the types a bit more effecient

Before
```
> tsc --extendedDiagnostics

Files:                        1176
Lines of Library:            40097
Lines of Definitions:       198223
Lines of TypeScript:         32262
Lines of JavaScript:             0
Lines of JSON:                   0
Lines of Other:                  0
Identifiers:                314782
Symbols:                    502815
Types:                      148050
Instantiations:            2145468
Memory used:               576553K
Assignability cache size:    60760
Identity cache size:         15475
Subtype cache size:          44949
Strict subtype cache size:       9
I/O Read time:               0.19s
Parse time:                  0.94s
ResolveModule time:          0.58s
ResolveTypeReference time:   0.01s
ResolveLibrary time:         0.02s
Program time:                1.99s
Bind time:                   0.45s
Check time:                  7.12s
printTime time:              0.00s
Emit time:                   0.00s
Total time:                  9.56s
```

After
```
> tsc --extendedDiagnostics

Files:                        1176
Lines of Library:            40097
Lines of Definitions:       198222
Lines of TypeScript:         32262
Lines of JavaScript:             0
Lines of JSON:                   0
Lines of Other:                  0
Identifiers:                314756
Symbols:                    502530
Types:                      147088
Instantiations:            2052735
Memory used:               569929K
Assignability cache size:    60054
Identity cache size:         15475
Subtype cache size:          44949
Strict subtype cache size:       9
I/O Read time:               0.16s
Parse time:                  0.93s
ResolveModule time:          0.54s
ResolveTypeReference time:   0.01s
ResolveLibrary time:         0.02s
Program time:                1.88s
Bind time:                   0.39s
Check time:                  6.80s
printTime time:              0.00s
Emit time:                   0.00s
Total time:                  9.07s
```

