### PR TITLE
docs(router): walkthrough on using the ignore prefix for component colocation in the routing-concepts guide

### DIFF
--- a/docs/router/framework/react/routing/routing-concepts.md
+++ b/docs/router/framework/react/routing/routing-concepts.md
@@ -349,7 +349,7 @@ export const Route = createFileRoute('/posts')({
 
 function PostComponent() {
   const posts = Route.useLoaderData()
-  
+
   return (
     <div>
       <PostsHeader />
@@ -360,7 +360,7 @@ function PostComponent() {
 }
 ```
 
-The excluded files will not be added to `routeTree.gen.ts`. 
+The excluded files will not be added to `routeTree.gen.ts`.
 
 ## Pathless Route Group Directories
 

--- a/docs/router/framework/react/routing/routing-concepts.md
+++ b/docs/router/framework/react/routing/routing-concepts.md
@@ -327,10 +327,10 @@ Consider the following route tree:
 ```
 routes/
 ├── posts.tsx
-├── -posts-table.tsx
-├── -components.tsx
-│   ├── header.tsx
-│   ├── footer.tsx
+├── -posts-table.tsx // 👈🏼 ignored
+├── -components/ // 👈🏼 ignored
+│   ├── header.tsx // 👈🏼 ignored
+│   ├── footer.tsx // 👈🏼 ignored
 │   ├── ...
 ```
 

--- a/docs/router/framework/react/routing/routing-concepts.md
+++ b/docs/router/framework/react/routing/routing-concepts.md
@@ -318,6 +318,50 @@ The following table shows which component will be rendered based on the URL:
 - The `posts.$postId.tsx` route is nested as normal under the `posts.tsx` route and will render `<Posts><Post>`.
 - The `posts_.$postId.edit.tsx` route **does not share** the same `posts` prefix as the other routes and therefore will be treated as if it is a top-level route and will render `<PostEditor>`.
 
+## Excluding Files and Folders from Routes
+
+Files and folders can be excluded from route generation with a `-` prefix attached to the file name. This gives you the ability to colocate logic in the route directories.
+
+Consider the following route tree:
+
+```
+routes/
+├── posts.tsx
+├── -posts-table.tsx
+├── -components.tsx
+│   ├── header.tsx
+│   ├── footer.tsx
+│   ├── ...
+```
+
+We can import from the excluded files into our posts route
+
+```tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { PostsTable } from './-posts-table'
+import { PostsHeader } from './-components/header'
+import { PostsFooter } from './-components/footer'
+
+export const Route = createFileRoute('/posts')({
+  loader: () => fetchPosts(),
+  component: PostComponent,
+})
+
+function PostComponent() {
+  const posts = Route.useLoaderData()
+  
+  return (
+    <div>
+      <PostsHeader />
+      <PostsTable posts={posts} />
+      <PostsFooter />
+    </div>
+  )
+}
+```
+
+The excluded files will not be added to `routeTree.gen.ts`. 
+
 ## Pathless Route Group Directories
 
 Pathless route group directories use `()` as a way to group routes files together regardless of their path. They are purely organizational and do not affect the route tree or component tree in any way.


### PR DESCRIPTION
## Description
This PR imroves on the documentation on the routing concepts of the router by giving an explanation and example on how to exclude files and folders from the routing logic

### Changes made
- Added an extra example and explanation convention that highlights the concepts to exclude files and folders from being generated as routes

### Why these changes are necessary
This enables developes to be aware of the feature included as a core concept to exclude files and folders from the routing logic by referencing the documentation

---
I've verified that these changes:
- [x] Follow the project's documentation style guide
- [x] Include all necessary links and references
- [x] Have been tested for proper rendering