### PR TITLE
fix(react-start-client): export `ServerFnResponseType` type

### DIFF
--- a/packages/react-start-client/src/index.tsx
+++ b/packages/react-start-client/src/index.tsx
@@ -19,6 +19,7 @@ export {
   type FetcherBaseOptions,
   type ServerFn,
   type ServerFnCtx,
+  type ServerFnResponseType,
 } from './createServerFn'
 export {
   createMiddleware,


### PR DESCRIPTION
Example
```
import { createMiddleware } from "@tanstack/react-start";

export const middleware = createMiddleware();
```

Issue
```
The inferred type of middleware cannot be named without a reference to ../../../../node_modules/@tanstack/react-start-client/dist/esm/createServerFn . This is likely not portable. A type annotation is necessary.
```

Solution
exporting `ServerFnResponseType` resolves this. 