### PR TITLE
fix(start): fix serverOnly implementation/types, and add clientOnly counterpart

### DIFF
--- a/e2e/start/basic/app/routeTree.gen.ts
+++ b/e2e/start/basic/app/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as SearchParamsImport } from './routes/search-params'
 import { Route as RedirectImport } from './routes/redirect'
 import { Route as PostsImport } from './routes/posts'
 import { Route as IsomorphicFnsImport } from './routes/isomorphic-fns'
+import { Route as EnvOnlyImport } from './routes/env-only'
 import { Route as DeferredImport } from './routes/deferred'
 import { Route as LayoutImport } from './routes/_layout'
 import { Route as IndexImport } from './routes/index'
@@ -71,6 +72,12 @@ const PostsRoute = PostsImport.update({
 const IsomorphicFnsRoute = IsomorphicFnsImport.update({
   id: '/isomorphic-fns',
   path: '/isomorphic-fns',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const EnvOnlyRoute = EnvOnlyImport.update({
+  id: '/env-only',
+  path: '/env-only',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -161,6 +168,13 @@ declare module '@tanstack/react-router' {
       path: '/deferred'
       fullPath: '/deferred'
       preLoaderRoute: typeof DeferredImport
+      parentRoute: typeof rootRoute
+    }
+    '/env-only': {
+      id: '/env-only'
+      path: '/env-only'
+      fullPath: '/env-only'
+      preLoaderRoute: typeof EnvOnlyImport
       parentRoute: typeof rootRoute
     }
     '/isomorphic-fns': {
@@ -326,6 +340,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '': typeof LayoutLayout2RouteWithChildren
   '/deferred': typeof DeferredRoute
+  '/env-only': typeof EnvOnlyRoute
   '/isomorphic-fns': typeof IsomorphicFnsRoute
   '/posts': typeof PostsRouteWithChildren
   '/redirect': typeof RedirectRoute
@@ -346,6 +361,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '': typeof LayoutLayout2RouteWithChildren
   '/deferred': typeof DeferredRoute
+  '/env-only': typeof EnvOnlyRoute
   '/isomorphic-fns': typeof IsomorphicFnsRoute
   '/redirect': typeof RedirectRoute
   '/search-params': typeof SearchParamsRoute
@@ -365,6 +381,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/_layout': typeof LayoutRouteWithChildren
   '/deferred': typeof DeferredRoute
+  '/env-only': typeof EnvOnlyRoute
   '/isomorphic-fns': typeof IsomorphicFnsRoute
   '/posts': typeof PostsRouteWithChildren
   '/redirect': typeof RedirectRoute
@@ -388,6 +405,7 @@ export interface FileRouteTypes {
     | '/'
     | ''
     | '/deferred'
+    | '/env-only'
     | '/isomorphic-fns'
     | '/posts'
     | '/redirect'
@@ -407,6 +425,7 @@ export interface FileRouteTypes {
     | '/'
     | ''
     | '/deferred'
+    | '/env-only'
     | '/isomorphic-fns'
     | '/redirect'
     | '/search-params'
@@ -424,6 +443,7 @@ export interface FileRouteTypes {
     | '/'
     | '/_layout'
     | '/deferred'
+    | '/env-only'
     | '/isomorphic-fns'
     | '/posts'
     | '/redirect'
@@ -446,6 +466,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   LayoutRoute: typeof LayoutRouteWithChildren
   DeferredRoute: typeof DeferredRoute
+  EnvOnlyRoute: typeof EnvOnlyRoute
   IsomorphicFnsRoute: typeof IsomorphicFnsRoute
   PostsRoute: typeof PostsRouteWithChildren
   RedirectRoute: typeof RedirectRoute
@@ -460,6 +481,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   LayoutRoute: LayoutRouteWithChildren,
   DeferredRoute: DeferredRoute,
+  EnvOnlyRoute: EnvOnlyRoute,
   IsomorphicFnsRoute: IsomorphicFnsRoute,
   PostsRoute: PostsRouteWithChildren,
   RedirectRoute: RedirectRoute,
@@ -483,6 +505,7 @@ export const routeTree = rootRoute
         "/",
         "/_layout",
         "/deferred",
+        "/env-only",
         "/isomorphic-fns",
         "/posts",
         "/redirect",
@@ -504,6 +527,9 @@ export const routeTree = rootRoute
     },
     "/deferred": {
       "filePath": "deferred.tsx"
+    },
+    "/env-only": {
+      "filePath": "env-only.tsx"
     },
     "/isomorphic-fns": {
       "filePath": "isomorphic-fns.tsx"

--- a/e2e/start/basic/app/routes/env-only.tsx
+++ b/e2e/start/basic/app/routes/env-only.tsx
@@ -1,0 +1,76 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { clientOnly, createServerFn, serverOnly } from '@tanstack/start'
+import { useState } from 'react'
+
+const serverEcho = serverOnly((input: string) => 'server got: ' + input)
+const clientEcho = clientOnly((input: string) => 'client got: ' + input)
+
+const testOnServer = createServerFn().handler(() => {
+  const serverOnServer = serverEcho('hello')
+  let clientOnServer: string
+  try {
+    clientOnServer = clientEcho('hello')
+  } catch (e) {
+    clientOnServer =
+      'clientEcho threw an error: ' +
+      (e instanceof Error ? e.message : String(e))
+  }
+  return { serverOnServer, clientOnServer }
+})
+
+export const Route = createFileRoute('/env-only')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const [results, setResults] = useState<Partial<Record<string, string>>>()
+
+  async function handleClick() {
+    const { serverOnServer, clientOnServer } = await testOnServer()
+    const clientOnClient = clientEcho('hello')
+    let serverOnClient: string
+    try {
+      serverOnClient = serverEcho('hello')
+    } catch (e) {
+      serverOnClient =
+        'serverEcho threw an error: ' +
+        (e instanceof Error ? e.message : String(e))
+    }
+    setResults({
+      serverOnServer,
+      clientOnServer,
+      clientOnClient,
+      serverOnClient,
+    })
+  }
+
+  const { serverOnServer, clientOnServer, clientOnClient, serverOnClient } =
+    results || {}
+
+  return (
+    <div>
+      <button onClick={handleClick} data-testid="test-env-only-results-btn">
+        Run
+      </button>
+      {!!results && (
+        <div>
+          <h1>
+            <code>serverEcho</code>
+          </h1>
+          When we called the function on the server:
+          <pre data-testid="server-on-server">{serverOnServer}</pre>
+          When we called the function on the client:
+          <pre data-testid="server-on-client">{serverOnClient}</pre>
+          <br />
+          <h1>
+            <code>clientEcho</code>
+          </h1>
+          When we called the function on the server:
+          <pre data-testid="client-on-server">{clientOnServer}</pre>
+          When we called the function on the client:
+          <pre data-testid="client-on-client">{clientOnClient}</pre>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/e2e/start/basic/tests/base.spec.ts
+++ b/e2e/start/basic/tests/base.spec.ts
@@ -167,3 +167,28 @@ test('isomorphic functions can have different implementations on client and serv
     'client received hello',
   )
 })
+
+test('env-only functions can only be called on the server or client respectively', async ({
+  page,
+}) => {
+  await page.goto('/env-only')
+
+  await page.waitForLoadState('networkidle')
+
+  await page.getByTestId('test-env-only-results-btn').click()
+  await page.waitForLoadState('networkidle')
+
+  await expect(page.getByTestId('server-on-server')).toContainText(
+    'server got: hello',
+  )
+  await expect(page.getByTestId('server-on-client')).toContainText(
+    'serverEcho threw an error: serverOnly() functions can only be called on the server!',
+  )
+
+  await expect(page.getByTestId('client-on-server')).toContainText(
+    'clientEcho threw an error: clientOnly() functions can only be called on the client!',
+  )
+  await expect(page.getByTestId('client-on-client')).toContainText(
+    'client got: hello',
+  )
+})

--- a/packages/start-vite-plugin/src/compilers.ts
+++ b/packages/start-vite-plugin/src/compilers.ts
@@ -59,6 +59,7 @@ export function compileStartOutput(opts: ParseAstOptions) {
           createServerFn: IdentifierConfig
           createMiddleware: IdentifierConfig
           serverOnly: IdentifierConfig
+          clientOnly: IdentifierConfig
           createIsomorphicFn: IdentifierConfig
         } = {
           createServerFn: {
@@ -79,7 +80,14 @@ export function compileStartOutput(opts: ParseAstOptions) {
             name: 'serverOnly',
             type: 'ImportSpecifier',
             namespaceId: '',
-            handleCallExpression: handleServerOnlyCallExpression,
+            handleCallExpression: buildEnvOnlyCallExpressionHandler('server'),
+            paths: [],
+          },
+          clientOnly: {
+            name: 'clientOnly',
+            type: 'ImportSpecifier',
+            namespaceId: '',
+            handleCallExpression: buildEnvOnlyCallExpressionHandler('client'),
             paths: [],
           },
           createIsomorphicFn: {
@@ -548,36 +556,45 @@ function handleCreateMiddlewareCallExpression(
   }
 }
 
-function handleServerOnlyCallExpression(
-  path: babel.NodePath<t.CallExpression>,
-  opts: ParseAstOptions,
-) {
-  if (debug)
-    console.info('Handling serverOnly call expression:', path.toString())
+function buildEnvOnlyCallExpressionHandler(env: 'client' | 'server') {
+  return function envOnlyCallExpressionHandler(
+    path: babel.NodePath<t.CallExpression>,
+    opts: ParseAstOptions,
+  ) {
+    if (debug)
+      console.info(`Handling ${env}Only call expression:`, path.toString())
 
-  if (opts.env === 'server') {
-    // Do nothing on the server.
-    return
+    if (opts.env === env) {
+      // extract the inner function from the call expression
+      const innerInputExpression = path.node.arguments[0]
+
+      if (!t.isExpression(innerInputExpression)) {
+        throw new Error(
+          `${env}Only() functions must be called with a function!`,
+        )
+      }
+
+      path.replaceWith(innerInputExpression)
+      return
+    }
+
+    // If we're on the wrong environment, replace the call expression
+    // with a function that always throws an error.
+    path.replaceWith(
+      t.arrowFunctionExpression(
+        [],
+        t.blockStatement([
+          t.throwStatement(
+            t.newExpression(t.identifier('Error'), [
+              t.stringLiteral(
+                `${env}Only() functions can only be called on the ${env}!`,
+              ),
+            ]),
+          ),
+        ]),
+      ),
+    )
   }
-
-  // If we're on the client, replace the call expression with a function
-  // that has a single always-triggering invariant.
-
-  path.replaceWith(
-    t.arrowFunctionExpression(
-      [],
-      t.blockStatement([
-        t.expressionStatement(
-          t.callExpression(t.identifier('invariant'), [
-            t.booleanLiteral(false),
-            t.stringLiteral(
-              'serverOnly() functions can only be called on the server!',
-            ),
-          ]),
-        ),
-      ]),
-    ),
-  )
 }
 
 function handleCreateIsomorphicFnCallExpression(

--- a/packages/start-vite-plugin/src/compilers.ts
+++ b/packages/start-vite-plugin/src/compilers.ts
@@ -570,6 +570,10 @@ function buildEnvOnlyCallExpressionHandler(env: 'client' | 'server') {
     if (debug)
       console.info(`Handling ${env}Only call expression:`, path.toString())
 
+    if (!path.parentPath.isVariableDeclarator()) {
+      throw new Error(`${env}Only() functions must be assigned to a variable!`)
+    }
+
     if (opts.env === env) {
       // extract the inner function from the call expression
       const innerInputExpression = path.node.arguments[0]

--- a/packages/start-vite-plugin/src/compilers.ts
+++ b/packages/start-vite-plugin/src/compilers.ts
@@ -32,6 +32,12 @@ export function compileEliminateDeadCode(opts: ParseAstOptions) {
 
 const debug = process.env.TSR_VITE_DEBUG === 'true'
 
+// build these once and reuse them
+const handleServerOnlyCallExpression =
+  buildEnvOnlyCallExpressionHandler('server')
+const handleClientOnlyCallExpression =
+  buildEnvOnlyCallExpressionHandler('client')
+
 type IdentifierConfig = {
   name: string
   type: 'ImportSpecifier' | 'ImportNamespaceSpecifier'
@@ -80,14 +86,14 @@ export function compileStartOutput(opts: ParseAstOptions) {
             name: 'serverOnly',
             type: 'ImportSpecifier',
             namespaceId: '',
-            handleCallExpression: buildEnvOnlyCallExpressionHandler('server'),
+            handleCallExpression: handleServerOnlyCallExpression,
             paths: [],
           },
           clientOnly: {
             name: 'clientOnly',
             type: 'ImportSpecifier',
             namespaceId: '',
-            handleCallExpression: buildEnvOnlyCallExpressionHandler('client'),
+            handleCallExpression: handleClientOnlyCallExpression,
             paths: [],
           },
           createIsomorphicFn: {

--- a/packages/start-vite-plugin/src/index.ts
+++ b/packages/start-vite-plugin/src/index.ts
@@ -96,6 +96,7 @@ export function TanStackStartViteDeadCodeElimination(
         code.includes('createServerFn') ||
         code.includes('createMiddleware') ||
         code.includes('serverOnly') ||
+        code.includes('clientOnly') ||
         code.includes('createIsomorphicFn')
       ) {
         const compiled = compileEliminateDeadCode({

--- a/packages/start-vite-plugin/tests/envOnly/envOnly.test.ts
+++ b/packages/start-vite-plugin/tests/envOnly/envOnly.test.ts
@@ -1,0 +1,80 @@
+import { readFile, readdir } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, test } from 'vitest'
+
+import { compileStartOutput } from '../../src/compilers'
+
+async function getFilenames() {
+  return await readdir(path.resolve(import.meta.dirname, './test-files'))
+}
+
+describe('envOnly functions compile correctly', async () => {
+  const filenames = await getFilenames()
+
+  describe.each(filenames)('should handle "%s"', async (filename) => {
+    const file = await readFile(
+      path.resolve(import.meta.dirname, `./test-files/${filename}`),
+    )
+    const code = file.toString()
+
+    test.each(['client', 'server'] as const)(
+      `should compile for ${filename} %s`,
+      async (env) => {
+        const compiledResult = compileStartOutput({
+          env,
+          code,
+          root: './test-files',
+          filename,
+        })
+
+        await expect(compiledResult.code).toMatchFileSnapshot(
+          `./snapshots/${env}/${filename}`,
+        )
+      },
+    )
+  })
+  test('should error if implementation not provided', () => {
+    expect(() => {
+      compileStartOutput({
+        env: 'client',
+        code: `
+        import { clientOnly } from '@tanstack/start'
+        const fn = clientOnly()`,
+        root: './test-files',
+        filename: 'no-fn.ts',
+      })
+    }).toThrowError()
+    expect(() => {
+      compileStartOutput({
+        env: 'server',
+        code: `
+        import { serverOnly } from '@tanstack/start'
+        const fn = serverOnly()`,
+        root: './test-files',
+        filename: 'no-fn.ts',
+      })
+    }).toThrowError()
+  })
+  test('should be assigned to a variable', () => {
+    expect(() => {
+      compileStartOutput({
+        env: 'server',
+        code: `
+        import { serverOnly } from '@tanstack/start'
+        serverOnly()`,
+        root: './test-files',
+        filename: 'no-fn.ts',
+      })
+    }).toThrowError()
+    expect(() => {
+      compileStartOutput({
+        env: 'client',
+        code: `
+        import { clientOnly } from '@tanstack/start'
+        clientOnly()`,
+        root: './test-files',
+        filename: 'no-fn.ts',
+      })
+    }).toThrowError()
+  })
+})

--- a/packages/start-vite-plugin/tests/envOnly/snapshots/client/envOnlyDestructured.tsx
+++ b/packages/start-vite-plugin/tests/envOnly/snapshots/client/envOnlyDestructured.tsx
@@ -1,0 +1,5 @@
+import { serverOnly, clientOnly } from '@tanstack/start';
+const serverFunc = () => {
+  throw new Error("serverOnly() functions can only be called on the server!");
+};
+const clientFunc = () => 'client';

--- a/packages/start-vite-plugin/tests/envOnly/snapshots/client/envOnlyDestructuredRename.tsx
+++ b/packages/start-vite-plugin/tests/envOnly/snapshots/client/envOnlyDestructuredRename.tsx
@@ -1,0 +1,5 @@
+import { serverOnly as serverFn, clientOnly as clientFn } from '@tanstack/start';
+const serverFunc = () => {
+  throw new Error("serverOnly() functions can only be called on the server!");
+};
+const clientFunc = () => 'client';

--- a/packages/start-vite-plugin/tests/envOnly/snapshots/client/envOnlyStarImport.tsx
+++ b/packages/start-vite-plugin/tests/envOnly/snapshots/client/envOnlyStarImport.tsx
@@ -1,0 +1,5 @@
+import * as TanstackStart from '@tanstack/start';
+const serverFunc = () => {
+  throw new Error("serverOnly() functions can only be called on the server!");
+};
+const clientFunc = () => 'client';

--- a/packages/start-vite-plugin/tests/envOnly/snapshots/server/envOnlyDestructured.tsx
+++ b/packages/start-vite-plugin/tests/envOnly/snapshots/server/envOnlyDestructured.tsx
@@ -1,0 +1,5 @@
+import { serverOnly, clientOnly } from '@tanstack/start';
+const serverFunc = () => 'server';
+const clientFunc = () => {
+  throw new Error("clientOnly() functions can only be called on the client!");
+};

--- a/packages/start-vite-plugin/tests/envOnly/snapshots/server/envOnlyDestructuredRename.tsx
+++ b/packages/start-vite-plugin/tests/envOnly/snapshots/server/envOnlyDestructuredRename.tsx
@@ -1,0 +1,5 @@
+import { serverOnly as serverFn, clientOnly as clientFn } from '@tanstack/start';
+const serverFunc = () => 'server';
+const clientFunc = () => {
+  throw new Error("clientOnly() functions can only be called on the client!");
+};

--- a/packages/start-vite-plugin/tests/envOnly/snapshots/server/envOnlyStarImport.tsx
+++ b/packages/start-vite-plugin/tests/envOnly/snapshots/server/envOnlyStarImport.tsx
@@ -1,0 +1,5 @@
+import * as TanstackStart from '@tanstack/start';
+const serverFunc = () => 'server';
+const clientFunc = () => {
+  throw new Error("clientOnly() functions can only be called on the client!");
+};

--- a/packages/start-vite-plugin/tests/envOnly/test-files/envOnlyDestructured.tsx
+++ b/packages/start-vite-plugin/tests/envOnly/test-files/envOnlyDestructured.tsx
@@ -1,0 +1,5 @@
+import { serverOnly, clientOnly } from '@tanstack/start'
+
+const serverFunc = serverOnly(() => 'server')
+
+const clientFunc = clientOnly(() => 'client')

--- a/packages/start-vite-plugin/tests/envOnly/test-files/envOnlyDestructuredRename.tsx
+++ b/packages/start-vite-plugin/tests/envOnly/test-files/envOnlyDestructuredRename.tsx
@@ -1,0 +1,5 @@
+import { serverOnly as serverFn, clientOnly as clientFn } from '@tanstack/start'
+
+const serverFunc = serverFn(() => 'server')
+
+const clientFunc = clientFn(() => 'client')

--- a/packages/start-vite-plugin/tests/envOnly/test-files/envOnlyStarImport.tsx
+++ b/packages/start-vite-plugin/tests/envOnly/test-files/envOnlyStarImport.tsx
@@ -1,0 +1,5 @@
+import * as TanstackStart from '@tanstack/start'
+
+const serverFunc = TanstackStart.serverOnly(() => 'server')
+
+const clientFunc = TanstackStart.clientOnly(() => 'client')

--- a/packages/start/src/client/envOnly.ts
+++ b/packages/start/src/client/envOnly.ts
@@ -1,0 +1,13 @@
+// A function that will only be available in the server build
+// If called on the client, it will throw an error
+
+export function serverOnly<TFn extends (...args: any[]) => any>(fn: TFn): TFn {
+  return fn
+}
+
+// A function that will only be available in the client build
+// If called on the server, it will throw an error
+
+export function clientOnly<TFn extends (...args: any[]) => any>(fn: TFn): TFn {
+  return fn
+}

--- a/packages/start/src/client/envOnly.ts
+++ b/packages/start/src/client/envOnly.ts
@@ -1,13 +1,17 @@
 // A function that will only be available in the server build
 // If called on the client, it will throw an error
 
-export function serverOnly<TFn extends (...args: any[]) => any>(fn: TFn): TFn {
+export function serverOnly<TFn extends (...args: Array<any>) => any>(
+  fn: TFn,
+): TFn {
   return fn
 }
 
 // A function that will only be available in the client build
 // If called on the server, it will throw an error
 
-export function clientOnly<TFn extends (...args: any[]) => any>(fn: TFn): TFn {
+export function clientOnly<TFn extends (...args: Array<any>) => any>(
+  fn: TFn,
+): TFn {
   return fn
 }

--- a/packages/start/src/client/index.tsx
+++ b/packages/start/src/client/index.tsx
@@ -41,7 +41,7 @@ export {
   registerGlobalMiddleware,
   globalMiddleware,
 } from './registerGlobalMiddleware'
-export { serverOnly } from './serverOnly'
+export { serverOnly, clientOnly } from './envOnly'
 export { DehydrateRouter } from './DehydrateRouter'
 export { json } from './json'
 export { Meta } from './Meta'

--- a/packages/start/src/client/serverOnly.ts
+++ b/packages/start/src/client/serverOnly.ts
@@ -1,6 +1,0 @@
-// A function that will have its contents removed on the client build and only be available on the server build
-// it can accept any value, a function that will return a value, or an async function that will return a value
-
-export function serverOnly<T>(value: () => T): () => T | undefined {
-  return value
-}

--- a/packages/start/src/client/tests/envOnly.test-d.ts
+++ b/packages/start/src/client/tests/envOnly.test-d.ts
@@ -1,0 +1,34 @@
+import { expectTypeOf, test } from 'vitest'
+import { clientOnly, serverOnly } from '../envOnly'
+
+const inputFn = () => 'output'
+
+const genericInputFn = <T>(input: T) => input
+
+function overloadedFn(input: string): string
+function overloadedFn(input: number): number
+function overloadedFn(input: any) {
+  return input
+}
+
+test("clientOnly returns the function it's given", () => {
+  const outputFn = clientOnly(inputFn)
+  expectTypeOf(outputFn).toEqualTypeOf<typeof inputFn>()
+
+  const genericOutputFn = clientOnly(genericInputFn)
+  expectTypeOf(genericOutputFn).toEqualTypeOf<typeof genericInputFn>()
+
+  const overloadedOutputFn = clientOnly(overloadedFn)
+  expectTypeOf(overloadedOutputFn).toEqualTypeOf<typeof overloadedFn>()
+})
+
+test("serverOnly returns the function it's given", () => {
+  const outputFn = serverOnly(inputFn)
+  expectTypeOf(outputFn).toEqualTypeOf<typeof inputFn>()
+
+  const genericOutputFn = serverOnly(genericInputFn)
+  expectTypeOf(genericOutputFn).toEqualTypeOf<typeof genericInputFn>()
+
+  const overloadedOutputFn = serverOnly(overloadedFn)
+  expectTypeOf(overloadedOutputFn).toEqualTypeOf<typeof overloadedFn>()
+})


### PR DESCRIPTION
fixes #2938 
fixes #2828

This makes the following changes to serverOnly:

- Changes types to allow passing any function, not just ones that don't accept any arguments (and fixes return type, as the replacement function throws instead of no-op'ing)
- Changes replacement function to actually throw an error instead of referencing a missing `invariant` function
- Extracts out function instead of passing to serverOnly in runtime

This also adds `clientOnly`, which does the same as `serverOnly` but for the client.