### PR TITLE
fix(start-plugin-core): enable pre-rendering with just `pages`

### DIFF
--- a/packages/start-plugin-core/src/nitro/nitro-plugin.ts
+++ b/packages/start-plugin-core/src/nitro/nitro-plugin.ts
@@ -89,6 +89,18 @@ export function nitroPlugin(
 
               await buildNitroEnvironment(nitro, () => build(nitro))
 
+              // If the user has not set a prerender option, we need to set it to true
+              // if the pages array is not empty and has sub options required for prerendering
+              if (options.prerender?.enabled !== false) {
+                options.prerender = {
+                  ...options.prerender,
+                  enabled: options.pages.some((d) =>
+                    typeof d === 'string' ? false : !!d.prerender?.enabled,
+                  ),
+                }
+              }
+
+              // Setup the options for prerendering the SPA shell (i.e `src/routes/__root.tsx`)
               if (options.spa?.enabled) {
                 options.prerender = {
                   ...options.prerender,
@@ -111,12 +123,8 @@ export function nitroPlugin(
                 })
               }
 
-              if (
-                options.prerender?.enabled ||
-                options.pages.some((d) =>
-                  typeof d === 'string' ? false : !!d.prerender?.enabled,
-                )
-              ) {
+              // Start prerendering!!!
+              if (options.prerender.enabled) {
                 await prerender({
                   options,
                   nitro,

--- a/packages/start-plugin-core/src/nitro/nitro-plugin.ts
+++ b/packages/start-plugin-core/src/nitro/nitro-plugin.ts
@@ -111,7 +111,12 @@ export function nitroPlugin(
                 })
               }
 
-              if (options.prerender?.enabled) {
+              if (
+                options.prerender?.enabled ||
+                options.pages.some((d) =>
+                  typeof d === 'string' ? false : !!d.prerender?.enabled,
+                )
+              ) {
                 await prerender({
                   options,
                   nitro,

--- a/packages/start-plugin-core/src/nitro/nitro-plugin.ts
+++ b/packages/start-plugin-core/src/nitro/nitro-plugin.ts
@@ -90,7 +90,7 @@ export function nitroPlugin(
               await buildNitroEnvironment(nitro, () => build(nitro))
 
               // If the user has not set a prerender option, we need to set it to true
-              // if the pages array is not empty and has sub options required for prerendering
+              // if the pages array is not empty and has sub options requiring for prerendering
               if (options.prerender?.enabled !== false) {
                 options.prerender = {
                   ...options.prerender,


### PR DESCRIPTION
Pre-rendering should be enabled, if any of the `config.pages` specify that it should be (i.e `config.pages = [{ path: '/posts', prerender: { enabled: true } }]`. However, if the user has explicitly set `config.prerender.enabled = false`, then even `config.pages` will NOT override the global `config.prerender.enabled` setting.