### PR TITLE
feat(start-server-core): resolve relative requests to the same origin

### DIFF
--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -67,9 +67,17 @@ export function createStartHandler<TRouter extends AnyRouter>({
           return startRequestResolver({ request: fetchRequest })
         }
 
+        function getOrigin() {
+          return (
+            request.headers.get('Origin') ||
+            request.headers.get('Referer') ||
+            'http://localhost'
+          )
+        }
+
         if (typeof input === 'string' && input.startsWith('/')) {
           // e.g: fetch('/api/data')
-          const url = new URL(input, 'http://localhost')
+          const url = new URL(input, getOrigin())
           return resolve(url, init)
         } else if (
           typeof input === 'object' &&
@@ -78,7 +86,7 @@ export function createStartHandler<TRouter extends AnyRouter>({
           input.url.startsWith('/')
         ) {
           // e.g: fetch(new Request('/api/data'))
-          const url = new URL(input.url, 'http://localhost')
+          const url = new URL(input.url, getOrigin())
           return resolve(url, init)
         }
 

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -60,8 +60,9 @@ export function createStartHandler<TRouter extends AnyRouter>({
     }) => {
       // Patching fetch function to use our request resolver
       // if the input starts with `/` which is a common pattern for
-      // client-side routing and we can assume that the user want to
-      // use the same origin as the current request
+      // client-side routing.
+      // When we encounter similar requests, we can assume that the
+      // user wants to use the same origin as the current request.
       globalThis.fetch = async function (input, init) {
         function resolve(url: URL, requestOptions: RequestInit | undefined) {
           const fetchRequest = new Request(url, requestOptions)
@@ -69,7 +70,6 @@ export function createStartHandler<TRouter extends AnyRouter>({
         }
 
         if (typeof input === 'string' && input.startsWith('/')) {
-          // input is a string and starts with `/`
           // e.g: fetch('/api/data')
           const url = new URL(input, 'https://localhost')
           return resolve(url, init)
@@ -79,7 +79,6 @@ export function createStartHandler<TRouter extends AnyRouter>({
           typeof input.url === 'string' &&
           input.url.startsWith('/')
         ) {
-          // input is of type Request or RequestInfo object
           // e.g: fetch(new Request('/api/data'))
           const url = new URL(input.url, 'https://localhost')
           return resolve(url, init)

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -69,7 +69,7 @@ export function createStartHandler<TRouter extends AnyRouter>({
 
         if (typeof input === 'string' && input.startsWith('/')) {
           // e.g: fetch('/api/data')
-          const url = new URL(input, 'https://localhost')
+          const url = new URL(input, 'http://localhost')
           return resolve(url, init)
         } else if (
           typeof input === 'object' &&
@@ -78,7 +78,7 @@ export function createStartHandler<TRouter extends AnyRouter>({
           input.url.startsWith('/')
         ) {
           // e.g: fetch(new Request('/api/data'))
-          const url = new URL(input.url, 'https://localhost')
+          const url = new URL(input.url, 'http://localhost')
           return resolve(url, init)
         }
 

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -53,7 +53,42 @@ export function createStartHandler<TRouter extends AnyRouter>({
   createRouter: () => TRouter
 }): CustomizeStartHandler<TRouter> {
   return (cb) => {
-    return requestHandler(async ({ request }) => {
+    const originalFetch = globalThis.fetch
+
+    const startRequestResolver: ReturnType<typeof requestHandler> = async ({
+      request,
+    }) => {
+      // Patching fetch function to use our request resolver
+      // if the input starts with `/` which is a common pattern for
+      // client-side routing and we can assume that the user want to
+      // use the same origin as the current request
+      globalThis.fetch = async function (input, init) {
+        function resolve(url: URL, requestOptions: RequestInit | undefined) {
+          const fetchRequest = new Request(url, requestOptions)
+          return startRequestResolver({ request: fetchRequest })
+        }
+
+        if (typeof input === 'string' && input.startsWith('/')) {
+          // input is a string and starts with `/`
+          // e.g: fetch('/api/data')
+          const url = new URL(input, 'https://localhost')
+          return resolve(url, init)
+        } else if (
+          typeof input === 'object' &&
+          'url' in input &&
+          typeof input.url === 'string' &&
+          input.url.startsWith('/')
+        ) {
+          // input is of type Request or RequestInfo object
+          // e.g: fetch(new Request('/api/data'))
+          const url = new URL(input.url, 'https://localhost')
+          return resolve(url, init)
+        }
+
+        // If not, it should just use the original fetch
+        return originalFetch(input, init)
+      }
+
       const url = new URL(request.url)
       const href = url.href.replace(url.origin, '')
 
@@ -222,7 +257,9 @@ export function createStartHandler<TRouter extends AnyRouter>({
       }
 
       return response
-    })
+    }
+
+    return requestHandler(startRequestResolver)
   }
 }
 

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -55,9 +55,7 @@ export function createStartHandler<TRouter extends AnyRouter>({
   return (cb) => {
     const originalFetch = globalThis.fetch
 
-    const startRequestResolver: ReturnType<typeof requestHandler> = async ({
-      request,
-    }) => {
+    const startRequestResolver: RequestHandler = async ({ request }) => {
       // Patching fetch function to use our request resolver
       // if the input starts with `/` which is a common pattern for
       // client-side routing.


### PR DESCRIPTION
Adds in the same "interceptor" functionality which `undici` previously fulfilled.