### PR TITLE
fix(react-router): lazyRouteComponent reload guard key fallsback to importer's import.meta.url on Safari

### DIFF
--- a/e2e/react-router/basic-file-based-code-splitting/src/main.tsx
+++ b/e2e/react-router/basic-file-based-code-splitting/src/main.tsx
@@ -10,6 +10,7 @@ const router = createRouter({
   defaultPreload: 'intent',
   defaultStaleTime: 5000,
   scrollRestoration: true,
+  defaultErrorComponent: () => <div>This is the error component</div>,
 })
 
 // Register things for typesafety

--- a/e2e/react-router/basic-file-based-code-splitting/tests/app.spec.ts
+++ b/e2e/react-router/basic-file-based-code-splitting/tests/app.spec.ts
@@ -31,3 +31,41 @@ test('Navigating to a not-found route', async ({ page }) => {
   await page.getByRole('link', { name: 'Start Over' }).click()
   await expect(page.getByRole('heading')).toContainText('Welcome Home!')
 })
+
+test('Navigating to a route where the lazy component fails to load', async ({ page }) => {
+  // block (and count) all requests to the posts.index route component
+  let requested = 0
+  await page.route('**/assets/posts.index-*', (route) => {
+    requested++
+    return route.fulfill({
+      status: 404,
+      contentType: 'text/plain',
+      body: 'Not Found!'
+    })
+  })
+
+  // count how many times the page reloads
+  let reloaded = 0
+  page.on('load', () => {
+    reloaded++
+  })
+
+  // navigate to the posts page
+  await page.getByRole('link', { name: 'Posts' }).click()
+
+  // will reload only once, despite failing twice, because the name of the module is the same both times
+  await expect(() => {
+    expect(reloaded).toBe(1)
+    expect(requested).toBe(2)
+  }).toPass({
+    intervals: [50],
+    timeout: 3000
+  })
+
+  // the error component should be rendered
+  await page.getByText('This is the error component')
+
+  // make sure it doesn't reload again (handle edge-case where `.toPass` above was executed right before a 2nd page reload)
+  await page.waitForTimeout(200)
+  expect(reloaded).toBe(1)
+})

--- a/e2e/react-router/basic-file-based-code-splitting/tests/app.spec.ts
+++ b/e2e/react-router/basic-file-based-code-splitting/tests/app.spec.ts
@@ -32,7 +32,9 @@ test('Navigating to a not-found route', async ({ page }) => {
   await expect(page.getByRole('heading')).toContainText('Welcome Home!')
 })
 
-test('Navigating to a route where the lazy component fails to load', async ({ page }) => {
+test('Navigating to a route where the lazy component fails to load', async ({
+  page,
+}) => {
   // block (and count) all requests to the posts.index route component
   let requested = 0
   await page.route('**/assets/posts.index-*', (route) => {
@@ -40,7 +42,7 @@ test('Navigating to a route where the lazy component fails to load', async ({ pa
     return route.fulfill({
       status: 404,
       contentType: 'text/plain',
-      body: 'Not Found!'
+      body: 'Not Found!',
     })
   })
 
@@ -59,7 +61,7 @@ test('Navigating to a route where the lazy component fails to load', async ({ pa
     expect(requested).toBe(2)
   }).toPass({
     intervals: [50],
-    timeout: 3000
+    timeout: 3000,
   })
 
   // the error component should be rendered

--- a/packages/react-router/src/lazyRouteComponent.tsx
+++ b/packages/react-router/src/lazyRouteComponent.tsx
@@ -7,7 +7,10 @@ import type { AsyncRouteComponent } from './route'
 // If this happens, the old version in the user's browser would have an outdated
 // URL to the lazy module.
 // In that case, we want to attempt one window refresh to get the latest.
-function getModuleNotFoundErrorKey(error: any, importerName?: string): string | false {
+function getModuleNotFoundErrorKey(
+  error: any,
+  importerName?: string,
+): string | false {
   // chrome: "Failed to fetch dynamically imported module: http://localhost:5173/src/routes/posts.index.tsx?tsr-split"
   // firefox: "error loading dynamically imported module: http://localhost:5173/src/routes/posts.index.tsx?tsr-split"
   // safari: "Importing a module script failed."

--- a/packages/react-router/src/lazyRouteComponent.tsx
+++ b/packages/react-router/src/lazyRouteComponent.tsx
@@ -7,16 +7,21 @@ import type { AsyncRouteComponent } from './route'
 // If this happens, the old version in the user's browser would have an outdated
 // URL to the lazy module.
 // In that case, we want to attempt one window refresh to get the latest.
-function isModuleNotFoundError(error: any): boolean {
+function getModuleNotFoundErrorKey(error: any, importerName?: string): string | false {
   // chrome: "Failed to fetch dynamically imported module: http://localhost:5173/src/routes/posts.index.tsx?tsr-split"
   // firefox: "error loading dynamically imported module: http://localhost:5173/src/routes/posts.index.tsx?tsr-split"
   // safari: "Importing a module script failed."
   if (typeof error?.message !== 'string') return false
-  return (
+  if (
     error.message.startsWith('Failed to fetch dynamically imported module') ||
-    error.message.startsWith('error loading dynamically imported module') ||
-    error.message.startsWith('Importing a module script failed')
+    error.message.startsWith('error loading dynamically imported module')
   )
+    // Use error.message as key because it contains the module path that failed.
+    return error.message
+
+  if (error.message.startsWith('Importing a module script failed'))
+    return importerName ?? error.message
+  return false
 }
 
 export function ClientOnly({
@@ -45,6 +50,7 @@ export function lazyRouteComponent<
   importer: () => Promise<T>,
   exportName?: TKey,
   ssr?: () => boolean,
+  importerName?: string,
 ): T[TKey] extends (props: infer TProps) => any
   ? AsyncRouteComponent<TProps>
   : never {
@@ -69,7 +75,8 @@ export function lazyRouteComponent<
           // there's nothing we want to do about module not found during preload.
           // Record the error, the rest is handled during the render path.
           error = err
-          if (isModuleNotFoundError(error)) {
+          const key = getModuleNotFoundErrorKey(err, importerName)
+          if (key) {
             if (
               error instanceof Error &&
               typeof window !== 'undefined' &&
@@ -78,8 +85,7 @@ export function lazyRouteComponent<
               // Again, we want to reload one time on module not found error and not enter
               // a reload loop if there is some other issue besides an old deploy.
               // That's why we store our reload attempt in sessionStorage.
-              // Use error.message as key because it contains the module path that failed.
-              const storageKey = `tanstack_router_reload:${error.message}`
+              const storageKey = `tanstack_router_reload:${key}`
               if (!sessionStorage.getItem(storageKey)) {
                 sessionStorage.setItem(storageKey, '1')
                 reload = true

--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -576,9 +576,7 @@ export async function generator(config: Config, root: string) {
               )
                 .filter((d) => d[1])
                 .map((d) => {
-                  return `${
-                    d[0]
-                  }: lazyRouteComponent(() => import('./${replaceBackslash(
+                  const importPath = replaceBackslash(
                     removeExt(
                       path.relative(
                         path.dirname(config.generatedRouteTree),
@@ -586,7 +584,13 @@ export async function generator(config: Config, root: string) {
                       ),
                       config.addExtensions,
                     ),
-                  )}'), '${d[0]}')`
+                  )
+                  return `${d[0]}: lazyRouteComponent(
+                    () => import('./${importPath}'),
+                    '${d[0]}',
+                    undefined,
+                    import.meta.url
+                  )`
                 })
                 .join('\n,')}
             })`

--- a/packages/router-plugin/src/core/code-splitter/compilers.ts
+++ b/packages/router-plugin/src/core/code-splitter/compilers.ts
@@ -275,11 +275,11 @@ export function compileCodeSplitReferenceRoute(
                           // If it's a component, we need to pass the function to check the Route.ssr value
                           if (key === 'component') {
                             prop.value = template.expression(
-                              `${LAZY_ROUTE_COMPONENT_IDENT}(${splitNodeMeta.localImporterIdent}, '${splitNodeMeta.exporterIdent}', () => Route.ssr)`,
+                              `${LAZY_ROUTE_COMPONENT_IDENT}(${splitNodeMeta.localImporterIdent}, '${splitNodeMeta.exporterIdent}', () => Route.ssr, import.meta.url)`,
                             )()
                           } else {
                             prop.value = template.expression(
-                              `${LAZY_ROUTE_COMPONENT_IDENT}(${splitNodeMeta.localImporterIdent}, '${splitNodeMeta.exporterIdent}')`,
+                              `${LAZY_ROUTE_COMPONENT_IDENT}(${splitNodeMeta.localImporterIdent}, '${splitNodeMeta.exporterIdent}', undefined, import.meta.url)`,
                             )()
                           }
 

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/arrow-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/arrow-function.tsx
@@ -4,7 +4,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { fetchPosts } from '../posts';
 export const Route = createFileRoute('/posts')({
   loader: fetchPosts,
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/chinese.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/chinese.tsx
@@ -2,7 +2,7 @@ const $$splitComponentImporter = () => import('chinese.tsx?tsr-split=component')
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 interface DemoProps {
   title: string;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/conditional-properties.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/conditional-properties.tsx
@@ -5,7 +5,7 @@ import { isEnabled } from '@features/feature-flags';
 import TrueImport from '@modules/true-component';
 import { falseLoader } from '@modules/false-component';
 export const Route = createFileRoute('/posts')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: isEnabled ? TrueImport.loader : falseLoader
 });
 export function TSRDummyComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/destructured-react-memo-imported-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/destructured-react-memo-imported-component.tsx
@@ -3,7 +3,7 @@ import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 import { importedLoader } from '../../shared/imported';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: importedLoader
 });
 export function TSRDummyComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/function-declaration.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/function-declaration.tsx
@@ -4,7 +4,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { fetchPosts } from '../posts';
 export const Route = createFileRoute('/posts')({
   loader: fetchPosts,
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/importAttribute.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/importAttribute.tsx
@@ -2,7 +2,7 @@ const $$splitComponentImporter = () => import('importAttribute.tsx?tsr-split=com
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-default-component-destructured-loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-default-component-destructured-loader.tsx
@@ -3,7 +3,7 @@ import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 import { importedLoader } from '../../shared/imported';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: importedLoader
 });
 export function TSRDummyComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-default-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-default-component.tsx
@@ -2,7 +2,7 @@ const $$splitComponentImporter = () => import('imported-default-component.tsx?ts
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-errorComponent.tsx
@@ -3,8 +3,8 @@ const $$splitComponentImporter = () => import('imported-errorComponent.tsx?tsr-s
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
-  errorComponent: lazyRouteComponent($$splitErrorComponentImporter, 'errorComponent')
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
+  errorComponent: lazyRouteComponent($$splitErrorComponentImporter, 'errorComponent', undefined, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-notFoundComponent.tsx
@@ -3,8 +3,8 @@ const $$splitComponentImporter = () => import('imported-notFoundComponent.tsx?ts
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
-  notFoundComponent: lazyRouteComponent($$splitNotFoundComponentImporter, 'notFoundComponent')
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
+  notFoundComponent: lazyRouteComponent($$splitNotFoundComponentImporter, 'notFoundComponent', undefined, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported-pendingComponent.tsx
@@ -3,8 +3,8 @@ const $$splitComponentImporter = () => import('imported-pendingComponent.tsx?tsr
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
-  pendingComponent: lazyRouteComponent($$splitPendingComponentImporter, 'pendingComponent')
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
+  pendingComponent: lazyRouteComponent($$splitPendingComponentImporter, 'pendingComponent', undefined, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/imported.tsx
@@ -3,7 +3,7 @@ import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 import { importedLoader } from '../../shared';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: importedLoader
 });
 export function TSRDummyComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/inline.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/inline.tsx
@@ -2,7 +2,7 @@ const $$splitComponentImporter = () => import('inline.tsx?tsr-split=component');
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 Route.addChildren([]);
 export const test = 'test';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/random-number.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/random-number.tsx
@@ -11,7 +11,7 @@ export const Route = createFileRoute('/')({
       sponsorsPromise: defer(getSponsorsForSponsorPack())
     };
   },
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/react-memo-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/react-memo-component.tsx
@@ -3,7 +3,7 @@ import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 import { importedLoader } from '../../shared/imported';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: importedLoader
 });
 export function TSRDummyComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/react-memo-imported-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/react-memo-imported-component.tsx
@@ -3,7 +3,7 @@ import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 import { importedLoader } from '../../shared/imported';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: importedLoader
 });
 export function TSRDummyComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/retain-exports-loader.tsx
@@ -7,7 +7,7 @@ export function loaderFn() {
   };
 }
 export const Route = createFileRoute('/_layout')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: loaderFn
 });
 export const SIDEBAR_WIDTH = '150px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/useStateDestructure.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/development/useStateDestructure.tsx
@@ -4,7 +4,7 @@ import { startProject } from '~/projects/start';
 import { createFileRoute } from '@tanstack/react-router';
 import { seo } from '~/utils/seo';
 export const Route = createFileRoute('/_libraries/start/$version/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   meta: () => seo({
     title: startProject.name,
     description: startProject.description

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/arrow-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/arrow-function.tsx
@@ -4,5 +4,5 @@ import { createFileRoute } from '@tanstack/react-router';
 import { fetchPosts } from '../posts';
 export const Route = createFileRoute('/posts')({
   loader: fetchPosts,
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/chinese.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/chinese.tsx
@@ -2,7 +2,7 @@ const $$splitComponentImporter = () => import('chinese.tsx?tsr-split=component')
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 interface DemoProps {
   title: string;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/conditional-properties.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/conditional-properties.tsx
@@ -5,6 +5,6 @@ import { isEnabled } from '@features/feature-flags';
 import TrueImport from '@modules/true-component';
 import { falseLoader } from '@modules/false-component';
 export const Route = createFileRoute('/posts')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: isEnabled ? TrueImport.loader : falseLoader
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/destructured-react-memo-imported-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/destructured-react-memo-imported-component.tsx
@@ -3,6 +3,6 @@ import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 import { importedLoader } from '../../shared/imported';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: importedLoader
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/function-declaration.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/function-declaration.tsx
@@ -4,5 +4,5 @@ import { createFileRoute } from '@tanstack/react-router';
 import { fetchPosts } from '../posts';
 export const Route = createFileRoute('/posts')({
   loader: fetchPosts,
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/importAttribute.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/importAttribute.tsx
@@ -2,5 +2,5 @@ const $$splitComponentImporter = () => import('importAttribute.tsx?tsr-split=com
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-default-component-destructured-loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-default-component-destructured-loader.tsx
@@ -3,6 +3,6 @@ import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 import { importedLoader } from '../../shared/imported';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: importedLoader
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-default-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-default-component.tsx
@@ -2,5 +2,5 @@ const $$splitComponentImporter = () => import('imported-default-component.tsx?ts
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-errorComponent.tsx
@@ -3,6 +3,6 @@ const $$splitComponentImporter = () => import('imported-errorComponent.tsx?tsr-s
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
-  errorComponent: lazyRouteComponent($$splitErrorComponentImporter, 'errorComponent')
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
+  errorComponent: lazyRouteComponent($$splitErrorComponentImporter, 'errorComponent', undefined, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-notFoundComponent.tsx
@@ -3,6 +3,6 @@ const $$splitComponentImporter = () => import('imported-notFoundComponent.tsx?ts
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
-  notFoundComponent: lazyRouteComponent($$splitNotFoundComponentImporter, 'notFoundComponent')
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
+  notFoundComponent: lazyRouteComponent($$splitNotFoundComponentImporter, 'notFoundComponent', undefined, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported-pendingComponent.tsx
@@ -3,6 +3,6 @@ const $$splitComponentImporter = () => import('imported-pendingComponent.tsx?tsr
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
-  pendingComponent: lazyRouteComponent($$splitPendingComponentImporter, 'pendingComponent')
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
+  pendingComponent: lazyRouteComponent($$splitPendingComponentImporter, 'pendingComponent', undefined, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/imported.tsx
@@ -3,6 +3,6 @@ import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 import { importedLoader } from '../../shared';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: importedLoader
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/inline.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/inline.tsx
@@ -2,7 +2,7 @@ const $$splitComponentImporter = () => import('inline.tsx?tsr-split=component');
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 Route.addChildren([]);
 export const test = 'test';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/random-number.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/random-number.tsx
@@ -11,5 +11,5 @@ export const Route = createFileRoute('/')({
       sponsorsPromise: defer(getSponsorsForSponsorPack())
     };
   },
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/react-memo-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/react-memo-component.tsx
@@ -3,6 +3,6 @@ import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 import { importedLoader } from '../../shared/imported';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: importedLoader
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/react-memo-imported-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/react-memo-imported-component.tsx
@@ -3,6 +3,6 @@ import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 import { importedLoader } from '../../shared/imported';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: importedLoader
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/retain-exports-loader.tsx
@@ -7,7 +7,7 @@ export function loaderFn() {
   };
 }
 export const Route = createFileRoute('/_layout')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: loaderFn
 });
 export const SIDEBAR_WIDTH = '150px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/useStateDestructure.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/production/useStateDestructure.tsx
@@ -4,7 +4,7 @@ import { startProject } from '~/projects/start';
 import { createFileRoute } from '@tanstack/react-router';
 import { seo } from '~/utils/seo';
 export const Route = createFileRoute('/_libraries/start/$version/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   meta: () => seo({
     title: startProject.name,
     description: startProject.description

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/arrow-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/arrow-function.tsx
@@ -5,7 +5,7 @@ import { lazyFn } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/posts')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/chinese.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/chinese.tsx
@@ -2,7 +2,7 @@ const $$splitComponentImporter = () => import('chinese.tsx?tsr-split=component--
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 interface DemoProps {
   title: string;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/conditional-properties.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/conditional-properties.tsx
@@ -4,7 +4,7 @@ const $$splitComponentImporter = () => import('conditional-properties.tsx?tsr-sp
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/posts')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });
 export function TSRDummyComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/destructured-react-memo-imported-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/destructured-react-memo-imported-component.tsx
@@ -4,7 +4,7 @@ const $$splitComponentImporter = () => import('destructured-react-memo-imported-
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });
 export function TSRDummyComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/function-declaration.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/function-declaration.tsx
@@ -5,7 +5,7 @@ import { lazyFn } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/posts')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/importAttribute.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/importAttribute.tsx
@@ -2,7 +2,7 @@ const $$splitComponentImporter = () => import('importAttribute.tsx?tsr-split=com
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-default-component-destructured-loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-default-component-destructured-loader.tsx
@@ -4,7 +4,7 @@ const $$splitComponentImporter = () => import('imported-default-component-destru
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });
 export function TSRDummyComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-default-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-default-component.tsx
@@ -2,7 +2,7 @@ const $$splitComponentImporter = () => import('imported-default-component.tsx?ts
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-errorComponent.tsx
@@ -3,8 +3,8 @@ const $$splitComponentImporter = () => import('imported-errorComponent.tsx?tsr-s
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
-  errorComponent: lazyRouteComponent($$splitErrorComponentImporter, 'errorComponent')
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
+  errorComponent: lazyRouteComponent($$splitErrorComponentImporter, 'errorComponent', undefined, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-notFoundComponent.tsx
@@ -3,8 +3,8 @@ const $$splitComponentImporter = () => import('imported-notFoundComponent.tsx?ts
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
-  notFoundComponent: lazyRouteComponent($$splitNotFoundComponentImporter, 'notFoundComponent')
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
+  notFoundComponent: lazyRouteComponent($$splitNotFoundComponentImporter, 'notFoundComponent', undefined, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported-pendingComponent.tsx
@@ -3,8 +3,8 @@ const $$splitComponentImporter = () => import('imported-pendingComponent.tsx?tsr
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
-  pendingComponent: lazyRouteComponent($$splitPendingComponentImporter, 'pendingComponent')
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
+  pendingComponent: lazyRouteComponent($$splitPendingComponentImporter, 'pendingComponent', undefined, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/imported.tsx
@@ -4,7 +4,7 @@ const $$splitComponentImporter = () => import('imported.tsx?tsr-split=component-
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });
 export function TSRDummyComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/inline.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/inline.tsx
@@ -2,7 +2,7 @@ const $$splitComponentImporter = () => import('inline.tsx?tsr-split=component---
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 Route.addChildren([]);
 export const test = 'test';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/random-number.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/random-number.tsx
@@ -7,7 +7,7 @@ export const textColors = [`text-rose-500`, `text-yellow-500`, `text-teal-500`, 
 export const gradients = [`from-rose-500 to-yellow-500`, `from-yellow-500 to-teal-500`, `from-teal-500 to-violet-500`, `from-blue-500 to-pink-500`];
 export const Route = createFileRoute('/')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/react-memo-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/react-memo-component.tsx
@@ -4,7 +4,7 @@ const $$splitComponentImporter = () => import('react-memo-component.tsx?tsr-spli
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });
 export function TSRDummyComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/react-memo-imported-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/react-memo-imported-component.tsx
@@ -4,7 +4,7 @@ const $$splitComponentImporter = () => import('react-memo-imported-component.tsx
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });
 export function TSRDummyComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-exports-loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/retain-exports-loader.tsx
@@ -7,7 +7,7 @@ export function loaderFn() {
   };
 }
 export const Route = createFileRoute('/_layout')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: loaderFn
 });
 export const SIDEBAR_WIDTH = '150px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/useStateDestructure.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/development/useStateDestructure.tsx
@@ -4,7 +4,7 @@ import { startProject } from '~/projects/start';
 import { createFileRoute } from '@tanstack/react-router';
 import { seo } from '~/utils/seo';
 export const Route = createFileRoute('/_libraries/start/$version/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   meta: () => seo({
     title: startProject.name,
     description: startProject.description

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/arrow-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/arrow-function.tsx
@@ -5,5 +5,5 @@ import { lazyFn } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/posts')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/chinese.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/chinese.tsx
@@ -2,7 +2,7 @@ const $$splitComponentImporter = () => import('chinese.tsx?tsr-split=component--
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 interface DemoProps {
   title: string;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/conditional-properties.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/conditional-properties.tsx
@@ -4,6 +4,6 @@ const $$splitComponentImporter = () => import('conditional-properties.tsx?tsr-sp
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/posts')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/destructured-react-memo-imported-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/destructured-react-memo-imported-component.tsx
@@ -4,6 +4,6 @@ const $$splitComponentImporter = () => import('destructured-react-memo-imported-
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/function-declaration.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/function-declaration.tsx
@@ -5,5 +5,5 @@ import { lazyFn } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/posts')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/importAttribute.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/importAttribute.tsx
@@ -2,5 +2,5 @@ const $$splitComponentImporter = () => import('importAttribute.tsx?tsr-split=com
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-default-component-destructured-loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-default-component-destructured-loader.tsx
@@ -4,6 +4,6 @@ const $$splitComponentImporter = () => import('imported-default-component-destru
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-default-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-default-component.tsx
@@ -2,5 +2,5 @@ const $$splitComponentImporter = () => import('imported-default-component.tsx?ts
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-errorComponent.tsx
@@ -3,6 +3,6 @@ const $$splitComponentImporter = () => import('imported-errorComponent.tsx?tsr-s
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
-  errorComponent: lazyRouteComponent($$splitErrorComponentImporter, 'errorComponent')
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
+  errorComponent: lazyRouteComponent($$splitErrorComponentImporter, 'errorComponent', undefined, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-notFoundComponent.tsx
@@ -3,6 +3,6 @@ const $$splitComponentImporter = () => import('imported-notFoundComponent.tsx?ts
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
-  notFoundComponent: lazyRouteComponent($$splitNotFoundComponentImporter, 'notFoundComponent')
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
+  notFoundComponent: lazyRouteComponent($$splitNotFoundComponentImporter, 'notFoundComponent', undefined, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported-pendingComponent.tsx
@@ -3,6 +3,6 @@ const $$splitComponentImporter = () => import('imported-pendingComponent.tsx?tsr
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
-  pendingComponent: lazyRouteComponent($$splitPendingComponentImporter, 'pendingComponent')
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
+  pendingComponent: lazyRouteComponent($$splitPendingComponentImporter, 'pendingComponent', undefined, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/imported.tsx
@@ -4,6 +4,6 @@ const $$splitComponentImporter = () => import('imported.tsx?tsr-split=component-
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/inline.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/inline.tsx
@@ -2,7 +2,7 @@ const $$splitComponentImporter = () => import('inline.tsx?tsr-split=component---
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 Route.addChildren([]);
 export const test = 'test';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/random-number.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/random-number.tsx
@@ -7,5 +7,5 @@ export const textColors = [`text-rose-500`, `text-yellow-500`, `text-teal-500`, 
 export const gradients = [`from-rose-500 to-yellow-500`, `from-yellow-500 to-teal-500`, `from-teal-500 to-violet-500`, `from-blue-500 to-pink-500`];
 export const Route = createFileRoute('/')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/react-memo-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/react-memo-component.tsx
@@ -4,6 +4,6 @@ const $$splitComponentImporter = () => import('react-memo-component.tsx?tsr-spli
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/react-memo-imported-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/react-memo-imported-component.tsx
@@ -4,6 +4,6 @@ const $$splitComponentImporter = () => import('react-memo-imported-component.tsx
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-exports-loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/retain-exports-loader.tsx
@@ -7,7 +7,7 @@ export function loaderFn() {
   };
 }
 export const Route = createFileRoute('/_layout')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: loaderFn
 });
 export const SIDEBAR_WIDTH = '150px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/useStateDestructure.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/production/useStateDestructure.tsx
@@ -4,7 +4,7 @@ import { startProject } from '~/projects/start';
 import { createFileRoute } from '@tanstack/react-router';
 import { seo } from '~/utils/seo';
 export const Route = createFileRoute('/_libraries/start/$version/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   meta: () => seo({
     title: startProject.name,
     description: startProject.description

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/arrow-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/arrow-function.tsx
@@ -5,7 +5,7 @@ import { lazyFn } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/posts')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/chinese.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/chinese.tsx
@@ -2,7 +2,7 @@ const $$splitComponentImporter = () => import('chinese.tsx?tsr-split=component--
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 interface DemoProps {
   title: string;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/conditional-properties.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/conditional-properties.tsx
@@ -4,7 +4,7 @@ const $$splitComponentImporter = () => import('conditional-properties.tsx?tsr-sp
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/posts')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });
 export function TSRDummyComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/destructured-react-memo-imported-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/destructured-react-memo-imported-component.tsx
@@ -4,7 +4,7 @@ const $$splitComponentImporter = () => import('destructured-react-memo-imported-
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });
 export function TSRDummyComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/function-declaration.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/function-declaration.tsx
@@ -5,7 +5,7 @@ import { lazyFn } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/posts')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/importAttribute.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/importAttribute.tsx
@@ -2,7 +2,7 @@ const $$splitComponentImporter = () => import('importAttribute.tsx?tsr-split=com
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-default-component-destructured-loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-default-component-destructured-loader.tsx
@@ -4,7 +4,7 @@ const $$splitComponentImporter = () => import('imported-default-component-destru
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });
 export function TSRDummyComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-default-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-default-component.tsx
@@ -2,7 +2,7 @@ const $$splitComponentImporter = () => import('imported-default-component.tsx?ts
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-errorComponent.tsx
@@ -3,8 +3,8 @@ const $$splitComponentImporter = () => import('imported-errorComponent.tsx?tsr-s
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
-  errorComponent: lazyRouteComponent($$splitErrorComponentImporter, 'errorComponent')
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
+  errorComponent: lazyRouteComponent($$splitErrorComponentImporter, 'errorComponent', undefined, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-notFoundComponent.tsx
@@ -3,8 +3,8 @@ const $$splitComponentImporter = () => import('imported-notFoundComponent.tsx?ts
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
-  notFoundComponent: lazyRouteComponent($$splitNotFoundComponentImporter, 'notFoundComponent')
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
+  notFoundComponent: lazyRouteComponent($$splitNotFoundComponentImporter, 'notFoundComponent', undefined, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported-pendingComponent.tsx
@@ -3,8 +3,8 @@ const $$splitComponentImporter = () => import('imported-pendingComponent.tsx?tsr
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
-  pendingComponent: lazyRouteComponent($$splitPendingComponentImporter, 'pendingComponent')
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
+  pendingComponent: lazyRouteComponent($$splitPendingComponentImporter, 'pendingComponent', undefined, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/imported.tsx
@@ -4,7 +4,7 @@ const $$splitComponentImporter = () => import('imported.tsx?tsr-split=component-
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });
 export function TSRDummyComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/inline.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/inline.tsx
@@ -2,7 +2,7 @@ const $$splitComponentImporter = () => import('inline.tsx?tsr-split=component---
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 Route.addChildren([]);
 export const test = 'test';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/random-number.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/random-number.tsx
@@ -7,7 +7,7 @@ export const textColors = [`text-rose-500`, `text-yellow-500`, `text-teal-500`, 
 export const gradients = [`from-rose-500 to-yellow-500`, `from-yellow-500 to-teal-500`, `from-teal-500 to-violet-500`, `from-blue-500 to-pink-500`];
 export const Route = createFileRoute('/')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/react-memo-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/react-memo-component.tsx
@@ -4,7 +4,7 @@ const $$splitComponentImporter = () => import('react-memo-component.tsx?tsr-spli
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });
 export function TSRDummyComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/react-memo-imported-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/react-memo-imported-component.tsx
@@ -4,7 +4,7 @@ const $$splitComponentImporter = () => import('react-memo-imported-component.tsx
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });
 export function TSRDummyComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-exports-loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/retain-exports-loader.tsx
@@ -7,7 +7,7 @@ export function loaderFn() {
   };
 }
 export const Route = createFileRoute('/_layout')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: loaderFn
 });
 export const SIDEBAR_WIDTH = '150px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/useStateDestructure.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/development/useStateDestructure.tsx
@@ -4,7 +4,7 @@ import { startProject } from '~/projects/start';
 import { createFileRoute } from '@tanstack/react-router';
 import { seo } from '~/utils/seo';
 export const Route = createFileRoute('/_libraries/start/$version/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   meta: () => seo({
     title: startProject.name,
     description: startProject.description

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/arrow-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/arrow-function.tsx
@@ -5,5 +5,5 @@ import { lazyFn } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/posts')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/chinese.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/chinese.tsx
@@ -2,7 +2,7 @@ const $$splitComponentImporter = () => import('chinese.tsx?tsr-split=component--
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 interface DemoProps {
   title: string;

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/conditional-properties.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/conditional-properties.tsx
@@ -4,6 +4,6 @@ const $$splitComponentImporter = () => import('conditional-properties.tsx?tsr-sp
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/posts')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/destructured-react-memo-imported-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/destructured-react-memo-imported-component.tsx
@@ -4,6 +4,6 @@ const $$splitComponentImporter = () => import('destructured-react-memo-imported-
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/function-declaration.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/function-declaration.tsx
@@ -5,5 +5,5 @@ import { lazyFn } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/posts')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/importAttribute.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/importAttribute.tsx
@@ -2,5 +2,5 @@ const $$splitComponentImporter = () => import('importAttribute.tsx?tsr-split=com
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-default-component-destructured-loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-default-component-destructured-loader.tsx
@@ -4,6 +4,6 @@ const $$splitComponentImporter = () => import('imported-default-component-destru
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-default-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-default-component.tsx
@@ -2,5 +2,5 @@ const $$splitComponentImporter = () => import('imported-default-component.tsx?ts
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-errorComponent.tsx
@@ -3,6 +3,6 @@ const $$splitComponentImporter = () => import('imported-errorComponent.tsx?tsr-s
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
-  errorComponent: lazyRouteComponent($$splitErrorComponentImporter, 'errorComponent')
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
+  errorComponent: lazyRouteComponent($$splitErrorComponentImporter, 'errorComponent', undefined, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-notFoundComponent.tsx
@@ -3,6 +3,6 @@ const $$splitComponentImporter = () => import('imported-notFoundComponent.tsx?ts
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
-  notFoundComponent: lazyRouteComponent($$splitNotFoundComponentImporter, 'notFoundComponent')
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
+  notFoundComponent: lazyRouteComponent($$splitNotFoundComponentImporter, 'notFoundComponent', undefined, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported-pendingComponent.tsx
@@ -3,6 +3,6 @@ const $$splitComponentImporter = () => import('imported-pendingComponent.tsx?tsr
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
-  pendingComponent: lazyRouteComponent($$splitPendingComponentImporter, 'pendingComponent')
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
+  pendingComponent: lazyRouteComponent($$splitPendingComponentImporter, 'pendingComponent', undefined, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/imported.tsx
@@ -4,6 +4,6 @@ const $$splitComponentImporter = () => import('imported.tsx?tsr-split=component-
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/inline.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/inline.tsx
@@ -2,7 +2,7 @@ const $$splitComponentImporter = () => import('inline.tsx?tsr-split=component---
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 Route.addChildren([]);
 export const test = 'test';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/random-number.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/random-number.tsx
@@ -7,5 +7,5 @@ export const textColors = [`text-rose-500`, `text-yellow-500`, `text-teal-500`, 
 export const gradients = [`from-rose-500 to-yellow-500`, `from-yellow-500 to-teal-500`, `from-teal-500 to-violet-500`, `from-blue-500 to-pink-500`];
 export const Route = createFileRoute('/')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/react-memo-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/react-memo-component.tsx
@@ -4,6 +4,6 @@ const $$splitComponentImporter = () => import('react-memo-component.tsx?tsr-spli
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/react-memo-imported-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/react-memo-imported-component.tsx
@@ -4,6 +4,6 @@ const $$splitComponentImporter = () => import('react-memo-imported-component.tsx
 import { lazyRouteComponent } from '@tanstack/react-router';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: lazyFn($$splitLoaderImporter, 'loader')
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-exports-loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/retain-exports-loader.tsx
@@ -7,7 +7,7 @@ export function loaderFn() {
   };
 }
 export const Route = createFileRoute('/_layout')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   loader: loaderFn
 });
 export const SIDEBAR_WIDTH = '150px';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/useStateDestructure.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/production/useStateDestructure.tsx
@@ -4,7 +4,7 @@ import { startProject } from '~/projects/start';
 import { createFileRoute } from '@tanstack/react-router';
 import { seo } from '~/utils/seo';
 export const Route = createFileRoute('/_libraries/start/$version/')({
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr),
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url),
   meta: () => seo({
     title: startProject.name,
     description: startProject.description

--- a/packages/router-plugin/tests/code-splitter/snapshots/solid/1-default/development/arrow-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/solid/1-default/development/arrow-function.tsx
@@ -4,7 +4,7 @@ import { createFileRoute } from '@tanstack/solid-router';
 import { fetchPosts } from '../posts';
 export const Route = createFileRoute('/posts')({
   loader: fetchPosts,
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/solid/1-default/production/arrow-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/solid/1-default/production/arrow-function.tsx
@@ -4,5 +4,5 @@ import { createFileRoute } from '@tanstack/solid-router';
 import { fetchPosts } from '../posts';
 export const Route = createFileRoute('/posts')({
   loader: fetchPosts,
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/solid/2-components-combined-loader-separate/development/arrow-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/solid/2-components-combined-loader-separate/development/arrow-function.tsx
@@ -5,7 +5,7 @@ import { lazyFn } from '@tanstack/solid-router';
 import { createFileRoute } from '@tanstack/solid-router';
 export const Route = createFileRoute('/posts')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/solid/2-components-combined-loader-separate/production/arrow-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/solid/2-components-combined-loader-separate/production/arrow-function.tsx
@@ -5,5 +5,5 @@ import { lazyFn } from '@tanstack/solid-router';
 import { createFileRoute } from '@tanstack/solid-router';
 export const Route = createFileRoute('/posts')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });

--- a/packages/router-plugin/tests/code-splitter/snapshots/solid/3-all-combined-errorComponent-separate/development/arrow-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/solid/3-all-combined-errorComponent-separate/development/arrow-function.tsx
@@ -5,7 +5,7 @@ import { lazyFn } from '@tanstack/solid-router';
 import { createFileRoute } from '@tanstack/solid-router';
 export const Route = createFileRoute('/posts')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });
 export function TSRDummyComponent() {
   return null;

--- a/packages/router-plugin/tests/code-splitter/snapshots/solid/3-all-combined-errorComponent-separate/production/arrow-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/solid/3-all-combined-errorComponent-separate/production/arrow-function.tsx
@@ -5,5 +5,5 @@ import { lazyFn } from '@tanstack/solid-router';
 import { createFileRoute } from '@tanstack/solid-router';
 export const Route = createFileRoute('/posts')({
   loader: lazyFn($$splitLoaderImporter, 'loader'),
-  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr)
+  component: lazyRouteComponent($$splitComponentImporter, 'component', () => Route.ssr, import.meta.url)
 });


### PR DESCRIPTION
Fixes https://github.com/TanStack/router/issues/3327

This PR might be easier to review as commit-by-commit (because there are many changes in generated files `packages/router-plugin/tests/code-splitter/snapshots/...`).

- `e2e/react-router/basic-file-based-code-splitting`
    Add an E2E playwright spec for validating the reload behavior of pages where a lazy import fails to load
- `packages/react-router/src/lazyRouteComponent.tsx`
    Accept a 4th parameter to provide a unique key to the sessionStorage entry used as a reload guard on a failed lazy load
- `packages/router-generator/src/generator.ts` and `packages/router-plugin/src/core/code-splitter/compilers.ts`
    Provide 4th parameter to `lazyRouteComponent` calls as `import.meta.url`. This is native in browsers, so should be "bundler independant" (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta).

> [!NOTE]
> The playwright spec added by this PR tests a behavior that might be browser-specific. However, the E2E tests run on chromium only. Maybe it might be worth it to enable multiple "projects" in playwright?
> 
> See implementation:
> https://github.com/TanStack/router/blob/adcdde4d576a9242303400f4112a883328af4554/packages/react-router/src/lazyRouteComponent.tsx#L10-L20

---


In a future PR, it might be a good idea to apply the same (or similar) behavior on import fail to the `lazyFn` since it's used in a way that feels similar to `lazyRouteComponent`, but has no error handling.

https://github.com/TanStack/router/blob/adcdde4d576a9242303400f4112a883328af4554/packages/react-router/src/router.ts#L3060-L3073