### PR TITLE
Fix CI - Revert "refactor(react-router,solid-router): move redirect to router-core"

### DIFF
--- a/packages/react-router/src/Match.tsx
+++ b/packages/react-router/src/Match.tsx
@@ -6,12 +6,12 @@ import {
   getLocationChangeInfo,
   pick,
   rootRouteId,
-  isRedirect,
 } from '@tanstack/router-core'
 import { CatchBoundary, ErrorComponent } from './CatchBoundary'
 import { useRouterState } from './useRouterState'
 import { useRouter } from './useRouter'
 import { CatchNotFound, isNotFound } from './not-found'
+import { isRedirect } from './redirects'
 import { matchContext } from './matchContext'
 import { SafeFragment } from './SafeFragment'
 import { renderRouteNotFound } from './renderRouteNotFound'

--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -35,8 +35,6 @@ export {
   createControlledPromise,
   retainSearchParams,
   stripSearchParams,
-  redirect,
-  isRedirect,
 } from '@tanstack/router-core'
 
 export type {
@@ -262,6 +260,8 @@ export { Match, Outlet } from './Match'
 export { useMatch } from './useMatch'
 export { useLoaderDeps } from './useLoaderDeps'
 export { useLoaderData } from './useLoaderData'
+
+export { redirect, isRedirect } from './redirects'
 
 export {
   RouteApi,

--- a/packages/react-router/src/redirects.ts
+++ b/packages/react-router/src/redirects.ts
@@ -1,0 +1,41 @@
+import type {
+  AnyRedirect,
+  Redirect,
+  RegisteredRouter,
+  ResolvedRedirect,
+} from '@tanstack/router-core'
+
+export function redirect<
+  TRouter extends RegisteredRouter,
+  const TTo extends string | undefined,
+  const TFrom extends string = string,
+  const TMaskFrom extends string = TFrom,
+  const TMaskTo extends string = '',
+>(
+  opts: Redirect<TRouter, TFrom, TTo, TMaskFrom, TMaskTo>,
+): Redirect<TRouter, TFrom, TTo, TMaskFrom, TMaskTo> {
+  ;(opts as any).isRedirect = true
+  opts.statusCode = opts.statusCode || opts.code || 307
+  opts.headers = opts.headers || {}
+  if (!opts.reloadDocument) {
+    opts.reloadDocument = false
+    try {
+      new URL(`${opts.href}`)
+      opts.reloadDocument = true
+    } catch {}
+  }
+
+  if (opts.throw) {
+    throw opts
+  }
+
+  return opts
+}
+
+export function isRedirect(obj: any): obj is AnyRedirect {
+  return !!obj?.isRedirect
+}
+
+export function isResolvedRedirect(obj: any): obj is ResolvedRedirect {
+  return !!obj?.isRedirect && obj.href
+}

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -25,9 +25,8 @@ import {
   trimPath,
   trimPathLeft,
   trimPathRight,
-  isRedirect,
-  isResolvedRedirect,
 } from '@tanstack/router-core'
+import { isRedirect, isResolvedRedirect } from './redirects'
 import { isNotFound } from './not-found'
 
 import { setupScrollRestoration } from './scroll-restoration'

--- a/packages/router-core/src/index.ts
+++ b/packages/router-core/src/index.ts
@@ -357,5 +357,3 @@ export type { UseLoaderDepsResult, ResolveUseLoaderDeps } from './useLoaderDeps'
 export type { UseLoaderDataResult, ResolveUseLoaderData } from './useLoaderData'
 
 export type { Redirect, ResolvedRedirect, AnyRedirect } from './redirect'
-
-export { redirect, isRedirect, isResolvedRedirect } from './redirect'

--- a/packages/router-core/src/redirect.ts
+++ b/packages/router-core/src/redirect.ts
@@ -34,38 +34,3 @@ export type ResolvedRedirect<
 > & {
   href: string
 }
-
-export function redirect<
-  TRouter extends RegisteredRouter,
-  const TTo extends string | undefined,
-  const TFrom extends string = string,
-  const TMaskFrom extends string = TFrom,
-  const TMaskTo extends string = '',
->(
-  opts: Redirect<TRouter, TFrom, TTo, TMaskFrom, TMaskTo>,
-): Redirect<TRouter, TFrom, TTo, TMaskFrom, TMaskTo> {
-  ;(opts as any).isRedirect = true
-  opts.statusCode = opts.statusCode || opts.code || 307
-  opts.headers = opts.headers || {}
-  if (!opts.reloadDocument) {
-    opts.reloadDocument = false
-    try {
-      new URL(`${opts.href}`)
-      opts.reloadDocument = true
-    } catch {}
-  }
-
-  if (opts.throw) {
-    throw opts
-  }
-
-  return opts
-}
-
-export function isRedirect(obj: any): obj is AnyRedirect {
-  return !!obj?.isRedirect
-}
-
-export function isResolvedRedirect(obj: any): obj is ResolvedRedirect {
-  return !!obj?.isRedirect && obj.href
-}

--- a/packages/solid-router/src/Match.tsx
+++ b/packages/solid-router/src/Match.tsx
@@ -6,13 +6,13 @@ import {
   getLocationChangeInfo,
   pick,
   rootRouteId,
-  isRedirect,
 } from '@tanstack/router-core'
 import { Dynamic } from 'solid-js/web'
 import { CatchBoundary, ErrorComponent } from './CatchBoundary'
 import { useRouterState } from './useRouterState'
 import { useRouter } from './useRouter'
 import { CatchNotFound, isNotFound } from './not-found'
+import { isRedirect } from './redirects'
 import { matchContext } from './matchContext'
 import { SafeFragment } from './SafeFragment'
 import { renderRouteNotFound } from './renderRouteNotFound'

--- a/packages/solid-router/src/index.tsx
+++ b/packages/solid-router/src/index.tsx
@@ -35,8 +35,6 @@ export {
   createControlledPromise,
   retainSearchParams,
   stripSearchParams,
-  redirect,
-  isRedirect,
 } from '@tanstack/router-core'
 
 export type {
@@ -270,6 +268,8 @@ export { Match, Outlet } from './Match'
 export { useMatch } from './useMatch'
 export { useLoaderDeps } from './useLoaderDeps'
 export { useLoaderData } from './useLoaderData'
+
+export { redirect, isRedirect } from './redirects'
 
 export {
   RouteApi,

--- a/packages/solid-router/src/redirects.ts
+++ b/packages/solid-router/src/redirects.ts
@@ -1,0 +1,41 @@
+import type {
+  AnyRedirect,
+  Redirect,
+  RegisteredRouter,
+  ResolvedRedirect,
+} from '@tanstack/router-core'
+
+export function redirect<
+  TRouter extends RegisteredRouter,
+  const TTo extends string | undefined,
+  const TFrom extends string = string,
+  const TMaskFrom extends string = TFrom,
+  const TMaskTo extends string = '',
+>(
+  opts: Redirect<TRouter, TFrom, TTo, TMaskFrom, TMaskTo>,
+): Redirect<TRouter, TFrom, TTo, TMaskFrom, TMaskTo> {
+  ;(opts as any).isRedirect = true
+  opts.statusCode = opts.statusCode || opts.code || 307
+  opts.headers = opts.headers || {}
+  if (!opts.reloadDocument) {
+    opts.reloadDocument = false
+    try {
+      new URL(`${opts.href}`)
+      opts.reloadDocument = true
+    } catch {}
+  }
+
+  if (opts.throw) {
+    throw opts
+  }
+
+  return opts
+}
+
+export function isRedirect(obj: any): obj is AnyRedirect {
+  return !!obj?.isRedirect
+}
+
+export function isResolvedRedirect(obj: any): obj is ResolvedRedirect {
+  return !!obj?.isRedirect && obj.href
+}

--- a/packages/solid-router/src/router.ts
+++ b/packages/solid-router/src/router.ts
@@ -25,9 +25,8 @@ import {
   trimPath,
   trimPathLeft,
   trimPathRight,
-  isRedirect,
-  isResolvedRedirect,
 } from '@tanstack/router-core'
+import { isRedirect, isResolvedRedirect } from './redirects'
 import { isNotFound } from './not-found'
 import { setupScrollRestoration } from './scroll-restoration'
 import type * as Solid from 'solid-js'


### PR DESCRIPTION
Reverts TanStack/router#3662

The change appeared trivial, but apparently it broke CI (despite everything passing locally), so until I understand what went wrong I'd like to revert it.