### PR TITLE
feat: add biome lint ignore comment to routegen

### DIFF
--- a/packages/router-generator/src/config.ts
+++ b/packages/router-generator/src/config.ts
@@ -27,6 +27,7 @@ export const configSchema = z.object({
       '/* eslint-disable */',
       '// @ts-nocheck',
       '// noinspection JSUnusedGlobalSymbols',
+      '// biome-ignore-all'
     ]),
   routeTreeFileFooter: z.array(z.string()).optional().default([]),
   autoCodeSplitting: z.boolean().optional(),


### PR DESCRIPTION
Biome just dropped their [2.0 beta](https://biomejs.dev/blog/biome-v2-0-beta/) and you can now add a comment to ignore all lint rules in a file. It would be cool if Tanstack router should included that comment in the generated routes file, like it does for ESLint.