### PR TITLE
fix(start): Ensure h3 versions match

### DIFF
--- a/packages/start-server/package.json
+++ b/packages/start-server/package.json
@@ -65,7 +65,7 @@
     "@tanstack/react-router": "workspace:^",
     "@tanstack/start-client": "workspace:^",
     "@vitejs/plugin-react": "^4.3.4",
-    "h3": "^1.14.0",
+    "h3": "1.13.0",
     "isbot": "^5.1.21",
     "jsesc": "^3.1.0",
     "unctx": "^2.4.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4667,8 +4667,8 @@ importers:
         specifier: ^4.3.4
         version: 4.3.4(vite@6.0.11(@types/node@22.13.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
       h3:
-        specifier: ^1.14.0
-        version: 1.14.0
+        specifier: 1.13.0
+        version: 1.13.0
       isbot:
         specifier: ^5.1.21
         version: 5.1.22
@@ -8994,9 +8994,6 @@ packages:
 
   h3@1.13.0:
     resolution: {integrity: sha512-vFEAu/yf8UMUcB4s43OaDaigcqpQd14yanmOsn+NcRX3/guSKncyE2rOYhq8RIchgJrPSs/QiIddnTTR1ddiAg==}
-
-  h3@1.14.0:
-    resolution: {integrity: sha512-ao22eiONdgelqcnknw0iD645qW0s9NnrJHr5OBz4WOMdBdycfSas1EQf1wXRsm+PcB2Yoj43pjBPwqIpJQTeWg==}
 
   handle-thing@2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
@@ -14307,7 +14304,7 @@ snapshots:
       consola: 3.4.0
       defu: 6.1.4
       get-port-please: 3.1.2
-      h3: 1.14.0
+      h3: 1.13.0
       http-shutdown: 1.2.2
       jiti: 1.21.7
       mlly: 1.7.4
@@ -16318,19 +16315,6 @@ snapshots:
       uncrypto: 0.1.3
       unenv: 1.10.0
 
-  h3@1.14.0:
-    dependencies:
-      cookie-es: 1.2.2
-      crossws: 0.3.3
-      defu: 6.1.4
-      destr: 2.0.3
-      iron-webcrypto: 1.2.1
-      ohash: 1.1.4
-      radix3: 1.1.2
-      ufo: 1.5.4
-      uncrypto: 0.1.3
-      unenv: 1.10.0
-
   handle-thing@2.0.1: {}
 
   has-flag@4.0.0: {}
@@ -16810,7 +16794,7 @@ snapshots:
       crossws: 0.3.3
       defu: 6.1.4
       get-port-please: 3.1.2
-      h3: 1.14.0
+      h3: 1.13.0
       http-shutdown: 1.2.2
       jiti: 2.4.2
       mlly: 1.7.4
@@ -17152,7 +17136,7 @@ snapshots:
       fs-extra: 11.3.0
       globby: 14.0.2
       gzip-size: 7.0.0
-      h3: 1.14.0
+      h3: 1.13.0
       hookable: 5.5.3
       httpxy: 0.1.7
       ioredis: 5.4.2
@@ -18840,7 +18824,7 @@ snapshots:
       anymatch: 3.1.3
       chokidar: 3.6.0
       destr: 2.0.3
-      h3: 1.14.0
+      h3: 1.13.0
       lru-cache: 10.4.3
       node-fetch-native: 1.6.6
       ofetch: 1.4.1


### PR DESCRIPTION
Fixes https://github.com/TanStack/router/issues/3298

I think it makes sense to pin this version for now to maintain consistency and avoid type errors, while waiting for Vinxi to be removed.