### PR TITLE
fix: extract props from validator issues

### DIFF
--- a/packages/react-start-client/src/createServerFn.ts
+++ b/packages/react-start-client/src/createServerFn.ts
@@ -1,6 +1,7 @@
 import { default as invariant } from 'tiny-invariant'
 import { default as warning } from 'tiny-warning'
 import { isNotFound, isRedirect } from '@tanstack/react-router'
+import { normalizeValidatorIssues } from '@tanstack/router-core'
 import { mergeHeaders } from './headers'
 import { globalMiddleware } from './registerGlobalMiddleware'
 import { startSerializer } from './serializer'
@@ -802,8 +803,10 @@ function execValidator(validator: AnyValidator, input: unknown): unknown {
     if (result instanceof Promise)
       throw new Error('Async validation not supported')
 
-    if (result.issues)
-      throw new Error(JSON.stringify(result.issues, undefined, 2))
+    if (result.issues) {
+      const issues = normalizeValidatorIssues(result.issues)
+      throw new Error(JSON.stringify(issues, undefined, 2))
+    }
 
     return result.value
   }

--- a/packages/router-core/src/index.ts
+++ b/packages/router-core/src/index.ts
@@ -312,6 +312,7 @@ export type {
   StrictOrFrom,
 } from './utils'
 
+export { normalizeValidatorIssues } from './validators'
 export type {
   StandardSchemaValidatorProps,
   StandardSchemaValidator,


### PR DESCRIPTION
## Changes Summary

Replaces naive JSON serialization of validator issues by extracting [known properties](https://github.com/standard-schema/standard-schema?tab=readme-ov-file#the-interface) first, and then serializing extracted values instead of the error itself.

This makes is possible to avoid errors such as validation library having non-serializable errors.

Changes introduced based on the [Discord discussion](https://discord.com/channels/719702312431386674/1346288913521705002).

## How

Introduces [utilities](https://github.com/standard-schema/standard-schema/tree/main/packages/utils) provided by Standard Schema to the core package, adds `path` attribute which schema defines, exports the normalization function and uses it within the `execValidator.`

## Result

The validation result is provided under message key in the error response:
```json
{
  "$error": {
    "message": "{\n  \"root\": [\n    \"must be an object (was a string)\"\n  ],\n  \"issues\": {}\n}",
    "stack": "... error stacktrace ...",
    "cause": { "$undefined": 0 }
  }
}
```

The validation result is split into two parts - root and issues. `root` aggregates all validation messages that happened at the root (as explained in [When is Issue.path allowed to be undefined? #60](https://github.com/standard-schema/standard-schema/issues/60)), while `issues` contains all errors for which the `path` was present.

## Future Work

### Docs

Maybe it would be good to reword a [docs](https://github.com/standard-schema/standard-schema/issues/60), to mention that `validator` integrate seamlessly with external validators, that implement Standard Schema?

```diff
-Validators also integrate seamlessly with external validators, if you want to use something like Zod.
+Validators also integrate seamlessly with external validators that implement Standard Schema, which includes Zod, Valibot or Arktype among others. Full list of spec-compliant libraries can be found [here](https://github.com/standard-schema/standard-schema?tab=readme-ov-file#what-schema-libraries-implement-the-spec).
``` 