### PR TITLE
Experiment with using findReferencedIdentifiers to avoid extra aggressive DCE

### DIFF
--- a/e2e/start/basic/app/routes/-server-fns/dead-code-fn-call.tsx
+++ b/e2e/start/basic/app/routes/-server-fns/dead-code-fn-call.tsx
@@ -1,0 +1,37 @@
+import { createServerFn } from '@tanstack/start'
+import { useState } from 'react'
+// by using this we make sure DCE still works - this errors when imported on the client
+import { getRequestHeader } from 'vinxi/http'
+
+function sideEffect() {
+  console.log('side effect')
+  return true
+}
+
+const serverFn = createServerFn().handler(() => {
+  // eslint-disable-next-line unused-imports/no-unused-vars
+  const test = sideEffect()
+  const header = getRequestHeader('X-Test')
+  return header
+})
+
+export function DeadCodeFnCall() {
+  const [serverFnOutput, setServerFnOutput] = useState<string>()
+  return (
+    <div className="p-2 border m-2 grid gap-2">
+      <h3>Dead code test</h3>
+      <p>Clicking the button should result in a console log on the server</p>
+      <p>Check the server logs for the message "side effect"</p>
+      <button
+        className="rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+        onClick={() =>
+          serverFn({ headers: { 'X-Test': 'hello' } }).then(setServerFnOutput)
+        }
+      >
+        Call Dead Code Fn
+      </button>
+      <h4>Server output</h4>
+      <pre>{serverFnOutput}</pre>
+    </div>
+  )
+}

--- a/e2e/start/basic/app/routes/-server-fns/dead-code-fn-call.tsx
+++ b/e2e/start/basic/app/routes/-server-fns/dead-code-fn-call.tsx
@@ -1,37 +1,55 @@
+import * as fs from 'node:fs'
 import { createServerFn } from '@tanstack/start'
 import { useState } from 'react'
 // by using this we make sure DCE still works - this errors when imported on the client
 import { getRequestHeader } from 'vinxi/http'
 
-function sideEffect() {
-  console.log('side effect')
+const filePath = 'count-effect.txt'
+
+async function readCount() {
+  return parseInt(
+    await fs.promises.readFile(filePath, 'utf-8').catch(() => '0'),
+  )
+}
+
+async function updateCount() {
+  const count = await readCount()
+  await fs.promises.writeFile(filePath, `${count + 1}`)
   return true
 }
 
-const serverFn = createServerFn().handler(() => {
+const writeFileServerFn = createServerFn().handler(async () => {
   // eslint-disable-next-line unused-imports/no-unused-vars
-  const test = sideEffect()
+  const test = await updateCount()
   const header = getRequestHeader('X-Test')
   return header
 })
 
+const readFileServerFn = createServerFn().handler(async () => {
+  const data = await readCount()
+  return data
+})
+
 export function DeadCodeFnCall() {
-  const [serverFnOutput, setServerFnOutput] = useState<string>()
+  const [serverFnOutput, setServerFnOutput] = useState<number>()
   return (
     <div className="p-2 border m-2 grid gap-2">
       <h3>Dead code test</h3>
-      <p>Clicking the button should result in a console log on the server</p>
-      <p>Check the server logs for the message "side effect"</p>
+      <p>
+        This server function writes to a file as a side effect, then reads it.
+      </p>
       <button
         className="rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
-        onClick={() =>
-          serverFn({ headers: { 'X-Test': 'hello' } }).then(setServerFnOutput)
-        }
+        data-testid="test-dead-code-fn-call-btn"
+        onClick={async () => {
+          await writeFileServerFn({ headers: { 'X-Test': 'test' } })
+          setServerFnOutput(await readFileServerFn())
+        }}
       >
         Call Dead Code Fn
       </button>
       <h4>Server output</h4>
-      <pre>{serverFnOutput}</pre>
+      <pre data-testid="dead-code-fn-call-response">{serverFnOutput}</pre>
     </div>
   )
 }

--- a/e2e/start/basic/app/routes/server-fns.tsx
+++ b/e2e/start/basic/app/routes/server-fns.tsx
@@ -5,6 +5,7 @@ import { ConsistentServerFnCalls } from './-server-fns/consistent-fn-calls'
 import { MultipartServerFnCall } from './-server-fns/multipart-formdata-fn-call'
 import { AllowServerFnReturnNull } from './-server-fns/allow-fn-return-null'
 import { SerializeFormDataFnCall } from './-server-fns/serialize-formdata-fn-call'
+import { DeadCodeFnCall } from './-server-fns/dead-code-fn-call'
 
 export const Route = createFileRoute('/server-fns')({
   component: RouteComponent,
@@ -17,6 +18,7 @@ function RouteComponent() {
       <MultipartServerFnCall />
       <AllowServerFnReturnNull />
       <SerializeFormDataFnCall />
+      <DeadCodeFnCall />
     </>
   )
 }

--- a/e2e/start/basic/tests/base.spec.ts
+++ b/e2e/start/basic/tests/base.spec.ts
@@ -243,3 +243,17 @@ test('Server function can correctly send and receive FormData', async ({
     page.getByTestId('serialize-formdata-form-response'),
   ).toContainText(expected)
 })
+
+test("server function's dead code is preserved if already there", async ({
+  page,
+}) => {
+  await page.goto('/server-fns')
+
+  await page.waitForLoadState('networkidle')
+  await page.getByTestId('test-dead-code-fn-call-btn').click()
+  await page.waitForLoadState('networkidle')
+
+  await expect(page.getByTestId('dead-code-fn-call-response')).toContainText(
+    '1',
+  )
+})

--- a/packages/start-vite-plugin/package.json
+++ b/packages/start-vite-plugin/package.json
@@ -79,6 +79,7 @@
     "@babel/parser": "^7.26.3",
     "@babel/plugin-syntax-typescript": "^7.25.9",
     "@babel/traverse": "^7.26.4",
-    "@babel/types": "^7.26.3"
+    "@babel/types": "^7.26.3",
+    "rollup": "^4.0.0"
   }
 }

--- a/packages/start-vite-plugin/tests/createIsomorphicFn/createIsomorphicFn.test.ts
+++ b/packages/start-vite-plugin/tests/createIsomorphicFn/createIsomorphicFn.test.ts
@@ -36,14 +36,14 @@ describe('createIsomorphicFn compiles correctly', async () => {
     test.each(['client', 'server'] as const)(
       `should compile for ${filename} %s`,
       async (env) => {
-        const compiledResult = compileStartOutput({
+        const { compiled } = compileStartOutput({
           env,
           code,
           root: './test-files',
           filename,
         })
 
-        await expect(compiledResult.code).toMatchFileSnapshot(
+        await expect(compiled.code).toMatchFileSnapshot(
           `./snapshots/${env}/${filename}`,
         )
       },

--- a/packages/start-vite-plugin/tests/createMiddleware/createMiddleware.test.ts
+++ b/packages/start-vite-plugin/tests/createMiddleware/createMiddleware.test.ts
@@ -20,14 +20,14 @@ describe('createMiddleware compiles correctly', async () => {
     test.each(['client', 'server'] as const)(
       `should compile for ${filename} %s`,
       async (env) => {
-        const compiledResult = compileStartOutput({
+        const { compiled } = compileStartOutput({
           env,
           code,
           root: './test-files',
           filename,
         })
 
-        await expect(compiledResult.code).toMatchFileSnapshot(
+        await expect(compiled.code).toMatchFileSnapshot(
           `./snapshots/${env}/${filename}`,
         )
       },

--- a/packages/start-vite-plugin/tests/createServerFn/createServerFn.test.ts
+++ b/packages/start-vite-plugin/tests/createServerFn/createServerFn.test.ts
@@ -20,14 +20,14 @@ describe('createServerFn compiles correctly', async () => {
     test.each(['client', 'server'] as const)(
       `should compile for ${filename} %s`,
       async (env) => {
-        const compiledResult = compileStartOutput({
+        const { compiled } = compileStartOutput({
           env,
           code,
           root: './test-files',
           filename,
         })
 
-        await expect(compiledResult.code).toMatchFileSnapshot(
+        await expect(compiled.code).toMatchFileSnapshot(
           `./snapshots/${env}/${filename}`,
         )
       },

--- a/packages/start-vite-plugin/tests/envOnly/envOnly.test.ts
+++ b/packages/start-vite-plugin/tests/envOnly/envOnly.test.ts
@@ -20,14 +20,14 @@ describe('envOnly functions compile correctly', async () => {
     test.each(['client', 'server'] as const)(
       `should compile for ${filename} %s`,
       async (env) => {
-        const compiledResult = compileStartOutput({
+        const { compiled } = compileStartOutput({
           env,
           code,
           root: './test-files',
           filename,
         })
 
-        await expect(compiledResult.code).toMatchFileSnapshot(
+        await expect(compiled.code).toMatchFileSnapshot(
           `./snapshots/${env}/${filename}`,
         )
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3706,6 +3706,9 @@ importers:
       babel-dead-code-elimination:
         specifier: ^1.0.8
         version: 1.0.8
+      rollup:
+        specifier: ^4.0.0
+        version: 4.29.1
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3
@@ -5494,19 +5497,9 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.28.0':
-    resolution: {integrity: sha512-wLJuPLT6grGZsy34g4N1yRfYeouklTgPhH1gWXCYspenKYD0s3cR99ZevOGw5BexMNywkbV3UkjADisozBmpPQ==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm-eabi@4.29.1':
     resolution: {integrity: sha512-ssKhA8RNltTZLpG6/QNkCSge+7mBQGUqJRisZ2MDQcEGaK93QESEgWK2iOpIDZ7k9zPVkG5AS3ksvD5ZWxmItw==}
     cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.28.0':
-    resolution: {integrity: sha512-eiNkznlo0dLmVG/6wf+Ifi/v78G4d4QxRhuUl+s8EWZpDewgk7PX3ZyECUXU0Zq/Ca+8nU8cQpNC4Xgn2gFNDA==}
-    cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.29.1':
@@ -5514,19 +5507,9 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.28.0':
-    resolution: {integrity: sha512-lmKx9yHsppblnLQZOGxdO66gT77bvdBtr/0P+TPOseowE7D9AJoBw8ZDULRasXRWf1Z86/gcOdpBrV6VDUY36Q==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.29.1':
     resolution: {integrity: sha512-2ORr7T31Y0Mnk6qNuwtyNmy14MunTAMx06VAPI6/Ju52W10zk1i7i5U3vlDRWjhOI5quBcrvhkCHyF76bI7kEw==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.28.0':
-    resolution: {integrity: sha512-8hxgfReVs7k9Js1uAIhS6zq3I+wKQETInnWQtgzt8JfGx51R1N6DRVy3F4o0lQwumbErRz52YqwjfvuwRxGv1w==}
-    cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.29.1':
@@ -5534,19 +5517,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.28.0':
-    resolution: {integrity: sha512-lA1zZB3bFx5oxu9fYud4+g1mt+lYXCoch0M0V/xhqLoGatbzVse0wlSQ1UYOWKpuSu3gyN4qEc0Dxf/DII1bhQ==}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@rollup/rollup-freebsd-arm64@4.29.1':
     resolution: {integrity: sha512-91C//G6Dm/cv724tpt7nTyP+JdN12iqeXGFM1SqnljCmi5yTXriH7B1r8AD9dAZByHpKAumqP1Qy2vVNIdLZqw==}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.28.0':
-    resolution: {integrity: sha512-aI2plavbUDjCQB/sRbeUZWX9qp12GfYkYSJOrdYTL/C5D53bsE2/nBPuoiJKoWp5SN78v2Vr8ZPnB+/VbQ2pFA==}
-    cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.29.1':
@@ -5554,18 +5527,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.28.0':
-    resolution: {integrity: sha512-WXveUPKtfqtaNvpf0iOb0M6xC64GzUX/OowbqfiCSXTdi/jLlOmH0Ba94/OkiY2yTGTwteo4/dsHRfh5bDCZ+w==}
-    cpu: [arm]
-    os: [linux]
-
   '@rollup/rollup-linux-arm-gnueabihf@4.29.1':
     resolution: {integrity: sha512-Py5vFd5HWYN9zxBv3WMrLAXY3yYJ6Q/aVERoeUFwiDGiMOWsMs7FokXihSOaT/PMWUty/Pj60XDQndK3eAfE6A==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.28.0':
-    resolution: {integrity: sha512-yLc3O2NtOQR67lI79zsSc7lk31xjwcaocvdD1twL64PK1yNaIqCeWI9L5B4MFPAVGEVjH5k1oWSGuYX1Wutxpg==}
     cpu: [arm]
     os: [linux]
 
@@ -5574,18 +5537,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.28.0':
-    resolution: {integrity: sha512-+P9G9hjEpHucHRXqesY+3X9hD2wh0iNnJXX/QhS/J5vTdG6VhNYMxJ2rJkQOxRUd17u5mbMLHM7yWGZdAASfcg==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rollup/rollup-linux-arm64-gnu@4.29.1':
     resolution: {integrity: sha512-Z80O+taYxTQITWMjm/YqNoe9d10OX6kDh8X5/rFCMuPqsKsSyDilvfg+vd3iXIqtfmp+cnfL1UrYirkaF8SBZA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-musl@4.28.0':
-    resolution: {integrity: sha512-1xsm2rCKSTpKzi5/ypT5wfc+4bOGa/9yI/eaOLW0oMs7qpC542APWhl4A37AENGZ6St6GBMWhCCMM6tXgTIplw==}
     cpu: [arm64]
     os: [linux]
 
@@ -5599,19 +5552,9 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.28.0':
-    resolution: {integrity: sha512-zgWxMq8neVQeXL+ouSf6S7DoNeo6EPgi1eeqHXVKQxqPy1B2NvTbaOUWPn/7CfMKL7xvhV0/+fq/Z/J69g1WAQ==}
-    cpu: [ppc64]
-    os: [linux]
-
   '@rollup/rollup-linux-powerpc64le-gnu@4.29.1':
     resolution: {integrity: sha512-9b4Mg5Yfz6mRnlSPIdROcfw1BU22FQxmfjlp/CShWwO3LilKQuMISMTtAu/bxmmrE6A902W2cZJuzx8+gJ8e9w==}
     cpu: [ppc64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.28.0':
-    resolution: {integrity: sha512-VEdVYacLniRxbRJLNtzwGt5vwS0ycYshofI7cWAfj7Vg5asqj+pt+Q6x4n+AONSZW/kVm+5nklde0qs2EUwU2g==}
-    cpu: [riscv64]
     os: [linux]
 
   '@rollup/rollup-linux-riscv64-gnu@4.29.1':
@@ -5619,28 +5562,13 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.28.0':
-    resolution: {integrity: sha512-LQlP5t2hcDJh8HV8RELD9/xlYtEzJkm/aWGsauvdO2ulfl3QYRjqrKW+mGAIWP5kdNCBheqqqYIGElSRCaXfpw==}
-    cpu: [s390x]
-    os: [linux]
-
   '@rollup/rollup-linux-s390x-gnu@4.29.1':
     resolution: {integrity: sha512-WM9lIkNdkhVwiArmLxFXpWndFGuOka4oJOZh8EP3Vb8q5lzdSCBuhjavJsw68Q9AKDGeOOIHYzYm4ZFvmWez5g==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.28.0':
-    resolution: {integrity: sha512-Nl4KIzteVEKE9BdAvYoTkW19pa7LR/RBrT6F1dJCV/3pbjwDcaOq+edkP0LXuJ9kflW/xOK414X78r+K84+msw==}
-    cpu: [x64]
-    os: [linux]
-
   '@rollup/rollup-linux-x64-gnu@4.29.1':
     resolution: {integrity: sha512-87xYCwb0cPGZFoGiErT1eDcssByaLX4fc0z2nRM6eMtV9njAfEE6OW3UniAoDhX4Iq5xQVpE6qO9aJbCFumKYQ==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-musl@4.28.0':
-    resolution: {integrity: sha512-eKpJr4vBDOi4goT75MvW+0dXcNUqisK4jvibY9vDdlgLx+yekxSm55StsHbxUsRxSTt3JEQvlr3cGDkzcSP8bw==}
     cpu: [x64]
     os: [linux]
 
@@ -5649,29 +5577,14 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.28.0':
-    resolution: {integrity: sha512-Vi+WR62xWGsE/Oj+mD0FNAPY2MEox3cfyG0zLpotZdehPFXwz6lypkGs5y38Jd/NVSbOD02aVad6q6QYF7i8Bg==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-arm64-msvc@4.29.1':
     resolution: {integrity: sha512-F2OiJ42m77lSkizZQLuC+jiZ2cgueWQL5YC9tjo3AgaEw+KJmVxHGSyQfDUoYR9cci0lAywv2Clmckzulcq6ig==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.28.0':
-    resolution: {integrity: sha512-kN/Vpip8emMLn/eOza+4JwqDZBL6MPNpkdaEsgUtW1NYN3DZvZqSQrbKzJcTL6hd8YNmFTn7XGWMwccOcJBL0A==}
-    cpu: [ia32]
-    os: [win32]
-
   '@rollup/rollup-win32-ia32-msvc@4.29.1':
     resolution: {integrity: sha512-rYRe5S0FcjlOBZQHgbTKNrqxCBUmgDJem/VQTCcTnA2KCabYSWQDrytOzX7avb79cAAweNmMUb/Zw18RNd4mng==}
     cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.28.0':
-    resolution: {integrity: sha512-Bvno2/aZT6usSa7lRDL2+hMjVAGjuqaymF1ApZm31JXzniR/hvr14jpU+/z4X6Gt5BPlzosscyJZGUvguXIqeQ==}
-    cpu: [x64]
     os: [win32]
 
   '@rollup/rollup-win32-x64-msvc@4.29.1':
@@ -9901,11 +9814,6 @@ packages:
       rollup:
         optional: true
 
-  rollup@4.28.0:
-    resolution: {integrity: sha512-G9GOrmgWHBma4YfCcX8PjH0qhXSdH8B4HDE2o4/jaxj93S4DPCIDoLcXz99eWMji4hB29UFCEd7B2gwGJDR9cQ==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-
   rollup@4.29.1:
     resolution: {integrity: sha512-RaJ45M/kmJUzSWDs1Nnd5DdV4eerC98idtUOVr6FfKcgxqvjwHmxc5upLF9qZU9EpsVzzhleFahrT3shLuJzIw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -12637,10 +12545,6 @@ snapshots:
       - encoding
       - supports-color
 
-  '@rollup/plugin-alias@5.1.1(rollup@4.28.0)':
-    optionalDependencies:
-      rollup: 4.28.0
-
   '@rollup/plugin-alias@5.1.1(rollup@4.29.1)':
     optionalDependencies:
       rollup: 4.29.1
@@ -12656,18 +12560,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rollup/plugin-commonjs@28.0.1(rollup@4.28.0)':
-    dependencies:
-      '@rollup/pluginutils': 5.1.3(rollup@4.28.0)
-      commondir: 1.0.1
-      estree-walker: 2.0.2
-      fdir: 6.4.2(picomatch@4.0.2)
-      is-reference: 1.2.1
-      magic-string: 0.30.14
-      picomatch: 4.0.2
-    optionalDependencies:
-      rollup: 4.28.0
-
   '@rollup/plugin-commonjs@28.0.1(rollup@4.29.1)':
     dependencies:
       '@rollup/pluginutils': 5.1.3(rollup@4.29.1)
@@ -12680,35 +12572,19 @@ snapshots:
     optionalDependencies:
       rollup: 4.29.1
 
-  '@rollup/plugin-inject@5.0.5(rollup@4.28.0)':
+  '@rollup/plugin-inject@5.0.5(rollup@4.29.1)':
     dependencies:
-      '@rollup/pluginutils': 5.1.3(rollup@4.28.0)
+      '@rollup/pluginutils': 5.1.3(rollup@4.29.1)
       estree-walker: 2.0.2
       magic-string: 0.30.14
     optionalDependencies:
-      rollup: 4.28.0
-
-  '@rollup/plugin-json@6.1.0(rollup@4.28.0)':
-    dependencies:
-      '@rollup/pluginutils': 5.1.3(rollup@4.28.0)
-    optionalDependencies:
-      rollup: 4.28.0
+      rollup: 4.29.1
 
   '@rollup/plugin-json@6.1.0(rollup@4.29.1)':
     dependencies:
       '@rollup/pluginutils': 5.1.3(rollup@4.29.1)
     optionalDependencies:
       rollup: 4.29.1
-
-  '@rollup/plugin-node-resolve@15.3.0(rollup@4.28.0)':
-    dependencies:
-      '@rollup/pluginutils': 5.1.3(rollup@4.28.0)
-      '@types/resolve': 1.20.2
-      deepmerge: 4.3.1
-      is-module: 1.0.0
-      resolve: 1.22.8
-    optionalDependencies:
-      rollup: 4.28.0
 
   '@rollup/plugin-node-resolve@15.3.0(rollup@4.29.1)':
     dependencies:
@@ -12720,13 +12596,6 @@ snapshots:
     optionalDependencies:
       rollup: 4.29.1
 
-  '@rollup/plugin-replace@6.0.1(rollup@4.28.0)':
-    dependencies:
-      '@rollup/pluginutils': 5.1.3(rollup@4.28.0)
-      magic-string: 0.30.14
-    optionalDependencies:
-      rollup: 4.28.0
-
   '@rollup/plugin-replace@6.0.1(rollup@4.29.1)':
     dependencies:
       '@rollup/pluginutils': 5.1.3(rollup@4.29.1)
@@ -12734,21 +12603,13 @@ snapshots:
     optionalDependencies:
       rollup: 4.29.1
 
-  '@rollup/plugin-terser@0.4.4(rollup@4.28.0)':
+  '@rollup/plugin-terser@0.4.4(rollup@4.29.1)':
     dependencies:
       serialize-javascript: 6.0.2
       smob: 1.5.0
       terser: 5.36.0
     optionalDependencies:
-      rollup: 4.28.0
-
-  '@rollup/pluginutils@5.1.3(rollup@4.28.0)':
-    dependencies:
-      '@types/estree': 1.0.6
-      estree-walker: 2.0.2
-      picomatch: 4.0.2
-    optionalDependencies:
-      rollup: 4.28.0
+      rollup: 4.29.1
 
   '@rollup/pluginutils@5.1.3(rollup@4.29.1)':
     dependencies:
@@ -12766,61 +12627,31 @@ snapshots:
     optionalDependencies:
       rollup: 4.29.1
 
-  '@rollup/rollup-android-arm-eabi@4.28.0':
-    optional: true
-
   '@rollup/rollup-android-arm-eabi@4.29.1':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.28.0':
     optional: true
 
   '@rollup/rollup-android-arm64@4.29.1':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.28.0':
-    optional: true
-
   '@rollup/rollup-darwin-arm64@4.29.1':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.28.0':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.29.1':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.28.0':
-    optional: true
-
   '@rollup/rollup-freebsd-arm64@4.29.1':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.28.0':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.29.1':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.28.0':
-    optional: true
-
   '@rollup/rollup-linux-arm-gnueabihf@4.29.1':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.28.0':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.29.1':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.28.0':
-    optional: true
-
   '@rollup/rollup-linux-arm64-gnu@4.29.1':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.28.0':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.29.1':
@@ -12829,49 +12660,25 @@ snapshots:
   '@rollup/rollup-linux-loongarch64-gnu@4.29.1':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.28.0':
-    optional: true
-
   '@rollup/rollup-linux-powerpc64le-gnu@4.29.1':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-gnu@4.28.0':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.29.1':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.28.0':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.29.1':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.28.0':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.29.1':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.28.0':
-    optional: true
-
   '@rollup/rollup-linux-x64-musl@4.29.1':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.28.0':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.29.1':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.28.0':
-    optional: true
-
   '@rollup/rollup-win32-ia32-msvc@4.29.1':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.28.0':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.29.1':
@@ -13667,10 +13474,10 @@ snapshots:
       '@typescript-eslint/types': 8.18.2
       eslint-visitor-keys: 4.2.0
 
-  '@vercel/nft@0.27.7(rollup@4.28.0)':
+  '@vercel/nft@0.27.7(rollup@4.29.1)':
     dependencies:
       '@mapbox/node-pre-gyp': 1.0.11
-      '@rollup/pluginutils': 5.1.3(rollup@4.28.0)
+      '@rollup/pluginutils': 5.1.3(rollup@4.29.1)
       acorn: 8.14.0
       acorn-import-attributes: 1.9.5(acorn@8.14.0)
       async-sema: 3.1.1
@@ -16661,16 +16468,16 @@ snapshots:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.4
       '@netlify/functions': 2.8.2
-      '@rollup/plugin-alias': 5.1.1(rollup@4.28.0)
-      '@rollup/plugin-commonjs': 28.0.1(rollup@4.28.0)
-      '@rollup/plugin-inject': 5.0.5(rollup@4.28.0)
-      '@rollup/plugin-json': 6.1.0(rollup@4.28.0)
-      '@rollup/plugin-node-resolve': 15.3.0(rollup@4.28.0)
-      '@rollup/plugin-replace': 6.0.1(rollup@4.28.0)
-      '@rollup/plugin-terser': 0.4.4(rollup@4.28.0)
-      '@rollup/pluginutils': 5.1.3(rollup@4.28.0)
+      '@rollup/plugin-alias': 5.1.1(rollup@4.29.1)
+      '@rollup/plugin-commonjs': 28.0.1(rollup@4.29.1)
+      '@rollup/plugin-inject': 5.0.5(rollup@4.29.1)
+      '@rollup/plugin-json': 6.1.0(rollup@4.29.1)
+      '@rollup/plugin-node-resolve': 15.3.0(rollup@4.29.1)
+      '@rollup/plugin-replace': 6.0.1(rollup@4.29.1)
+      '@rollup/plugin-terser': 0.4.4(rollup@4.29.1)
+      '@rollup/pluginutils': 5.1.3(rollup@4.29.1)
       '@types/http-proxy': 1.17.15
-      '@vercel/nft': 0.27.7(rollup@4.28.0)
+      '@vercel/nft': 0.27.7(rollup@4.29.1)
       archiver: 7.0.1
       c12: 2.0.1(magicast@0.3.5)
       chokidar: 3.6.0
@@ -16712,8 +16519,8 @@ snapshots:
       pkg-types: 1.2.1
       pretty-bytes: 6.1.1
       radix3: 1.1.2
-      rollup: 4.28.0
-      rollup-plugin-visualizer: 5.12.0(rollup@4.28.0)
+      rollup: 4.29.1
+      rollup-plugin-visualizer: 5.12.0(rollup@4.29.1)
       scule: 1.3.0
       semver: 7.6.3
       serve-placeholder: 2.0.2
@@ -16723,7 +16530,7 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.3.1
       unenv: 1.10.0
-      unimport: 3.14.3(rollup@4.28.0)
+      unimport: 3.14.3(rollup@4.29.1)
       unstorage: 1.13.1(ioredis@5.4.1)
       untyped: 1.5.1
       unwasm: 0.3.9
@@ -17619,38 +17426,14 @@ snapshots:
       magic-string: 0.30.14
       rollup: 4.29.1
 
-  rollup-plugin-visualizer@5.12.0(rollup@4.28.0):
+  rollup-plugin-visualizer@5.12.0(rollup@4.29.1):
     dependencies:
       open: 8.4.2
       picomatch: 2.3.1
       source-map: 0.7.4
       yargs: 17.7.2
     optionalDependencies:
-      rollup: 4.28.0
-
-  rollup@4.28.0:
-    dependencies:
-      '@types/estree': 1.0.6
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.28.0
-      '@rollup/rollup-android-arm64': 4.28.0
-      '@rollup/rollup-darwin-arm64': 4.28.0
-      '@rollup/rollup-darwin-x64': 4.28.0
-      '@rollup/rollup-freebsd-arm64': 4.28.0
-      '@rollup/rollup-freebsd-x64': 4.28.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.28.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.28.0
-      '@rollup/rollup-linux-arm64-gnu': 4.28.0
-      '@rollup/rollup-linux-arm64-musl': 4.28.0
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.28.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.28.0
-      '@rollup/rollup-linux-s390x-gnu': 4.28.0
-      '@rollup/rollup-linux-x64-gnu': 4.28.0
-      '@rollup/rollup-linux-x64-musl': 4.28.0
-      '@rollup/rollup-win32-arm64-msvc': 4.28.0
-      '@rollup/rollup-win32-ia32-msvc': 4.28.0
-      '@rollup/rollup-win32-x64-msvc': 4.28.0
-      fsevents: 2.3.3
+      rollup: 4.29.1
 
   rollup@4.29.1:
     dependencies:
@@ -18414,9 +18197,9 @@ snapshots:
 
   unicorn-magic@0.1.0: {}
 
-  unimport@3.14.3(rollup@4.28.0):
+  unimport@3.14.3(rollup@4.29.1):
     dependencies:
-      '@rollup/pluginutils': 5.1.3(rollup@4.28.0)
+      '@rollup/pluginutils': 5.1.3(rollup@4.29.1)
       acorn: 8.14.0
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
@@ -18805,7 +18588,7 @@ snapshots:
     dependencies:
       esbuild: 0.24.2
       postcss: 8.4.49
-      rollup: 4.28.0
+      rollup: 4.29.1
     optionalDependencies:
       '@types/node': 22.10.1
       fsevents: 2.3.3
@@ -18818,7 +18601,7 @@ snapshots:
     dependencies:
       esbuild: 0.24.2
       postcss: 8.4.49
-      rollup: 4.28.0
+      rollup: 4.29.1
     optionalDependencies:
       '@types/node': 22.10.2
       fsevents: 2.3.3


### PR DESCRIPTION
this is pretty messy currently, but the idea based on https://github.com/pcattori/babel-dead-code-elimination/issues/34#issuecomment-2585541436 is to find some way of getting the referenced identifiers *before* Start does any transformations, so it can use them when doing dead code elimination. this would mean that the only dead code that gets eliminated is any that wasn't there before Start.

I also have no idea how to test that a server side effect happened in Playwright, so that'll be a fun hurdle to cross.

from research i have basically found two "accepted" ways of communicating between plugins:

- attaching things to `options` in one plugin and getting them out in the other
- exposing methods on one plugin and finding the plugin from the other using buildStart

This PR currently uses the first, because buildStart seems to be receiving an empty object in my tests.