### PR TITLE
cleanup(react-router) remove DehydrateRouter from tsconfig

### DIFF
--- a/packages/react-router/tsconfig.json
+++ b/packages/react-router/tsconfig.json
@@ -8,7 +8,6 @@
     "src",
     "tests",
     "vite.config.ts",
-    "eslint.config.ts",
-    "../start/src/client/DehydrateRouter.tsx"
+    "eslint.config.ts"
   ]
 }

--- a/packages/react-router/tsconfig.json
+++ b/packages/react-router/tsconfig.json
@@ -4,10 +4,5 @@
     "jsx": "react-jsx",
     "jsxImportSource": "react"
   },
-  "include": [
-    "src",
-    "tests",
-    "vite.config.ts",
-    "eslint.config.ts"
-  ]
+  "include": ["src", "tests", "vite.config.ts", "eslint.config.ts"]
 }


### PR DESCRIPTION
There's an unused reference to ../start from the react-router tsconfig.json