### PR TITLE
docs: fix path-params guide link in file-naming-conventions.md

### DIFF
--- a/docs/router/framework/react/routing/file-naming-conventions.md
+++ b/docs/router/framework/react/routing/file-naming-conventions.md
@@ -29,7 +29,7 @@ Dynamic path params can be used in both flat and directory routes to create rout
 | ...                   | ...              | ...                   |
 | ʦ `posts.$postId.tsx` | `/posts/$postId` | `<Root><Posts><Post>` |
 
-We'll learn more about dynamic path params in the [Path Params](./path-params.md) guide.
+We'll learn more about dynamic path params in the [Path Params](../guide/path-params) guide.
 
 ## Pathless Routes
 


### PR DESCRIPTION
# Fix invalid link in File Naming Conventions documentation

## Description
Fixed an invalid link in the File Naming Conventions documentation that was pointing to a non-existent path. The link to the Path Params guide was using an incorrect relative path.

### Changes
- Updated the link from `./path-params.md` to `../guide/path-params` in `docs/router/framework/react/routing/file-naming-conventions.md`
- The new path correctly points to the Path Params guide located in the guide directory

### Before
Clicking the Path Params link led to a 404 error:
`https://tanstack.com/router/latest/docs/framework/react/routing/path-params`

### After
Link now correctly points to:
`https://tanstack.com/router/latest/docs/framework/react/guide/path-params`

## Additional Context
This change follows the documentation guidelines mentioned in CONTRIBUTING.md which states that internal links should be written relative to the `docs` folder.