### PR TITLE
feat(start): silence serverFn errors in prod

### DIFF
--- a/packages/start-server-functions-handler/src/index.ts
+++ b/packages/start-server-functions-handler/src/index.ts
@@ -261,11 +261,13 @@ async function handleServerRequest({
         return redirectOrNotFoundResponse(error)
       }
 
-      console.info()
-      console.info('Server Fn Error!')
-      console.info()
-      console.error(error)
-      console.info()
+      if (process.env.NODE_ENV === 'development') {
+        console.info()
+        console.info('Server Fn Error!')
+        console.info()
+        console.error(error)
+        console.info()
+      }
 
       return new Response(startSerializer.stringify(error), {
         status: 500,


### PR DESCRIPTION
Silence serverFn error logs on production builds. IMO this should not be the responsibility of the framework, but something that is up to the user to implement (like on a middleware).

Admittedly, this is kind of a breaking change, given that currently users may be relying on these logs. I leave it up to the maintainers to decide a course of action on this (or to just discard it)