### PR TITLE
fix(router-core): Accept AnyRouter in `redirect`

### DIFF
--- a/packages/router-core/src/redirect.ts
+++ b/packages/router-core/src/redirect.ts
@@ -51,8 +51,8 @@ export type ResolvedRedirect<
 }
 
 export function redirect<
-  TRouter extends RegisteredRouter,
-  const TTo extends string | undefined,
+  TRouter extends AnyRouter = RegisteredRouter,
+  const TTo extends string | undefined = string | undefined,
   const TFrom extends string = string,
   const TMaskFrom extends string = TFrom,
   const TMaskTo extends string = '',

--- a/packages/router-core/src/redirect.ts
+++ b/packages/router-core/src/redirect.ts
@@ -52,7 +52,7 @@ export type ResolvedRedirect<
 
 export function redirect<
   TRouter extends AnyRouter = RegisteredRouter,
-  const TTo extends string | undefined = string | undefined,
+  const TTo extends string | undefined = '.',
   const TFrom extends string = string,
   const TMaskFrom extends string = TFrom,
   const TMaskTo extends string = '',


### PR DESCRIPTION
PR #2243 introduced a tighter type for the `TRouter` type parameter in `redirect`, making it not possible to pass a different router than the currently registered one.

This PR brings back the previous behaviour, and allows any `Router` to be passed, with a default of `RegisteredRouter`. `TTo` also needed to be changed as the first parameter became optional. 

First time contributing here, do I need to create an issue for this?