### PR TITLE
fix(start): Fix json() helper merging of headers, and set up unit tests for @tanstack/start

### DIFF
--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -25,6 +25,7 @@
   ],
   "scripts": {
     "clean": "rimraf ./dist && rimraf ./coverage",
+    "test": "vitest",
     "test:eslint": "eslint ./src",
     "test:types": "pnpm run \"/^test:types:ts[0-9]{2}$/\"",
     "test:types:ts52": "node ../../node_modules/typescript52/lib/tsc.js",

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -25,6 +25,7 @@
   ],
   "scripts": {
     "clean": "rimraf ./dist && rimraf ./coverage",
+    "test": "pnpm test:eslint && pnpm test:types && pnpm test:build && pnpm test:unit",
     "test:unit": "vitest",
     "test:eslint": "eslint ./src",
     "test:types": "pnpm run \"/^test:types:ts[0-9]{2}$/\"",

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "clean": "rimraf ./dist && rimraf ./coverage",
-    "test": "vitest",
+    "test:unit": "vitest",
     "test:eslint": "eslint ./src",
     "test:types": "pnpm run \"/^test:types:ts[0-9]{2}$/\"",
     "test:types:ts52": "node ../../node_modules/typescript52/lib/tsc.js",

--- a/packages/start/src/client/json.ts
+++ b/packages/start/src/client/json.ts
@@ -6,7 +6,8 @@ export function json<TData>(
 ): JsonResponse<TData> {
   const headers = new Headers(init?.headers)
 
-  headers.set('Content-Type', 'application/json')
+  if (!headers.has('Content-Type'))
+    headers.set('Content-Type', 'application/json')
 
   return new Response(JSON.stringify(payload), {
     ...init,

--- a/packages/start/src/client/json.ts
+++ b/packages/start/src/client/json.ts
@@ -2,21 +2,14 @@ import type { JsonResponse } from './createServerFn'
 
 export function json<TData>(
   payload: TData,
-  opts?: {
-    status?: number
-    statusText?: string
-    headers?: HeadersInit
-  },
+  init?: ResponseInit,
 ): JsonResponse<TData> {
-  const status = opts?.status || 200
-  const statusText = opts?.statusText
+  const headers = new Headers(init?.headers)
+
+  headers.set('Content-Type', 'application/json')
 
   return new Response(JSON.stringify(payload), {
-    status,
-    statusText,
-    headers: {
-      'Content-Type': 'application/json',
-      ...opts?.headers,
-    },
+    ...init,
+    headers,
   })
 }

--- a/packages/start/src/client/tests/index.test.tsx
+++ b/packages/start/src/client/tests/index.test.tsx
@@ -69,11 +69,7 @@ describe('ssr scripts', () => {
     const { container } = render(<RouterProvider router={router} />)
 
     expect(container.innerHTML).toEqual(
-      `<script id="__TSR_DEHYDRATED__">
-          __TSR_DEHYDRATED__ = {
-            data: '{}'
-          }
-        </script><script src="script.js"></script><script src="script2.js"></script><script src="script3.js"></script>`,
+      `<script src="script.js"></script><script src="script2.js"></script><script src="script3.js"></script>`,
     )
   })
 })

--- a/packages/start/src/client/tests/json.test.ts
+++ b/packages/start/src/client/tests/json.test.ts
@@ -13,6 +13,11 @@ describe('json', () => {
 
     await expect(response.json()).resolves.toEqual(data)
   })
+  it("doesn't override the content type if it's already set", () => {
+    const response = json(null, { headers: { 'Content-Type': 'text/plain' } })
+
+    expect(response.headers.get('Content-Type')).toBe('text/plain')
+  })
   it('reflects passed status and statusText', () => {
     const response = json(null, { status: 404, statusText: 'Not Found' })
 

--- a/packages/start/src/client/tests/json.test.ts
+++ b/packages/start/src/client/tests/json.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { json } from '../json'
+
+describe('json', () => {
+  it('sets the content type to application/json and stringifies the data', async () => {
+    const data = { foo: 'bar' }
+    const response = json(data)
+
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+
+    const responseClone = response.clone()
+    await expect(responseClone.text()).resolves.toEqual(JSON.stringify(data))
+
+    await expect(response.json()).resolves.toEqual(data)
+  })
+  it('reflects passed status and statusText', () => {
+    const response = json(null, { status: 404, statusText: 'Not Found' })
+
+    expect(response.status).toBe(404)
+    expect(response.statusText).toBe('Not Found')
+  })
+  it.each<[string, HeadersInit]>([
+    ['plain object', { 'X-TYPE': 'example' }],
+    ['array', [['X-TYPE', 'example']]],
+    ['Headers', new Headers({ 'X-TYPE': 'example' })],
+  ])('merges headers from %s', (_, headers) => {
+    const response = json(null, { headers })
+
+    expect(response.headers.get('X-TYPE')).toBe('example')
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+  })
+})

--- a/packages/start/vite.config.ts
+++ b/packages/start/vite.config.ts
@@ -1,12 +1,14 @@
 import { defineConfig, mergeConfig } from 'vitest/config'
 import { tanstackViteConfig } from '@tanstack/config/vite'
 import react from '@vitejs/plugin-react'
+import packageJson from './package.json'
 import type { ViteUserConfig } from 'vitest/config'
 
 const config = defineConfig({
   plugins: [react()] as ViteUserConfig['plugins'],
   test: {
-    include: ['src/**/*.test.{ts,tsx}'],
+    name: packageJson.name,
+    watch: false,
     environment: 'jsdom',
   },
 })

--- a/packages/start/vite.config.ts
+++ b/packages/start/vite.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig, mergeConfig } from 'vitest/config'
 import { tanstackViteConfig } from '@tanstack/config/vite'
 import react from '@vitejs/plugin-react'
-import type { UserConfig } from 'vitest/config'
+import type { ViteUserConfig } from 'vitest/config'
 
 const config = defineConfig({
-  plugins: [react()] as UserConfig['plugins'],
+  plugins: [react()] as ViteUserConfig['plugins'],
+  test: {
+    include: ['src/**/*.test.{ts,tsx}'],
+    environment: 'jsdom',
+  },
 })
 
 export default mergeConfig(


### PR DESCRIPTION
This PR was originally meant to just be an improvement for the json() helper, but in the process of writing a unit test for it, I realised that unit tests in the @tanstack/start package were not being run.

The existing headers merging wouldn't work correctly for arrays of entries, or Headers instances, both of which were allowed by the types. This PR fixes that by contructing a Headers instance ourselves, *then* adding the Content-Type header.