### PR TITLE
docs: Slightly improve navigation-blocking.md to avoid confusion

### DIFF
--- a/docs/framework/react/guide/navigation-blocking.md
+++ b/docs/framework/react/guide/navigation-blocking.md
@@ -159,7 +159,7 @@ function MyComponent() {
         return false
       }
 
-      const shouldLeave = new Promise<boolean>((resolve) => {
+      const shouldBlock = new Promise<boolean>((resolve) => {
         // Using a modal manager of your choice
         modals.open({
           title: 'Are you sure you want to leave?',
@@ -167,7 +167,7 @@ function MyComponent() {
             <SaveBlocker
               confirm={() => {
                 modals.closeAll()
-                resolve(true)
+                resolve(false)
               }}
               reject={() => {
                 modals.closeAll()
@@ -175,10 +175,10 @@ function MyComponent() {
               }}
             />
           ),
-          onClose: () => resolve(false),
+          onClose: () => resolve(true),
         })
       })
-      return !shouldLeave
+      return shouldBlock
     },
   })
 


### PR DESCRIPTION
This is something really small. I'd expect for the `reject` of the example `SaveBlocker`:
```
<SaveBlocker
  confirm={() => {
    modals.closeAll()
    resolve(true)
  }}
  reject={() => {
    modals.closeAll()
    resolve(true)
  }}
/>
```
to block the navigation instead of letting in through, as it currently does.

I also think that having the inverted shouldLeave is needlessly confusing when not using `window.confirm`.