### PR TITLE
fix(react-router): build correct `href` when reloading the document with `Router.navigate`

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1855,7 +1855,7 @@ export class Router<
     if (reloadDocument) {
       if (!href) {
         const location = this.buildLocation({ to, ...rest } as any)
-        href = location.href
+        href = this.history.createHref(location.href)
       }
       if (rest.replace) {
         window.location.replace(href)


### PR DESCRIPTION
Reload the document with `navigate` function now builds the correct location href, in cases where hash history is used.

Similar to: https://github.com/TanStack/router/pull/1414