### PR TITLE
fix: prepend `/@fs` when a custom client entry is detected

### DIFF
--- a/packages/start-plugin-core/src/plugin.ts
+++ b/packages/start-plugin-core/src/plugin.ts
@@ -77,7 +77,10 @@ export function TanStackStartVitePluginCore(
           )
             ? startConfig.clientEntryPath
             : vite.normalizePath(
-                path.resolve(startConfig.root, startConfig.clientEntryPath),
+                path.join(
+                  '/@fs',
+                  path.resolve(startConfig.root, startConfig.clientEntryPath),
+                ),
               )
 
           return entry


### PR DESCRIPTION
This is related to https://github.com/TanStack/router/pull/4179. If there isn't `@fs` in the client entry path when a custom client.tsx file exists, the browser loads the script via file:///D:/router/examples/react/start-basic/src/client.tsx, which will fail to load. Prepending `/@fs/` results in the correct request URL: http://localhost:3000/@fs/D:/router/examples/react/start-basic/src/client.tsx.

A `/` is also needed after `/@fs`, otherwise the request URL becomes http://localhost:3000/@fsD:/router/examples/react/start-basic/src/client.tsx, leading to 404.

Since `getClientEntryPath(...)` is also used at [plugin.ts#L85](https://github.com/TanStack/router/blob/alpha/packages/start-plugin-core/src/plugin.ts#L85), I am unsure of the impact of `@fs` there. Nevertheless, I didn't find issues when using the dev server and building the app (start-basic).