### PR TITLE
docs(router): correct ReturnType of `Router.matchRoute` to match the runtime output

### DIFF
--- a/docs/router/framework/react/api/router/RouterType.md
+++ b/docs/router/framework/react/api/router/RouterType.md
@@ -189,7 +189,7 @@ Loads the JS chunk of the route.
 
 Matches a pathname and search params against the router's route tree and returns a route match's params or false if no match was found.
 
-- Type: `(dest: ToOptions, matchOpts?: MatchRouteOptions) => RouteMatch | false`
+- Type: `(dest: ToOptions, matchOpts?: MatchRouteOptions) => RouteMatch['params'] | false`
 - Properties
   - `dest`
     - Type: `ToOptions`
@@ -200,7 +200,7 @@ Matches a pathname and search params against the router's route tree and returns
     - Optional
     - Options that will be used to match the destination.
 - Returns
-  - A route match object if a match was found.
+  - A route match's params if a match was found.
   - `false` if no match was found.
 
 ### `.dehydrate` method


### PR DESCRIPTION
The `.matchRoute` method on the Router type page previously stated it returns a `RouteMatch` object. In reality, it returns only the route match's params.

This update corrects the return type in docs to reflect actual behavior.

Fix #3875 