### PR TITLE
fix(solid-start-config): adjust package name in noExternal

### DIFF
--- a/packages/solid-start-config/src/index.ts
+++ b/packages/solid-start-config/src/index.ts
@@ -393,7 +393,7 @@ export async function defineConfig(
     '@tanstack/solid-start-server-functions-client',
     '@tanstack/solid-start-server-functions-ssr',
     '@tanstack/start-server-functions-server',
-    '@tanstack/start-router-manifest',
+    '@tanstack/solid-start-router-manifest',
     '@tanstack/solid-start-config',
     '@tanstack/solid-start-api-routes',
     '@tanstack/server-functions-plugin',


### PR DESCRIPTION
It appear theres a `solid-` missing in this noExternal array

the package name is [solid-start-router-manifest](https://github.com/TanStack/router/blob/main/packages/solid-start-router-manifest/package.json)

aligning with react-start-config
- https://github.com/TanStack/router/blob/e2ac863540b3e9c009cb8c8d9f574d6cb6be28f6/packages/react-start-config/src/index.ts#L391

This fixes the dev server when using the prerelease versions