### PR TITLE
fix(react-router): missing Symbol declaration for HMR in root route

### DIFF
--- a/packages/react-router/src/route.ts
+++ b/packages/react-router/src/route.ts
@@ -378,6 +378,7 @@ export class RootRoute<
     >,
   ) {
     super(options)
+    ;(this as any).$$typeof = Symbol.for('react.memo')
   }
 
   useMatch: UseMatchRoute<RootRouteId> = (opts) => {


### PR DESCRIPTION
Similar to #3821, the React Symbol declaration was missing on the `RootRoute` class.

fixes #3917 