### PR TITLE
Update api-routes.md

### DIFF
--- a/docs/start/framework/react/api-routes.md
+++ b/docs/start/framework/react/api-routes.md
@@ -63,7 +63,7 @@ API Routes export an APIRoute instance by calling the `createAPIFileRoute` funct
 > If you've already got the dev server running, when you create a new API route, it'll automatically have the initial handler set up for you. From there on, you can customize the handler as needed.
 
 > [!NOTE]
-> The export variable must be  named `APIRoute` or the resulting response will be a `404 not found`.
+> The export variable must be named `APIRoute` or the resulting response will be a `404 not found`.
 
 ```ts
 // routes/api/hello.ts

--- a/docs/start/framework/react/api-routes.md
+++ b/docs/start/framework/react/api-routes.md
@@ -60,7 +60,10 @@ This file is responsible for creating the API handler that will be used to route
 API Routes export an APIRoute instance by calling the `createAPIFileRoute` function. Similar to other file-based routes in TanStack Router, the first argument to this function is the path of the route. The function returned is called again with an object that defines the route handlers for each HTTP method.
 
 > [!TIP]
-> If you've already got the dev server running, when you create a new API route, it'll automatically have the initial handler set up for you. From there on, you can customize the handler as needed. Note: the constant you export must be named `APIRoute` or the respone will be a `404 not found`.
+> If you've already got the dev server running, when you create a new API route, it'll automatically have the initial handler set up for you. From there on, you can customize the handler as needed.
+
+> [!NOTE]
+> The export variable must be  named `APIRoute` or the resulting response will be a `404 not found`.
 
 ```ts
 // routes/api/hello.ts

--- a/docs/start/framework/react/api-routes.md
+++ b/docs/start/framework/react/api-routes.md
@@ -60,7 +60,7 @@ This file is responsible for creating the API handler that will be used to route
 API Routes export an APIRoute instance by calling the `createAPIFileRoute` function. Similar to other file-based routes in TanStack Router, the first argument to this function is the path of the route. The function returned is called again with an object that defines the route handlers for each HTTP method.
 
 > [!TIP]
-> If you've already got the dev server running, when you create a new API route, it'll automatically have the initial handler set up for you. From there on, you can customize the handler as needed.
+> If you've already got the dev server running, when you create a new API route, it'll automatically have the initial handler set up for you. From there on, you can customize the handler as needed. Note: the constant you export must be named `APIRoute` or the respone will be a `404 not found`.
 
 ```ts
 // routes/api/hello.ts


### PR DESCRIPTION
quick note to prevent 404s for others (I had copy & pasted from a non-api regular file route, changed the function to `createAPIFileRoute` and had accidentally left `export const Route`