### PR TITLE
fix(router-generator) use explicit routes export by default

### DIFF
--- a/packages/router-generator/src/filesystem/virtual/getRouteNodes.ts
+++ b/packages/router-generator/src/filesystem/virtual/getRouteNodes.ts
@@ -108,7 +108,7 @@ async function getVirtualRouteConfigFromFileExport(
   }
 
   const virtualRouteConfig =
-    'default' in exports ? exports.default : exports.routes
+    'routes' in exports ? exports.routes : exports.default
 
   return virtualRootRouteSchema.parse(virtualRouteConfig)
 }


### PR DESCRIPTION
There is an issue with Virtual File Router when [config provided as as path](https://tanstack.com/router/latest/docs/framework/react/guide/virtual-file-routes#configuration-via-the-tanstackrouter-plugin).

For some reason there is an explicit default export added
<img width="711" alt="Screenshot 2025-01-04 at 12 11 09" src="https://github.com/user-attachments/assets/9ca0204f-fed1-4e26-933b-d4daec467b60" />

an there is clearly no default export provided in original config:
```ts
import { index, rootRoute, route } from '@tanstack/virtual-file-routes';

export const routes = rootRoute('root.tsx', [
  index('index.tsx'),
  route('about-us', 'about-us/index.lazy.tsx'),
]);

```

---

I've found a similar [issue](https://github.com/privatenumber/tsx/issues/427) in `tsx` package repo, and looks like it has something to do with internal module resolution of NodeJS, see [minimal reproduction](https://stackblitz.com/edit/stackblitz-starters-sykrfb?file=index.js) provided in discussion there.

Looks like we can easily solve this problem by using explicit `routes` export from `routes.ts` file.