### PR TITLE
chore(examples,e2e): incorrect label value for "email"

### DIFF
--- a/e2e/react-start/basic-auth/src/components/Auth.tsx
+++ b/e2e/react-start/basic-auth/src/components/Auth.tsx
@@ -22,7 +22,7 @@ export function Auth({
         >
           <div>
             <label htmlFor="email" className="block text-xs">
-              Username
+              Email
             </label>
             <input
               type="email"

--- a/examples/react/start-basic-auth/src/components/Auth.tsx
+++ b/examples/react/start-basic-auth/src/components/Auth.tsx
@@ -22,7 +22,7 @@ export function Auth({
         >
           <div>
             <label htmlFor="email" className="block text-xs">
-              Username
+              Email
             </label>
             <input
               type="email"


### PR DESCRIPTION
It should be "Email" instead of "Username"

See:

<img width="1441" alt="image" src="https://github.com/user-attachments/assets/20ef0b42-ba39-4ac0-ad91-0380347964bc" />