### PR TITLE
fix(history): `parseLocation` in createHashHistory to handle search params correctly

### DIFF
--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -546,7 +546,9 @@ export function createHashHistory(opts?: { window?: any }): RouterHistory {
   return createBrowserHistory({
     window: win,
     parseLocation: () => {
-      const hashHref = win.location.hash.split('#').slice(1).join('#') ?? '/'
+      const search = win.location.search
+      const pathname = win.location.hash.substring(1)
+      const hashHref = search ? `/${pathname}${search}` : `/${pathname}`
       return parseHref(hashHref, win.history.state)
     },
     createHref: (href) =>

--- a/packages/history/tests/createHashHistory.test.ts
+++ b/packages/history/tests/createHashHistory.test.ts
@@ -4,35 +4,29 @@ import { createHashHistory } from '../src'
 
 describe('createHashHistory', () => {
     describe('parseLocation', () => {
-        test('neither search params nor hash', () => {
-            const history = createHashHistory()
-            window.history.pushState({}, "", "/")
-            expect(history.location.pathname).toBe('/')
-            expect(history.location.search).toBe('')
-        })
-        test('hash present, no search params', () => {
-            const history = createHashHistory()
-            window.history.pushState({}, "", "/#hello")
-            expect(history.location.pathname).toBe('/hello')
-            expect(history.location.search).toBe('')
-        })
-        test('search params present, no hash', () => {
-            const history = createHashHistory()
-            window.history.pushState({}, "", "/?search=params")
-            expect(history.location.pathname).toBe('/')
-            expect(history.location.search).toBe('?search=params')
-        })
-        test('both hash and search params present, in that order', () => {
-            const history = createHashHistory()
-            window.history.pushState({}, "", "/#hello?search=params")
-            expect(history.location.pathname).toBe('/hello')
-            expect(history.location.search).toBe('?search=params')
-        })
-        test('both search params and hash present, in that order', () => {
-            const history = createHashHistory()
-            window.history.pushState({}, "", "/?search=params#hello")
-            expect(history.location.pathname).toBe('/hello')
-            expect(history.location.search).toBe('?search=params')
+        describe.each([
+            ['/', {pathname: '/', search: ''}, 'neither search params nor hash'],
+            ['/#hello', {pathname: '/hello', search: ''}, 'hash present, no search params'],
+            ['/?search=params', {pathname: '/', search: '?search=params'}, 'search params present, no hash'],
+            ['/#hello?search=params', {pathname: '/hello', search: '?search=params'}, 'both hash and search params present, in that order'],
+            ['/?search=params#hello', {pathname: '/hello', search: '?search=params'}, 'both search params and hash present, in that order'],
+        ])('check for %s', (...[path, exp, desc]) => {
+            test(`onLoad with ${path} (${desc})`, () => {
+                const mockWindow = {
+                    addEventListener: window.addEventListener,
+                    history: window.history,
+                    location: new URL(`https://www.example.com${path}`)
+                }
+                const history = createHashHistory({window: mockWindow})
+                expect(history.location.pathname).toBe(exp.pathname)
+                expect(history.location.search).toBe(exp.search)
+            })
+            test(`onNavigate with ${path} (${desc})`, () => {
+                const history = createHashHistory()
+                window.history.pushState({}, "", path)
+                expect(history.location.pathname).toBe(exp.pathname)
+                expect(history.location.search).toBe(exp.search)
+            })
         })
     })
 })

--- a/packages/history/tests/createHashHistory.test.ts
+++ b/packages/history/tests/createHashHistory.test.ts
@@ -3,22 +3,36 @@ import { describe, expect, test } from 'vitest'
 import {createHashHistory} from '../src'
 
 describe('createHashHistory', () => {
-    test('parseLocation', () => {
-        const history = createHashHistory()
-        window.history.pushState({}, "", "/")
-        expect(history.location.pathname).toBe('/')
-        expect(history.location.search).toBe('')
-        window.history.pushState({}, "", "/#hello")
-        expect(history.location.pathname).toBe('/hello')
-        expect(history.location.search).toBe('')
-        window.history.pushState({}, "", "/?search=params")
-        expect(history.location.pathname).toBe('/')
-        expect(history.location.search).toBe('?search=params')
-        window.history.pushState({}, "", "/#hello?search=params")
-        expect(history.location.pathname).toBe('/hello')
-        expect(history.location.search).toBe('?search=params')
-        window.history.pushState({}, "", "/?search=params#hello")
-        expect(history.location.pathname).toBe('/hello')
-        expect(history.location.search).toBe('?search=params')
+    describe('parseLocation', () => {
+        test('neither search params nor hash', () => {
+            const history = createHashHistory()
+            window.history.pushState({}, "", "/")
+            expect(history.location.pathname).toBe('/')
+            expect(history.location.search).toBe('')
+        })
+        test('hash present, no search params', () => {
+            const history = createHashHistory()
+            window.history.pushState({}, "", "/#hello")
+            expect(history.location.pathname).toBe('/hello')
+            expect(history.location.search).toBe('')
+        })
+        test('search params present, no hash', () => {
+            const history = createHashHistory()
+            window.history.pushState({}, "", "/?search=params")
+            expect(history.location.pathname).toBe('/')
+            expect(history.location.search).toBe('?search=params')
+        })
+        test('both search params and hash present, in that order', () => {
+            const history = createHashHistory()
+            window.history.pushState({}, "", "/#hello?search=params")
+            expect(history.location.pathname).toBe('/hello')
+            expect(history.location.search).toBe('?search=params')
+        })
+        test('both hash and search params present, in that order', () => {
+            const history = createHashHistory()
+            window.history.pushState({}, "", "/?search=params#hello")
+            expect(history.location.pathname).toBe('/hello')
+            expect(history.location.search).toBe('?search=params')
+        })
     })
 })

--- a/packages/history/tests/createHashHistory.test.ts
+++ b/packages/history/tests/createHashHistory.test.ts
@@ -12,12 +12,8 @@ describe('createHashHistory', () => {
             ['/?search=params#hello', {pathname: '/hello', search: '?search=params'}, 'both search params and hash present, in that order'],
         ])('check for %s', (...[path, exp, desc]) => {
             test(`onLoad with ${path} (${desc})`, () => {
-                const mockWindow = {
-                    addEventListener: window.addEventListener,
-                    history: window.history,
-                    location: new URL(`https://www.example.com${path}`)
-                }
-                const history = createHashHistory({window: mockWindow})
+                window.history.replaceState({}, "", path)
+                const history = createHashHistory()
                 expect(history.location.pathname).toBe(exp.pathname)
                 expect(history.location.search).toBe(exp.search)
             })

--- a/packages/history/tests/createHashHistory.test.ts
+++ b/packages/history/tests/createHashHistory.test.ts
@@ -22,13 +22,13 @@ describe('createHashHistory', () => {
             expect(history.location.pathname).toBe('/')
             expect(history.location.search).toBe('?search=params')
         })
-        test('both search params and hash present, in that order', () => {
+        test('both hash and search params present, in that order', () => {
             const history = createHashHistory()
             window.history.pushState({}, "", "/#hello?search=params")
             expect(history.location.pathname).toBe('/hello')
             expect(history.location.search).toBe('?search=params')
         })
-        test('both hash and search params present, in that order', () => {
+        test('both search params and hash present, in that order', () => {
             const history = createHashHistory()
             window.history.pushState({}, "", "/?search=params#hello")
             expect(history.location.pathname).toBe('/hello')

--- a/packages/history/tests/createHashHistory.test.ts
+++ b/packages/history/tests/createHashHistory.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest'
+
+import {createHashHistory} from '../src'
+
+describe('createHashHistory', () => {
+    test('parseLocation', () => {
+        const history = createHashHistory()
+        window.history.pushState({}, "", "/")
+        expect(history.location.pathname).toBe('/')
+        expect(history.location.search).toBe('')
+        window.history.pushState({}, "", "/#hello")
+        expect(history.location.pathname).toBe('/hello')
+        expect(history.location.search).toBe('')
+        window.history.pushState({}, "", "/?search=params")
+        expect(history.location.pathname).toBe('/')
+        expect(history.location.search).toBe('?search=params')
+        window.history.pushState({}, "", "/#hello?search=params")
+        expect(history.location.pathname).toBe('/hello')
+        expect(history.location.search).toBe('?search=params')
+        window.history.pushState({}, "", "/?search=params#hello")
+        expect(history.location.pathname).toBe('/hello')
+        expect(history.location.search).toBe('?search=params')
+    })
+})

--- a/packages/history/tests/createHashHistory.test.ts
+++ b/packages/history/tests/createHashHistory.test.ts
@@ -3,26 +3,42 @@ import { describe, expect, test } from 'vitest'
 import { createHashHistory } from '../src'
 
 describe('createHashHistory', () => {
-    describe('parseLocation', () => {
-        describe.each([
-            ['/', {pathname: '/', search: ''}, 'neither search params nor hash'],
-            ['/#hello', {pathname: '/hello', search: ''}, 'hash present, no search params'],
-            ['/?search=params', {pathname: '/', search: '?search=params'}, 'search params present, no hash'],
-            ['/#hello?search=params', {pathname: '/hello', search: '?search=params'}, 'both hash and search params present, in that order'],
-            ['/?search=params#hello', {pathname: '/hello', search: '?search=params'}, 'both search params and hash present, in that order'],
-        ])('check for %s', (...[path, exp, desc]) => {
-            test(`onLoad with ${path} (${desc})`, () => {
-                window.history.replaceState({}, "", path)
-                const history = createHashHistory()
-                expect(history.location.pathname).toBe(exp.pathname)
-                expect(history.location.search).toBe(exp.search)
-            })
-            test(`onNavigate with ${path} (${desc})`, () => {
-                const history = createHashHistory()
-                window.history.pushState({}, "", path)
-                expect(history.location.pathname).toBe(exp.pathname)
-                expect(history.location.search).toBe(exp.search)
-            })
-        })
+  describe('parseLocation', () => {
+    describe.each([
+      ['/', { pathname: '/', search: '' }, 'neither search params nor hash'],
+      [
+        '/#hello',
+        { pathname: '/hello', search: '' },
+        'hash present, no search params',
+      ],
+      [
+        '/?search=params',
+        { pathname: '/', search: '?search=params' },
+        'search params present, no hash',
+      ],
+      [
+        '/#hello?search=params',
+        { pathname: '/hello', search: '?search=params' },
+        'both hash and search params present, in that order',
+      ],
+      [
+        '/?search=params#hello',
+        { pathname: '/hello', search: '?search=params' },
+        'both search params and hash present, in that order',
+      ],
+    ])('check for %s', (...[path, exp, desc]) => {
+      test(`onLoad with ${path} (${desc})`, () => {
+        window.history.replaceState({}, '', path)
+        const history = createHashHistory()
+        expect(history.location.pathname).toBe(exp.pathname)
+        expect(history.location.search).toBe(exp.search)
+      })
+      test(`onNavigate with ${path} (${desc})`, () => {
+        const history = createHashHistory()
+        window.history.pushState({}, '', path)
+        expect(history.location.pathname).toBe(exp.pathname)
+        expect(history.location.search).toBe(exp.search)
+      })
     })
+  })
 })


### PR DESCRIPTION
`parseLocation` in createHashHistory failed to parse search params when they appeared before the hash. This PR updates the parsing logic so that search params are correctly extracted and processed, regardless of their position.
fixes #3595 