### PR TITLE
docs: Update build-from-scratch.md

### DIFF
--- a/docs/framework/react/start/build-from-scratch.md
+++ b/docs/framework/react/start/build-from-scratch.md
@@ -86,8 +86,17 @@ To tell Vinxi that it should start TanStack Start's minimal behavior, we need to
 ```typescript
 // app.config.ts
 import { defineConfig } from '@tanstack/start/config'
+import tsConfigPaths from "vite-tsconfig-paths";
 
-export default defineConfig({})
+export default defineConfig({
+    vite: {
+        plugins: [
+            tsConfigPaths({
+                projects: ["./tsconfig.json"],
+            }),
+        ],
+    },
+});
 ```
 
 ## Add the Basic Templating


### PR DESCRIPTION
When running `npm run dev`, vinxi fails with an error.

```
 ERROR  Cannot read properties of undefined (reading 'server')                             

    at createDevServer (node_modules/vinxi/lib/dev-server.js:111:27)
    at Object.run (node_modules/vinxi/bin/cli.mjs:186:23)
    at async runCommand (node_modules/citty/dist/index.mjs:316:16)
    at async runCommand (node_modules/citty/dist/index.mjs:307:11)
    at async runMain (node_modules/citty/dist/index.mjs:445:7) 

 ERROR  Cannot read properties of undefined (reading 'server')      
```

Copying these lines from the example projects `app.config.ts` fixes the issue.