### PR TITLE
docs(start): missing syntax snippet from static-prerendering guide

### DIFF
--- a/docs/start/framework/react/static-prerendering.md
+++ b/docs/start/framework/react/static-prerendering.md
@@ -34,8 +34,8 @@ Nitro ships with some prebuilt hooks that let you customize the prerendering pro
 
 For this example, let's pretend we have a blog with a list of posts. We want to prerender each post page. Our post route looks like `/posts/$postId`. We can use the `prerender:routes` hook to fetch the all of our posts and add each post path to the routes set.
 
-```js
-// app.config.js
+```ts
+// app.config.ts
 
 import { defineConfig } from '@tanstack/react-start/config'
 

--- a/docs/start/framework/react/static-prerendering.md
+++ b/docs/start/framework/react/static-prerendering.md
@@ -36,7 +36,6 @@ For this example, let's pretend we have a blog with a list of posts. We want to 
 
 ```ts
 // app.config.ts
-
 import { defineConfig } from '@tanstack/react-start/config'
 
 export default defineConfig({

--- a/docs/start/framework/react/static-prerendering.md
+++ b/docs/start/framework/react/static-prerendering.md
@@ -42,16 +42,16 @@ import { defineConfig } from '@tanstack/react-start/config'
 export default defineConfig({
   server: {
     hooks: {
-      "prerender:routes": async (routes) => {
-          // fetch the pages you want to render
-          const posts = await fetch('https://api.example.com/posts')
-          const postsData = await posts.json()
+      'prerender:routes': async (routes) => {
+        // fetch the pages you want to render
+        const posts = await fetch('https://api.example.com/posts')
+        const postsData = await posts.json()
 
-          // add each post path to the routes set
-          postsData.forEach((post) => {
-            routes.add(`/posts/${post.id}`)
-          })
-      }
+        // add each post path to the routes set
+        postsData.forEach((post) => {
+          routes.add(`/posts/${post.id}`)
+        })
+      },
     },
     prerender: {
       routes: ['/'],

--- a/docs/start/framework/react/static-prerendering.md
+++ b/docs/start/framework/react/static-prerendering.md
@@ -34,7 +34,7 @@ Nitro ships with some prebuilt hooks that let you customize the prerendering pro
 
 For this example, let's pretend we have a blog with a list of posts. We want to prerender each post page. Our post route looks like `/posts/$postId`. We can use the `prerender:routes` hook to fetch the all of our posts and add each post path to the routes set.
 
-```
+```js
 // app.config.js
 
 import { defineConfig } from '@tanstack/react-start/config'


### PR DESCRIPTION
currently the snippet is all gray (one color)