### PR TITLE
docs(start): clarify that `__root.tsx` has two `_` characters

### DIFF
--- a/docs/router/framework/react/quick-start.md
+++ b/docs/router/framework/react/quick-start.md
@@ -69,7 +69,7 @@ export default defineConfig({
 
 Create the following files:
 
-- `src/routes/__root.tsx`
+- `src/routes/__root.tsx` (with two '`_`' characters)
 - `src/routes/index.tsx`
 - `src/routes/about.tsx`
 - `src/main.tsx`


### PR DESCRIPTION
Dumb PR but this did trip me up when reading the docs and not using a quick start. On the fence if this is worthwhile or not.