### PR TITLE
fix(history): browser transitions being skipped for `router.history` navigation calls

### DIFF
--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -405,7 +405,7 @@ export function createMemoryHistory(
     createHref: (path) => path,
   })
 
-  return history;
+  return history
 }
 
 export function parseHref(


### PR DESCRIPTION
Fixes #2983 

When using `back()`, `forward()` and `go()` on `router.history` for the browser history implementation, native transitions are not occurring.

This is caused by `notify()` being called twice, once for the `back()` from the default history implementation and again for when the window event listener is called by the browser for a navigation event.

This PR fixes it by moving calls for `notify()` to the implementation for the history API, so that the browser history implementation does not call `notify()` (instead relying on the event subscriber), while the memory implementation calls `notify()` on every history navigation call.

(fix suggested by @schiller-manuel )