### PR TITLE
fix: add failing test for anon default export for server fns

### DIFF
--- a/packages/directive-functions-plugin/tests/compiler.test.ts
+++ b/packages/directive-functions-plugin/tests/compiler.test.ts
@@ -710,4 +710,53 @@ describe('server function compilation', () => {
       export { serverFnConstWithImport_1, serverFnNamedWithImport_1 };"
     `)
   })
+  test('async function with anonymous default export', () => {
+    const code = `
+      async function bytesSignupServerFn({ email }: { email: string }) {
+        'use server'
+
+        return 'test'
+      }
+
+      export default function () {
+        return null;
+      }
+
+    `
+
+    const client = compileDirectives({ ...clientConfig, code })
+    const ssr = compileDirectives({ ...ssrConfig, code })
+    const server = compileDirectives({
+      ...serverConfig,
+      code,
+      filename:
+        ssr.directiveFnsById[Object.keys(ssr.directiveFnsById)[0]!]!
+          .extractedFilename,
+    })
+
+    expect(client.compiledResult.code).toMatchInlineSnapshot(`
+      "export default function () {
+        return null;
+      }"
+    `)
+    expect(ssr.compiledResult.code).toMatchInlineSnapshot(`
+      "export default function () {
+        return null;
+      }"
+    `)
+    expect(server.compiledResult.code).toMatchInlineSnapshot(`
+      "import { createServerRpc } from "my-rpc-lib-server";
+      const bytesSignupServerFn_1 = createServerRpc("test_ts--bytesSignupServerFn_1", async function ({
+        email
+      }: {
+        email: string;
+      }) {
+        return 'test';
+      });
+      export default function () {
+        return null;
+      }
+      export { bytesSignupServerFn_1 };"
+    `)
+  })
 })


### PR DESCRIPTION
When using an anonymous default export the directives plugin produces invalid javascript like the following

```
function() {
}
```

When it has an identifier its fine:

```
function Home() {
}
```