### PR TITLE
fix(react-router-devtools): remove useRouter warning for panel

### DIFF
--- a/packages/react-router-devtools/src/TanStackRouterDevtoolsPanel.tsx
+++ b/packages/react-router-devtools/src/TanStackRouterDevtoolsPanel.tsx
@@ -38,7 +38,7 @@ export const TanStackRouterDevtoolsPanel: React.FC<DevtoolsPanelOptions> = (
   props,
 ): React.ReactElement | null => {
   const { router: propsRouter, ...rest } = props
-  const hookRouter = useRouter({ warn: propsRouter !== undefined })
+  const hookRouter = useRouter({ warn: false })
   const activeRouter = propsRouter ?? hookRouter
   const activeRouterState = useRouterState({ router: activeRouter })
 


### PR DESCRIPTION
PR https://github.com/TanStack/router/pull/3770 removed the warning for the full Devtools component, but left if for the Panel one. This PR removes the warning to align the two devtools implementations.