### PR TITLE
Replace `redaxios` with native `fetch`

### DIFF
--- a/examples/react/start-basic/package.json
+++ b/examples/react/start-basic/package.json
@@ -14,7 +14,6 @@
     "@tanstack/react-start": "^1.116.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "redaxios": "^0.5.1",
     "tailwind-merge": "^2.6.0",
     "vinxi": "0.5.3"
   },
@@ -22,8 +21,8 @@
     "@types/node": "^22.5.4",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
-    "postcss": "^8.5.1",
     "autoprefixer": "^10.4.20",
+    "postcss": "^8.5.1",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.2",
     "vite-tsconfig-paths": "^5.1.4"

--- a/examples/react/start-basic/src/routes/api/users.$id.ts
+++ b/examples/react/start-basic/src/routes/api/users.$id.ts
@@ -6,12 +6,14 @@ export const APIRoute = createAPIFileRoute('/api/users/$id')({
   GET: async ({ request, params }) => {
     console.info(`Fetching users by id=${params.id}... @`, request.url)
     try {
-      const res = await fetch('https://jsonplaceholder.typicode.com/users/' + params.id)
+      const res = await fetch(
+        'https://jsonplaceholder.typicode.com/users/' + params.id,
+      )
       if (!res.ok) {
         throw new Error('Failed to fetch user')
       }
 
-      const user = await res.json() as User
+      const user = (await res.json()) as User
 
       return json({
         id: user.id,

--- a/examples/react/start-basic/src/routes/api/users.$id.ts
+++ b/examples/react/start-basic/src/routes/api/users.$id.ts
@@ -1,20 +1,22 @@
 import { json } from '@tanstack/react-start'
 import { createAPIFileRoute } from '@tanstack/react-start/api'
-import axios from 'redaxios'
 import type { User } from '../../utils/users'
 
 export const APIRoute = createAPIFileRoute('/api/users/$id')({
   GET: async ({ request, params }) => {
     console.info(`Fetching users by id=${params.id}... @`, request.url)
     try {
-      const res = await axios.get<User>(
-        'https://jsonplaceholder.typicode.com/users/' + params.id,
-      )
+      const res = await fetch('https://jsonplaceholder.typicode.com/users/' + params.id)
+      if (!res.ok) {
+        throw new Error('Failed to fetch user')
+      }
+
+      const user = await res.json() as User
 
       return json({
-        id: res.data.id,
-        name: res.data.name,
-        email: res.data.email,
+        id: user.id,
+        name: user.name,
+        email: user.email,
       })
     } catch (e) {
       console.error(e)

--- a/examples/react/start-basic/src/routes/api/users.ts
+++ b/examples/react/start-basic/src/routes/api/users.ts
@@ -1,16 +1,18 @@
 import { json } from '@tanstack/react-start'
 import { createAPIFileRoute } from '@tanstack/react-start/api'
-import axios from 'redaxios'
 import type { User } from '../../utils/users'
 
 export const APIRoute = createAPIFileRoute('/api/users')({
   GET: async ({ request }) => {
     console.info('Fetching users... @', request.url)
-    const res = await axios.get<Array<User>>(
-      'https://jsonplaceholder.typicode.com/users',
-    )
+    const res = await fetch('https://jsonplaceholder.typicode.com/users')
+    if (!res.ok) {
+      throw new Error('Failed to fetch users')
+    }
 
-    const list = res.data.slice(0, 10)
+    const data = await res.json() as Array<User>
+
+    const list = data.slice(0, 10)
 
     return json(list.map((u) => ({ id: u.id, name: u.name, email: u.email })))
   },

--- a/examples/react/start-basic/src/routes/api/users.ts
+++ b/examples/react/start-basic/src/routes/api/users.ts
@@ -10,7 +10,7 @@ export const APIRoute = createAPIFileRoute('/api/users')({
       throw new Error('Failed to fetch users')
     }
 
-    const data = await res.json() as Array<User>
+    const data = (await res.json()) as Array<User>
 
     const list = data.slice(0, 10)
 

--- a/examples/react/start-basic/src/routes/users.$userId.tsx
+++ b/examples/react/start-basic/src/routes/users.$userId.tsx
@@ -12,7 +12,7 @@ export const Route = createFileRoute('/users/$userId')({
         throw new Error('Unexpected status code')
       }
 
-      const data = await res.json() as User
+      const data = (await res.json()) as User
 
       return data
     } catch {

--- a/examples/react/start-basic/src/routes/users.$userId.tsx
+++ b/examples/react/start-basic/src/routes/users.$userId.tsx
@@ -1,5 +1,4 @@
 import { createFileRoute } from '@tanstack/react-router'
-import axios from 'redaxios'
 import type { User } from '~/utils/users'
 import { DEPLOY_URL } from '~/utils/users'
 import { NotFound } from '~/components/NotFound'
@@ -7,12 +6,18 @@ import { UserErrorComponent } from '~/components/UserError'
 
 export const Route = createFileRoute('/users/$userId')({
   loader: async ({ params: { userId } }) => {
-    return await axios
-      .get<User>(DEPLOY_URL + '/api/users/' + userId)
-      .then((r) => r.data)
-      .catch(() => {
-        throw new Error('Failed to fetch user')
-      })
+    try {
+      const res = await fetch(DEPLOY_URL + '/api/users/' + userId)
+      if (!res.ok) {
+        throw new Error('Unexpected status code')
+      }
+
+      const data = await res.json() as User
+
+      return data
+    } catch {
+      throw new Error('Failed to fetch user')
+    }
   },
   errorComponent: UserErrorComponent,
   component: UserComponent,

--- a/examples/react/start-basic/src/routes/users.route.tsx
+++ b/examples/react/start-basic/src/routes/users.route.tsx
@@ -10,7 +10,7 @@ export const Route = createFileRoute('/users')({
         throw new Error('Unexpected status code')
       }
 
-      const data = await res.json() as Array<User>
+      const data = (await res.json()) as Array<User>
 
       return data
     } catch {

--- a/examples/react/start-basic/src/routes/users.route.tsx
+++ b/examples/react/start-basic/src/routes/users.route.tsx
@@ -1,16 +1,21 @@
 import { Link, Outlet, createFileRoute } from '@tanstack/react-router'
-import axios from 'redaxios'
 import { DEPLOY_URL } from '../utils/users'
 import type { User } from '../utils/users'
 
 export const Route = createFileRoute('/users')({
   loader: async () => {
-    return await axios
-      .get<Array<User>>(DEPLOY_URL + '/api/users')
-      .then((r) => r.data)
-      .catch(() => {
-        throw new Error('Failed to fetch users')
-      })
+    try {
+      const res = await fetch(DEPLOY_URL + '/api/users')
+      if (!res.ok) {
+        throw new Error('Unexpected status code')
+      }
+
+      const data = await res.json() as Array<User>
+
+      return data
+    } catch {
+      throw new Error('Failed to fetch users')
+    }
   },
   component: UsersLayoutComponent,
 })

--- a/examples/react/start-basic/src/utils/posts.tsx
+++ b/examples/react/start-basic/src/utils/posts.tsx
@@ -1,6 +1,5 @@
 import { notFound } from '@tanstack/react-router'
 import { createServerFn } from '@tanstack/react-start'
-import axios from 'redaxios'
 
 export type PostType = {
   id: string
@@ -12,16 +11,16 @@ export const fetchPost = createServerFn({ method: 'GET' })
   .validator((d: string) => d)
   .handler(async ({ data }) => {
     console.info(`Fetching post with id ${data}...`)
-    const post = await axios
-      .get<PostType>(`https://jsonplaceholder.typicode.com/posts/${data}`)
-      .then((r) => r.data)
-      .catch((err) => {
-        console.error(err)
-        if (err.status === 404) {
-          throw notFound()
-        }
-        throw err
-      })
+    const res = await fetch(`https://jsonplaceholder.typicode.com/posts/${data}`)
+    if (!res.ok) {
+      if (res.status === 404) {
+        throw notFound()
+      }
+
+      throw new Error('Failed to fetch post')
+    }
+
+    const post = await res.json() as PostType
 
     return post
   })
@@ -29,8 +28,13 @@ export const fetchPost = createServerFn({ method: 'GET' })
 export const fetchPosts = createServerFn({ method: 'GET' }).handler(
   async () => {
     console.info('Fetching posts...')
-    return axios
-      .get<Array<PostType>>('https://jsonplaceholder.typicode.com/posts')
-      .then((r) => r.data.slice(0, 10))
+    const res = await fetch('https://jsonplaceholder.typicode.com/posts')
+    if (!res.ok) {
+      throw new Error('Failed to fetch posts')
+    }
+
+    const posts = await res.json() as Array<PostType>
+
+    return posts
   },
 )

--- a/examples/react/start-basic/src/utils/posts.tsx
+++ b/examples/react/start-basic/src/utils/posts.tsx
@@ -11,7 +11,9 @@ export const fetchPost = createServerFn({ method: 'GET' })
   .validator((d: string) => d)
   .handler(async ({ data }) => {
     console.info(`Fetching post with id ${data}...`)
-    const res = await fetch(`https://jsonplaceholder.typicode.com/posts/${data}`)
+    const res = await fetch(
+      `https://jsonplaceholder.typicode.com/posts/${data}`,
+    )
     if (!res.ok) {
       if (res.status === 404) {
         throw notFound()
@@ -20,7 +22,7 @@ export const fetchPost = createServerFn({ method: 'GET' })
       throw new Error('Failed to fetch post')
     }
 
-    const post = await res.json() as PostType
+    const post = (await res.json()) as PostType
 
     return post
   })
@@ -33,7 +35,7 @@ export const fetchPosts = createServerFn({ method: 'GET' }).handler(
       throw new Error('Failed to fetch posts')
     }
 
-    const posts = await res.json() as Array<PostType>
+    const posts = (await res.json()) as Array<PostType>
 
     return posts
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4304,9 +4304,6 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
-      redaxios:
-        specifier: ^0.5.1
-        version: 0.5.1
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0


### PR DESCRIPTION
Replaces the usage of `redaxios` with the native `fetch` on the Basic Start example.