### PR TITLE
fix(docs): Complete server function mutation example and fix broken links.

### DIFF
--- a/docs/start/framework/react/learn-the-basics.md
+++ b/docs/start/framework/react/learn-the-basics.md
@@ -276,7 +276,7 @@ Here's a quick example of how you can use server functions to perform a mutation
 ```tsx
 import { createServerFn } from '@tanstack/react-start'
 import { z } from 'zod'
-import { db } from '...'
+import { dbUpdateUser } from '...'
 
 const UserSchema = z.object({
   id: z.string(),
@@ -286,16 +286,7 @@ export type User = z.infer<typeof UserSchema>
 
 export const updateUser = createServerFn({ method: 'POST' })
   .validator(UserSchema)
-  .handler(async ({ data }) => {
-    const result = await db.users.update({
-      where: {
-        id: data.id,
-      },
-      data: {
-        name: data.name,
-      },
-    })
-  })
+  .handler(({ data }) => dbUpdateUser(data))
 
 // Somewhere else in your application
 import { useQueryClient } from '@tanstack/react-query'
@@ -319,18 +310,30 @@ export function useUpdateUser() {
 
       return result
     },
-    [router, queryClient, _updateUser],
+    [router, queryClient, _updateUser]
   )
 }
 
 // Somewhere else in your application
 import { useUpdateUser } from '...'
 
-const updateUser = useUpdateUser()
-await updateUser({ id: '1', name: 'John' })
+function MyComponent() {
+  const updateUser = useUpdateUser()
+  const onClick = useCallback(
+    async () => {
+      await updateUser({ id: '1', name: 'John' });
+      console.log('Updated user')
+    },
+    [updateUser]
+  )
+  
+  return (
+    <button onClick={onClick}>Click Me</button>
+  )
+}
 ```
 
-To learn more about mutations, check out the [mutations guide](../../../router/framework/react/guide/data-mutations).
+To learn more about mutations, check out the [mutations guide](/router/framework/react/guide/data-mutations).
 
 ## Data Loading
 
@@ -343,4 +346,4 @@ Here's a quick overview of how data loading works:
 - For performing server-only logic, call a server function from within the loader.
 - Similar to TanStack Query, data loaders are cached on the client and are re-used and even re-fetched in the background when the data is stale.
 
-To learn more about data loading, check out the [data loading guide](../../../router/framework/react/guide/data-loading).
+To learn more about data loading, check out the [data loading guide](/router/framework/react/guide/data-loading).

--- a/docs/start/framework/react/learn-the-basics.md
+++ b/docs/start/framework/react/learn-the-basics.md
@@ -282,7 +282,7 @@ const UserSchema = z.object({
   id: z.string(),
   name: z.string(),
 })
-type User = z.infer<typeof UserSchema>
+export type User = z.infer<typeof UserSchema>
 
 export const updateUser = createServerFn({ method: 'POST' })
   .validator(UserSchema)
@@ -301,7 +301,7 @@ export const updateUser = createServerFn({ method: 'POST' })
 import { useQueryClient } from '@tanstack/react-query'
 import { useRouter } from '@tanstack/react-router'
 import { useServerFunction } from '@tanstack/react-start'
-import { updateUser } from '...'
+import { updateUser, type User } from '...'
 
 export function useUpdateUser() {
   const router = useRouter();

--- a/docs/start/framework/react/learn-the-basics.md
+++ b/docs/start/framework/react/learn-the-basics.md
@@ -328,7 +328,7 @@ function MyComponent() {
 }
 ```
 
-To learn more about mutations, check out the [mutations guide](/router/framework/react/guide/data-mutations).
+To learn more about mutations, check out the [mutations guide](/router/latest/docs/framework/react/guide/data-mutations).
 
 ## Data Loading
 
@@ -341,4 +341,4 @@ Here's a quick overview of how data loading works:
 - For performing server-only logic, call a server function from within the loader.
 - Similar to TanStack Query, data loaders are cached on the client and are re-used and even re-fetched in the background when the data is stale.
 
-To learn more about data loading, check out the [data loading guide](/router/framework/react/guide/data-loading).
+To learn more about data loading, check out the [data loading guide](/router/latest/docs/framework/react/guide/data-loading).

--- a/docs/start/framework/react/learn-the-basics.md
+++ b/docs/start/framework/react/learn-the-basics.md
@@ -327,7 +327,7 @@ export function useUpdateUser() {
 import { useUpdateUser } from '...'
 
 const updateUser = useUpdateUser();
-await updateUser({ data: { id: '1', name: 'John' } })
+await updateUser({ id: '1', name: 'John' })
 ```
 
 To learn more about mutations, check out the [mutations guide](../../../router/framework/react/guide/data-mutations).

--- a/docs/start/framework/react/learn-the-basics.md
+++ b/docs/start/framework/react/learn-the-basics.md
@@ -289,11 +289,11 @@ export const updateUser = createServerFn({ method: 'POST' })
   .handler(async ({ data }) => {
     const result = await db.users.update({
       where: {
-        id: data.id
+        id: data.id,
       },
       data: {
-        name: data.name
-      }
+        name: data.name,
+      },
     })
   })
 
@@ -304,29 +304,29 @@ import { useServerFunction } from '@tanstack/react-start'
 import { updateUser, type User } from '...'
 
 export function useUpdateUser() {
-  const router = useRouter();
-  const queryClient = useQueryClient();
-  const _updateUser = useServerFunction(updateUser);
+  const router = useRouter()
+  const queryClient = useQueryClient()
+  const _updateUser = useServerFunction(updateUser)
 
   return useCallback(
     async (user: User) => {
-      const result = await _updateUser({ data: user });
+      const result = await _updateUser({ data: user })
 
-      router.invalidate();
+      router.invalidate()
       queryClient.invalidateQueries({
-        queryKey: ['users', 'updateUser', user.id]
+        queryKey: ['users', 'updateUser', user.id],
       })
 
-      return result;
+      return result
     },
-    [router, queryClient, _updateUser]
-  );
+    [router, queryClient, _updateUser],
+  )
 }
 
 // Somewhere else in your application
 import { useUpdateUser } from '...'
 
-const updateUser = useUpdateUser();
+const updateUser = useUpdateUser()
 await updateUser({ id: '1', name: 'John' })
 ```
 

--- a/docs/start/framework/react/learn-the-basics.md
+++ b/docs/start/framework/react/learn-the-basics.md
@@ -310,7 +310,7 @@ export function useUpdateUser() {
 
       return result
     },
-    [router, queryClient, _updateUser]
+    [router, queryClient, _updateUser],
   )
 }
 
@@ -319,17 +319,12 @@ import { useUpdateUser } from '...'
 
 function MyComponent() {
   const updateUser = useUpdateUser()
-  const onClick = useCallback(
-    async () => {
-      await updateUser({ id: '1', name: 'John' });
-      console.log('Updated user')
-    },
-    [updateUser]
-  )
-  
-  return (
-    <button onClick={onClick}>Click Me</button>
-  )
+  const onClick = useCallback(async () => {
+    await updateUser({ id: '1', name: 'John' })
+    console.log('Updated user')
+  }, [updateUser])
+
+  return <button onClick={onClick}>Click Me</button>
 }
 ```
 


### PR DESCRIPTION
Fixes the following in the "learn the basics" doc for Tanstack Start:
1. The example snippet for server function mutations is incomplete and does not do what the description says it does.
2. The link to the full mutation docs was a broken, non-relative link.
3. Another link in this doc was also broken and non-relative.

I'm just getting started with Tanstack Start, so my example might not contain best practices--I would like feedback before merging!

Context (from discord):

> Hi, I'm looking at https://tanstack.com/start/latest/docs/framework/react/learn-the-basics, and the example in the "Mutations" section seems to be missing a lot:
> * Missing import: `z`
> * Missing definition/import: `db`
> * Missing definition/import: `users`
> 
> It also doesn't seem to do what the description says:
> > Here's a quick example of how you can use server functions to perform a mutation on the server and invalidate the data on the client:
> Unless I'm missing something, the example doesn't do any type of invalidation.
> 
> For context, here is the example:
> 
> ```ts
> import { createServerFn } from '@tanstack/react-start'
> 
> const UserSchema = z.object({
>   id: z.string(),
>   name: z.string(),
> })
> 
> const updateUser = createServerFn({ method: 'POST' })
>   .validator(UserSchema)
>   .handler(async ({ data }) => {
>     return db
>       .update(users)
>       .set({ name: data.name })
>       .where(eq(users.id, data.id))
>   })
> 
> // Somewhere else in your application
> await updateUser({ data: { id: '1', name: 'John' } })
> ```