### PR TITLE
docs(router): Fix broken link to SSR page from Deferred Data Loading page

### DIFF
--- a/docs/router/framework/react/guide/deferred-data-loading.md
+++ b/docs/router/framework/react/guide/deferred-data-loading.md
@@ -139,7 +139,7 @@ Streamed promises follow the same lifecycle as the loader data they are associat
 
 **Streaming requires a server that supports it and for TanStack Router to be configured to use it properly.**
 
-Please read the entire [Streaming SSR Guide](/docs/framework/react/guide/ssr#streaming-ssr) for step by step instructions on how to set up your server for streaming.
+Please read the entire [Streaming SSR Guide](./ssr.md#streaming-ssr) for step by step instructions on how to set up your server for streaming.
 
 ## SSR Streaming Lifecycle
 


### PR DESCRIPTION
There is a broken link to SSR page from Deferred Data Loading page

Link:
- AS-IS: https://tanstack.com/docs/framework/react/guide/ssr#streaming-ssr (which is a blank page)
- TO-BE: https://tanstack.com/router/latest/docs/framework/react/guide/ssr#streaming-ssr

Fixed by using relative link like other links in the same document, also referenced [contributing doc](https://github.com/TanStack/router/blob/af455d812f220a6df3d43dbe1610cf0d173ea092/CONTRIBUTING.md)