### PR TITLE
fix(react-router-devtools): remove console warnings from useRouter

### DIFF
--- a/packages/react-router-devtools/src/TanStackRouterDevtools.tsx
+++ b/packages/react-router-devtools/src/TanStackRouterDevtools.tsx
@@ -57,7 +57,7 @@ export function TanStackRouterDevtools(
     router: propsRouter,
   } = props
 
-  const hookRouter = useRouter({ warn: propsRouter !== undefined })
+  const hookRouter = useRouter({warn: false})
   const activeRouter = propsRouter ?? hookRouter
 
   const activeRouterState = useRouterState({ router: activeRouter })

--- a/packages/react-router-devtools/src/TanStackRouterDevtools.tsx
+++ b/packages/react-router-devtools/src/TanStackRouterDevtools.tsx
@@ -57,7 +57,7 @@ export function TanStackRouterDevtools(
     router: propsRouter,
   } = props
 
-  const hookRouter = useRouter({warn: false})
+  const hookRouter = useRouter({ warn: false })
   const activeRouter = propsRouter ?? hookRouter
 
   const activeRouterState = useRouterState({ router: activeRouter })


### PR DESCRIPTION
Closes https://github.com/TanStack/router/issues/3723

The hooks rules makes it impossible to have the same conditional logic for the useRouter call as the solid-router-devtools has, so this mutes the warning to avoid flooding the browser console, because the setup here is intentional.