### PR TITLE
docs(router): improve data mutations libraries list readability

### DIFF
--- a/docs/framework/react/guide/data-mutations.md
+++ b/docs/framework/react/guide/data-mutations.md
@@ -13,6 +13,8 @@ Look for and use mutation utilities that support:
 - Organizing mutation state as a globally accessible resource
 - Submission state history and garbage collection
 
+Some suggested libraries:
+
 - [TanStack Query](https://tanstack.com/query/latest/docs/react/guides/mutations)
 - [SWR](https://swr.vercel.app/)
 - [RTK Query](https://redux-toolkit.js.org/rtk-query/overview)


### PR DESCRIPTION
Tiny fix on this page, that empty space (L15) was breaking the markdown list

<details><summary>Before</summary>

![image](https://github.com/user-attachments/assets/e986acd1-992e-4082-924c-3bb08e46c87c)

</details> 

<details><summary>After</summary>

![image](https://github.com/user-attachments/assets/2a399b05-30bc-4028-97b0-ec3fef4f83da)

</details> 
