### PR TITLE
fix: remove hard locks on related packages

### DIFF
--- a/packages/react-router-with-query/package.json
+++ b/packages/react-router-with-query/package.json
@@ -67,7 +67,7 @@
     "@vitejs/plugin-react": "^4.3.4",
     "react": ">=18",
     "react-dom": ">=18",
-    "@tanstack/react-router": "workspace:*",
+    "@tanstack/react-router": "workspace:^",
     "@tanstack/react-query": ">=5.62.0"
   },
   "peerDependencies": {

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -83,7 +83,7 @@
     "zod": "^3.23.8"
   },
   "peerDependencies": {
-    "@tanstack/router-generator": "workspace:*",
+    "@tanstack/router-generator": "workspace:^",
     "react": ">=18",
     "react-dom": ">=18"
   },

--- a/packages/router-cli/package.json
+++ b/packages/router-cli/package.json
@@ -65,7 +65,7 @@
     "node": ">=12"
   },
   "dependencies": {
-    "@tanstack/router-generator": "workspace:*",
+    "@tanstack/router-generator": "workspace:^",
     "chokidar": "^3.6.0",
     "yargs": "^17.7.2"
   },

--- a/packages/valibot-adapter/package.json
+++ b/packages/valibot-adapter/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",
-    "@tanstack/react-router": "workspace:*",
+    "@tanstack/react-router": "workspace:^",
     "valibot": "1.0.0-beta.9",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/packages/zod-adapter/package.json
+++ b/packages/zod-adapter/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",
-    "@tanstack/react-router": "workspace:*",
+    "@tanstack/react-router": "workspace:^",
     "zod": "^3.23.8",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"


### PR DESCRIPTION
Removes the hard locks on our packages towards other packages in the repo, thereby allowing the package versions to be free floating and letting package managers maintain a single source.

```diff
{
	"dependencies": {
-		"@tanstack/react-router": "workspace:*"
+ 		"@tanstack/react-router": "workspace:^",
	}
}
```

Related to https://github.com/TanStack/router/issues/2540#issuecomment-2521870993