### PR TITLE
fix: vite peer dependencies

### DIFF
--- a/packages/start-api-routes/package.json
+++ b/packages/start-api-routes/package.json
@@ -64,17 +64,16 @@
   "dependencies": {
     "@tanstack/react-router": "workspace:^",
     "@tanstack/start-server": "workspace:^",
-    "@vitejs/plugin-react": "^4.3.4",
     "vinxi": "0.5.3"
   },
   "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "typescript": "^5.7.2"
   },
   "peerDependencies": {
     "react": ">=18.0.0 || >=19.0.0",
-    "react-dom": ">=18.0.0 || >=19.0.0",
-    "vite": "^6.0.0"
+    "react-dom": ">=18.0.0 || >=19.0.0"
   }
 }

--- a/packages/start-router-manifest/package.json
+++ b/packages/start-router-manifest/package.json
@@ -59,10 +59,10 @@
   },
   "dependencies": {
     "@tanstack/react-router": "workspace:^",
-    "@vitejs/plugin-react": "^4.3.4",
     "vinxi": "0.5.3"
   },
   "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "typescript": "^5.7.2"

--- a/packages/start-server-functions-client/package.json
+++ b/packages/start-server-functions-client/package.json
@@ -63,11 +63,10 @@
   },
   "dependencies": {
     "@tanstack/server-functions-plugin": "workspace:^",
-    "@tanstack/start-server-functions-fetcher": "workspace:^",
-    "@vitejs/plugin-react": "^4.3.4",
-    "tiny-invariant": "^1.3.3"
+    "@tanstack/start-server-functions-fetcher": "workspace:^"
   },
   "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "typescript": "^5.7.2"

--- a/packages/start-server-functions-fetcher/package.json
+++ b/packages/start-server-functions-fetcher/package.json
@@ -63,10 +63,10 @@
   },
   "dependencies": {
     "@tanstack/react-router": "workspace:^",
-    "@tanstack/start-client": "workspace:^",
-    "@vitejs/plugin-react": "^4.3.4"
+    "@tanstack/start-client": "workspace:^"
   },
   "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "typescript": "^5.7.2"

--- a/packages/start-server-functions-handler/package.json
+++ b/packages/start-server-functions-handler/package.json
@@ -65,17 +65,16 @@
     "@tanstack/react-router": "workspace:^",
     "@tanstack/start-client": "workspace:^",
     "@tanstack/start-server": "workspace:^",
-    "@vitejs/plugin-react": "^4.3.4",
     "tiny-invariant": "^1.3.3"
   },
   "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "typescript": "^5.7.2"
   },
   "peerDependencies": {
     "react": ">=18.0.0 || >=19.0.0",
-    "react-dom": ">=18.0.0 || >=19.0.0",
-    "vite": "^6.0.0"
+    "react-dom": ">=18.0.0 || >=19.0.0"
   }
 }

--- a/packages/start-server-functions-server/package.json
+++ b/packages/start-server-functions-server/package.json
@@ -63,10 +63,10 @@
   },
   "dependencies": {
     "@tanstack/server-functions-plugin": "workspace:^",
-    "@vitejs/plugin-react": "^4.3.4",
     "tiny-invariant": "^1.3.3"
   },
   "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "typescript": "^5.7.2"

--- a/packages/start-server-functions-ssr/package.json
+++ b/packages/start-server-functions-ssr/package.json
@@ -66,17 +66,16 @@
     "@tanstack/start-client": "workspace:^",
     "@tanstack/start-server": "workspace:^",
     "@tanstack/start-server-functions-fetcher": "workspace:^",
-    "@vitejs/plugin-react": "^4.3.4",
     "tiny-invariant": "^1.3.3"
   },
   "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "typescript": "^5.7.2"
   },
   "peerDependencies": {
     "react": ">=18.0.0 || >=19.0.0",
-    "react-dom": ">=18.0.0 || >=19.0.0",
-    "vite": "^6.0.0"
+    "react-dom": ">=18.0.0 || >=19.0.0"
   }
 }

--- a/packages/start-server/package.json
+++ b/packages/start-server/package.json
@@ -65,13 +65,13 @@
     "@tanstack/react-cross-context": "workspace:^",
     "@tanstack/react-router": "workspace:^",
     "@tanstack/start-client": "workspace:^",
-    "@vitejs/plugin-react": "^4.3.4",
     "h3": "1.13.0",
     "isbot": "^5.1.22",
     "jsesc": "^3.1.0",
     "unctx": "^2.4.1"
   },
   "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.4",
     "@types/jsesc": "^3.0.3",
     "esbuild": "^0.25.0",
     "react": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4498,16 +4498,13 @@ importers:
       '@tanstack/start-server':
         specifier: workspace:*
         version: link:../start-server
-      '@vitejs/plugin-react':
-        specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.0(@types/node@22.13.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
       vinxi:
         specifier: 0.5.3
         version: 0.5.3(@types/node@22.13.0)(db0@0.2.3)(ioredis@5.4.2)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0)
-      vite:
-        specifier: 6.1.0
-        version: 6.1.0(@types/node@22.13.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
     devDependencies:
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.3.4(vite@6.1.0(@types/node@22.13.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -4650,13 +4647,13 @@ importers:
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../react-router
-      '@vitejs/plugin-react':
-        specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.0(@types/node@22.13.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
       vinxi:
         specifier: 0.5.3
         version: 0.5.3(@types/node@22.13.0)(db0@0.2.3)(ioredis@5.4.2)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0)
     devDependencies:
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.3.4(vite@6.1.0(@types/node@22.13.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -4678,9 +4675,6 @@ importers:
       '@tanstack/start-client':
         specifier: workspace:*
         version: link:../start-client
-      '@vitejs/plugin-react':
-        specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.0(@types/node@22.13.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
       h3:
         specifier: 1.13.0
         version: 1.13.0
@@ -4697,6 +4691,9 @@ importers:
       '@types/jsesc':
         specifier: ^3.0.3
         version: 3.0.3
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.3.4(vite@6.1.0(@types/node@22.13.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
       esbuild:
         specifier: ^0.25.0
         version: 0.25.0
@@ -4718,13 +4715,10 @@ importers:
       '@tanstack/start-server-functions-fetcher':
         specifier: workspace:*
         version: link:../start-server-functions-fetcher
+    devDependencies:
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.3.4(vite@6.1.0(@types/node@22.13.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
-      tiny-invariant:
-        specifier: ^1.3.3
-        version: 1.3.3
-    devDependencies:
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -4743,10 +4737,10 @@ importers:
       '@tanstack/start-client':
         specifier: workspace:*
         version: link:../start-client
+    devDependencies:
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.3.4(vite@6.1.0(@types/node@22.13.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
-    devDependencies:
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -4768,16 +4762,13 @@ importers:
       '@tanstack/start-server':
         specifier: workspace:*
         version: link:../start-server
-      '@vitejs/plugin-react':
-        specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.0(@types/node@22.13.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3
-      vite:
-        specifier: 6.1.0
-        version: 6.1.0(@types/node@22.13.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
     devDependencies:
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.3.4(vite@6.1.0(@types/node@22.13.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -4793,13 +4784,13 @@ importers:
       '@tanstack/server-functions-plugin':
         specifier: workspace:*
         version: link:../server-functions-plugin
-      '@vitejs/plugin-react':
-        specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.0(@types/node@22.13.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3
     devDependencies:
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.3.4(vite@6.1.0(@types/node@22.13.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -4824,16 +4815,13 @@ importers:
       '@tanstack/start-server-functions-fetcher':
         specifier: workspace:*
         version: link:../start-server-functions-fetcher
-      '@vitejs/plugin-react':
-        specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.0(@types/node@22.13.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3
-      vite:
-        specifier: 6.1.0
-        version: 6.1.0(@types/node@22.13.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
     devDependencies:
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.3.4(vite@6.1.0(@types/node@22.13.0)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
       react:
         specifier: ^19.0.0
         version: 19.0.0


### PR DESCRIPTION
Vite was still be duplicated for me with Yarn PnP. Not a big deal, but indicating something was not entirely accurate.
All of these packages were declaring the react plugin, which would require them to also declare vite as a peer dep.
However, in all of these cases here the plugin was only being used in the vite configs, not being imported into src.
Moving them to dev removes the need to declare the peer dep, and fix the duplication problem by consumers.
I also removed vite from a couple of packages that declared them as a peer dep, which I had added in #3318, since this is the real solution.