### PR TITLE
fix(react-router): use correct type for TRouter generic

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -1001,7 +1001,7 @@ export type CreateLinkProps = LinkProps<
 >
 
 export type LinkComponent<TComp> = <
-  TRouter extends RegisteredRouter = RegisteredRouter,
+  TRouter extends AnyRouter = RegisteredRouter,
   TFrom extends string = string,
   TTo extends string | undefined = undefined,
   TMaskFrom extends string = TFrom,


### PR DESCRIPTION
I think this is a typo.

There are many instances with `TRouter extends AnyRouter`: https://github.com/search?q=repo%3ATanStack%2Frouter+%22TRouter+extends+AnyRouter%22&type=code

There are a few other instances with `TRouter extends RegisteredRouter` which should probably be audited: https://github.com/search?q=repo%3ATanStack%2Frouter+%22TRouter+extends+RegisteredRouter%22&type=code.