### PR TITLE
fix(react-router): fix issue with scroll restoration

### DIFF
--- a/packages/react-router/src/Match.tsx
+++ b/packages/react-router/src/Match.tsx
@@ -113,10 +113,10 @@ export const Match = React.memo(function MatchImpl({
           </ResolvedCatchBoundary>
         </ResolvedSuspenseBoundary>
       </matchContext.Provider>
-      {parentRouteId === rootRouteId && router.options.scrollRestoration ? (
+      {parentRouteId === rootRouteId ? (
         <>
           <OnRendered />
-          <ScrollRestoration />
+          {router.options.scrollRestoration && <ScrollRestoration />}
         </>
       ) : null}
     </>
@@ -139,20 +139,19 @@ function OnRendered() {
 
   return (
     <script
-      key={router.state.resolvedLocation?.state.key}
+      key={router.latestLocation.state.key}
       suppressHydrationWarning
       ref={(el) => {
         if (
           el &&
           (prevLocationRef.current === undefined ||
-            prevLocationRef.current.href !==
-              router.state.resolvedLocation?.href)
+            prevLocationRef.current.href !== router.latestLocation.href)
         ) {
           router.emit({
             type: 'onRendered',
             ...getLocationChangeInfo(router.state),
           })
-          prevLocationRef.current = router.state.resolvedLocation
+          prevLocationRef.current = router.latestLocation
         }
       }}
     />

--- a/packages/react-router/src/Match.tsx
+++ b/packages/react-router/src/Match.tsx
@@ -113,10 +113,10 @@ export const Match = React.memo(function MatchImpl({
           </ResolvedCatchBoundary>
         </ResolvedSuspenseBoundary>
       </matchContext.Provider>
-      {parentRouteId === rootRouteId ? (
+      {parentRouteId === rootRouteId && router.options.scrollRestoration ? (
         <>
           <OnRendered />
-          {router.options.scrollRestoration && <ScrollRestoration />}
+          <ScrollRestoration />
         </>
       ) : null}
     </>


### PR DESCRIPTION
fixes https://github.com/TanStack/router/issues/3680

It seems like `resolvedLocation` does not always point to the latest location state in the ref callback; sometimes it points to the previous location and `onRendered` is not triggered.
