### PR TITLE
test: add failing test on passing a server function to useMutation

### DIFF
--- a/packages/start-client/src/tests/createServerFn.test-d.tsx
+++ b/packages/start-client/src/tests/createServerFn.test-d.tsx
@@ -388,3 +388,19 @@ test('createServerFn can validate FormData', () => {
       >
     >()
 })
+
+test('createServerFn can be used as a mutation function', () => {
+  const serverFn = createServerFn()
+    .validator((data: number) => data)
+    .handler(() => 'foo')
+
+  type MutationFunction<TData = unknown, TVariables = unknown> = (
+    variables: TVariables,
+  ) => Promise<TData>
+
+  const useMutation = <TData, TVariables>(
+    fn: MutationFunction<TData, TVariables>,
+  ) => {}
+
+  useMutation(serverFn)
+})


### PR DESCRIPTION
This test passes on start `v1.102.1` and fails since `v1.102.2`