### PR TITLE
docs(start): fix installation script in "build-from-scratch" guide

### DIFF
--- a/docs/start/framework/react/build-from-scratch.md
+++ b/docs/start/framework/react/build-from-scratch.md
@@ -58,7 +58,8 @@ npm i @tanstack/react-start @tanstack/react-router vinxi
 You'll also need React and the Vite React plugin, so install them too:
 
 ```shell
-npm i react react-dom && npm i -D @vitejs/plugin-react vite-tsconfig-paths
+npm i react react-dom
+npm i -D @vitejs/plugin-react vite-tsconfig-paths
 ```
 
 and some TypeScript:


### PR DESCRIPTION
Switched to pnpm but missed a second npm reference  

Initially, I only changed the first `npm` to `pnpm` and overlooked the second one, which caused an error:  

```
npm ERR! Cannot read properties of null (reading 'matches')
```

This held me up for a few minutes. To avoid similar issues, I suggest formatting commands with each command on a new line for better readability.  

Lesson learned: double-check commands before running them! :)