### PR TITLE
fix: resolve custom `server` entry path on windows fs

### DIFF
--- a/e2e/react-start/basic/src/server.ts
+++ b/e2e/react-start/basic/src/server.ts
@@ -1,0 +1,11 @@
+// DO NOT DELETE THIS FILE!!!
+// This file is a good smoke test to make sure the custom server entry is working
+import {
+  createStartHandler,
+  defaultStreamHandler,
+} from '@tanstack/react-start/server'
+import { createRouter } from './router'
+
+export default createStartHandler({
+  createRouter,
+})(defaultStreamHandler)

--- a/e2e/solid-start/basic/src/server.ts
+++ b/e2e/solid-start/basic/src/server.ts
@@ -1,0 +1,11 @@
+// DO NOT DELETE THIS FILE!!!
+// This file is a good smoke test to make sure the custom server entry is working
+import {
+  createStartHandler,
+  defaultStreamHandler,
+} from '@tanstack/solid-start/server'
+import { createRouter } from './router'
+
+export default createStartHandler({
+  createRouter,
+})(defaultStreamHandler)

--- a/packages/react-start-plugin/src/index.ts
+++ b/packages/react-start-plugin/src/index.ts
@@ -60,10 +60,14 @@ export function TanStackStartVitePlugin(
         )
 
         if (id === '/~start/server-entry.tsx') {
-          const ssrEntryPath = path.resolve(
-            resolvedConfig.root,
-            options.serverEntryPath,
+          const ssrEntryPath = options.serverEntryPath.startsWith(
+            '/~start/default-server-entry',
           )
+            ? options.serverEntryPath
+            : path
+                .resolve(resolvedConfig.root, options.serverEntryPath)
+                .replaceAll('\\', '/')
+
           return `
 import { toWebRequest, defineEventHandler } from '@tanstack/react-start/server';
 import serverEntry from '${ssrEntryPath}';

--- a/packages/react-start-plugin/src/index.ts
+++ b/packages/react-start-plugin/src/index.ts
@@ -5,6 +5,7 @@ import {
   TanStackStartServerRoutesVite,
   TanStackStartVitePluginCore,
 } from '@tanstack/start-plugin-core'
+import * as vite from 'vite'
 import { getTanStackStartOptions } from './schema'
 import type { TanStackStartInputConfig, WithReactPlugin } from './schema'
 import type { PluginOption, ResolvedConfig } from 'vite'
@@ -64,9 +65,9 @@ export function TanStackStartVitePlugin(
             '/~start/default-server-entry',
           )
             ? options.serverEntryPath
-            : path
-                .resolve(resolvedConfig.root, options.serverEntryPath)
-                .replaceAll('\\', '/')
+            : vite.normalizePath(
+                path.resolve(resolvedConfig.root, options.serverEntryPath),
+              )
 
           return `
 import { toWebRequest, defineEventHandler } from '@tanstack/react-start/server';

--- a/packages/solid-start-plugin/src/index.ts
+++ b/packages/solid-start-plugin/src/index.ts
@@ -5,6 +5,7 @@ import {
   TanStackStartServerRoutesVite,
   TanStackStartVitePluginCore,
 } from '@tanstack/start-plugin-core'
+import * as vite from 'vite'
 import { getTanStackStartOptions } from './schema'
 import type { PluginOption, ResolvedConfig } from 'vite'
 import type { TanStackStartInputConfig, WithSolidPlugin } from './schema'
@@ -57,10 +58,14 @@ export function TanStackStartVitePlugin(
         )
 
         if (id === '/~start/server-entry.tsx') {
-          const ssrEntryPath = path.resolve(
-            resolvedConfig.root,
-            options.serverEntryPath,
+          const ssrEntryPath = options.serverEntryPath.startsWith(
+            '/~start/default-server-entry',
           )
+            ? options.serverEntryPath
+            : vite.normalizePath(
+                path.resolve(resolvedConfig.root, options.serverEntryPath),
+              )
+
           return `
 import { toWebRequest, defineEventHandler } from '@tanstack/solid-start/server';
 import serverEntry from '${ssrEntryPath}';


### PR DESCRIPTION
This is a patch following https://github.com/TanStack/router/issues/4138 and https://github.com/TanStack/router/pull/4172. The virtual path should be kept intact when there isn't a custom `server.ts` entry file. Excluding the root path resolves the following error:

```
Error: Cannot find module 'D:~startdefault-server-entry' imported from '/~start/server-entry.tsx'
```

On Windows, `path.resolve(...)` returns a path with backslashes, e.g., D:\\router\\examples\\react\\start-basic\\src\\server.ts. Injecting it directly into an import statement leads to the following error. I replaced all backslashes with forward slashes and got it working on start-basic.

```
Error: Cannot find module 'D:routerexamplesreactstart-basic_srcserver.ts' imported from '/~start/server-entry.tsx'
```