### PR TITLE
feat: add bindings for `Route.Link` and `routeApi.Link`

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -452,9 +452,12 @@ export type CreateLinkProps = LinkProps<
   string
 >
 
-export type LinkComponent<TComp> = <
+export type LinkComponent<
+  in out TComp,
+  in out TDefaultFrom extends string = string,
+> = <
   TRouter extends AnyRouter = RegisteredRouter,
-  const TFrom extends string = string,
+  const TFrom extends string = TDefaultFrom,
   const TTo extends string | undefined = undefined,
   const TMaskFrom extends string = TFrom,
   const TMaskTo extends string = '',

--- a/packages/react-router/src/route.tsx
+++ b/packages/react-router/src/route.tsx
@@ -255,7 +255,7 @@ export class Route<
     return useNavigate({ from: this.fullPath })
   }
 
-  Link = React.forwardRef(
+  Link: LinkComponent<'a', TFullPath> = React.forwardRef(
     (props, ref: React.ForwardedRef<HTMLAnchorElement>) => {
       const router = useRouter()
       return (
@@ -453,7 +453,7 @@ export class RootRoute<
     return useNavigate({ from: this.fullPath })
   }
 
-  Link = React.forwardRef(
+  Link: LinkComponent<'a', '/'> = React.forwardRef(
     (props, ref: React.ForwardedRef<HTMLAnchorElement>) => {
       const router = useRouter()
       return (

--- a/packages/react-router/src/route.tsx
+++ b/packages/react-router/src/route.tsx
@@ -4,6 +4,7 @@ import {
   BaseRouteApi,
   notFound,
 } from '@tanstack/router-core'
+import React from 'react'
 import { useLoaderData } from './useLoaderData'
 import { useLoaderDeps } from './useLoaderDeps'
 import { useParams } from './useParams'
@@ -11,6 +12,7 @@ import { useSearch } from './useSearch'
 import { useNavigate } from './useNavigate'
 import { useMatch } from './useMatch'
 import { useRouter } from './useRouter'
+import { Link } from './link'
 import type {
   AnyContext,
   AnyRoute,
@@ -39,8 +41,8 @@ import type { UseMatchRoute } from './useMatch'
 import type { UseLoaderDepsRoute } from './useLoaderDeps'
 import type { UseParamsRoute } from './useParams'
 import type { UseSearchRoute } from './useSearch'
-import type * as Solid from 'solid-js'
 import type { UseRouteContextRoute } from './useRouteContext'
+import type { LinkComponent } from './link'
 
 declare module '@tanstack/router-core' {
   export interface UpdatableRouteOptionsExtensions {
@@ -61,6 +63,7 @@ declare module '@tanstack/router-core' {
     useLoaderDeps: UseLoaderDepsRoute<TId>
     useLoaderData: UseLoaderDataRoute<TId>
     useNavigate: () => UseNavigateResult<TFullPath>
+    Link: LinkComponent<'a', TFullPath>
   }
 }
 
@@ -86,6 +89,7 @@ export class RouteApi<
     return useMatch({
       select: opts?.select,
       from: this.id,
+      structuralSharing: opts?.structuralSharing,
     } as any) as any
   }
 
@@ -97,15 +101,19 @@ export class RouteApi<
   }
 
   useSearch: UseSearchRoute<TId> = (opts) => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     return useSearch({
       select: opts?.select,
+      structuralSharing: opts?.structuralSharing,
       from: this.id,
     } as any) as any
   }
 
   useParams: UseParamsRoute<TId> = (opts) => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     return useParams({
       select: opts?.select,
+      structuralSharing: opts?.structuralSharing,
       from: this.id,
     } as any) as any
   }
@@ -128,6 +136,16 @@ export class RouteApi<
   notFound = (opts?: NotFoundError) => {
     return notFound({ routeId: this.id as string, ...opts })
   }
+
+  Link: LinkComponent<'a', RouteTypesById<TRouter, TId>['fullPath']> =
+    React.forwardRef((props, ref: React.ForwardedRef<HTMLAnchorElement>) => {
+      const router = useRouter()
+      const fullPath = router.routesById[this.id as string].fullPath
+      return <Link ref={ref} from={fullPath as never} {...props} />
+    }) as unknown as LinkComponent<
+      'a',
+      RouteTypesById<TRouter, TId>['fullPath']
+    >
 }
 
 export class Route<
@@ -188,12 +206,14 @@ export class Route<
     >,
   ) {
     super(options)
+    ;(this as any).$$typeof = Symbol.for('react.memo')
   }
 
   useMatch: UseMatchRoute<TId> = (opts) => {
     return useMatch({
       select: opts?.select,
       from: this.id,
+      structuralSharing: opts?.structuralSharing,
     } as any) as any
   }
 
@@ -206,15 +226,19 @@ export class Route<
   }
 
   useSearch: UseSearchRoute<TId> = (opts) => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     return useSearch({
       select: opts?.select,
+      structuralSharing: opts?.structuralSharing,
       from: this.id,
     } as any) as any
   }
 
   useParams: UseParamsRoute<TId> = (opts) => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     return useParams({
       select: opts?.select,
+      structuralSharing: opts?.structuralSharing,
       from: this.id,
     } as any) as any
   }
@@ -230,6 +254,19 @@ export class Route<
   useNavigate = (): UseNavigateResult<TFullPath> => {
     return useNavigate({ from: this.fullPath })
   }
+
+  Link = React.forwardRef(
+    (props, ref: React.ForwardedRef<HTMLAnchorElement>) => {
+      const router = useRouter()
+      return (
+        <Link
+          ref={ref}
+          from={router.routesById[this.id].fullPath as never}
+          {...props}
+        />
+      )
+    },
+  ) as unknown as LinkComponent<'a', TFullPath>
 }
 
 export function createRoute<
@@ -280,8 +317,7 @@ export function createRoute<
   TBeforeLoadFn,
   TLoaderDeps,
   TLoaderFn,
-  TChildren,
-  unknown
+  TChildren
 > {
   return new Route<
     TParentRoute,
@@ -296,8 +332,7 @@ export function createRoute<
     TBeforeLoadFn,
     TLoaderDeps,
     TLoaderFn,
-    TChildren,
-    unknown
+    TChildren
   >(options)
 }
 
@@ -369,12 +404,14 @@ export class RootRoute<
     >,
   ) {
     super(options)
+    ;(this as any).$$typeof = Symbol.for('react.memo')
   }
 
   useMatch: UseMatchRoute<RootRouteId> = (opts) => {
     return useMatch({
       select: opts?.select,
       from: this.id,
+      structuralSharing: opts?.structuralSharing,
     } as any) as any
   }
 
@@ -387,15 +424,19 @@ export class RootRoute<
   }
 
   useSearch: UseSearchRoute<RootRouteId> = (opts) => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     return useSearch({
       select: opts?.select,
+      structuralSharing: opts?.structuralSharing,
       from: this.id,
     } as any) as any
   }
 
   useParams: UseParamsRoute<RootRouteId> = (opts) => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     return useParams({
       select: opts?.select,
+      structuralSharing: opts?.structuralSharing,
       from: this.id,
     } as any) as any
   }
@@ -411,6 +452,55 @@ export class RootRoute<
   useNavigate = (): UseNavigateResult<'/'> => {
     return useNavigate({ from: this.fullPath })
   }
+
+  Link = React.forwardRef(
+    (props, ref: React.ForwardedRef<HTMLAnchorElement>) => {
+      const router = useRouter()
+      return (
+        <Link
+          ref={ref}
+          from={router.routesById[this.id].fullPath as never}
+          {...props}
+        />
+      )
+    },
+  ) as unknown as LinkComponent<'a', '/'>
+}
+
+export function createRootRoute<
+  TSearchValidator = undefined,
+  TRouterContext = {},
+  TRouteContextFn = AnyContext,
+  TBeforeLoadFn = AnyContext,
+  TLoaderDeps extends Record<string, any> = {},
+  TLoaderFn = undefined,
+>(
+  options?: RootRouteOptions<
+    TSearchValidator,
+    TRouterContext,
+    TRouteContextFn,
+    TBeforeLoadFn,
+    TLoaderDeps,
+    TLoaderFn
+  >,
+): RootRoute<
+  TSearchValidator,
+  TRouterContext,
+  TRouteContextFn,
+  TBeforeLoadFn,
+  TLoaderDeps,
+  TLoaderFn,
+  unknown,
+  unknown
+> {
+  return new RootRoute<
+    TSearchValidator,
+    TRouterContext,
+    TRouteContextFn,
+    TBeforeLoadFn,
+    TLoaderDeps,
+    TLoaderFn
+  >(options)
 }
 
 export function createRouteMask<
@@ -420,14 +510,16 @@ export function createRouteMask<
 >(
   opts: {
     routeTree: TRouteTree
-  } & ToMaskOptions<RouterCore<TRouteTree, 'never', false>, TFrom, TTo>,
+  } & ToMaskOptions<RouterCore<TRouteTree, 'never', boolean>, TFrom, TTo>,
 ): RouteMask<TRouteTree> {
   return opts as any
 }
 
-export type SolidNode = Solid.JSX.Element
+export type ReactNode = any
 
-export type SyncRouteComponent<TProps> = (props: TProps) => Solid.JSX.Element
+export type SyncRouteComponent<TProps> =
+  | ((props: TProps) => ReactNode)
+  | React.LazyExoticComponent<(props: TProps) => ReactNode>
 
 export type AsyncRouteComponent<TProps> = SyncRouteComponent<TProps> & {
   preload?: () => Promise<void>
@@ -492,40 +584,4 @@ export class NotFoundRoute<
       id: '404',
     })
   }
-}
-
-export function createRootRoute<
-  TSearchValidator = undefined,
-  TRouterContext = {},
-  TRouteContextFn = AnyContext,
-  TBeforeLoadFn = AnyContext,
-  TLoaderDeps extends Record<string, any> = {},
-  TLoaderFn = undefined,
->(
-  options?: RootRouteOptions<
-    TSearchValidator,
-    TRouterContext,
-    TRouteContextFn,
-    TBeforeLoadFn,
-    TLoaderDeps,
-    TLoaderFn
-  >,
-): RootRoute<
-  TSearchValidator,
-  TRouterContext,
-  TRouteContextFn,
-  TBeforeLoadFn,
-  TLoaderDeps,
-  TLoaderFn,
-  unknown,
-  unknown
-> {
-  return new RootRoute<
-    TSearchValidator,
-    TRouterContext,
-    TRouteContextFn,
-    TBeforeLoadFn,
-    TLoaderDeps,
-    TLoaderFn
-  >(options)
 }

--- a/packages/react-router/tests/routeApi.test-d.tsx
+++ b/packages/react-router/tests/routeApi.test-d.tsx
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, test } from 'vitest'
 import { createRootRoute, createRoute, createRouter, getRouteApi } from '../src'
-import type { MakeRouteMatch, UseNavigateResult } from '../src'
+import type { LinkComponent, MakeRouteMatch, UseNavigateResult } from '../src'
 
 const rootRoute = createRootRoute()
 
@@ -85,6 +85,12 @@ describe('getRouteApi', () => {
   test('useMatch', () => {
     expectTypeOf(invoiceRouteApi.useMatch<DefaultRouter>()).toEqualTypeOf<
       MakeRouteMatch<typeof routeTree, '/invoices/$invoiceId'>
+    >()
+  })
+  test('Link', () => {
+    const Link = invoiceRouteApi.Link
+    expectTypeOf(Link).toEqualTypeOf<
+      LinkComponent<'a', '/invoices/$invoiceId'>
     >()
   })
 })

--- a/packages/solid-router/src/link.tsx
+++ b/packages/solid-router/src/link.tsx
@@ -509,9 +509,12 @@ export type CreateLinkProps = LinkProps<
   string
 >
 
-export type LinkComponent<TComp> = <
+export type LinkComponent<
+  in out TComp,
+  in out TDefaultFrom extends string = string,
+> = <
   TRouter extends AnyRouter = RegisteredRouter,
-  const TFrom extends string = string,
+  const TFrom extends string = TDefaultFrom,
   const TTo extends string | undefined = undefined,
   const TMaskFrom extends string = TFrom,
   const TMaskTo extends string = '',

--- a/packages/solid-router/tests/routeApi.test-d.tsx
+++ b/packages/solid-router/tests/routeApi.test-d.tsx
@@ -1,5 +1,6 @@
 import { describe, expectTypeOf, test } from 'vitest'
 import { createRootRoute, createRoute, createRouter, getRouteApi } from '../src'
+import type { LinkComponent } from '../src'
 import type { Accessor } from 'solid-js'
 import type { MakeRouteMatch, UseNavigateResult } from '@tanstack/router-core'
 
@@ -94,6 +95,12 @@ describe('getRouteApi', () => {
   test('useMatch', () => {
     expectTypeOf(invoiceRouteApi.useMatch<DefaultRouter>()).toEqualTypeOf<
       Accessor<MakeRouteMatch<typeof routeTree, '/invoices/$invoiceId'>>
+    >()
+  })
+  test('Link', () => {
+    const Link = invoiceRouteApi.Link
+    expectTypeOf(Link).toEqualTypeOf<
+      LinkComponent<'a', '/invoices/$invoiceId'>
     >()
   })
 })


### PR DESCRIPTION
This allows `Route.Link` and `routeApi.Link` bindings instead of manual `from`.

We never used to be able to do this due to circular issues but it seems this is no longer an issue since all the changes to the types