### PR TITLE
chore(docs): specify that not found errors are handled by the nearest parent when called within `loader`

### DIFF
--- a/docs/router/framework/react/guide/not-found-errors.md
+++ b/docs/router/framework/react/guide/not-found-errors.md
@@ -16,7 +16,7 @@ There are 2 uses for not-found errors in TanStack Router:
     - Attempting to access `/posts/1/edit` when the route tree only handles `/posts/$postId`
 - **Missing resources**: When a resource cannot be found, such as a post with a given ID or any asynchronous data that is not available or does not exist
   - **You, the developer** must throw a not-found error when a resource cannot be found. This can be done in the `beforeLoad` or `loader` functions using the `notFound` utility.
-  - Will be handled by the nearest parent route with a `notFoundComponent` or the root route
+  - Will be handled by the nearest parent route with a `notFoundComponent` (when `notFound` is called within `loader`) or the root route.
   - Examples:
     - Attempting to access `/posts/1` when the post with ID 1 does not exist
     - Attempting to access `/docs/path/to/document` when the document does not exist


### PR DESCRIPTION
This PR is to improve the not found error docs slightly, based on confusion about how they bubble up, as reflected in this thread: https://discord.com/channels/719702312431386674/1023930177224462388/threads/1303321797537828864