### PR TITLE
fix(react-router): ensure updated context in `beforeLoad` when returning same properties

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -2397,7 +2397,6 @@ export class Router<
                     context: {
                       ...getParentMatchContext(),
                       ...prev.__routeContext,
-                      ...prev.__beforeLoadContext,
                     },
                   }))
 

--- a/packages/react-router/tests/routeContext.test.tsx
+++ b/packages/react-router/tests/routeContext.test.tsx
@@ -1407,6 +1407,59 @@ describe('beforeLoad in the route definition', () => {
     expect(mock).toHaveBeenCalledWith({ foo: 'bar', layout: 'layout' })
     expect(mock).toHaveBeenCalledTimes(1)
   })
+
+  test('child route receives updated values after the values were previously returned by the child route and then updated by the parent route', async () => {
+    const mockIndexBeforeLoadFn = vi.fn()
+    let counter = 0
+
+    const rootRoute = createRootRoute({
+      beforeLoad: () => {
+        counter++
+        return {
+          counter,
+        }
+      },
+    })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      beforeLoad: ({ context }) => {
+        mockIndexBeforeLoadFn(context)
+        return {
+          counter: context.counter,
+        }
+      },
+      component: () => {
+        const { counter } = indexRoute.useRouteContext()
+        return (
+          <div>
+            <span data-testid="index-page">Index page</span>
+            <span data-testid="counter">{counter}</span>
+          </div>
+        )
+      },
+    })
+    const routeTree = rootRoute.addChildren([indexRoute])
+    const router = createRouter({ routeTree, history })
+
+    render(<RouterProvider router={router} />)
+
+    const rootElement = await screen.findByTestId('index-page')
+    expect(rootElement).toBeInTheDocument()
+
+    async function check(expectedCounter: number) {
+      const counterElement = await screen.findByTestId('counter')
+      expect(counterElement).toHaveTextContent(`${expectedCounter}`)
+
+      expect(mockIndexBeforeLoadFn).toHaveBeenCalledWith({
+        counter: expectedCounter,
+      })
+    }
+
+    await check(1)
+    await router.invalidate()
+    await check(2)
+  })
 })
 
 describe('loader in the route definition', () => {


### PR DESCRIPTION
fixes #3051