### PR TITLE
refactor(react-router): remove unsed `router` prop from `Route` class

### DIFF
--- a/packages/react-router/src/route.ts
+++ b/packages/react-router/src/route.ts
@@ -721,7 +721,6 @@ export class Route<
   >
 
   // The following properties are set up in this.init()
-  router!: AnyRouter
   parentRoute!: TParentRoute
   private _id!: TId
   private _path!: TPath
@@ -835,13 +834,7 @@ export class Route<
     loaderDeps: TLoaderDeps
   }
 
-  init = (opts: {
-    router: AnyRouter
-    originalIndex: number
-    defaultSsr?: boolean
-  }): void => {
-    this.router = opts.router
-
+  init = (opts: { originalIndex: number; defaultSsr?: boolean }): void => {
     this.originalIndex = opts.originalIndex
 
     const options = this.options as

--- a/packages/react-router/src/route.ts
+++ b/packages/react-router/src/route.ts
@@ -721,8 +721,8 @@ export class Route<
   >
 
   // The following properties are set up in this.init()
-  parentRoute!: TParentRoute
   router!: AnyRouter
+  parentRoute!: TParentRoute
   private _id!: TId
   private _path!: TPath
   private _fullPath!: TFullPath
@@ -836,13 +836,13 @@ export class Route<
   }
 
   init = (opts: {
+    router: AnyRouter
     originalIndex: number
     defaultSsr?: boolean
-    router: AnyRouter
   }): void => {
-    this.originalIndex = opts.originalIndex
-
     this.router = opts.router
+
+    this.originalIndex = opts.originalIndex
 
     const options = this.options as
       | (RouteOptions<

--- a/packages/react-router/src/route.ts
+++ b/packages/react-router/src/route.ts
@@ -835,7 +835,11 @@ export class Route<
     loaderDeps: TLoaderDeps
   }
 
-  init = (opts: { originalIndex: number; defaultSsr?: boolean; router: AnyRouter }): void => {
+  init = (opts: {
+    originalIndex: number
+    defaultSsr?: boolean
+    router: AnyRouter
+  }): void => {
     this.originalIndex = opts.originalIndex
 
     this.router = opts.router

--- a/packages/react-router/src/route.ts
+++ b/packages/react-router/src/route.ts
@@ -722,6 +722,7 @@ export class Route<
 
   // The following properties are set up in this.init()
   parentRoute!: TParentRoute
+  router!: AnyRouter
   private _id!: TId
   private _path!: TPath
   private _fullPath!: TFullPath
@@ -768,7 +769,6 @@ export class Route<
   // Optional
   children?: TChildren
   originalIndex?: number
-  router?: AnyRouter
   rank!: number
   lazyFn?: () => Promise<LazyRoute<any>>
   _lazyPromise?: Promise<void>
@@ -835,8 +835,10 @@ export class Route<
     loaderDeps: TLoaderDeps
   }
 
-  init = (opts: { originalIndex: number; defaultSsr?: boolean }): void => {
+  init = (opts: { originalIndex: number; defaultSsr?: boolean; router: AnyRouter }): void => {
     this.originalIndex = opts.originalIndex
+
+    this.router = opts.router
 
     const options = this.options as
       | (RouteOptions<

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -835,9 +835,9 @@ export class Router<
     const notFoundRoute = this.options.notFoundRoute
     if (notFoundRoute) {
       notFoundRoute.init({
+        router: this,
         originalIndex: 99999999999,
         defaultSsr: this.options.defaultSsr,
-        router: this,
       })
       ;(this.routesById as any)[notFoundRoute.id] = notFoundRoute
     }
@@ -845,9 +845,9 @@ export class Router<
     const recurseRoutes = (childRoutes: Array<AnyRoute>) => {
       childRoutes.forEach((childRoute, i) => {
         childRoute.init({
+          router: this,
           originalIndex: i,
           defaultSsr: this.options.defaultSsr,
-          router: this,
         })
 
         const existingRoute = (this.routesById as any)[childRoute.id]

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -837,6 +837,7 @@ export class Router<
       notFoundRoute.init({
         originalIndex: 99999999999,
         defaultSsr: this.options.defaultSsr,
+        router: this,
       })
       ;(this.routesById as any)[notFoundRoute.id] = notFoundRoute
     }
@@ -846,6 +847,7 @@ export class Router<
         childRoute.init({
           originalIndex: i,
           defaultSsr: this.options.defaultSsr,
+          router: this,
         })
 
         const existingRoute = (this.routesById as any)[childRoute.id]

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -835,7 +835,6 @@ export class Router<
     const notFoundRoute = this.options.notFoundRoute
     if (notFoundRoute) {
       notFoundRoute.init({
-        router: this,
         originalIndex: 99999999999,
         defaultSsr: this.options.defaultSsr,
       })
@@ -845,7 +844,6 @@ export class Router<
     const recurseRoutes = (childRoutes: Array<AnyRoute>) => {
       childRoutes.forEach((childRoute, i) => {
         childRoute.init({
-          router: this,
           originalIndex: i,
           defaultSsr: this.options.defaultSsr,
         })


### PR DESCRIPTION
Route's `router` prop is always undefined as it is not initialized anywhere.
Should it be assigned in `init()`?