### PR TITLE
fix(start,router): Change DCE so it only affects *newly* dead code

### DIFF
--- a/e2e/start/server-functions/app/routeTree.gen.ts
+++ b/e2e/start/server-functions/app/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as MultipartImport } from './routes/multipart'
 import { Route as IsomorphicFnsImport } from './routes/isomorphic-fns'
 import { Route as HeadersImport } from './routes/headers'
 import { Route as EnvOnlyImport } from './routes/env-only'
+import { Route as DeadCodePreserveImport } from './routes/dead-code-preserve'
 import { Route as ConsistentImport } from './routes/consistent'
 import { Route as IndexImport } from './routes/index'
 import { Route as CookiesIndexImport } from './routes/cookies/index'
@@ -74,6 +75,12 @@ const EnvOnlyRoute = EnvOnlyImport.update({
   getParentRoute: () => rootRoute,
 } as any)
 
+const DeadCodePreserveRoute = DeadCodePreserveImport.update({
+  id: '/dead-code-preserve',
+  path: '/dead-code-preserve',
+  getParentRoute: () => rootRoute,
+} as any)
+
 const ConsistentRoute = ConsistentImport.update({
   id: '/consistent',
   path: '/consistent',
@@ -114,6 +121,13 @@ declare module '@tanstack/react-router' {
       path: '/consistent'
       fullPath: '/consistent'
       preLoaderRoute: typeof ConsistentImport
+      parentRoute: typeof rootRoute
+    }
+    '/dead-code-preserve': {
+      id: '/dead-code-preserve'
+      path: '/dead-code-preserve'
+      fullPath: '/dead-code-preserve'
+      preLoaderRoute: typeof DeadCodePreserveImport
       parentRoute: typeof rootRoute
     }
     '/env-only': {
@@ -194,6 +208,7 @@ declare module '@tanstack/react-router' {
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/consistent': typeof ConsistentRoute
+  '/dead-code-preserve': typeof DeadCodePreserveRoute
   '/env-only': typeof EnvOnlyRoute
   '/headers': typeof HeadersRoute
   '/isomorphic-fns': typeof IsomorphicFnsRoute
@@ -209,6 +224,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/consistent': typeof ConsistentRoute
+  '/dead-code-preserve': typeof DeadCodePreserveRoute
   '/env-only': typeof EnvOnlyRoute
   '/headers': typeof HeadersRoute
   '/isomorphic-fns': typeof IsomorphicFnsRoute
@@ -225,6 +241,7 @@ export interface FileRoutesById {
   __root__: typeof rootRoute
   '/': typeof IndexRoute
   '/consistent': typeof ConsistentRoute
+  '/dead-code-preserve': typeof DeadCodePreserveRoute
   '/env-only': typeof EnvOnlyRoute
   '/headers': typeof HeadersRoute
   '/isomorphic-fns': typeof IsomorphicFnsRoute
@@ -242,6 +259,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/consistent'
+    | '/dead-code-preserve'
     | '/env-only'
     | '/headers'
     | '/isomorphic-fns'
@@ -256,6 +274,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/consistent'
+    | '/dead-code-preserve'
     | '/env-only'
     | '/headers'
     | '/isomorphic-fns'
@@ -270,6 +289,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/consistent'
+    | '/dead-code-preserve'
     | '/env-only'
     | '/headers'
     | '/isomorphic-fns'
@@ -286,6 +306,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   ConsistentRoute: typeof ConsistentRoute
+  DeadCodePreserveRoute: typeof DeadCodePreserveRoute
   EnvOnlyRoute: typeof EnvOnlyRoute
   HeadersRoute: typeof HeadersRoute
   IsomorphicFnsRoute: typeof IsomorphicFnsRoute
@@ -301,6 +322,7 @@ export interface RootRouteChildren {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   ConsistentRoute: ConsistentRoute,
+  DeadCodePreserveRoute: DeadCodePreserveRoute,
   EnvOnlyRoute: EnvOnlyRoute,
   HeadersRoute: HeadersRoute,
   IsomorphicFnsRoute: IsomorphicFnsRoute,
@@ -325,6 +347,7 @@ export const routeTree = rootRoute
       "children": [
         "/",
         "/consistent",
+        "/dead-code-preserve",
         "/env-only",
         "/headers",
         "/isomorphic-fns",
@@ -342,6 +365,9 @@ export const routeTree = rootRoute
     },
     "/consistent": {
       "filePath": "consistent.tsx"
+    },
+    "/dead-code-preserve": {
+      "filePath": "dead-code-preserve.tsx"
     },
     "/env-only": {
       "filePath": "env-only.tsx"

--- a/e2e/start/server-functions/app/routes/dead-code-preserve.tsx
+++ b/e2e/start/server-functions/app/routes/dead-code-preserve.tsx
@@ -1,0 +1,60 @@
+import * as fs from 'node:fs'
+import { createServerFn } from '@tanstack/start'
+import {getRequestHeader} from '@tanstack/start/server'
+import { useState } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/dead-code-preserve')({
+  component: RouteComponent,
+})
+
+// by using this we make sure DCE still works - this errors when imported on the client
+
+const filePath = 'count-effect.txt'
+
+async function readCount() {
+  return parseInt(
+    await fs.promises.readFile(filePath, 'utf-8').catch(() => '0'),
+  )
+}
+
+async function updateCount() {
+  const count = await readCount()
+  await fs.promises.writeFile(filePath, `${count + 1}`)
+  return true
+}
+
+const writeFileServerFn = createServerFn().handler(async () => {
+  // eslint-disable-next-line unused-imports/no-unused-vars
+  const test = await updateCount()
+  return getRequestHeader('X-Test')
+})
+
+const readFileServerFn = createServerFn().handler(async () => {
+  const data = await readCount()
+  return data
+})
+
+function RouteComponent() {
+  const [serverFnOutput, setServerFnOutput] = useState<number>()
+  return (
+    <div className="p-2 m-2 grid gap-2">
+      <h3>Dead code test</h3>
+      <p>
+        This server function writes to a file as a side effect, then reads it.
+      </p>
+      <button
+        className="rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+        data-testid="test-dead-code-fn-call-btn"
+        onClick={async () => {
+          await writeFileServerFn({ headers: { 'X-Test': 'test' } })
+          setServerFnOutput(await readFileServerFn())
+        }}
+      >
+        Call Dead Code Fn
+      </button>
+      <h4>Server output</h4>
+      <pre data-testid="dead-code-fn-call-response">{serverFnOutput}</pre>
+    </div>
+  )
+}

--- a/e2e/start/server-functions/app/routes/dead-code-preserve.tsx
+++ b/e2e/start/server-functions/app/routes/dead-code-preserve.tsx
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs'
 import { createServerFn } from '@tanstack/start'
-import {getRequestHeader} from '@tanstack/start/server'
+import { getRequestHeader } from '@tanstack/start/server'
 import { useState } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 

--- a/e2e/start/server-functions/app/routes/index.tsx
+++ b/e2e/start/server-functions/app/routes/index.tsx
@@ -61,6 +61,9 @@ function Home() {
         <li>
           <Link to="/cookies">server function sets cookies</Link>
         </li>
+        <li>
+          <Link to="/dead-code-preserve">dead code elimation only affects code after transformation</Link>
+        </li>
       </ul>
     </div>
   )

--- a/e2e/start/server-functions/app/routes/index.tsx
+++ b/e2e/start/server-functions/app/routes/index.tsx
@@ -62,7 +62,9 @@ function Home() {
           <Link to="/cookies">server function sets cookies</Link>
         </li>
         <li>
-          <Link to="/dead-code-preserve">dead code elimation only affects code after transformation</Link>
+          <Link to="/dead-code-preserve">
+            dead code elimation only affects code after transformation
+          </Link>
         </li>
       </ul>
     </div>

--- a/e2e/start/server-functions/tests/server-functions.spec.ts
+++ b/e2e/start/server-functions/tests/server-functions.spec.ts
@@ -277,26 +277,3 @@ test.describe('server function sets cookies', () => {
     await runCookieTest(page, expectedCookieValue)
   })
 })
-
-test.describe('server function sets cookies', () => {
-  async function runCookieTest(page: Page, expectedCookieValue: string) {
-    for (let i = 1; i <= 4; i++) {
-      const key = `cookie-${i}-${expectedCookieValue}`
-
-      const actualValue = await page.getByTestId(key).textContent()
-      expect(actualValue).toBe(expectedCookieValue)
-    }
-  }
-  test('SSR', async ({ page }) => {
-    const expectedCookieValue = `SSR-${Date.now()}`
-    await page.goto(`/cookies/set?value=${expectedCookieValue}`)
-    await runCookieTest(page, expectedCookieValue)
-  })
-
-  test('client side navigation', async ({ page }) => {
-    const expectedCookieValue = `CLIENT-${Date.now()}`
-    await page.goto(`/cookies?value=${expectedCookieValue}`)
-    await page.getByTestId('link-to-set').click()
-    await runCookieTest(page, expectedCookieValue)
-  })
-})

--- a/e2e/start/server-functions/tests/server-functions.spec.ts
+++ b/e2e/start/server-functions/tests/server-functions.spec.ts
@@ -1,3 +1,4 @@
+import * as fs from 'node:fs'
 import { expect, test } from '@playwright/test'
 import { PORT } from '../playwright.config'
 import type { Page } from '@playwright/test'
@@ -250,6 +251,31 @@ test("server function's dead code is preserved if already there", async ({
   await expect(page.getByTestId('dead-code-fn-call-response')).toContainText(
     '1',
   )
+
+  await fs.promises.rm('count-effect.txt')
+})
+
+test.describe('server function sets cookies', () => {
+  async function runCookieTest(page: Page, expectedCookieValue: string) {
+    for (let i = 1; i <= 4; i++) {
+      const key = `cookie-${i}-${expectedCookieValue}`
+
+      const actualValue = await page.getByTestId(key).textContent()
+      expect(actualValue).toBe(expectedCookieValue)
+    }
+  }
+  test('SSR', async ({ page }) => {
+    const expectedCookieValue = `SSR-${Date.now()}`
+    await page.goto(`/cookies/set?value=${expectedCookieValue}`)
+    await runCookieTest(page, expectedCookieValue)
+  })
+
+  test('client side navigation', async ({ page }) => {
+    const expectedCookieValue = `CLIENT-${Date.now()}`
+    await page.goto(`/cookies?value=${expectedCookieValue}`)
+    await page.getByTestId('link-to-set').click()
+    await runCookieTest(page, expectedCookieValue)
+  })
 })
 
 test.describe('server function sets cookies', () => {

--- a/e2e/start/server-functions/tests/server-functions.spec.ts
+++ b/e2e/start/server-functions/tests/server-functions.spec.ts
@@ -238,6 +238,20 @@ test('Direct POST submitting FormData to a Server function returns the correct m
   expect(result).toBe(expected)
 })
 
+test("server function's dead code is preserved if already there", async ({
+  page,
+}) => {
+  await page.goto('/dead-code-preserve')
+
+  await page.waitForLoadState('networkidle')
+  await page.getByTestId('test-dead-code-fn-call-btn').click()
+  await page.waitForLoadState('networkidle')
+
+  await expect(page.getByTestId('dead-code-fn-call-response')).toContainText(
+    '1',
+  )
+})
+
 test.describe('server function sets cookies', () => {
   async function runCookieTest(page: Page, expectedCookieValue: string) {
     for (let i = 1; i <= 4; i++) {

--- a/packages/directive-functions-plugin/src/compilers.ts
+++ b/packages/directive-functions-plugin/src/compilers.ts
@@ -1,7 +1,10 @@
 import * as babel from '@babel/core'
 import { isIdentifier, isVariableDeclarator } from '@babel/types'
 import { codeFrameColumns } from '@babel/code-frame'
-import { deadCodeElimination } from 'babel-dead-code-elimination'
+import {
+  deadCodeElimination,
+  findReferencedIdentifiers,
+} from 'babel-dead-code-elimination'
 import { generateFromAst, parseAst } from '@tanstack/router-utils'
 import type { GeneratorResult, ParseAstOptions } from '@tanstack/router-utils'
 
@@ -51,6 +54,7 @@ export function compileDirectives(opts: CompileDirectivesOpts): {
   const isDirectiveSplitParam = opts.filename.includes(directiveSplitParam)
 
   const ast = parseAst(opts)
+  const refIdents = findReferencedIdentifiers(ast)
   const directiveFnsById = findDirectives(ast, {
     ...opts,
     directiveSplitParam,
@@ -99,7 +103,7 @@ export function compileDirectives(opts: CompileDirectivesOpts): {
     )
   }
 
-  deadCodeElimination(ast)
+  deadCodeElimination(ast, refIdents)
 
   const compiledResult = generateFromAst(ast, {
     sourceMaps: true,

--- a/packages/directive-functions-plugin/tests/compiler.test.ts
+++ b/packages/directive-functions-plugin/tests/compiler.test.ts
@@ -139,8 +139,12 @@ describe('server function compilation', () => {
       export const exportedArrowFunction = wrapper(exportedArrowFunction_wrapper);
       const namedExportConst_1 = createClientRpc("test_ts--namedExportConst_1");
       export const namedExportConst = namedExportConst_1;
+      function unusedFn() {
+        return 'hello';
+      }
       const namedDefaultExport = 'namedDefaultExport';
       export default namedDefaultExport;
+      const usedButNotExported = 'usedButNotExported';
       const namedExport = 'namedExport';
       export { namedExport };"
     `)
@@ -165,8 +169,12 @@ describe('server function compilation', () => {
       export const exportedArrowFunction = wrapper(exportedArrowFunction_wrapper);
       const namedExportConst_1 = createSsrRpc("test_ts--namedExportConst_1");
       export const namedExportConst = namedExportConst_1;
+      function unusedFn() {
+        return 'hello';
+      }
       const namedDefaultExport = 'namedDefaultExport';
       export default namedDefaultExport;
+      const usedButNotExported = 'usedButNotExported';
       const namedExport = 'namedExport';
       export { namedExport };"
     `)
@@ -206,6 +214,11 @@ describe('server function compilation', () => {
       function usedFn() {
         return 'hello';
       }
+      function unusedFn() {
+        return 'hello';
+      }
+      const usedButNotExported = 'usedButNotExported';
+      const namedExportFn = namedExportFn_1;
       export { namedFunction_createServerFn_namedFunction, arrowFunction_createServerFn, anonymousFunction_createServerFn, multipleDirectives_multipleDirectives, iife_1, defaultExportFn_1, namedExportFn_1, exportedArrowFunction_wrapper, namedExportConst_1 };"
     `,
     )
@@ -481,6 +494,9 @@ describe('server function compilation', () => {
       import { createClientRpc } from "my-rpc-lib-client";
       const useServer_1 = createClientRpc("test_ts--useServer_1");
       export const useServer = useServer_1;
+      function notExported() {
+        return 'hello';
+      }
       const defaultExport_1 = createClientRpc("test_ts--defaultExport_1");
       export default defaultExport_1;"
     `)
@@ -490,6 +506,9 @@ describe('server function compilation', () => {
       import { createSsrRpc } from "my-rpc-lib-server";
       const useServer_1 = createSsrRpc("test_ts--useServer_1");
       export const useServer = useServer_1;
+      function notExported() {
+        return 'hello';
+      }
       const defaultExport_1 = createSsrRpc("test_ts--defaultExport_1");
       export default defaultExport_1;"
     `)
@@ -500,12 +519,16 @@ describe('server function compilation', () => {
       const useServer_1 = createServerRpc("test_ts--useServer_1", function useServer() {
         return usedInUseServer();
       });
+      function notExported() {
+        return 'hello';
+      }
       function usedInUseServer() {
         return 'hello';
       }
       const defaultExport_1 = createServerRpc("test_ts--defaultExport_1", function defaultExport() {
         return 'hello';
       });
+      const useServer = useServer_1;
       export { useServer_1, defaultExport_1 };"
     `)
   })

--- a/packages/directive-functions-plugin/tests/compiler.test.ts
+++ b/packages/directive-functions-plugin/tests/compiler.test.ts
@@ -730,6 +730,7 @@ describe('server function compilation', () => {
       const serverFnNamedWithImport_1 = createServerRpc("test_ts--serverFnNamedWithImport_1", function serverFnNamedWithImport() {
         return imported;
       });
+      const serverFnNamedWithImport = serverFnNamedWithImport_1;
       export { serverFnConstWithImport_1, serverFnNamedWithImport_1 };"
     `)
   })
@@ -755,12 +756,18 @@ describe('server function compilation', () => {
     })
 
     expect(client.compiledResult.code).toMatchInlineSnapshot(`
-      "export default function () {
+      "import { createClientRpc } from "my-rpc-lib-client";
+      const bytesSignupServerFn_1 = createClientRpc("test_ts--bytesSignupServerFn_1");
+      const bytesSignupServerFn = bytesSignupServerFn_1;
+      export default function () {
         return null;
       }"
     `)
     expect(ssr.compiledResult.code).toMatchInlineSnapshot(`
-      "export default function () {
+      "import { createSsrRpc } from "my-rpc-lib-server";
+      const bytesSignupServerFn_1 = createSsrRpc("test_ts--bytesSignupServerFn_1");
+      const bytesSignupServerFn = bytesSignupServerFn_1;
+      export default function () {
         return null;
       }"
     `)
@@ -773,6 +780,7 @@ describe('server function compilation', () => {
       }) {
         return 'test';
       });
+      const bytesSignupServerFn = bytesSignupServerFn_1;
       export default function () {
         return null;
       }

--- a/packages/router-plugin/src/core/code-splitter/compilers.ts
+++ b/packages/router-plugin/src/core/code-splitter/compilers.ts
@@ -1,7 +1,10 @@
 import * as t from '@babel/types'
 import babel from '@babel/core'
 import * as template from '@babel/template'
-import { deadCodeElimination } from 'babel-dead-code-elimination'
+import {
+  deadCodeElimination,
+  findReferencedIdentifiers,
+} from 'babel-dead-code-elimination'
 import { generateFromAst, parseAst } from '@tanstack/router-utils'
 import { tsrSplit } from '../constants'
 import { createIdentifier } from './path-ids'
@@ -117,6 +120,8 @@ export function compileCodeSplitReferenceRoute(
   },
 ): GeneratorResult {
   const ast = parseAst(opts)
+
+  const refIdents = findReferencedIdentifiers(ast)
 
   function findIndexForSplitNode(str: string) {
     return opts.codeSplitGroupings.findIndex((group) =>
@@ -389,7 +394,7 @@ export function compileCodeSplitReferenceRoute(
     },
   })
 
-  deadCodeElimination(ast)
+  deadCodeElimination(ast, refIdents)
 
   return generateFromAst(ast, {
     sourceMaps: true,
@@ -404,6 +409,7 @@ export function compileCodeSplitVirtualRoute(
   },
 ): GeneratorResult {
   const ast = parseAst(opts)
+  const refIdents = findReferencedIdentifiers(ast)
 
   const intendedSplitNodes = new Set(opts.splitTargets)
 
@@ -675,7 +681,7 @@ export function compileCodeSplitVirtualRoute(
     },
   })
 
-  deadCodeElimination(ast)
+  deadCodeElimination(ast, refIdents)
 
   // if there are exported identifiers, then we need to add a warning
   // to the file to let the user know that the exported identifiers

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/arrow-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/arrow-function.tsx
@@ -1,5 +1,6 @@
 const $$splitComponentImporter = () => import('arrow-function.tsx?tsr-split=component');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 import { fetchPosts } from '../posts';
 export const Route = createFileRoute('/posts')({

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/arrow-function@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/arrow-function@component.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { Link, Outlet } from '@tanstack/react-router';
 import { Route } from "arrow-function.tsx";
 const SplitComponent = () => {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/arrow-function@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/arrow-function@errorComponent.tsx
@@ -1,0 +1,2 @@
+import * as React from 'react';
+import { Route } from "arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/arrow-function@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/arrow-function@notFoundComponent.tsx
@@ -1,0 +1,2 @@
+import * as React from 'react';
+import { Route } from "arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/arrow-function@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/arrow-function@pendingComponent.tsx
@@ -1,0 +1,2 @@
+import * as React from 'react';
+import { Route } from "arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/chinese.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/chinese.tsx
@@ -1,5 +1,6 @@
 const $$splitComponentImporter = () => import('chinese.tsx?tsr-split=component');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/chinese@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/chinese@component.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import { Route } from "chinese.tsx";
 interface DemoProps {
   title: string;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/chinese@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/chinese@errorComponent.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import { Route } from "chinese.tsx";
 interface DemoProps {
   title: string;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/chinese@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/chinese@notFoundComponent.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import { Route } from "chinese.tsx";
 interface DemoProps {
   title: string;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/chinese@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/chinese@pendingComponent.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import { Route } from "chinese.tsx";
 interface DemoProps {
   title: string;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/conditional-properties@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/conditional-properties@component.tsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@features/feature-flags';
 import TrueImport from '@modules/true-component';
 import { FalseComponent } from '@modules/false-component';
+import { Route } from "conditional-properties.tsx";
 const SplitComponent = isEnabled ? TrueImport.Component : FalseComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/conditional-properties@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/conditional-properties@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "conditional-properties.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/conditional-properties@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/conditional-properties@notFoundComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "conditional-properties.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/conditional-properties@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/conditional-properties@pendingComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "conditional-properties.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/destructured-react-memo-imported-component@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/destructured-react-memo-imported-component@component.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { Route } from "destructured-react-memo-imported-component.tsx";
 function Component() {
   return <div>Component</div>;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/destructured-react-memo-imported-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/destructured-react-memo-imported-component@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "destructured-react-memo-imported-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/destructured-react-memo-imported-component@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/destructured-react-memo-imported-component@notFoundComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "destructured-react-memo-imported-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/destructured-react-memo-imported-component@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/destructured-react-memo-imported-component@pendingComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "destructured-react-memo-imported-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/function-as-parameter.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/function-as-parameter.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // @ts-expect-error
 import { useMemo } from 'tan-react';
+const useUsedVar = 'i-am-unused';
 const ReactUseMemoCall1 = React.useMemo(function performAction() {
   return 'true';
 }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/function-as-parameter@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/function-as-parameter@component.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // @ts-expect-error
 import { useMemo } from 'tan-react';
+const useUsedVar = 'i-am-unused';
 const ReactUseMemoCall1 = React.useMemo(function performAction() {
   return 'true';
 }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/function-as-parameter@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/function-as-parameter@errorComponent.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // @ts-expect-error
 import { useMemo } from 'tan-react';
+const useUsedVar = 'i-am-unused';
 const ReactUseMemoCall1 = React.useMemo(function performAction() {
   return 'true';
 }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/function-as-parameter@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/function-as-parameter@notFoundComponent.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // @ts-expect-error
 import { useMemo } from 'tan-react';
+const useUsedVar = 'i-am-unused';
 const ReactUseMemoCall1 = React.useMemo(function performAction() {
   return 'true';
 }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/function-as-parameter@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/function-as-parameter@pendingComponent.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // @ts-expect-error
 import { useMemo } from 'tan-react';
+const useUsedVar = 'i-am-unused';
 const ReactUseMemoCall1 = React.useMemo(function performAction() {
   return 'true';
 }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/function-declaration.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/function-declaration.tsx
@@ -1,5 +1,6 @@
 const $$splitComponentImporter = () => import('function-declaration.tsx?tsr-split=component');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 import { fetchPosts } from '../posts';
 export const Route = createFileRoute('/posts')({

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/function-declaration@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/function-declaration@component.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { Link, Outlet } from '@tanstack/react-router';
 import { Route } from "function-declaration.tsx";
 const SplitComponent = function PostsComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/function-declaration@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/function-declaration@errorComponent.tsx
@@ -1,0 +1,2 @@
+import * as React from 'react';
+import { Route } from "function-declaration.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/function-declaration@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/function-declaration@notFoundComponent.tsx
@@ -1,0 +1,2 @@
+import * as React from 'react';
+import { Route } from "function-declaration.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/function-declaration@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/function-declaration@pendingComponent.tsx
@@ -1,0 +1,2 @@
+import * as React from 'react';
+import { Route } from "function-declaration.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/importAttribute@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/importAttribute@component.tsx
@@ -1,3 +1,4 @@
 import { test } from './test' with { type: 'macro' };
+import { Route } from "importAttribute.tsx";
 const SplitComponent = () => test;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/importAttribute@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/importAttribute@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "importAttribute.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/importAttribute@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/importAttribute@notFoundComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "importAttribute.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/importAttribute@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/importAttribute@pendingComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "importAttribute.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-default-component-destructured-loader@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-default-component-destructured-loader@component.tsx
@@ -1,3 +1,4 @@
 import importedComponent from '../../shared/imported';
+import { Route } from "imported-default-component-destructured-loader.tsx";
 const SplitComponent = importedComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-default-component-destructured-loader@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-default-component-destructured-loader@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-default-component-destructured-loader.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-default-component-destructured-loader@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-default-component-destructured-loader@notFoundComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-default-component-destructured-loader.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-default-component-destructured-loader@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-default-component-destructured-loader@pendingComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-default-component-destructured-loader.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-default-component@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-default-component@component.tsx
@@ -1,3 +1,4 @@
 import ImportedDefaultComponent from '../../shared/imported';
+import { Route } from "imported-default-component.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-default-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-default-component@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-default-component@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-default-component@notFoundComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-default-component@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-default-component@pendingComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-errorComponent@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-errorComponent@component.tsx
@@ -1,3 +1,4 @@
 import ImportedDefaultComponent from '../../shared/imported';
+import { Route } from "imported-errorComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-errorComponent@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-errorComponent@errorComponent.tsx
@@ -1,3 +1,4 @@
 import { importedErrorComponent } from '../../shared/imported';
+import { Route } from "imported-errorComponent.tsx";
 const SplitErrorComponent = importedErrorComponent;
 export { SplitErrorComponent as errorComponent };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-errorComponent@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-errorComponent@notFoundComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-errorComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-errorComponent@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-errorComponent@pendingComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-errorComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-notFoundComponent@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-notFoundComponent@component.tsx
@@ -1,3 +1,4 @@
 import ImportedDefaultComponent from '../../shared/imported';
+import { Route } from "imported-notFoundComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-notFoundComponent@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-notFoundComponent@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-notFoundComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-notFoundComponent@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-notFoundComponent@notFoundComponent.tsx
@@ -1,3 +1,4 @@
 import { importedNotFoundComponent } from '../../shared/imported';
+import { Route } from "imported-notFoundComponent.tsx";
 const SplitNotFoundComponent = importedNotFoundComponent;
 export { SplitNotFoundComponent as notFoundComponent };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-notFoundComponent@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-notFoundComponent@pendingComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-notFoundComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-pendingComponent@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-pendingComponent@component.tsx
@@ -1,3 +1,4 @@
 import ImportedDefaultComponent from '../../shared/imported';
+import { Route } from "imported-pendingComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-pendingComponent@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-pendingComponent@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-pendingComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-pendingComponent@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-pendingComponent@notFoundComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-pendingComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-pendingComponent@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-pendingComponent@pendingComponent.tsx
@@ -1,3 +1,4 @@
 import { importedPendingComponent } from '../../shared/imported';
+import { Route } from "imported-pendingComponent.tsx";
 const SplitPendingComponent = importedPendingComponent;
 export { SplitPendingComponent as pendingComponent };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported@component.tsx
@@ -1,3 +1,4 @@
 import { importedComponent } from '../../shared';
+import { Route } from "imported.tsx";
 const SplitComponent = importedComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported@notFoundComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported@pendingComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/inline.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/inline.tsx
@@ -1,5 +1,6 @@
 const $$splitComponentImporter = () => import('inline.tsx?tsr-split=component');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/inline@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/inline@component.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import * as styles from '../style.css';
 import { TEST_DATA } from '../test.const';
 const Button = (props: {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/inline@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/inline@errorComponent.tsx
@@ -1,2 +1,4 @@
+import * as React from 'react';
 import { Route } from "inline.tsx";
 Route.addChildren([]);
+import { test } from "inline.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/inline@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/inline@notFoundComponent.tsx
@@ -1,2 +1,4 @@
+import * as React from 'react';
 import { Route } from "inline.tsx";
 Route.addChildren([]);
+import { test } from "inline.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/inline@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/inline@pendingComponent.tsx
@@ -1,2 +1,4 @@
+import * as React from 'react';
 import { Route } from "inline.tsx";
 Route.addChildren([]);
+import { test } from "inline.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/random-number.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/random-number.tsx
@@ -1,9 +1,26 @@
 const $$splitComponentImporter = () => import('random-number.tsx?tsr-split=component');
 import { lazyRouteComponent } from '@tanstack/react-router';
-import { createFileRoute, defer } from '@tanstack/react-router';
+import { Await, Link, createFileRoute, defer } from '@tanstack/react-router';
+import { Carbon } from '~/components/Carbon';
+import { twMerge } from 'tailwind-merge';
+import { FaDiscord, FaGithub, FaTshirt } from 'react-icons/fa';
+import { CgMusicSpeaker, CgSpinner } from 'react-icons/cg';
+import { Footer } from '~/components/Footer';
+import SponsorPack from '~/components/SponsorPack';
+import { LogoColor } from '~/components/LogoColor';
 import { getSponsorsForSponsorPack } from '~/server/sponsors';
+import agGridImage from '~/images/ag-grid.png';
+import nozzleImage from '~/images/nozzle.png';
+import bytesImage from '~/images/bytes.svg';
+import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
 export const textColors = [`text-rose-500`, `text-yellow-500`, `text-teal-500`, `text-blue-500`];
 export const gradients = [`from-rose-500 to-yellow-500`, `from-yellow-500 to-teal-500`, `from-teal-500 to-violet-500`, `from-blue-500 to-pink-500`];
+const courses = [{
+  name: 'The Official TanStack React Query Course',
+  cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
+  href: 'https://query.gg/?s=tanstack',
+  description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
+}];
 export const Route = createFileRoute('/')({
   loader: () => {
     return {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/random-number@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/random-number@component.tsx
@@ -1,9 +1,50 @@
+import { Await, Link } from '@tanstack/react-router';
+import { Carbon } from '~/components/Carbon';
+import { twMerge } from 'tailwind-merge';
+import { FaDiscord, FaGithub, FaTshirt } from 'react-icons/fa';
+import { CgMusicSpeaker, CgSpinner } from 'react-icons/cg';
+import { Footer } from '~/components/Footer';
+import SponsorPack from '~/components/SponsorPack';
+import { LogoColor } from '~/components/LogoColor';
 import discordImage from '~/images/discord-logo-white.svg';
+import agGridImage from '~/images/ag-grid.png';
+import nozzleImage from '~/images/nozzle.png';
+import bytesImage from '~/images/bytes.svg';
+import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
+import { useMutation } from '~/hooks/useMutation';
 import { sample } from '~/utils/utils';
 import { textColors } from "random-number.tsx";
 import { gradients } from "random-number.tsx";
+const courses = [{
+  name: 'The Official TanStack React Query Course',
+  cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
+  href: 'https://query.gg/?s=tanstack',
+  description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
+}];
 import { Route } from "random-number.tsx";
+async function bytesSignupServerFn({
+  email
+}: {
+  email: string;
+}) {
+  'use server';
+
+  return fetch(`https://bytes.dev/api/bytes-optin-cors`, {
+    method: 'POST',
+    body: JSON.stringify({
+      email,
+      influencer: 'tanstack'
+    }),
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    }
+  });
+}
 const SplitComponent = function Index() {
+  const bytesSignupMutation = useMutation({
+    fn: bytesSignupServerFn
+  });
   const {
     randomNumber
   } = Route.useLoaderData();

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/random-number@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/random-number@errorComponent.tsx
@@ -1,0 +1,21 @@
+import { Await, Link } from '@tanstack/react-router';
+import { Carbon } from '~/components/Carbon';
+import { twMerge } from 'tailwind-merge';
+import { FaDiscord, FaGithub, FaTshirt } from 'react-icons/fa';
+import { CgMusicSpeaker, CgSpinner } from 'react-icons/cg';
+import { Footer } from '~/components/Footer';
+import SponsorPack from '~/components/SponsorPack';
+import { LogoColor } from '~/components/LogoColor';
+import agGridImage from '~/images/ag-grid.png';
+import nozzleImage from '~/images/nozzle.png';
+import bytesImage from '~/images/bytes.svg';
+import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
+import { textColors } from "random-number.tsx";
+import { gradients } from "random-number.tsx";
+const courses = [{
+  name: 'The Official TanStack React Query Course',
+  cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
+  href: 'https://query.gg/?s=tanstack',
+  description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
+}];
+import { Route } from "random-number.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/random-number@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/random-number@notFoundComponent.tsx
@@ -1,0 +1,21 @@
+import { Await, Link } from '@tanstack/react-router';
+import { Carbon } from '~/components/Carbon';
+import { twMerge } from 'tailwind-merge';
+import { FaDiscord, FaGithub, FaTshirt } from 'react-icons/fa';
+import { CgMusicSpeaker, CgSpinner } from 'react-icons/cg';
+import { Footer } from '~/components/Footer';
+import SponsorPack from '~/components/SponsorPack';
+import { LogoColor } from '~/components/LogoColor';
+import agGridImage from '~/images/ag-grid.png';
+import nozzleImage from '~/images/nozzle.png';
+import bytesImage from '~/images/bytes.svg';
+import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
+import { textColors } from "random-number.tsx";
+import { gradients } from "random-number.tsx";
+const courses = [{
+  name: 'The Official TanStack React Query Course',
+  cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
+  href: 'https://query.gg/?s=tanstack',
+  description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
+}];
+import { Route } from "random-number.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/random-number@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/random-number@pendingComponent.tsx
@@ -1,0 +1,21 @@
+import { Await, Link } from '@tanstack/react-router';
+import { Carbon } from '~/components/Carbon';
+import { twMerge } from 'tailwind-merge';
+import { FaDiscord, FaGithub, FaTshirt } from 'react-icons/fa';
+import { CgMusicSpeaker, CgSpinner } from 'react-icons/cg';
+import { Footer } from '~/components/Footer';
+import SponsorPack from '~/components/SponsorPack';
+import { LogoColor } from '~/components/LogoColor';
+import agGridImage from '~/images/ag-grid.png';
+import nozzleImage from '~/images/nozzle.png';
+import bytesImage from '~/images/bytes.svg';
+import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
+import { textColors } from "random-number.tsx";
+import { gradients } from "random-number.tsx";
+const courses = [{
+  name: 'The Official TanStack React Query Course',
+  cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
+  href: 'https://query.gg/?s=tanstack',
+  description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
+}];
+import { Route } from "random-number.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/react-memo-component@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/react-memo-component@component.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Route } from "react-memo-component.tsx";
 function Component() {
   return <div>Component</div>;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/react-memo-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/react-memo-component@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "react-memo-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/react-memo-component@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/react-memo-component@notFoundComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "react-memo-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/react-memo-component@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/react-memo-component@pendingComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "react-memo-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/react-memo-imported-component@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/react-memo-imported-component@component.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
 import { importedComponent } from '../../shared/imported';
+import { Route } from "react-memo-imported-component.tsx";
 const SplitComponent = React.memo(importedComponent);
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/react-memo-imported-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/react-memo-imported-component@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "react-memo-imported-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/react-memo-imported-component@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/react-memo-imported-component@notFoundComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "react-memo-imported-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/react-memo-imported-component@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/react-memo-imported-component@pendingComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "react-memo-imported-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-export-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-export-component.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent, importedLoader } from '../../shared/imported';
 export function Layout() {
@@ -23,3 +24,5 @@ export const Route = createFileRoute('/_layout')({
 });
 const HEADER_HEIGHT = '63px';
 export const SIDEBAR_WIDTH = '150px';
+const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-export-component@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-export-component@component.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-export-component.tsx";
+import { SIDEBAR_WIDTH } from "retain-export-component.tsx";
+const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-export-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-export-component@errorComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-export-component.tsx";
+import { SIDEBAR_WIDTH } from "retain-export-component.tsx";
+const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-export-component@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-export-component@notFoundComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-export-component.tsx";
+import { SIDEBAR_WIDTH } from "retain-export-component.tsx";
+const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-export-component@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-export-component@pendingComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-export-component.tsx";
+import { SIDEBAR_WIDTH } from "retain-export-component.tsx";
+const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-const.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-const.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent, importedLoader } from '../../shared/imported';
 export const loaderFn = () => {
@@ -27,4 +28,5 @@ export const Route = createFileRoute('/_layout')({
 const HEADER_HEIGHT = '63px';
 export const SIDEBAR_WIDTH = '150px';
 export const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';
 export default Layout;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-const@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-const@component.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-const.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-const.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-const@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-const@errorComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-const.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-const.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-const@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-const@notFoundComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-const.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-const.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-const@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-const@pendingComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-const.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-const.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-function.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent, importedLoader } from '../../shared/imported';
 export function loaderFn() {
@@ -27,4 +28,5 @@ export const Route = createFileRoute('/_layout')({
 const HEADER_HEIGHT = '63px';
 export const SIDEBAR_WIDTH = '150px';
 export const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';
 export default Layout;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-function@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-function@component.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-function.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-function.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-function@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-function@errorComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-function.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-function.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-function@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-function@notFoundComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-function.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-function.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-function@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-function@pendingComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-function.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-function.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-loader.tsx
@@ -1,5 +1,6 @@
 const $$splitComponentImporter = () => import('retain-exports-loader.tsx?tsr-split=component');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export function loaderFn() {
   return {
@@ -12,6 +13,7 @@ export const Route = createFileRoute('/_layout')({
 });
 export const SIDEBAR_WIDTH = '150px';
 export const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';
 export function TSRDummyComponent() {
   return null;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-loader@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-loader@component.tsx
@@ -1,6 +1,11 @@
+import * as React from 'react';
 import { Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent } from '../../shared/imported';
+import { Route } from "retain-exports-loader.tsx";
 const HEADER_HEIGHT = '63px';
+import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-loader.tsx";
+const ASIDE_WIDTH = '250px';
 const SplitComponent = function Layout() {
   return <main>
       <header style={{

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-loader@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-loader@errorComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-loader.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-loader.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-loader@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-loader@notFoundComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-loader.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-loader.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-loader@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-loader@pendingComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-loader.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-loader.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/useStateDestructure.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/useStateDestructure.tsx
@@ -1,5 +1,7 @@
 const $$splitComponentImporter = () => import('useStateDestructure.tsx?tsr-split=component');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import { FaBolt, FaBook, FaCheckCircle, FaCogs } from 'react-icons/fa';
+import { VscPreview, VscWand } from 'react-icons/vsc';
 import { startProject } from '~/projects/start';
 import { createFileRoute } from '@tanstack/react-router';
 import { seo } from '~/utils/seo';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/useStateDestructure@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/useStateDestructure@component.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { CgCornerUpLeft, CgSpinner } from 'react-icons/cg';
-import { FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
+import { FaBolt, FaBook, FaCheckCircle, FaCogs, FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
 import { Await, Link, getRouteApi } from '@tanstack/react-router';
 import { Carbon } from '~/components/Carbon';
 import { Footer } from '~/components/Footer';
+import { VscPreview, VscWand } from 'react-icons/vsc';
 import { TbHeartHandshake } from 'react-icons/tb';
 import SponsorPack from '~/components/SponsorPack';
 import { startProject } from '~/projects/start';
+import { Framework, getBranch } from '~/projects';
 const menu = [{
   label: <div className="flex items-center gap-2">
         <CgCornerUpLeft className="text-lg" /> TanStack
@@ -57,7 +59,9 @@ export default function VersionIndex() {
   const {
     version
   } = Route.useParams();
-  const [, setIsDark] = React.useState(true);
+  const branch = getBranch(startProject, version);
+  const [framework, setFramework] = React.useState<Framework>('react');
+  const [isDark, setIsDark] = React.useState(true);
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches);
   }, []);
@@ -449,7 +453,9 @@ const SplitComponent = function VersionIndex() {
   const {
     version
   } = Route.useParams();
-  const [, setIsDark] = React.useState(true);
+  const branch = getBranch(startProject, version);
+  const [framework, setFramework] = React.useState<Framework>('react');
+  const [isDark, setIsDark] = React.useState(true);
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches);
   }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/useStateDestructure@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/useStateDestructure@errorComponent.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { CgCornerUpLeft, CgSpinner } from 'react-icons/cg';
-import { FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
+import { FaBolt, FaBook, FaCheckCircle, FaCogs, FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
 import { Await, Link, getRouteApi } from '@tanstack/react-router';
 import { Carbon } from '~/components/Carbon';
 import { Footer } from '~/components/Footer';
+import { VscPreview, VscWand } from 'react-icons/vsc';
 import { TbHeartHandshake } from 'react-icons/tb';
 import SponsorPack from '~/components/SponsorPack';
 import { startProject } from '~/projects/start';
+import { Framework, getBranch } from '~/projects';
 const menu = [{
   label: <div className="flex items-center gap-2">
         <CgCornerUpLeft className="text-lg" /> TanStack
@@ -57,7 +59,9 @@ export default function VersionIndex() {
   const {
     version
   } = Route.useParams();
-  const [, setIsDark] = React.useState(true);
+  const branch = getBranch(startProject, version);
+  const [framework, setFramework] = React.useState<Framework>('react');
+  const [isDark, setIsDark] = React.useState(true);
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches);
   }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/useStateDestructure@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/useStateDestructure@notFoundComponent.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { CgCornerUpLeft, CgSpinner } from 'react-icons/cg';
-import { FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
+import { FaBolt, FaBook, FaCheckCircle, FaCogs, FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
 import { Await, Link, getRouteApi } from '@tanstack/react-router';
 import { Carbon } from '~/components/Carbon';
 import { Footer } from '~/components/Footer';
+import { VscPreview, VscWand } from 'react-icons/vsc';
 import { TbHeartHandshake } from 'react-icons/tb';
 import SponsorPack from '~/components/SponsorPack';
 import { startProject } from '~/projects/start';
+import { Framework, getBranch } from '~/projects';
 const menu = [{
   label: <div className="flex items-center gap-2">
         <CgCornerUpLeft className="text-lg" /> TanStack
@@ -57,7 +59,9 @@ export default function VersionIndex() {
   const {
     version
   } = Route.useParams();
-  const [, setIsDark] = React.useState(true);
+  const branch = getBranch(startProject, version);
+  const [framework, setFramework] = React.useState<Framework>('react');
+  const [isDark, setIsDark] = React.useState(true);
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches);
   }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/useStateDestructure@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/useStateDestructure@pendingComponent.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { CgCornerUpLeft, CgSpinner } from 'react-icons/cg';
-import { FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
+import { FaBolt, FaBook, FaCheckCircle, FaCogs, FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
 import { Await, Link, getRouteApi } from '@tanstack/react-router';
 import { Carbon } from '~/components/Carbon';
 import { Footer } from '~/components/Footer';
+import { VscPreview, VscWand } from 'react-icons/vsc';
 import { TbHeartHandshake } from 'react-icons/tb';
 import SponsorPack from '~/components/SponsorPack';
 import { startProject } from '~/projects/start';
+import { Framework, getBranch } from '~/projects';
 const menu = [{
   label: <div className="flex items-center gap-2">
         <CgCornerUpLeft className="text-lg" /> TanStack
@@ -57,7 +59,9 @@ export default function VersionIndex() {
   const {
     version
   } = Route.useParams();
-  const [, setIsDark] = React.useState(true);
+  const branch = getBranch(startProject, version);
+  const [framework, setFramework] = React.useState<Framework>('react');
+  const [isDark, setIsDark] = React.useState(true);
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches);
   }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/arrow-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/arrow-function.tsx
@@ -1,5 +1,6 @@
 const $$splitComponentImporter = () => import('arrow-function.tsx?tsr-split=component');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 import { fetchPosts } from '../posts';
 export const Route = createFileRoute('/posts')({

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/arrow-function@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/arrow-function@component.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { Link, Outlet } from '@tanstack/react-router';
 import { Route } from "arrow-function.tsx";
 const SplitComponent = () => {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/arrow-function@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/arrow-function@errorComponent.tsx
@@ -1,0 +1,2 @@
+import * as React from 'react';
+import { Route } from "arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/arrow-function@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/arrow-function@notFoundComponent.tsx
@@ -1,0 +1,2 @@
+import * as React from 'react';
+import { Route } from "arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/arrow-function@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/arrow-function@pendingComponent.tsx
@@ -1,0 +1,2 @@
+import * as React from 'react';
+import { Route } from "arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/chinese.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/chinese.tsx
@@ -1,5 +1,6 @@
 const $$splitComponentImporter = () => import('chinese.tsx?tsr-split=component');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/chinese@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/chinese@component.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import { Route } from "chinese.tsx";
 interface DemoProps {
   title: string;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/chinese@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/chinese@errorComponent.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import { Route } from "chinese.tsx";
 interface DemoProps {
   title: string;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/chinese@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/chinese@notFoundComponent.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import { Route } from "chinese.tsx";
 interface DemoProps {
   title: string;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/chinese@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/chinese@pendingComponent.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import { Route } from "chinese.tsx";
 interface DemoProps {
   title: string;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/conditional-properties@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/conditional-properties@component.tsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@features/feature-flags';
 import TrueImport from '@modules/true-component';
 import { FalseComponent } from '@modules/false-component';
+import { Route } from "conditional-properties.tsx";
 const SplitComponent = isEnabled ? TrueImport.Component : FalseComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/conditional-properties@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/conditional-properties@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "conditional-properties.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/conditional-properties@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/conditional-properties@notFoundComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "conditional-properties.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/conditional-properties@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/conditional-properties@pendingComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "conditional-properties.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/destructured-react-memo-imported-component@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/destructured-react-memo-imported-component@component.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { Route } from "destructured-react-memo-imported-component.tsx";
 function Component() {
   return <div>Component</div>;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/destructured-react-memo-imported-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/destructured-react-memo-imported-component@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "destructured-react-memo-imported-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/destructured-react-memo-imported-component@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/destructured-react-memo-imported-component@notFoundComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "destructured-react-memo-imported-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/destructured-react-memo-imported-component@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/destructured-react-memo-imported-component@pendingComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "destructured-react-memo-imported-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/function-as-parameter.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/function-as-parameter.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // @ts-expect-error
 import { useMemo } from 'tan-react';
+const useUsedVar = 'i-am-unused';
 const ReactUseMemoCall1 = React.useMemo(function performAction() {
   return 'true';
 }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/function-as-parameter@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/function-as-parameter@component.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // @ts-expect-error
 import { useMemo } from 'tan-react';
+const useUsedVar = 'i-am-unused';
 const ReactUseMemoCall1 = React.useMemo(function performAction() {
   return 'true';
 }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/function-as-parameter@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/function-as-parameter@errorComponent.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // @ts-expect-error
 import { useMemo } from 'tan-react';
+const useUsedVar = 'i-am-unused';
 const ReactUseMemoCall1 = React.useMemo(function performAction() {
   return 'true';
 }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/function-as-parameter@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/function-as-parameter@notFoundComponent.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // @ts-expect-error
 import { useMemo } from 'tan-react';
+const useUsedVar = 'i-am-unused';
 const ReactUseMemoCall1 = React.useMemo(function performAction() {
   return 'true';
 }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/function-as-parameter@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/function-as-parameter@pendingComponent.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // @ts-expect-error
 import { useMemo } from 'tan-react';
+const useUsedVar = 'i-am-unused';
 const ReactUseMemoCall1 = React.useMemo(function performAction() {
   return 'true';
 }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/function-declaration.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/function-declaration.tsx
@@ -1,5 +1,6 @@
 const $$splitComponentImporter = () => import('function-declaration.tsx?tsr-split=component');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 import { fetchPosts } from '../posts';
 export const Route = createFileRoute('/posts')({

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/function-declaration@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/function-declaration@component.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { Link, Outlet } from '@tanstack/react-router';
 import { Route } from "function-declaration.tsx";
 const SplitComponent = function PostsComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/function-declaration@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/function-declaration@errorComponent.tsx
@@ -1,0 +1,2 @@
+import * as React from 'react';
+import { Route } from "function-declaration.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/function-declaration@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/function-declaration@notFoundComponent.tsx
@@ -1,0 +1,2 @@
+import * as React from 'react';
+import { Route } from "function-declaration.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/function-declaration@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/function-declaration@pendingComponent.tsx
@@ -1,0 +1,2 @@
+import * as React from 'react';
+import { Route } from "function-declaration.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/importAttribute@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/importAttribute@component.tsx
@@ -1,3 +1,4 @@
 import { test } from './test' with { type: 'macro' };
+import { Route } from "importAttribute.tsx";
 const SplitComponent = () => test;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/importAttribute@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/importAttribute@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "importAttribute.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/importAttribute@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/importAttribute@notFoundComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "importAttribute.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/importAttribute@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/importAttribute@pendingComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "importAttribute.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-default-component-destructured-loader@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-default-component-destructured-loader@component.tsx
@@ -1,3 +1,4 @@
 import importedComponent from '../../shared/imported';
+import { Route } from "imported-default-component-destructured-loader.tsx";
 const SplitComponent = importedComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-default-component-destructured-loader@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-default-component-destructured-loader@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-default-component-destructured-loader.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-default-component-destructured-loader@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-default-component-destructured-loader@notFoundComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-default-component-destructured-loader.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-default-component-destructured-loader@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-default-component-destructured-loader@pendingComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-default-component-destructured-loader.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-default-component@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-default-component@component.tsx
@@ -1,3 +1,4 @@
 import ImportedDefaultComponent from '../../shared/imported';
+import { Route } from "imported-default-component.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-default-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-default-component@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-default-component@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-default-component@notFoundComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-default-component@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-default-component@pendingComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-errorComponent@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-errorComponent@component.tsx
@@ -1,3 +1,4 @@
 import ImportedDefaultComponent from '../../shared/imported';
+import { Route } from "imported-errorComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-errorComponent@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-errorComponent@errorComponent.tsx
@@ -1,3 +1,4 @@
 import { importedErrorComponent } from '../../shared/imported';
+import { Route } from "imported-errorComponent.tsx";
 const SplitErrorComponent = importedErrorComponent;
 export { SplitErrorComponent as errorComponent };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-errorComponent@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-errorComponent@notFoundComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-errorComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-errorComponent@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-errorComponent@pendingComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-errorComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-notFoundComponent@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-notFoundComponent@component.tsx
@@ -1,3 +1,4 @@
 import ImportedDefaultComponent from '../../shared/imported';
+import { Route } from "imported-notFoundComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-notFoundComponent@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-notFoundComponent@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-notFoundComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-notFoundComponent@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-notFoundComponent@notFoundComponent.tsx
@@ -1,3 +1,4 @@
 import { importedNotFoundComponent } from '../../shared/imported';
+import { Route } from "imported-notFoundComponent.tsx";
 const SplitNotFoundComponent = importedNotFoundComponent;
 export { SplitNotFoundComponent as notFoundComponent };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-notFoundComponent@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-notFoundComponent@pendingComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-notFoundComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-pendingComponent@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-pendingComponent@component.tsx
@@ -1,3 +1,4 @@
 import ImportedDefaultComponent from '../../shared/imported';
+import { Route } from "imported-pendingComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-pendingComponent@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-pendingComponent@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-pendingComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-pendingComponent@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-pendingComponent@notFoundComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-pendingComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-pendingComponent@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-pendingComponent@pendingComponent.tsx
@@ -1,3 +1,4 @@
 import { importedPendingComponent } from '../../shared/imported';
+import { Route } from "imported-pendingComponent.tsx";
 const SplitPendingComponent = importedPendingComponent;
 export { SplitPendingComponent as pendingComponent };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported@component.tsx
@@ -1,3 +1,4 @@
 import { importedComponent } from '../../shared';
+import { Route } from "imported.tsx";
 const SplitComponent = importedComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported@notFoundComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported@pendingComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/inline.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/inline.tsx
@@ -1,5 +1,6 @@
 const $$splitComponentImporter = () => import('inline.tsx?tsr-split=component');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/inline@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/inline@component.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import * as styles from '../style.css';
 import { TEST_DATA } from '../test.const';
 const Button = (props: {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/inline@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/inline@errorComponent.tsx
@@ -1,2 +1,4 @@
+import * as React from 'react';
 import { Route } from "inline.tsx";
 Route.addChildren([]);
+import { test } from "inline.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/inline@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/inline@notFoundComponent.tsx
@@ -1,2 +1,4 @@
+import * as React from 'react';
 import { Route } from "inline.tsx";
 Route.addChildren([]);
+import { test } from "inline.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/inline@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/inline@pendingComponent.tsx
@@ -1,2 +1,4 @@
+import * as React from 'react';
 import { Route } from "inline.tsx";
 Route.addChildren([]);
+import { test } from "inline.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/random-number.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/random-number.tsx
@@ -1,9 +1,26 @@
 const $$splitComponentImporter = () => import('random-number.tsx?tsr-split=component');
 import { lazyRouteComponent } from '@tanstack/react-router';
-import { createFileRoute, defer } from '@tanstack/react-router';
+import { Await, Link, createFileRoute, defer } from '@tanstack/react-router';
+import { Carbon } from '~/components/Carbon';
+import { twMerge } from 'tailwind-merge';
+import { FaDiscord, FaGithub, FaTshirt } from 'react-icons/fa';
+import { CgMusicSpeaker, CgSpinner } from 'react-icons/cg';
+import { Footer } from '~/components/Footer';
+import SponsorPack from '~/components/SponsorPack';
+import { LogoColor } from '~/components/LogoColor';
 import { getSponsorsForSponsorPack } from '~/server/sponsors';
+import agGridImage from '~/images/ag-grid.png';
+import nozzleImage from '~/images/nozzle.png';
+import bytesImage from '~/images/bytes.svg';
+import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
 export const textColors = [`text-rose-500`, `text-yellow-500`, `text-teal-500`, `text-blue-500`];
 export const gradients = [`from-rose-500 to-yellow-500`, `from-yellow-500 to-teal-500`, `from-teal-500 to-violet-500`, `from-blue-500 to-pink-500`];
+const courses = [{
+  name: 'The Official TanStack React Query Course',
+  cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
+  href: 'https://query.gg/?s=tanstack',
+  description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
+}];
 export const Route = createFileRoute('/')({
   loader: () => {
     return {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/random-number@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/random-number@component.tsx
@@ -1,9 +1,50 @@
+import { Await, Link } from '@tanstack/react-router';
+import { Carbon } from '~/components/Carbon';
+import { twMerge } from 'tailwind-merge';
+import { FaDiscord, FaGithub, FaTshirt } from 'react-icons/fa';
+import { CgMusicSpeaker, CgSpinner } from 'react-icons/cg';
+import { Footer } from '~/components/Footer';
+import SponsorPack from '~/components/SponsorPack';
+import { LogoColor } from '~/components/LogoColor';
 import discordImage from '~/images/discord-logo-white.svg';
+import agGridImage from '~/images/ag-grid.png';
+import nozzleImage from '~/images/nozzle.png';
+import bytesImage from '~/images/bytes.svg';
+import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
+import { useMutation } from '~/hooks/useMutation';
 import { sample } from '~/utils/utils';
 import { textColors } from "random-number.tsx";
 import { gradients } from "random-number.tsx";
+const courses = [{
+  name: 'The Official TanStack React Query Course',
+  cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
+  href: 'https://query.gg/?s=tanstack',
+  description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
+}];
 import { Route } from "random-number.tsx";
+async function bytesSignupServerFn({
+  email
+}: {
+  email: string;
+}) {
+  'use server';
+
+  return fetch(`https://bytes.dev/api/bytes-optin-cors`, {
+    method: 'POST',
+    body: JSON.stringify({
+      email,
+      influencer: 'tanstack'
+    }),
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    }
+  });
+}
 const SplitComponent = function Index() {
+  const bytesSignupMutation = useMutation({
+    fn: bytesSignupServerFn
+  });
   const {
     randomNumber
   } = Route.useLoaderData();

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/random-number@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/random-number@errorComponent.tsx
@@ -1,0 +1,21 @@
+import { Await, Link } from '@tanstack/react-router';
+import { Carbon } from '~/components/Carbon';
+import { twMerge } from 'tailwind-merge';
+import { FaDiscord, FaGithub, FaTshirt } from 'react-icons/fa';
+import { CgMusicSpeaker, CgSpinner } from 'react-icons/cg';
+import { Footer } from '~/components/Footer';
+import SponsorPack from '~/components/SponsorPack';
+import { LogoColor } from '~/components/LogoColor';
+import agGridImage from '~/images/ag-grid.png';
+import nozzleImage from '~/images/nozzle.png';
+import bytesImage from '~/images/bytes.svg';
+import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
+import { textColors } from "random-number.tsx";
+import { gradients } from "random-number.tsx";
+const courses = [{
+  name: 'The Official TanStack React Query Course',
+  cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
+  href: 'https://query.gg/?s=tanstack',
+  description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
+}];
+import { Route } from "random-number.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/random-number@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/random-number@notFoundComponent.tsx
@@ -1,0 +1,21 @@
+import { Await, Link } from '@tanstack/react-router';
+import { Carbon } from '~/components/Carbon';
+import { twMerge } from 'tailwind-merge';
+import { FaDiscord, FaGithub, FaTshirt } from 'react-icons/fa';
+import { CgMusicSpeaker, CgSpinner } from 'react-icons/cg';
+import { Footer } from '~/components/Footer';
+import SponsorPack from '~/components/SponsorPack';
+import { LogoColor } from '~/components/LogoColor';
+import agGridImage from '~/images/ag-grid.png';
+import nozzleImage from '~/images/nozzle.png';
+import bytesImage from '~/images/bytes.svg';
+import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
+import { textColors } from "random-number.tsx";
+import { gradients } from "random-number.tsx";
+const courses = [{
+  name: 'The Official TanStack React Query Course',
+  cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
+  href: 'https://query.gg/?s=tanstack',
+  description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
+}];
+import { Route } from "random-number.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/random-number@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/random-number@pendingComponent.tsx
@@ -1,0 +1,21 @@
+import { Await, Link } from '@tanstack/react-router';
+import { Carbon } from '~/components/Carbon';
+import { twMerge } from 'tailwind-merge';
+import { FaDiscord, FaGithub, FaTshirt } from 'react-icons/fa';
+import { CgMusicSpeaker, CgSpinner } from 'react-icons/cg';
+import { Footer } from '~/components/Footer';
+import SponsorPack from '~/components/SponsorPack';
+import { LogoColor } from '~/components/LogoColor';
+import agGridImage from '~/images/ag-grid.png';
+import nozzleImage from '~/images/nozzle.png';
+import bytesImage from '~/images/bytes.svg';
+import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
+import { textColors } from "random-number.tsx";
+import { gradients } from "random-number.tsx";
+const courses = [{
+  name: 'The Official TanStack React Query Course',
+  cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
+  href: 'https://query.gg/?s=tanstack',
+  description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
+}];
+import { Route } from "random-number.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/react-memo-component@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/react-memo-component@component.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Route } from "react-memo-component.tsx";
 function Component() {
   return <div>Component</div>;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/react-memo-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/react-memo-component@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "react-memo-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/react-memo-component@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/react-memo-component@notFoundComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "react-memo-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/react-memo-component@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/react-memo-component@pendingComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "react-memo-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/react-memo-imported-component@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/react-memo-imported-component@component.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
 import { importedComponent } from '../../shared/imported';
+import { Route } from "react-memo-imported-component.tsx";
 const SplitComponent = React.memo(importedComponent);
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/react-memo-imported-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/react-memo-imported-component@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "react-memo-imported-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/react-memo-imported-component@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/react-memo-imported-component@notFoundComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "react-memo-imported-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/react-memo-imported-component@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/react-memo-imported-component@pendingComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "react-memo-imported-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-export-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-export-component.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent, importedLoader } from '../../shared/imported';
 export function Layout() {
@@ -23,3 +24,5 @@ export const Route = createFileRoute('/_layout')({
 });
 const HEADER_HEIGHT = '63px';
 export const SIDEBAR_WIDTH = '150px';
+const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-export-component@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-export-component@component.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-export-component.tsx";
+import { SIDEBAR_WIDTH } from "retain-export-component.tsx";
+const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-export-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-export-component@errorComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-export-component.tsx";
+import { SIDEBAR_WIDTH } from "retain-export-component.tsx";
+const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-export-component@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-export-component@notFoundComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-export-component.tsx";
+import { SIDEBAR_WIDTH } from "retain-export-component.tsx";
+const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-export-component@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-export-component@pendingComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-export-component.tsx";
+import { SIDEBAR_WIDTH } from "retain-export-component.tsx";
+const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-const.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-const.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent, importedLoader } from '../../shared/imported';
 export const loaderFn = () => {
@@ -27,4 +28,5 @@ export const Route = createFileRoute('/_layout')({
 const HEADER_HEIGHT = '63px';
 export const SIDEBAR_WIDTH = '150px';
 export const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';
 export default Layout;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-const@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-const@component.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-const.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-const.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-const@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-const@errorComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-const.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-const.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-const@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-const@notFoundComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-const.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-const.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-const@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-const@pendingComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-const.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-const.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-function.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent, importedLoader } from '../../shared/imported';
 export function loaderFn() {
@@ -27,4 +28,5 @@ export const Route = createFileRoute('/_layout')({
 const HEADER_HEIGHT = '63px';
 export const SIDEBAR_WIDTH = '150px';
 export const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';
 export default Layout;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-function@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-function@component.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-function.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-function.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-function@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-function@errorComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-function.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-function.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-function@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-function@notFoundComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-function.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-function.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-function@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-function@pendingComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-function.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-function.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-loader.tsx
@@ -1,5 +1,6 @@
 const $$splitComponentImporter = () => import('retain-exports-loader.tsx?tsr-split=component');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export function loaderFn() {
   return {
@@ -12,3 +13,4 @@ export const Route = createFileRoute('/_layout')({
 });
 export const SIDEBAR_WIDTH = '150px';
 export const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-loader@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-loader@component.tsx
@@ -1,6 +1,11 @@
+import * as React from 'react';
 import { Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent } from '../../shared/imported';
+import { Route } from "retain-exports-loader.tsx";
 const HEADER_HEIGHT = '63px';
+import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-loader.tsx";
+const ASIDE_WIDTH = '250px';
 const SplitComponent = function Layout() {
   return <main>
       <header style={{

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-loader@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-loader@errorComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-loader.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-loader.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-loader@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-loader@notFoundComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-loader.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-loader.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-loader@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-loader@pendingComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-loader.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-loader.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/useStateDestructure.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/useStateDestructure.tsx
@@ -1,5 +1,7 @@
 const $$splitComponentImporter = () => import('useStateDestructure.tsx?tsr-split=component');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import { FaBolt, FaBook, FaCheckCircle, FaCogs } from 'react-icons/fa';
+import { VscPreview, VscWand } from 'react-icons/vsc';
 import { startProject } from '~/projects/start';
 import { createFileRoute } from '@tanstack/react-router';
 import { seo } from '~/utils/seo';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/useStateDestructure@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/useStateDestructure@component.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { CgCornerUpLeft, CgSpinner } from 'react-icons/cg';
-import { FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
+import { FaBolt, FaBook, FaCheckCircle, FaCogs, FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
 import { Await, Link, getRouteApi } from '@tanstack/react-router';
 import { Carbon } from '~/components/Carbon';
 import { Footer } from '~/components/Footer';
+import { VscPreview, VscWand } from 'react-icons/vsc';
 import { TbHeartHandshake } from 'react-icons/tb';
 import SponsorPack from '~/components/SponsorPack';
 import { startProject } from '~/projects/start';
+import { Framework, getBranch } from '~/projects';
 const menu = [{
   label: <div className="flex items-center gap-2">
         <CgCornerUpLeft className="text-lg" /> TanStack
@@ -57,7 +59,9 @@ export default function VersionIndex() {
   const {
     version
   } = Route.useParams();
-  const [, setIsDark] = React.useState(true);
+  const branch = getBranch(startProject, version);
+  const [framework, setFramework] = React.useState<Framework>('react');
+  const [isDark, setIsDark] = React.useState(true);
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches);
   }, []);
@@ -449,7 +453,9 @@ const SplitComponent = function VersionIndex() {
   const {
     version
   } = Route.useParams();
-  const [, setIsDark] = React.useState(true);
+  const branch = getBranch(startProject, version);
+  const [framework, setFramework] = React.useState<Framework>('react');
+  const [isDark, setIsDark] = React.useState(true);
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches);
   }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/useStateDestructure@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/useStateDestructure@errorComponent.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { CgCornerUpLeft, CgSpinner } from 'react-icons/cg';
-import { FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
+import { FaBolt, FaBook, FaCheckCircle, FaCogs, FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
 import { Await, Link, getRouteApi } from '@tanstack/react-router';
 import { Carbon } from '~/components/Carbon';
 import { Footer } from '~/components/Footer';
+import { VscPreview, VscWand } from 'react-icons/vsc';
 import { TbHeartHandshake } from 'react-icons/tb';
 import SponsorPack from '~/components/SponsorPack';
 import { startProject } from '~/projects/start';
+import { Framework, getBranch } from '~/projects';
 const menu = [{
   label: <div className="flex items-center gap-2">
         <CgCornerUpLeft className="text-lg" /> TanStack
@@ -57,7 +59,9 @@ export default function VersionIndex() {
   const {
     version
   } = Route.useParams();
-  const [, setIsDark] = React.useState(true);
+  const branch = getBranch(startProject, version);
+  const [framework, setFramework] = React.useState<Framework>('react');
+  const [isDark, setIsDark] = React.useState(true);
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches);
   }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/useStateDestructure@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/useStateDestructure@notFoundComponent.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { CgCornerUpLeft, CgSpinner } from 'react-icons/cg';
-import { FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
+import { FaBolt, FaBook, FaCheckCircle, FaCogs, FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
 import { Await, Link, getRouteApi } from '@tanstack/react-router';
 import { Carbon } from '~/components/Carbon';
 import { Footer } from '~/components/Footer';
+import { VscPreview, VscWand } from 'react-icons/vsc';
 import { TbHeartHandshake } from 'react-icons/tb';
 import SponsorPack from '~/components/SponsorPack';
 import { startProject } from '~/projects/start';
+import { Framework, getBranch } from '~/projects';
 const menu = [{
   label: <div className="flex items-center gap-2">
         <CgCornerUpLeft className="text-lg" /> TanStack
@@ -57,7 +59,9 @@ export default function VersionIndex() {
   const {
     version
   } = Route.useParams();
-  const [, setIsDark] = React.useState(true);
+  const branch = getBranch(startProject, version);
+  const [framework, setFramework] = React.useState<Framework>('react');
+  const [isDark, setIsDark] = React.useState(true);
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches);
   }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/useStateDestructure@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/useStateDestructure@pendingComponent.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { CgCornerUpLeft, CgSpinner } from 'react-icons/cg';
-import { FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
+import { FaBolt, FaBook, FaCheckCircle, FaCogs, FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
 import { Await, Link, getRouteApi } from '@tanstack/react-router';
 import { Carbon } from '~/components/Carbon';
 import { Footer } from '~/components/Footer';
+import { VscPreview, VscWand } from 'react-icons/vsc';
 import { TbHeartHandshake } from 'react-icons/tb';
 import SponsorPack from '~/components/SponsorPack';
 import { startProject } from '~/projects/start';
+import { Framework, getBranch } from '~/projects';
 const menu = [{
   label: <div className="flex items-center gap-2">
         <CgCornerUpLeft className="text-lg" /> TanStack
@@ -57,7 +59,9 @@ export default function VersionIndex() {
   const {
     version
   } = Route.useParams();
-  const [, setIsDark] = React.useState(true);
+  const branch = getBranch(startProject, version);
+  const [framework, setFramework] = React.useState<Framework>('react');
+  const [isDark, setIsDark] = React.useState(true);
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches);
   }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/arrow-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/arrow-function.tsx
@@ -2,6 +2,7 @@ const $$splitComponentImporter = () => import('arrow-function.tsx?tsr-split=comp
 import { lazyRouteComponent } from '@tanstack/react-router';
 const $$splitLoaderImporter = () => import('arrow-function.tsx?tsr-split=loader');
 import { lazyFn } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/posts')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/arrow-function@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/arrow-function@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { Link, Outlet } from '@tanstack/react-router';
 import { Route } from "arrow-function.tsx";
 const SplitComponent = () => {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/arrow-function@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/arrow-function@loader.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
 import { fetchPosts } from '../posts';
+import { Route } from "arrow-function.tsx";
 const SplitLoader = fetchPosts;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/chinese.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/chinese.tsx
@@ -1,5 +1,6 @@
 const $$splitComponentImporter = () => import('chinese.tsx?tsr-split=component---errorComponent---notFoundComponent---pendingComponent');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/chinese@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/chinese@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import { Route } from "chinese.tsx";
 interface DemoProps {
   title: string;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/chinese@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/chinese@loader.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import { Route } from "chinese.tsx";
 interface DemoProps {
   title: string;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/conditional-properties@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/conditional-properties@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@features/feature-flags';
 import TrueImport from '@modules/true-component';
 import { FalseComponent } from '@modules/false-component';
+import { Route } from "conditional-properties.tsx";
 const SplitComponent = isEnabled ? TrueImport.Component : FalseComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/conditional-properties@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/conditional-properties@loader.tsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@features/feature-flags';
 import TrueImport from '@modules/true-component';
 import { falseLoader } from '@modules/false-component';
+import { Route } from "conditional-properties.tsx";
 const SplitLoader = isEnabled ? TrueImport.loader : falseLoader;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/destructured-react-memo-imported-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/destructured-react-memo-imported-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { Route } from "destructured-react-memo-imported-component.tsx";
 function Component() {
   return <div>Component</div>;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/destructured-react-memo-imported-component@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/destructured-react-memo-imported-component@loader.tsx
@@ -1,3 +1,4 @@
 import { importedLoader } from '../../shared/imported';
+import { Route } from "destructured-react-memo-imported-component.tsx";
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/function-as-parameter.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/function-as-parameter.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // @ts-expect-error
 import { useMemo } from 'tan-react';
+const useUsedVar = 'i-am-unused';
 const ReactUseMemoCall1 = React.useMemo(function performAction() {
   return 'true';
 }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/function-as-parameter@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/function-as-parameter@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // @ts-expect-error
 import { useMemo } from 'tan-react';
+const useUsedVar = 'i-am-unused';
 const ReactUseMemoCall1 = React.useMemo(function performAction() {
   return 'true';
 }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/function-as-parameter@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/function-as-parameter@loader.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // @ts-expect-error
 import { useMemo } from 'tan-react';
+const useUsedVar = 'i-am-unused';
 const ReactUseMemoCall1 = React.useMemo(function performAction() {
   return 'true';
 }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/function-declaration.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/function-declaration.tsx
@@ -2,6 +2,7 @@ const $$splitComponentImporter = () => import('function-declaration.tsx?tsr-spli
 import { lazyRouteComponent } from '@tanstack/react-router';
 const $$splitLoaderImporter = () => import('function-declaration.tsx?tsr-split=loader');
 import { lazyFn } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/posts')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/function-declaration@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/function-declaration@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { Link, Outlet } from '@tanstack/react-router';
 import { Route } from "function-declaration.tsx";
 const SplitComponent = function PostsComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/function-declaration@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/function-declaration@loader.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
 import { fetchPosts } from '../posts';
+import { Route } from "function-declaration.tsx";
 const SplitLoader = fetchPosts;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/importAttribute@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/importAttribute@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
 import { test } from './test' with { type: 'macro' };
+import { Route } from "importAttribute.tsx";
 const SplitComponent = () => test;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/importAttribute@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/importAttribute@loader.tsx
@@ -1,0 +1,1 @@
+import { Route } from "importAttribute.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-default-component-destructured-loader@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-default-component-destructured-loader@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
 import importedComponent from '../../shared/imported';
+import { Route } from "imported-default-component-destructured-loader.tsx";
 const SplitComponent = importedComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-default-component-destructured-loader@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-default-component-destructured-loader@loader.tsx
@@ -1,3 +1,4 @@
 import { importedLoader } from '../../shared/imported';
+import { Route } from "imported-default-component-destructured-loader.tsx";
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-default-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-default-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
 import ImportedDefaultComponent from '../../shared/imported';
+import { Route } from "imported-default-component.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-default-component@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-default-component@loader.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-errorComponent@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-errorComponent@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,5 @@
 import ImportedDefaultComponent, { importedErrorComponent } from '../../shared/imported';
+import { Route } from "imported-errorComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };
 const SplitErrorComponent = importedErrorComponent;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-errorComponent@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-errorComponent@loader.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-errorComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-notFoundComponent@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-notFoundComponent@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,5 @@
 import ImportedDefaultComponent, { importedNotFoundComponent } from '../../shared/imported';
+import { Route } from "imported-notFoundComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };
 const SplitNotFoundComponent = importedNotFoundComponent;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-notFoundComponent@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-notFoundComponent@loader.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-notFoundComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-pendingComponent@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-pendingComponent@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,5 @@
 import ImportedDefaultComponent, { importedPendingComponent } from '../../shared/imported';
+import { Route } from "imported-pendingComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };
 const SplitPendingComponent = importedPendingComponent;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-pendingComponent@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-pendingComponent@loader.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-pendingComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
 import { importedComponent } from '../../shared';
+import { Route } from "imported.tsx";
 const SplitComponent = importedComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported@loader.tsx
@@ -1,3 +1,4 @@
 import { importedLoader } from '../../shared';
+import { Route } from "imported.tsx";
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/inline.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/inline.tsx
@@ -1,5 +1,6 @@
 const $$splitComponentImporter = () => import('inline.tsx?tsr-split=component---errorComponent---notFoundComponent---pendingComponent');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/inline@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/inline@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import * as styles from '../style.css';
 import { TEST_DATA } from '../test.const';
 const Button = (props: {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/inline@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/inline@loader.tsx
@@ -1,2 +1,4 @@
+import * as React from 'react';
 import { Route } from "inline.tsx";
 Route.addChildren([]);
+import { test } from "inline.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/random-number.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/random-number.tsx
@@ -2,9 +2,26 @@ const $$splitComponentImporter = () => import('random-number.tsx?tsr-split=compo
 import { lazyRouteComponent } from '@tanstack/react-router';
 const $$splitLoaderImporter = () => import('random-number.tsx?tsr-split=loader');
 import { lazyFn } from '@tanstack/react-router';
-import { createFileRoute } from '@tanstack/react-router';
+import { Await, Link, createFileRoute } from '@tanstack/react-router';
+import { Carbon } from '~/components/Carbon';
+import { twMerge } from 'tailwind-merge';
+import { FaDiscord, FaGithub, FaTshirt } from 'react-icons/fa';
+import { CgMusicSpeaker, CgSpinner } from 'react-icons/cg';
+import { Footer } from '~/components/Footer';
+import SponsorPack from '~/components/SponsorPack';
+import { LogoColor } from '~/components/LogoColor';
+import agGridImage from '~/images/ag-grid.png';
+import nozzleImage from '~/images/nozzle.png';
+import bytesImage from '~/images/bytes.svg';
+import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
 export const textColors = [`text-rose-500`, `text-yellow-500`, `text-teal-500`, `text-blue-500`];
 export const gradients = [`from-rose-500 to-yellow-500`, `from-yellow-500 to-teal-500`, `from-teal-500 to-violet-500`, `from-blue-500 to-pink-500`];
+const courses = [{
+  name: 'The Official TanStack React Query Course',
+  cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
+  href: 'https://query.gg/?s=tanstack',
+  description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
+}];
 export const Route = createFileRoute('/')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/random-number@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/random-number@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,9 +1,50 @@
+import { Await, Link } from '@tanstack/react-router';
+import { Carbon } from '~/components/Carbon';
+import { twMerge } from 'tailwind-merge';
+import { FaDiscord, FaGithub, FaTshirt } from 'react-icons/fa';
+import { CgMusicSpeaker, CgSpinner } from 'react-icons/cg';
+import { Footer } from '~/components/Footer';
+import SponsorPack from '~/components/SponsorPack';
+import { LogoColor } from '~/components/LogoColor';
 import discordImage from '~/images/discord-logo-white.svg';
+import agGridImage from '~/images/ag-grid.png';
+import nozzleImage from '~/images/nozzle.png';
+import bytesImage from '~/images/bytes.svg';
+import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
+import { useMutation } from '~/hooks/useMutation';
 import { sample } from '~/utils/utils';
 import { textColors } from "random-number.tsx";
 import { gradients } from "random-number.tsx";
+const courses = [{
+  name: 'The Official TanStack React Query Course',
+  cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
+  href: 'https://query.gg/?s=tanstack',
+  description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
+}];
 import { Route } from "random-number.tsx";
+async function bytesSignupServerFn({
+  email
+}: {
+  email: string;
+}) {
+  'use server';
+
+  return fetch(`https://bytes.dev/api/bytes-optin-cors`, {
+    method: 'POST',
+    body: JSON.stringify({
+      email,
+      influencer: 'tanstack'
+    }),
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    }
+  });
+}
 const SplitComponent = function Index() {
+  const bytesSignupMutation = useMutation({
+    fn: bytesSignupServerFn
+  });
   const {
     randomNumber
   } = Route.useLoaderData();

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/random-number@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/random-number@loader.tsx
@@ -1,5 +1,25 @@
-import { defer } from '@tanstack/react-router';
+import { Await, Link, defer } from '@tanstack/react-router';
+import { Carbon } from '~/components/Carbon';
+import { twMerge } from 'tailwind-merge';
+import { FaDiscord, FaGithub, FaTshirt } from 'react-icons/fa';
+import { CgMusicSpeaker, CgSpinner } from 'react-icons/cg';
+import { Footer } from '~/components/Footer';
+import SponsorPack from '~/components/SponsorPack';
+import { LogoColor } from '~/components/LogoColor';
 import { getSponsorsForSponsorPack } from '~/server/sponsors';
+import agGridImage from '~/images/ag-grid.png';
+import nozzleImage from '~/images/nozzle.png';
+import bytesImage from '~/images/bytes.svg';
+import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
+import { textColors } from "random-number.tsx";
+import { gradients } from "random-number.tsx";
+const courses = [{
+  name: 'The Official TanStack React Query Course',
+  cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
+  href: 'https://query.gg/?s=tanstack',
+  description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
+}];
+import { Route } from "random-number.tsx";
 const SplitLoader = () => {
   return {
     randomNumber: Math.random(),

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/react-memo-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/react-memo-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Route } from "react-memo-component.tsx";
 function Component() {
   return <div>Component</div>;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/react-memo-component@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/react-memo-component@loader.tsx
@@ -1,3 +1,4 @@
 import { importedLoader } from '../../shared/imported';
+import { Route } from "react-memo-component.tsx";
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/react-memo-imported-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/react-memo-imported-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
 import { importedComponent } from '../../shared/imported';
+import { Route } from "react-memo-imported-component.tsx";
 const SplitComponent = React.memo(importedComponent);
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/react-memo-imported-component@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/react-memo-imported-component@loader.tsx
@@ -1,3 +1,4 @@
 import { importedLoader } from '../../shared/imported';
+import { Route } from "react-memo-imported-component.tsx";
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-export-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-export-component.tsx
@@ -1,5 +1,6 @@
 const $$splitLoaderImporter = () => import('retain-export-component.tsx?tsr-split=loader');
 import { lazyFn } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent } from '../../shared/imported';
 export function Layout() {
@@ -25,3 +26,5 @@ export const Route = createFileRoute('/_layout')({
 });
 const HEADER_HEIGHT = '63px';
 export const SIDEBAR_WIDTH = '150px';
+const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-export-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-export-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-export-component.tsx";
+import { SIDEBAR_WIDTH } from "retain-export-component.tsx";
+const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-export-component@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-export-component@loader.tsx
@@ -1,3 +1,8 @@
+import * as React from 'react';
 import { importedLoader } from '../../shared/imported';
+import { Route } from "retain-export-component.tsx";
+import { SIDEBAR_WIDTH } from "retain-export-component.tsx";
+const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-exports-const.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-exports-const.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent, importedLoader } from '../../shared/imported';
 export const loaderFn = () => {
@@ -27,4 +28,5 @@ export const Route = createFileRoute('/_layout')({
 const HEADER_HEIGHT = '63px';
 export const SIDEBAR_WIDTH = '150px';
 export const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';
 export default Layout;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-exports-const@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-exports-const@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-const.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-const.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-exports-const@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-exports-const@loader.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-const.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-const.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-exports-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-exports-function.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent, importedLoader } from '../../shared/imported';
 export function loaderFn() {
@@ -27,4 +28,5 @@ export const Route = createFileRoute('/_layout')({
 const HEADER_HEIGHT = '63px';
 export const SIDEBAR_WIDTH = '150px';
 export const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';
 export default Layout;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-exports-function@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-exports-function@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-function.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-function.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-exports-function@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-exports-function@loader.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-function.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-function.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-exports-loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-exports-loader.tsx
@@ -1,5 +1,6 @@
 const $$splitComponentImporter = () => import('retain-exports-loader.tsx?tsr-split=component---errorComponent---notFoundComponent---pendingComponent');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export function loaderFn() {
   return {
@@ -12,6 +13,7 @@ export const Route = createFileRoute('/_layout')({
 });
 export const SIDEBAR_WIDTH = '150px';
 export const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';
 export function TSRDummyComponent() {
   return null;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-exports-loader@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-exports-loader@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,6 +1,11 @@
+import * as React from 'react';
 import { Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent } from '../../shared/imported';
+import { Route } from "retain-exports-loader.tsx";
 const HEADER_HEIGHT = '63px';
+import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-loader.tsx";
+const ASIDE_WIDTH = '250px';
 const SplitComponent = function Layout() {
   return <main>
       <header style={{

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-exports-loader@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-exports-loader@loader.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-loader.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-loader.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/useStateDestructure.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/useStateDestructure.tsx
@@ -1,5 +1,7 @@
 const $$splitComponentImporter = () => import('useStateDestructure.tsx?tsr-split=component---errorComponent---notFoundComponent---pendingComponent');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import { FaBolt, FaBook, FaCheckCircle, FaCogs } from 'react-icons/fa';
+import { VscPreview, VscWand } from 'react-icons/vsc';
 import { startProject } from '~/projects/start';
 import { createFileRoute } from '@tanstack/react-router';
 import { seo } from '~/utils/seo';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/useStateDestructure@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/useStateDestructure@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { CgCornerUpLeft, CgSpinner } from 'react-icons/cg';
-import { FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
+import { FaBolt, FaBook, FaCheckCircle, FaCogs, FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
 import { Await, Link, getRouteApi } from '@tanstack/react-router';
 import { Carbon } from '~/components/Carbon';
 import { Footer } from '~/components/Footer';
+import { VscPreview, VscWand } from 'react-icons/vsc';
 import { TbHeartHandshake } from 'react-icons/tb';
 import SponsorPack from '~/components/SponsorPack';
 import { startProject } from '~/projects/start';
+import { Framework, getBranch } from '~/projects';
 const menu = [{
   label: <div className="flex items-center gap-2">
         <CgCornerUpLeft className="text-lg" /> TanStack
@@ -57,7 +59,9 @@ export default function VersionIndex() {
   const {
     version
   } = Route.useParams();
-  const [, setIsDark] = React.useState(true);
+  const branch = getBranch(startProject, version);
+  const [framework, setFramework] = React.useState<Framework>('react');
+  const [isDark, setIsDark] = React.useState(true);
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches);
   }, []);
@@ -449,7 +453,9 @@ const SplitComponent = function VersionIndex() {
   const {
     version
   } = Route.useParams();
-  const [, setIsDark] = React.useState(true);
+  const branch = getBranch(startProject, version);
+  const [framework, setFramework] = React.useState<Framework>('react');
+  const [isDark, setIsDark] = React.useState(true);
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches);
   }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/useStateDestructure@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/useStateDestructure@loader.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { CgCornerUpLeft, CgSpinner } from 'react-icons/cg';
-import { FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
+import { FaBolt, FaBook, FaCheckCircle, FaCogs, FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
 import { Await, Link, getRouteApi } from '@tanstack/react-router';
 import { Carbon } from '~/components/Carbon';
 import { Footer } from '~/components/Footer';
+import { VscPreview, VscWand } from 'react-icons/vsc';
 import { TbHeartHandshake } from 'react-icons/tb';
 import SponsorPack from '~/components/SponsorPack';
 import { startProject } from '~/projects/start';
+import { Framework, getBranch } from '~/projects';
 const menu = [{
   label: <div className="flex items-center gap-2">
         <CgCornerUpLeft className="text-lg" /> TanStack
@@ -57,7 +59,9 @@ export default function VersionIndex() {
   const {
     version
   } = Route.useParams();
-  const [, setIsDark] = React.useState(true);
+  const branch = getBranch(startProject, version);
+  const [framework, setFramework] = React.useState<Framework>('react');
+  const [isDark, setIsDark] = React.useState(true);
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches);
   }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/arrow-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/arrow-function.tsx
@@ -2,6 +2,7 @@ const $$splitComponentImporter = () => import('arrow-function.tsx?tsr-split=comp
 import { lazyRouteComponent } from '@tanstack/react-router';
 const $$splitLoaderImporter = () => import('arrow-function.tsx?tsr-split=loader');
 import { lazyFn } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/posts')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/arrow-function@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/arrow-function@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { Link, Outlet } from '@tanstack/react-router';
 import { Route } from "arrow-function.tsx";
 const SplitComponent = () => {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/arrow-function@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/arrow-function@loader.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
 import { fetchPosts } from '../posts';
+import { Route } from "arrow-function.tsx";
 const SplitLoader = fetchPosts;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/chinese.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/chinese.tsx
@@ -1,5 +1,6 @@
 const $$splitComponentImporter = () => import('chinese.tsx?tsr-split=component---errorComponent---notFoundComponent---pendingComponent');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/chinese@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/chinese@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import { Route } from "chinese.tsx";
 interface DemoProps {
   title: string;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/chinese@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/chinese@loader.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import { Route } from "chinese.tsx";
 interface DemoProps {
   title: string;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/conditional-properties@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/conditional-properties@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@features/feature-flags';
 import TrueImport from '@modules/true-component';
 import { FalseComponent } from '@modules/false-component';
+import { Route } from "conditional-properties.tsx";
 const SplitComponent = isEnabled ? TrueImport.Component : FalseComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/conditional-properties@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/conditional-properties@loader.tsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@features/feature-flags';
 import TrueImport from '@modules/true-component';
 import { falseLoader } from '@modules/false-component';
+import { Route } from "conditional-properties.tsx";
 const SplitLoader = isEnabled ? TrueImport.loader : falseLoader;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/destructured-react-memo-imported-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/destructured-react-memo-imported-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { Route } from "destructured-react-memo-imported-component.tsx";
 function Component() {
   return <div>Component</div>;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/destructured-react-memo-imported-component@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/destructured-react-memo-imported-component@loader.tsx
@@ -1,3 +1,4 @@
 import { importedLoader } from '../../shared/imported';
+import { Route } from "destructured-react-memo-imported-component.tsx";
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/function-as-parameter.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/function-as-parameter.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // @ts-expect-error
 import { useMemo } from 'tan-react';
+const useUsedVar = 'i-am-unused';
 const ReactUseMemoCall1 = React.useMemo(function performAction() {
   return 'true';
 }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/function-as-parameter@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/function-as-parameter@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // @ts-expect-error
 import { useMemo } from 'tan-react';
+const useUsedVar = 'i-am-unused';
 const ReactUseMemoCall1 = React.useMemo(function performAction() {
   return 'true';
 }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/function-as-parameter@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/function-as-parameter@loader.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // @ts-expect-error
 import { useMemo } from 'tan-react';
+const useUsedVar = 'i-am-unused';
 const ReactUseMemoCall1 = React.useMemo(function performAction() {
   return 'true';
 }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/function-declaration.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/function-declaration.tsx
@@ -2,6 +2,7 @@ const $$splitComponentImporter = () => import('function-declaration.tsx?tsr-spli
 import { lazyRouteComponent } from '@tanstack/react-router';
 const $$splitLoaderImporter = () => import('function-declaration.tsx?tsr-split=loader');
 import { lazyFn } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/posts')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/function-declaration@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/function-declaration@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { Link, Outlet } from '@tanstack/react-router';
 import { Route } from "function-declaration.tsx";
 const SplitComponent = function PostsComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/function-declaration@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/function-declaration@loader.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
 import { fetchPosts } from '../posts';
+import { Route } from "function-declaration.tsx";
 const SplitLoader = fetchPosts;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/importAttribute@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/importAttribute@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
 import { test } from './test' with { type: 'macro' };
+import { Route } from "importAttribute.tsx";
 const SplitComponent = () => test;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/importAttribute@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/importAttribute@loader.tsx
@@ -1,0 +1,1 @@
+import { Route } from "importAttribute.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-default-component-destructured-loader@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-default-component-destructured-loader@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
 import importedComponent from '../../shared/imported';
+import { Route } from "imported-default-component-destructured-loader.tsx";
 const SplitComponent = importedComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-default-component-destructured-loader@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-default-component-destructured-loader@loader.tsx
@@ -1,3 +1,4 @@
 import { importedLoader } from '../../shared/imported';
+import { Route } from "imported-default-component-destructured-loader.tsx";
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-default-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-default-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
 import ImportedDefaultComponent from '../../shared/imported';
+import { Route } from "imported-default-component.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-default-component@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-default-component@loader.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-errorComponent@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-errorComponent@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,5 @@
 import ImportedDefaultComponent, { importedErrorComponent } from '../../shared/imported';
+import { Route } from "imported-errorComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };
 const SplitErrorComponent = importedErrorComponent;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-errorComponent@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-errorComponent@loader.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-errorComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-notFoundComponent@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-notFoundComponent@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,5 @@
 import ImportedDefaultComponent, { importedNotFoundComponent } from '../../shared/imported';
+import { Route } from "imported-notFoundComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };
 const SplitNotFoundComponent = importedNotFoundComponent;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-notFoundComponent@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-notFoundComponent@loader.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-notFoundComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-pendingComponent@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-pendingComponent@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,5 @@
 import ImportedDefaultComponent, { importedPendingComponent } from '../../shared/imported';
+import { Route } from "imported-pendingComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };
 const SplitPendingComponent = importedPendingComponent;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-pendingComponent@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-pendingComponent@loader.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-pendingComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
 import { importedComponent } from '../../shared';
+import { Route } from "imported.tsx";
 const SplitComponent = importedComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported@loader.tsx
@@ -1,3 +1,4 @@
 import { importedLoader } from '../../shared';
+import { Route } from "imported.tsx";
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/inline.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/inline.tsx
@@ -1,5 +1,6 @@
 const $$splitComponentImporter = () => import('inline.tsx?tsr-split=component---errorComponent---notFoundComponent---pendingComponent');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/inline@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/inline@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import * as styles from '../style.css';
 import { TEST_DATA } from '../test.const';
 const Button = (props: {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/inline@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/inline@loader.tsx
@@ -1,2 +1,4 @@
+import * as React from 'react';
 import { Route } from "inline.tsx";
 Route.addChildren([]);
+import { test } from "inline.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/random-number.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/random-number.tsx
@@ -2,9 +2,26 @@ const $$splitComponentImporter = () => import('random-number.tsx?tsr-split=compo
 import { lazyRouteComponent } from '@tanstack/react-router';
 const $$splitLoaderImporter = () => import('random-number.tsx?tsr-split=loader');
 import { lazyFn } from '@tanstack/react-router';
-import { createFileRoute } from '@tanstack/react-router';
+import { Await, Link, createFileRoute } from '@tanstack/react-router';
+import { Carbon } from '~/components/Carbon';
+import { twMerge } from 'tailwind-merge';
+import { FaDiscord, FaGithub, FaTshirt } from 'react-icons/fa';
+import { CgMusicSpeaker, CgSpinner } from 'react-icons/cg';
+import { Footer } from '~/components/Footer';
+import SponsorPack from '~/components/SponsorPack';
+import { LogoColor } from '~/components/LogoColor';
+import agGridImage from '~/images/ag-grid.png';
+import nozzleImage from '~/images/nozzle.png';
+import bytesImage from '~/images/bytes.svg';
+import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
 export const textColors = [`text-rose-500`, `text-yellow-500`, `text-teal-500`, `text-blue-500`];
 export const gradients = [`from-rose-500 to-yellow-500`, `from-yellow-500 to-teal-500`, `from-teal-500 to-violet-500`, `from-blue-500 to-pink-500`];
+const courses = [{
+  name: 'The Official TanStack React Query Course',
+  cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
+  href: 'https://query.gg/?s=tanstack',
+  description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
+}];
 export const Route = createFileRoute('/')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/random-number@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/random-number@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,9 +1,50 @@
+import { Await, Link } from '@tanstack/react-router';
+import { Carbon } from '~/components/Carbon';
+import { twMerge } from 'tailwind-merge';
+import { FaDiscord, FaGithub, FaTshirt } from 'react-icons/fa';
+import { CgMusicSpeaker, CgSpinner } from 'react-icons/cg';
+import { Footer } from '~/components/Footer';
+import SponsorPack from '~/components/SponsorPack';
+import { LogoColor } from '~/components/LogoColor';
 import discordImage from '~/images/discord-logo-white.svg';
+import agGridImage from '~/images/ag-grid.png';
+import nozzleImage from '~/images/nozzle.png';
+import bytesImage from '~/images/bytes.svg';
+import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
+import { useMutation } from '~/hooks/useMutation';
 import { sample } from '~/utils/utils';
 import { textColors } from "random-number.tsx";
 import { gradients } from "random-number.tsx";
+const courses = [{
+  name: 'The Official TanStack React Query Course',
+  cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
+  href: 'https://query.gg/?s=tanstack',
+  description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
+}];
 import { Route } from "random-number.tsx";
+async function bytesSignupServerFn({
+  email
+}: {
+  email: string;
+}) {
+  'use server';
+
+  return fetch(`https://bytes.dev/api/bytes-optin-cors`, {
+    method: 'POST',
+    body: JSON.stringify({
+      email,
+      influencer: 'tanstack'
+    }),
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    }
+  });
+}
 const SplitComponent = function Index() {
+  const bytesSignupMutation = useMutation({
+    fn: bytesSignupServerFn
+  });
   const {
     randomNumber
   } = Route.useLoaderData();

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/random-number@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/random-number@loader.tsx
@@ -1,5 +1,25 @@
-import { defer } from '@tanstack/react-router';
+import { Await, Link, defer } from '@tanstack/react-router';
+import { Carbon } from '~/components/Carbon';
+import { twMerge } from 'tailwind-merge';
+import { FaDiscord, FaGithub, FaTshirt } from 'react-icons/fa';
+import { CgMusicSpeaker, CgSpinner } from 'react-icons/cg';
+import { Footer } from '~/components/Footer';
+import SponsorPack from '~/components/SponsorPack';
+import { LogoColor } from '~/components/LogoColor';
 import { getSponsorsForSponsorPack } from '~/server/sponsors';
+import agGridImage from '~/images/ag-grid.png';
+import nozzleImage from '~/images/nozzle.png';
+import bytesImage from '~/images/bytes.svg';
+import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
+import { textColors } from "random-number.tsx";
+import { gradients } from "random-number.tsx";
+const courses = [{
+  name: 'The Official TanStack React Query Course',
+  cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
+  href: 'https://query.gg/?s=tanstack',
+  description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
+}];
+import { Route } from "random-number.tsx";
 const SplitLoader = () => {
   return {
     randomNumber: Math.random(),

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/react-memo-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/react-memo-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Route } from "react-memo-component.tsx";
 function Component() {
   return <div>Component</div>;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/react-memo-component@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/react-memo-component@loader.tsx
@@ -1,3 +1,4 @@
 import { importedLoader } from '../../shared/imported';
+import { Route } from "react-memo-component.tsx";
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/react-memo-imported-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/react-memo-imported-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
 import { importedComponent } from '../../shared/imported';
+import { Route } from "react-memo-imported-component.tsx";
 const SplitComponent = React.memo(importedComponent);
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/react-memo-imported-component@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/react-memo-imported-component@loader.tsx
@@ -1,3 +1,4 @@
 import { importedLoader } from '../../shared/imported';
+import { Route } from "react-memo-imported-component.tsx";
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-export-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-export-component.tsx
@@ -1,5 +1,6 @@
 const $$splitLoaderImporter = () => import('retain-export-component.tsx?tsr-split=loader');
 import { lazyFn } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent } from '../../shared/imported';
 export function Layout() {
@@ -25,3 +26,5 @@ export const Route = createFileRoute('/_layout')({
 });
 const HEADER_HEIGHT = '63px';
 export const SIDEBAR_WIDTH = '150px';
+const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-export-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-export-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-export-component.tsx";
+import { SIDEBAR_WIDTH } from "retain-export-component.tsx";
+const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-export-component@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-export-component@loader.tsx
@@ -1,3 +1,8 @@
+import * as React from 'react';
 import { importedLoader } from '../../shared/imported';
+import { Route } from "retain-export-component.tsx";
+import { SIDEBAR_WIDTH } from "retain-export-component.tsx";
+const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-exports-const.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-exports-const.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent, importedLoader } from '../../shared/imported';
 export const loaderFn = () => {
@@ -27,4 +28,5 @@ export const Route = createFileRoute('/_layout')({
 const HEADER_HEIGHT = '63px';
 export const SIDEBAR_WIDTH = '150px';
 export const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';
 export default Layout;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-exports-const@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-exports-const@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-const.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-const.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-exports-const@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-exports-const@loader.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-const.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-const.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-exports-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-exports-function.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent, importedLoader } from '../../shared/imported';
 export function loaderFn() {
@@ -27,4 +28,5 @@ export const Route = createFileRoute('/_layout')({
 const HEADER_HEIGHT = '63px';
 export const SIDEBAR_WIDTH = '150px';
 export const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';
 export default Layout;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-exports-function@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-exports-function@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-function.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-function.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-exports-function@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-exports-function@loader.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-function.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-function.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-exports-loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-exports-loader.tsx
@@ -1,5 +1,6 @@
 const $$splitComponentImporter = () => import('retain-exports-loader.tsx?tsr-split=component---errorComponent---notFoundComponent---pendingComponent');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export function loaderFn() {
   return {
@@ -12,3 +13,4 @@ export const Route = createFileRoute('/_layout')({
 });
 export const SIDEBAR_WIDTH = '150px';
 export const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-exports-loader@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-exports-loader@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,6 +1,11 @@
+import * as React from 'react';
 import { Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent } from '../../shared/imported';
+import { Route } from "retain-exports-loader.tsx";
 const HEADER_HEIGHT = '63px';
+import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-loader.tsx";
+const ASIDE_WIDTH = '250px';
 const SplitComponent = function Layout() {
   return <main>
       <header style={{

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-exports-loader@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-exports-loader@loader.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-loader.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-loader.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/useStateDestructure.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/useStateDestructure.tsx
@@ -1,5 +1,7 @@
 const $$splitComponentImporter = () => import('useStateDestructure.tsx?tsr-split=component---errorComponent---notFoundComponent---pendingComponent');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import { FaBolt, FaBook, FaCheckCircle, FaCogs } from 'react-icons/fa';
+import { VscPreview, VscWand } from 'react-icons/vsc';
 import { startProject } from '~/projects/start';
 import { createFileRoute } from '@tanstack/react-router';
 import { seo } from '~/utils/seo';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/useStateDestructure@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/useStateDestructure@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { CgCornerUpLeft, CgSpinner } from 'react-icons/cg';
-import { FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
+import { FaBolt, FaBook, FaCheckCircle, FaCogs, FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
 import { Await, Link, getRouteApi } from '@tanstack/react-router';
 import { Carbon } from '~/components/Carbon';
 import { Footer } from '~/components/Footer';
+import { VscPreview, VscWand } from 'react-icons/vsc';
 import { TbHeartHandshake } from 'react-icons/tb';
 import SponsorPack from '~/components/SponsorPack';
 import { startProject } from '~/projects/start';
+import { Framework, getBranch } from '~/projects';
 const menu = [{
   label: <div className="flex items-center gap-2">
         <CgCornerUpLeft className="text-lg" /> TanStack
@@ -57,7 +59,9 @@ export default function VersionIndex() {
   const {
     version
   } = Route.useParams();
-  const [, setIsDark] = React.useState(true);
+  const branch = getBranch(startProject, version);
+  const [framework, setFramework] = React.useState<Framework>('react');
+  const [isDark, setIsDark] = React.useState(true);
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches);
   }, []);
@@ -449,7 +453,9 @@ const SplitComponent = function VersionIndex() {
   const {
     version
   } = Route.useParams();
-  const [, setIsDark] = React.useState(true);
+  const branch = getBranch(startProject, version);
+  const [framework, setFramework] = React.useState<Framework>('react');
+  const [isDark, setIsDark] = React.useState(true);
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches);
   }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/useStateDestructure@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/useStateDestructure@loader.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { CgCornerUpLeft, CgSpinner } from 'react-icons/cg';
-import { FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
+import { FaBolt, FaBook, FaCheckCircle, FaCogs, FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
 import { Await, Link, getRouteApi } from '@tanstack/react-router';
 import { Carbon } from '~/components/Carbon';
 import { Footer } from '~/components/Footer';
+import { VscPreview, VscWand } from 'react-icons/vsc';
 import { TbHeartHandshake } from 'react-icons/tb';
 import SponsorPack from '~/components/SponsorPack';
 import { startProject } from '~/projects/start';
+import { Framework, getBranch } from '~/projects';
 const menu = [{
   label: <div className="flex items-center gap-2">
         <CgCornerUpLeft className="text-lg" /> TanStack
@@ -57,7 +59,9 @@ export default function VersionIndex() {
   const {
     version
   } = Route.useParams();
-  const [, setIsDark] = React.useState(true);
+  const branch = getBranch(startProject, version);
+  const [framework, setFramework] = React.useState<Framework>('react');
+  const [isDark, setIsDark] = React.useState(true);
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches);
   }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/arrow-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/arrow-function.tsx
@@ -2,6 +2,7 @@ const $$splitComponentImporter = () => import('arrow-function.tsx?tsr-split=comp
 import { lazyRouteComponent } from '@tanstack/react-router';
 const $$splitLoaderImporter = () => import('arrow-function.tsx?tsr-split=component---loader---notFoundComponent---pendingComponent');
 import { lazyFn } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/posts')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/arrow-function@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/arrow-function@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { Link, Outlet } from '@tanstack/react-router';
 import { fetchPosts } from '../posts';
 import { Route } from "arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/arrow-function@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/arrow-function@errorComponent.tsx
@@ -1,0 +1,2 @@
+import * as React from 'react';
+import { Route } from "arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/chinese.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/chinese.tsx
@@ -1,5 +1,6 @@
 const $$splitComponentImporter = () => import('chinese.tsx?tsr-split=component---loader---notFoundComponent---pendingComponent');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/chinese@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/chinese@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import { Route } from "chinese.tsx";
 interface DemoProps {
   title: string;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/chinese@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/chinese@errorComponent.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import { Route } from "chinese.tsx";
 interface DemoProps {
   title: string;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/conditional-properties@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/conditional-properties@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,6 +1,7 @@
 import { isEnabled } from '@features/feature-flags';
 import TrueImport from '@modules/true-component';
 import { FalseComponent, falseLoader } from '@modules/false-component';
+import { Route } from "conditional-properties.tsx";
 const SplitLoader = isEnabled ? TrueImport.loader : falseLoader;
 export { SplitLoader as loader };
 const SplitComponent = isEnabled ? TrueImport.Component : FalseComponent;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/conditional-properties@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/conditional-properties@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "conditional-properties.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/destructured-react-memo-imported-component@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/destructured-react-memo-imported-component@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { importedLoader } from '../../shared/imported';
+import { Route } from "destructured-react-memo-imported-component.tsx";
 function Component() {
   return <div>Component</div>;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/destructured-react-memo-imported-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/destructured-react-memo-imported-component@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "destructured-react-memo-imported-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/function-as-parameter.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/function-as-parameter.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // @ts-expect-error
 import { useMemo } from 'tan-react';
+const useUsedVar = 'i-am-unused';
 const ReactUseMemoCall1 = React.useMemo(function performAction() {
   return 'true';
 }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/function-as-parameter@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/function-as-parameter@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // @ts-expect-error
 import { useMemo } from 'tan-react';
+const useUsedVar = 'i-am-unused';
 const ReactUseMemoCall1 = React.useMemo(function performAction() {
   return 'true';
 }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/function-as-parameter@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/function-as-parameter@errorComponent.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // @ts-expect-error
 import { useMemo } from 'tan-react';
+const useUsedVar = 'i-am-unused';
 const ReactUseMemoCall1 = React.useMemo(function performAction() {
   return 'true';
 }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/function-declaration.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/function-declaration.tsx
@@ -2,6 +2,7 @@ const $$splitComponentImporter = () => import('function-declaration.tsx?tsr-spli
 import { lazyRouteComponent } from '@tanstack/react-router';
 const $$splitLoaderImporter = () => import('function-declaration.tsx?tsr-split=component---loader---notFoundComponent---pendingComponent');
 import { lazyFn } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/posts')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/function-declaration@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/function-declaration@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { Link, Outlet } from '@tanstack/react-router';
 import { fetchPosts } from '../posts';
 import { Route } from "function-declaration.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/function-declaration@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/function-declaration@errorComponent.tsx
@@ -1,0 +1,2 @@
+import * as React from 'react';
+import { Route } from "function-declaration.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/importAttribute@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/importAttribute@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
 import { test } from './test' with { type: 'macro' };
+import { Route } from "importAttribute.tsx";
 const SplitComponent = () => test;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/importAttribute@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/importAttribute@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "importAttribute.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-default-component-destructured-loader@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-default-component-destructured-loader@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,5 @@
 import importedComponent, { importedLoader } from '../../shared/imported';
+import { Route } from "imported-default-component-destructured-loader.tsx";
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };
 const SplitComponent = importedComponent;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-default-component-destructured-loader@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-default-component-destructured-loader@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-default-component-destructured-loader.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-default-component@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-default-component@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
 import ImportedDefaultComponent from '../../shared/imported';
+import { Route } from "imported-default-component.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-default-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-default-component@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-errorComponent@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-errorComponent@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
 import ImportedDefaultComponent from '../../shared/imported';
+import { Route } from "imported-errorComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-errorComponent@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-errorComponent@errorComponent.tsx
@@ -1,3 +1,4 @@
 import { importedErrorComponent } from '../../shared/imported';
+import { Route } from "imported-errorComponent.tsx";
 const SplitErrorComponent = importedErrorComponent;
 export { SplitErrorComponent as errorComponent };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-notFoundComponent@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-notFoundComponent@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,5 @@
 import ImportedDefaultComponent, { importedNotFoundComponent } from '../../shared/imported';
+import { Route } from "imported-notFoundComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };
 const SplitNotFoundComponent = importedNotFoundComponent;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-notFoundComponent@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-notFoundComponent@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-notFoundComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-pendingComponent@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-pendingComponent@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,5 @@
 import ImportedDefaultComponent, { importedPendingComponent } from '../../shared/imported';
+import { Route } from "imported-pendingComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };
 const SplitPendingComponent = importedPendingComponent;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-pendingComponent@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-pendingComponent@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-pendingComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,5 @@
 import { importedComponent, importedLoader } from '../../shared';
+import { Route } from "imported.tsx";
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };
 const SplitComponent = importedComponent;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/inline.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/inline.tsx
@@ -1,5 +1,6 @@
 const $$splitComponentImporter = () => import('inline.tsx?tsr-split=component---loader---notFoundComponent---pendingComponent');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/inline@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/inline@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import * as styles from '../style.css';
 import { TEST_DATA } from '../test.const';
 const Button = (props: {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/inline@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/inline@errorComponent.tsx
@@ -1,2 +1,4 @@
+import * as React from 'react';
 import { Route } from "inline.tsx";
 Route.addChildren([]);
+import { test } from "inline.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/random-number.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/random-number.tsx
@@ -2,9 +2,26 @@ const $$splitComponentImporter = () => import('random-number.tsx?tsr-split=compo
 import { lazyRouteComponent } from '@tanstack/react-router';
 const $$splitLoaderImporter = () => import('random-number.tsx?tsr-split=component---loader---notFoundComponent---pendingComponent');
 import { lazyFn } from '@tanstack/react-router';
-import { createFileRoute } from '@tanstack/react-router';
+import { Await, Link, createFileRoute } from '@tanstack/react-router';
+import { Carbon } from '~/components/Carbon';
+import { twMerge } from 'tailwind-merge';
+import { FaDiscord, FaGithub, FaTshirt } from 'react-icons/fa';
+import { CgMusicSpeaker, CgSpinner } from 'react-icons/cg';
+import { Footer } from '~/components/Footer';
+import SponsorPack from '~/components/SponsorPack';
+import { LogoColor } from '~/components/LogoColor';
+import agGridImage from '~/images/ag-grid.png';
+import nozzleImage from '~/images/nozzle.png';
+import bytesImage from '~/images/bytes.svg';
+import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
 export const textColors = [`text-rose-500`, `text-yellow-500`, `text-teal-500`, `text-blue-500`];
 export const gradients = [`from-rose-500 to-yellow-500`, `from-yellow-500 to-teal-500`, `from-teal-500 to-violet-500`, `from-blue-500 to-pink-500`];
+const courses = [{
+  name: 'The Official TanStack React Query Course',
+  cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
+  href: 'https://query.gg/?s=tanstack',
+  description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
+}];
 export const Route = createFileRoute('/')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/random-number@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/random-number@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,10 +1,47 @@
-import { defer } from '@tanstack/react-router';
+import { Await, Link, defer } from '@tanstack/react-router';
+import { Carbon } from '~/components/Carbon';
+import { twMerge } from 'tailwind-merge';
+import { FaDiscord, FaGithub, FaTshirt } from 'react-icons/fa';
+import { CgMusicSpeaker, CgSpinner } from 'react-icons/cg';
+import { Footer } from '~/components/Footer';
+import SponsorPack from '~/components/SponsorPack';
+import { LogoColor } from '~/components/LogoColor';
 import { getSponsorsForSponsorPack } from '~/server/sponsors';
 import discordImage from '~/images/discord-logo-white.svg';
+import agGridImage from '~/images/ag-grid.png';
+import nozzleImage from '~/images/nozzle.png';
+import bytesImage from '~/images/bytes.svg';
+import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
+import { useMutation } from '~/hooks/useMutation';
 import { sample } from '~/utils/utils';
 import { textColors } from "random-number.tsx";
 import { gradients } from "random-number.tsx";
+const courses = [{
+  name: 'The Official TanStack React Query Course',
+  cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
+  href: 'https://query.gg/?s=tanstack',
+  description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
+}];
 import { Route } from "random-number.tsx";
+async function bytesSignupServerFn({
+  email
+}: {
+  email: string;
+}) {
+  'use server';
+
+  return fetch(`https://bytes.dev/api/bytes-optin-cors`, {
+    method: 'POST',
+    body: JSON.stringify({
+      email,
+      influencer: 'tanstack'
+    }),
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    }
+  });
+}
 const SplitLoader = () => {
   return {
     randomNumber: Math.random(),
@@ -13,6 +50,9 @@ const SplitLoader = () => {
 };
 export { SplitLoader as loader };
 const SplitComponent = function Index() {
+  const bytesSignupMutation = useMutation({
+    fn: bytesSignupServerFn
+  });
   const {
     randomNumber
   } = Route.useLoaderData();

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/random-number@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/random-number@errorComponent.tsx
@@ -1,0 +1,21 @@
+import { Await, Link } from '@tanstack/react-router';
+import { Carbon } from '~/components/Carbon';
+import { twMerge } from 'tailwind-merge';
+import { FaDiscord, FaGithub, FaTshirt } from 'react-icons/fa';
+import { CgMusicSpeaker, CgSpinner } from 'react-icons/cg';
+import { Footer } from '~/components/Footer';
+import SponsorPack from '~/components/SponsorPack';
+import { LogoColor } from '~/components/LogoColor';
+import agGridImage from '~/images/ag-grid.png';
+import nozzleImage from '~/images/nozzle.png';
+import bytesImage from '~/images/bytes.svg';
+import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
+import { textColors } from "random-number.tsx";
+import { gradients } from "random-number.tsx";
+const courses = [{
+  name: 'The Official TanStack React Query Course',
+  cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
+  href: 'https://query.gg/?s=tanstack',
+  description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
+}];
+import { Route } from "random-number.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/react-memo-component@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/react-memo-component@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { importedLoader } from '../../shared/imported';
+import { Route } from "react-memo-component.tsx";
 function Component() {
   return <div>Component</div>;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/react-memo-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/react-memo-component@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "react-memo-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/react-memo-imported-component@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/react-memo-imported-component@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { importedLoader, importedComponent } from '../../shared/imported';
+import { Route } from "react-memo-imported-component.tsx";
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };
 const SplitComponent = React.memo(importedComponent);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/react-memo-imported-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/react-memo-imported-component@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "react-memo-imported-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-export-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-export-component.tsx
@@ -1,5 +1,6 @@
 const $$splitLoaderImporter = () => import('retain-export-component.tsx?tsr-split=component---loader---notFoundComponent---pendingComponent');
 import { lazyFn } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent } from '../../shared/imported';
 export function Layout() {
@@ -25,3 +26,5 @@ export const Route = createFileRoute('/_layout')({
 });
 const HEADER_HEIGHT = '63px';
 export const SIDEBAR_WIDTH = '150px';
+const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-export-component@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-export-component@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,8 @@
+import * as React from 'react';
 import { importedLoader } from '../../shared/imported';
+import { Route } from "retain-export-component.tsx";
+import { SIDEBAR_WIDTH } from "retain-export-component.tsx";
+const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-export-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-export-component@errorComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-export-component.tsx";
+import { SIDEBAR_WIDTH } from "retain-export-component.tsx";
+const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-exports-const.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-exports-const.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent, importedLoader } from '../../shared/imported';
 export const loaderFn = () => {
@@ -27,4 +28,5 @@ export const Route = createFileRoute('/_layout')({
 const HEADER_HEIGHT = '63px';
 export const SIDEBAR_WIDTH = '150px';
 export const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';
 export default Layout;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-exports-const@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-exports-const@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-const.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-const.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-exports-const@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-exports-const@errorComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-const.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-const.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-exports-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-exports-function.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent, importedLoader } from '../../shared/imported';
 export function loaderFn() {
@@ -27,4 +28,5 @@ export const Route = createFileRoute('/_layout')({
 const HEADER_HEIGHT = '63px';
 export const SIDEBAR_WIDTH = '150px';
 export const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';
 export default Layout;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-exports-function@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-exports-function@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-function.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-function.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-exports-function@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-exports-function@errorComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-function.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-function.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-exports-loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-exports-loader.tsx
@@ -1,5 +1,6 @@
 const $$splitComponentImporter = () => import('retain-exports-loader.tsx?tsr-split=component---loader---notFoundComponent---pendingComponent');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export function loaderFn() {
   return {
@@ -12,6 +13,7 @@ export const Route = createFileRoute('/_layout')({
 });
 export const SIDEBAR_WIDTH = '150px';
 export const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';
 export function TSRDummyComponent() {
   return null;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-exports-loader@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-exports-loader@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,6 +1,11 @@
+import * as React from 'react';
 import { Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent } from '../../shared/imported';
+import { Route } from "retain-exports-loader.tsx";
 const HEADER_HEIGHT = '63px';
+import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-loader.tsx";
+const ASIDE_WIDTH = '250px';
 const SplitComponent = function Layout() {
   return <main>
       <header style={{

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-exports-loader@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-exports-loader@errorComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-loader.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-loader.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/useStateDestructure.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/useStateDestructure.tsx
@@ -1,5 +1,7 @@
 const $$splitComponentImporter = () => import('useStateDestructure.tsx?tsr-split=component---loader---notFoundComponent---pendingComponent');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import { FaBolt, FaBook, FaCheckCircle, FaCogs } from 'react-icons/fa';
+import { VscPreview, VscWand } from 'react-icons/vsc';
 import { startProject } from '~/projects/start';
 import { createFileRoute } from '@tanstack/react-router';
 import { seo } from '~/utils/seo';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/useStateDestructure@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/useStateDestructure@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { CgCornerUpLeft, CgSpinner } from 'react-icons/cg';
-import { FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
+import { FaBolt, FaBook, FaCheckCircle, FaCogs, FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
 import { Await, Link, getRouteApi } from '@tanstack/react-router';
 import { Carbon } from '~/components/Carbon';
 import { Footer } from '~/components/Footer';
+import { VscPreview, VscWand } from 'react-icons/vsc';
 import { TbHeartHandshake } from 'react-icons/tb';
 import SponsorPack from '~/components/SponsorPack';
 import { startProject } from '~/projects/start';
+import { Framework, getBranch } from '~/projects';
 const menu = [{
   label: <div className="flex items-center gap-2">
         <CgCornerUpLeft className="text-lg" /> TanStack
@@ -57,7 +59,9 @@ export default function VersionIndex() {
   const {
     version
   } = Route.useParams();
-  const [, setIsDark] = React.useState(true);
+  const branch = getBranch(startProject, version);
+  const [framework, setFramework] = React.useState<Framework>('react');
+  const [isDark, setIsDark] = React.useState(true);
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches);
   }, []);
@@ -449,7 +453,9 @@ const SplitComponent = function VersionIndex() {
   const {
     version
   } = Route.useParams();
-  const [, setIsDark] = React.useState(true);
+  const branch = getBranch(startProject, version);
+  const [framework, setFramework] = React.useState<Framework>('react');
+  const [isDark, setIsDark] = React.useState(true);
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches);
   }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/useStateDestructure@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/useStateDestructure@errorComponent.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { CgCornerUpLeft, CgSpinner } from 'react-icons/cg';
-import { FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
+import { FaBolt, FaBook, FaCheckCircle, FaCogs, FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
 import { Await, Link, getRouteApi } from '@tanstack/react-router';
 import { Carbon } from '~/components/Carbon';
 import { Footer } from '~/components/Footer';
+import { VscPreview, VscWand } from 'react-icons/vsc';
 import { TbHeartHandshake } from 'react-icons/tb';
 import SponsorPack from '~/components/SponsorPack';
 import { startProject } from '~/projects/start';
+import { Framework, getBranch } from '~/projects';
 const menu = [{
   label: <div className="flex items-center gap-2">
         <CgCornerUpLeft className="text-lg" /> TanStack
@@ -57,7 +59,9 @@ export default function VersionIndex() {
   const {
     version
   } = Route.useParams();
-  const [, setIsDark] = React.useState(true);
+  const branch = getBranch(startProject, version);
+  const [framework, setFramework] = React.useState<Framework>('react');
+  const [isDark, setIsDark] = React.useState(true);
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches);
   }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/arrow-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/arrow-function.tsx
@@ -2,6 +2,7 @@ const $$splitComponentImporter = () => import('arrow-function.tsx?tsr-split=comp
 import { lazyRouteComponent } from '@tanstack/react-router';
 const $$splitLoaderImporter = () => import('arrow-function.tsx?tsr-split=component---loader---notFoundComponent---pendingComponent');
 import { lazyFn } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/posts')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/arrow-function@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/arrow-function@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { Link, Outlet } from '@tanstack/react-router';
 import { fetchPosts } from '../posts';
 import { Route } from "arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/arrow-function@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/arrow-function@errorComponent.tsx
@@ -1,0 +1,2 @@
+import * as React from 'react';
+import { Route } from "arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/chinese.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/chinese.tsx
@@ -1,5 +1,6 @@
 const $$splitComponentImporter = () => import('chinese.tsx?tsr-split=component---loader---notFoundComponent---pendingComponent');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/chinese@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/chinese@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import { Route } from "chinese.tsx";
 interface DemoProps {
   title: string;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/chinese@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/chinese@errorComponent.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+import { Route } from "chinese.tsx";
 interface DemoProps {
   title: string;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/conditional-properties@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/conditional-properties@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,6 +1,7 @@
 import { isEnabled } from '@features/feature-flags';
 import TrueImport from '@modules/true-component';
 import { FalseComponent, falseLoader } from '@modules/false-component';
+import { Route } from "conditional-properties.tsx";
 const SplitLoader = isEnabled ? TrueImport.loader : falseLoader;
 export { SplitLoader as loader };
 const SplitComponent = isEnabled ? TrueImport.Component : FalseComponent;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/conditional-properties@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/conditional-properties@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "conditional-properties.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/destructured-react-memo-imported-component@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/destructured-react-memo-imported-component@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { importedLoader } from '../../shared/imported';
+import { Route } from "destructured-react-memo-imported-component.tsx";
 function Component() {
   return <div>Component</div>;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/destructured-react-memo-imported-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/destructured-react-memo-imported-component@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "destructured-react-memo-imported-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/function-as-parameter.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/function-as-parameter.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // @ts-expect-error
 import { useMemo } from 'tan-react';
+const useUsedVar = 'i-am-unused';
 const ReactUseMemoCall1 = React.useMemo(function performAction() {
   return 'true';
 }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/function-as-parameter@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/function-as-parameter@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // @ts-expect-error
 import { useMemo } from 'tan-react';
+const useUsedVar = 'i-am-unused';
 const ReactUseMemoCall1 = React.useMemo(function performAction() {
   return 'true';
 }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/function-as-parameter@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/function-as-parameter@errorComponent.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // @ts-expect-error
 import { useMemo } from 'tan-react';
+const useUsedVar = 'i-am-unused';
 const ReactUseMemoCall1 = React.useMemo(function performAction() {
   return 'true';
 }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/function-declaration.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/function-declaration.tsx
@@ -2,6 +2,7 @@ const $$splitComponentImporter = () => import('function-declaration.tsx?tsr-spli
 import { lazyRouteComponent } from '@tanstack/react-router';
 const $$splitLoaderImporter = () => import('function-declaration.tsx?tsr-split=component---loader---notFoundComponent---pendingComponent');
 import { lazyFn } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/posts')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/function-declaration@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/function-declaration@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { Link, Outlet } from '@tanstack/react-router';
 import { fetchPosts } from '../posts';
 import { Route } from "function-declaration.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/function-declaration@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/function-declaration@errorComponent.tsx
@@ -1,0 +1,2 @@
+import * as React from 'react';
+import { Route } from "function-declaration.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/importAttribute@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/importAttribute@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
 import { test } from './test' with { type: 'macro' };
+import { Route } from "importAttribute.tsx";
 const SplitComponent = () => test;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/importAttribute@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/importAttribute@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "importAttribute.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-default-component-destructured-loader@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-default-component-destructured-loader@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,5 @@
 import importedComponent, { importedLoader } from '../../shared/imported';
+import { Route } from "imported-default-component-destructured-loader.tsx";
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };
 const SplitComponent = importedComponent;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-default-component-destructured-loader@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-default-component-destructured-loader@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-default-component-destructured-loader.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-default-component@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-default-component@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
 import ImportedDefaultComponent from '../../shared/imported';
+import { Route } from "imported-default-component.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-default-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-default-component@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-errorComponent@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-errorComponent@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
 import ImportedDefaultComponent from '../../shared/imported';
+import { Route } from "imported-errorComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-errorComponent@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-errorComponent@errorComponent.tsx
@@ -1,3 +1,4 @@
 import { importedErrorComponent } from '../../shared/imported';
+import { Route } from "imported-errorComponent.tsx";
 const SplitErrorComponent = importedErrorComponent;
 export { SplitErrorComponent as errorComponent };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-notFoundComponent@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-notFoundComponent@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,5 @@
 import ImportedDefaultComponent, { importedNotFoundComponent } from '../../shared/imported';
+import { Route } from "imported-notFoundComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };
 const SplitNotFoundComponent = importedNotFoundComponent;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-notFoundComponent@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-notFoundComponent@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-notFoundComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-pendingComponent@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-pendingComponent@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,5 @@
 import ImportedDefaultComponent, { importedPendingComponent } from '../../shared/imported';
+import { Route } from "imported-pendingComponent.tsx";
 const SplitComponent = ImportedDefaultComponent;
 export { SplitComponent as component };
 const SplitPendingComponent = importedPendingComponent;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-pendingComponent@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-pendingComponent@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported-pendingComponent.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,5 @@
 import { importedComponent, importedLoader } from '../../shared';
+import { Route } from "imported.tsx";
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };
 const SplitComponent = importedComponent;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "imported.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/inline.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/inline.tsx
@@ -1,5 +1,6 @@
 const $$splitComponentImporter = () => import('inline.tsx?tsr-split=component---loader---notFoundComponent---pendingComponent');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/inline@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/inline@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import * as styles from '../style.css';
 import { TEST_DATA } from '../test.const';
 const Button = (props: {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/inline@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/inline@errorComponent.tsx
@@ -1,2 +1,4 @@
+import * as React from 'react';
 import { Route } from "inline.tsx";
 Route.addChildren([]);
+import { test } from "inline.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/random-number.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/random-number.tsx
@@ -2,9 +2,26 @@ const $$splitComponentImporter = () => import('random-number.tsx?tsr-split=compo
 import { lazyRouteComponent } from '@tanstack/react-router';
 const $$splitLoaderImporter = () => import('random-number.tsx?tsr-split=component---loader---notFoundComponent---pendingComponent');
 import { lazyFn } from '@tanstack/react-router';
-import { createFileRoute } from '@tanstack/react-router';
+import { Await, Link, createFileRoute } from '@tanstack/react-router';
+import { Carbon } from '~/components/Carbon';
+import { twMerge } from 'tailwind-merge';
+import { FaDiscord, FaGithub, FaTshirt } from 'react-icons/fa';
+import { CgMusicSpeaker, CgSpinner } from 'react-icons/cg';
+import { Footer } from '~/components/Footer';
+import SponsorPack from '~/components/SponsorPack';
+import { LogoColor } from '~/components/LogoColor';
+import agGridImage from '~/images/ag-grid.png';
+import nozzleImage from '~/images/nozzle.png';
+import bytesImage from '~/images/bytes.svg';
+import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
 export const textColors = [`text-rose-500`, `text-yellow-500`, `text-teal-500`, `text-blue-500`];
 export const gradients = [`from-rose-500 to-yellow-500`, `from-yellow-500 to-teal-500`, `from-teal-500 to-violet-500`, `from-blue-500 to-pink-500`];
+const courses = [{
+  name: 'The Official TanStack React Query Course',
+  cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
+  href: 'https://query.gg/?s=tanstack',
+  description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
+}];
 export const Route = createFileRoute('/')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),
   component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/random-number@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/random-number@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,10 +1,47 @@
-import { defer } from '@tanstack/react-router';
+import { Await, Link, defer } from '@tanstack/react-router';
+import { Carbon } from '~/components/Carbon';
+import { twMerge } from 'tailwind-merge';
+import { FaDiscord, FaGithub, FaTshirt } from 'react-icons/fa';
+import { CgMusicSpeaker, CgSpinner } from 'react-icons/cg';
+import { Footer } from '~/components/Footer';
+import SponsorPack from '~/components/SponsorPack';
+import { LogoColor } from '~/components/LogoColor';
 import { getSponsorsForSponsorPack } from '~/server/sponsors';
 import discordImage from '~/images/discord-logo-white.svg';
+import agGridImage from '~/images/ag-grid.png';
+import nozzleImage from '~/images/nozzle.png';
+import bytesImage from '~/images/bytes.svg';
+import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
+import { useMutation } from '~/hooks/useMutation';
 import { sample } from '~/utils/utils';
 import { textColors } from "random-number.tsx";
 import { gradients } from "random-number.tsx";
+const courses = [{
+  name: 'The Official TanStack React Query Course',
+  cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
+  href: 'https://query.gg/?s=tanstack',
+  description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
+}];
 import { Route } from "random-number.tsx";
+async function bytesSignupServerFn({
+  email
+}: {
+  email: string;
+}) {
+  'use server';
+
+  return fetch(`https://bytes.dev/api/bytes-optin-cors`, {
+    method: 'POST',
+    body: JSON.stringify({
+      email,
+      influencer: 'tanstack'
+    }),
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    }
+  });
+}
 const SplitLoader = () => {
   return {
     randomNumber: Math.random(),
@@ -13,6 +50,9 @@ const SplitLoader = () => {
 };
 export { SplitLoader as loader };
 const SplitComponent = function Index() {
+  const bytesSignupMutation = useMutation({
+    fn: bytesSignupServerFn
+  });
   const {
     randomNumber
   } = Route.useLoaderData();

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/random-number@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/random-number@errorComponent.tsx
@@ -1,0 +1,21 @@
+import { Await, Link } from '@tanstack/react-router';
+import { Carbon } from '~/components/Carbon';
+import { twMerge } from 'tailwind-merge';
+import { FaDiscord, FaGithub, FaTshirt } from 'react-icons/fa';
+import { CgMusicSpeaker, CgSpinner } from 'react-icons/cg';
+import { Footer } from '~/components/Footer';
+import SponsorPack from '~/components/SponsorPack';
+import { LogoColor } from '~/components/LogoColor';
+import agGridImage from '~/images/ag-grid.png';
+import nozzleImage from '~/images/nozzle.png';
+import bytesImage from '~/images/bytes.svg';
+import bytesUidotdevImage from '~/images/bytes-uidotdev.png';
+import { textColors } from "random-number.tsx";
+import { gradients } from "random-number.tsx";
+const courses = [{
+  name: 'The Official TanStack React Query Course',
+  cardStyles: `border-t-4 border-red-500 hover:(border-green-500)`,
+  href: 'https://query.gg/?s=tanstack',
+  description: `Learn how to build enterprise quality apps with TanStack's React Query the easy way with our brand new course.`
+}];
+import { Route } from "random-number.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/react-memo-component@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/react-memo-component@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { importedLoader } from '../../shared/imported';
+import { Route } from "react-memo-component.tsx";
 function Component() {
   return <div>Component</div>;
 }

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/react-memo-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/react-memo-component@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "react-memo-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/react-memo-imported-component@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/react-memo-imported-component@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { importedLoader, importedComponent } from '../../shared/imported';
+import { Route } from "react-memo-imported-component.tsx";
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };
 const SplitComponent = React.memo(importedComponent);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/react-memo-imported-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/react-memo-imported-component@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "react-memo-imported-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-export-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-export-component.tsx
@@ -1,5 +1,6 @@
 const $$splitLoaderImporter = () => import('retain-export-component.tsx?tsr-split=component---loader---notFoundComponent---pendingComponent');
 import { lazyFn } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent } from '../../shared/imported';
 export function Layout() {
@@ -25,3 +26,5 @@ export const Route = createFileRoute('/_layout')({
 });
 const HEADER_HEIGHT = '63px';
 export const SIDEBAR_WIDTH = '150px';
+const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-export-component@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-export-component@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,8 @@
+import * as React from 'react';
 import { importedLoader } from '../../shared/imported';
+import { Route } from "retain-export-component.tsx";
+import { SIDEBAR_WIDTH } from "retain-export-component.tsx";
+const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';
 const SplitLoader = importedLoader;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-export-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-export-component@errorComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-export-component.tsx";
+import { SIDEBAR_WIDTH } from "retain-export-component.tsx";
+const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-exports-const.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-exports-const.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent, importedLoader } from '../../shared/imported';
 export const loaderFn = () => {
@@ -27,4 +28,5 @@ export const Route = createFileRoute('/_layout')({
 const HEADER_HEIGHT = '63px';
 export const SIDEBAR_WIDTH = '150px';
 export const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';
 export default Layout;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-exports-const@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-exports-const@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-const.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-const.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-exports-const@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-exports-const@errorComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-const.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-const.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-exports-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-exports-function.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent, importedLoader } from '../../shared/imported';
 export function loaderFn() {
@@ -27,4 +28,5 @@ export const Route = createFileRoute('/_layout')({
 const HEADER_HEIGHT = '63px';
 export const SIDEBAR_WIDTH = '150px';
 export const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';
 export default Layout;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-exports-function@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-exports-function@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-function.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-function.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-exports-function@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-exports-function@errorComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-function.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-function.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-exports-loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-exports-loader.tsx
@@ -1,5 +1,6 @@
 const $$splitComponentImporter = () => import('retain-exports-loader.tsx?tsr-split=component---loader---notFoundComponent---pendingComponent');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import * as React from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export function loaderFn() {
   return {
@@ -12,3 +13,4 @@ export const Route = createFileRoute('/_layout')({
 });
 export const SIDEBAR_WIDTH = '150px';
 export const SIDEBAR_MINI_WIDTH = '80px';
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-exports-loader@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-exports-loader@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,6 +1,11 @@
+import * as React from 'react';
 import { Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent } from '../../shared/imported';
+import { Route } from "retain-exports-loader.tsx";
 const HEADER_HEIGHT = '63px';
+import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-loader.tsx";
+const ASIDE_WIDTH = '250px';
 const SplitComponent = function Layout() {
   return <main>
       <header style={{

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-exports-loader@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-exports-loader@errorComponent.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { Route } from "retain-exports-loader.tsx";
+import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";
+import { SIDEBAR_MINI_WIDTH } from "retain-exports-loader.tsx";
+const ASIDE_WIDTH = '250px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/useStateDestructure.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/useStateDestructure.tsx
@@ -1,5 +1,7 @@
 const $$splitComponentImporter = () => import('useStateDestructure.tsx?tsr-split=component---loader---notFoundComponent---pendingComponent');
 import { lazyRouteComponent } from '@tanstack/react-router';
+import { FaBolt, FaBook, FaCheckCircle, FaCogs } from 'react-icons/fa';
+import { VscPreview, VscWand } from 'react-icons/vsc';
 import { startProject } from '~/projects/start';
 import { createFileRoute } from '@tanstack/react-router';
 import { seo } from '~/utils/seo';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/useStateDestructure@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/useStateDestructure@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { CgCornerUpLeft, CgSpinner } from 'react-icons/cg';
-import { FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
+import { FaBolt, FaBook, FaCheckCircle, FaCogs, FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
 import { Await, Link, getRouteApi } from '@tanstack/react-router';
 import { Carbon } from '~/components/Carbon';
 import { Footer } from '~/components/Footer';
+import { VscPreview, VscWand } from 'react-icons/vsc';
 import { TbHeartHandshake } from 'react-icons/tb';
 import SponsorPack from '~/components/SponsorPack';
 import { startProject } from '~/projects/start';
+import { Framework, getBranch } from '~/projects';
 const menu = [{
   label: <div className="flex items-center gap-2">
         <CgCornerUpLeft className="text-lg" /> TanStack
@@ -57,7 +59,9 @@ export default function VersionIndex() {
   const {
     version
   } = Route.useParams();
-  const [, setIsDark] = React.useState(true);
+  const branch = getBranch(startProject, version);
+  const [framework, setFramework] = React.useState<Framework>('react');
+  const [isDark, setIsDark] = React.useState(true);
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches);
   }, []);
@@ -449,7 +453,9 @@ const SplitComponent = function VersionIndex() {
   const {
     version
   } = Route.useParams();
-  const [, setIsDark] = React.useState(true);
+  const branch = getBranch(startProject, version);
+  const [framework, setFramework] = React.useState<Framework>('react');
+  const [isDark, setIsDark] = React.useState(true);
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches);
   }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/useStateDestructure@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/useStateDestructure@errorComponent.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { CgCornerUpLeft, CgSpinner } from 'react-icons/cg';
-import { FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
+import { FaBolt, FaBook, FaCheckCircle, FaCogs, FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';
 import { Await, Link, getRouteApi } from '@tanstack/react-router';
 import { Carbon } from '~/components/Carbon';
 import { Footer } from '~/components/Footer';
+import { VscPreview, VscWand } from 'react-icons/vsc';
 import { TbHeartHandshake } from 'react-icons/tb';
 import SponsorPack from '~/components/SponsorPack';
 import { startProject } from '~/projects/start';
+import { Framework, getBranch } from '~/projects';
 const menu = [{
   label: <div className="flex items-center gap-2">
         <CgCornerUpLeft className="text-lg" /> TanStack
@@ -57,7 +59,9 @@ export default function VersionIndex() {
   const {
     version
   } = Route.useParams();
-  const [, setIsDark] = React.useState(true);
+  const branch = getBranch(startProject, version);
+  const [framework, setFramework] = React.useState<Framework>('react');
+  const [isDark, setIsDark] = React.useState(true);
   React.useEffect(() => {
     setIsDark(window.matchMedia?.(`(prefers-color-scheme: dark)`).matches);
   }, []);

--- a/packages/router-plugin/tests/code-splitter/snapshots/solid/1-default/development/arrow-function@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/solid/1-default/development/arrow-function@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/solid/1-default/development/arrow-function@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/solid/1-default/development/arrow-function@notFoundComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/solid/1-default/development/arrow-function@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/solid/1-default/development/arrow-function@pendingComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/solid/1-default/production/arrow-function@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/solid/1-default/production/arrow-function@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/solid/1-default/production/arrow-function@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/solid/1-default/production/arrow-function@notFoundComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/solid/1-default/production/arrow-function@pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/solid/1-default/production/arrow-function@pendingComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/solid/2-components-combined-loader-separate/development/arrow-function@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/solid/2-components-combined-loader-separate/development/arrow-function@loader.tsx
@@ -1,3 +1,4 @@
 import { fetchPosts } from '../posts';
+import { Route } from "arrow-function.tsx";
 const SplitLoader = fetchPosts;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/solid/2-components-combined-loader-separate/production/arrow-function@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/solid/2-components-combined-loader-separate/production/arrow-function@loader.tsx
@@ -1,3 +1,4 @@
 import { fetchPosts } from '../posts';
+import { Route } from "arrow-function.tsx";
 const SplitLoader = fetchPosts;
 export { SplitLoader as loader };

--- a/packages/router-plugin/tests/code-splitter/snapshots/solid/3-all-combined-errorComponent-separate/development/arrow-function@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/solid/3-all-combined-errorComponent-separate/development/arrow-function@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "arrow-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/solid/3-all-combined-errorComponent-separate/production/arrow-function@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/solid/3-all-combined-errorComponent-separate/production/arrow-function@errorComponent.tsx
@@ -1,0 +1,1 @@
+import { Route } from "arrow-function.tsx";

--- a/packages/start-plugin/tests/createServerFn/createServerFn.test.ts
+++ b/packages/start-plugin/tests/createServerFn/createServerFn.test.ts
@@ -136,6 +136,11 @@ describe('createServerFn compiles correctly', async () => {
         "use server";
 
         return exportedFn.__executeServer(opts);
+      });
+      const nonExportedFn = createServerFn().handler(opts => {
+        "use server";
+
+        return nonExportedFn.__executeServer(opts);
       });"
     `)
 
@@ -157,6 +162,14 @@ describe('createServerFn compiles correctly', async () => {
         return exportedFn.__executeServer(opts);
       }, async () => {
         return exportedVar;
+      });
+      const nonExportedVar = 'non-exported';
+      const nonExportedFn = createServerFn().handler(opts => {
+        "use server";
+
+        return nonExportedFn.__executeServer(opts);
+      }, async () => {
+        return nonExportedVar;
       });"
     `)
   })


### PR DESCRIPTION
The dead code elimination being done currently removes *all* potentially dead code, including parts created by the user. This creates issues such as https://github.com/pcattori/babel-dead-code-elimination/issues/34, where the user wasn't expecting code to be considered "dead" and it got removed anyway.

This PR uses `findReferencedIdentifiers` to limit DCE to code that's *newly* dead after transformation, deferring the rest for Vite to decide (which no doubt does plenty by itself).