### PR TITLE
docs(router): simplify route variable naming in search params guide

### DIFF
--- a/docs/router/framework/react/guide/search-params.md
+++ b/docs/router/framework/react/guide/search-params.md
@@ -420,14 +420,15 @@ const ProductList = () => {
 You can access your route's validated search params anywhere in your app using the `useSearch` hook. By passing the `from` id/path of your origin route, you'll get even better type safety:
 
 ```tsx
-const Route = createRoute({
-  getParentRoute: () => shopRoute,
-  path: 'products',
+// /routes/shop.products.tsx
+export const Route = createFileRoute('/shop/products')({
   validateSearch: productSearchSchema,
+  // ...
 })
 
 // Somewhere else...
 
+// /components/product-list-sidebar.tsx
 const routeApi = getRouteApi('/shop/products')
 
 const ProductList = () => {

--- a/docs/router/framework/react/guide/search-params.md
+++ b/docs/router/framework/react/guide/search-params.md
@@ -481,10 +481,7 @@ export const Route = createFileRoute('/shop/products')({
 const ProductList = () => {
   return (
     <div>
-      <Link
-        from={Route.fullPath}
-        search={(prev) => ({ page: prev.page + 1 })}
-      >
+      <Link from={Route.fullPath} search={(prev) => ({ page: prev.page + 1 })}>
         Next Page
       </Link>
     </div>

--- a/docs/router/framework/react/guide/search-params.md
+++ b/docs/router/framework/react/guide/search-params.md
@@ -111,7 +111,7 @@ export const Route = createFileRoute('/shop/products')({
 })
 ```
 
-In the above example, we're validating the search params of the `allProductsRoute` and returning a typed `ProductSearch` object. This typed object is then made available to this route's other options **and any child routes, too!**
+In the above example, we're validating the search params of the `Route` and returning a typed `ProductSearch` object. This typed object is then made available to this route's other options **and any child routes, too!**
 
 ### Validating Search Params
 
@@ -420,7 +420,7 @@ const ProductList = () => {
 You can access your route's validated search params anywhere in your app using the `useSearch` hook. By passing the `from` id/path of your origin route, you'll get even better type safety:
 
 ```tsx
-const allProductsRoute = createRoute({
+const Route = createRoute({
   getParentRoute: () => shopRoute,
   path: 'products',
   validateSearch: productSearchSchema,
@@ -436,7 +436,7 @@ const ProductList = () => {
   // OR
 
   const { page, filter, sort } = useSearch({
-    from: allProductsRoute.fullPath,
+    from: Route.fullPath,
   })
 
   return <div>...</div>
@@ -481,7 +481,7 @@ const ProductList = () => {
   return (
     <div>
       <Link
-        from={allProductsRoute.fullPath}
+        from={Route.fullPath}
         search={(prev) => ({ page: prev.page + 1 })}
       >
         Next Page


### PR DESCRIPTION
In the "search params" guide, the usage of the variable `allProductsRoute` has been changed to `Route` in the code-block examples for consistency and clarity.
This makes the examples easier to follow since `Route` is used throughout the rest of the documentation.