### PR TITLE
fix: use top-level `types` in package.json for use in JetBrains IDEs

### DIFF
--- a/packages/router-cli/package.json
+++ b/packages/router-cli/package.json
@@ -37,6 +37,7 @@
     "build": "vite build"
   },
   "type": "module",
+  "types": "dist/esm/index.d.ts",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.js",
   "exports": {

--- a/packages/router-plugin/package.json
+++ b/packages/router-plugin/package.json
@@ -41,6 +41,7 @@
     "build": "vite build"
   },
   "type": "module",
+  "types": "dist/esm/index.d.ts",
   "exports": {
     ".": {
       "import": {

--- a/packages/start-api-routes/package.json
+++ b/packages/start-api-routes/package.json
@@ -39,6 +39,7 @@
     "build": "vite build"
   },
   "type": "module",
+  "types": "dist/esm/index.d.ts",
   "exports": {
     ".": {
       "import": {

--- a/packages/start-client/package.json
+++ b/packages/start-client/package.json
@@ -39,6 +39,7 @@
     "build": "vite build"
   },
   "type": "module",
+  "types": "dist/esm/index.d.ts",
   "exports": {
     ".": {
       "import": {

--- a/packages/start-config/package.json
+++ b/packages/start-config/package.json
@@ -32,6 +32,7 @@
     "test:types": "exit 0; vitest"
   },
   "type": "module",
+  "types": "dist/esm/index.d.ts",
   "exports": {
     ".": {
       "import": {

--- a/packages/start-router-manifest/package.json
+++ b/packages/start-router-manifest/package.json
@@ -39,6 +39,7 @@
     "build": "tsc"
   },
   "type": "module",
+  "types": "dist/esm/index.d.ts",
   "exports": {
     ".": {
       "import": {

--- a/packages/start-server-functions-client/package.json
+++ b/packages/start-server-functions-client/package.json
@@ -39,6 +39,7 @@
     "build": "vite build"
   },
   "type": "module",
+  "types": "dist/esm/index.d.ts",
   "exports": {
     ".": {
       "import": {

--- a/packages/start-server-functions-fetcher/package.json
+++ b/packages/start-server-functions-fetcher/package.json
@@ -39,6 +39,7 @@
     "build": "vite build"
   },
   "type": "module",
+  "types": "dist/esm/index.d.ts",
   "exports": {
     ".": {
       "import": {

--- a/packages/start-server-functions-handler/package.json
+++ b/packages/start-server-functions-handler/package.json
@@ -39,6 +39,7 @@
     "build": "vite build"
   },
   "type": "module",
+  "types": "dist/esm/index.d.ts",
   "exports": {
     ".": {
       "import": {

--- a/packages/start-server-functions-server/package.json
+++ b/packages/start-server-functions-server/package.json
@@ -39,6 +39,7 @@
     "build": "vite build"
   },
   "type": "module",
+  "types": "dist/esm/index.d.ts",
   "exports": {
     ".": {
       "import": {

--- a/packages/start-server-functions-ssr/package.json
+++ b/packages/start-server-functions-ssr/package.json
@@ -39,6 +39,7 @@
     "build": "vite build"
   },
   "type": "module",
+  "types": "dist/esm/index.d.ts",
   "exports": {
     ".": {
       "import": {

--- a/packages/start-server/package.json
+++ b/packages/start-server/package.json
@@ -39,6 +39,7 @@
     "build": "vite build"
   },
   "type": "module",
+  "types": "dist/esm/index.d.ts",
   "exports": {
     ".": {
       "import": {

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -30,6 +30,7 @@
     "build": "vite build"
   },
   "type": "module",
+  "types": "dist/esm/client.d.ts",
   "exports": {
     ".": {
       "import": {


### PR DESCRIPTION
For some reason, the IDE does support `exports` section when using Yarn PnP.
But it still supports the old `types` entry.
2/3rds of the packages here already have this entry declared; the newer ones do not.
Thank you for your consideration, this would help my DX a lot!