### PR TITLE
docs(router): add viewTransition docs in NavigateOptionsType

### DIFF
--- a/docs/router/framework/react/api/router/NavigateOptionsType.md
+++ b/docs/router/framework/react/api/router/NavigateOptionsType.md
@@ -10,6 +10,7 @@ type NavigateOptions = ToOptions & {
   replace?: boolean
   resetScroll?: boolean
   hashScrollIntoView?: boolean | ScrollIntoViewOptions
+  viewTransition?: boolean | ViewTransitionOptions
   ignoreBlocker?: boolean
   reloadDocument?: boolean
   href?: string
@@ -33,6 +34,17 @@ The `NavigateOptions` object accepts the following properties:
 - Optional
 - Defaults to `true` so that the scroll position will be reset to 0,0 after the location is committed to the browser history.
 - If `false`, the scroll position will not be reset to 0,0 after the location is committed to history.
+
+### `viewTransition`
+
+- Type: `boolean | ViewTransitionOptions`
+- Optional
+- Defaults to `false`.
+- If `true`, navigation will be called using `document.startViewTransition()`.
+- If [`ViewTransitionOptions`](./ViewTransitionOptionsType.md), route navigations will be called using `document.startViewTransition({update, types})` where `types` will be the strings array passed with `ViewTransitionOptions["types"]`. If the browser does not support viewTransition types, the navigation will fall back to normal `document.startTransition()`, same as if `true` was passed.
+- If the browser does not support this api, this option will be ignored.
+- See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document/startViewTransition) for more information on how this function works.
+- See [Google](https://developer.chrome.com/docs/web-platform/view-transitions/same-document#view-transition-types) for more information on viewTransition types
 
 ### `ignoreBlocker`
 


### PR DESCRIPTION
This PR adds viewTransition documentation to the NavigateOptionsType, giving users more info on how they can use the viewTransition API in Links and Navigates.

Will follow up in the next day or so with an example as well. 