### PR TITLE
docs(start): fix serialization error in clerk auth example

### DIFF
--- a/examples/react/start-clerk-basic/app/routes/__root.tsx
+++ b/examples/react/start-clerk-basic/app/routes/__root.tsx
@@ -22,10 +22,10 @@ import { NotFound } from '~/components/NotFound.js'
 import appCss from '~/styles/app.css?url'
 
 const fetchClerkAuth = createServerFn({ method: 'GET' }).handler(async () => {
-  const user = await getAuth(getWebRequest())
+  const { userId } = await getAuth(getWebRequest())
 
   return {
-    user,
+    userId,
   }
 })
 
@@ -64,10 +64,10 @@ export const Route = createRootRoute({
     ],
   }),
   beforeLoad: async () => {
-    const { user } = await fetchClerkAuth()
+    const { userId } = await fetchClerkAuth()
 
     return {
-      user,
+      userId,
     }
   },
   errorComponent: (props) => {

--- a/examples/react/start-clerk-basic/app/routes/_authed.tsx
+++ b/examples/react/start-clerk-basic/app/routes/_authed.tsx
@@ -3,7 +3,7 @@ import { SignIn } from '@clerk/tanstack-start'
 
 export const Route = createFileRoute('/_authed')({
   beforeLoad: ({ context }) => {
-    if (!context.user.userId) {
+    if (!context.userId) {
       throw new Error('Not authenticated')
     }
   },


### PR DESCRIPTION
The current example gets the entire user object from getAuth(). This causes a serialization error, and is also inconsistent with the clerk documentation.

This pull request resolves this issue by simply changing the clerk getAuth() call to only retrieve and return the userId.