### PR TITLE
docs(solid-router) fix examples that import workspace packages

### DIFF
--- a/examples/solid/basic-file-based/package.json
+++ b/examples/solid/basic-file-based/package.json
@@ -9,9 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@tanstack/router-devtools": "^1.111.11",
-    "@tanstack/router-plugin": "^1.111.12",
-    "@tanstack/solid-router": "workspace:^",
+    "@tanstack/solid-router": "^1.111.11",
     "autoprefixer": "^10.4.20",
     "postcss": "^8.5.1",
     "redaxios": "^0.5.1",
@@ -20,6 +18,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@tanstack/router-plugin": "^1.111.12",
     "typescript": "^5.7.2",
     "vite": "^6.1.0",
     "vite-plugin-solid": "^2.11.2"

--- a/examples/solid/basic-file-based/src/routes/__root.tsx
+++ b/examples/solid/basic-file-based/src/routes/__root.tsx
@@ -1,5 +1,4 @@
 import { Link, Outlet, createRootRoute } from '@tanstack/solid-router'
-// import { TanStackRouterDevtools } from '@tanstack/router-devtools'
 
 export const Route = createRootRoute({
   component: RootComponent,
@@ -55,7 +54,6 @@ function RootComponent() {
       <hr />
       <Outlet />
       {/* Start rendering router matches */}
-      {/* <TanStackRouterDevtools position="bottom-right" /> */}
     </>
   )
 }

--- a/examples/solid/basic-solid-query-file-based/package.json
+++ b/examples/solid/basic-solid-query-file-based/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@tanstack/solid-query": "^5.66.0",
     "@tanstack/solid-query-devtools": "^5.66.0",
-    "@tanstack/solid-router": "workspace:^",
+    "@tanstack/solid-router": "^1.111.11",
     "solid-js": "^1.9.4",
     "redaxios": "^0.5.1",
     "postcss": "^8.5.1",
@@ -21,8 +21,9 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
-    "@tanstack/router-plugin": "workspace:^",
-    "vite-plugin-solid": "^2.11.2",
-    "vite": "^6.1.0"
+    "@tanstack/router-plugin": "^1.111.12",
+    "typescript": "^5.7.2",
+    "vite": "^6.1.0",
+    "vite-plugin-solid": "^2.11.2"
   }
 }

--- a/examples/solid/basic-solid-query-file-based/src/routes/__root.tsx
+++ b/examples/solid/basic-solid-query-file-based/src/routes/__root.tsx
@@ -3,7 +3,6 @@ import {
   Outlet,
   createRootRouteWithContext,
 } from '@tanstack/solid-router'
-// import { TanStackRouterDevtools } from '@tanstack/router-devtools'
 import { SolidQueryDevtools } from '@tanstack/solid-query-devtools'
 import type { QueryClient } from '@tanstack/solid-query'
 
@@ -63,7 +62,6 @@ function RootComponent() {
       <hr />
       <Outlet />
       <SolidQueryDevtools buttonPosition="top-right" />
-      {/* <TanStackRouterDevtools position="bottom-right" /> */}
     </>
   )
 }

--- a/examples/solid/basic-solid-query/package.json
+++ b/examples/solid/basic-solid-query/package.json
@@ -19,8 +19,9 @@
     "tailwindcss": "^3.4.17"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^2.11.2",
+    "@tanstack/router-plugin": "^1.111.12",
     "typescript": "^5.7.2",
-    "vite": "^6.1.0"
+    "vite": "^6.1.0",
+    "vite-plugin-solid": "^2.11.2"
   }
 }

--- a/examples/solid/kitchen-sink-file-based/package.json
+++ b/examples/solid/kitchen-sink-file-based/package.json
@@ -10,8 +10,6 @@
   },
   "dependencies": {
     "@tanstack/solid-router": "^1.111.11",
-    "@tanstack/router-devtools": "^1.111.11",
-    "@tanstack/router-plugin": "^1.111.12",
     "immer": "^10.1.1",
     "solid-js": "^1.9.4",
     "redaxios": "^0.5.1",
@@ -21,8 +19,9 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^2.11.2",
+    "@tanstack/router-plugin": "^1.111.12",
     "typescript": "^5.7.2",
-    "vite": "^6.0.11"
+    "vite": "^6.1.0",
+    "vite-plugin-solid": "^2.11.2"
   }
 }

--- a/examples/solid/kitchen-sink-file-based/src/routes/__root.tsx
+++ b/examples/solid/kitchen-sink-file-based/src/routes/__root.tsx
@@ -5,7 +5,6 @@ import {
   createRootRouteWithContext,
   useRouterState,
 } from '@tanstack/solid-router'
-// import { TanStackRouterDevtools } from '@tanstack/router-devtools'
 import { Spinner } from '../components/Spinner'
 import { Breadcrumbs } from '../components/Breadcrumbs'
 import type { Auth } from '../utils/auth'
@@ -75,7 +74,6 @@ function RootComponent() {
           </div>
         </div>
       </div>
-      {/* <TanStackRouterDevtools position="bottom-right" /> */}
     </>
   )
 }

--- a/examples/solid/quickstart-file-based/package.json
+++ b/examples/solid/quickstart-file-based/package.json
@@ -9,9 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@tanstack/router-devtools": "^1.111.11",
-    "@tanstack/router-plugin": "^1.111.12",
-    "@tanstack/solid-router": "workspace:^",
+    "@tanstack/solid-router": "^1.111.11",
     "autoprefixer": "^10.4.20",
     "postcss": "^8.5.1",
     "redaxios": "^0.5.1",
@@ -20,6 +18,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@tanstack/router-plugin": "^1.111.12",
     "typescript": "^5.7.2",
     "vite": "^6.1.0",
     "vite-plugin-solid": "^2.11.2"

--- a/examples/solid/quickstart-file-based/src/routes/__root.tsx
+++ b/examples/solid/quickstart-file-based/src/routes/__root.tsx
@@ -1,5 +1,4 @@
 import { Link, Outlet, createRootRoute } from '@tanstack/solid-router'
-// import { TanStackRouterDevtools } from '@tanstack/router-devtools'
 
 export const Route = createRootRoute({
   component: RootComponent,
@@ -29,7 +28,6 @@ function RootComponent() {
       </div>
       <hr />
       <Outlet />
-      {/* <TanStackRouterDevtools position="bottom-right" /> */}
     </>
   )
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4531,14 +4531,8 @@ importers:
 
   examples/solid/basic-file-based:
     dependencies:
-      '@tanstack/router-devtools':
-        specifier: workspace:*
-        version: link:../../../packages/router-devtools
-      '@tanstack/router-plugin':
-        specifier: workspace:*
-        version: link:../../../packages/router-plugin
       '@tanstack/solid-router':
-        specifier: workspace:^
+        specifier: ^1.111.11
         version: link:../../../packages/solid-router
       autoprefixer:
         specifier: ^10.4.20
@@ -4559,6 +4553,9 @@ importers:
         specifier: ^3.24.1
         version: 3.24.1
     devDependencies:
+      '@tanstack/router-plugin':
+        specifier: workspace:*
+        version: link:../../../packages/router-plugin
       typescript:
         specifier: ^5.7.2
         version: 5.7.3
@@ -4596,6 +4593,9 @@ importers:
         specifier: ^3.4.17
         version: 3.4.17
     devDependencies:
+      '@tanstack/router-plugin':
+        specifier: workspace:*
+        version: link:../../../packages/router-plugin
       typescript:
         specifier: ^5.7.2
         version: 5.7.3
@@ -4615,7 +4615,7 @@ importers:
         specifier: ^5.66.0
         version: 5.66.0(@tanstack/solid-query@5.66.0(solid-js@1.9.5))(solid-js@1.9.5)
       '@tanstack/solid-router':
-        specifier: workspace:^
+        specifier: ^1.111.11
         version: link:../../../packages/solid-router
       autoprefixer:
         specifier: ^10.4.20
@@ -4639,6 +4639,9 @@ importers:
       '@tanstack/router-plugin':
         specifier: workspace:*
         version: link:../../../packages/router-plugin
+      typescript:
+        specifier: ^5.7.2
+        version: 5.7.3
       vite:
         specifier: 6.1.0
         version: 6.1.0(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
@@ -4648,12 +4651,6 @@ importers:
 
   examples/solid/kitchen-sink-file-based:
     dependencies:
-      '@tanstack/router-devtools':
-        specifier: workspace:*
-        version: link:../../../packages/router-devtools
-      '@tanstack/router-plugin':
-        specifier: workspace:*
-        version: link:../../../packages/router-plugin
       '@tanstack/solid-router':
         specifier: ^1.111.11
         version: link:../../../packages/solid-router
@@ -4679,6 +4676,9 @@ importers:
         specifier: ^3.24.1
         version: 3.24.1
     devDependencies:
+      '@tanstack/router-plugin':
+        specifier: workspace:*
+        version: link:../../../packages/router-plugin
       typescript:
         specifier: ^5.7.2
         version: 5.7.3
@@ -4691,14 +4691,8 @@ importers:
 
   examples/solid/quickstart-file-based:
     dependencies:
-      '@tanstack/router-devtools':
-        specifier: workspace:*
-        version: link:../../../packages/router-devtools
-      '@tanstack/router-plugin':
-        specifier: workspace:*
-        version: link:../../../packages/router-plugin
       '@tanstack/solid-router':
-        specifier: workspace:^
+        specifier: ^1.111.11
         version: link:../../../packages/solid-router
       autoprefixer:
         specifier: ^10.4.20
@@ -4719,6 +4713,9 @@ importers:
         specifier: ^3.24.1
         version: 3.24.1
     devDependencies:
+      '@tanstack/router-plugin':
+        specifier: workspace:*
+        version: link:../../../packages/router-plugin
       typescript:
         specifier: ^5.7.2
         version: 5.7.3


### PR DESCRIPTION
Follow up to
- https://github.com/TanStack/router/pull/3585

@SeanCassiere the new examples import from workspace which breaks when opening them in stackblitz in the docs. 

This import the published versions, so it works

I also cleaned up references to react router devtools