### PR TITLE
Typo issue - getParent Does not Exists in type RouteOptions

### DIFF
--- a/docs/framework/react/guide/code-splitting.md
+++ b/docs/framework/react/guide/code-splitting.md
@@ -300,7 +300,7 @@ Then, call the `.lazy` method on the route definition in your `app.tsx` to impor
 ```tsx
 // src/app.tsx
 const postsRoute = createRoute({
-  getParent: () => rootRoute,
+  getParentRoute: () => rootRoute,
   path: '/posts',
 }).lazy(() => import('./posts.lazy').then((d) => d.Route))
 ```


### PR DESCRIPTION
codesplitting documentation has this typo issue. Here it should comes as getParentRoute but it was wrongly typed as getParent