### PR TITLE
fix(router-devtools-core): remove floating panel style on close

### DIFF
--- a/packages/router-devtools-core/src/FloatingTanStackRouterDevtools.tsx
+++ b/packages/router-devtools-core/src/FloatingTanStackRouterDevtools.tsx
@@ -161,6 +161,16 @@ export function FloatingTanStackRouterDevtools({
           }
         }
       }
+    } else {
+      // Reset padding when devtools are closed
+      if (rootEl()?.parentElement) {
+        setRootEl((prev) => {
+          if (prev?.parentElement) {
+            prev.parentElement.style.paddingBottom = '0px'
+          }
+          return prev
+        })
+      }
     }
     return
   })

--- a/packages/router-devtools-core/src/FloatingTanStackRouterDevtools.tsx
+++ b/packages/router-devtools-core/src/FloatingTanStackRouterDevtools.tsx
@@ -166,7 +166,7 @@ export function FloatingTanStackRouterDevtools({
       if (rootEl()?.parentElement) {
         setRootEl((prev) => {
           if (prev?.parentElement) {
-            prev.parentElement.style.removeProperty('padding-bottom')
+            prev.parentElement.removeAttribute('style')
           }
           return prev
         })

--- a/packages/router-devtools-core/src/FloatingTanStackRouterDevtools.tsx
+++ b/packages/router-devtools-core/src/FloatingTanStackRouterDevtools.tsx
@@ -166,7 +166,7 @@ export function FloatingTanStackRouterDevtools({
       if (rootEl()?.parentElement) {
         setRootEl((prev) => {
           if (prev?.parentElement) {
-            prev.parentElement.style.paddingBottom = '0px'
+            prev.parentElement.style.removeProperty('padding-bottom')
           }
           return prev
         })


### PR DESCRIPTION
closes https://github.com/TanStack/router/issues/3897
- #3897

When the devtools are closed, this removes the style attribute, including the lingering padding-bottom property