### PR TITLE
refactor(router-generator): reduce use of `boolean` to identify file-system routes

### DIFF
--- a/packages/router-generator/src/filesystem/physical/getRouteNodes.ts
+++ b/packages/router-generator/src/filesystem/physical/getRouteNodes.ts
@@ -127,10 +127,6 @@ export async function getRouteNodes(
             routePath = routePath.replace(/\/lazy$/, '')
           }
 
-          const isComponent = routeType === 'component'
-          const isErrorComponent = routeType === 'errorComponent'
-          const isPendingComponent = routeType === 'pendingComponent'
-
           // this check needs to happen after the lazy route has been cleaned up
           // since the routePath is used to determine if a route is pathless
           if (determineRouteIsPathless(routePath, config)) {
@@ -170,11 +166,8 @@ export async function getRouteNodes(
             filePath,
             fullPath,
             routePath,
-            variableName,
-            isComponent,
-            isErrorComponent,
-            isPendingComponent,
             routeType,
+            variableName,
           })
         }
       }),

--- a/packages/router-generator/src/filesystem/physical/getRouteNodes.ts
+++ b/packages/router-generator/src/filesystem/physical/getRouteNodes.ts
@@ -15,7 +15,7 @@ import type {
   VirtualRootRoute,
   VirtualRouteSubtreeConfig,
 } from '@tanstack/virtual-file-routes'
-import type { GetRouteNodesResult, RouteNode, RouteType } from '../../types'
+import type { FsRouteType, GetRouteNodesResult, RouteNode } from '../../types'
 import type { Config } from '../../config'
 
 const disallowedRouteGroupConfiguration = /\(([^)]+)\).(ts|js|tsx|jsx)/
@@ -121,7 +121,7 @@ export async function getRouteNodes(
 
           const meta = getRouteMeta(routePath, config)
           const variableName = meta.variableName
-          let routeType: RouteType = meta.routeType
+          let routeType: FsRouteType = meta.routeType
 
           if (routeType === 'lazy') {
             routePath = routePath.replace(/\/lazy$/, '')
@@ -139,7 +139,7 @@ export async function getRouteNodes(
               ['errorComponent', 'errorComponent'],
               ['pendingComponent', 'pendingComponent'],
               ['loader', 'loader'],
-            ] satisfies Array<[RouteType, string]>
+            ] satisfies Array<[FsRouteType, string]>
           ).forEach(([matcher, type]) => {
             if (routeType === matcher) {
               logger.warn(
@@ -200,7 +200,7 @@ export function getRouteMeta(
   // `__root` is can be more easily determined by filtering down to routePath === /${rootPathId}
   // `pathless` is needs to determined after `lazy` has been cleaned up from the routePath
   routeType: Extract<
-    RouteType,
+    FsRouteType,
     | 'static'
     | 'layout'
     | 'api'
@@ -212,7 +212,7 @@ export function getRouteMeta(
   >
   variableName: string
 } {
-  let routeType: RouteType = 'static'
+  let routeType: FsRouteType = 'static'
 
   if (routePath.endsWith(`/${config.routeToken}`)) {
     // layout routes, i.e `/foo/route.tsx` or `/foo/_layout/route.tsx`
@@ -250,7 +250,7 @@ export function getRouteMeta(
  */
 function isValidPathlessLayoutRoute(
   normalizedRoutePath: string,
-  routeType: RouteType,
+  routeType: FsRouteType,
   config: Config,
 ): boolean {
   if (routeType === 'lazy') {

--- a/packages/router-generator/src/filesystem/physical/getRouteNodes.ts
+++ b/packages/router-generator/src/filesystem/physical/getRouteNodes.ts
@@ -129,7 +129,7 @@ export async function getRouteNodes(
 
           // this check needs to happen after the lazy route has been cleaned up
           // since the routePath is used to determine if a route is pathless
-          if (determineRouteIsPathless(routePath, config)) {
+          if (determineRouteIsPathlessLayout(routePath, config)) {
             routeType = 'pathless'
           }
 
@@ -236,12 +236,15 @@ export function getRouteMeta(
 }
 
 /**
- * Used to determine if a route is a layout route
+ * Used to determine if a route is a pathless layout route
  * @param normalizedRoutePath Normalized route path, i.e `/foo/_layout/route.tsx` and `/foo._layout.route.tsx` to `/foo/_layout/route`
  * @param config The `router-generator` configuration object
- * @returns Boolean indicating if the route is a layout route
+ * @returns Boolean indicating if the route is a pathless layout route
  */
-function determineRouteIsPathless(normalizedRoutePath: string, config: Config) {
+function determineRouteIsPathlessLayout(
+  normalizedRoutePath: string,
+  config: Config,
+) {
   const segments = normalizedRoutePath.split('/').filter(Boolean)
 
   if (segments.length === 0) {

--- a/packages/router-generator/src/filesystem/physical/getRouteNodes.ts
+++ b/packages/router-generator/src/filesystem/physical/getRouteNodes.ts
@@ -130,7 +130,7 @@ export async function getRouteNodes(
           // this check needs to happen after the lazy route has been cleaned up
           // since the routePath is used to determine if a route is pathless
           if (determineRouteIsPathlessLayout(routePath, config)) {
-            routeType = 'pathless-layout'
+            routeType = 'pathless_layout'
           }
 
           ;(
@@ -166,7 +166,7 @@ export async function getRouteNodes(
             filePath,
             fullPath,
             routePath,
-            routeType,
+            _fsRouteType: routeType,
             variableName,
           })
         }
@@ -180,7 +180,7 @@ export async function getRouteNodes(
 
   const rootRouteNode = routeNodes.find((d) => d.routePath === `/${rootPathId}`)
   if (rootRouteNode) {
-    rootRouteNode.routeType = '__root'
+    rootRouteNode._fsRouteType = '__root'
   }
 
   return { rootRouteNode, routeNodes }

--- a/packages/router-generator/src/filesystem/physical/getRouteNodes.ts
+++ b/packages/router-generator/src/filesystem/physical/getRouteNodes.ts
@@ -121,16 +121,16 @@ export async function getRouteNodes(
 
           const meta = getRouteMeta(routePath, config)
           const variableName = meta.variableName
-          let fsRouteType: FsRouteType = meta.fsRouteType
+          let routeType: FsRouteType = meta.fsRouteType
 
-          if (fsRouteType === 'lazy') {
+          if (routeType === 'lazy') {
             routePath = routePath.replace(/\/lazy$/, '')
           }
 
           // this check needs to happen after the lazy route has been cleaned up
           // since the routePath is used to determine if a route is pathless
-          if (isValidPathlessLayoutRoute(routePath, fsRouteType, config)) {
-            fsRouteType = 'pathless_layout'
+          if (isValidPathlessLayoutRoute(routePath, routeType, config)) {
+            routeType = 'pathless_layout'
           }
 
           ;(
@@ -141,7 +141,7 @@ export async function getRouteNodes(
               ['loader', 'loader'],
             ] satisfies Array<[FsRouteType, string]>
           ).forEach(([matcher, type]) => {
-            if (fsRouteType === matcher) {
+            if (routeType === matcher) {
               logger.warn(
                 `WARNING: The \`.${type}.tsx\` suffix used for the ${filePath} file is deprecated. Use the new \`.lazy.tsx\` suffix instead.`,
               )
@@ -166,8 +166,8 @@ export async function getRouteNodes(
             filePath,
             fullPath,
             routePath,
-            _fsRouteType: fsRouteType,
             variableName,
+            _fsRouteType: routeType,
           })
         }
       }),

--- a/packages/router-generator/src/filesystem/physical/getRouteNodes.ts
+++ b/packages/router-generator/src/filesystem/physical/getRouteNodes.ts
@@ -129,7 +129,10 @@ export async function getRouteNodes(
 
           // this check needs to happen after the lazy route has been cleaned up
           // since the routePath is used to determine if a route is pathless
-          if (determineRouteIsPathlessLayout(routePath, config)) {
+          if (
+            routeType !== 'lazy' &&
+            determineRouteIsPathlessLayout(routePath, config)
+          ) {
             routeType = 'pathless_layout'
           }
 

--- a/packages/router-generator/src/filesystem/physical/getRouteNodes.ts
+++ b/packages/router-generator/src/filesystem/physical/getRouteNodes.ts
@@ -130,7 +130,7 @@ export async function getRouteNodes(
           // this check needs to happen after the lazy route has been cleaned up
           // since the routePath is used to determine if a route is pathless
           if (determineRouteIsPathlessLayout(routePath, config)) {
-            routeType = 'pathless'
+            routeType = 'pathless-layout'
           }
 
           ;(

--- a/packages/router-generator/src/filesystem/physical/getRouteNodes.ts
+++ b/packages/router-generator/src/filesystem/physical/getRouteNodes.ts
@@ -121,16 +121,16 @@ export async function getRouteNodes(
 
           const meta = getRouteMeta(routePath, config)
           const variableName = meta.variableName
-          let routeType: FsRouteType = meta.routeType
+          let fsRouteType: FsRouteType = meta.fsRouteType
 
-          if (routeType === 'lazy') {
+          if (fsRouteType === 'lazy') {
             routePath = routePath.replace(/\/lazy$/, '')
           }
 
           // this check needs to happen after the lazy route has been cleaned up
           // since the routePath is used to determine if a route is pathless
-          if (isValidPathlessLayoutRoute(routePath, routeType, config)) {
-            routeType = 'pathless_layout'
+          if (isValidPathlessLayoutRoute(routePath, fsRouteType, config)) {
+            fsRouteType = 'pathless_layout'
           }
 
           ;(
@@ -141,7 +141,7 @@ export async function getRouteNodes(
               ['loader', 'loader'],
             ] satisfies Array<[FsRouteType, string]>
           ).forEach(([matcher, type]) => {
-            if (routeType === matcher) {
+            if (fsRouteType === matcher) {
               logger.warn(
                 `WARNING: The \`.${type}.tsx\` suffix used for the ${filePath} file is deprecated. Use the new \`.lazy.tsx\` suffix instead.`,
               )
@@ -166,7 +166,7 @@ export async function getRouteNodes(
             filePath,
             fullPath,
             routePath,
-            _fsRouteType: routeType,
+            _fsRouteType: fsRouteType,
             variableName,
           })
         }
@@ -199,7 +199,7 @@ export function getRouteMeta(
 ): {
   // `__root` is can be more easily determined by filtering down to routePath === /${rootPathId}
   // `pathless` is needs to determined after `lazy` has been cleaned up from the routePath
-  routeType: Extract<
+  fsRouteType: Extract<
     FsRouteType,
     | 'static'
     | 'layout'
@@ -212,34 +212,34 @@ export function getRouteMeta(
   >
   variableName: string
 } {
-  let routeType: FsRouteType = 'static'
+  let fsRouteType: FsRouteType = 'static'
 
   if (routePath.endsWith(`/${config.routeToken}`)) {
     // layout routes, i.e `/foo/route.tsx` or `/foo/_layout/route.tsx`
-    routeType = 'layout'
+    fsRouteType = 'layout'
   } else if (routePath.startsWith(`${removeTrailingSlash(config.apiBase)}/`)) {
     // api routes, i.e. `/api/foo.ts`
-    routeType = 'api'
+    fsRouteType = 'api'
   } else if (routePath.endsWith('/lazy')) {
     // lazy routes, i.e. `/foo.lazy.tsx`
-    routeType = 'lazy'
+    fsRouteType = 'lazy'
   } else if (routePath.endsWith('/loader')) {
     // loader routes, i.e. `/foo.loader.tsx`
-    routeType = 'loader'
+    fsRouteType = 'loader'
   } else if (routePath.endsWith('/component')) {
     // component routes, i.e. `/foo.component.tsx`
-    routeType = 'component'
+    fsRouteType = 'component'
   } else if (routePath.endsWith('/pendingComponent')) {
     // pending component routes, i.e. `/foo.pendingComponent.tsx`
-    routeType = 'pendingComponent'
+    fsRouteType = 'pendingComponent'
   } else if (routePath.endsWith('/errorComponent')) {
     // error component routes, i.e. `/foo.errorComponent.tsx`
-    routeType = 'errorComponent'
+    fsRouteType = 'errorComponent'
   }
 
   const variableName = routePathToVariable(routePath)
 
-  return { routeType, variableName }
+  return { fsRouteType, variableName }
 }
 
 /**

--- a/packages/router-generator/src/filesystem/physical/getRouteNodes.ts
+++ b/packages/router-generator/src/filesystem/physical/getRouteNodes.ts
@@ -15,7 +15,7 @@ import type {
   VirtualRootRoute,
   VirtualRouteSubtreeConfig,
 } from '@tanstack/virtual-file-routes'
-import type { GetRouteNodesResult, RouteNode } from '../../types'
+import type { GetRouteNodesResult, RouteNode, RouteType } from '../../types'
 import type { Config } from '../../config'
 
 const disallowedRouteGroupConfiguration = /\(([^)]+)\).(ts|js|tsx|jsx)/
@@ -119,33 +119,33 @@ export async function getRouteNodes(
             throw new Error(errorMessage)
           }
 
-          const variableName = routePathToVariable(routePath)
+          const meta = getRouteMeta(routePath, config)
+          const variableName = meta.variableName
+          let routeType: RouteType = meta.routeType
 
-          const isLazy = routePath.endsWith('/lazy')
-
-          if (isLazy) {
+          if (routeType === 'lazy') {
             routePath = routePath.replace(/\/lazy$/, '')
           }
 
-          const isRoute = routePath.endsWith(`/${config.routeToken}`)
-          const isComponent = routePath.endsWith('/component')
-          const isErrorComponent = routePath.endsWith('/errorComponent')
-          const isPendingComponent = routePath.endsWith('/pendingComponent')
-          const isLoader = routePath.endsWith('/loader')
-          const isAPIRoute = routePath.startsWith(
-            `${removeTrailingSlash(config.apiBase)}/`,
-          )
-          const isLayout = determineRouteIsLayout(routePath, config)
+          const isComponent = routeType === 'component'
+          const isErrorComponent = routeType === 'errorComponent'
+          const isPendingComponent = routeType === 'pendingComponent'
+
+          // this check needs to happen after the lazy route has been cleaned up
+          // since the routePath is used to determine if a route is pathless
+          if (determineRouteIsPathless(routePath, config)) {
+            routeType = 'pathless'
+          }
 
           ;(
             [
-              [isComponent, 'component'],
-              [isErrorComponent, 'errorComponent'],
-              [isPendingComponent, 'pendingComponent'],
-              [isLoader, 'loader'],
-            ] as const
-          ).forEach(([isType, type]) => {
-            if (isType) {
+              ['component', 'component'],
+              ['errorComponent', 'errorComponent'],
+              ['pendingComponent', 'pendingComponent'],
+              ['loader', 'loader'],
+            ] satisfies Array<[RouteType, string]>
+          ).forEach(([matcher, type]) => {
+            if (routeType === matcher) {
               logger.warn(
                 `WARNING: The \`.${type}.tsx\` suffix used for the ${filePath} file is deprecated. Use the new \`.lazy.tsx\` suffix instead.`,
               )
@@ -171,14 +171,10 @@ export async function getRouteNodes(
             fullPath,
             routePath,
             variableName,
-            isRoute,
             isComponent,
             isErrorComponent,
             isPendingComponent,
-            isLoader,
-            isLazy,
-            isLayout,
-            isAPIRoute,
+            routeType,
           })
         }
       }),
@@ -190,7 +186,60 @@ export async function getRouteNodes(
   await recurse('./')
 
   const rootRouteNode = routeNodes.find((d) => d.routePath === `/${rootPathId}`)
+  if (rootRouteNode) {
+    rootRouteNode.routeType = '__root'
+  }
+
   return { rootRouteNode, routeNodes }
+}
+
+export function getRouteMeta(
+  routePath: string,
+  config: Config,
+): {
+  // `__root` is can be more easily determined by filtering down to routePath === /${rootPathId}
+  // `pathless` is needs to determined after `lazy` has been cleaned up from the routePath
+  routeType: Extract<
+    RouteType,
+    | 'static'
+    | 'layout'
+    | 'api'
+    | 'lazy'
+    | 'loader'
+    | 'component'
+    | 'pendingComponent'
+    | 'errorComponent'
+  >
+  variableName: string
+} {
+  let routeType: RouteType = 'static'
+
+  if (routePath.endsWith(`/${config.routeToken}`)) {
+    // layout routes, i.e `/foo/route.tsx` or `/foo/_layout/route.tsx`
+    routeType = 'layout'
+  } else if (routePath.startsWith(`${removeTrailingSlash(config.apiBase)}/`)) {
+    // api routes, i.e. `/api/foo.ts`
+    routeType = 'api'
+  } else if (routePath.endsWith('/lazy')) {
+    // lazy routes, i.e. `/foo.lazy.tsx`
+    routeType = 'lazy'
+  } else if (routePath.endsWith('/loader')) {
+    // loader routes, i.e. `/foo.loader.tsx`
+    routeType = 'loader'
+  } else if (routePath.endsWith('/component')) {
+    // component routes, i.e. `/foo.component.tsx`
+    routeType = 'component'
+  } else if (routePath.endsWith('/pendingComponent')) {
+    // pending component routes, i.e. `/foo.pendingComponent.tsx`
+    routeType = 'pendingComponent'
+  } else if (routePath.endsWith('/errorComponent')) {
+    // error component routes, i.e. `/foo.errorComponent.tsx`
+    routeType = 'errorComponent'
+  }
+
+  const variableName = routePathToVariable(routePath)
+
+  return { routeType, variableName }
 }
 
 /**
@@ -199,7 +248,7 @@ export async function getRouteNodes(
  * @param config The `router-generator` configuration object
  * @returns Boolean indicating if the route is a layout route
  */
-function determineRouteIsLayout(normalizedRoutePath: string, config: Config) {
+function determineRouteIsPathless(normalizedRoutePath: string, config: Config) {
   const segments = normalizedRoutePath.split('/').filter(Boolean)
 
   if (segments.length === 0) {

--- a/packages/router-generator/src/filesystem/physical/getRouteNodes.ts
+++ b/packages/router-generator/src/filesystem/physical/getRouteNodes.ts
@@ -129,10 +129,7 @@ export async function getRouteNodes(
 
           // this check needs to happen after the lazy route has been cleaned up
           // since the routePath is used to determine if a route is pathless
-          if (
-            routeType !== 'lazy' &&
-            determineRouteIsPathlessLayout(routePath, config)
-          ) {
+          if (isValidPathlessLayoutRoute(routePath, routeType, config)) {
             routeType = 'pathless_layout'
           }
 
@@ -189,6 +186,13 @@ export async function getRouteNodes(
   return { rootRouteNode, routeNodes }
 }
 
+/**
+ * Determines the metadata for a given route path based on the provided configuration.
+ *
+ * @param routePath - The determined initial routePath.
+ * @param config - The user configuration object.
+ * @returns An object containing the type of the route and the variable name derived from the route path.
+ */
 export function getRouteMeta(
   routePath: string,
   config: Config,
@@ -239,15 +243,20 @@ export function getRouteMeta(
 }
 
 /**
- * Used to determine if a route is a pathless layout route
+ * Used to validate if a route is a pathless layout route
  * @param normalizedRoutePath Normalized route path, i.e `/foo/_layout/route.tsx` and `/foo._layout.route.tsx` to `/foo/_layout/route`
  * @param config The `router-generator` configuration object
  * @returns Boolean indicating if the route is a pathless layout route
  */
-function determineRouteIsPathlessLayout(
+function isValidPathlessLayoutRoute(
   normalizedRoutePath: string,
+  routeType: RouteType,
   config: Config,
-) {
+): boolean {
+  if (routeType === 'lazy') {
+    return false
+  }
+
   const segments = normalizedRoutePath.split('/').filter(Boolean)
 
   if (segments.length === 0) {

--- a/packages/router-generator/src/filesystem/virtual/getRouteNodes.ts
+++ b/packages/router-generator/src/filesystem/virtual/getRouteNodes.ts
@@ -65,7 +65,7 @@ export async function getRouteNodes(
     fullPath: join(fullDir, virtualRouteConfig.file),
     variableName: 'rootRoute',
     routePath: '/',
-    isRoot: true,
+    routeType: '__root',
   })
 
   const rootRouteNode = allNodes[0]
@@ -150,7 +150,7 @@ export async function getRouteNodesRecursive(
         return { filePath, variableName, fullPath }
       }
       const parentRoutePath = removeTrailingSlash(parent?.routePath ?? '/')
-      const isLayout = node.type === 'layout'
+
       switch (node.type) {
         case 'index': {
           const { filePath, variableName, fullPath } = getFile(node.file)
@@ -160,7 +160,7 @@ export async function getRouteNodesRecursive(
             fullPath,
             variableName,
             routePath,
-            isLayout,
+            routeType: 'static',
           } satisfies RouteNode
         }
 
@@ -176,7 +176,7 @@ export async function getRouteNodesRecursive(
               fullPath,
               variableName,
               routePath,
-              isLayout,
+              routeType: 'static',
             }
           } else {
             routeNode = {
@@ -184,8 +184,8 @@ export async function getRouteNodesRecursive(
               fullPath: '',
               variableName: routePathToVariable(routePath),
               routePath,
-              isLayout,
               isVirtual: true,
+              routeType: 'static',
             }
           }
 
@@ -216,10 +216,10 @@ export async function getRouteNodesRecursive(
 
           const routeNode: RouteNode = {
             fullPath,
-            isLayout,
             filePath,
             variableName,
             routePath,
+            routeType: 'pathless',
           }
 
           if (node.children !== undefined) {

--- a/packages/router-generator/src/filesystem/virtual/getRouteNodes.ts
+++ b/packages/router-generator/src/filesystem/virtual/getRouteNodes.ts
@@ -219,7 +219,7 @@ export async function getRouteNodesRecursive(
             filePath,
             variableName,
             routePath,
-            routeType: 'pathless',
+            routeType: 'pathless-layout',
           }
 
           if (node.children !== undefined) {

--- a/packages/router-generator/src/filesystem/virtual/getRouteNodes.ts
+++ b/packages/router-generator/src/filesystem/virtual/getRouteNodes.ts
@@ -65,7 +65,7 @@ export async function getRouteNodes(
     fullPath: join(fullDir, virtualRouteConfig.file),
     variableName: 'rootRoute',
     routePath: '/',
-    routeType: '__root',
+    _fsRouteType: '__root',
   })
 
   const rootRouteNode = allNodes[0]
@@ -160,7 +160,7 @@ export async function getRouteNodesRecursive(
             fullPath,
             variableName,
             routePath,
-            routeType: 'static',
+            _fsRouteType: 'static',
           } satisfies RouteNode
         }
 
@@ -176,7 +176,7 @@ export async function getRouteNodesRecursive(
               fullPath,
               variableName,
               routePath,
-              routeType: 'static',
+              _fsRouteType: 'static',
             }
           } else {
             routeNode = {
@@ -185,7 +185,7 @@ export async function getRouteNodesRecursive(
               variableName: routePathToVariable(routePath),
               routePath,
               isVirtual: true,
-              routeType: 'static',
+              _fsRouteType: 'static',
             }
           }
 
@@ -219,7 +219,7 @@ export async function getRouteNodesRecursive(
             filePath,
             variableName,
             routePath,
-            routeType: 'pathless-layout',
+            _fsRouteType: 'pathless_layout',
           }
 
           if (node.children !== undefined) {

--- a/packages/router-generator/src/filesystem/virtual/getRouteNodes.ts
+++ b/packages/router-generator/src/filesystem/virtual/getRouteNodes.ts
@@ -6,6 +6,7 @@ import {
   routePathToVariable,
 } from '../../utils'
 import { getRouteNodes as getRouteNodesPhysical } from '../physical/getRouteNodes'
+import { rootPathId } from '../physical/rootPathId'
 import { virtualRootRouteSchema } from './config'
 import { loadConfigFile } from './loadConfigFile'
 import type {
@@ -64,7 +65,7 @@ export async function getRouteNodes(
     filePath: virtualRouteConfig.file,
     fullPath: join(fullDir, virtualRouteConfig.file),
     variableName: 'rootRoute',
-    routePath: '/',
+    routePath: `/${rootPathId}`,
     _fsRouteType: '__root',
   })
 
@@ -198,6 +199,9 @@ export async function getRouteNodesRecursive(
               routeNode,
             )
             routeNode.children = children
+
+            // If the route has children, it should be a layout
+            routeNode._fsRouteType = 'layout'
           }
           return routeNode
         }

--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -314,7 +314,7 @@ export async function generator(config: Config, root: string) {
     const cleanedPathIsEmpty = (node.cleanedPath || '').length === 0
     const nonPathRoute = node.routeType === 'layout' && node.isNonPath
     node.isVirtualParentRequired =
-      node.routeType === 'pathless' || nonPathRoute
+      node.routeType === 'pathless-layout' || nonPathRoute
         ? !cleanedPathIsEmpty
         : false
     if (!node.isVirtual && node.isVirtualParentRequired) {
@@ -344,7 +344,7 @@ export async function generator(config: Config, root: string) {
 
         node.parent = parentNode
 
-        if (node.routeType === 'pathless') {
+        if (node.routeType === 'pathless-layout') {
           // since `node.path` is used as the `id` on the route definition, we need to update it
           node.path = determineNodePath(node)
         }
@@ -444,7 +444,7 @@ export async function generator(config: Config, root: string) {
         return
       }
 
-      if (node.routeType === 'pathless' && !node.children?.length) {
+      if (node.routeType === 'pathless-layout' && !node.children?.length) {
         return
       }
 

--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -222,9 +222,9 @@ export async function generator(config: Config, root: string) {
           )
         } else if (
           node.routeType === 'layout' ||
-          (!node.isComponent &&
-            !node.isErrorComponent &&
-            !node.isPendingComponent &&
+          (node.routeType !== 'component' &&
+            node.routeType !== 'errorComponent' &&
+            node.routeType !== 'pendingComponent' &&
             node.routeType !== 'loader')
         ) {
           replaced = await fillTemplate(
@@ -271,9 +271,9 @@ export async function generator(config: Config, root: string) {
     if (
       !node.isVirtual &&
       (node.routeType === 'loader' ||
-        node.isComponent ||
-        node.isErrorComponent ||
-        node.isPendingComponent ||
+        node.routeType === 'component' ||
+        node.routeType === 'errorComponent' ||
+        node.routeType === 'pendingComponent' ||
         node.routeType === 'lazy')
     ) {
       routePiecesByPath[node.routePath!] =
@@ -284,9 +284,9 @@ export async function generator(config: Config, root: string) {
           ? 'lazy'
           : node.routeType === 'loader'
             ? 'loader'
-            : node.isErrorComponent
+            : node.routeType === 'errorComponent'
               ? 'errorComponent'
-              : node.isPendingComponent
+              : node.routeType === 'pendingComponent'
                 ? 'pendingComponent'
                 : 'component'
       ] = node
@@ -298,9 +298,6 @@ export async function generator(config: Config, root: string) {
           ...node,
           isVirtual: true,
           routeType: 'static',
-          isComponent: false,
-          isErrorComponent: false,
-          isPendingComponent: false,
         })
       }
       return

--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -214,6 +214,7 @@ export async function generator(config: Config, root: string) {
       const tLazyRouteTemplate = ROUTE_TEMPLATE.lazyRoute
 
       if (!routeCode) {
+        // Creating a new lazy route file
         if (node._fsRouteType === 'lazy') {
           // Check by default check if the user has a specific lazy route template
           // If not, check if the user has a route template and use that instead
@@ -231,11 +232,10 @@ export async function generator(config: Config, root: string) {
             },
           )
         } else if (
-          // Check if the route is "normal" route
+          // Creating a new normal route file
           (['layout', 'static'] satisfies Array<FsRouteType>).some(
             (d) => d === node._fsRouteType,
           ) ||
-          // Make sure that the route is not a component, pendingComponent, errorComponent or loader
           (
             [
               'component',
@@ -259,6 +259,7 @@ export async function generator(config: Config, root: string) {
           )
         }
       } else {
+        // Update the existing route file
         replaced = routeCode
           .replace(
             /(FileRoute\(\s*['"])([^\s]*)(['"],?\s*\))/g,

--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -23,7 +23,7 @@ import {
   fillTemplate,
   getTargetTemplate,
 } from './template'
-import type { GetRouteNodesResult, RouteNode } from './types'
+import type { GetRouteNodesResult, RouteNode, RouteType } from './types'
 import type { Config } from './config'
 
 export const CONSTANTS = {
@@ -222,10 +222,14 @@ export async function generator(config: Config, root: string) {
           )
         } else if (
           node.routeType === 'layout' ||
-          (node.routeType !== 'component' &&
-            node.routeType !== 'errorComponent' &&
-            node.routeType !== 'pendingComponent' &&
-            node.routeType !== 'loader')
+          (
+            [
+              'component',
+              'pendingComponent',
+              'errorComponent',
+              'loader',
+            ] satisfies Array<RouteType>
+          ).every((d) => d !== node.routeType)
         ) {
           replaced = await fillTemplate(
             config,
@@ -270,11 +274,15 @@ export async function generator(config: Config, root: string) {
 
     if (
       !node.isVirtual &&
-      (node.routeType === 'loader' ||
-        node.routeType === 'component' ||
-        node.routeType === 'errorComponent' ||
-        node.routeType === 'pendingComponent' ||
-        node.routeType === 'lazy')
+      (
+        [
+          'lazy',
+          'loader',
+          'component',
+          'pendingComponent',
+          'errorComponent',
+        ] satisfies Array<RouteType>
+      ).some((d) => d === node.routeType)
     ) {
       routePiecesByPath[node.routePath!] =
         routePiecesByPath[node.routePath!] || {}

--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -23,7 +23,7 @@ import {
   fillTemplate,
   getTargetTemplate,
 } from './template'
-import type { GetRouteNodesResult, RouteNode, RouteType } from './types'
+import type { FsRouteType, GetRouteNodesResult, RouteNode } from './types'
 import type { Config } from './config'
 
 export const CONSTANTS = {
@@ -222,7 +222,7 @@ export async function generator(config: Config, root: string) {
           )
         } else if (
           // Check if the route is "normal" route
-          (['layout', 'static'] satisfies Array<RouteType>).some(
+          (['layout', 'static'] satisfies Array<FsRouteType>).some(
             (d) => d === node._fsRouteType,
           ) ||
           // Make sure that the route is not a component, pendingComponent, errorComponent or loader
@@ -232,7 +232,7 @@ export async function generator(config: Config, root: string) {
               'pendingComponent',
               'errorComponent',
               'loader',
-            ] satisfies Array<RouteType>
+            ] satisfies Array<FsRouteType>
           ).every((d) => d !== node._fsRouteType)
         ) {
           replaced = await fillTemplate(
@@ -285,7 +285,7 @@ export async function generator(config: Config, root: string) {
           'component',
           'pendingComponent',
           'errorComponent',
-        ] satisfies Array<RouteType>
+        ] satisfies Array<FsRouteType>
       ).some((d) => d === node._fsRouteType)
     ) {
       routePiecesByPath[node.routePath!] =
@@ -381,7 +381,7 @@ export async function generator(config: Config, root: string) {
     preRouteNodes.filter(
       (d) =>
         d.children === undefined &&
-        (['api', 'lazy'] satisfies Array<RouteType>).every(
+        (['api', 'lazy'] satisfies Array<FsRouteType>).every(
           (type) => type !== d._fsRouteType,
         ),
     ),

--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -376,9 +376,10 @@ export async function generator(config: Config, root: string) {
   checkRouteFullPathUniqueness(
     preRouteNodes.filter(
       (d) =>
-        d.routeType !== 'api' &&
-        d.routeType !== 'lazy' &&
-        d.children === undefined,
+        d.children === undefined &&
+        (['api', 'lazy'] satisfies Array<RouteType>).every(
+          (type) => type !== d.routeType,
+        ),
     ),
     config,
   )

--- a/packages/router-generator/src/types.ts
+++ b/packages/router-generator/src/types.ts
@@ -2,7 +2,7 @@ export type RouteNode = {
   filePath: string
   fullPath: string
   variableName: string
-  _fsRouteType: RouteType
+  _fsRouteType: FsRouteType
   routePath?: string
   cleanedPath?: string
   path?: string
@@ -19,7 +19,7 @@ export interface GetRouteNodesResult {
   routeNodes: Array<RouteNode>
 }
 
-export type RouteType =
+export type FsRouteType =
   | '__root'
   | 'static'
   | 'layout'

--- a/packages/router-generator/src/types.ts
+++ b/packages/router-generator/src/types.ts
@@ -6,23 +6,30 @@ export type RouteNode = {
   cleanedPath?: string
   path?: string
   isNonPath?: boolean
-  isLayout?: boolean
   isVirtualParentRequired?: boolean
   isVirtualParentRoute?: boolean
-  isRoute?: boolean
-  isAPIRoute?: boolean
-  isLoader?: boolean
   isComponent?: boolean
   isErrorComponent?: boolean
   isPendingComponent?: boolean
   isVirtual?: boolean
-  isLazy?: boolean
-  isRoot?: boolean
   children?: Array<RouteNode>
   parent?: RouteNode
+  routeType: RouteType
 }
 
 export interface GetRouteNodesResult {
   rootRouteNode?: RouteNode
   routeNodes: Array<RouteNode>
 }
+
+export type RouteType =
+  | '__root'
+  | 'static'
+  | 'layout'
+  | 'pathless'
+  | 'lazy'
+  | 'api'
+  | 'loader' // @deprecated
+  | 'component' // @deprecated
+  | 'pendingComponent' // @deprecated
+  | 'errorComponent' // @deprecated

--- a/packages/router-generator/src/types.ts
+++ b/packages/router-generator/src/types.ts
@@ -2,19 +2,16 @@ export type RouteNode = {
   filePath: string
   fullPath: string
   variableName: string
+  routeType: RouteType
   routePath?: string
   cleanedPath?: string
   path?: string
   isNonPath?: boolean
   isVirtualParentRequired?: boolean
   isVirtualParentRoute?: boolean
-  isComponent?: boolean
-  isErrorComponent?: boolean
-  isPendingComponent?: boolean
   isVirtual?: boolean
   children?: Array<RouteNode>
   parent?: RouteNode
-  routeType: RouteType
 }
 
 export interface GetRouteNodesResult {

--- a/packages/router-generator/src/types.ts
+++ b/packages/router-generator/src/types.ts
@@ -2,7 +2,7 @@ export type RouteNode = {
   filePath: string
   fullPath: string
   variableName: string
-  routeType: RouteType
+  _fsRouteType: RouteType
   routePath?: string
   cleanedPath?: string
   path?: string
@@ -23,7 +23,7 @@ export type RouteType =
   | '__root'
   | 'static'
   | 'layout'
-  | 'pathless-layout'
+  | 'pathless_layout'
   | 'lazy'
   | 'api'
   | 'loader' // @deprecated

--- a/packages/router-generator/src/types.ts
+++ b/packages/router-generator/src/types.ts
@@ -23,7 +23,7 @@ export type RouteType =
   | '__root'
   | 'static'
   | 'layout'
-  | 'pathless'
+  | 'pathless-layout'
   | 'lazy'
   | 'api'
   | 'loader' // @deprecated


### PR DESCRIPTION
Currently, we are tracking the different expected filesystem route types using individual boolean flags.
 These are the current flags.

- `isRoot`
- `isRoute`
- `isLayout`
- `isAPIRoute`
- `isLazy`
- `isLoader` `@deprecated`
- `isComponent` `@deprecated`
- `isPendingComponent` `@deprecated`
- `isErrorComponent` `@deprecated`

This makes it possible for a route that's read from the filesystem, to get into an incorrect state either when reading the list of files or when performing updating in the core generator function.

The change being made, makes it so that a route will have a single `_fsRouteType` property attached to the route node so that it correctly describes the nature of the route when it was read from the filesystem.

| flag | `_fsRouteType` value |
|--------|--------|
| Default | `static` |
| `isRoot` | `__root` |
| `isRoute`| `layout` |
| `isLayout` | `pathless_layout` |
| `isAPIRoute` | `api` |
| `isLazy` | `lazy` |
| `isLoader` `@deprecated` | `loader` | 
| `isComponent` `@deprecated` | `component` | 
| `isPendingComponent` `@deprecated` | `pendingComponent` | 
| `isErrorComponent` `@deprecated` | `errorComponent` | 