### PR TITLE
fix(router-generator): exit conditions when using `verboseFileRoutes`

### DIFF
--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -310,6 +310,16 @@ export async function generator(config: Config, root: string) {
               `${node._fsRouteType === 'lazy' ? 'createLazyFileRoute' : 'createFileRoute'}`,
           )
       } else {
+        // Check if the route file has a Route export
+        if (
+          !routeCode
+            .split('\n')
+            .some((line) => line.trim().startsWith('export const Route'))
+        ) {
+          return
+        }
+
+        // Update the existing route file
         replaced = routeCode
           // fix wrong ids
           .replace(


### PR DESCRIPTION
When using `verboseFileRoutes`, the `router-generator` shouldn't try to includes routes where `export const Route` isn't present in the body of the source file.