### PR TITLE
fix: transform should return null to preserve source maps. Fixes #3661

### DIFF
--- a/packages/react-start-plugin/src/index.ts
+++ b/packages/react-start-plugin/src/index.ts
@@ -62,7 +62,7 @@ export function createTanStackStartPlugin(opts: TanStackStartViteOptions): {
             }
           }
         }
-        return code
+        return null
       },
     }
   }


### PR DESCRIPTION
Fixes #3661

I tested this in my own codebase. With this change, the warnings are gone.

Rollup plugin docs specifically say that you should return `null` if you didn't transform anything. Vite follows rollup's API.