### PR TITLE
feat: add WrapProvider to routerWithQueryClient

### DIFF
--- a/packages/react-router-with-query/src/index.tsx
+++ b/packages/react-router-with-query/src/index.tsx
@@ -12,11 +12,16 @@ import type {
   UseQueryOptions,
 } from '@tanstack/react-query'
 
+type AdditionalOptions = {
+  WrapProvider: (props: { children: any }) => React.JSX.Element
+}
+
 export function routerWithQueryClient<TRouter extends AnyRouter>(
   router: TRouter['options']['context'] extends { queryClient: QueryClient }
     ? TRouter
     : never,
   queryClient: QueryClient,
+  additionalOpts?: AdditionalOptions,
 ): TRouter {
   const seenQueryKeys = new Set<string>()
   const streamedQueryKeys = new Set<string>()
@@ -116,11 +121,14 @@ export function routerWithQueryClient<TRouter extends AnyRouter>(
     },
     // Wrap the app in a QueryClientProvider
     Wrap: ({ children }) => {
+      const OuterWrapper = additionalOpts?.WrapProvider || Fragment
       const OGWrap = ogOptions.Wrap || Fragment
       return (
-        <QueryClientProvider client={queryClient}>
-          <OGWrap>{children}</OGWrap>
-        </QueryClientProvider>
+        <OuterWrapper>
+          <QueryClientProvider client={queryClient}>
+            <OGWrap>{children}</OGWrap>
+          </QueryClientProvider>
+        </OuterWrapper>
       )
     },
   }

--- a/packages/react-router-with-query/src/index.tsx
+++ b/packages/react-router-with-query/src/index.tsx
@@ -13,7 +13,7 @@ import type {
 } from '@tanstack/react-query'
 
 type AdditionalOptions = {
-  WrapProvider: (props: { children: any }) => React.JSX.Element
+  WrapProvider?: (props: { children: any }) => React.JSX.Element
 }
 
 export function routerWithQueryClient<TRouter extends AnyRouter>(
@@ -34,7 +34,7 @@ export function routerWithQueryClient<TRouter extends AnyRouter>(
       ...ogClientOptions.queries,
       _experimental_beforeQuery: (options: UseQueryOptions) => {
         // Call the original beforeQuery
-        ;(ogClientOptions.queries as any)?._experimental_beforeQuery?.(options)
+        ; (ogClientOptions.queries as any)?._experimental_beforeQuery?.(options)
 
         const hash = options.queryKeyHashFn || hashKey
         // On the server, check if we've already seen the query before
@@ -49,7 +49,7 @@ export function routerWithQueryClient<TRouter extends AnyRouter>(
           // That means it's going to get dehydrated with critical
           // data, so we can skip the injection
           if (queryClient.getQueryData(options.queryKey) !== undefined) {
-            ;(options as any).__skipInjection = true
+            ; (options as any).__skipInjection = true
             return
           }
         } else {
@@ -91,7 +91,7 @@ export function routerWithQueryClient<TRouter extends AnyRouter>(
         }
 
         // Call the original afterQuery
-        ;(ogClientOptions.queries as any)?._experimental_afterQuery?.(
+        ; (ogClientOptions.queries as any)?._experimental_afterQuery?.(
           options,
           _result,
         )

--- a/packages/react-router-with-query/src/index.tsx
+++ b/packages/react-router-with-query/src/index.tsx
@@ -34,7 +34,7 @@ export function routerWithQueryClient<TRouter extends AnyRouter>(
       ...ogClientOptions.queries,
       _experimental_beforeQuery: (options: UseQueryOptions) => {
         // Call the original beforeQuery
-        ; (ogClientOptions.queries as any)?._experimental_beforeQuery?.(options)
+        ;(ogClientOptions.queries as any)?._experimental_beforeQuery?.(options)
 
         const hash = options.queryKeyHashFn || hashKey
         // On the server, check if we've already seen the query before
@@ -49,7 +49,7 @@ export function routerWithQueryClient<TRouter extends AnyRouter>(
           // That means it's going to get dehydrated with critical
           // data, so we can skip the injection
           if (queryClient.getQueryData(options.queryKey) !== undefined) {
-            ; (options as any).__skipInjection = true
+            ;(options as any).__skipInjection = true
             return
           }
         } else {
@@ -91,7 +91,7 @@ export function routerWithQueryClient<TRouter extends AnyRouter>(
         }
 
         // Call the original afterQuery
-        ; (ogClientOptions.queries as any)?._experimental_afterQuery?.(
+        ;(ogClientOptions.queries as any)?._experimental_afterQuery?.(
           options,
           _result,
         )


### PR DESCRIPTION
Added an optional 3rd argument to `routerWithQueryClient(...)` that allows the user to wrap the QueryClientProvider in a component.

This is useful when using a library that requires a Provider, and that provider creates its on queryClient, doesn't detect existing queryClients, and doesn't allow for supplying your own.

Without this functionality, the user has no ability to place the Vendor's provider above Tanstack's enshrined QCProvider. Thus, the queryClient available in the loaders references the correct (Tanstack) query client, while all hooks inside components would walk up the tree to find the the incorrect (Vendor) queryClient. This would potentially break auto-streaming with `useSuspenseQuery(...)` and de-sync hooks from loaders.

By giving an entrypoint to place a provider above Router's enshrined queryClient, this can be mitigated.

Usage matches  `createTanstackRouter.Wrap` and `.InnerWrap`, but this option is added in with routerWithQueryClient, as it is unique to its users.