### PR TITLE
fix(solid-start-server-functions-ssr,react-start-server-functions-ssr,solid-start-server-functions-handler,react-start-server-functions-handler): use start-server-core package

### DIFF
--- a/packages/react-start-server-functions-handler/package.json
+++ b/packages/react-start-server-functions-handler/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@tanstack/react-router": "workspace:^",
     "@tanstack/start-client-core": "workspace:^",
-    "@tanstack/react-start-server": "workspace:^",
+    "@tanstack/start-server-core": "workspace:^",
     "tiny-invariant": "^1.3.3"
   },
   "devDependencies": {

--- a/packages/react-start-server-functions-handler/src/index.ts
+++ b/packages/react-start-server-functions-handler/src/index.ts
@@ -5,11 +5,11 @@ import {
   getEvent,
   getResponseStatus,
   toWebRequest,
-} from '@tanstack/react-start-server'
+} from '@tanstack/start-server-core'
 import { startSerializer } from '@tanstack/start-client-core'
 // @ts-expect-error
 import _serverFnManifest from 'tsr:server-fn-manifest'
-import type { H3Event } from '@tanstack/react-start-server'
+import type { H3Event } from '@tanstack/start-server-core'
 
 // NOTE: This is a dummy export to silence warnings about
 // only having a default export.

--- a/packages/react-start-server-functions-ssr/package.json
+++ b/packages/react-start-server-functions-ssr/package.json
@@ -62,9 +62,9 @@
   },
   "dependencies": {
     "@tanstack/server-functions-plugin": "workspace:^",
-    "@tanstack/react-start-server": "workspace:^",
     "@tanstack/react-start-server-functions-fetcher": "workspace:^",
     "@tanstack/start-client-core": "workspace:^",
+    "@tanstack/start-server-core": "workspace:^",
     "tiny-invariant": "^1.3.3"
   },
   "devDependencies": {

--- a/packages/react-start-server-functions-ssr/src/index.ts
+++ b/packages/react-start-server-functions-ssr/src/index.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 import { serverFnFetcher } from '@tanstack/react-start-server-functions-fetcher'
 import { mergeHeaders } from '@tanstack/start-client-core'
-import { getEvent, getHeaders } from '@tanstack/react-start-server'
+import { getEvent, getHeaders } from '@tanstack/start-server-core'
 import type { CreateRpcFn } from '@tanstack/server-functions-plugin'
 
 function sanitizeBase(base: string) {

--- a/packages/solid-start-server-functions-handler/package.json
+++ b/packages/solid-start-server-functions-handler/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/start-client-core": "workspace:^",
-    "@tanstack/solid-start-server": "workspace:^",
+    "@tanstack/start-server-core": "workspace:^",
     "tiny-invariant": "^1.3.3"
   },
   "devDependencies": {

--- a/packages/solid-start-server-functions-handler/src/index.ts
+++ b/packages/solid-start-server-functions-handler/src/index.ts
@@ -5,11 +5,11 @@ import {
   getEvent,
   getResponseStatus,
   toWebRequest,
-} from '@tanstack/solid-start-server'
+} from '@tanstack/start-server-core'
 import { startSerializer } from '@tanstack/start-client-core'
 // @ts-expect-error
 import _serverFnManifest from 'tsr:server-fn-manifest'
-import type { H3Event } from '@tanstack/solid-start-server'
+import type { H3Event } from '@tanstack/start-server-core'
 
 // NOTE: This is a dummy export to silence warnings about
 // only having a default export.

--- a/packages/solid-start-server-functions-ssr/package.json
+++ b/packages/solid-start-server-functions-ssr/package.json
@@ -62,9 +62,9 @@
   },
   "dependencies": {
     "@tanstack/server-functions-plugin": "workspace:^",
-    "@tanstack/solid-start-server": "workspace:^",
     "@tanstack/solid-start-server-functions-fetcher": "workspace:^",
     "@tanstack/start-client-core": "workspace:^",
+    "@tanstack/start-server-core": "workspace:^",
     "tiny-invariant": "^1.3.3"
   },
   "devDependencies": {

--- a/packages/solid-start-server-functions-ssr/src/index.ts
+++ b/packages/solid-start-server-functions-ssr/src/index.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 import { serverFnFetcher } from '@tanstack/solid-start-server-functions-fetcher'
 import { mergeHeaders } from '@tanstack/start-client-core'
-import { getEvent, getHeaders } from '@tanstack/solid-start-server'
+import { getEvent, getHeaders } from '@tanstack/start-server-core'
 import type { CreateRpcFn } from '@tanstack/server-functions-plugin'
 
 function sanitizeBase(base: string) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6054,12 +6054,12 @@ importers:
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../react-router
-      '@tanstack/react-start-server':
-        specifier: workspace:*
-        version: link:../react-start-server
       '@tanstack/start-client-core':
         specifier: workspace:*
         version: link:../start-client-core
+      '@tanstack/start-server-core':
+        specifier: workspace:*
+        version: link:../start-server-core
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3
@@ -6079,9 +6079,6 @@ importers:
 
   packages/react-start-server-functions-ssr:
     dependencies:
-      '@tanstack/react-start-server':
-        specifier: workspace:*
-        version: link:../react-start-server
       '@tanstack/react-start-server-functions-fetcher':
         specifier: workspace:*
         version: link:../react-start-server-functions-fetcher
@@ -6091,6 +6088,9 @@ importers:
       '@tanstack/start-client-core':
         specifier: workspace:*
         version: link:../start-client-core
+      '@tanstack/start-server-core':
+        specifier: workspace:*
+        version: link:../start-server-core
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3
@@ -6700,12 +6700,12 @@ importers:
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../solid-router
-      '@tanstack/solid-start-server':
-        specifier: workspace:^
-        version: link:../solid-start-server
       '@tanstack/start-client-core':
         specifier: workspace:*
         version: link:../start-client-core
+      '@tanstack/start-server-core':
+        specifier: workspace:*
+        version: link:../start-server-core
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3
@@ -6725,15 +6725,15 @@ importers:
       '@tanstack/server-functions-plugin':
         specifier: workspace:*
         version: link:../server-functions-plugin
-      '@tanstack/solid-start-server':
-        specifier: workspace:^
-        version: link:../solid-start-server
       '@tanstack/solid-start-server-functions-fetcher':
         specifier: workspace:^
         version: link:../solid-start-server-functions-fetcher
       '@tanstack/start-client-core':
         specifier: workspace:*
         version: link:../start-client-core
+      '@tanstack/start-server-core':
+        specifier: workspace:*
+        version: link:../start-server-core
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3


### PR DESCRIPTION
instead of
- solid-start-server
- react-start-server

Use in the *-start-server-functions-* packages the agnostic
- start-server-core