### PR TITLE
fix(react-router,solid-router): scroll to element does not work for hash history

### DIFF
--- a/e2e/react-router/scroll-restoration-sandbox-vite/.gitignore
+++ b/e2e/react-router/scroll-restoration-sandbox-vite/.gitignore
@@ -2,5 +2,6 @@ node_modules
 .DS_Store
 dist
 dist-ssr
+dist-hash
 *.local
 test-results

--- a/e2e/react-router/scroll-restoration-sandbox-vite/package.json
+++ b/e2e/react-router/scroll-restoration-sandbox-vite/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000",
+    "dev:hash": "VITE_APP_HISTORY=hash vite --port 3000",
     "dev:e2e": "vite",
     "build": "vite build && tsc --noEmit",
     "serve": "vite preview",

--- a/e2e/react-router/scroll-restoration-sandbox-vite/package.json
+++ b/e2e/react-router/scroll-restoration-sandbox-vite/package.json
@@ -8,7 +8,9 @@
     "build": "vite build && tsc --noEmit",
     "serve": "vite preview",
     "start": "vite",
-    "test:e2e": "playwright test --project=chromium"
+    "test:e2e:browser": "VITE_APP_HISTORY=browser playwright test --config=playwright.browser.config.ts --project=chromium",
+    "test:e2e:hash": "VITE_APP_HISTORY=hash playwright test --config=playwright.hash.config.ts --project=chromium",
+    "test:e2e": "pnpm run test:e2e:browser && pnpm run test:e2e:hash"
   },
   "dependencies": {
     "@tanstack/react-router": "workspace:^",

--- a/e2e/react-router/scroll-restoration-sandbox-vite/playwright.browser.config.ts
+++ b/e2e/react-router/scroll-restoration-sandbox-vite/playwright.browser.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, devices } from '@playwright/test'
 import { derivePort } from '@tanstack/router-e2e-utils'
 import packageJson from './package.json' with { type: 'json' }
 
-const PORT = derivePort(packageJson.name)
+const PORT = derivePort(packageJson.name + '-browser')
 const baseURL = `http://localhost:${PORT}`
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -19,7 +19,7 @@ export default defineConfig({
   },
 
   webServer: {
-    command: `VITE_SERVER_PORT=${PORT} pnpm build && VITE_SERVER_PORT=${PORT} pnpm serve --port ${PORT}`,
+    command: `VITE_SERVER_PORT=${PORT} VITE_APP_HISTORY=browser pnpm build && VITE_SERVER_PORT=${PORT} VITE_APP_HISTORY=browser pnpm serve --port ${PORT}`,
     url: baseURL,
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',

--- a/e2e/react-router/scroll-restoration-sandbox-vite/playwright.hash.config.ts
+++ b/e2e/react-router/scroll-restoration-sandbox-vite/playwright.hash.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test'
+import { derivePort } from '@tanstack/router-e2e-utils'
+import packageJson from './package.json' with { type: 'json' }
+
+const PORT = derivePort(packageJson.name + '-hash')
+const baseURL = `http://localhost:${PORT}`
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests',
+  workers: 1,
+
+  reporter: [['line']],
+
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL,
+  },
+
+  webServer: {
+    command: `VITE_SERVER_PORT=${PORT} VITE_APP_HISTORY=hash vite build --outDir dist-hash && VITE_SERVER_PORT=${PORT} VITE_APP_HISTORY=hash pnpm serve --port ${PORT} --outDir dist-hash`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    stdout: 'pipe',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})

--- a/e2e/react-router/scroll-restoration-sandbox-vite/src/main.tsx
+++ b/e2e/react-router/scroll-restoration-sandbox-vite/src/main.tsx
@@ -1,12 +1,24 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { RouterProvider, createRouter } from '@tanstack/react-router'
+import {
+  RouterProvider,
+  createHashHistory,
+  createRouter,
+} from '@tanstack/react-router'
 import { routeTree } from './routeTree.gen'
+import type { RouterHistory } from '@tanstack/react-router'
 import './styles.css'
+
+let history: RouterHistory | undefined
+
+if (import.meta.env.VITE_APP_HISTORY === 'hash') {
+  history = createHashHistory()
+}
 
 // Set up a Router instance
 const router = createRouter({
   routeTree,
+  history,
   scrollRestoration: true,
 })
 

--- a/e2e/react-router/scroll-restoration-sandbox-vite/tests/app.spec.ts
+++ b/e2e/react-router/scroll-restoration-sandbox-vite/tests/app.spec.ts
@@ -1,8 +1,13 @@
 import { expect, test } from '@playwright/test'
 import { linkOptions } from '@tanstack/react-router'
 
+function toValue(input: string) {
+  const value = process.env.VITE_APP_HISTORY === 'hash' ? `/#${input}` : input
+  return value
+}
+
 test('Smoke - Renders home', async ({ page }) => {
-  await page.goto('/')
+  await page.goto(toValue('/'))
   await expect(
     page.getByRole('heading', { name: 'Welcome Home!' }),
   ).toBeVisible()
@@ -19,7 +24,7 @@ test('Smoke - Renders home', async ({ page }) => {
   test(`On navigate to ${options.to} (from the header), scroll should be at top`, async ({
     page,
   }) => {
-    await page.goto('/')
+    await page.goto(toValue('/'))
     await page.getByRole('link', { name: `Head-${options.to}` }).click()
     await expect(page.getByTestId('at-the-top')).toBeInViewport()
   })
@@ -28,7 +33,7 @@ test('Smoke - Renders home', async ({ page }) => {
   test(`On navigate via index page tests to ${options.to}, scroll should resolve at the bottom`, async ({
     page,
   }) => {
-    await page.goto('/')
+    await page.goto(toValue('/'))
     await page
       .getByRole('link', { name: `${options.to}#at-the-bottom` })
       .click()
@@ -41,9 +46,9 @@ test('Smoke - Renders home', async ({ page }) => {
   }) => {
     let url: string = options.to
     if ('search' in options) {
-      url = `${url}?where=${options.search}`
+      url = `${url}?where=${options.search.where}`
     }
-    await page.goto(`${url}#at-the-bottom`)
+    await page.goto(toValue(`${url}#at-the-bottom`))
     await expect(page.getByTestId('at-the-bottom')).toBeInViewport()
   })
 })

--- a/e2e/react-router/scroll-restoration-sandbox-vite/tsconfig.json
+++ b/e2e/react-router/scroll-restoration-sandbox-vite/tsconfig.json
@@ -8,7 +8,8 @@
     "module": "ESNext",
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "allowJs": true
+    "allowJs": true,
+    "types": ["vite/client", "node"]
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/e2e/solid-router/scroll-restoration-sandbox-vite/.gitignore
+++ b/e2e/solid-router/scroll-restoration-sandbox-vite/.gitignore
@@ -2,5 +2,6 @@ node_modules
 .DS_Store
 dist
 dist-ssr
+dist-hash
 *.local
 test-results

--- a/e2e/solid-router/scroll-restoration-sandbox-vite/package.json
+++ b/e2e/solid-router/scroll-restoration-sandbox-vite/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000",
+    "dev:hash": "VITE_APP_HISTORY=hash vite --port 3000",
     "dev:e2e": "vite",
     "build": "vite build && tsc --noEmit",
     "serve": "vite preview",

--- a/e2e/solid-router/scroll-restoration-sandbox-vite/package.json
+++ b/e2e/solid-router/scroll-restoration-sandbox-vite/package.json
@@ -8,7 +8,9 @@
     "build": "vite build && tsc --noEmit",
     "serve": "vite preview",
     "start": "vite",
-    "test:e2e": "playwright test --project=chromium"
+    "test:e2e:browser": "VITE_APP_HISTORY=browser playwright test --config=playwright.browser.config.ts --project=chromium",
+    "test:e2e:hash": "VITE_APP_HISTORY=hash playwright test --config=playwright.hash.config.ts --project=chromium",
+    "test:e2e": "pnpm run test:e2e:browser && pnpm run test:e2e:hash"
   },
   "dependencies": {
     "@tanstack/solid-router": "workspace:^",

--- a/e2e/solid-router/scroll-restoration-sandbox-vite/playwright.browser.config.ts
+++ b/e2e/solid-router/scroll-restoration-sandbox-vite/playwright.browser.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test'
+import { derivePort } from '@tanstack/router-e2e-utils'
+import packageJson from './package.json' with { type: 'json' }
+
+const PORT = derivePort(packageJson.name + '-browser')
+const baseURL = `http://localhost:${PORT}`
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests',
+  workers: 1,
+
+  reporter: [['line']],
+
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL,
+  },
+
+  webServer: {
+    command: `VITE_SERVER_PORT=${PORT} VITE_APP_HISTORY=browser pnpm build && VITE_SERVER_PORT=${PORT} VITE_APP_HISTORY=browser pnpm serve --port ${PORT}`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    stdout: 'pipe',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})

--- a/e2e/solid-router/scroll-restoration-sandbox-vite/playwright.hash.config.ts
+++ b/e2e/solid-router/scroll-restoration-sandbox-vite/playwright.hash.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test'
+import { derivePort } from '@tanstack/router-e2e-utils'
+import packageJson from './package.json' with { type: 'json' }
+
+const PORT = derivePort(packageJson.name + '-hash')
+const baseURL = `http://localhost:${PORT}`
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests',
+  workers: 1,
+
+  reporter: [['line']],
+
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL,
+  },
+
+  webServer: {
+    command: `VITE_SERVER_PORT=${PORT} VITE_APP_HISTORY=hash vite build --outDir dist-hash && VITE_SERVER_PORT=${PORT} VITE_APP_HISTORY=hash pnpm serve --port ${PORT} --outDir dist-hash`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    stdout: 'pipe',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})

--- a/e2e/solid-router/scroll-restoration-sandbox-vite/src/main.tsx
+++ b/e2e/solid-router/scroll-restoration-sandbox-vite/src/main.tsx
@@ -1,11 +1,23 @@
 import { render } from 'solid-js/web'
-import { RouterProvider, createRouter } from '@tanstack/solid-router'
+import {
+  RouterProvider,
+  createHashHistory,
+  createRouter,
+} from '@tanstack/solid-router'
 import { routeTree } from './routeTree.gen'
+import type { RouterHistory } from '@tanstack/solid-router'
 import './styles.css'
+
+let history: RouterHistory | undefined
+
+if (import.meta.env.VITE_APP_HISTORY === 'hash') {
+  history = createHashHistory()
+}
 
 // Set up a Router instance
 const router = createRouter({
   routeTree,
+  history,
   scrollRestoration: true,
 })
 

--- a/e2e/solid-router/scroll-restoration-sandbox-vite/src/routeTree.gen.ts
+++ b/e2e/solid-router/scroll-restoration-sandbox-vite/src/routeTree.gen.ts
@@ -197,3 +197,39 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRoute
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+/* ROUTE_MANIFEST_START
+{
+  "routes": {
+    "__root__": {
+      "filePath": "__root.tsx",
+      "children": [
+        "/",
+        "/(tests)/lazy-page",
+        "/(tests)/lazy-with-loader-page",
+        "/(tests)/normal-page",
+        "/(tests)/page-with-search",
+        "/(tests)/virtual-page"
+      ]
+    },
+    "/": {
+      "filePath": "index.tsx"
+    },
+    "/(tests)/lazy-page": {
+      "filePath": "(tests)/lazy-page.tsx"
+    },
+    "/(tests)/lazy-with-loader-page": {
+      "filePath": "(tests)/lazy-with-loader-page.tsx"
+    },
+    "/(tests)/normal-page": {
+      "filePath": "(tests)/normal-page.tsx"
+    },
+    "/(tests)/page-with-search": {
+      "filePath": "(tests)/page-with-search.tsx"
+    },
+    "/(tests)/virtual-page": {
+      "filePath": "(tests)/virtual-page.lazy.tsx"
+    }
+  }
+}
+ROUTE_MANIFEST_END */

--- a/e2e/solid-router/scroll-restoration-sandbox-vite/tests/app.spec.ts
+++ b/e2e/solid-router/scroll-restoration-sandbox-vite/tests/app.spec.ts
@@ -1,7 +1,12 @@
 import { expect, test } from '@playwright/test'
 
+function toValue(input: string) {
+  const value = process.env.VITE_APP_HISTORY === 'hash' ? `/#${input}` : input
+  return value
+}
+
 test('Smoke - Renders home', async ({ page }) => {
-  await page.goto('/')
+  await page.goto(toValue('/'))
   await expect(
     page.getByRole('heading', { name: 'Welcome Home!' }),
   ).toBeVisible()
@@ -18,7 +23,7 @@ test('Smoke - Renders home', async ({ page }) => {
   test(`On navigate to ${options.to} (from the header), scroll should be at top`, async ({
     page,
   }) => {
-    await page.goto('/')
+    await page.goto(toValue('/'))
     await page.getByRole('link', { name: `Head-${options.to}` }).click()
     await page.waitForTimeout(0)
     await expect(page.getByTestId('at-the-top')).toBeInViewport()
@@ -28,7 +33,7 @@ test('Smoke - Renders home', async ({ page }) => {
   test(`On navigate via index page tests to ${options.to}, scroll should resolve at the bottom`, async ({
     page,
   }) => {
-    await page.goto('/')
+    await page.goto(toValue('/'))
     await page
       .getByRole('link', { name: `${options.to}#at-the-bottom` })
       .click()
@@ -42,9 +47,9 @@ test('Smoke - Renders home', async ({ page }) => {
   }) => {
     let url: string = options.to
     if ('search' in options) {
-      url = `${url}?where=${options.search}`
+      url = `${url}?where=${options.search?.where}`
     }
-    await page.goto(`${url}#at-the-bottom`)
+    await page.goto(toValue(`${url}#at-the-bottom`))
     await page.waitForTimeout(0)
     await expect(page.getByTestId('at-the-bottom')).toBeInViewport()
   })

--- a/e2e/solid-router/scroll-restoration-sandbox-vite/tsconfig.json
+++ b/e2e/solid-router/scroll-restoration-sandbox-vite/tsconfig.json
@@ -9,7 +9,8 @@
     "module": "ESNext",
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "allowJs": true
+    "allowJs": true,
+    "types": ["vite/client", "node"]
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/react-router/src/scroll-restoration.tsx
+++ b/packages/react-router/src/scroll-restoration.tsx
@@ -6,6 +6,7 @@ import type {
   NonNullableUpdater,
   ParsedLocation,
 } from '@tanstack/router-core'
+import type { RouterHistory } from '@tanstack/history'
 
 export type ScrollRestorationEntry = { scrollX: number; scrollY: number }
 
@@ -92,6 +93,7 @@ let ignoreScroll = false
 // toString() it into a script tag to execute as early as possible in the browser
 // during SSR. Additionally, we also call it from within the router lifecycle
 export function restoreScroll(
+  routerHistory: RouterHistory,
   storageKey: string,
   key?: string,
   behavior?: ScrollToOptions['behavior'],
@@ -142,7 +144,7 @@ export function restoreScroll(
     // Which means we've never seen this location before,
     // we need to check if there is a hash in the URL.
     // If there is, we need to scroll it's ID into view.
-    const hash = window.location.hash.split('#')[1]
+    const hash = routerHistory.location.hash.split('#')[1]
 
     if (hash) {
       const hashScrollIntoViewOptions =
@@ -304,6 +306,7 @@ export function setupScrollRestoration(router: AnyRouter, force?: boolean) {
     }
 
     restoreScroll(
+      router.history,
       storageKey,
       cacheKey,
       router.options.scrollRestorationBehavior,

--- a/packages/solid-router/src/scroll-restoration.tsx
+++ b/packages/solid-router/src/scroll-restoration.tsx
@@ -145,7 +145,6 @@ export function restoreScroll(
     // Which means we've never seen this location before,
     // we need to check if there is a hash in the URL.
     // If there is, we need to scroll it's ID into view.
-    // const hash = window.location.hash.split('#')[1]
     const hash = routerHistory.location.hash.split('#')[1]
 
     if (hash) {

--- a/packages/solid-router/src/scroll-restoration.tsx
+++ b/packages/solid-router/src/scroll-restoration.tsx
@@ -7,6 +7,7 @@ import type {
   NonNullableUpdater,
   ParsedLocation,
 } from '@tanstack/router-core'
+import type { RouterHistory } from '@tanstack/history'
 
 export type ScrollRestorationEntry = { scrollX: number; scrollY: number }
 
@@ -52,6 +53,7 @@ export const scrollRestorationCache: ScrollRestorationCache = sessionsStorage
         // update.
         set: (updater) => (
           (scrollRestorationCache.state =
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
             functionalUpdate(updater, scrollRestorationCache.state) ||
             scrollRestorationCache.state),
           window.sessionStorage.setItem(
@@ -92,6 +94,7 @@ let ignoreScroll = false
 // toString() it into a script tag to execute as early as possible in the browser
 // during SSR. Additionally, we also call it from within the router lifecycle
 export function restoreScroll(
+  routerHistory: RouterHistory,
   storageKey: string,
   key?: string,
   behavior?: ScrollToOptions['behavior'],
@@ -142,7 +145,8 @@ export function restoreScroll(
     // Which means we've never seen this location before,
     // we need to check if there is a hash in the URL.
     // If there is, we need to scroll it's ID into view.
-    const hash = window.location.hash.split('#')[1]
+    // const hash = window.location.hash.split('#')[1]
+    const hash = routerHistory.location.hash.split('#')[1]
 
     if (hash) {
       const hashScrollIntoViewOptions =
@@ -304,6 +308,7 @@ export function setupScrollRestoration(router: AnyRouter, force?: boolean) {
     }
 
     restoreScroll(
+      router.history,
       storageKey,
       cacheKey,
       router.options.scrollRestorationBehavior,


### PR DESCRIPTION
The `restoreScroll` function was directly interfacing with `window.location.hash` to get the 'hash' value, which conflicts with how hash routing functions. As such, when the hash value was retrieved, it came back as `#/page#foo` instead of just `#foo` like it would with regular browser history.

Switching it to use the `history` driver attached to the `router` instance, correctly returns the `hash` value irrespective of the type of routing being used.

Fixes #3479 