### PR TITLE
fix(react-router): improve error handling for module loading failures in lazyRouteComponent

### DIFF
--- a/packages/react-router/src/lazyRouteComponent.tsx
+++ b/packages/react-router/src/lazyRouteComponent.tsx
@@ -8,9 +8,14 @@ import type { AsyncRouteComponent } from './route'
 // URL to the lazy module.
 // In that case, we want to attempt one window refresh to get the latest.
 function isModuleNotFoundError(error: any): boolean {
+  // chrome: "Failed to fetch dynamically imported module: http://localhost:5173/src/routes/posts.index.tsx?tsr-split"
+  // firefox: "error loading dynamically imported module: http://localhost:5173/src/routes/posts.index.tsx?tsr-split"
+  // safari: "Importing a module script failed."
+  if (typeof error?.message !== 'string') return false
   return (
-    typeof error?.message === 'string' &&
-    /Failed to fetch dynamically imported module/.test(error.message)
+    error.message.startsWith('Failed to fetch dynamically imported module')
+    || error.message.startsWith('error loading dynamically imported module')
+    || error.message.startsWith('Importing a module script failed')
   )
 }
 
@@ -46,6 +51,7 @@ export function lazyRouteComponent<
   let loadPromise: Promise<any> | undefined
   let comp: T[TKey] | T['default']
   let error: any
+  let reload: boolean
 
   const load = () => {
     if (typeof document === 'undefined' && ssr?.() === false) {
@@ -59,7 +65,27 @@ export function lazyRouteComponent<
           comp = res[exportName ?? 'default']
         })
         .catch((err) => {
+          // We don't want an error thrown from preload in this case, because
+          // there's nothing we want to do about module not found during preload.
+          // Record the error, the rest is handled during the render path.
           error = err
+          if (isModuleNotFoundError(error)) {
+            if (
+              error instanceof Error &&
+              typeof window !== 'undefined' &&
+              typeof sessionStorage !== 'undefined'
+            ) {
+              // Again, we want to reload one time on module not found error and not enter
+              // a reload loop if there is some other issue besides an old deploy.
+              // That's why we store our reload attempt in sessionStorage.
+              // Use error.message as key because it contains the module path that failed.
+              const storageKey = `tanstack_router_reload:${error.message}`
+              if (!sessionStorage.getItem(storageKey)) {
+                sessionStorage.setItem(storageKey, '1')
+                reload = true
+              }
+            }
+          }
         })
     }
 
@@ -68,36 +94,13 @@ export function lazyRouteComponent<
 
   const lazyComp = function Lazy(props: any) {
     // Now that we're out of preload and into actual render path,
-    // throw the error if it was a module not found error during preload
+    if (reload) {
+      // If it was a module loading error,
+      // throw eternal suspense while we wait for window to reload
+      window.location.reload()
+      throw new Promise(() => {})
+    }
     if (error) {
-      if (isModuleNotFoundError(error)) {
-        // We don't want an error thrown from preload in this case, because
-        // there's nothing we want to do about module not found during preload.
-        // Record the error, recover the promise with a null return,
-        // and we will attempt module not found resolution during the render path.
-
-        if (
-          error instanceof Error &&
-          typeof window !== 'undefined' &&
-          typeof sessionStorage !== 'undefined'
-        ) {
-          // Again, we want to reload one time on module not found error and not enter
-          // a reload loop if there is some other issue besides an old deploy.
-          // That's why we store our reload attempt in sessionStorage.
-          // Use error.message as key because it contains the module path that failed.
-          const storageKey = `tanstack_router_reload:${error.message}`
-          if (!sessionStorage.getItem(storageKey)) {
-            sessionStorage.setItem(storageKey, '1')
-            window.location.reload()
-
-            // Return empty component while we wait for window to reload
-            return {
-              default: () => null,
-            }
-          }
-        }
-      }
-
       // Otherwise, just throw the error
       throw error
     }

--- a/packages/react-router/src/lazyRouteComponent.tsx
+++ b/packages/react-router/src/lazyRouteComponent.tsx
@@ -13,9 +13,9 @@ function isModuleNotFoundError(error: any): boolean {
   // safari: "Importing a module script failed."
   if (typeof error?.message !== 'string') return false
   return (
-    error.message.startsWith('Failed to fetch dynamically imported module')
-    || error.message.startsWith('error loading dynamically imported module')
-    || error.message.startsWith('Importing a module script failed')
+    error.message.startsWith('Failed to fetch dynamically imported module') ||
+    error.message.startsWith('error loading dynamically imported module') ||
+    error.message.startsWith('Importing a module script failed')
   )
 }
 


### PR DESCRIPTION
Issues currently on main for `lazyRouteComponent`:
1. The placeholder `ReactNode` used "while we wait for the page to reload" is not a valid react node
    ```tsx
    return {
      default: () => null,
    }
    ```
    Based on the comment messages around, and the git history, I'm assuming this is a typo brought from when error handling was done at the module loading level instead of in-render (see https://github.com/TanStack/router/commit/e5e80afbaa30d1581cafc1cbddd5022dba646c4b). There are 2 options now:
      - `return null`
      - `throw new Promise(() => {})`

     My vote would go towards the suspense one, because this is the least likely to flash content before the page reloads, and instead will continue the loading state already triggered by the navigation that brought us here.

2. If the component re-renders "while we wait for the page to reload", the `sessionStorage` condition won't be met a 2nd time and we throw the error.
    ```tsx
    // inside `Lazy` component
    if (!sessionStorage.getItem(storageKey)) {
      sessionStorage.setItem(storageKey, '1')
      window.location.reload()
    ```
    If `Lazy` re-renders, this condition won't be met the 2nd time around because we wrote to `sessionStorage`. This means that upon re-render, we're throwing the initial `error` that we were currently handling.
    I'm not 100% sure a re-render is *possible* here, so maybe there's not need to worry

3. The technique used to differentiate a "module loading error" vs any other kind of error is only compatible with chromium browsers. Each browser throws a different error, because the specs say "rejects with an *implementation-defined* error":
    ```
    chrome: "Failed to fetch dynamically imported module: http://localhost:5173/src/routes/posts.index.tsx?tsr-split"
    firefox: "error loading dynamically imported module: http://localhost:5173/src/routes/posts.index.tsx?tsr-split"
    safari: "Importing a module script failed."
    ```
    So the `isModuleNotFoundError` implementation needs to be updated to handle those 3 types of errors.

4. The key used for `sessionStorage` is not *always* unique to a specific file. As per the previous point, Safari does not include the imported module name anywhere (that I could see) in the `Error` object. So in the case of Safari, a user session can span across 1 deployment, but not 2 as the 2nd time we encounter a module loading issue we won't reload the page.

    I do not have a good solution for this:
    - It feels like the `lazyRouteComponent` function would have to take in the module name as a 4th param, but then we have to play with bundler stuff to obtain the module name and that's complicated.
    - ~~Alternatively, maybe there's something to be done with a `useId` inside the `Lazy` component, since this is supposed to be stable across reloads IIRC~~ After inspection, `useId` is not stable in this context, so it's not a possible solution to this problem