### PR TITLE
docs(start): switch from `degit` to `gitpick`

### DIFF
--- a/docs/start/framework/react/quick-start.md
+++ b/docs/start/framework/react/quick-start.md
@@ -8,7 +8,7 @@ title: Quick Start
 If you're impatient, you can clone and run the [Basic](../examples/start-basic) example right away with the following commands:
 
 ```bash
-npx degit https://github.com/tanstack/router/examples/react/start-basic start-basic
+npx gitpick TanStack/router/tree/main/examples/react/start-basic start-basic
 cd start-basic
 npm install
 npm run dev
@@ -45,7 +45,7 @@ To quickly deploy an example, click the **Deploy to Netlify** button on an examp
 To manually clone and deploy the example to anywhere else you'd like, use the following commands replacing `EXAMPLE_SLUG` with the slug of the example you'd like to use from above:
 
 ```bash
-npx degit https://github.com/tanstack/router/examples/react/EXAMPLE_SLUG my-new-project
+npx gitpick TanStack/router/tree/main/examples/react/EXAMPLE_SLUG my-new-project
 cd my-new-project
 npm install
 npm run dev


### PR DESCRIPTION
### FROM

<img width="581" alt="Screenshot 2025-03-27 at 5 19 56 AM" src="https://github.com/user-attachments/assets/48d681ad-d2c6-4540-94fc-db184c21da8d" />

- initial cloning with degit takes 30s and more
- unnatural url, user/repo/subdir? when shared if you copy and visit the url, results in not found
- creates cache directory in "$HOME/.degit" i.e. unknown to the user (user does cd ~, and wonder can I delete .degit dir?)
- not maintained anymore, degit --help doesn't work either

### TO

<img width="681" alt="Screenshot 2025-03-27 at 5 20 41 AM" src="https://github.com/user-attachments/assets/fdf3c4a0-7887-428a-a566-df606c0b2a83" />

- [gitpick](https://github.com/nrjdalal/gitpick) takes 2-3 secs, be that initially or any run, no cache dir, always updated to latest repository status
- can use shorter URLs like `TanStack/router/tree/main/examples/react/start-basic`, no need to prepend github.com
- natural URL, you can just copy any URL and paste it from the github repository (can copy any branch or any URL, even files)
- follows exact `git` behaviour, with extension like `-o` for overwrite
- can clone from private repository, see [docs](https://github.com/nrjdalal/gitpick#readme) for more

### GitPick

<img width="400" alt="GitPick Meme" src="https://github.com/user-attachments/assets/dde09ae9-1ee4-4cd8-a181-91f8e6ed6ba6" />
