### PR TITLE
fix(start): Remove variable check for createIsomorphicFn and envOnly functions.

### DIFF
--- a/packages/start-vite-plugin/src/compilers.ts
+++ b/packages/start-vite-plugin/src/compilers.ts
@@ -570,10 +570,6 @@ function buildEnvOnlyCallExpressionHandler(env: 'client' | 'server') {
     if (debug)
       console.info(`Handling ${env}Only call expression:`, path.toString())
 
-    if (!path.parentPath.isVariableDeclarator()) {
-      throw new Error(`${env}Only() functions must be assigned to a variable!`)
-    }
-
     if (opts.env === env) {
       // extract the inner function from the call expression
       const innerInputExpression = path.node.arguments[0]
@@ -619,11 +615,6 @@ function handleCreateIsomorphicFnCallExpression(
       rootCallExpression.toString(),
     )
 
-  // Check if the call is assigned to a variable
-  if (!rootCallExpression.parentPath.isVariableDeclarator()) {
-    throw new Error('createIsomorphicFn must be assigned to a variable!')
-  }
-
   const callExpressionPaths = {
     client: null as babel.NodePath<t.CallExpression> | null,
     server: null as babel.NodePath<t.CallExpression> | null,
@@ -653,7 +644,9 @@ function handleCreateIsomorphicFnCallExpression(
         !callExpressionPaths[method as keyof typeof callExpressionPaths],
     )
   ) {
-    const variableId = rootCallExpression.parentPath.node.id
+    const variableId = rootCallExpression.parentPath.isVariableDeclarator()
+      ? rootCallExpression.parentPath.node.id
+      : null
     console.warn(
       'createIsomorphicFn called without a client or server implementation!',
       'This will result in a no-op function.',

--- a/packages/start-vite-plugin/tests/createIsomorphicFn/createIsomorphicFn.test.ts
+++ b/packages/start-vite-plugin/tests/createIsomorphicFn/createIsomorphicFn.test.ts
@@ -71,18 +71,6 @@ describe('createIsomorphicFn compiles correctly', async () => {
       })
     }).toThrowError()
   })
-  test('should be assigned to a variable', () => {
-    expect(() => {
-      compileStartOutput({
-        env: 'client',
-        code: `
-        import { createIsomorphicFn } from '@tanstack/start'
-        createIsomorphicFn()`,
-        root: './test-files',
-        filename: 'no-fn.ts',
-      })
-    }).toThrowError()
-  })
   test('should warn to console if no implementations provided', () => {
     compileStartOutput({
       env: 'client',

--- a/packages/start-vite-plugin/tests/envOnly/envOnly.test.ts
+++ b/packages/start-vite-plugin/tests/envOnly/envOnly.test.ts
@@ -55,26 +55,4 @@ describe('envOnly functions compile correctly', async () => {
       })
     }).toThrowError()
   })
-  test('should be assigned to a variable', () => {
-    expect(() => {
-      compileStartOutput({
-        env: 'server',
-        code: `
-        import { serverOnly } from '@tanstack/start'
-        serverOnly()`,
-        root: './test-files',
-        filename: 'no-fn.ts',
-      })
-    }).toThrowError()
-    expect(() => {
-      compileStartOutput({
-        env: 'client',
-        code: `
-        import { clientOnly } from '@tanstack/start'
-        clientOnly()`,
-        root: './test-files',
-        filename: 'no-fn.ts',
-      })
-    }).toThrowError()
-  })
 })


### PR DESCRIPTION
createServerFn checks that it's assigned to a variable because the compiled code references that variable.

createIsomorphicFn and envOnly functions don't have this restriction, so we don't actually need this check.

It also causes issues when the AST has something else before the variable, for example 
```ts
const test = serverOnly(fn) as Type
```
The parent path in this AST would be the `as` expression, not the variable declaration.