### PR TITLE
Update build-from-scratch.md - Fix spelling of 'bunder'

### DIFF
--- a/docs/start/framework/react/build-from-scratch.md
+++ b/docs/start/framework/react/build-from-scratch.md
@@ -34,7 +34,7 @@ We highly recommend using TypeScript with TanStack Start. Create a `tsconfig.jso
 {
   "compilerOptions": {
     "jsx": "react-jsx",
-    "moduleResolution": "Bundler",
+    "moduleResolution": "bundler",
     "module": "ESNext",
     "target": "ES2022",
     "skipLibCheck": true,


### PR DESCRIPTION
As per https://www.typescriptlang.org/tsconfig/#moduleResolution

The value should be `"Bundler"` not `"Bundler"`.