### PR TITLE
docs(start): how to deploy to cloudflare workers

### DIFF
--- a/docs/start/framework/react/hosting.md
+++ b/docs/start/framework/react/hosting.md
@@ -35,6 +35,7 @@ When a TanStack Start application is being deployed, the `server.preset` value i
 
 - [`netlify`](#netlify): Deploy to Netlify
 - [`vercel`](#vercel): Deploy to Vercel
+- [`cloudflare-modules`](#cloudflare-workers): Deploy to Cloudflare Workers
 - [`cloudflare-pages`](#cloudflare-pages): Deploy to Cloudflare Pages
 - [`node-server`](#nodejs): Deploy to a Node.js server
 - [`bun`](#bun): Deploy to a Bun server
@@ -87,6 +88,53 @@ npm run build --preset vercel
 ```
 
 Deploy you application to Vercel using their one-click deployment process, and you're ready to go!
+
+### Cloudflare Workers
+
+When deploying to Cloudflare Workers, you'll need to complete a few extra steps before your users can start using your app.
+
+1. Installation
+
+First you will need to install `unenv`
+
+```sh
+npm install unenv
+```
+
+Set the `server.preset` value to `cloudflare-modules` in your `app.config.ts` file.
+
+2. Update `app.config.ts`
+
+```ts
+// app.config.ts
+import { defineConfig } from '@tanstack/react-start/config'
+import { cloudflare } from 'unenv'
+
+export default defineConfig({
+  server: {
+    preset: 'cloudflare-modules',
+    unenv: cloudflare,
+  },
+})
+```
+
+3. Add a `wrangler.jsonc` config file
+
+```jsonc
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "your-cloudflare-project-name",
+  "compatibility_date": "2025-04-24",
+  "compatibility_flags": ["nodejs_compat"],
+  "main": "./.output/server/index.mjs",
+  "assets": {
+    "directory": "./.output/public/",
+    "binding": "ASSETS"
+  },
+}
+```
+
+Deploy you application to Cloudflare Workers using their one-click deployment process, and you're ready to go!
 
 ### Cloudflare Pages
 


### PR DESCRIPTION
This pull request updates the deployment documentation for TanStack Start applications to include instructions for deploying to Cloudflare Workers. The most important changes are as follows:

### Documentation Updates for Deployment:

* **Added Cloudflare Workers to Deployment Options**: Updated the list of deployment options in `docs/start/framework/react/hosting.md` to include Cloudflare Workers.
* **Detailed Deployment Instructions for Cloudflare Workers**: Added a new section with step-by-step instructions for deploying to Cloudflare Workers, including installation of `unenv`, configuration of `app.config.ts`, and creation of a `wrangler.jsonc` file.