### PR TITLE
fix(example): fix typescript error for "../styles/app.css?url"

### DIFF
--- a/examples/react/start-bare/src/routes/__root.tsx
+++ b/examples/react/start-bare/src/routes/__root.tsx
@@ -1,3 +1,4 @@
+/// <reference types="vinxi/types/client" />
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
 import {
   createRootRoute,

--- a/examples/react/start-basic-auth/src/routes/__root.tsx
+++ b/examples/react/start-basic-auth/src/routes/__root.tsx
@@ -1,3 +1,4 @@
+/// <reference types="vinxi/types/client" />
 import {
   HeadContent,
   Link,

--- a/examples/react/start-basic-react-query/src/routes/__root.tsx
+++ b/examples/react/start-basic-react-query/src/routes/__root.tsx
@@ -1,3 +1,4 @@
+/// <reference types="vinxi/types/client" />
 import {
   HeadContent,
   Link,

--- a/examples/react/start-basic-rsc/src/routes/__root.tsx
+++ b/examples/react/start-basic-rsc/src/routes/__root.tsx
@@ -1,3 +1,4 @@
+/// <reference types="vinxi/types/client" />
 import {
   HeadContent,
   Link,

--- a/examples/react/start-basic-static/src/routes/__root.tsx
+++ b/examples/react/start-basic-static/src/routes/__root.tsx
@@ -1,3 +1,4 @@
+/// <reference types="vinxi/types/client" />
 import {
   HeadContent,
   Link,

--- a/examples/react/start-basic/src/routes/__root.tsx
+++ b/examples/react/start-basic/src/routes/__root.tsx
@@ -1,3 +1,4 @@
+/// <reference types="vinxi/types/client" />
 import {
   HeadContent,
   Link,

--- a/examples/react/start-convex-trellaux/src/routes/__root.tsx
+++ b/examples/react/start-convex-trellaux/src/routes/__root.tsx
@@ -1,3 +1,4 @@
+/// <reference types="vinxi/types/client" />
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools/production'
 import {
   Link,

--- a/examples/react/start-supabase-basic/src/routes/__root.tsx
+++ b/examples/react/start-supabase-basic/src/routes/__root.tsx
@@ -1,3 +1,4 @@
+/// <reference types="vinxi/types/client" />
 import {
   HeadContent,
   Link,

--- a/examples/react/start-trellaux/src/routes/__root.tsx
+++ b/examples/react/start-trellaux/src/routes/__root.tsx
@@ -1,3 +1,4 @@
+/// <reference types="vinxi/types/client" />
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools/production'
 import {
   HeadContent,


### PR DESCRIPTION
Like #2413 

If there's an import `../styles/app.css?url` (or any similar, that import something with a `?url` postfix), there'll be a typescript error without referencing `vinxi/types/client`
