### PR TITLE
fix(start): preserve multiple values for same key in `FormData` serialization

### DIFF
--- a/e2e/start/basic/app/routes/-server-fns/serialize-formdata-fn-call.tsx
+++ b/e2e/start/basic/app/routes/-server-fns/serialize-formdata-fn-call.tsx
@@ -28,16 +28,9 @@ export const greetUser = createServerFn()
       pets: pets.map((pet) => pet.toString()),
     }
   })
-  .handler(
-    ({
-      data: {
-        name,
-        age,
-        pets: [pet1, pet2],
-      },
-    }) =>
-      `Hello, ${name}! You are ${age + testValues.__adder} years old, and your favorite pets are ${pet1} and ${pet2}.`,
-  )
+  .handler(({ data: { name, age, pets } }) => {
+    return `Hello, ${name}! You are ${age + testValues.__adder} years old, and your favorite pets are ${pets.join(',')}.`
+  })
 
 // Usage
 export function SerializeFormDataFnCall() {
@@ -52,7 +45,7 @@ export function SerializeFormDataFnCall() {
           <pre data-testid="expected-serialize-formdata-server-fn-result">
             Hello, {testValues.name}! You are{' '}
             {testValues.age + testValues.__adder} years old, and your favorite{' '}
-            pets are {testValues.pet1} and {testValues.pet2}.
+            pets are {testValues.pet1},{testValues.pet2}.
           </pre>
         </code>
       </div>

--- a/e2e/start/basic/app/routes/-server-fns/serialize-formdata-fn-call.tsx
+++ b/e2e/start/basic/app/routes/-server-fns/serialize-formdata-fn-call.tsx
@@ -4,6 +4,8 @@ import { createServerFn } from '@tanstack/start'
 const testValues = {
   name: 'Sean',
   age: 25,
+  pet1: 'dog',
+  pet2: 'cat',
   __adder: 1,
 }
 
@@ -14,19 +16,27 @@ export const greetUser = createServerFn()
     }
     const name = data.get('name')
     const age = data.get('age')
+    const pets = data.getAll('pet')
 
-    if (!name || !age) {
-      throw new Error('Name and age are required')
+    if (!name || !age || pets.length === 0) {
+      throw new Error('Name, age and pets are required')
     }
 
     return {
       name: name.toString(),
       age: parseInt(age.toString(), 10),
+      pets: pets.map((pet) => pet.toString()),
     }
   })
   .handler(
-    ({ data: { name, age } }) =>
-      `Hello, ${name}! You are ${age + testValues.__adder} years old.`,
+    ({
+      data: {
+        name,
+        age,
+        pets: [pet1, pet2],
+      },
+    }) =>
+      `Hello, ${name}! You are ${age + testValues.__adder} years old, and your favorite pets are ${pet1} and ${pet2}.`,
   )
 
 // Usage
@@ -41,7 +51,8 @@ export function SerializeFormDataFnCall() {
         <code>
           <pre data-testid="expected-serialize-formdata-server-fn-result">
             Hello, {testValues.name}! You are{' '}
-            {testValues.age + testValues.__adder} years old.
+            {testValues.age + testValues.__adder} years old, and your favorite{' '}
+            pets are {testValues.pet1} and {testValues.pet2}.
           </pre>
         </code>
       </div>
@@ -56,6 +67,8 @@ export function SerializeFormDataFnCall() {
       >
         <input type="text" name="name" defaultValue={testValues.name} />
         <input type="number" name="age" defaultValue={testValues.age} />
+        <input type="text" name="pet" defaultValue={testValues.pet1} />
+        <input type="text" name="pet" defaultValue={testValues.pet2} />
         <button
           type="submit"
           data-testid="test-serialize-formdata-fn-calls-btn"

--- a/e2e/start/basic/app/routes/-server-fns/serialize-formdata-fn-call.tsx
+++ b/e2e/start/basic/app/routes/-server-fns/serialize-formdata-fn-call.tsx
@@ -8,7 +8,7 @@ const testValues = {
 }
 
 export const greetUser = createServerFn()
-  .validator((data: unknown) => {
+  .validator((data: FormData) => {
     if (!(data instanceof FormData)) {
       throw new Error('Invalid! FormData is required')
     }
@@ -24,9 +24,10 @@ export const greetUser = createServerFn()
       age: parseInt(age.toString(), 10),
     }
   })
-  .handler(async ({ data: { name, age } }) => {
-    return `Hello, ${name}! You are ${age + testValues.__adder} years old.`
-  })
+  .handler(
+    ({ data: { name, age } }) =>
+      `Hello, ${name}! You are ${age + testValues.__adder} years old.`,
+  )
 
 // Usage
 export function SerializeFormDataFnCall() {

--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -291,6 +291,7 @@ export type {
   RouterTransformer,
   TransformerParse,
   TransformerStringify,
+  DefaultSerializeable,
   DefaultTransformerParse,
   DefaultTransformerStringify,
 } from './transformer'

--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -291,7 +291,7 @@ export type {
   RouterTransformer,
   TransformerParse,
   TransformerStringify,
-  DefaultSerializeable,
+  DefaultSerializable,
   DefaultTransformerParse,
   DefaultTransformerStringify,
 } from './transformer'

--- a/packages/react-router/src/transformer.ts
+++ b/packages/react-router/src/transformer.ts
@@ -140,7 +140,7 @@ const transformers = [
       > = {}
       v.forEach((value, key) => {
         const entry = entries[key]
-        if (entry) {
+        if (entry !== undefined) {
           if (Array.isArray(entry)) {
             entry.push(value)
           } else {

--- a/packages/react-router/src/transformer.ts
+++ b/packages/react-router/src/transformer.ts
@@ -133,18 +133,16 @@ const transformers = [
     (v) => v instanceof FormData,
     // To
     (v) => {
-      const entries: Record<string, any> = {}
-      v.forEach((value, key) => {
-        entries[key] = value
-      })
+      const entries: Record<string, Array<any>> = {}
+      v.forEach((value, key) => (entries[key] ??= []).push(value))
       return entries
     },
     // From
     (v) => {
       const formData = new FormData()
-      Object.entries(v).forEach(([key, value]) => {
-        formData.append(key, value)
-      })
+      Object.entries(v).forEach(([key, values]) =>
+        values.forEach((value) => formData.append(key, value)),
+      )
       return formData
     },
   ),

--- a/packages/react-router/src/transformer.ts
+++ b/packages/react-router/src/transformer.ts
@@ -100,7 +100,7 @@ const transformers = [
     // Key
     'undefined',
     // Check
-    (v) => typeof v === 'undefined',
+    (v): v is undefined => v === undefined,
     // To
     () => 0,
     // From
@@ -110,7 +110,7 @@ const transformers = [
     // Key
     'date',
     // Check
-    (v) => v instanceof Date,
+    (v): v is Date => v instanceof Date,
     // To
     (v) => v.toISOString(),
     // From
@@ -120,7 +120,7 @@ const transformers = [
     // Key
     'error',
     // Check
-    (v) => v instanceof Error,
+    (v): v is Error => v instanceof Error,
     // To
     (v) => ({ ...v, message: v.message, stack: v.stack, cause: v.cause }),
     // From
@@ -130,7 +130,7 @@ const transformers = [
     // Key
     'formData',
     // Check
-    (v) => v instanceof FormData,
+    (v): v is FormData => v instanceof FormData,
     // To
     (v) => {
       const entries: Record<string, Array<any>> = {}

--- a/packages/react-router/src/transformer.ts
+++ b/packages/react-router/src/transformer.ts
@@ -80,11 +80,11 @@ export const defaultTransformer: RouterTransformer = {
   },
 }
 
-const createTransformer = <TKey extends string, TFrom, TTo>(
+const createTransformer = <TKey extends string, TFancy, TPlain>(
   key: TKey,
-  check: (value: any) => value is TFrom,
-  toValue: (value: TFrom) => TTo = (v) => v as never,
-  fromValue: (value: TTo) => TFrom = (v) => v as never,
+  check: (value: any) => value is TFancy,
+  toValue: (value: TFancy) => TPlain,
+  fromValue: (value: TPlain) => TFancy,
 ) => ({
   key,
   stringifyCondition: check,

--- a/packages/react-router/src/transformer.ts
+++ b/packages/react-router/src/transformer.ts
@@ -139,11 +139,12 @@ const transformers = [
         Array<FormDataEntryValue> | FormDataEntryValue
       > = {}
       v.forEach((value, key) => {
-        if (entries[key]) {
-          if (Array.isArray(entries[key])) {
-            entries[key].push(value)
+        const entry = entries[key]
+        if (entry) {
+          if (Array.isArray(entry)) {
+            entry.push(value)
           } else {
-            entries[key] = [entries[key], value]
+            entries[key] = [entry, value]
           }
         } else {
           entries[key] = value

--- a/packages/react-router/src/transformer.ts
+++ b/packages/react-router/src/transformer.ts
@@ -80,11 +80,11 @@ export const defaultTransformer: RouterTransformer = {
   },
 }
 
-const createTransformer = <T extends string>(
-  key: T,
-  check: (value: any) => boolean,
-  toValue: (value: any) => any = (v) => v,
-  fromValue: (value: any) => any = (v) => v,
+const createTransformer = <TKey extends string, TFrom, TTo>(
+  key: TKey,
+  check: (value: any) => value is TFrom,
+  toValue: (value: TFrom) => TTo = (v) => v as never,
+  fromValue: (value: TTo) => TFrom = (v) => v as never,
 ) => ({
   key,
   stringifyCondition: check,
@@ -100,7 +100,7 @@ const transformers = [
     // Key
     'undefined',
     // Check
-    (v) => v === undefined,
+    (v) => typeof v === 'undefined',
     // To
     () => 0,
     // From
@@ -132,7 +132,7 @@ const transformers = [
     // Check
     (v) => v instanceof FormData,
     // To
-    (v: FormData) => {
+    (v) => {
       const entries: Record<string, any> = {}
       v.forEach((value, key) => {
         entries[key] = value
@@ -143,7 +143,7 @@ const transformers = [
     (v) => {
       const formData = new FormData()
       Object.entries(v).forEach(([key, value]) => {
-        formData.append(key, value as string | Blob)
+        formData.append(key, value)
       })
       return formData
     },
@@ -162,9 +162,14 @@ export type TransformerParse<T, TSerializable> = T extends TSerializable
     ? ReadableStream
     : { [K in keyof T]: TransformerParse<T[K], TSerializable> }
 
+export type DefaultSerializeable = Date | undefined | Error | FormData
+
 export type DefaultTransformerStringify<T> = TransformerStringify<
   T,
-  Date | undefined
+  DefaultSerializeable
 >
 
-export type DefaultTransformerParse<T> = TransformerParse<T, Date | undefined>
+export type DefaultTransformerParse<T> = TransformerParse<
+  T,
+  DefaultSerializeable
+>

--- a/packages/react-router/src/transformer.ts
+++ b/packages/react-router/src/transformer.ts
@@ -80,11 +80,11 @@ export const defaultTransformer: RouterTransformer = {
   },
 }
 
-const createTransformer = <TKey extends string, TFancy, TPlain>(
+const createTransformer = <TKey extends string, TInput, TSerialized>(
   key: TKey,
-  check: (value: any) => value is TFancy,
-  toValue: (value: TFancy) => TPlain,
-  fromValue: (value: TPlain) => TFancy,
+  check: (value: any) => value is TInput,
+  toValue: (value: TInput) => TSerialized,
+  fromValue: (value: TSerialized) => TInput,
 ) => ({
   key,
   stringifyCondition: check,
@@ -179,14 +179,14 @@ export type TransformerParse<T, TSerializable> = T extends TSerializable
     ? ReadableStream
     : { [K in keyof T]: TransformerParse<T[K], TSerializable> }
 
-export type DefaultSerializeable = Date | undefined | Error | FormData
+export type DefaultSerializable = Date | undefined | Error | FormData
 
 export type DefaultTransformerStringify<T> = TransformerStringify<
   T,
-  DefaultSerializeable
+  DefaultSerializable
 >
 
 export type DefaultTransformerParse<T> = TransformerParse<
   T,
-  DefaultSerializeable
+  DefaultSerializable
 >

--- a/packages/react-router/tests/transformer.test.tsx
+++ b/packages/react-router/tests/transformer.test.tsx
@@ -43,7 +43,7 @@ describe('transformer.stringify', () => {
     formData.append('foo', 'bar')
     formData.append('name', 'Sean')
     expect(tf.stringify(formData)).toMatchInlineSnapshot(
-      `"{"$formData":{"foo":["bar"],"name":["Sean"]}}"`,
+      `"{"$formData":{"foo":"bar","name":"Sean"}}"`,
     )
   })
   it('should stringify FormData with multiple values for the same key', () => {

--- a/packages/react-router/tests/transformer.test.tsx
+++ b/packages/react-router/tests/transformer.test.tsx
@@ -43,7 +43,15 @@ describe('transformer.stringify', () => {
     formData.append('foo', 'bar')
     formData.append('name', 'Sean')
     expect(tf.stringify(formData)).toMatchInlineSnapshot(
-      `"{"$formData":{"foo":"bar","name":"Sean"}}"`,
+      `"{"$formData":{"foo":["bar"],"name":["Sean"]}}"`,
+    )
+  })
+  it('should stringify FormData with multiple values for the same key', () => {
+    const formData = new FormData()
+    formData.append('foo', 'bar')
+    formData.append('foo', 'baz')
+    expect(tf.stringify(formData)).toMatchInlineSnapshot(
+      `"{"$formData":{"foo":["bar","baz"]}}"`,
     )
   })
 })
@@ -97,6 +105,18 @@ describe('transformer.parse', () => {
     expect([...parsed.entries()]).toEqual([
       ['foo', 'bar'],
       ['name', 'Sean'],
+    ])
+  })
+  it('should parse FormData with multiple values for the same key', () => {
+    const formData = new FormData()
+    formData.append('foo', 'bar')
+    formData.append('foo', 'baz')
+    const str = tf.stringify(formData)
+    const parsed = tf.parse(str) as FormData
+    expect(parsed).toBeInstanceOf(FormData)
+    expect([...parsed.entries()]).toEqual([
+      ['foo', 'bar'],
+      ['foo', 'baz'],
     ])
   })
 })


### PR DESCRIPTION
Also adds Error and FormData to the allowed list of "serializable" values in Typescript, and make createTransformer more helpful with its types.