### PR TITLE
refactor(react-router,start): use react prefixed `JSX` types

### DIFF
--- a/packages/react-router/src/transformer.ts
+++ b/packages/react-router/src/transformer.ts
@@ -56,7 +56,7 @@ export type TransformerStringify<T, TSerializable> = T extends TSerializable
 
 export type TransformerParse<T, TSerializable> = T extends TSerializable
   ? T
-  : T extends JSX.Element
+  : T extends React.JSX.Element
     ? ReadableStream
     : { [K in keyof T]: TransformerParse<T[K], TSerializable> }
 

--- a/packages/start/src/client/serialization.tsx
+++ b/packages/start/src/client/serialization.tsx
@@ -341,7 +341,7 @@ function StreamChunks({
   __index = 0,
 }: {
   streamState: StreamState
-  children: (chunk: string | null) => JSX.Element
+  children: (chunk: string | null) => React.JSX.Element
   __index?: number
 }) {
   const promise = streamState.promises[__index]


### PR DESCRIPTION
Same as #1598 and #2618 