### PR TITLE
docs(router): fix docs related to parsed state

### DIFF
--- a/docs/framework/react/api/router.md
+++ b/docs/framework/react/api/router.md
@@ -60,6 +60,7 @@ title: Router API
   - [`MatchRouteOptions Type`](./router/MatchRouteOptionsType.md)
   - [`NavigateOptions Type`](./router/NavigateOptionsType.md)
   - [`NotFoundError Type`](./router/NotFoundErrorType.md)
+  - [`ParsedHistoryState Type`](./router/ParsedHistoryStateType.md)
   - [`ParsedLocation Type`](./router/ParsedLocationType.md)
   - [`Redirect Type`](./router/RedirectType.md)
   - [`Register Type`](./router/RegisterType.md)

--- a/docs/framework/react/api/router/ParsedHistoryStateType.md
+++ b/docs/framework/react/api/router/ParsedHistoryStateType.md
@@ -1,0 +1,13 @@
+---
+id: ParsedHistoryStateType
+title: ParsedHistoryState type
+---
+
+The `ParsedHistoryState` type represents a parsed state object. Additionally to `HistoryState`, it contains the index and the unique key of the route.
+
+```tsx
+export type ParsedHistoryState = HistoryState & {
+  key?: string
+  __TSR_index: number
+}
+```

--- a/docs/framework/react/api/router/ParsedLocationType.md
+++ b/docs/framework/react/api/router/ParsedLocationType.md
@@ -11,7 +11,7 @@ interface ParsedLocation {
   pathname: string
   search: TFullSearchSchema
   searchStr: string
-  state: HistoryState
+  state: ParsedHistoryState
   hash: string
   maskedLocation?: ParsedLocation
   unmaskOnReload?: boolean

--- a/docs/framework/react/api/router/historyStateInterface.md
+++ b/docs/framework/react/api/router/historyStateInterface.md
@@ -8,7 +8,10 @@ The `HistoryState` interface is an interface exported by the `history` package t
 You can extend this interface to add additional properties to the state object across your application.
 
 ```tsx
-interface HistoryState {
-  key: string // This is the unique ID for any given history entry
+declare module '@tanstack/react-router' {
+  interface HistoryState {
+    additionalRequiredProperty: number;
+    additionalProperty?: string;
+  }
 }
 ```

--- a/docs/framework/react/api/router/historyStateInterface.md
+++ b/docs/framework/react/api/router/historyStateInterface.md
@@ -8,7 +8,10 @@ The `HistoryState` interface is an interface exported by the `history` package t
 You can extend this interface to add additional properties to the state object across your application.
 
 ```tsx
+// src/main.tsx
 declare module '@tanstack/react-router' {
+  // ...
+
   interface HistoryState {
     additionalRequiredProperty: number
     additionalProperty?: string

--- a/docs/framework/react/api/router/historyStateInterface.md
+++ b/docs/framework/react/api/router/historyStateInterface.md
@@ -10,8 +10,8 @@ You can extend this interface to add additional properties to the state object a
 ```tsx
 declare module '@tanstack/react-router' {
   interface HistoryState {
-    additionalRequiredProperty: number;
-    additionalProperty?: string;
+    additionalRequiredProperty: number
+    additionalProperty?: string
   }
 }
 ```


### PR DESCRIPTION
Fixes docs for `ParsedLocation` type, adds docs for `ParsedHistoryState` type and clarifies how `HistoryState` interface should be extended

`HistoryState` should be extended in the `@tanstack/react-router` package, as trying to extend it in `@tanstack/history` might error due to the way package managers like pnpm structure the `node_modules/` folder.

![image](https://github.com/user-attachments/assets/2d593229-12eb-4efd-a215-eac9b647ee28)
