### PR TITLE
fix(react-router-with-query): skip client-side redirect handling during ssr

### DIFF
--- a/packages/react-router-with-query/src/index.tsx
+++ b/packages/react-router-with-query/src/index.tsx
@@ -116,7 +116,7 @@ export function routerWithQueryClient<TRouter extends AnyRouter>(
     queryClient.getMutationCache().config = {
       ...ogMutationCacheConfig,
       onError: (error, _variables, _context, _mutation) => {
-        if (isRedirect(error)) {
+        if (isRedirect(error) && !router.isServer) {
           return router.navigate(
             router.resolveRedirect({
               ...error,
@@ -138,7 +138,7 @@ export function routerWithQueryClient<TRouter extends AnyRouter>(
     queryClient.getQueryCache().config = {
       ...ogQueryCacheConfig,
       onError: (error, _query) => {
-        if (isRedirect(error)) {
+        if (isRedirect(error) && !router.isServer) {
           return router.navigate(
             router.resolveRedirect({
               ...error,


### PR DESCRIPTION
When a query function throws a redirect during ssr, it causes mismatch errors on the client. This seems to be because `react-router-with-query` applies its client-side redirect handling in server contexts.

This change skips the client-side redirection handling during ssr, preventing these mismatches.