### PR TITLE
Allow serializer.ts to handle branded types

### DIFF
--- a/packages/router-core/src/serializer.ts
+++ b/packages/router-core/src/serializer.ts
@@ -1,42 +1,56 @@
 export interface StartSerializer {
-    stringify: (obj: unknown) => string;
-    parse: (str: string) => unknown;
-    encode: <T>(value: T) => T;
-    decode: <T>(value: T) => T;
+  stringify: (obj: unknown) => string
+  parse: (str: string) => unknown
+  encode: <T>(value: T) => T
+  decode: <T>(value: T) => T
 }
 
-export type SerializerStringifyBy<T, TSerializable> = 
-    // Preserve unknown type
-    unknown extends T ? unknown :
-    // Preserve exact primitive types (including brands)
-    [T] extends [string] ? T :
-    [T] extends [number] ? T :
-    [T] extends [boolean] ? T :
-    [T] extends [bigint] ? T :
-    // Standard cases
-    T extends TSerializable ? T : 
-    T extends (...args: Array<any>) => any ? 'Function is not serializable' : 
-    // Recursively process object properties
-    {
-        [K in keyof T]: SerializerStringifyBy<T[K], TSerializable>;
-    };
+export type SerializerStringifyBy<T, TSerializable> =
+  // Preserve unknown type
+  unknown extends T
+    ? unknown
+    : // Preserve exact primitive types (including brands)
+      [T] extends [string]
+      ? T
+      : [T] extends [number]
+        ? T
+        : [T] extends [boolean]
+          ? T
+          : [T] extends [bigint]
+            ? T
+            : // Standard cases
+              T extends TSerializable
+              ? T
+              : T extends (...args: Array<any>) => any
+                ? 'Function is not serializable'
+                : // Recursively process object properties
+                  {
+                    [K in keyof T]: SerializerStringifyBy<T[K], TSerializable>
+                  }
 
-export type SerializerParseBy<T, TSerializable> = 
-    // Preserve unknown type
-    unknown extends T ? unknown :
-    // Preserve exact primitive types (including brands)
-    [T] extends [string] ? T :
-    [T] extends [number] ? T :
-    [T] extends [boolean] ? T :
-    [T] extends [bigint] ? T :
-    // Standard cases
-    T extends TSerializable ? T : 
-    T extends React.JSX.Element ? ReadableStream : 
-    // Recursively process object properties
-    {
-        [K in keyof T]: SerializerParseBy<T[K], TSerializable>;
-    };
+export type SerializerParseBy<T, TSerializable> =
+  // Preserve unknown type
+  unknown extends T
+    ? unknown
+    : // Preserve exact primitive types (including brands)
+      [T] extends [string]
+      ? T
+      : [T] extends [number]
+        ? T
+        : [T] extends [boolean]
+          ? T
+          : [T] extends [bigint]
+            ? T
+            : // Standard cases
+              T extends TSerializable
+              ? T
+              : T extends React.JSX.Element
+                ? ReadableStream
+                : // Recursively process object properties
+                  {
+                    [K in keyof T]: SerializerParseBy<T[K], TSerializable>
+                  }
 
-export type Serializable = Date | undefined | Error | FormData | bigint;
-export type SerializerStringify<T> = SerializerStringifyBy<T, Serializable>;
-export type SerializerParse<T> = SerializerParseBy<T, Serializable>;
+export type Serializable = Date | undefined | Error | FormData | bigint
+export type SerializerStringify<T> = SerializerStringifyBy<T, Serializable>
+export type SerializerParse<T> = SerializerParseBy<T, Serializable>

--- a/packages/router-core/src/serializer.ts
+++ b/packages/router-core/src/serializer.ts
@@ -1,24 +1,42 @@
 export interface StartSerializer {
-  stringify: (obj: unknown) => string
-  parse: (str: string) => unknown
-  encode: <T>(value: T) => T
-  decode: <T>(value: T) => T
+    stringify: (obj: unknown) => string;
+    parse: (str: string) => unknown;
+    encode: <T>(value: T) => T;
+    decode: <T>(value: T) => T;
 }
 
-export type SerializerStringifyBy<T, TSerializable> = T extends TSerializable
-  ? T
-  : T extends (...args: Array<any>) => any
-    ? 'Function is not serializable'
-    : { [K in keyof T]: SerializerStringifyBy<T[K], TSerializable> }
+export type SerializerStringifyBy<T, TSerializable> = 
+    // Preserve unknown type
+    unknown extends T ? unknown :
+    // Preserve exact primitive types (including brands)
+    [T] extends [string] ? T :
+    [T] extends [number] ? T :
+    [T] extends [boolean] ? T :
+    [T] extends [bigint] ? T :
+    // Standard cases
+    T extends TSerializable ? T : 
+    T extends (...args: Array<any>) => any ? 'Function is not serializable' : 
+    // Recursively process object properties
+    {
+        [K in keyof T]: SerializerStringifyBy<T[K], TSerializable>;
+    };
 
-export type SerializerParseBy<T, TSerializable> = T extends TSerializable
-  ? T
-  : T extends React.JSX.Element
-    ? ReadableStream
-    : { [K in keyof T]: SerializerParseBy<T[K], TSerializable> }
+export type SerializerParseBy<T, TSerializable> = 
+    // Preserve unknown type
+    unknown extends T ? unknown :
+    // Preserve exact primitive types (including brands)
+    [T] extends [string] ? T :
+    [T] extends [number] ? T :
+    [T] extends [boolean] ? T :
+    [T] extends [bigint] ? T :
+    // Standard cases
+    T extends TSerializable ? T : 
+    T extends React.JSX.Element ? ReadableStream : 
+    // Recursively process object properties
+    {
+        [K in keyof T]: SerializerParseBy<T[K], TSerializable>;
+    };
 
-export type Serializable = Date | undefined | Error | FormData | bigint
-
-export type SerializerStringify<T> = SerializerStringifyBy<T, Serializable>
-
-export type SerializerParse<T> = SerializerParseBy<T, Serializable>
+export type Serializable = Date | undefined | Error | FormData | bigint;
+export type SerializerStringify<T> = SerializerStringifyBy<T, Serializable>;
+export type SerializerParse<T> = SerializerParseBy<T, Serializable>;


### PR DESCRIPTION
Closes #3157 

I think this might break a test that expects types to be widened (eg: from a string literal to a string) `/createServerMiddleware.test-d.ts` but I'd love a second pair of eyes.

This update should preserve both string literals and brands.