### PR TITLE
docs(router): improve navigation guide and NavigateOptions documentation

### DIFF
--- a/docs/router/framework/react/api/router/NavigateOptionsType.md
+++ b/docs/router/framework/react/api/router/NavigateOptionsType.md
@@ -35,6 +35,15 @@ The `NavigateOptions` object accepts the following properties:
 - Defaults to `true` so that the scroll position will be reset to 0,0 after the location is committed to the browser history.
 - If `false`, the scroll position will not be reset to 0,0 after the location is committed to history.
 
+### `hashScrollIntoView`
+
+- Type: `boolean | ScrollIntoViewOptions`
+- Optional
+- Defaults to `true` so the element with an id matching the hash will be scrolled into view after the location is committed to history.
+- If `false`, the element with an id matching the hash will not be scrolled into view after the location is committed to history.
+- If an object is provided, it will be passed to the `scrollIntoView` method as options.
+- See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) for more information on `ScrollIntoViewOptions`.
+
 ### `viewTransition`
 
 - Type: `boolean | ViewTransitionOptions`

--- a/docs/router/framework/react/guide/navigation.md
+++ b/docs/router/framework/react/guide/navigation.md
@@ -70,6 +70,18 @@ export type NavigateOptions<
 > = ToOptions<TRouteTree, TFrom, TTo> & {
   // `replace` is a boolean that determines whether the navigation should replace the current history entry or push a new one.
   replace?: boolean
+  // `resetScroll` is a boolean that determines whether scroll position will be reset to 0,0 after the location is committed to browser history.
+  resetScroll?: boolean
+  // `hashScrollIntoView` is a boolean or object that determines whether an id matching the hash will be scrolled into view after the location is committed to history.
+  hashScrollIntoView?: boolean | ScrollIntoViewOptions
+  // `viewTransition` is either a boolean or function that determines if and how the browser will call document.startViewTransition() when navigating.
+  viewTransition?: boolean | ViewTransitionOptions
+  // `ignoreBlocker` is a boolean that determines if navigation should ignore any blockers that might prevent it.
+  ignoreBlocker?: boolean
+  // `reloadDocument` is a boolean that determines if navigation to a route inside of router will trigger a full page load instead of the traditional SPA navigation.
+  reloadDocument?: boolean
+  // `href` is a string that can be used in place of `to` to navigate to a full built href, e.g. pointing to an external target.
+  href?: string
 }
 ```
 


### PR DESCRIPTION
This PR adds missing documentation for both the NavigationOptions type and the Navigation guide.