### PR TITLE
docs(start): Remove unplanned feature from docs

### DIFF
--- a/docs/start/framework/react/server-functions.md
+++ b/docs/start/framework/react/server-functions.md
@@ -7,7 +7,7 @@ title: Server Functions
 
 Server functions allow you to specify logic that can be invoked almost anywhere (even the client), but run **only** on the server. In fact, they are not so different from an API Route, but with a few key differences:
 
-- They do not have stable public URL (but you'll be able to do this very soon!)
+- They do not have stable public URL
 - They can be called from anywhere in your application, including loaders, hooks, components, etc., but cannot be called from API Routes.
 
 However, they are similar to regular API Routes in that:


### PR DESCRIPTION
I asked about stable url's for server functions and was informed that this feature is no longer planned. This PR updates the docs to reflect this. 