### PR TITLE
fix(react-router): missing `Symbol` declaration for HMR

### DIFF
--- a/packages/react-router/src/route.ts
+++ b/packages/react-router/src/route.ts
@@ -193,6 +193,7 @@ export class Route<
     >,
   ) {
     super(options)
+    ;(this as any).$$typeof = Symbol.for('react.memo')
   }
 
   useMatch: UseMatchRoute<TId> = (opts) => {


### PR DESCRIPTION
As part of the move to `router-core` in https://github.com/TanStack/router/pull/3803, we accidentally removed the `Symbol` declaration that was being performed in the constructor of the `Route` class. This had a downstream effect on the HMR functionality provided by `@vitejs/plugin-react`.

Fixes #3815 