### PR TITLE
fix: solid router crashing with useRouterState

### DIFF
--- a/e2e/react-router/basic-file-based/src/routes/__root.tsx
+++ b/e2e/react-router/basic-file-based/src/routes/__root.tsx
@@ -5,6 +5,7 @@ import {
   createRootRoute,
   useCanGoBack,
   useRouter,
+  useRouterState,
 } from '@tanstack/react-router'
 import { TanStackRouterDevtools } from '@tanstack/router-devtools'
 
@@ -23,6 +24,8 @@ export const Route = createRootRoute({
 function RootComponent() {
   const router = useRouter()
   const canGoBack = useCanGoBack()
+  // test useRouterState doesn't crash client side navigation
+  const _state = useRouterState()
 
   return (
     <>

--- a/e2e/solid-router/basic-file-based/src/routes/__root.tsx
+++ b/e2e/solid-router/basic-file-based/src/routes/__root.tsx
@@ -5,6 +5,7 @@ import {
   createRootRoute,
   useCanGoBack,
   useRouter,
+  useRouterState,
 } from '@tanstack/solid-router'
 // // import { TanStackRouterDevtools } from '@tanstack/router-devtools'
 
@@ -23,6 +24,8 @@ export const Route = createRootRoute({
 function RootComponent() {
   const router = useRouter()
   const canGoBack = useCanGoBack()
+  // test useRouterState doesn't crash client side navigation
+  const _state = useRouterState()
 
   return (
     <>

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -2314,7 +2314,9 @@ export class Router<
                   updateMatch(matchId, (prev) => ({
                     ...prev,
                     loadPromise: createControlledPromise<void>(() => {
-                      prev.loadPromise?.resolve()
+                      if (prev.loadPromise?.status !== 'resolved') {
+                        prev.loadPromise?.resolve()
+                      }
                     }),
                     beforeLoadPromise: createControlledPromise<void>(),
                   }))

--- a/packages/solid-router/src/router.ts
+++ b/packages/solid-router/src/router.ts
@@ -2287,6 +2287,11 @@ export class Router<
                 try {
                   updateMatch(matchId, (prev) => ({
                     ...prev,
+                    loadPromise: createControlledPromise<void>(() => {
+                      if (prev.loadPromise?.status !== 'resolved') {
+                        prev.loadPromise?.resolve()
+                      }
+                    }),
                     beforeLoadPromise: createControlledPromise<void>(),
                   }))
 

--- a/packages/solid-router/src/router.ts
+++ b/packages/solid-router/src/router.ts
@@ -2287,9 +2287,6 @@ export class Router<
                 try {
                   updateMatch(matchId, (prev) => ({
                     ...prev,
-                    loadPromise: createControlledPromise<void>(() => {
-                      prev.loadPromise?.resolve()
-                    }),
                     beforeLoadPromise: createControlledPromise<void>(),
                   }))
 


### PR DESCRIPTION
Seems to fix the issue of `useRouterState` causing the client side navigation to break. Not sure why exactly this causes it to break but all the unit tests seem to pass without it.

Also helps unblock the devtools that @birkskyum is working on

Fixes #3639 