### PR TITLE
fix: declare `vite` as a `peerDependency`

### DIFF
--- a/e2e/react-start/basic/package.json
+++ b/e2e/react-start/basic/package.json
@@ -18,18 +18,19 @@
     "react-dom": "^19.0.0",
     "redaxios": "^0.5.1",
     "tailwind-merge": "^2.6.0",
+    "vite": "6.3.5",
     "zod": "^3.24.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
+    "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
-    "@tanstack/router-e2e-utils": "workspace:^",
     "@vitejs/plugin-react": "^4.3.4",
+    "autoprefixer": "^10.4.20",
     "combinate": "^1.1.11",
     "postcss": "^8.5.1",
-    "autoprefixer": "^10.4.20",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.2",
     "vite-tsconfig-paths": "^5.1.4"

--- a/e2e/solid-start/basic-tsr-config/package.json
+++ b/e2e/solid-start/basic-tsr-config/package.json
@@ -14,7 +14,8 @@
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "^1.9.5"
+    "solid-js": "^1.9.5",
+    "vite": "6.3.5"
   },
   "devDependencies": {
     "@tanstack/router-e2e-utils": "workspace:^",

--- a/e2e/solid-start/basic/package.json
+++ b/e2e/solid-start/basic/package.json
@@ -14,21 +14,22 @@
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "^1.9.5",
     "redaxios": "^0.5.1",
+    "solid-js": "^1.9.5",
     "tailwind-merge": "^2.6.0",
+    "vite": "6.3.5",
     "zod": "^3.24.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
-    "@types/node": "^22.10.2",
     "@tanstack/router-e2e-utils": "workspace:^",
-    "vite-plugin-solid": "^2.11.2",
+    "@types/node": "^22.10.2",
+    "autoprefixer": "^10.4.20",
     "combinate": "^1.1.11",
     "postcss": "^8.5.1",
-    "autoprefixer": "^10.4.20",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.2",
+    "vite-plugin-solid": "^2.11.2",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/e2e/solid-start/scroll-restoration/package.json
+++ b/e2e/solid-start/scroll-restoration/package.json
@@ -15,21 +15,22 @@
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "@tanstack/zod-adapter": "workspace:^",
-    "solid-js": "^1.9.5",
     "redaxios": "^0.5.1",
+    "solid-js": "^1.9.5",
     "tailwind-merge": "^2.6.0",
+    "vite": "6.3.5",
     "zod": "^3.24.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",
-    "vite-plugin-solid": "^2.11.6",
     "autoprefixer": "^10.4.20",
     "combinate": "^1.1.11",
     "postcss": "^8.5.1",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.2",
+    "vite-plugin-solid": "^2.11.6",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/e2e/solid-start/server-functions/package.json
+++ b/e2e/solid-start/server-functions/package.json
@@ -15,9 +15,10 @@
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "js-cookie": "^3.0.5",
-    "solid-js": "^1.9.5",
     "redaxios": "^0.5.1",
+    "solid-js": "^1.9.5",
     "tailwind-merge": "^2.6.0",
+    "vite": "6.3.5",
     "zod": "^3.24.2"
   },
   "devDependencies": {
@@ -25,12 +26,12 @@
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/js-cookie": "^3.0.6",
     "@types/node": "^22.10.2",
-    "vite-plugin-solid": "^2.11.6",
     "autoprefixer": "^10.4.20",
     "combinate": "^1.1.11",
     "postcss": "^8.5.1",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.2",
+    "vite-plugin-solid": "^2.11.6",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/e2e/solid-start/website/package.json
+++ b/e2e/solid-start/website/package.json
@@ -14,20 +14,21 @@
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "^1.9.5",
     "redaxios": "^0.5.1",
+    "solid-js": "^1.9.5",
     "tailwind-merge": "^2.6.0",
+    "vite": "6.3.5",
     "zod": "^3.24.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",
-    "vite-plugin-solid": "^2.11.6",
-    "postcss": "^8.5.1",
     "autoprefixer": "^10.4.20",
+    "postcss": "^8.5.1",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.2",
+    "vite-plugin-solid": "^2.11.6",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/packages/directive-functions-plugin/package.json
+++ b/packages/directive-functions-plugin/package.json
@@ -74,14 +74,16 @@
     "@babel/types": "^7.26.8",
     "@tanstack/router-utils": "workspace:^",
     "babel-dead-code-elimination": "^1.0.10",
-    "dedent": "^1.5.3",
-    "tiny-invariant": "^1.3.3",
-    "vite": "^6.0.0"
+    "tiny-invariant": "^1.3.3"
   },
   "devDependencies": {
     "@types/babel__code-frame": "^7.0.6",
     "@types/babel__core": "^7.20.5",
     "@types/babel__template": "^7.4.4",
-    "@types/babel__traverse": "^7.20.6"
+    "@types/babel__traverse": "^7.20.6",
+    "vite": "^6.0.0"
+  },
+  "peerDependencies": {
+    "vite": ">=6.0.0"
   }
 }

--- a/packages/react-start-plugin/package.json
+++ b/packages/react-start-plugin/package.json
@@ -69,8 +69,14 @@
     "@tanstack/router-utils": "workspace:^",
     "@tanstack/server-functions-plugin": "workspace:^",
     "@tanstack/start-plugin-core": "workspace:^",
-    "@vitejs/plugin-react": "^4.3.4",
-    "vite": "^6.0.0",
     "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.4",
+    "vite": "^6.0.0"
+  },
+  "peerDependencies": {
+    "@vitejs/plugin-react": ">=4.3.4",
+    "vite": ">=6.0.0"
   }
 }

--- a/packages/react-start/package.json
+++ b/packages/react-start/package.json
@@ -113,7 +113,7 @@
     "@vitejs/plugin-react": ">=4.3.4",
     "react": ">=18.0.0 || >=19.0.0",
     "react-dom": ">=18.0.0 || >=19.0.0",
-    "vite": "^6.0.0"
+    "vite": ">=6.0.0"
   },
   "devDependencies": {
     "esbuild": "^0.25.0"

--- a/packages/react-start/package.json
+++ b/packages/react-start/package.json
@@ -110,6 +110,7 @@
     "@tanstack/start-server-functions-server": "workspace:^"
   },
   "peerDependencies": {
+    "@vitejs/plugin-react": ">=4.3.4",
     "react": ">=18.0.0 || >=19.0.0",
     "react-dom": ">=18.0.0 || >=19.0.0",
     "vite": "^6.0.0"

--- a/packages/server-functions-plugin/package.json
+++ b/packages/server-functions-plugin/package.json
@@ -74,7 +74,6 @@
     "@babel/traverse": "^7.26.8",
     "@babel/types": "^7.26.8",
     "babel-dead-code-elimination": "^1.0.9",
-    "dedent": "^1.5.3",
     "tiny-invariant": "^1.3.3"
   },
   "devDependencies": {

--- a/packages/solid-start-plugin/package.json
+++ b/packages/solid-start-plugin/package.json
@@ -69,8 +69,14 @@
     "@tanstack/router-utils": "workspace:^",
     "@tanstack/server-functions-plugin": "workspace:^",
     "@tanstack/start-plugin-core": "workspace:^",
-    "vite": "^6.0.0",
-    "vite-plugin-solid": "^2.11.6",
     "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "vite": "^6.0.0",
+    "vite-plugin-solid": "^2.11.6"
+  },
+  "peerDependencies": {
+    "vite": ">=6.0.0",
+    "vite-plugin-solid": ">=2.11.6"
   }
 }

--- a/packages/solid-start/package.json
+++ b/packages/solid-start/package.json
@@ -111,7 +111,8 @@
   },
   "peerDependencies": {
     "solid-js": ">=1.0.0",
-    "vite": ">=6.0.0"
+    "vite": ">=6.0.0",
+    "vite-plugin-solid": ">=2.11.6"
   },
   "devDependencies": {
     "esbuild": "^0.25.0"

--- a/packages/solid-start/package.json
+++ b/packages/solid-start/package.json
@@ -111,7 +111,7 @@
   },
   "peerDependencies": {
     "solid-js": ">=1.0.0",
-    "vite": "^6.0.0"
+    "vite": ">=6.0.0"
   },
   "devDependencies": {
     "esbuild": "^0.25.0"

--- a/packages/start-plugin-core/package.json
+++ b/packages/start-plugin-core/package.json
@@ -80,8 +80,13 @@
     "nitropack": "^2.11.8",
     "pathe": "^2.0.3",
     "ufo": "^1.5.4",
-    "vite": "^6.0.0",
     "xmlbuilder2": "^3.1.1",
     "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "vite": "^6.0.0"
+  },
+  "peerDependencies": {
+    "vite": ">=6.0.0"
   }
 }

--- a/packages/start-server-functions-fetcher/package.json
+++ b/packages/start-server-functions-fetcher/package.json
@@ -66,7 +66,6 @@
     "@tanstack/start-client-core": "workspace:^"
   },
   "devDependencies": {
-    "typescript": "^5.7.2",
-    "vite": "^6.3.5"
+    "typescript": "^5.7.2"
   }
 }

--- a/packages/start-server-functions-server/package.json
+++ b/packages/start-server-functions-server/package.json
@@ -63,8 +63,7 @@
   },
   "dependencies": {
     "@tanstack/server-functions-plugin": "workspace:^",
-    "tiny-invariant": "^1.3.3",
-    "vite": "^6.0.0"
+    "tiny-invariant": "^1.3.3"
   },
   "devDependencies": {
     "typescript": "^5.7.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2030,6 +2030,9 @@ importers:
       solid-js:
         specifier: ^1.9.5
         version: 1.9.5
+      vite:
+        specifier: 6.3.5
+        version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
     devDependencies:
       '@tanstack/router-e2e-utils':
         specifier: workspace:^

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6069,6 +6069,9 @@ importers:
       vite:
         specifier: 6.3.5
         version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
+      vite-plugin-solid:
+        specifier: '>=2.11.6'
+        version: 2.11.6(@testing-library/jest-dom@6.6.3)(solid-js@1.9.5)(vite@6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
     devDependencies:
       esbuild:
         specifier: ^0.25.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5658,15 +5658,16 @@ importers:
       '@tanstack/start-plugin-core':
         specifier: workspace:*
         version: link:../start-plugin-core
+      zod:
+        specifier: ^3.24.2
+        version: 3.24.2
+    devDependencies:
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.3.4(vite@6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
       vite:
         specifier: 6.3.5
         version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
-      zod:
-        specifier: ^3.24.2
-        version: 3.24.2
 
   packages/react-start-server:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2189,6 +2189,9 @@ importers:
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0
+      vite:
+        specifier: 6.3.5
+        version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
       zod:
         specifier: ^3.24.2
         version: 3.24.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6344,9 +6344,6 @@ importers:
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3
-      vite:
-        specifier: 6.3.5
-        version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
     devDependencies:
       typescript:
         specifier: ^5.7.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1978,6 +1978,9 @@ importers:
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0
+      vite:
+        specifier: 6.3.5
+        version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
       zod:
         specifier: ^3.24.2
         version: 3.24.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2131,6 +2131,9 @@ importers:
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0
+      vite:
+        specifier: 6.3.5
+        version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
       zod:
         specifier: ^3.24.2
         version: 3.24.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6128,15 +6128,16 @@ importers:
       '@tanstack/start-plugin-core':
         specifier: workspace:*
         version: link:../start-plugin-core
+      zod:
+        specifier: ^3.24.2
+        version: 3.24.2
+    devDependencies:
       vite:
         specifier: 6.3.5
         version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
       vite-plugin-solid:
         specifier: ^2.11.6
         version: 2.11.6(@testing-library/jest-dom@6.6.3)(solid-js@1.9.5)(vite@6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
-      zod:
-        specifier: ^3.24.2
-        version: 3.24.2
 
   packages/solid-start-server:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6253,15 +6253,16 @@ importers:
       ufo:
         specifier: ^1.5.4
         version: 1.5.4
-      vite:
-        specifier: 6.3.5
-        version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
       xmlbuilder2:
         specifier: ^3.1.1
         version: 3.1.1
       zod:
         specifier: ^3.24.2
         version: 3.24.2
+    devDependencies:
+      vite:
+        specifier: 6.3.5
+        version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
 
   packages/start-server-core:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6335,9 +6335,6 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.8.2
-      vite:
-        specifier: 6.3.5
-        version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
 
   packages/start-server-functions-server:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5446,15 +5446,9 @@ importers:
       babel-dead-code-elimination:
         specifier: ^1.0.10
         version: 1.0.10
-      dedent:
-        specifier: ^1.5.3
-        version: 1.5.3(babel-plugin-macros@3.1.0)
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3
-      vite:
-        specifier: 6.3.5
-        version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
     devDependencies:
       '@types/babel__code-frame':
         specifier: ^7.0.6
@@ -5468,6 +5462,9 @@ importers:
       '@types/babel__traverse':
         specifier: ^7.20.6
         version: 7.20.6
+      vite:
+        specifier: 6.3.5
+        version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
 
   packages/eslint-plugin-router:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5590,6 +5590,9 @@ importers:
       '@tanstack/start-server-functions-server':
         specifier: workspace:*
         version: link:../start-server-functions-server
+      '@vitejs/plugin-react':
+        specifier: '>=4.3.4'
+        version: 4.3.4(vite@6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
       react:
         specifier: ^19.0.0
         version: 19.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -953,6 +953,9 @@ importers:
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0
+      vite:
+        specifier: 6.3.5
+        version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
       zod:
         specifier: ^3.24.2
         version: 3.24.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5955,9 +5955,6 @@ importers:
       babel-dead-code-elimination:
         specifier: ^1.0.9
         version: 1.0.10
-      dedent:
-        specifier: ^1.5.3
-        version: 1.5.3(babel-plugin-macros@3.1.0)
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3
@@ -10706,14 +10703,6 @@ packages:
 
   decimal.js@10.5.0:
     resolution: {integrity: sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==}
-
-  dedent@1.5.3:
-    resolution: {integrity: sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==}
-    peerDependencies:
-      babel-plugin-macros: ^3.1.0
-    peerDependenciesMeta:
-      babel-plugin-macros:
-        optional: true
 
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
@@ -19014,10 +19003,6 @@ snapshots:
       ms: 2.1.3
 
   decimal.js@10.5.0: {}
-
-  dedent@1.5.3(babel-plugin-macros@3.1.0):
-    optionalDependencies:
-      babel-plugin-macros: 3.1.0
 
   deep-eql@5.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2070,6 +2070,9 @@ importers:
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0
+      vite:
+        specifier: 6.3.5
+        version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
       zod:
         specifier: ^3.24.2
         version: 3.24.2


### PR DESCRIPTION
Currently, none of the packages (i.e `packages/*`) need `vite` bundled as a `dependency`. So its been moved to the `devDependencies` and had the version opened using `"peerDependencies": { "vite": ">=6.0.0" }`.

Additionally, `vite` has been added as a `dependency` to the Start end-to-end sandboxes.

In a later PR, `vite` will need to be added to all the TanStack Start examples (i.e. `examples/**/start-*`).