### PR TITLE
fix(start): discard stream controller errors when closed

### DIFF
--- a/packages/start/src/client/tsrScript.ts
+++ b/packages/start/src/client/tsrScript.ts
@@ -50,8 +50,16 @@ const __TSR__: StartTSRGlobal = {
             ex.value = new ReadableStream({
               start(c) {
                 controller = {
-                  enqueue: (chunk: unknown) => { try { c.enqueue(chunk); } catch {} },
-                  close: () => { try { c.close(); } catch {} },
+                  enqueue: (chunk: unknown) => {
+                    try {
+                      c.enqueue(chunk)
+                    } catch {}
+                  },
+                  close: () => {
+                    try {
+                      c.close()
+                    } catch {}
+                  },
                 }
               },
             })

--- a/packages/start/src/client/tsrScript.ts
+++ b/packages/start/src/client/tsrScript.ts
@@ -49,7 +49,10 @@ const __TSR__: StartTSRGlobal = {
             let controller
             ex.value = new ReadableStream({
               start(c) {
-                controller = c
+                controller = {
+                  enqueue: (chunk: unknown) => { try { c.enqueue(chunk); } catch {} },
+                  close: () => { try { c.close(); } catch {} },
+                }
               },
             })
             ex.value.controller = controller


### PR DESCRIPTION
### Stream Controller: try enqueue/close without throwing error

Both `controller.enqueue` and `controller.close` [throw an error if the stream has already been closed](https://streams.spec.whatwg.org/#rs-default-controller-prototype).

This could be the case because the reading side just doesn't have interest in more incoming values and has closed the stream on the reading side.

Up until now, this would cause an error to be thrown on the console once more chunks or a close request were streamed in.

This wraps `.close` and `.enqueue` in a `try..catch` block and disregards the result.

Reading the standard I don't see any possible other reasons for an error to be thrown, so this should be fine.