### PR TITLE
fix(solid-router): remove delete linkProps.disabled

### DIFF
--- a/packages/solid-router/src/link.tsx
+++ b/packages/solid-router/src/link.tsx
@@ -540,12 +540,6 @@ export const Link: LinkComponent<'a'> = (props: any) => {
         })
       : rest.children
 
-  if (typeof local._asChild === 'undefined') {
-    // the Retlocal.urnType of useLinkProps returns the correct type for a <a> element, not a general component that has a disabled prop
-    // @ts-expect-error
-    delete linkProps.disabled
-  }
-
   return (
     <Dynamic component={local._asChild ? local._asChild : 'a'} {...linkProps}>
       {children}


### PR DESCRIPTION
We were getting a TypeError around this in the Tanstack Solid Start when working with it.

I am not sure if this is a proper fix as maybe something won't work as expected then?

The error we get is:

> TypeError: Cannot delete property 'disabled' of #<Object> 