### PR TITLE
feat: allow use of nitro zero conf

### DIFF
--- a/packages/react-start-config/src/index.ts
+++ b/packages/react-start-config/src/index.ts
@@ -88,7 +88,7 @@ export async function defineConfig(
     serverSchema.parse(opts.server || {})
 
   const deploymentPreset = checkDeploymentPresetInput(
-    configDeploymentPreset || 'node-server',
+    configDeploymentPreset,
   )
   const tsr = setTsrDefaults(opts.tsr)
   const tsrConfig = getConfig(tsr)

--- a/packages/react-start-config/src/index.ts
+++ b/packages/react-start-config/src/index.ts
@@ -87,9 +87,7 @@ export async function defineConfig(
   const { preset: configDeploymentPreset, ...serverOptions } =
     serverSchema.parse(opts.server || {})
 
-  const deploymentPreset = checkDeploymentPresetInput(
-    configDeploymentPreset,
-  )
+  const deploymentPreset = checkDeploymentPresetInput(configDeploymentPreset)
   const tsr = setTsrDefaults(opts.tsr)
   const tsrConfig = getConfig(tsr)
 

--- a/packages/react-start-config/src/schema.ts
+++ b/packages/react-start-config/src/schema.ts
@@ -80,7 +80,9 @@ const testedDeploymentPresets: Array<DeploymentPreset> = [
   'node-server',
 ]
 
-export function checkDeploymentPresetInput(preset?: string): DeploymentPreset | undefined {
+export function checkDeploymentPresetInput(
+  preset?: string,
+): DeploymentPreset | undefined {
   if (preset) {
     if (!vinxiDeploymentPresets.includes(preset as any)) {
       console.warn(

--- a/packages/react-start-config/src/schema.ts
+++ b/packages/react-start-config/src/schema.ts
@@ -80,19 +80,21 @@ const testedDeploymentPresets: Array<DeploymentPreset> = [
   'node-server',
 ]
 
-export function checkDeploymentPresetInput(preset: string): DeploymentPreset {
-  if (!vinxiDeploymentPresets.includes(preset as any)) {
-    console.warn(
-      `Invalid deployment preset "${preset}". Available presets are: ${vinxiDeploymentPresets
-        .map((p) => `"${p}"`)
-        .join(', ')}.`,
-    )
-  }
+export function checkDeploymentPresetInput(preset?: string): DeploymentPreset | undefined {
+  if (preset) {
+    if (!vinxiDeploymentPresets.includes(preset as any)) {
+      console.warn(
+        `Invalid deployment preset "${preset}". Available presets are: ${vinxiDeploymentPresets
+          .map((p) => `"${p}"`)
+          .join(', ')}.`,
+      )
+    }
 
-  if (!testedDeploymentPresets.includes(preset as any)) {
-    console.warn(
-      `The deployment preset '${preset}' is not fully supported yet and may not work as expected.`,
-    )
+    if (!testedDeploymentPresets.includes(preset as any)) {
+      console.warn(
+        `The deployment preset '${preset}' is not fully supported yet and may not work as expected.`,
+      )
+    }
   }
 
   return preset

--- a/packages/solid-start-config/src/index.ts
+++ b/packages/solid-start-config/src/index.ts
@@ -88,7 +88,7 @@ export async function defineConfig(
     serverSchema.parse(opts.server || {})
 
   const deploymentPreset = checkDeploymentPresetInput(
-    configDeploymentPreset || 'node-server',
+    configDeploymentPreset,
   )
   const tsr = setTsrDefaults(opts.tsr)
   const tsrConfig = getConfig(tsr)

--- a/packages/solid-start-config/src/index.ts
+++ b/packages/solid-start-config/src/index.ts
@@ -87,9 +87,7 @@ export async function defineConfig(
   const { preset: configDeploymentPreset, ...serverOptions } =
     serverSchema.parse(opts.server || {})
 
-  const deploymentPreset = checkDeploymentPresetInput(
-    configDeploymentPreset,
-  )
+  const deploymentPreset = checkDeploymentPresetInput(configDeploymentPreset)
   const tsr = setTsrDefaults(opts.tsr)
   const tsrConfig = getConfig(tsr)
 

--- a/packages/solid-start-config/src/schema.ts
+++ b/packages/solid-start-config/src/schema.ts
@@ -80,7 +80,9 @@ const testedDeploymentPresets: Array<DeploymentPreset> = [
   'node-server',
 ]
 
-export function checkDeploymentPresetInput(preset?: string): DeploymentPreset | undefined {
+export function checkDeploymentPresetInput(
+  preset?: string,
+): DeploymentPreset | undefined {
   if (preset) {
     if (!vinxiDeploymentPresets.includes(preset as any)) {
       console.warn(

--- a/packages/solid-start-config/src/schema.ts
+++ b/packages/solid-start-config/src/schema.ts
@@ -80,19 +80,21 @@ const testedDeploymentPresets: Array<DeploymentPreset> = [
   'node-server',
 ]
 
-export function checkDeploymentPresetInput(preset: string): DeploymentPreset {
-  if (!vinxiDeploymentPresets.includes(preset as any)) {
-    console.warn(
-      `Invalid deployment preset "${preset}". Available presets are: ${vinxiDeploymentPresets
-        .map((p) => `"${p}"`)
-        .join(', ')}.`,
-    )
-  }
+export function checkDeploymentPresetInput(preset?: string): DeploymentPreset | undefined {
+  if (preset) {
+    if (!vinxiDeploymentPresets.includes(preset as any)) {
+      console.warn(
+        `Invalid deployment preset "${preset}". Available presets are: ${vinxiDeploymentPresets
+          .map((p) => `"${p}"`)
+          .join(', ')}.`,
+      )
+    }
 
-  if (!testedDeploymentPresets.includes(preset as any)) {
-    console.warn(
-      `The deployment preset '${preset}' is not fully supported yet and may not work as expected.`,
-    )
+    if (!testedDeploymentPresets.includes(preset as any)) {
+      console.warn(
+        `The deployment preset '${preset}' is not fully supported yet and may not work as expected.`,
+      )
+    }
   }
 
   return preset

--- a/packages/start-config/src/index.ts
+++ b/packages/start-config/src/index.ts
@@ -88,7 +88,7 @@ export async function defineConfig(
     serverSchema.parse(opts.server || {})
 
   const deploymentPreset = checkDeploymentPresetInput(
-    configDeploymentPreset || 'node-server',
+    configDeploymentPreset,
   )
   const tsr = setTsrDefaults(opts.tsr)
   const tsrConfig = getConfig(tsr)

--- a/packages/start-config/src/index.ts
+++ b/packages/start-config/src/index.ts
@@ -87,9 +87,7 @@ export async function defineConfig(
   const { preset: configDeploymentPreset, ...serverOptions } =
     serverSchema.parse(opts.server || {})
 
-  const deploymentPreset = checkDeploymentPresetInput(
-    configDeploymentPreset,
-  )
+  const deploymentPreset = checkDeploymentPresetInput(configDeploymentPreset)
   const tsr = setTsrDefaults(opts.tsr)
   const tsrConfig = getConfig(tsr)
 

--- a/packages/start-config/src/schema.ts
+++ b/packages/start-config/src/schema.ts
@@ -80,7 +80,9 @@ const testedDeploymentPresets: Array<DeploymentPreset> = [
   'node-server',
 ]
 
-export function checkDeploymentPresetInput(preset?: string): DeploymentPreset | undefined {
+export function checkDeploymentPresetInput(
+  preset?: string,
+): DeploymentPreset | undefined {
   if (preset) {
     if (!vinxiDeploymentPresets.includes(preset as any)) {
       console.warn(

--- a/packages/start-config/src/schema.ts
+++ b/packages/start-config/src/schema.ts
@@ -80,19 +80,21 @@ const testedDeploymentPresets: Array<DeploymentPreset> = [
   'node-server',
 ]
 
-export function checkDeploymentPresetInput(preset: string): DeploymentPreset {
-  if (!vinxiDeploymentPresets.includes(preset as any)) {
-    console.warn(
-      `Invalid deployment preset "${preset}". Available presets are: ${vinxiDeploymentPresets
-        .map((p) => `"${p}"`)
-        .join(', ')}.`,
-    )
-  }
+export function checkDeploymentPresetInput(preset?: string): DeploymentPreset | undefined {
+  if (preset) {
+    if (!vinxiDeploymentPresets.includes(preset as any)) {
+      console.warn(
+        `Invalid deployment preset "${preset}". Available presets are: ${vinxiDeploymentPresets
+          .map((p) => `"${p}"`)
+          .join(', ')}.`,
+      )
+    }
 
-  if (!testedDeploymentPresets.includes(preset as any)) {
-    console.warn(
-      `The deployment preset '${preset}' is not fully supported yet and may not work as expected.`,
-    )
+    if (!testedDeploymentPresets.includes(preset as any)) {
+      console.warn(
+        `The deployment preset '${preset}' is not fully supported yet and may not work as expected.`,
+      )
+    }
   }
 
   return preset


### PR DESCRIPTION
Ref: https://nitro.build/deploy#zero-config-providers

Nitro will automatically fallback to `node-server` if it doesn't recognize environment of one of supported zero configuration deploy targets https://nitro.build/deploy#default-output.

Note https://github.com/nksaraf/vinxi/pull/325 was similar change done some time ago in Vinxi to allow for zero-configuration