### PR TITLE
fix(router-devtools-core): propagate toggleButtonProps properly

### DIFF
--- a/packages/react-router-devtools/src/TanStackRouterDevtools.tsx
+++ b/packages/react-router-devtools/src/TanStackRouterDevtools.tsx
@@ -3,6 +3,7 @@ import { Fragment, useEffect, useRef, useState } from 'react'
 import { useRouter, useRouterState } from '@tanstack/react-router'
 import type { AnyRouter } from '@tanstack/react-router'
 import type React from 'react'
+import type { JSX } from 'solid-js'
 
 interface DevtoolsOptions {
   /**
@@ -12,24 +13,15 @@ interface DevtoolsOptions {
   /**
    * Use this to add props to the panel. For example, you can add className, style (merge and override default style), etc.
    */
-  panelProps?: React.DetailedHTMLProps<
-    React.HTMLAttributes<HTMLDivElement>,
-    HTMLDivElement
-  >
+  panelProps?: JSX.HTMLAttributes<HTMLDivElement>
   /**
    * Use this to add props to the close button. For example, you can add className, style (merge and override default style), onClick (extend default handler), etc.
    */
-  closeButtonProps?: React.DetailedHTMLProps<
-    React.ButtonHTMLAttributes<HTMLButtonElement>,
-    HTMLButtonElement
-  >
+  closeButtonProps?: JSX.ButtonHTMLAttributes<HTMLButtonElement>
   /**
    * Use this to add props to the toggle button. For example, you can add className, style (merge and override default style), onClick (extend default handler), etc.
    */
-  toggleButtonProps?: React.DetailedHTMLProps<
-    React.ButtonHTMLAttributes<HTMLButtonElement>,
-    HTMLButtonElement
-  >
+  toggleButtonProps?: JSX.ButtonHTMLAttributes<HTMLButtonElement>
   /**
    * The position of the TanStack Router logo to open and close the devtools panel.
    * Defaults to 'bottom-left'.

--- a/packages/router-devtools-core/src/TanStackRouterDevtoolsCore.tsx
+++ b/packages/router-devtools-core/src/TanStackRouterDevtoolsCore.tsx
@@ -54,19 +54,25 @@ class TanStackRouterDevtoolsCore {
   #position: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
   #initialIsOpen: boolean
   #shadowDOMTarget?: ShadowRoot
+
+  #panelProps: any
+  #closeButtonProps: any
+  #toggleButtonProps: any
+
   #isMounted = false
   #Component: any
   #dispose?: () => void
 
   constructor(config: DevtoolsOptions) {
-    const { router, routerState, position, initialIsOpen, shadowDOMTarget } =
-      config
+    this.#router = createSignal(config.router)
+    this.#routerState = createSignal(config.routerState)
+    this.#position = config.position ?? 'bottom-left'
+    this.#initialIsOpen = config.initialIsOpen ?? false
+    this.#shadowDOMTarget = config.shadowDOMTarget
 
-    this.#router = createSignal(router)
-    this.#routerState = createSignal(routerState)
-    this.#position = position ?? 'bottom-left'
-    this.#initialIsOpen = initialIsOpen ?? false
-    this.#shadowDOMTarget = shadowDOMTarget
+    this.#panelProps = config.panelProps
+    this.#closeButtonProps = config.closeButtonProps
+    this.#toggleButtonProps = config.toggleButtonProps
   }
 
   mount<T extends HTMLElement>(el: T) {
@@ -80,6 +86,10 @@ class TanStackRouterDevtoolsCore {
       const position = this.#position
       const initialIsOpen = this.#initialIsOpen
       const shadowDOMTarget = this.#shadowDOMTarget
+
+      const panelProps = this.#panelProps
+      const closeButtonProps = this.#closeButtonProps
+      const toggleButtonProps = this.#toggleButtonProps
 
       let Devtools
 
@@ -97,6 +107,9 @@ class TanStackRouterDevtoolsCore {
           shadowDOMTarget={shadowDOMTarget}
           router={router}
           routerState={routerState}
+          panelProps={panelProps}
+          closeButtonProps={closeButtonProps}
+          toggleButtonProps={toggleButtonProps}
         />
       )
     }, el)


### PR DESCRIPTION
Closes https://github.com/TanStack/router/issues/3746

With this change, setting on the DevTools the properties:
- panelProps
- closeButtonProps
- toggleButtonProps

Will propagate those values, such as `style` or `class`  correctly to the respective DOM elements.