### PR TITLE
tests: stabilize e2e test

### DIFF
--- a/e2e/start/server-functions/tests/server-functions.spec.ts
+++ b/e2e/start/server-functions/tests/server-functions.spec.ts
@@ -9,7 +9,6 @@ test('invoking a server function with custom response status code', async ({
   await page.goto('/status')
 
   await page.waitForLoadState('networkidle')
-  await page.getByTestId('invoke-server-fn').click()
 
   const requestPromise = new Promise<void>((resolve) => {
     page.on('response', async (response) => {
@@ -25,6 +24,7 @@ test('invoking a server function with custom response status code', async ({
       resolve()
     })
   })
+  await page.getByTestId('invoke-server-fn').click()
   await requestPromise
 })
 


### PR DESCRIPTION
setup event handler before click to make sure we don't miss the event