### PR TITLE
fix(history): double `/` being added in hash routing

### DIFF
--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -546,11 +546,12 @@ export function createHashHistory(opts?: { window?: any }): RouterHistory {
   return createBrowserHistory({
     window: win,
     parseLocation: () => {
-      const hashSplit = win.location.hash.split("#").slice(1)
-      const pathPart = hashSplit[0] ?? "/"
+      const hashSplit = win.location.hash.split('#').slice(1)
+      const pathPart = hashSplit[0] ?? '/'
       const searchPart = win.location.search
       const hashEntries = hashSplit.slice(1)
-      const hashPart = hashEntries.length === 0 ? "" : `#${hashEntries.join("#")}`
+      const hashPart =
+        hashEntries.length === 0 ? '' : `#${hashEntries.join('#')}`
       const hashHref = `${pathPart}${searchPart}${hashPart}`
       return parseHref(hashHref, win.history.state)
     },

--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -546,9 +546,12 @@ export function createHashHistory(opts?: { window?: any }): RouterHistory {
   return createBrowserHistory({
     window: win,
     parseLocation: () => {
-      const search = win.location.search
-      const pathname = win.location.hash.substring(1)
-      const hashHref = search ? `/${pathname}${search}` : `/${pathname}`
+      const hashSplit = win.location.hash.split("#").slice(1)
+      const pathPart = hashSplit[0] ?? "/"
+      const searchPart = win.location.search
+      const hashEntries = hashSplit.slice(1)
+      const hashPart = hashEntries.length === 0 ? "" : `#${hashEntries.join("#")}`
+      const hashHref = `${pathPart}${searchPart}${hashPart}`
       return parseHref(hashHref, win.history.state)
     },
     createHref: (href) =>

--- a/packages/history/tests/createHashHistory.test.ts
+++ b/packages/history/tests/createHashHistory.test.ts
@@ -7,7 +7,7 @@ describe('createHashHistory', () => {
     describe.each([
       ['/', { pathname: '/', search: '' }, 'neither search params nor hash'],
       [
-        '/#hello',
+        '/#/hello',
         { pathname: '/hello', search: '' },
         'hash present, no search params',
       ],
@@ -17,12 +17,12 @@ describe('createHashHistory', () => {
         'search params present, no hash',
       ],
       [
-        '/#hello?search=params',
+        '/#/hello?search=params',
         { pathname: '/hello', search: '?search=params' },
         'both hash and search params present, in that order',
       ],
       [
-        '/?search=params#hello',
+        '/?search=params#/hello',
         { pathname: '/hello', search: '?search=params' },
         'both search params and hash present, in that order',
       ],


### PR DESCRIPTION
This more cleanly and safely constructs a href with search parameters and prevents incorrectly adding a double slash to the start of the URL that was introduced in #3644.

Fixes #3739
Fixes #3699