### PR TITLE
fix: global middleware

### DIFF
--- a/docs/start/framework/react/middleware.md
+++ b/docs/start/framework/react/middleware.md
@@ -294,15 +294,19 @@ Middleware can be used in two different ways:
 
 ## Global Middleware
 
-Global middleware is registered using the `registerGlobalMiddleware` function. This function receives an array of middleware to be appended to the global middleware array. There is currently no way to remove global middleware once it has been registered.
+Global middleware runs automatically for every server function in your application. This is useful for functionality like authentication, logging, and monitoring that should apply to all requests.
 
-Here's an example of registering global middleware:
+To use global middleware, create a `server-functions.ts` file in your project (typically at `app/server-functions.ts`). This file runs in both client and server environments and is where you register global middleware.
+
+Here's how to register global middleware:
 
 ```tsx
+// app/server-functions.ts
 import { registerGlobalMiddleware } from '@tanstack/start'
+import { authMiddleware } from './middleware'
 
 registerGlobalMiddleware({
-  middleware: [authMiddleware, loggingMiddleware],
+  middleware: [authMiddleware],
 })
 ```
 
@@ -311,12 +315,14 @@ registerGlobalMiddleware({
 Global middleware types are inherently **detached** from server functions themselves. This means that if a global middleware supplies additional context to server functions or other server function specific middleware, the types will not be automatically passed through to the server function or other server function specific middleware.
 
 ```tsx
-// globalMiddleware.ts
+// app/server-functions.ts
 registerGlobalMiddleware({
   middleware: [authMiddleware],
 })
+```
 
-// serverFunction.ts
+```tsx
+// authMiddleware.ts
 const authMiddleware = createMiddleware().server(({ next, context }) => {
   console.log(context.user) // <-- This will not be typed!
   // ...

--- a/docs/start/framework/react/middleware.md
+++ b/docs/start/framework/react/middleware.md
@@ -296,12 +296,12 @@ Middleware can be used in two different ways:
 
 Global middleware runs automatically for every server function in your application. This is useful for functionality like authentication, logging, and monitoring that should apply to all requests.
 
-To use global middleware, create a `server-functions.ts` file in your project (typically at `app/server-functions.ts`). This file runs in both client and server environments and is where you register global middleware.
+To use global middleware, create a `global-middleware.ts` file in your project (typically at `app/global-middleware.ts`). This file runs in both client and server environments and is where you register global middleware.
 
 Here's how to register global middleware:
 
 ```tsx
-// app/server-functions.ts
+// app/global-middleware.ts
 import { registerGlobalMiddleware } from '@tanstack/start'
 import { authMiddleware } from './middleware'
 
@@ -315,7 +315,7 @@ registerGlobalMiddleware({
 Global middleware types are inherently **detached** from server functions themselves. This means that if a global middleware supplies additional context to server functions or other server function specific middleware, the types will not be automatically passed through to the server function or other server function specific middleware.
 
 ```tsx
-// app/server-functions.ts
+// app/global-middleware.ts
 registerGlobalMiddleware({
   middleware: [authMiddleware],
 })

--- a/examples/react/start-basic/app/global-middleware.ts
+++ b/examples/react/start-basic/app/global-middleware.ts
@@ -4,5 +4,3 @@ import { logMiddleware } from './utils/loggingMiddleware'
 registerGlobalMiddleware({
   middleware: [logMiddleware],
 })
-
-console.log('hello')

--- a/examples/react/start-basic/app/server-functions.ts
+++ b/examples/react/start-basic/app/server-functions.ts
@@ -1,0 +1,8 @@
+import { registerGlobalMiddleware } from '@tanstack/start'
+import { logMiddleware } from './utils/loggingMiddleware'
+
+registerGlobalMiddleware({
+  middleware: [logMiddleware],
+})
+
+console.log('hello')

--- a/examples/react/start-basic/app/utils/loggingMiddleware.tsx
+++ b/examples/react/start-basic/app/utils/loggingMiddleware.tsx
@@ -1,6 +1,6 @@
 import { createMiddleware } from '@tanstack/start'
 
-export const logMiddleware = createMiddleware()
+const preLogMiddleware = createMiddleware()
   .client(async (ctx) => {
     const clientTime = new Date()
 
@@ -24,14 +24,18 @@ export const logMiddleware = createMiddleware()
       },
     })
   })
-  .clientAfter(async (ctx) => {
-    const now = new Date()
 
+export const logMiddleware = createMiddleware()
+  .middleware([preLogMiddleware])
+  .client(async (ctx) => {
+    const res = await ctx.next()
+
+    const now = new Date()
     console.log('Client Req/Res:', {
-      duration: ctx.context.clientTime.getTime() - now.getTime(),
-      durationToServer: ctx.context.durationToServer,
-      durationFromServer: now.getTime() - ctx.context.serverTime.getTime(),
+      duration: res.context.clientTime.getTime() - now.getTime(),
+      durationToServer: res.context.durationToServer,
+      durationFromServer: now.getTime() - res.context.serverTime.getTime(),
     })
 
-    return ctx.next()
+    return res
   })

--- a/packages/start-config/src/index.ts
+++ b/packages/start-config/src/index.ts
@@ -5,13 +5,13 @@ import { fileURLToPath } from 'node:url'
 import viteReact from '@vitejs/plugin-react'
 import { resolve } from 'import-meta-resolve'
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
-import { TanStackStartVitePlugin } from '@tanstack/start-plugin'
 import { getConfig } from '@tanstack/router-generator'
 import { createApp } from 'vinxi'
 import { config } from 'vinxi/plugins/config'
 // // @ts-expect-error
 // import { serverComponents } from '@vinxi/server-components/plugin'
 import { createTanStackServerFnPlugin } from '@tanstack/server-functions-plugin'
+import { createTanStackStartPlugin } from '@tanstack/start-plugin'
 import { createFetch } from 'ofetch'
 import { createNitro } from 'nitropack'
 import { tanstackStartVinxiFileRouter } from './vinxi-file-router.js'
@@ -110,7 +110,9 @@ export async function defineConfig(
   const ssrEntry =
     opts.routers?.ssr?.entry || path.join(appDirectory, 'ssr.tsx')
   const apiEntry = opts.routers?.api?.entry || path.join(appDirectory, 'api.ts')
-
+  const serverFnEntry =
+    opts.routers?.server?.entry ||
+    path.join(appDirectory, 'server-functions.ts')
   const apiEntryExists = existsSync(apiEntry)
 
   const viteConfig = getUserViteConfig(opts.vite)
@@ -136,6 +138,11 @@ export async function defineConfig(
       replacer: (opts) =>
         `createServerRpc('${opts.functionId}', '${serverBase}', ${opts.fn})`,
     },
+  })
+
+  const TanStackStartPlugin = createTanStackStartPlugin({
+    serverFnEntry,
+    manifestVirtualImportId: 'tsr:start-manifest',
   })
 
   // Create a dummy nitro app to get the resolved public output path
@@ -215,9 +222,7 @@ export async function defineConfig(
                 ...tsrConfig.experimental,
               },
             }),
-            TanStackStartVitePlugin({
-              env: 'client',
-            }),
+            TanStackStartPlugin.client,
             TanStackServerFnsPlugin.client,
             ...(viteConfig.plugins || []),
             ...(clientViteConfig.plugins || []),
@@ -280,9 +285,7 @@ export async function defineConfig(
                 ...tsrConfig.experimental,
               },
             }),
-            TanStackStartVitePlugin({
-              env: 'ssr',
-            }),
+            TanStackStartPlugin.ssr,
             TanStackServerFnsPlugin.ssr,
             tsrRoutesManifest({
               tsrConfig,
@@ -348,9 +351,7 @@ export async function defineConfig(
                 ...tsrConfig.experimental,
               },
             }),
-            TanStackStartVitePlugin({
-              env: 'server',
-            }),
+            TanStackStartPlugin.server,
             TanStackServerFnsPlugin.server,
             // TODO: RSCS - remove this
             // resolve: {

--- a/packages/start-config/src/index.ts
+++ b/packages/start-config/src/index.ts
@@ -110,9 +110,9 @@ export async function defineConfig(
   const ssrEntry =
     opts.routers?.ssr?.entry || path.join(appDirectory, 'ssr.tsx')
   const apiEntry = opts.routers?.api?.entry || path.join(appDirectory, 'api.ts')
-  const serverFnEntry =
-    opts.routers?.server?.entry ||
-    path.join(appDirectory, 'server-functions.ts')
+  const globalMiddlewareEntry =
+    opts.routers?.server?.globalMiddlewareEntry ||
+    path.join(appDirectory, 'global-middleware.ts')
   const apiEntryExists = existsSync(apiEntry)
 
   const viteConfig = getUserViteConfig(opts.vite)
@@ -141,8 +141,7 @@ export async function defineConfig(
   })
 
   const TanStackStartPlugin = createTanStackStartPlugin({
-    serverFnEntry,
-    manifestVirtualImportId: 'tsr:start-manifest',
+    globalMiddlewareEntry,
   })
 
   // Create a dummy nitro app to get the resolved public output path

--- a/packages/start-config/src/schema.ts
+++ b/packages/start-config/src/schema.ts
@@ -158,7 +158,7 @@ const routersSchema = z.object({
   server: z
     .object({
       base: z.string().optional(),
-      entry: z.string().optional(),
+      globalMiddlewareEntry: z.string().optional(),
       middleware: z.string().optional(),
       vite: viteSchema.optional(),
     })

--- a/packages/start-config/src/schema.ts
+++ b/packages/start-config/src/schema.ts
@@ -158,6 +158,7 @@ const routersSchema = z.object({
   server: z
     .object({
       base: z.string().optional(),
+      entry: z.string().optional(),
       middleware: z.string().optional(),
       vite: viteSchema.optional(),
     })

--- a/packages/start-plugin/src/index.ts
+++ b/packages/start-plugin/src/index.ts
@@ -10,8 +10,7 @@ const debug =
   ['true', 'start-plugin'].includes(process.env.TSR_VITE_DEBUG)
 
 export type TanStackStartViteOptions = {
-  manifestVirtualImportId: string
-  serverFnEntry: string
+  globalMiddlewareEntry: string
 }
 
 const transformFuncs = [
@@ -50,7 +49,7 @@ export function createTanStackStartPlugin(opts: TanStackStartViteOptions): {
           transform(code, id) {
             if (entry && id.includes(entry)) {
               return {
-                code: `${code}\n\nimport '${path.resolve(ROOT, opts.serverFnEntry)}'`,
+                code: `${code}\n\nimport '${path.resolve(ROOT, opts.globalMiddlewareEntry)}'`,
                 map: null,
               }
             }
@@ -78,7 +77,7 @@ export function createTanStackStartPlugin(opts: TanStackStartViteOptions): {
           transform(code, id) {
             if (entry && id.includes(entry)) {
               return {
-                code: `${code}\n\nimport '${path.resolve(ROOT, opts.serverFnEntry)}'`,
+                code: `${code}\n\nimport '${path.resolve(ROOT, opts.globalMiddlewareEntry)}'`,
                 map: null,
               }
             }
@@ -106,7 +105,7 @@ export function createTanStackStartPlugin(opts: TanStackStartViteOptions): {
           transform(code, id) {
             if (entry && id.includes(entry)) {
               return {
-                code: `${code}\n\nimport '${path.resolve(ROOT, opts.serverFnEntry)}'`,
+                code: `${code}\n\nimport '${path.resolve(ROOT, opts.globalMiddlewareEntry)}'`,
                 map: null,
               }
             }


### PR DESCRIPTION
Fixes global middleware via a new `app/global-middleware.ts` file (configurable path) that is side-loaded automatically into the client and server-fn environment to ensure registerGlobalMiddleware will run in both environments

Fixes #3315 