### PR TITLE
fix(start): use FetcherData by default for return type

### DIFF
--- a/packages/start-client/src/createServerFn.ts
+++ b/packages/start-client/src/createServerFn.ts
@@ -53,26 +53,30 @@ export interface FetcherBase {
   }) => Promise<unknown>
 }
 
+export type FetchResult<
+  TMiddlewares,
+  TResponse,
+  TFullResponse extends boolean,
+> = false extends TFullResponse
+  ? Promise<FetcherData<TResponse>>
+  : Promise<FullFetcherData<TMiddlewares, TResponse>>
+
 export interface OptionalFetcher<TMiddlewares, TValidator, TResponse>
   extends FetcherBase {
-  <TFullResponse extends boolean = false>(
+  <TFullResponse extends boolean>(
     options?: OptionalFetcherDataOptions<
       TMiddlewares,
       TValidator,
       TFullResponse
     >,
-  ): TFullResponse extends true
-    ? Promise<FullFetcherData<TMiddlewares, TResponse>>
-    : Promise<FetcherData<TResponse>>
+  ): FetchResult<TMiddlewares, TResponse, TFullResponse>
 }
 
 export interface RequiredFetcher<TMiddlewares, TValidator, TResponse>
   extends FetcherBase {
-  <TFullResponse extends boolean = false>(
+  <TFullResponse extends boolean>(
     opts: RequiredFetcherDataOptions<TMiddlewares, TValidator, TFullResponse>,
-  ): TFullResponse extends true
-    ? Promise<FullFetcherData<TMiddlewares, TResponse>>
-    : Promise<FetcherData<TResponse>>
+  ): FetchResult<TMiddlewares, TResponse, TFullResponse>
 }
 
 export type FetcherBaseOptions<TFullResponse extends boolean = false> = {

--- a/packages/start-client/src/tests/createServerFn.test-d.tsx
+++ b/packages/start-client/src/tests/createServerFn.test-d.tsx
@@ -50,6 +50,8 @@ test('createServerFn with validator', () => {
     type?: 'static' | 'dynamic'
     fullResponse?: boolean
   }>()
+
+  expectTypeOf(fn).returns.resolves.toEqualTypeOf<void>()
 })
 
 test('createServerFn with middleware and context', () => {
@@ -152,6 +154,8 @@ test('createServerFn with middleware and validator', () => {
     type?: 'static' | 'dynamic'
     fullResponse?: boolean
   }>()
+
+  expectTypeOf(fn).returns.resolves.toEqualTypeOf<'data'>()
 
   expectTypeOf(() =>
     fn({
@@ -283,6 +287,8 @@ test('createServerFn where validator is optional if object is optional', () => {
       }
     | undefined
   >()
+
+  expectTypeOf(fn).returns.resolves.toEqualTypeOf<void>()
 })
 
 test('createServerFn where data is optional if there is no validator', () => {
@@ -303,6 +309,8 @@ test('createServerFn where data is optional if there is no validator', () => {
       }
     | undefined
   >()
+
+  expectTypeOf(fn).returns.resolves.toEqualTypeOf<void>()
 })
 
 test('createServerFn returns Date', () => {


### PR DESCRIPTION
`fullResponse` introduced a small type issue when inferring the type of a server function. By default `fullResponse` should be false. And that is true at runtime but because a server function is now a inference site something like this:

```tsx
const fn = createServerFn().handler(() => 'test')
type test = ReturnType<typeof fn>
```

Would infer a union of `Promise<"test"> | Promise<FullFetcherData<undefined, "test">>`. This is because TypeScript will fallback to the constraint here (`boolean`) not the default.

This change flips the conditional so if `false` is a subset of `TFullResponse` then we can safely say the return type is `Promise<"test">` because it is possible that it is `false`