### PR TITLE
fix: safely access window.CSS.supports

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -878,7 +878,7 @@ export class Router<
     if (
       typeof window !== 'undefined' &&
       'CSS' in window &&
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       typeof window.CSS?.supports === 'function'
     ) {
       this.isViewTransitionTypesSupported = window.CSS.supports(

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -878,7 +878,8 @@ export class Router<
     if (
       typeof window !== 'undefined' &&
       'CSS' in window &&
-      typeof window.CSS.supports === 'function'
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      typeof window.CSS?.supports === 'function'
     ) {
       this.isViewTransitionTypesSupported = window.CSS.supports(
         'selector(:active-view-transition-type(a)',


### PR DESCRIPTION
I'm getting error while running tests with jsdom 25.0.1 and vitest, but without importing:

```js
// setupTests.tsx

// if this line is missing, I'm getting error below
// import '@testing-library/jest-dom/vitest'
```

```
TypeError: Cannot read properties of undefined (reading 'supports')
    at Router.update (file:///C:/Users/lislo/src/other/env-hopper/node_modules/@tanstack/react-router/src/router.ts:881:25)
    at new Router (file:///C:/Users/lislo/src/other/env-hopper/node_modules/@tanstack/react-router/src/router.ts:773:10)
    at Module.createRouter (file:///C:/Users/lislo/src/other/env-hopper/node_modules/@tanstack/react-router/src/router.ts:679:10)
    at Module.createEhRouter (C:\Users\lislo\src\other\env-hopper\apps\frontend\src\createEhRouter.ts:15:10)
    at given (C:\Users\lislo\src\other\env-hopper\apps\frontend\src\app\integration-tests\integration-tests.spec.tsx:135:18)
    at C:\Users\lislo\src\other\env-hopper\apps\frontend\src\app\integration-tests\integration-tests.spec.tsx:228:28
    at file:///C:/Users/lislo/src/other/env-hopper/node_modules/@vitest/runner/dist/index.js:146:14
    at file:///C:/Users/lislo/src/other/env-hopper/node_modules/@vitest/runner/dist/index.js:533:11
    at runWithTimeout (file:///C:/Users/lislo/src/other/env-hopper/node_modules/@vitest/runner/dist/index.js:39:7)
```