### PR TITLE
revert(react-router,solid-router): revert #3700

### DIFF
--- a/e2e/react-router/scroll-restoration-sandbox-vite/package.json
+++ b/e2e/react-router/scroll-restoration-sandbox-vite/package.json
@@ -10,7 +10,7 @@
     "serve": "vite preview",
     "start": "vite",
     "test:e2e:browser": "VITE_APP_HISTORY=browser playwright test --config=playwright.browser.config.ts --project=chromium",
-    "test:e2e:hash": "VITE_APP_HISTORY=hash playwright test --config=playwright.hash.config.ts --project=chromium",
+    "test:e2e:hash": "exit 0; VITE_APP_HISTORY=hash playwright test --config=playwright.hash.config.ts --project=chromium",
     "test:e2e": "pnpm run test:e2e:browser && pnpm run test:e2e:hash"
   },
   "dependencies": {

--- a/e2e/solid-router/scroll-restoration-sandbox-vite/package.json
+++ b/e2e/solid-router/scroll-restoration-sandbox-vite/package.json
@@ -10,7 +10,7 @@
     "serve": "vite preview",
     "start": "vite",
     "test:e2e:browser": "VITE_APP_HISTORY=browser playwright test --config=playwright.browser.config.ts --project=chromium",
-    "test:e2e:hash": "VITE_APP_HISTORY=hash playwright test --config=playwright.hash.config.ts --project=chromium",
+    "test:e2e:hash": "exit 0; VITE_APP_HISTORY=hash playwright test --config=playwright.hash.config.ts --project=chromium",
     "test:e2e": "pnpm run test:e2e:browser && pnpm run test:e2e:hash"
   },
   "dependencies": {

--- a/packages/react-router/src/scroll-restoration.tsx
+++ b/packages/react-router/src/scroll-restoration.tsx
@@ -6,7 +6,6 @@ import type {
   NonNullableUpdater,
   ParsedLocation,
 } from '@tanstack/router-core'
-import type { RouterHistory } from '@tanstack/history'
 
 export type ScrollRestorationEntry = { scrollX: number; scrollY: number }
 
@@ -93,12 +92,12 @@ let ignoreScroll = false
 // toString() it into a script tag to execute as early as possible in the browser
 // during SSR. Additionally, we also call it from within the router lifecycle
 export function restoreScroll(
-  routerHistory: RouterHistory,
   storageKey: string,
-  key?: string,
-  behavior?: ScrollToOptions['behavior'],
-  shouldScrollRestoration?: boolean,
-  scrollToTopSelectors?: Array<string>,
+  key: string | undefined,
+  behavior: ScrollToOptions['behavior'] | undefined,
+  shouldScrollRestoration: boolean | undefined,
+  scrollToTopSelectors: Array<string> | undefined,
+  toHash: string,
 ) {
   let byKey: ScrollRestorationByKey
 
@@ -144,7 +143,7 @@ export function restoreScroll(
     // Which means we've never seen this location before,
     // we need to check if there is a hash in the URL.
     // If there is, we need to scroll it's ID into view.
-    const hash = routerHistory.location.hash.split('#')[1]
+    const hash = toHash.split('#')[1]
 
     if (hash) {
       const hashScrollIntoViewOptions =
@@ -305,13 +304,15 @@ export function setupScrollRestoration(router: AnyRouter, force?: boolean) {
       return
     }
 
+    const hash = event.toLocation.hash || ''
+
     restoreScroll(
-      router.history,
       storageKey,
       cacheKey,
-      router.options.scrollRestorationBehavior,
-      router.isScrollRestoring,
-      router.options.scrollToTopSelectors,
+      router.options.scrollRestorationBehavior || undefined,
+      router.isScrollRestoring || undefined,
+      router.options.scrollToTopSelectors || undefined,
+      hash,
     )
 
     if (router.isScrollRestoring) {

--- a/packages/react-router/src/scroll-restoration.tsx
+++ b/packages/react-router/src/scroll-restoration.tsx
@@ -97,7 +97,6 @@ export function restoreScroll(
   behavior: ScrollToOptions['behavior'] | undefined,
   shouldScrollRestoration: boolean | undefined,
   scrollToTopSelectors: Array<string> | undefined,
-  toHash: string,
 ) {
   let byKey: ScrollRestorationByKey
 
@@ -143,7 +142,7 @@ export function restoreScroll(
     // Which means we've never seen this location before,
     // we need to check if there is a hash in the URL.
     // If there is, we need to scroll it's ID into view.
-    const hash = toHash.split('#')[1]
+    const hash = window.location.hash.split('#')[1]
 
     if (hash) {
       const hashScrollIntoViewOptions =
@@ -304,15 +303,12 @@ export function setupScrollRestoration(router: AnyRouter, force?: boolean) {
       return
     }
 
-    const hash = event.toLocation.hash || ''
-
     restoreScroll(
       storageKey,
       cacheKey,
       router.options.scrollRestorationBehavior || undefined,
       router.isScrollRestoring || undefined,
       router.options.scrollToTopSelectors || undefined,
-      hash,
     )
 
     if (router.isScrollRestoring) {

--- a/packages/solid-router/src/scroll-restoration.tsx
+++ b/packages/solid-router/src/scroll-restoration.tsx
@@ -7,7 +7,6 @@ import type {
   NonNullableUpdater,
   ParsedLocation,
 } from '@tanstack/router-core'
-import type { RouterHistory } from '@tanstack/history'
 
 export type ScrollRestorationEntry = { scrollX: number; scrollY: number }
 
@@ -94,12 +93,12 @@ let ignoreScroll = false
 // toString() it into a script tag to execute as early as possible in the browser
 // during SSR. Additionally, we also call it from within the router lifecycle
 export function restoreScroll(
-  routerHistory: RouterHistory,
   storageKey: string,
-  key?: string,
-  behavior?: ScrollToOptions['behavior'],
-  shouldScrollRestoration?: boolean,
-  scrollToTopSelectors?: Array<string>,
+  key: string | undefined,
+  behavior: ScrollToOptions['behavior'] | undefined,
+  shouldScrollRestoration: boolean | undefined,
+  scrollToTopSelectors: Array<string> | undefined,
+  toHash: string,
 ) {
   let byKey: ScrollRestorationByKey
 
@@ -145,7 +144,7 @@ export function restoreScroll(
     // Which means we've never seen this location before,
     // we need to check if there is a hash in the URL.
     // If there is, we need to scroll it's ID into view.
-    const hash = routerHistory.location.hash.split('#')[1]
+    const hash = toHash.split('#')[1]
 
     if (hash) {
       const hashScrollIntoViewOptions =
@@ -306,13 +305,15 @@ export function setupScrollRestoration(router: AnyRouter, force?: boolean) {
       return
     }
 
+    const hash = event.toLocation.hash || ''
+
     restoreScroll(
-      router.history,
       storageKey,
       cacheKey,
-      router.options.scrollRestorationBehavior,
-      router.isScrollRestoring,
-      router.options.scrollToTopSelectors,
+      router.options.scrollRestorationBehavior || undefined,
+      router.isScrollRestoring || undefined,
+      router.options.scrollToTopSelectors || undefined,
+      hash,
     )
 
     if (router.isScrollRestoring) {

--- a/packages/solid-router/src/scroll-restoration.tsx
+++ b/packages/solid-router/src/scroll-restoration.tsx
@@ -98,7 +98,6 @@ export function restoreScroll(
   behavior: ScrollToOptions['behavior'] | undefined,
   shouldScrollRestoration: boolean | undefined,
   scrollToTopSelectors: Array<string> | undefined,
-  toHash: string,
 ) {
   let byKey: ScrollRestorationByKey
 
@@ -144,7 +143,7 @@ export function restoreScroll(
     // Which means we've never seen this location before,
     // we need to check if there is a hash in the URL.
     // If there is, we need to scroll it's ID into view.
-    const hash = toHash.split('#')[1]
+    const hash = window.location.hash.split('#')[1]
 
     if (hash) {
       const hashScrollIntoViewOptions =
@@ -305,15 +304,12 @@ export function setupScrollRestoration(router: AnyRouter, force?: boolean) {
       return
     }
 
-    const hash = event.toLocation.hash || ''
-
     restoreScroll(
       storageKey,
       cacheKey,
       router.options.scrollRestorationBehavior || undefined,
       router.isScrollRestoring || undefined,
       router.options.scrollToTopSelectors || undefined,
-      hash,
     )
 
     if (router.isScrollRestoring) {


### PR DESCRIPTION
#3700 introduced an unintended side-effect with the scroll restoration process in TanStack Start.

This revets the code changes in `@tanstack/react-router` and `@tanstack/solid-router` and short-circuits the tests relevant test scripts introduced in the offending PR.