### PR TITLE
docs(router): remove unnecessary inline TOC in routing concepts guide

### DIFF
--- a/docs/router/framework/react/guide/routing-concepts.md
+++ b/docs/router/framework/react/guide/routing-concepts.md
@@ -4,14 +4,14 @@ title: Routing Concepts
 
 TanStack Router supports a number of powerful routing concepts that allow you to build complex and dynamic routing systems with ease.
 
-- [The Root Route](./routing-concepts.md#the-root-route)
-- [Static Routes](./routing-concepts.md#static-routes)
-- [Index Routes](./routing-concepts.md#index-routes)
-- [Dynamic Route Segments](./routing-concepts.md#dynamic-route-segments)
-- [Splat / Catch-All Routes](./routing-concepts.md#splat--catch-all-routes)
-- [Pathless Routes](./routing-concepts.md#pathless-routes)
-- [Non-Nested Routes](./routing-concepts.md#non-nested-routes)
-- [Not-Found Routes](./routing-concepts.md#404--notfoundroutes)
+- [The Root Route](./guide/routing-concepts.md#the-root-route)
+- [Static Routes](./guide/routing-concepts.md#static-routes)
+- [Index Routes](./guide/routing-concepts.md#index-routes)
+- [Dynamic Route Segments](./guide/routing-concepts.md#dynamic-route-segments)
+- [Splat / Catch-All Routes](./guide/routing-concepts.md#splat--catch-all-routes)
+- [Pathless Routes](./guide/routing-concepts.md#pathless-routes)
+- [Non-Nested Routes](./guide/routing-concepts.md#non-nested-routes)
+- [Not-Found Routes](./guide/routing-concepts.md#404--notfoundroutes)
 
 Each of these concepts is useful and powerful, and we'll dive into each of them in the following sections.
 

--- a/docs/router/framework/react/guide/routing-concepts.md
+++ b/docs/router/framework/react/guide/routing-concepts.md
@@ -4,15 +4,6 @@ title: Routing Concepts
 
 TanStack Router supports a number of powerful routing concepts that allow you to build complex and dynamic routing systems with ease.
 
-- [The Root Route](./guide/routing-concepts.md#the-root-route)
-- [Static Routes](./guide/routing-concepts.md#static-routes)
-- [Index Routes](./guide/routing-concepts.md#index-routes)
-- [Dynamic Route Segments](./guide/routing-concepts.md#dynamic-route-segments)
-- [Splat / Catch-All Routes](./guide/routing-concepts.md#splat--catch-all-routes)
-- [Pathless Routes](./guide/routing-concepts.md#pathless-routes)
-- [Non-Nested Routes](./guide/routing-concepts.md#non-nested-routes)
-- [Not-Found Routes](./guide/routing-concepts.md#404--notfoundroutes)
-
 Each of these concepts is useful and powerful, and we'll dive into each of them in the following sections.
 
 ## The Root Route


### PR DESCRIPTION
Saw this thread: https://x.com/mitsuhiko/status/1893686348571152745 and experienced some 404's myself. Ran into these tonight (and figured I ought to get my feet wet contributing to these docs if I can, since I can see myself wanting to help add a lot more where possible/needed).

CONTRIBUTING.md mentions:
> Be sure that internal links are written always relative to docs folder. E.g. ./guide/data-loading

These links lack a `/guide`, the URLs 404 in prod here: https://tanstack.com/router/latest/docs/framework/react/guide/routing-concepts
![CleanShot 2025-02-23 at 21 41 21@2x](https://github.com/user-attachments/assets/f420e1ae-dc01-4472-98ce-a352046141d3)

(maybe the real question is whether 2 ToC's are needed at the top of the file, but I suppose maybe that's better left up to the maintainers)