### PR TITLE
docs: fix broken example link

### DIFF
--- a/docs/router/framework/react/guide/authenticated-routes.md
+++ b/docs/router/framework/react/guide/authenticated-routes.md
@@ -85,7 +85,7 @@ If your authentication flow relies on interactions with React context and/or hoo
 
 We'll cover the `router.context` options in-detail in the [Router Context](./router-context.md) section.
 
-Here's an example that uses React context and hooks for protecting authenticated routes in TanStack Router. See the entire working setup in the [Authenticated Routes example](../../examples/authenticated-routes).
+Here's an example that uses React context and hooks for protecting authenticated routes in TanStack Router. See the entire working setup in the [Authenticated Routes example](../examples/authenticated-routes).
 
 - `src/routes/__root.tsx`
 


### PR DESCRIPTION
Currently the link points to https://tanstack.com/router/latest/docs/framework/examples/authenticated-routes which is 404.