### PR TITLE
fix(start): include vite react plugin in SSR router

### DIFF
--- a/packages/start-config/src/index.ts
+++ b/packages/start-config/src/index.ts
@@ -272,6 +272,7 @@ export function defineConfig(
             }),
             ...(getUserViteConfig(opts.vite).plugins || []),
             ...(getUserViteConfig(opts.routers?.ssr?.vite).plugins || []),
+            viteReact(opts.react),
           ]
         },
       },


### PR DESCRIPTION
Any particular reason to exclude the vite react plugin in the ssr router? Without it, we can't make effective use of react vite options such as babel transforms. 

For example, in order to use decorators with mobx, we need to add the `@babel/plugin-proposal-decorators` babel plugin (https://mobx.js.org/enabling-decorators.html#enabling-decorators). We can do this like so:

```ts
export default defineConfig({
  react: {
    babel: {
      plugins: [
        ['@babel/plugin-proposal-decorators', { version: '2023-05' }]
      ],
    },
  },
})
```

However the react vite plugin is not included in the vinxi ssr router, which means any isomporphic code that requires decorators will break. Obv decorators are just one example - applies to any babel transformations the end user might want on both client and server.