### PR TITLE
fix(react-router): broken docs link on the deprecation of the NotFoundRoute API

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -732,7 +732,7 @@ export class Router<
   ) => {
     if (newOptions.notFoundRoute) {
       console.warn(
-        'The notFoundRoute API is deprecated and will be removed in the next major version. See https://tanstack.com/router/v1/docs/guide/not-found-errors#migrating-from-notfoundroute for more info.',
+        'The notFoundRoute API is deprecated and will be removed in the next major version. See https://tanstack.com/router/v1/docs/framework/react/guide/not-found-errors#migrating-from-notfoundroute for more info.',
       )
     }
 


### PR DESCRIPTION
Closes #3237 