### PR TITLE
Fix HeadContent docs

### DIFF
--- a/docs/router/framework/react/guide/document-head-management.md
+++ b/docs/router/framework/react/guide/document-head-management.md
@@ -20,7 +20,7 @@ To manage the document head, it's required that you render both the `<HeadConten
 ## Managing the Document Head
 
 ```tsx
-export const Route = createRootRoute()({
+export const Route = createRootRoute({
   head: () => ({
     meta: [
       {
@@ -64,7 +64,7 @@ It should be **rendered either in the `<head>` tag of your root layout or as hig
 ```tsx
 import { HeadContent } from '@tanstack/react-router'
 
-export const Route = createRootRoute()({
+export const Route = createRootRoute({
   component: () => (
     <html>
       <head>
@@ -83,7 +83,7 @@ export const Route = createRootRoute()({
 ```tsx
 import { HeadContent } from '@tanstack/react-router'
 
-const rootRoute = createRootRoute()({
+const rootRoute = createRootRoute({
   component: () => (
     <>
       <HeadContent />
@@ -103,7 +103,7 @@ To do this, you must:
 - [Render the `<Scripts />` component](#scripts)
 
 ```tsx
-export const Route = createRootRoute()({
+export const Route = createRootRoute({
   scripts: [
     {
       children: 'console.log("Hello, world!")',
@@ -136,7 +136,7 @@ export const Router = createFileRoute('/')({
 ```tsx
 import { Scripts, createRootRoute } from '@tanstack/react-router'
 
-export const Route = createRootRoute()({
+export const Route = createRootRoute({
   component: () => (
     <>
       <Outlet />

--- a/docs/router/framework/react/guide/document-head-management.md
+++ b/docs/router/framework/react/guide/document-head-management.md
@@ -83,7 +83,7 @@ export const Route = createRootRoute()({
 ```tsx
 import { HeadContent } from '@tanstack/react-router'
 
-const rootRoute = createRoute({
+const rootRoute = createRootRoute()({
   component: () => (
     <>
       <HeadContent />


### PR DESCRIPTION
## Changes

1. **Fix createRootRoute syntax**: Updated all examples in the document head management guide to use the correct `createRootRoute({...})` syntax instead of the incorrect `createRootRoute()({...})` syntax.

2. **Fix HeadContent placement**: The previous commit corrected the code example for Single-Page Applications to properly show the correct syntax for creating a root route with HeadContent.

## Why these changes matter

- The incorrect syntax examples could lead to confusion for developers implementing document head management in their applications
- These fixes ensure consistency throughout the documentation and provide developers with the correct implementation patterns
- Proper documentation helps reduce support requests and improves developer experience

## Technical details

- Fixed 5 instances of incorrect `createRootRoute()({...})` syntax throughout the document
- Previously fixed the SPA example which had an incorrect API reference

These changes ensure that all code examples in the document head management guide are correct and consistent with the actual API implementation.