### PR TITLE
fix(react-router,solid-router): prevent crashes if sessionStorage isn't available

### DIFF
--- a/packages/react-router/src/scroll-restoration.tsx
+++ b/packages/react-router/src/scroll-restoration.tsx
@@ -20,7 +20,10 @@ export type ScrollRestorationOptions = {
 }
 
 export const storageKey = 'tsr-scroll-restoration-v1_3'
-const sessionsStorage = typeof window !== 'undefined' && window.sessionStorage
+let sessionsStorage = false
+try {
+  sessionsStorage = typeof window !== 'undefined' && typeof window.sessionStorage === 'object'
+} catch { }
 const throttle = (fn: (...args: Array<any>) => void, wait: number) => {
   let timeout: any
   return (...args: Array<any>) => {

--- a/packages/react-router/src/scroll-restoration.tsx
+++ b/packages/react-router/src/scroll-restoration.tsx
@@ -22,8 +22,9 @@ export type ScrollRestorationOptions = {
 export const storageKey = 'tsr-scroll-restoration-v1_3'
 let sessionsStorage = false
 try {
-  sessionsStorage = typeof window !== 'undefined' && typeof window.sessionStorage === 'object'
-} catch { }
+  sessionsStorage =
+    typeof window !== 'undefined' && typeof window.sessionStorage === 'object'
+} catch {}
 const throttle = (fn: (...args: Array<any>) => void, wait: number) => {
   let timeout: any
   return (...args: Array<any>) => {

--- a/packages/solid-router/src/scroll-restoration.tsx
+++ b/packages/solid-router/src/scroll-restoration.tsx
@@ -20,7 +20,10 @@ export type ScrollRestorationOptions = {
 }
 
 export const storageKey = 'tsr-scroll-restoration-v1_3'
-const sessionsStorage = typeof window !== 'undefined' && window.sessionStorage
+let sessionsStorage = false
+try {
+  sessionsStorage = typeof window !== 'undefined' && typeof window.sessionStorage === 'object'
+} catch { }
 const throttle = (fn: (...args: Array<any>) => void, wait: number) => {
   let timeout: any
   return (...args: Array<any>) => {

--- a/packages/solid-router/src/scroll-restoration.tsx
+++ b/packages/solid-router/src/scroll-restoration.tsx
@@ -22,8 +22,9 @@ export type ScrollRestorationOptions = {
 export const storageKey = 'tsr-scroll-restoration-v1_3'
 let sessionsStorage = false
 try {
-  sessionsStorage = typeof window !== 'undefined' && typeof window.sessionStorage === 'object'
-} catch { }
+  sessionsStorage =
+    typeof window !== 'undefined' && typeof window.sessionStorage === 'object'
+} catch {}
 const throttle = (fn: (...args: Array<any>) => void, wait: number) => {
   let timeout: any
   return (...args: Array<any>) => {


### PR DESCRIPTION
Fixes #3634 

Simply checking the type of `window.sessionStorage` is apparently enough to trigger `SecurityError`. To address it we use try/catch and set the var to true only if it's indeed available.