### PR TITLE
docs(react-router): update import from `viteReact` to `react`

### DIFF
--- a/docs/router/framework/react/guide/code-splitting.md
+++ b/docs/router/framework/react/guide/code-splitting.md
@@ -80,7 +80,7 @@ To enable automatic code-splitting, you just need to add the following to the co
 ```ts
 // vite.config.ts
 import { defineConfig } from 'vite'
-import viteReact from '@vitejs/plugin-react'
+import react from '@vitejs/plugin-react'
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 
 export default defineConfig({
@@ -89,7 +89,7 @@ export default defineConfig({
       // ...
       autoCodeSplitting: true,
     }),
-    viteReact(), // Make sure to add this plugin after the TanStack Router Bundler plugin
+    react(), // Make sure to add this plugin after the TanStack Router Bundler plugin
   ],
 })
 ```

--- a/docs/router/framework/react/migrate-from-react-location.md
+++ b/docs/router/framework/react/migrate-from-react-location.md
@@ -48,12 +48,12 @@ And add it to your `vite.config.js`:
 
 ```js
 import { defineConfig } from 'vite'
-import viteReact from '@vitejs/plugin-react'
+import react from '@vitejs/plugin-react'
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 
 export default defineConfig({
   // ...
-  plugins: [TanStackRouterVite(), viteReact()],
+  plugins: [TanStackRouterVite(), react()],
 })
 ```
 

--- a/docs/router/framework/react/quick-start.md
+++ b/docs/router/framework/react/quick-start.md
@@ -51,14 +51,14 @@ deno add npm:@tanstack/react-router npm:@tanstack/router-plugin npm:@tanstack/ro
 ```tsx
 // vite.config.ts
 import { defineConfig } from 'vite'
-import viteReact from '@vitejs/plugin-react'
+import react from '@vitejs/plugin-react'
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
     TanStackRouterVite({ target: 'react', autoCodeSplitting: true }),
-    viteReact(),
+    react(),
     // ...,
   ],
 })

--- a/docs/router/framework/react/routing/installation-with-vite.md
+++ b/docs/router/framework/react/routing/installation-with-vite.md
@@ -15,14 +15,14 @@ Once installed, you'll need to add the plugin to your Vite configuration.
 ```ts
 // vite.config.ts
 import { defineConfig } from 'vite'
-import viteReact from '@vitejs/plugin-react'
+import react from '@vitejs/plugin-react'
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
     TanStackRouterVite({ target: 'react', autoCodeSplitting: true }),
-    viteReact(),
+    react(),
     // ...
   ],
 })


### PR DESCRIPTION
the plugin imported from `@vitejs/plugin-react` is called `react`, not `viteReact`.