### PR TITLE
fix(start): ensure generic h3 functions remain generic, including new overloads

### DIFF
--- a/packages/start-server-functions-ssr/src/index.tsx
+++ b/packages/start-server-functions-ssr/src/index.tsx
@@ -20,11 +20,12 @@ export const createSsrRpc: CreateRpcFn = (functionId, serverBase) => {
       const event = getEvent()
       const mergedHeaders = mergeHeaders(
         res.headers,
-        event.___ssrRpcResponseHeaders,
+        (event as any).___ssrRpcResponseHeaders,
       )
+
       // any response headers set in the server function need to be set on the document response
       // we attach the headers to the event so we can later set them
-      event.___ssrRpcResponseHeaders = mergedHeaders
+      ;(event as any).___ssrRpcResponseHeaders = mergedHeaders
       return res
     })
   }

--- a/packages/start-server/src/index.tsx
+++ b/packages/start-server/src/index.tsx
@@ -68,7 +68,13 @@ import {
   writeEarlyHints as _writeEarlyHints,
 } from 'h3'
 import { getContext as getUnctxContext } from 'unctx'
-import type { _RequestMiddleware, _ResponseMiddleware } from 'h3'
+import type {
+  Encoding,
+  HTTPHeaderName,
+  InferEventInput,
+  _RequestMiddleware,
+  _ResponseMiddleware,
+} from 'h3'
 
 export { StartServer } from './StartServer'
 export { createStartHandler } from './createStartHandler'
@@ -237,11 +243,22 @@ export function isEvent(obj: any) {
   // Implement logic to check if obj is an H3Event
 }
 
-type WrapFunction<TFn extends (...args: Array<any>) => any> = (
-  ...args: Parameters<TFn> extends [H3Event, ...infer TArgs]
-    ? TArgs | Parameters<TFn>
-    : Parameters<TFn>
-) => ReturnType<TFn>
+type Tail<T> = T extends [any, ...infer U] ? U : never
+
+type PrependOverload<
+  TOriginal extends (...args: Array<any>) => any,
+  TOverload extends (...args: Array<any>) => any,
+> = TOverload & TOriginal
+
+// add an overload to the function without the event argument
+type WrapFunction<TFn extends (...args: Array<any>) => any> = PrependOverload<
+  TFn,
+  (
+    ...args: Parameters<TFn> extends [H3Event, ...infer TArgs]
+      ? TArgs
+      : Parameters<TFn>
+  ) => ReturnType<TFn>
+>
 
 function createWrapperFunction<TFn extends (...args: Array<any>) => any>(
   h3Function: TFn,
@@ -269,21 +286,56 @@ function createWrapperFunction<TFn extends (...args: Array<any>) => any>(
     }
 
     return (h3Function as any)(...args)
-  }
+  } as any
 }
 
 // Creating wrappers for each utility and exporting them with their original names
-export const readRawBody = createWrapperFunction(_readRawBody)
-export const readBody = createWrapperFunction(_readBody)
-export const getQuery = createWrapperFunction(_getQuery)
+type WrappedReadRawBody = <TEncoding extends Encoding = 'utf8'>(
+  ...args: Tail<Parameters<typeof _readRawBody<TEncoding>>>
+) => ReturnType<typeof _readRawBody<TEncoding>>
+export const readRawBody: PrependOverload<
+  typeof _readRawBody,
+  WrappedReadRawBody
+> = createWrapperFunction(_readRawBody)
+type WrappedReadBody = <T, TEventInput = InferEventInput<'body', H3Event, T>>(
+  ...args: Tail<Parameters<typeof _readBody<T, H3Event, TEventInput>>>
+) => ReturnType<typeof _readBody<T, H3Event, TEventInput>>
+export const readBody: PrependOverload<typeof _readBody, WrappedReadBody> =
+  createWrapperFunction(_readBody)
+type WrappedGetQuery = <
+  T,
+  TEventInput = Exclude<InferEventInput<'query', H3Event, T>, undefined>,
+>(
+  ...args: Tail<Parameters<typeof _getQuery<T, H3Event, TEventInput>>>
+) => ReturnType<typeof _getQuery<T, H3Event, TEventInput>>
+export const getQuery: PrependOverload<typeof _getQuery, WrappedGetQuery> =
+  createWrapperFunction(_getQuery)
 export const isMethod = createWrapperFunction(_isMethod)
 export const isPreflightRequest = createWrapperFunction(_isPreflightRequest)
-export const getValidatedQuery = createWrapperFunction(_getValidatedQuery)
+type WrappedGetValidatedQuery = <
+  T,
+  TEventInput = InferEventInput<'query', H3Event, T>,
+>(
+  ...args: Tail<Parameters<typeof _getValidatedQuery<T, H3Event, TEventInput>>>
+) => ReturnType<typeof _getValidatedQuery<T, H3Event, TEventInput>>
+export const getValidatedQuery: PrependOverload<
+  typeof _getValidatedQuery,
+  WrappedGetValidatedQuery
+> = createWrapperFunction(_getValidatedQuery)
 export const getRouterParams = createWrapperFunction(_getRouterParams)
 export const getRouterParam = createWrapperFunction(_getRouterParam)
-export const getValidatedRouterParams = createWrapperFunction(
-  _getValidatedRouterParams,
-)
+type WrappedGetValidatedRouterParams = <
+  T,
+  TEventInput = InferEventInput<'routerParams', H3Event, T>,
+>(
+  ...args: Tail<
+    Parameters<typeof _getValidatedRouterParams<T, H3Event, TEventInput>>
+  >
+) => ReturnType<typeof _getValidatedRouterParams<T, H3Event, TEventInput>>
+export const getValidatedRouterParams: PrependOverload<
+  typeof _getValidatedRouterParams,
+  WrappedGetValidatedRouterParams
+> = createWrapperFunction(_getValidatedRouterParams)
 export const assertMethod = createWrapperFunction(_assertMethod)
 export const getRequestHeaders = createWrapperFunction(_getRequestHeaders)
 export const getRequestHeader = createWrapperFunction(_getRequestHeader)
@@ -301,11 +353,23 @@ export const getResponseStatusText = createWrapperFunction(
 export const getResponseHeaders = createWrapperFunction(_getResponseHeaders)
 export const getResponseHeader = createWrapperFunction(_getResponseHeader)
 export const setResponseHeaders = createWrapperFunction(_setResponseHeaders)
-export const setResponseHeader = createWrapperFunction(_setResponseHeader)
+type WrappedSetResponseHeader = <T extends HTTPHeaderName>(
+  ...args: Tail<Parameters<typeof _setResponseHeader<T>>>
+) => ReturnType<typeof _setResponseHeader<T>>
+export const setResponseHeader: PrependOverload<
+  typeof _setResponseHeader,
+  WrappedSetResponseHeader
+> = createWrapperFunction(_setResponseHeader)
 export const appendResponseHeaders = createWrapperFunction(
   _appendResponseHeaders,
 )
-export const appendResponseHeader = createWrapperFunction(_appendResponseHeader)
+type WrappedAppendResponseHeader = <T extends HTTPHeaderName>(
+  ...args: Tail<Parameters<typeof _appendResponseHeader<T>>>
+) => ReturnType<typeof _appendResponseHeader<T>>
+export const appendResponseHeader: PrependOverload<
+  typeof _appendResponseHeader,
+  WrappedAppendResponseHeader
+> = createWrapperFunction(_appendResponseHeader)
 export const defaultContentType = createWrapperFunction(_defaultContentType)
 export const sendRedirect = createWrapperFunction(_sendRedirect)
 export const sendStream = createWrapperFunction(_sendStream)
@@ -313,7 +377,17 @@ export const writeEarlyHints = createWrapperFunction(_writeEarlyHints)
 export const sendError = createWrapperFunction(_sendError)
 export const sendProxy = createWrapperFunction(_sendProxy)
 export const proxyRequest = createWrapperFunction(_proxyRequest)
-export const fetchWithEvent = createWrapperFunction(_fetchWithEvent)
+type WrappedFetchWithEvent = <
+  T = unknown,
+  TResponse = any,
+  TFetch extends (req: RequestInfo | URL, opts?: any) => any = typeof fetch,
+>(
+  ...args: Tail<Parameters<typeof _fetchWithEvent<T, TResponse, TFetch>>>
+) => ReturnType<typeof _fetchWithEvent<T, TResponse, TFetch>>
+export const fetchWithEvent: PrependOverload<
+  typeof _fetchWithEvent,
+  WrappedFetchWithEvent
+> = createWrapperFunction(_fetchWithEvent)
 export const getProxyRequestHeaders = createWrapperFunction(
   _getProxyRequestHeaders,
 )
@@ -323,10 +397,37 @@ export const getCookie = createWrapperFunction(_getCookie)
 export const setCookie = createWrapperFunction(_setCookie)
 export const deleteCookie = createWrapperFunction(_deleteCookie)
 export const useBase = createWrapperFunction(_useBase)
-export const useSession = createWrapperFunction(_useSession)
-export const getSession = createWrapperFunction(_getSession)
-export const updateSession = createWrapperFunction(_updateSession)
-export const sealSession = createWrapperFunction(_sealSession)
+// not exported :(
+type SessionDataT = Record<string, any>
+type WrappedUseSession = <T extends SessionDataT>(
+  ...args: Tail<Parameters<typeof _useSession<T>>>
+) => ReturnType<typeof _useSession<T>>
+// we need to `as` these because the WrapFunction doesn't work for them
+// because they also accept CompatEvent instead of H3Event
+export const useSession = createWrapperFunction(_useSession) as PrependOverload<
+  typeof _useSession,
+  WrappedUseSession
+>
+type WrappedGetSession = <T extends SessionDataT>(
+  ...args: Tail<Parameters<typeof _getSession<T>>>
+) => ReturnType<typeof _getSession<T>>
+export const getSession = createWrapperFunction(_getSession) as PrependOverload<
+  typeof _getSession,
+  WrappedGetSession
+>
+type WrappedUpdateSession = <T extends SessionDataT>(
+  ...args: Tail<Parameters<typeof _updateSession<T>>>
+) => ReturnType<typeof _updateSession<T>>
+export const updateSession: PrependOverload<
+  typeof _updateSession,
+  WrappedUpdateSession
+> = createWrapperFunction(_updateSession)
+type WrappedSealSession = <T extends SessionDataT>(
+  ...args: Tail<Parameters<typeof _sealSession<T>>>
+) => ReturnType<typeof _sealSession<T>>
+export const sealSession = createWrapperFunction(
+  _sealSession,
+) as PrependOverload<typeof _sealSession, WrappedSealSession>
 export const unsealSession = createWrapperFunction(_unsealSession)
 export const clearSession = createWrapperFunction(_clearSession)
 export const handleCacheHeaders = createWrapperFunction(_handleCacheHeaders)
@@ -336,9 +437,19 @@ export const appendCorsPreflightHeaders = createWrapperFunction(
   _appendCorsPreflightHeaders,
 )
 export const sendWebResponse = createWrapperFunction(_sendWebResponse)
-export const appendHeader = createWrapperFunction(_appendHeader)
+type WrappedAppendHeader = <T extends HTTPHeaderName>(
+  ...args: Tail<Parameters<typeof _appendHeader<T>>>
+) => ReturnType<typeof _appendHeader<T>>
+export const appendHeader: PrependOverload<
+  typeof _appendHeader,
+  WrappedAppendHeader
+> = createWrapperFunction(_appendHeader)
 export const appendHeaders = createWrapperFunction(_appendHeaders)
-export const setHeader = createWrapperFunction(_setHeader)
+type WrappedSetHeader = <T extends HTTPHeaderName>(
+  ...args: Tail<Parameters<typeof _setHeader<T>>>
+) => ReturnType<typeof _setHeader<T>>
+export const setHeader: PrependOverload<typeof _setHeader, WrappedSetHeader> =
+  createWrapperFunction(_setHeader)
 export const setHeaders = createWrapperFunction(_setHeaders)
 export const getHeader = createWrapperFunction(_getHeader)
 export const getHeaders = createWrapperFunction(_getHeaders)
@@ -350,7 +461,16 @@ export const readFormData = createWrapperFunction(_readFormData)
 export const readMultipartFormData = createWrapperFunction(
   _readMultipartFormData,
 )
-export const readValidatedBody = createWrapperFunction(_readValidatedBody)
+type WrappedReadValidatedBody = <
+  T,
+  TEventInput = InferEventInput<'body', H3Event, T>,
+>(
+  ...args: Tail<Parameters<typeof _readValidatedBody<T, H3Event, TEventInput>>>
+) => ReturnType<typeof _readValidatedBody<T, H3Event, TEventInput>>
+export const readValidatedBody: PrependOverload<
+  typeof _readValidatedBody,
+  WrappedReadValidatedBody
+> = createWrapperFunction(_readValidatedBody)
 export const removeResponseHeader = createWrapperFunction(_removeResponseHeader)
 export const getContext = createWrapperFunction(_getContext)
 export const setContext = createWrapperFunction(_setContext)
@@ -374,7 +494,7 @@ function getNitroAsyncContext() {
 }
 
 export function getEvent() {
-  return (getNitroAsyncContext().use() as any).event
+  return (getNitroAsyncContext().use() as any).event as H3Event | undefined
 }
 
 export async function handleHTTPEvent(event: H3Event) {

--- a/packages/start-server/src/index.tsx
+++ b/packages/start-server/src/index.tsx
@@ -63,7 +63,6 @@ import {
   setResponseStatus as _setResponseStatus,
   unsealSession as _unsealSession,
   updateSession as _updateSession,
-  useBase as _useBase,
   useSession as _useSession,
   writeEarlyHints as _writeEarlyHints,
 } from 'h3'
@@ -175,6 +174,7 @@ export {
   createError,
   sanitizeStatusCode,
   sanitizeStatusMessage,
+  useBase,
   type AddRouteShortcuts,
   type App,
   type AppOptions,
@@ -392,7 +392,6 @@ export const parseCookies = createWrapperFunction(_parseCookies)
 export const getCookie = createWrapperFunction(_getCookie)
 export const setCookie = createWrapperFunction(_setCookie)
 export const deleteCookie = createWrapperFunction(_deleteCookie)
-export const useBase = createWrapperFunction(_useBase)
 // not exported :(
 type SessionDataT = Record<string, any>
 type WrappedUseSession = <T extends SessionDataT>(

--- a/packages/start-server/tests/h3-wrappers.test-d.ts
+++ b/packages/start-server/tests/h3-wrappers.test-d.ts
@@ -1,0 +1,84 @@
+import { test } from 'vitest'
+import * as h3 from 'h3'
+import * as tssServer from '../src'
+
+interface Foo {
+  a: string
+}
+
+type Tail<T> = T extends [any, ...infer U] ? U : never
+type PrependOverload<
+  TOriginal extends (...args: Array<any>) => any,
+  TOverload extends (...args: Array<any>) => any,
+> = TOverload & TOriginal
+
+function expectWrapperToMatchH3<TFn extends (...args: any) => any>(
+  _h3Function: TFn,
+  _tssFunction: PrependOverload<
+    TFn,
+    (...args: Tail<Parameters<TFn>>) => ReturnType<TFn>
+  >,
+) {
+  /* equivalent to:
+  expectTypeOf<Parameters<typeof h3Function>>().toMatchTypeOf<
+    OverloadParameters<typeof tssFunction>
+  >()
+  expectTypeOf<Tail<Parameters<typeof h3Function>>>().toMatchTypeOf<
+    OverloadParameters<typeof tssFunction>
+  >()
+
+  expectTypeOf(tssFunction).returns.toEqualTypeOf<
+    ReturnType<typeof h3Function>
+  >()
+  */
+}
+
+test('wrappers can be used with generics', () => {
+  expectWrapperToMatchH3(h3.readRawBody<'hex'>, tssServer.readRawBody<'hex'>)
+
+  expectWrapperToMatchH3(h3.readBody<Foo>, tssServer.readBody<Foo>)
+
+  expectWrapperToMatchH3(h3.getQuery<Foo>, tssServer.getQuery<Foo>)
+
+  expectWrapperToMatchH3(
+    h3.getValidatedQuery<Foo>,
+    tssServer.getValidatedQuery<Foo>,
+  )
+
+  expectWrapperToMatchH3(
+    h3.getValidatedRouterParams<Foo>,
+    tssServer.getValidatedRouterParams<Foo>,
+  )
+
+  expectWrapperToMatchH3(
+    h3.setResponseHeader<'Age'>,
+    tssServer.setResponseHeader<'Age'>,
+  )
+
+  expectWrapperToMatchH3(
+    h3.appendResponseHeader<'Age'>,
+    tssServer.appendResponseHeader<'Age'>,
+  )
+
+  expectWrapperToMatchH3(
+    h3.fetchWithEvent<Foo, Foo, typeof fetch>,
+    tssServer.fetchWithEvent<Foo, Foo, typeof fetch>,
+  )
+
+  expectWrapperToMatchH3(h3.useSession<Foo>, tssServer.useSession<Foo>)
+
+  expectWrapperToMatchH3(h3.getSession<Foo>, tssServer.getSession<Foo>)
+
+  expectWrapperToMatchH3(h3.updateSession<Foo>, tssServer.updateSession<Foo>)
+
+  expectWrapperToMatchH3(h3.sealSession<Foo>, tssServer.sealSession<Foo>)
+
+  expectWrapperToMatchH3(h3.appendHeader<'Age'>, tssServer.appendHeader<'Age'>)
+
+  expectWrapperToMatchH3(h3.setHeader<'Age'>, tssServer.setHeader<'Age'>)
+
+  expectWrapperToMatchH3(
+    h3.readValidatedBody<Foo>,
+    tssServer.readValidatedBody<Foo>,
+  )
+})

--- a/packages/start-server/tests/h3-wrappers.test-d.ts
+++ b/packages/start-server/tests/h3-wrappers.test-d.ts
@@ -6,20 +6,74 @@ interface Foo {
   a: string
 }
 
+type AnyFn = (...args: Array<any>) => any
+type Satisfies<T extends TConstraint, TConstraint> = T
 type Tail<T> = T extends [any, ...infer U] ? U : never
 type PrependOverload<
   TOriginal extends (...args: Array<any>) => any,
   TOverload extends (...args: Array<any>) => any,
 > = TOverload & TOriginal
 
-function expectWrapperToMatchH3<TFn extends (...args: any) => any>(
-  _h3Function: TFn,
-  _tssFunction: PrependOverload<
-    TFn,
-    (...args: Tail<Parameters<TFn>>) => ReturnType<TFn>
-  >,
-) {
-  /* equivalent to:
+type SharedKeys = keyof typeof tssServer & keyof typeof h3
+// things we're not wrapping
+type KeysToIgnore = Satisfies<
+  | 'H3Error'
+  | 'H3Event'
+  | 'MIMES'
+  | 'callNodeListener'
+  | 'createApp'
+  | 'createAppEventHandler'
+  | 'createError'
+  | 'createEvent'
+  | 'createRouter'
+  | 'defineEventHandler'
+  | 'defineLazyEventHandler'
+  | 'defineNodeListener'
+  | 'defineNodeMiddleware'
+  | 'defineRequestMiddleware'
+  | 'defineResponseMiddleware'
+  | 'defineWebSocket'
+  | 'dynamicEventHandler'
+  | 'eventHandler'
+  | 'fromNodeMiddleware'
+  | 'fromPlainHandler'
+  | 'fromWebHandler'
+  | 'isCorsOriginAllowed'
+  | 'isError'
+  | 'isEvent'
+  | 'isEventHandler'
+  | 'isStream'
+  | 'isWebResponse'
+  | 'lazyEventHandler'
+  | 'promisifyNodeListener'
+  | 'sanitizeStatusCode'
+  | 'sanitizeStatusMessage'
+  | 'serveStatic'
+  | 'splitCookiesString'
+  | 'toEventHandler'
+  | 'toNodeListener'
+  | 'toPlainHandler'
+  | 'toWebHandler'
+  | 'toWebRequest'
+  | 'useBase',
+  SharedKeys
+>
+
+function expectWrappersToMatchH3<
+  TFnMap extends Record<Exclude<SharedKeys, KeysToIgnore>, AnyFn>,
+>(_map: {
+  [K in keyof TFnMap]: {
+    h3: TFnMap[K]
+    tss: TFnMap[K] extends AnyFn
+      ? PrependOverload<
+          TFnMap[K],
+          (...args: Tail<Parameters<TFnMap[K]>>) => ReturnType<TFnMap[K]>
+        >
+      : never
+  }
+}) {
+  /* equivalent to the below for each key
+
   expectTypeOf<Parameters<typeof h3Function>>().toMatchTypeOf<
     OverloadParameters<typeof tssFunction>
   >()
@@ -30,55 +84,267 @@ function expectWrapperToMatchH3<TFn extends (...args: any) => any>(
   expectTypeOf(tssFunction).returns.toEqualTypeOf<
     ReturnType<typeof h3Function>
   >()
+    
   */
 }
 
-test('wrappers can be used with generics', () => {
-  expectWrapperToMatchH3(h3.readRawBody<'hex'>, tssServer.readRawBody<'hex'>)
-
-  expectWrapperToMatchH3(h3.readBody<Foo>, tssServer.readBody<Foo>)
-
-  expectWrapperToMatchH3(h3.getQuery<Foo>, tssServer.getQuery<Foo>)
-
-  expectWrapperToMatchH3(
-    h3.getValidatedQuery<Foo>,
-    tssServer.getValidatedQuery<Foo>,
-  )
-
-  expectWrapperToMatchH3(
-    h3.getValidatedRouterParams<Foo>,
-    tssServer.getValidatedRouterParams<Foo>,
-  )
-
-  expectWrapperToMatchH3(
-    h3.setResponseHeader<'Age'>,
-    tssServer.setResponseHeader<'Age'>,
-  )
-
-  expectWrapperToMatchH3(
-    h3.appendResponseHeader<'Age'>,
-    tssServer.appendResponseHeader<'Age'>,
-  )
-
-  expectWrapperToMatchH3(
-    h3.fetchWithEvent<Foo, Foo, typeof fetch>,
-    tssServer.fetchWithEvent<Foo, Foo, typeof fetch>,
-  )
-
-  expectWrapperToMatchH3(h3.useSession<Foo>, tssServer.useSession<Foo>)
-
-  expectWrapperToMatchH3(h3.getSession<Foo>, tssServer.getSession<Foo>)
-
-  expectWrapperToMatchH3(h3.updateSession<Foo>, tssServer.updateSession<Foo>)
-
-  expectWrapperToMatchH3(h3.sealSession<Foo>, tssServer.sealSession<Foo>)
-
-  expectWrapperToMatchH3(h3.appendHeader<'Age'>, tssServer.appendHeader<'Age'>)
-
-  expectWrapperToMatchH3(h3.setHeader<'Age'>, tssServer.setHeader<'Age'>)
-
-  expectWrapperToMatchH3(
-    h3.readValidatedBody<Foo>,
-    tssServer.readValidatedBody<Foo>,
-  )
+test('wrappers match original', () => {
+  expectWrappersToMatchH3({
+    readRawBody: {
+      h3: h3.readRawBody<'hex'>,
+      tss: tssServer.readRawBody<'hex'>,
+    },
+    readBody: {
+      h3: h3.readBody<Foo>,
+      tss: tssServer.readBody<Foo>,
+    },
+    getQuery: {
+      h3: h3.getQuery<Foo>,
+      tss: tssServer.getQuery<Foo>,
+    },
+    isMethod: {
+      h3: h3.isMethod,
+      tss: tssServer.isMethod,
+    },
+    isPreflightRequest: {
+      h3: h3.isPreflightRequest,
+      tss: tssServer.isPreflightRequest,
+    },
+    getValidatedQuery: {
+      h3: h3.getValidatedQuery<Foo>,
+      tss: tssServer.getValidatedQuery<Foo>,
+    },
+    getRouterParams: {
+      h3: h3.getRouterParams,
+      tss: tssServer.getRouterParams,
+    },
+    getRouterParam: {
+      h3: h3.getRouterParam,
+      tss: tssServer.getRouterParam,
+    },
+    getValidatedRouterParams: {
+      h3: h3.getValidatedRouterParams<Foo>,
+      tss: tssServer.getValidatedRouterParams<Foo>,
+    },
+    assertMethod: {
+      h3: h3.assertMethod,
+      tss: tssServer.assertMethod,
+    },
+    getRequestHeaders: {
+      h3: h3.getRequestHeaders,
+      tss: tssServer.getRequestHeaders,
+    },
+    getRequestHeader: {
+      h3: h3.getRequestHeader,
+      tss: tssServer.getRequestHeader,
+    },
+    getRequestURL: {
+      h3: h3.getRequestURL,
+      tss: tssServer.getRequestURL,
+    },
+    getRequestHost: {
+      h3: h3.getRequestHost,
+      tss: tssServer.getRequestHost,
+    },
+    getRequestProtocol: {
+      h3: h3.getRequestProtocol,
+      tss: tssServer.getRequestProtocol,
+    },
+    getRequestIP: {
+      h3: h3.getRequestIP,
+      tss: tssServer.getRequestIP,
+    },
+    send: {
+      h3: h3.send,
+      tss: tssServer.send,
+    },
+    sendNoContent: {
+      h3: h3.sendNoContent,
+      tss: tssServer.sendNoContent,
+    },
+    setResponseStatus: {
+      h3: h3.setResponseStatus,
+      tss: tssServer.setResponseStatus,
+    },
+    getResponseStatus: {
+      h3: h3.getResponseStatus,
+      tss: tssServer.getResponseStatus,
+    },
+    getResponseStatusText: {
+      h3: h3.getResponseStatusText,
+      tss: tssServer.getResponseStatusText,
+    },
+    getResponseHeaders: {
+      h3: h3.getResponseHeaders,
+      tss: tssServer.getResponseHeaders,
+    },
+    getResponseHeader: {
+      h3: h3.getResponseHeader,
+      tss: tssServer.getResponseHeader,
+    },
+    setResponseHeaders: {
+      h3: h3.setResponseHeaders,
+      tss: tssServer.setResponseHeaders,
+    },
+    setResponseHeader: {
+      h3: h3.setResponseHeader<'Age'>,
+      tss: tssServer.setResponseHeader<'Age'>,
+    },
+    appendResponseHeaders: {
+      h3: h3.appendResponseHeaders,
+      tss: tssServer.appendResponseHeaders,
+    },
+    appendResponseHeader: {
+      h3: h3.appendResponseHeader<'Age'>,
+      tss: tssServer.appendResponseHeader<'Age'>,
+    },
+    defaultContentType: {
+      h3: h3.defaultContentType,
+      tss: tssServer.defaultContentType,
+    },
+    sendRedirect: {
+      h3: h3.sendRedirect,
+      tss: tssServer.sendRedirect,
+    },
+    sendStream: {
+      h3: h3.sendStream,
+      tss: tssServer.sendStream,
+    },
+    writeEarlyHints: {
+      h3: h3.writeEarlyHints,
+      tss: tssServer.writeEarlyHints,
+    },
+    sendError: {
+      h3: h3.sendError,
+      tss: tssServer.sendError,
+    },
+    sendProxy: {
+      h3: h3.sendProxy,
+      tss: tssServer.sendProxy,
+    },
+    proxyRequest: {
+      h3: h3.proxyRequest,
+      tss: tssServer.proxyRequest,
+    },
+    fetchWithEvent: {
+      h3: h3.fetchWithEvent<Foo, Foo, typeof fetch>,
+      tss: tssServer.fetchWithEvent<Foo, Foo, typeof fetch>,
+    },
+    getProxyRequestHeaders: {
+      h3: h3.getProxyRequestHeaders,
+      tss: tssServer.getProxyRequestHeaders,
+    },
+    parseCookies: {
+      h3: h3.parseCookies,
+      tss: tssServer.parseCookies,
+    },
+    getCookie: {
+      h3: h3.getCookie,
+      tss: tssServer.getCookie,
+    },
+    setCookie: {
+      h3: h3.setCookie,
+      tss: tssServer.setCookie,
+    },
+    deleteCookie: {
+      h3: h3.deleteCookie,
+      tss: tssServer.deleteCookie,
+    },
+    useSession: {
+      h3: h3.useSession<Foo>,
+      tss: tssServer.useSession<Foo>,
+    },
+    getSession: {
+      h3: h3.getSession<Foo>,
+      tss: tssServer.getSession<Foo>,
+    },
+    updateSession: {
+      h3: h3.updateSession<Foo>,
+      tss: tssServer.updateSession<Foo>,
+    },
+    sealSession: {
+      h3: h3.sealSession<Foo>,
+      tss: tssServer.sealSession<Foo>,
+    },
+    unsealSession: {
+      h3: h3.unsealSession,
+      tss: tssServer.unsealSession,
+    },
+    clearSession: {
+      h3: h3.clearSession,
+      tss: tssServer.clearSession,
+    },
+    handleCacheHeaders: {
+      h3: h3.handleCacheHeaders,
+      tss: tssServer.handleCacheHeaders,
+    },
+    handleCors: {
+      h3: h3.handleCors,
+      tss: tssServer.handleCors,
+    },
+    appendCorsHeaders: {
+      h3: h3.appendCorsHeaders,
+      tss: tssServer.appendCorsHeaders,
+    },
+    appendCorsPreflightHeaders: {
+      h3: h3.appendCorsPreflightHeaders,
+      tss: tssServer.appendCorsPreflightHeaders,
+    },
+    sendWebResponse: {
+      h3: h3.sendWebResponse,
+      tss: tssServer.sendWebResponse,
+    },
+    appendHeader: {
+      h3: h3.appendHeader<'Age'>,
+      tss: tssServer.appendHeader<'Age'>,
+    },
+    appendHeaders: {
+      h3: h3.appendHeaders,
+      tss: tssServer.appendHeaders,
+    },
+    setHeader: {
+      h3: h3.setHeader<'Age'>,
+      tss: tssServer.setHeader<'Age'>,
+    },
+    setHeaders: {
+      h3: h3.setHeaders,
+      tss: tssServer.setHeaders,
+    },
+    getHeader: {
+      h3: h3.getHeader,
+      tss: tssServer.getHeader,
+    },
+    getHeaders: {
+      h3: h3.getHeaders,
+      tss: tssServer.getHeaders,
+    },
+    getRequestFingerprint: {
+      h3: h3.getRequestFingerprint,
+      tss: tssServer.getRequestFingerprint,
+    },
+    getRequestWebStream: {
+      h3: h3.getRequestWebStream,
+      tss: tssServer.getRequestWebStream,
+    },
+    readFormData: {
+      h3: h3.readFormData,
+      tss: tssServer.readFormData,
+    },
+    readMultipartFormData: {
+      h3: h3.readMultipartFormData,
+      tss: tssServer.readMultipartFormData,
+    },
+    readValidatedBody: {
+      h3: h3.readValidatedBody<Foo>,
+      tss: tssServer.readValidatedBody<Foo>,
+    },
+    removeResponseHeader: {
+      h3: h3.removeResponseHeader,
+      tss: tssServer.removeResponseHeader,
+    },
+    clearResponseHeaders: {
+      h3: h3.clearResponseHeaders,
+      tss: tssServer.clearResponseHeaders,
+    },
+  })
 })

--- a/packages/start-server/tsconfig.json
+++ b/packages/start-server/tsconfig.json
@@ -4,5 +4,10 @@
     "jsx": "react-jsx",
     "module": "esnext"
   },
-  "include": ["src", "vite.config.ts", "../start-client/src/tsrScript.ts"]
+  "include": [
+    "src",
+    "tests",
+    "vite.config.ts",
+    "../start-client/src/tsrScript.ts"
+  ]
 }


### PR DESCRIPTION
previously, type parameters weren't being passed through to wrapper functions, meaning things like `useSession<Data>(config)` didn't work properly.

This PR ensures the original signature is kept intact, along with providing specifically typed overloads for wrappers that need it.

breaking changes:
- getEvent returns H3Event, or throws an error if it couldn't find one. Previously it returned `any`, and didn't check whether event was truthy.