### PR TITLE
refactor: remove hardcoded references to `tsr.config.json`

### DIFF
--- a/packages/router-cli/src/watch.ts
+++ b/packages/router-cli/src/watch.ts
@@ -1,10 +1,14 @@
 import chokidar from 'chokidar'
-import { generator, getConfig, resolveConfigPath } from '@tanstack/router-generator'
+import {
+  generator,
+  getConfig,
+  resolveConfigPath,
+} from '@tanstack/router-generator'
 
 export function watch(root: string) {
   const configPath = resolveConfigPath({
     configDirectory: root,
-  });
+  })
   const configWatcher = chokidar.watch(configPath)
 
   let watcher = new chokidar.FSWatcher({})

--- a/packages/router-cli/src/watch.ts
+++ b/packages/router-cli/src/watch.ts
@@ -1,9 +1,11 @@
-import path from 'node:path'
 import chokidar from 'chokidar'
-import { generator, getConfig } from '@tanstack/router-generator'
+import { generator, getConfig, resolveConfigPath } from '@tanstack/router-generator'
 
 export function watch(root: string) {
-  const configWatcher = chokidar.watch(path.resolve(root, 'tsr.config.json'))
+  const configPath = resolveConfigPath({
+    configDirectory: root,
+  });
+  const configWatcher = chokidar.watch(configPath)
 
   let watcher = new chokidar.FSWatcher({})
 

--- a/packages/router-generator/src/config.ts
+++ b/packages/router-generator/src/config.ts
@@ -67,6 +67,14 @@ export const configSchema = z.object({
 
 export type Config = z.infer<typeof configSchema>
 
+type ResolveParams = {
+  configDirectory: string;
+}
+
+export function resolveConfigPath({ configDirectory }: ResolveParams) {
+  return path.resolve(configDirectory, 'tsr.config.json');  
+}
+
 export function getConfig(
   inlineConfig: Partial<Config> = {},
   configDirectory?: string,
@@ -74,7 +82,7 @@ export function getConfig(
   if (configDirectory === undefined) {
     configDirectory = process.cwd()
   }
-  const configFilePathJson = path.resolve(configDirectory, 'tsr.config.json')
+  const configFilePathJson = resolveConfigPath({ configDirectory });
   const exists = existsSync(configFilePathJson)
 
   let config: Config

--- a/packages/router-generator/src/config.ts
+++ b/packages/router-generator/src/config.ts
@@ -68,11 +68,11 @@ export const configSchema = z.object({
 export type Config = z.infer<typeof configSchema>
 
 type ResolveParams = {
-  configDirectory: string;
+  configDirectory: string
 }
 
 export function resolveConfigPath({ configDirectory }: ResolveParams) {
-  return path.resolve(configDirectory, 'tsr.config.json');  
+  return path.resolve(configDirectory, 'tsr.config.json')
 }
 
 export function getConfig(
@@ -82,7 +82,7 @@ export function getConfig(
   if (configDirectory === undefined) {
     configDirectory = process.cwd()
   }
-  const configFilePathJson = resolveConfigPath({ configDirectory });
+  const configFilePathJson = resolveConfigPath({ configDirectory })
   const exists = existsSync(configFilePathJson)
 
   let config: Config

--- a/packages/router-generator/src/index.ts
+++ b/packages/router-generator/src/index.ts
@@ -1,4 +1,4 @@
-export { configSchema, getConfig } from './config'
+export { configSchema, getConfig, resolveConfigPath } from './config'
 export type { Config } from './config'
 
 export {

--- a/packages/router-plugin/src/core/constants.ts
+++ b/packages/router-plugin/src/core/constants.ts
@@ -1,2 +1,1 @@
-export const CONFIG_FILE_NAME = 'tsr.config.json'
 export const splitPrefix = 'tsr-split'

--- a/packages/router-plugin/src/core/router-generator-plugin.ts
+++ b/packages/router-plugin/src/core/router-generator-plugin.ts
@@ -1,8 +1,7 @@
 import { isAbsolute, join, normalize, resolve } from 'node:path'
-import { generator } from '@tanstack/router-generator'
+import { generator, resolveConfigPath } from '@tanstack/router-generator'
 
 import { getConfig } from './config'
-import { CONFIG_FILE_NAME } from './constants'
 import type { UnpluginFactory } from 'unplugin'
 import type { Config } from './config'
 
@@ -49,7 +48,7 @@ export const unpluginRouterGeneratorFactory: UnpluginFactory<
   ) => {
     const filePath = normalize(file)
 
-    if (filePath === join(ROOT, CONFIG_FILE_NAME)) {
+    if (filePath === resolveConfigPath({ configDirectory: ROOT })) {
       userConfig = getConfig(options, ROOT)
       return
     }


### PR DESCRIPTION
Removes all hard coded references to `tsr.config.json`.

This PR removes all assumptions in code related to the filename of the config file and will eventually allow for configs to be defined in other formats.