### PR TITLE
fix: allow relative `navigate` without `from`

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1478,7 +1478,9 @@ export class Router<
       let pathname: string
       if (dest.to) {
         const resolvePathTo =
-          fromMatch?.fullPath || this.latestLocation.pathname
+          fromMatch?.fullPath ||
+          last(fromMatches)?.fullPath ||
+          this.latestLocation.pathname
         pathname = this.resolvePathWithBase(resolvePathTo, `${dest.to}`)
       } else {
         const fromRouteByFromPathRouteId =

--- a/packages/react-router/tests/navigate.test.tsx
+++ b/packages/react-router/tests/navigate.test.tsx
@@ -547,4 +547,23 @@ describe('relative navigation', () => {
 
     expect(router.state.location.pathname).toBe('/posts/tkdodo')
   })
+
+  it('should navigate to a sibling route without from', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/posts/tanner'] }),
+    )
+
+    await router.load()
+
+    expect(router.state.location.pathname).toBe('/posts/tanner')
+
+    await router.navigate({
+      to: '.',
+      params: { slug: 'tkdodo' },
+    })
+
+    await router.invalidate()
+
+    expect(router.state.location.pathname).toBe('/posts/tkdodo')
+  })
 })

--- a/packages/solid-router/src/router.ts
+++ b/packages/solid-router/src/router.ts
@@ -1452,7 +1452,9 @@ export class Router<
       let pathname: string
       if (dest.to) {
         const resolvePathTo =
-          fromMatch?.fullPath || this.latestLocation.pathname
+          fromMatch?.fullPath ||
+          last(fromMatches)?.fullPath ||
+          this.latestLocation.pathname
         pathname = this.resolvePathWithBase(resolvePathTo, `${dest.to}`)
       } else {
         const fromRouteByFromPathRouteId =

--- a/packages/solid-router/tests/navigate.test.tsx
+++ b/packages/solid-router/tests/navigate.test.tsx
@@ -547,4 +547,23 @@ describe('relative navigation', () => {
 
     expect(router.state.location.pathname).toBe('/posts/tkdodo')
   })
+
+  it('should navigate to a sibling route without from', async () => {
+    const { router } = createTestRouter(
+      createMemoryHistory({ initialEntries: ['/posts/tanner'] }),
+    )
+
+    await router.load()
+
+    expect(router.state.location.pathname).toBe('/posts/tanner')
+
+    await router.navigate({
+      to: '.',
+      params: { slug: 'tkdodo' },
+    })
+
+    await router.invalidate()
+
+    expect(router.state.location.pathname).toBe('/posts/tkdodo')
+  })
 })


### PR DESCRIPTION
if `from` is not specified, it defaults to the leaf match