### PR TITLE
fix(router-plugin): reduce route-tree bundle size

### DIFF
--- a/packages/router-plugin/src/core/code-splitter/compilers.ts
+++ b/packages/router-plugin/src/core/code-splitter/compilers.ts
@@ -69,7 +69,7 @@ const SPLIT_NOES_CONFIG = new Map<SplitRouteIdentNodes, SplitNodeMeta>([
 const SPLIT_ROUTE_IDENT_NODES = [...SPLIT_NOES_CONFIG.keys()] as const
 
 export function compileCodeSplitReferenceRoute(
-  opts: ParseAstOptions,
+  opts: ParseAstOptions & { isProduction: boolean },
 ): GeneratorResult {
   const ast = parseAst(opts)
 
@@ -206,6 +206,7 @@ export function compileCodeSplitReferenceRoute(
 
                           // If the TSRDummyComponent is not defined, define it
                           if (
+                            !opts.isProduction && // only in development
                             !hasImportedOrDefinedIdentifier('TSRDummyComponent')
                           ) {
                             programPath.pushContainer('body', [

--- a/packages/router-plugin/src/core/router-code-splitter-plugin.ts
+++ b/packages/router-plugin/src/core/router-code-splitter-plugin.ts
@@ -69,6 +69,8 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
   let ROOT: string = process.cwd()
   let userConfig = options as Config
 
+  const isProduction = process.env.NODE_ENV === 'production'
+
   const handleSplittingFile = (code: string, id: string) => {
     if (debug) console.info('Splitting Route: ', id)
 
@@ -93,6 +95,7 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
       code,
       root: ROOT,
       filename: id,
+      isProduction,
     })
 
     if (debug) {

--- a/packages/router-plugin/tests/code-splitter.test.ts
+++ b/packages/router-plugin/tests/code-splitter.test.ts
@@ -1,5 +1,5 @@
-import { readFile, readdir } from 'fs/promises'
-import path from 'path'
+import { readFile, readdir } from 'node:fs/promises'
+import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -30,6 +30,7 @@ describe.each(['development', 'production'])(
           code,
           root: './code-splitter/test-files',
           filename,
+          isProduction: NODE_ENV === 'production',
         })
 
         await expect(compileResult.code).toMatchFileSnapshot(

--- a/packages/router-plugin/tests/code-splitter/snapshots/production/arrow-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/production/arrow-function.tsx
@@ -7,6 +7,3 @@ export const Route = createFileRoute('/posts')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
 });
-export function TSRDummyComponent() {
-  return null;
-}

--- a/packages/router-plugin/tests/code-splitter/snapshots/production/chinese.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/production/chinese.tsx
@@ -7,6 +7,3 @@ export const Route = createFileRoute('/')({
 interface DemoProps {
   title: string;
 }
-export function TSRDummyComponent() {
-  return null;
-}

--- a/packages/router-plugin/tests/code-splitter/snapshots/production/destructured-react-memo-imported-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/production/destructured-react-memo-imported-component.tsx
@@ -7,6 +7,3 @@ export const Route = createFileRoute('/')({
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });
-export function TSRDummyComponent() {
-  return null;
-}

--- a/packages/router-plugin/tests/code-splitter/snapshots/production/function-declaration.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/production/function-declaration.tsx
@@ -7,6 +7,3 @@ export const Route = createFileRoute('/posts')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
 });
-export function TSRDummyComponent() {
-  return null;
-}

--- a/packages/router-plugin/tests/code-splitter/snapshots/production/importAttribute.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/production/importAttribute.tsx
@@ -4,6 +4,3 @@ import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
 });
-export function TSRDummyComponent() {
-  return null;
-}

--- a/packages/router-plugin/tests/code-splitter/snapshots/production/imported-default-component-destructured-loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/production/imported-default-component-destructured-loader.tsx
@@ -7,6 +7,3 @@ export const Route = createFileRoute('/')({
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });
-export function TSRDummyComponent() {
-  return null;
-}

--- a/packages/router-plugin/tests/code-splitter/snapshots/production/imported-default-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/production/imported-default-component.tsx
@@ -4,6 +4,3 @@ import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
 });
-export function TSRDummyComponent() {
-  return null;
-}

--- a/packages/router-plugin/tests/code-splitter/snapshots/production/imported.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/production/imported.tsx
@@ -7,6 +7,3 @@ export const Route = createFileRoute('/')({
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });
-export function TSRDummyComponent() {
-  return null;
-}

--- a/packages/router-plugin/tests/code-splitter/snapshots/production/inline.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/production/inline.tsx
@@ -6,6 +6,3 @@ export const Route = createFileRoute('/')({
 });
 Route.addChildren([]);
 export const test = 'test';
-export function TSRDummyComponent() {
-  return null;
-}

--- a/packages/router-plugin/tests/code-splitter/snapshots/production/random-number.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/production/random-number.tsx
@@ -9,6 +9,3 @@ export const Route = createFileRoute('/')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
 });
-export function TSRDummyComponent() {
-  return null;
-}

--- a/packages/router-plugin/tests/code-splitter/snapshots/production/react-memo-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/production/react-memo-component.tsx
@@ -7,6 +7,3 @@ export const Route = createFileRoute('/')({
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });
-export function TSRDummyComponent() {
-  return null;
-}

--- a/packages/router-plugin/tests/code-splitter/snapshots/production/react-memo-imported-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/production/react-memo-imported-component.tsx
@@ -7,6 +7,3 @@ export const Route = createFileRoute('/')({
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });
-export function TSRDummyComponent() {
-  return null;
-}

--- a/packages/router-plugin/tests/code-splitter/snapshots/production/retain-exports-loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/production/retain-exports-loader.tsx
@@ -12,6 +12,3 @@ export const Route = createFileRoute('/_layout')({
 });
 export const SIDEBAR_WIDTH = '150px';
 export const SIDEBAR_MINI_WIDTH = '80px';
-export function TSRDummyComponent() {
-  return null;
-}

--- a/packages/router-plugin/tests/code-splitter/snapshots/production/useStateDestructure.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/production/useStateDestructure.tsx
@@ -10,6 +10,3 @@ export const Route = createFileRoute('/_libraries/start/$version/')({
     description: startProject.description
   })
 });
-export function TSRDummyComponent() {
-  return null;
-}


### PR DESCRIPTION
Currently, when using `automaticCodeSplitting`, as part of compiling the "reference" route, we add a component (named `TSRDummyComponent`) to aid with the HMR trickery.

In removing this component from the production bundle, it impacts the visitor by reducing the initial js bundle that wires the route-tree.