### PR TITLE
doc: Update search-params.md Effect/Schema Adapter heading

### DIFF
--- a/docs/router/framework/react/guide/search-params.md
+++ b/docs/router/framework/react/guide/search-params.md
@@ -318,7 +318,7 @@ export const Route = createFileRoute('/shop/products/')({
 })
 ```
 
-## Effect/Schema
+### Effect/Schema
 
 When using [Effect/Schema](https://effect.website/docs/schema/introduction/) an adapter is not needed to ensure the correct `input` and `output` types are used for navigation and reading search params. This is because [Effect/Schema](https://effect.website/docs/schema/standard-schema/) implements [Standard Schema](https://github.com/standard-schema/standard-schema)
 


### PR DESCRIPTION
Fix heading level of the Effect/Schema Adapters section to have the right level relational level in the table of contents.