### PR TITLE
fix(router-core): Fixed decoding of "+" in search params

### DIFF
--- a/packages/router-core/src/qss.ts
+++ b/packages/router-core/src/qss.ts
@@ -50,6 +50,7 @@ export function encode(obj: any, pfx?: string) {
  */
 function toValue(mix: any) {
   if (!mix) return ''
+  mix = mix.replace(/\+/g, ' ')
   const str = hasUriEncodedChars(mix)
     ? decodeURIComponent(mix)
     : decodeURIComponent(encodeURIComponent(mix))

--- a/packages/router-core/tests/qss.test.ts
+++ b/packages/router-core/tests/qss.test.ts
@@ -98,4 +98,12 @@ describe('decode function', () => {
       key: 'value=',
     })
   })
+
+  it('should convert plus signs to spaces in decoded values', () => {
+    const queryString = 'name=John+Doe'
+    const decodedObj = decode(queryString)
+    expect(decodedObj).toEqual({
+      name: 'John Doe'
+    })
+  })
 })


### PR DESCRIPTION
Hi,

While trying to migrate an existing React Router application to TanStack Router I ran into a bug in qss, which I first reported in qss (https://github.com/lukeed/qss/issues/15), but then noticed that react-router already uses a fork of it, so I fixed the issue in the fork here.