### PR TITLE
docs(start): Add note for verbatimModuleSyntax setting in tsconfig docs

### DIFF
--- a/docs/start/framework/react/build-from-scratch.md
+++ b/docs/start/framework/react/build-from-scratch.md
@@ -43,6 +43,8 @@ We highly recommend using TypeScript with TanStack Start. Create a `tsconfig.jso
 }
 ```
 
+> [!NOTE] > Enabling `verbatimModuleSyntax` can result in server bundles leaking into client bundles. It is recommended to keep this option disabled.
+
 ## Install Dependencies
 
 TanStack Start is (currently\*) powered by [Vinxi](https://vinxi.vercel.app/) and [TanStack Router](https://tanstack.com/router) and requires them as dependencies.


### PR DESCRIPTION
verbatimModuleSyntax can cause server bundles to quietly leak into client bundles via exported types. It is an easy mistake to make that can be _very_ difficult to debug.

Inspired by #3401