### PR TITLE
feat(router): add shouldThrow to useRouteContext options

### DIFF
--- a/packages/react-router/src/useRouteContext.ts
+++ b/packages/react-router/src/useRouteContext.ts
@@ -1,6 +1,8 @@
 import { useMatch } from './useMatch'
+import type { ThrowConstraint } from './useMatch'
 import type { AnyRouter, RegisteredRouter } from './router'
 import type {
+  ThrowOrOptional,
   UseRouteContextBaseOptions,
   UseRouteContextOptions,
   UseRouteContextResult,
@@ -10,20 +12,33 @@ export type UseRouteContextRoute<out TFrom> = <
   TRouter extends AnyRouter = RegisteredRouter,
   TSelected = unknown,
 >(
-  opts?: UseRouteContextBaseOptions<TRouter, TFrom, true, TSelected>,
+  opts?: UseRouteContextBaseOptions<TRouter, TFrom, true, true, TSelected>,
 ) => UseRouteContextResult<TRouter, TFrom, true, TSelected>
 
 export function useRouteContext<
   TRouter extends AnyRouter = RegisteredRouter,
   const TFrom extends string | undefined = undefined,
   TStrict extends boolean = true,
+  TThrow extends boolean = true,
   TSelected = unknown,
 >(
-  opts: UseRouteContextOptions<TRouter, TFrom, TStrict, TSelected>,
-): UseRouteContextResult<TRouter, TFrom, TStrict, TSelected> {
+  opts: UseRouteContextOptions<
+    TRouter,
+    TFrom,
+    TStrict,
+    ThrowConstraint<TStrict, TThrow>,
+    TSelected
+  >,
+): ThrowOrOptional<
+  UseRouteContextResult<TRouter, TFrom, TStrict, TSelected>,
+  TThrow
+> {
   return useMatch({
     ...(opts as any),
     select: (match) =>
       opts.select ? opts.select(match.context) : match.context,
-  }) as UseRouteContextResult<TRouter, TFrom, TStrict, TSelected>
+  }) as ThrowOrOptional<
+    UseRouteContextResult<TRouter, TFrom, TStrict, TSelected>,
+    TThrow
+  >
 }

--- a/packages/react-router/tests/useRouteContext.test-d.tsx
+++ b/packages/react-router/tests/useRouteContext.test-d.tsx
@@ -130,8 +130,12 @@ test('when there is the root context', () => {
     .toEqualTypeOf<((search: { userId?: string }) => unknown) | undefined>()
 
   expectTypeOf(
-    useRouteContext<DefaultRouter, '/invoices', false, number>,
+    useRouteContext<DefaultRouter, '/invoices', false, true, number>,
   ).returns.toEqualTypeOf<number>()
+
+  expectTypeOf(
+    useRouteContext<DefaultRouter, '/invoices', false, false, number>,
+  ).returns.toEqualTypeOf<number | undefined>()
 })
 
 test('when there are multiple contexts', () => {

--- a/packages/router-core/src/useRouteContext.ts
+++ b/packages/router-core/src/useRouteContext.ts
@@ -6,20 +6,23 @@ export interface UseRouteContextBaseOptions<
   TRouter extends AnyRouter,
   TFrom,
   TStrict extends boolean,
+  TThrow extends boolean,
   TSelected,
 > {
   select?: (
     search: ResolveUseRouteContext<TRouter, TFrom, TStrict>,
   ) => TSelected
+  shouldThrow?: TThrow
 }
 
 export type UseRouteContextOptions<
   TRouter extends AnyRouter,
   TFrom extends string | undefined,
   TStrict extends boolean,
+  TThrow extends boolean,
   TSelected,
 > = StrictOrFrom<TRouter, TFrom, TStrict> &
-  UseRouteContextBaseOptions<TRouter, TFrom, TStrict, TSelected>
+  UseRouteContextBaseOptions<TRouter, TFrom, TStrict, TThrow, TSelected>
 
 export type ResolveUseRouteContext<
   TRouter extends AnyRouter,

--- a/packages/solid-router/src/useRouteContext.ts
+++ b/packages/solid-router/src/useRouteContext.ts
@@ -12,16 +12,17 @@ export type UseRouteContextRoute<out TFrom> = <
   TRouter extends AnyRouter = RegisteredRouter,
   TSelected = unknown,
 >(
-  opts?: UseRouteContextBaseOptions<TRouter, TFrom, true, TSelected>,
+  opts?: UseRouteContextBaseOptions<TRouter, TFrom, true, true, TSelected>,
 ) => Accessor<UseRouteContextResult<TRouter, TFrom, true, TSelected>>
 
 export function useRouteContext<
   TRouter extends AnyRouter = RegisteredRouter,
   const TFrom extends string | undefined = undefined,
   TStrict extends boolean = true,
+  TThrow extends boolean = true,
   TSelected = unknown,
 >(
-  opts: UseRouteContextOptions<TRouter, TFrom, TStrict, TSelected>,
+  opts: UseRouteContextOptions<TRouter, TFrom, TStrict, TThrow, TSelected>,
 ): Accessor<UseRouteContextResult<TRouter, TFrom, TStrict, TSelected>> {
   return useMatch({
     ...(opts as any),


### PR DESCRIPTION
### What
Added the `shouldThrow` property to `useRouteContext`. 


### Why
`useRouteContext` uses `useMatch`, which can throw an invariant exception.
