### PR TITLE
refactor: Make (zod|valibot|arktype)-adapter agnostic

### DIFF
--- a/packages/arktype-adapter/package.json
+++ b/packages/arktype-adapter/package.json
@@ -65,6 +65,7 @@
   },
   "devDependencies": {
     "@tanstack/react-router": "workspace:*",
+    "@tanstack/router-core": "workspace:^",
     "arktype": "^2.1.7",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
@@ -73,6 +74,6 @@
   },
   "peerDependencies": {
     "arktype": ">=2.0.0-rc <3",
-    "@tanstack/react-router": ">=1.43.2"
+    "@tanstack/router-core": "workspace:^"
   }
 }

--- a/packages/arktype-adapter/src/index.ts
+++ b/packages/arktype-adapter/src/index.ts
@@ -1,4 +1,4 @@
-import type { ValidatorAdapter } from '@tanstack/react-router'
+import type { ValidatorAdapter } from '@tanstack/router-core'
 
 export interface ArkTypeLike {
   infer: any

--- a/packages/valibot-adapter/package.json
+++ b/packages/valibot-adapter/package.json
@@ -67,12 +67,13 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
     "@tanstack/react-router": "workspace:^",
+    "@tanstack/router-core": "workspace:^",
     "valibot": "1.0.0-beta.15",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "peerDependencies": {
     "valibot": "^1.0.0 || ^1.0.0-beta.5 || ^1.0.0-rc",
-    "@tanstack/react-router": ">=1.43.2"
+    "@tanstack/router-core": "workspace:^"
   }
 }

--- a/packages/valibot-adapter/src/index.ts
+++ b/packages/valibot-adapter/src/index.ts
@@ -1,5 +1,5 @@
 import { parse } from 'valibot'
-import type { ValidatorAdapter } from '@tanstack/react-router'
+import type { ValidatorAdapter } from '@tanstack/router-core'
 import type { GenericSchema, InferInput, InferOutput } from 'valibot'
 
 export type ValibotValidatorAdapter<TOptions extends GenericSchema> =

--- a/packages/zod-adapter/package.json
+++ b/packages/zod-adapter/package.json
@@ -67,12 +67,13 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
     "@tanstack/react-router": "workspace:^",
+    "@tanstack/router-core": "workspace:^",
     "zod": "^3.24.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "peerDependencies": {
     "zod": "^3.23.8",
-    "@tanstack/react-router": ">=1.43.2"
+    "@tanstack/router-core": "workspace:^"
   }
 }

--- a/packages/zod-adapter/src/index.ts
+++ b/packages/zod-adapter/src/index.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import type { ValidatorAdapter } from '@tanstack/react-router'
+import type { ValidatorAdapter } from '@tanstack/router-core'
 
 export interface ZodTypeLike {
   _input: any

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5510,6 +5510,9 @@ importers:
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../react-router
+      '@tanstack/router-core':
+        specifier: workspace:*
+        version: link:../router-core
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.6.3
@@ -6907,6 +6910,9 @@ importers:
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../react-router
+      '@tanstack/router-core':
+        specifier: workspace:*
+        version: link:../router-core
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.6.3
@@ -6930,6 +6936,9 @@ importers:
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../react-router
+      '@tanstack/router-core':
+        specifier: workspace:*
+        version: link:../router-core
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.6.3


### PR DESCRIPTION
`@tanstack/react-router` remains a dev dependency because it's still used in tests