### PR TITLE
fix(history): SubscriberHistoryAction discriminated union

### DIFF
--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -8,7 +8,7 @@ export interface NavigateOptions {
 
 type SubscriberHistoryAction =
   | {
-      type: HistoryAction
+      type: Exclude<HistoryAction, 'GO'>
     }
   | {
       type: 'GO'


### PR DESCRIPTION
The `SubscriberHistoryAction` type used in the `history` package currently doesn't behave like a *discriminated union* because the `HistoryAction` union contains `'GO'`

This means we get the following "inconsistency":

```ts
if (action.type === 'GO') {
  const i = action.index
  //               ^^^^^ Property 'index' does not exist on type 'SubscriberHistoryAction'.
}
```

This PR proposes a fix to this type:
```ts
if (action.type === 'GO') {
  const i = action.index
  //               ^? number
}
```