### PR TITLE
docs(router): update quickstart guide on when routeTree generation occurs

### DIFF
--- a/docs/framework/react/quick-start.md
+++ b/docs/framework/react/quick-start.md
@@ -135,7 +135,7 @@ function About() {
 
 #### `src/main.tsx`
 
-Regardless if you are using the `@tanstack/router-plugin` package and running `vite`/`npm run dev` or manually running the `tsr watch`/`tsr generate` commands from your package scripts, the following file will be generated for you at `src/routeTree.gen.ts`.
+Regardless of whether you are using the `@tanstack/router-plugin` package and running the `npm run dev`/`npm run build` scripts, or manually running the `tsr watch`/`tsr generate` commands from your package scripts, the following file will be generated for you at `src/routeTree.gen.ts`.
 
 Import the generated route tree and create a new router instance:
 

--- a/docs/framework/react/quick-start.md
+++ b/docs/framework/react/quick-start.md
@@ -135,7 +135,7 @@ function About() {
 
 #### `src/main.tsx`
 
-Regardless if you are using the `@tanstack/router-plugin` package or manually running the `tsr watch`/`tsr generate` commands from your package scripts, the following file will be generated for you at `src/routeTree.gen.ts`.
+Regardless if you are using the `@tanstack/router-plugin` package and running `vite`/`npm run dev` or manually running the `tsr watch`/`tsr generate` commands from your package scripts, the following file will be generated for you at `src/routeTree.gen.ts`.
 
 Import the generated route tree and create a new router instance:
 


### PR DESCRIPTION
Clarify when exactly will `src/routeTree.gen.ts` be generated.