### PR TITLE
docs(router): require the use of React's `createRoot` function

### DIFF
--- a/docs/framework/react/installation.md
+++ b/docs/framework/react/installation.md
@@ -22,6 +22,7 @@ TanStack Router is currently only compatible with React and ReactDOM. If you wou
 
 - React v18.x.x
 - ReactDOM v18.x.x
+  - Note that `ReactDOM.createRoot` is also required and the legacy `render` function is not supported.
 - TypeScript >= v5.3.x (TypeScript is optional, but recommended)
   - We aim to support the last five minor versions of TypeScript. If you are using an older version, you may run into issues. Please upgrade to the latest version of TypeScript to ensure compatibility.
   - We may drop support for older versions of TypeScript, outside of the range mentioned above, without warning in a minor or patch release.

--- a/docs/framework/react/installation.md
+++ b/docs/framework/react/installation.md
@@ -22,7 +22,8 @@ TanStack Router is currently only compatible with React and ReactDOM. If you wou
 
 - React v18.x.x
 - ReactDOM v18.x.x
-  - Note that `ReactDOM.createRoot` is also required and the legacy `render` function is not supported.
+  - Note that `ReactDOM.createRoot` is required.
+  - The legacy `.render()` function is not supported.
 - TypeScript >= v5.3.x (TypeScript is optional, but recommended)
   - We aim to support the last five minor versions of TypeScript. If you are using an older version, you may run into issues. Please upgrade to the latest version of TypeScript to ensure compatibility.
   - We may drop support for older versions of TypeScript, outside of the range mentioned above, without warning in a minor or patch release.


### PR DESCRIPTION
While attempting to integrate Tanstack Router into an existing React 18 project which used the legacy `render` function, I've found that Tanstack Router requires use of React 18s concurrent renderer and does not function properly when using the legacy `render` function (example error while attempting to navigate, below). Updating one of the example projects to use the legacy `render` method also results in the error below being thrown on navigation.
- See this example repo for a reproduction: https://stackblitz.com/edit/tanstack-router-6idhfm1r?file=src%2Fmain.tsx

This updates the installation docs to call out this requirement.

<img width="770" alt="Screenshot 2025-01-12 at 5 32 03 PM" src="https://github.com/user-attachments/assets/b5a94cde-03ab-4547-88d2-080b8af84b08" />
