### PR TITLE
fix(react-router): restore scroll position onResolved

### DIFF
--- a/packages/react-router/src/Transitioner.tsx
+++ b/packages/react-router/src/Transitioner.tsx
@@ -117,6 +117,18 @@ export function Transitioner() {
         status: 'idle',
         resolvedLocation: s.location,
       }))
+
+      if (typeof document !== 'undefined' && (document as any).querySelector) {
+        const hashScrollIntoViewOptions =
+          router.state.location.state.__hashScrollIntoViewOptions ?? true
+
+        if (hashScrollIntoViewOptions && router.state.location.hash !== '') {
+          const el = document.getElementById(router.state.location.hash)
+          if (el) {
+            el.scrollIntoView(hashScrollIntoViewOptions)
+          }
+        }
+      }
     }
   }, [isAnyPending, previousIsAnyPending, router])
 

--- a/packages/react-router/src/Transitioner.tsx
+++ b/packages/react-router/src/Transitioner.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react'
-import { getLocationChangeInfo, trimPathRight } from '@tanstack/router-core'
+import {
+  getLocationChangeInfo,
+  handleHashScroll,
+  trimPathRight,
+} from '@tanstack/router-core'
 import { useLayoutEffect, usePrevious } from './utils'
 import { useRouter } from './useRouter'
 import { useRouterState } from './useRouterState'
@@ -118,17 +122,7 @@ export function Transitioner() {
         resolvedLocation: s.location,
       }))
 
-      if (typeof document !== 'undefined' && (document as any).querySelector) {
-        const hashScrollIntoViewOptions =
-          router.state.location.state.__hashScrollIntoViewOptions ?? true
-
-        if (hashScrollIntoViewOptions && router.state.location.hash !== '') {
-          const el = document.getElementById(router.state.location.hash)
-          if (el) {
-            el.scrollIntoView(hashScrollIntoViewOptions)
-          }
-        }
-      }
+      handleHashScroll(router)
     }
   }, [isAnyPending, previousIsAnyPending, router])
 

--- a/packages/router-core/src/index.ts
+++ b/packages/router-core/src/index.ts
@@ -382,6 +382,7 @@ export {
   getCssSelector,
   scrollRestorationCache,
   setupScrollRestoration,
+  handleHashScroll,
 } from './scroll-restoration'
 
 export type {

--- a/packages/router-core/src/scroll-restoration.ts
+++ b/packages/router-core/src/scroll-restoration.ts
@@ -317,6 +317,14 @@ export function setupScrollRestoration(router: AnyRouter, force?: boolean) {
   })
 }
 
+/**
+ * @internal
+ * Handles hash-based scrolling after navigation completes.
+ * To be used in framework-specific <Transitioner> components during the onResolved event.
+ *
+ * Provides hash scrolling for programmatic navigation when default browser handling is prevented.
+ * @param router The router instance containing current location and state
+ */
 export function handleHashScroll(router: AnyRouter) {
   if (typeof document !== 'undefined' && (document as any).querySelector) {
     const hashScrollIntoViewOptions =

--- a/packages/router-core/src/scroll-restoration.ts
+++ b/packages/router-core/src/scroll-restoration.ts
@@ -316,3 +316,17 @@ export function setupScrollRestoration(router: AnyRouter, force?: boolean) {
     }
   })
 }
+
+export function handleHashScroll(router: AnyRouter) {
+  if (typeof document !== 'undefined' && (document as any).querySelector) {
+    const hashScrollIntoViewOptions =
+      router.state.location.state.__hashScrollIntoViewOptions ?? true
+
+    if (hashScrollIntoViewOptions && router.state.location.hash !== '') {
+      const el = document.getElementById(router.state.location.hash)
+      if (el) {
+        el.scrollIntoView(hashScrollIntoViewOptions)
+      }
+    }
+  }
+}

--- a/packages/solid-router/src/Transitioner.tsx
+++ b/packages/solid-router/src/Transitioner.tsx
@@ -1,5 +1,9 @@
 import * as Solid from 'solid-js'
-import { getLocationChangeInfo, trimPathRight } from '@tanstack/router-core'
+import {
+  getLocationChangeInfo,
+  handleHashScroll,
+  trimPathRight,
+} from '@tanstack/router-core'
 import { useRouter } from './useRouter'
 import { useRouterState } from './useRouterState'
 import { usePrevious } from './utils'
@@ -126,23 +130,7 @@ export function Transitioner() {
             resolvedLocation: s.location,
           }))
 
-          if (
-            typeof document !== 'undefined' &&
-            (document as any).querySelector
-          ) {
-            const hashScrollIntoViewOptions =
-              router.state.location.state.__hashScrollIntoViewOptions ?? true
-
-            if (
-              hashScrollIntoViewOptions &&
-              router.state.location.hash !== ''
-            ) {
-              const el = document.getElementById(router.state.location.hash)
-              if (el) {
-                el.scrollIntoView(hashScrollIntoViewOptions)
-              }
-            }
-          }
+          handleHashScroll(router)
         }
       },
     ),


### PR DESCRIPTION
Fixes #3741 

Added hash scroll handling directly in the React `Transitioner` component's `onResolved`, similar to how it's implemented in the Solid version