### PR TITLE
feat(router-core): allow dynamic `ViewTransition` types

### DIFF
--- a/examples/react/view-transitions/src/main.tsx
+++ b/examples/react/view-transitions/src/main.tsx
@@ -12,9 +12,32 @@ const router = createRouter({
   scrollRestoration: true,
   /* 
   Using defaultViewTransition would prevent the need to
-  manually add `viewTransition: true` to every navigation
+  manually add `viewTransition: true` to every navigation.
+
+  If defaultViewTransition.types is a function, it will be called with the
+  location change info and should return an array of view transition types.
+  This is useful if you want to have different view transitions depending on
+  the navigation's specifics.
+
+  An example use case is sliding in a direction based on the index of the
+  previous and next routes when navigating via browser history back and forth.
   */
   // defaultViewTransition: true
+  // OR
+  // defaultViewTransition: {
+  //   types: ({ fromLocation, toLocation }) => {
+  //     let direction = 'none'
+
+  //     if (fromLocation) {
+  //       const fromIndex = fromLocation.state.__TSR_index
+  //       const toIndex = toLocation.state.__TSR_index
+
+  //       direction = fromIndex > toIndex ? 'right' : 'left'
+  //     }
+
+  //     return [`slide-${direction}`]
+  //   },
+  // },
 })
 
 // Register things for typesafety

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -2183,20 +2183,19 @@ export class RouterCore<
         const next = this.latestLocation
         const prevLocation = this.state.resolvedLocation
 
-        let types = shouldViewTransition.types
-
-        if (typeof types === 'function') {
-          types = types(
-            getLocationChangeInfo({
-              resolvedLocation: prevLocation,
-              location: next,
-            }),
-          )
-        }
+        const resolvedViewTransitionTypes =
+          typeof shouldViewTransition.types === 'function'
+            ? shouldViewTransition.types(
+                getLocationChangeInfo({
+                  resolvedLocation: prevLocation,
+                  location: next,
+                }),
+              )
+            : shouldViewTransition.types
 
         startViewTransitionParams = {
           update: fn,
-          types,
+          types: resolvedViewTransitionTypes,
         }
       } else {
         startViewTransitionParams = fn


### PR DESCRIPTION
Context: https://github.com/TanStack/router/discussions/4027

Changes the ViewTransitionOptions["types"] to also accept a function. This enables automatically applying different animations (for example sliding left or right) based on history navigation. When navigating via `history.back()/forward()`, it’s very common to want a "slide-left" vs "slide-right" effect based on direction.

This technically also works for `Link`s but it's not as useful there since the prop can already be dynamic. This is mostly for navigations that are triggered via other sources than links.