### PR TITLE
fix: awaiting `toMatchFileSnapshot` and `.rejects` statements in vitest files

### DIFF
--- a/packages/router-generator/tests/deny-route-group-config.test.ts
+++ b/packages/router-generator/tests/deny-route-group-config.test.ts
@@ -57,7 +57,7 @@ describe('deny-route-group-config throws', () => {
       const config = await setupConfig(folder)
       const folderRoot = makeFolderDir(folder)
 
-      expect(() => generator(config, folderRoot)).rejects.toThrowError(
+      await expect(() => generator(config, folderRoot)).rejects.toThrowError(
         expectedError,
       )
     },

--- a/packages/router-generator/tests/generator.test.ts
+++ b/packages/router-generator/tests/generator.test.ts
@@ -179,8 +179,8 @@ async function postprocess(folderName: string) {
       const routeFiles = await readDir(folderName, 'routes', '(test)')
       routeFiles
         .filter((r) => r.endsWith('.tsx'))
-        .forEach((routeFile) => {
-          expect(fooText).toMatchFileSnapshot(
+        .forEach(async (routeFile) => {
+          await expect(fooText).toMatchFileSnapshot(
             join('generator', folderName, 'snapshot', routeFile),
           )
         })
@@ -191,7 +191,7 @@ async function postprocess(folderName: string) {
       await traverseDirectory(startDir, async (filePath) => {
         const relativePath = relative(startDir, filePath)
         if (filePath.endsWith('.tsx')) {
-          expect(await fs.readFile(filePath, 'utf-8')).toMatchFileSnapshot(
+          await expect(await fs.readFile(filePath, 'utf-8')).toMatchFileSnapshot(
             join('generator', folderName, 'snapshot', relativePath),
           )
         }
@@ -222,13 +222,13 @@ describe('generator works', async () => {
       await preprocess(folderName)
       const error = shouldThrow(folderName)
       if (error) {
-        expect(() => generator(config, folderRoot)).rejects.toThrowError(error)
+        await expect(() => generator(config, folderRoot)).rejects.toThrowError(error)
       } else {
         await generator(config, folderRoot)
 
         const generatedRouteTree = await getRouteTreeFileText(config)
 
-        expect(generatedRouteTree).toMatchFileSnapshot(
+        await expect(generatedRouteTree).toMatchFileSnapshot(
           join(
             'generator',
             folderName,


### PR DESCRIPTION
Running `test:unit` in `router-generator` yields a legion of async vitest warnings: 

```
Promise returned by `expect(actual).toMatchFileSnapshot(expected)` was not awaited. Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in Vitest 3. Please remember to await the assertion.
```

This PR adds `await` statements where necessary. 