### PR TITLE
docs(quickstart): use create-tsrouter-app for scaffolding a tsrouter app

### DIFF
--- a/docs/router/framework/react/quick-start.md
+++ b/docs/router/framework/react/quick-start.md
@@ -11,15 +11,15 @@ File based route generation (through Vite, and other supported bundlers) is the 
 ### Scaffolding Your First TanStack Router Project
 
 ```sh
-npm create @tanstack/router@latest
+npm create tsrouter-app@latest my-app --template file-router
 # or
-pnpm create @tanstack/router
+pnpm create tsrouter-app@latest my-app --template file-router
 # or
-yarn create @tanstack/router
+yarn create tsrouter-app@latest my-app --template file-router
 # or
-bun create @tanstack/router
+bun create tsrouter-app@latest my-app --template file-router
 # or
-deno init --npm @tanstack/router
+deno run -A npm:create-tsrouter-app@latest my-app --template file-router
 ```
 
 Follow the prompts to scaffold a full TanStack Router project.

--- a/docs/router/framework/solid/quick-start.md
+++ b/docs/router/framework/solid/quick-start.md
@@ -8,9 +8,25 @@ If you're feeling impatient and prefer to skip all of our wonderful documentatio
 
 File based route generation (through Vite, and other supported bundlers) is the recommended way to use TanStack Router as it provides the best experience, performance, and ergonomics for the least amount of effort.
 
-### Setup
+### Scaffolding Your First TanStack Router Project
 
-You can setup the project using the following steps:
+```sh
+npm create tsrouter-app@latest my-app --template file-router
+# or
+pnpm create tsrouter-app@latest my-app --template file-router
+# or
+yarn create tsrouter-app@latest my-app --template file-router
+# or
+bun create tsrouter-app@latest my-app --template file-router
+# or
+deno run -A npm:create-tsrouter-app@latest my-app --template file-router
+```
+
+Follow the prompts to scaffold a full TanStack Router project.
+
+### Manual Setup
+
+Alternatively, you can manually setup the project using the following steps:
 
 #### Install TanStack Router, Vite Plugin
 

--- a/docs/router/framework/solid/quick-start.md
+++ b/docs/router/framework/solid/quick-start.md
@@ -11,15 +11,15 @@ File based route generation (through Vite, and other supported bundlers) is the 
 ### Scaffolding Your First TanStack Router Project
 
 ```sh
-npm create tsrouter-app@latest my-app --template file-router
+npm create tsrouter-app@latest my-app --template file-router --framework solid
 # or
-pnpm create tsrouter-app@latest my-app --template file-router
+pnpm create tsrouter-app@latest my-app --template file-router --framework solid
 # or
-yarn create tsrouter-app@latest my-app --template file-router
+yarn create tsrouter-app@latest my-app --template file-router --framework solid
 # or
-bun create tsrouter-app@latest my-app --template file-router
+bun create tsrouter-app@latest my-app --template file-router --framework solid
 # or
-deno run -A npm:create-tsrouter-app@latest my-app --template file-router
+deno run -A npm:create-tsrouter-app@latest my-app --template file-router --framework solid
 ```
 
 Follow the prompts to scaffold a full TanStack Router project.


### PR DESCRIPTION
This use the new create-tsrouter-app to scaffold tsrouter apps.

On this quickstart page
https://tanstack.com/router/latest/docs/framework/react/quick-start
https://tanstack.com/router/latest/docs/framework/solid/quick-start
