### PR TITLE
feat(history): access history entries

### DIFF
--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -44,7 +44,7 @@ export interface RouterMemoryHistory extends RouterHistory {
 }
 
 export interface HistoryEntry {
-  index: number;
+  index: number
   getState: () => ParsedHistoryState
 }
 
@@ -592,7 +592,8 @@ export function createMemoryHistory(
     }
   })
 
-  const getLocation = () => parseHref(entries[index]!.path, entries[index]!.entry.getState())
+  const getLocation = () =>
+    parseHref(entries[index]!.path, entries[index]!.entry.getState())
 
   const routerHistory = createHistory({
     getLocation,
@@ -600,7 +601,7 @@ export function createMemoryHistory(
     pushState: (path, state) => {
       // Removes all subsequent entries after the current index to start a new branch
       if (index < entries.length - 1) {
-        entries.splice(index + 1).forEach(entry => {
+        entries.splice(index + 1).forEach((entry) => {
           entry.entry.index = -1
         })
       }
@@ -611,7 +612,7 @@ export function createMemoryHistory(
       entries[index]!.entry.index = -1
       entries[index] = {
         path,
-        entry: { index, getState: () => state }
+        entry: { index, getState: () => state },
       }
     },
     back: () => {
@@ -626,7 +627,7 @@ export function createMemoryHistory(
     createHref: (path) => path,
   }) as RouterMemoryHistory
 
-  routerHistory.entries = () => entries.map(entry => entry.entry)
+  routerHistory.entries = () => entries.map((entry) => entry.entry)
 
   return routerHistory
 }

--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -23,6 +23,7 @@ type SubscriberArgs = {
 export interface RouterHistory {
   location: HistoryLocation
   length: number
+  entries: Array<HistoryEntry>
   subscribers: Set<(opts: SubscriberArgs) => void>
   subscribe: (cb: (opts: SubscriberArgs) => void) => () => void
   push: (path: string, state?: any, navigateOpts?: NavigateOptions) => void
@@ -37,15 +38,6 @@ export interface RouterHistory {
   destroy: () => void
   notify: (action: SubscriberHistoryAction) => void
   _ignoreSubscribers?: boolean
-}
-
-export interface RouterMemoryHistory extends RouterHistory {
-  entries: () => Array<HistoryEntry>
-}
-
-export interface HistoryEntry {
-  index: number
-  getState: () => ParsedHistoryState
 }
 
 export interface HistoryLocation extends ParsedPath {
@@ -66,9 +58,29 @@ export type ParsedHistoryState = HistoryState & {
   __TSR_index: number
 }
 
+export interface HistoryEntry {
+  key: string
+  index: number
+  path: ParsedPath
+  getState: () => ParsedHistoryState | undefined
+}
+
 type ShouldAllowNavigation = any
 
 export type HistoryAction = 'PUSH' | 'REPLACE' | 'FORWARD' | 'BACK' | 'GO'
+
+interface CachedHistoryEntry {
+  path: ParsedPath
+  state: ParsedHistoryState
+}
+
+type HistoryEntriesCache = {
+  get: () => Array<HistoryEntry>
+  push: (location: HistoryLocation) => void
+  replace: (location: HistoryLocation) => void
+  flush: () => void
+  clone: () => HistoryEntriesCache
+}
 
 export type BlockerFnArgs = {
   currentLocation: HistoryLocation
@@ -107,6 +119,7 @@ const beforeUnloadEvent = 'beforeunload'
 export function createHistory(opts: {
   getLocation: () => HistoryLocation
   getLength: () => number
+  getEntries: () => Array<HistoryEntry>
   pushState: (path: string, state: any) => void
   replaceState: (path: string, state: any) => void
   go: (n: number) => void
@@ -172,6 +185,9 @@ export function createHistory(opts: {
     },
     get length() {
       return opts.getLength()
+    },
+    get entries() {
+      return opts.getEntries()
     },
     subscribers,
     subscribe: (cb: (opts: SubscriberArgs) => void) => {
@@ -296,6 +312,9 @@ export function createBrowserHistory(opts?: {
   const originalPushState = win.history.pushState
   const originalReplaceState = win.history.replaceState
 
+  let entriesCache = createHistoryEntriesSessionCache() || createHistoryEntriesMemoryCache()
+  let rollbackEntriesCache: HistoryEntriesCache | undefined = undefined
+
   let blockers: Array<NavigationBlocker> = []
   const _getBlockers = () => blockers
   const _setBlockers = (newBlockers: Array<NavigationBlocker>) =>
@@ -310,8 +329,10 @@ export function createBrowserHistory(opts?: {
         win.history.state,
       ))
 
+  const _noInitialKey = !win.history.state?.key
+
   // Ensure there is always a key to start
-  if (!win.history.state?.key) {
+  if (_noInitialKey) {
     win.history.replaceState(
       {
         [stateIndexKey]: 0,
@@ -322,6 +343,12 @@ export function createBrowserHistory(opts?: {
   }
 
   let currentLocation = parseLocation()
+
+  if (_noInitialKey) {
+    entriesCache.push(currentLocation)
+    Promise.resolve().then(() => entriesCache.flush())
+  }
+
   let rollbackLocation: HistoryLocation | undefined
 
   let nextPopIsGo = false
@@ -362,6 +389,8 @@ export function createBrowserHistory(opts?: {
       next.href,
     )
 
+    entriesCache.flush()
+
     // Stop ignoring subscriber updates
     history._ignoreSubscribers = false
 
@@ -369,6 +398,7 @@ export function createBrowserHistory(opts?: {
     next = undefined
     scheduled = undefined
     rollbackLocation = undefined
+    rollbackEntriesCache = undefined
   }
 
   // This function queues up a call to update the browser history
@@ -381,10 +411,19 @@ export function createBrowserHistory(opts?: {
 
     if (!scheduled) {
       rollbackLocation = currentLocation
+      rollbackEntriesCache = entriesCache.clone()
+    } else {
+      entriesCache = rollbackEntriesCache!.clone()
     }
 
     // Update the location in memory
     currentLocation = parseHref(destHref, state)
+
+    if (type === 'push') {
+      entriesCache.push(currentLocation)
+    } else {
+      entriesCache.replace(currentLocation)
+    }
 
     // Keep track of the next location we need to flush to the URL
     next = {
@@ -399,9 +438,13 @@ export function createBrowserHistory(opts?: {
     }
   }
 
-  // NOTE: this function can probably be removed
   const onPushPop = (type: 'PUSH' | 'REPLACE') => {
     currentLocation = parseLocation()
+    if (type === 'PUSH') {
+      entriesCache.push(currentLocation)
+    } else {
+      entriesCache.replace(currentLocation)
+    }
     history.notify({ type })
   }
 
@@ -492,6 +535,7 @@ export function createBrowserHistory(opts?: {
   const history = createHistory({
     getLocation,
     getLength: () => win.history.length,
+    getEntries: () => entriesCache.get(),
     pushState: (href, state) => queueHistoryAction('push', href, state),
     replaceState: (href, state) => queueHistoryAction('replace', href, state),
     back: (ignoreBlocker) => {
@@ -523,6 +567,7 @@ export function createBrowserHistory(opts?: {
       // that we optimistically updated in memory.
       if (rollbackLocation && currentLocation !== rollbackLocation) {
         currentLocation = rollbackLocation
+        entriesCache = rollbackEntriesCache!.clone()
       }
     },
     getBlockers: _getBlockers,
@@ -570,66 +615,52 @@ export function createHashHistory(opts?: { window?: any }): RouterHistory {
 }
 
 export function createMemoryHistory(
-  opts: {
-    initialEntries: Array<string>
-    initialIndex?: number
-  } = {
-    initialEntries: ['/'],
-  },
-): RouterMemoryHistory {
+    opts: {
+      initialEntries: Array<string>
+      initialIndex?: number
+    } = {
+      initialEntries: ['/'],
+    },
+): RouterHistory {
   let index = opts.initialIndex
-    ? Math.min(Math.max(opts.initialIndex, 0), opts.initialEntries.length - 1)
-    : opts.initialEntries.length - 1
-  const entries = opts.initialEntries.map((path, index) => {
-    const state = assignKeyAndIndex(index, undefined)
-    const entry: HistoryEntry = {
-      index,
-      getState: () => state,
-    }
+      ? Math.min(Math.max(opts.initialIndex, 0), opts.initialEntries.length - 1)
+      : opts.initialEntries.length - 1
+  const entriesCache = createHistoryEntriesMemoryCache(opts.initialEntries.map((href, index) => {
+    const { state, ...path} = parseHref(href, assignKeyAndIndex(index, undefined))
     return {
       path,
-      entry,
-    }
-  })
+      state
+    } as CachedHistoryEntry
+  }))
 
-  const getLocation = () =>
-    parseHref(entries[index]!.path, entries[index]!.entry.getState())
+  const getLocation = () => {
+    const entry = entriesCache.get()[index]!
+    return { ...entry.path, state: entry.getState() } as HistoryLocation
+  }
 
-  const routerHistory = createHistory({
+  return createHistory({
     getLocation,
-    getLength: () => entries.length,
+    getLength: () => entriesCache.get().length,
+    getEntries: entriesCache.get,
     pushState: (path, state) => {
-      // Removes all subsequent entries after the current index to start a new branch
-      if (index < entries.length - 1) {
-        entries.splice(index + 1).forEach((entry) => {
-          entry.entry.index = -1
-        })
-      }
-      index = Math.max(entries.length, 0)
-      entries.push({ path, entry: { index, getState: () => state } })
+      const location = parseHref(path, state)
+      entriesCache.push(location)
+      index = location.state[stateIndexKey]
     },
     replaceState: (path, state) => {
-      entries[index]!.entry.index = -1
-      entries[index] = {
-        path,
-        entry: { index, getState: () => state },
-      }
+      entriesCache.replace(parseHref(path, state))
     },
     back: () => {
       index = Math.max(index - 1, 0)
     },
     forward: () => {
-      index = Math.min(index + 1, entries.length - 1)
+      index = Math.min(index + 1, entriesCache.get().length - 1)
     },
     go: (n) => {
-      index = Math.min(Math.max(index + n, 0), entries.length - 1)
+      index = Math.min(Math.max(index + n, 0), entriesCache.get().length - 1)
     },
     createHref: (path) => path,
-  }) as RouterMemoryHistory
-
-  routerHistory.entries = () => entries.map((entry) => entry.entry)
-
-  return routerHistory
+  })
 }
 
 export function parseHref(
@@ -658,6 +689,104 @@ export function parseHref(
         : '',
     state: state || { [stateIndexKey]: 0, key: createRandomKey() },
   }
+}
+
+function getSafeSessionStorage() {
+  try {
+    if (
+        typeof window !== 'undefined' &&
+        typeof window.sessionStorage === 'object'
+    ) {
+      return window.sessionStorage
+    }
+  } catch {
+    return undefined
+  }
+  return undefined
+}
+
+const entriesStorageKey = 'tsr-history-entries-v1'
+
+function createHistoryEntriesCache(opts: {
+  get: () => Array<CachedHistoryEntry>,
+  set: (entries: Array<CachedHistoryEntry>) => void,
+  clone: () => HistoryEntriesCache,
+  flush?: () => void,
+}): HistoryEntriesCache {
+  return {
+    get: () => opts.get().map(entry => ({ key: entry.state.key!, path: entry.path })).map(entry => ({
+        key: entry.key,
+        get index() {
+          return opts.get().findIndex(cmpEntry => cmpEntry.state.key === entry.key)
+        },
+        path: {...entry.path},
+        getState: () => {
+          const state = opts.get().find(cmpEntry => cmpEntry.state.key === entry.key)?.state
+          return state ? (typeof structuredClone === 'function' ? structuredClone(state) : {...state}) : undefined
+        },
+      })),
+    push: (location) => {
+      const index = location.state[stateIndexKey]
+      let entries = opts.get()
+      if (index < entries.length) {
+        entries = entries.slice(0, index) // Removes all subsequent entries after the current index to start a new branch
+      } else {
+        entries = [...entries]
+      }
+      const { state, ...path} = location
+      entries.push({
+        path,
+        state
+      })
+      opts.set(entries)
+    },
+    replace: (location) => {
+      const index = location.state[stateIndexKey]
+      const entries = opts.get()
+      const { state, ...path} = location
+      opts.set([...entries.slice(0, index), { path, state }, ...entries.slice(index + 1)])
+    },
+    clone: opts.clone,
+    flush: () => opts.flush?.(),
+  }
+}
+
+function createHistoryEntriesSessionCache(initialEntries?: Array<CachedHistoryEntry>): HistoryEntriesCache | undefined {
+  const safeSessionStorage = getSafeSessionStorage()
+  if (!safeSessionStorage) {
+    return undefined
+  }
+
+  let cachedEntries: Array<CachedHistoryEntry> | undefined = initialEntries
+
+  return createHistoryEntriesCache({
+    get: (): Array<CachedHistoryEntry> => {
+      if (cachedEntries !== undefined) {
+        return cachedEntries
+      }
+      const persistedStates = safeSessionStorage.getItem(entriesStorageKey)
+      return cachedEntries = persistedStates ? JSON.parse(persistedStates) : []
+    },
+    set: (entries: Array<CachedHistoryEntry>) => {
+      cachedEntries = entries
+    },
+    clone: () => createHistoryEntriesSessionCache(cachedEntries)!,
+    flush: () => {
+      safeSessionStorage.setItem(entriesStorageKey, JSON.stringify(cachedEntries))
+    }
+  })
+}
+
+function createHistoryEntriesMemoryCache(initialEntries?: Array<CachedHistoryEntry>): HistoryEntriesCache {
+  let cachedEntries: Array<CachedHistoryEntry> = initialEntries || []
+
+  return createHistoryEntriesCache({
+    get: () => cachedEntries,
+    set: (entries: Array<CachedHistoryEntry>) => {
+      cachedEntries = entries
+    },
+    clone: () => createHistoryEntriesMemoryCache(cachedEntries),
+  })
 }
 
 // Thanks co-pilot!

--- a/packages/history/tests/createMemoryHistory.test.ts
+++ b/packages/history/tests/createMemoryHistory.test.ts
@@ -76,4 +76,30 @@ describe('createMemoryHistory', () => {
     history.push('/c', { i: 3 })
     expect((history.location.state as any).i).toBe(3)
   })
+
+  test('entries', () => {
+    const history = createMemoryHistory()
+    const initialEntry = history.entries()[0]
+    expect(initialEntry.index).toBe(0)
+    history.push('/a', { i: 1 })
+    const entryA = history.entries()[1]
+    expect(entryA.index).toBe(1)
+    expect(entryA.getState()['i']).toBe(1)
+    history.replace('/b', { i: 2 })
+    const entryB = history.entries()[1]
+    expect(entryB.index).toBe(1)
+    expect(entryB.getState()['i']).toBe(2)
+    expect(entryA.index).toBe(-1)
+    history.back()
+    history.push('/c', { i: 3 })
+    const entryC = history.entries()[1]
+    expect(entryC.index).toBe(1)
+    expect(entryC.getState()['i']).toBe(3)
+    expect(entryB.index).toBe(-1)
+    history.push('/d', { i: 4 })
+    const entryD = history.entries()[2]
+    expect(entryD.index).toBe(2)
+    expect(entryD.getState()['i']).toBe(4)
+    expect(entryC.index).toBe(1)
+  })
 })

--- a/packages/history/tests/createMemoryHistory.test.ts
+++ b/packages/history/tests/createMemoryHistory.test.ts
@@ -79,27 +79,27 @@ describe('createMemoryHistory', () => {
 
   test('entries', () => {
     const history = createMemoryHistory()
-    const initialEntry = history.entries()[0]
-    expect(initialEntry.index).toBe(0)
+    const initialEntry = history.entries[0]
+    expect(initialEntry?.index).toBe(0)
     history.push('/a', { i: 1 })
-    const entryA = history.entries()[1]
-    expect(entryA.index).toBe(1)
-    expect(entryA.getState()['i']).toBe(1)
+    const entryA = history.entries[1]
+    expect(entryA?.index).toBe(1)
+    expect((entryA?.getState() as any)?.['i']).toBe(1)
     history.replace('/b', { i: 2 })
-    const entryB = history.entries()[1]
-    expect(entryB.index).toBe(1)
-    expect(entryB.getState()['i']).toBe(2)
-    expect(entryA.index).toBe(-1)
+    const entryB = history.entries[1]
+    expect(entryB?.index).toBe(1)
+    expect((entryB?.getState() as any)?.['i']).toBe(2)
+    expect(entryA?.index).toBe(-1)
     history.back()
     history.push('/c', { i: 3 })
-    const entryC = history.entries()[1]
-    expect(entryC.index).toBe(1)
-    expect(entryC.getState()['i']).toBe(3)
-    expect(entryB.index).toBe(-1)
+    const entryC = history.entries[1]
+    expect(entryC?.index).toBe(1)
+    expect((entryC?.getState() as any)?.['i']).toBe(3)
+    expect(entryB?.index).toBe(-1)
     history.push('/d', { i: 4 })
-    const entryD = history.entries()[2]
-    expect(entryD.index).toBe(2)
-    expect(entryD.getState()['i']).toBe(4)
-    expect(entryC.index).toBe(1)
+    const entryD = history.entries[2]
+    expect(entryD?.index).toBe(2)
+    expect((entryD?.getState() as any)?.['i']).toBe(4)
+    expect(entryC?.index).toBe(1)
   })
 })


### PR DESCRIPTION
Added a new `entries` function for the memory history to be able to access all entries.
An entry has an `index` property to get the current index of the entry in the entries or `-1` when it was removed. With `getState` the history state of the entry can be received.
Also added a new `entries` test case. 

The api is inspired by the [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation).