### PR TITLE
Update build-from-scratch.md - Fix typo in charset meta

### DIFF
--- a/docs/start/framework/react/build-from-scratch.md
+++ b/docs/start/framework/react/build-from-scratch.md
@@ -212,7 +212,7 @@ export const Route = createRootRoute({
   head: () => ({
     meta: [
       {
-        charSet: 'utf-8',
+        charset: 'utf-8',
       },
       {
         name: 'viewport',


### PR DESCRIPTION
I believe this should be `charset` not `charSet`.

- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#browser_compatibility
- https://www.w3.org/TR/2010/WD-html-markup-20101019/meta.charset.html

Build output when following the documentation.
![Screenshot 2025-02-11 at 4 24 37 PM](https://github.com/user-attachments/assets/9ece3061-b8c6-48f5-881e-8eb50eff9ef6)