### PR TITLE
fix(start): Fix issue when sometimes resolvePromise tsr-once script gets deleted before running

### DIFF
--- a/packages/react-router/src/ScriptOnce.tsx
+++ b/packages/react-router/src/ScriptOnce.tsx
@@ -21,6 +21,7 @@ export function ScriptOnce({
             ? `console.info(\`Injected From Server:
 ${jsesc(children.toString(), { quotes: 'backtick' })}\`)`
             : '',
+            "__TSR__.cleanScripts()"
         ]
           .filter(Boolean)
           .join('\n'),

--- a/packages/start/src/client/StartClient.tsx
+++ b/packages/start/src/client/StartClient.tsx
@@ -2,17 +2,10 @@ import { RouterProvider } from '@tanstack/react-router'
 import { afterHydrate } from './serialization'
 import type { AnyRouter } from '@tanstack/react-router'
 
-let cleaned = false
-
 export function StartClient(props: { router: AnyRouter }) {
   if (!props.router.state.matches.length) {
     props.router.hydrate()
     afterHydrate({ router: props.router })
-  }
-
-  if (!cleaned) {
-    cleaned = true
-    window.__TSR__?.cleanScripts()
   }
 
   return <RouterProvider router={props.router} />


### PR DESCRIPTION
In certain scenarios, the `StartClient` function invokes `cleanScripts`, which removes all `<script class="tsr-once">` elements from the DOM. This can inadvertently delete the `<script>` element responsible for resolving a deferred promise in a loader before it has a chance to execute.

This PR addresses the issue by removing the `cleanScripts` call from `StartClient`. Instead, it introduces a call to `__TSR__.cleanScripts()` directly within `ScriptOnce`, ensuring hydration errors are avoided while preserving the original intent of the `cleanScripts` functionality.