### PR TITLE
fix(router-core): Pathless Layout Route Renders Empty HTML

### DIFF
--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1040,6 +1040,13 @@ export class RouterCore<
         // Sort by original index
         return a.index - b.index
       })
+      .filter((d) => {
+        if (!d.child.children) return true
+        return (
+          Array.from(d.child.children).length > 0 &&
+          Array.from(d.child.children).every((c) => (c as AnyRoute).path)
+        )
+      })
       .map((d, i) => {
         d.child.rank = i
         return d.child


### PR DESCRIPTION
fixes #3843 