### PR TITLE
fix(router-generator): prevent route file being auto-formatted during updates

### DIFF
--- a/docs/router/framework/react/guide/file-based-routing.md
+++ b/docs/router/framework/react/guide/file-based-routing.md
@@ -424,9 +424,9 @@ The following options are available for configuration via the `tsr.config.json` 
   - See the [using automatic code-splitting](./code-splitting.md#using-automatic-code-splitting) guide.
 
 - **`quoteStyle`**
-  - (Optional, **Defaults to `single`**) whether to use `single` or `double` quotes when formatting the generated route tree file.
+  - (Optional, **Defaults to `single`**) whether to use `single` or `double` quotes when formatting the generated files.
 - **`semicolons`**
-  - (Optional, **Defaults to `false`**) whether to use semicolons in the generated route tree file.
+  - (Optional, **Defaults to `false`**) whether to use semicolons in the generated files.
 - **`apiBase`**
   - (Optional) The base path for API routes. Defaults to `/api`.
   - This option is reserved for future use by the TanStack Start for API routes.

--- a/packages/router-generator/src/template.ts
+++ b/packages/router-generator/src/template.ts
@@ -1,15 +1,18 @@
+import { format } from './utils'
 import type { Config } from './config'
 
 type TemplateTag = 'tsrImports' | 'tsrPath' | 'tsrExportStart' | 'tsrExportEnd'
 
 export function fillTemplate(
+  config: Config,
   template: string,
   values: Record<TemplateTag, string>,
 ) {
-  return template.replace(
+  const replaced = template.replace(
     /%%(\w+)%%/g,
     (_, key) => values[key as TemplateTag] || '',
   )
+  return format(replaced, config)
 }
 
 type TargetTemplate = {

--- a/packages/router-generator/src/utils.ts
+++ b/packages/router-generator/src/utils.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs'
 import * as prettier from 'prettier'
+import type { Config } from './config'
 
 export function multiSortBy<T>(
   arr: Array<T>,
@@ -123,7 +124,6 @@ export function removeExt(d: string, keepExtension: boolean = false) {
  * This function writes to a file if the content is different.
  *
  * @param filepath The path to the file
- * @param prettierOptions Prettier options
  * @param content Original content
  * @param incomingContent New content
  * @param callbacks Callbacks to run before and after writing
@@ -131,24 +131,33 @@ export function removeExt(d: string, keepExtension: boolean = false) {
  */
 export async function writeIfDifferent(
   filepath: string,
-  prettierOptions: prettier.Options,
   content: string,
   incomingContent: string,
   callbacks?: { beforeWrite?: () => void; afterWrite?: () => void },
 ): Promise<boolean> {
-  const [formattedContent, updatedContent] = await Promise.all([
-    prettier.format(content, prettierOptions),
-    prettier.format(incomingContent, prettierOptions),
-  ])
-
-  if (formattedContent !== updatedContent) {
+  if (content !== incomingContent) {
     callbacks?.beforeWrite?.()
-    fs.writeFileSync(filepath, updatedContent)
+    fs.writeFileSync(filepath, incomingContent)
     callbacks?.afterWrite?.()
     return true
   }
-
   return false
+}
+
+/**
+ * This function formats the source code using the default formatter (Prettier).
+ *
+ * @param source The content to format
+ * @param config The configuration object
+ * @returns The formatted content
+ */
+export async function format(source: string, config: Config): Promise<string> {
+  const prettierOptions: prettier.Config = {
+    semi: config.semicolons,
+    singleQuote: config.quoteStyle === 'single',
+    parser: 'typescript',
+  }
+  return prettier.format(source, prettierOptions)
 }
 
 /**


### PR DESCRIPTION
This PR adds a new configuration option (`formatter`) that allows the user to opt-out of having their route files auto formatted by Prettier.

This is useful when using a formatter other than Prettier (e.g. ESLint Stylistic, Biome, etc.)