### PR TITLE
fix: head execution

### DIFF
--- a/packages/react-router/tests/Scripts.test.tsx
+++ b/packages/react-router/tests/Scripts.test.tsx
@@ -139,7 +139,7 @@ describe('ssr HeadContent', () => {
             },
             {
               name: 'description',
-              content: loaderData.description,
+              content: loaderData?.description,
             },
             {
               name: 'image',
@@ -176,7 +176,7 @@ describe('ssr HeadContent', () => {
             },
             {
               name: 'description',
-              content: loaderData.description,
+              content: loaderData?.description,
             },
             {
               name: 'last-modified',

--- a/packages/react-router/tests/route.test.tsx
+++ b/packages/react-router/tests/route.test.tsx
@@ -283,7 +283,6 @@ describe('route.head', () => {
     ])
   })
 
-
   test('meta is set when loader throws notFound', async () => {
     const rootRoute = createRootRoute({
       head: () => ({

--- a/packages/react-router/tests/route.test.tsx
+++ b/packages/react-router/tests/route.test.tsx
@@ -9,6 +9,7 @@ import {
   createRoute,
   createRouter,
   getRouteApi,
+  notFound,
 } from '../src'
 import type { RouterHistory } from '../src'
 
@@ -269,6 +270,86 @@ describe('route.head', () => {
     render(<RouterProvider router={router} />)
     const indexElem = await screen.findByText('Index')
     expect(indexElem).toBeInTheDocument()
+
+    const metaState = router.state.matches.map((m) => m.meta)
+    expect(metaState).toEqual([
+      [
+        { title: 'Root' },
+        {
+          charSet: 'utf-8',
+        },
+      ],
+      [{ title: 'Index' }],
+    ])
+  })
+
+
+  test('meta is set when loader throws notFound', async () => {
+    const rootRoute = createRootRoute({
+      head: () => ({
+        meta: [
+          { title: 'Root' },
+          {
+            charSet: 'utf-8',
+          },
+        ],
+      }),
+    })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      head: () => ({
+        meta: [{ title: 'Index' }],
+      }),
+      loader: async () => {
+        throw notFound()
+      },
+      component: () => <div>Index</div>,
+    })
+    const routeTree = rootRoute.addChildren([indexRoute])
+    const router = createRouter({ routeTree })
+    render(<RouterProvider router={router} />)
+    expect(await screen.findByText('Not Found')).toBeInTheDocument()
+
+    const metaState = router.state.matches.map((m) => m.meta)
+    expect(metaState).toEqual([
+      [
+        { title: 'Root' },
+        {
+          charSet: 'utf-8',
+        },
+      ],
+      [{ title: 'Index' }],
+    ])
+  })
+
+  test('meta is set when loader throws an error', async () => {
+    const rootRoute = createRootRoute({
+      head: () => ({
+        meta: [
+          { title: 'Root' },
+          {
+            charSet: 'utf-8',
+          },
+        ],
+      }),
+    })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      head: () => ({
+        meta: [{ title: 'Index' }],
+      }),
+      loader: async () => {
+        throw new Error('Fly, you fools!')
+      },
+      component: () => <div>Index</div>,
+    })
+    const routeTree = rootRoute.addChildren([indexRoute])
+    const router = createRouter({ routeTree })
+    render(<RouterProvider router={router} />)
+
+    expect(await screen.findByText('Fly, you fools!')).toBeInTheDocument()
 
     const metaState = router.state.matches.map((m) => m.meta)
     expect(metaState).toEqual([

--- a/packages/router-core/src/route.ts
+++ b/packages/router-core/src/route.ts
@@ -982,7 +982,7 @@ type AssetFnContextOptions<
     TLoaderDeps
   >
   params: ResolveAllParamsFromParent<TParentRoute, TParams>
-  loaderData: ResolveLoaderData<TLoaderFn>
+  loaderData?: ResolveLoaderData<TLoaderFn>
 }
 
 export interface DefaultUpdatableRouteOptionsExtensions {
@@ -1092,9 +1092,20 @@ export interface UpdatableRouteOptions<
       TLoaderDeps
     >,
   ) => void
-  headers?: (ctx: {
-    loaderData: ResolveLoaderData<TLoaderFn>
-  }) => Record<string, string>
+  headers?: (
+    ctx: AssetFnContextOptions<
+      TRouteId,
+      TFullPath,
+      TParentRoute,
+      TParams,
+      TSearchValidator,
+      TLoaderFn,
+      TRouterContext,
+      TRouteContextFn,
+      TBeforeLoadFn,
+      TLoaderDeps
+    >,
+  ) => Record<string, string>
   head?: (
     ctx: AssetFnContextOptions<
       TRouteId,

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1363,7 +1363,6 @@ export class RouterCore<
           ...match.__beforeLoadContext,
         }
       }
-
     })
 
     return matches
@@ -2500,8 +2499,7 @@ export class RouterCore<
                         params: match.params,
                         loaderData: match.loaderData,
                       }
-                      const headFnContent =
-                        route.options.head?.(assetContext)
+                      const headFnContent = route.options.head?.(assetContext)
                       const meta = headFnContent?.meta
                       const links = headFnContent?.links
                       const headScripts = headFnContent?.scripts
@@ -2563,14 +2561,14 @@ export class RouterCore<
                           await route._componentsPromise
 
                           batch(() => {
-                          updateMatch(matchId, (prev) => ({
-                            ...prev,
-                            error: undefined,
-                            status: 'success',
-                            isFetching: false,
-                            updatedAt: Date.now(),
-                            loaderData,
-                          }))
+                            updateMatch(matchId, (prev) => ({
+                              ...prev,
+                              error: undefined,
+                              status: 'success',
+                              isFetching: false,
+                              updatedAt: Date.now(),
+                              loaderData,
+                            }))
                             executeHead()
                           })
                         } catch (e) {
@@ -2591,12 +2589,12 @@ export class RouterCore<
                           }
 
                           batch(() => {
-                          updateMatch(matchId, (prev) => ({
-                            ...prev,
-                            error,
-                            status: 'error',
-                            isFetching: false,
-                          }))
+                            updateMatch(matchId, (prev) => ({
+                              ...prev,
+                              error,
+                              status: 'error',
+                              isFetching: false,
+                            }))
                             executeHead()
                           })
                         }
@@ -2607,10 +2605,10 @@ export class RouterCore<
                         })
                       } catch (err) {
                         batch(() => {
-                        updateMatch(matchId, (prev) => ({
-                          ...prev,
-                          loaderPromise: undefined,
-                        }))
+                          updateMatch(matchId, (prev) => ({
+                            ...prev,
+                            loaderPromise: undefined,
+                          }))
                           executeHead()
                         })
                         handleRedirectAndNotFound(this.getMatch(matchId)!, err)
@@ -2648,8 +2646,7 @@ export class RouterCore<
                       (loaderShouldRunAsync && sync)
                     ) {
                       await runLoader()
-                    }
-                    else {
+                    } else {
                       // if the loader did not run, still update head.
                       // reason: parent's beforeLoad may have changed the route context
                       // and only now do we know the route context (and that the loader would not run)

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1364,25 +1364,6 @@ export class RouterCore<
         }
       }
 
-      // If it's already a success, update headers and head content
-      // These may get updated again if the match is refreshed
-      // due to being stale
-      if (match.status === 'success') {
-        match.headers = route.options.headers?.({
-          loaderData: match.loaderData,
-        })
-        const assetContext = {
-          matches,
-          match,
-          params: match.params,
-          loaderData: match.loaderData,
-        }
-        const headFnContent = route.options.head?.(assetContext)
-        match.links = headFnContent?.links
-        match.headScripts = headFnContent?.scripts
-        match.meta = headFnContent?.meta
-        match.scripts = route.options.scripts?.(assetContext)
-      }
     })
 
     return matches
@@ -2508,6 +2489,35 @@ export class RouterCore<
                         !this.state.matches.find((d) => d.id === matchId),
                     }))
 
+                    const executeHead = () => {
+                      if (preload) {
+                        return
+                      }
+                      const match = this.getMatch(matchId)!
+                      const assetContext = {
+                        matches,
+                        match,
+                        params: match.params,
+                        loaderData: match.loaderData,
+                      }
+                      const headFnContent =
+                        route.options.head?.(assetContext)
+                      const meta = headFnContent?.meta
+                      const links = headFnContent?.links
+                      const headScripts = headFnContent?.scripts
+
+                      const scripts = route.options.scripts?.(assetContext)
+                      const headers = route.options.headers?.(assetContext)
+                      updateMatch(matchId, (prev) => ({
+                        ...prev,
+                        meta,
+                        links,
+                        headScripts,
+                        headers,
+                        scripts,
+                      }))
+                    }
+
                     const runLoader = async () => {
                       try {
                         // If the Matches component rendered
@@ -2548,27 +2558,11 @@ export class RouterCore<
 
                           await potentialPendingMinPromise()
 
-                          const assetContext = {
-                            matches,
-                            match: this.getMatch(matchId)!,
-                            params: this.getMatch(matchId)!.params,
-                            loaderData,
-                          }
-                          const headFnContent =
-                            route.options.head?.(assetContext)
-                          const meta = headFnContent?.meta
-                          const links = headFnContent?.links
-                          const headScripts = headFnContent?.scripts
-
-                          const scripts = route.options.scripts?.(assetContext)
-                          const headers = route.options.headers?.({
-                            loaderData,
-                          })
-
                           // Last but not least, wait for the the components
                           // to be preloaded before we resolve the match
                           await route._componentsPromise
 
+                          batch(() => {
                           updateMatch(matchId, (prev) => ({
                             ...prev,
                             error: undefined,
@@ -2576,12 +2570,9 @@ export class RouterCore<
                             isFetching: false,
                             updatedAt: Date.now(),
                             loaderData,
-                            meta,
-                            links,
-                            headScripts,
-                            headers,
-                            scripts,
                           }))
+                            executeHead()
+                          })
                         } catch (e) {
                           let error = e
 
@@ -2599,12 +2590,15 @@ export class RouterCore<
                             )
                           }
 
+                          batch(() => {
                           updateMatch(matchId, (prev) => ({
                             ...prev,
                             error,
                             status: 'error',
                             isFetching: false,
                           }))
+                            executeHead()
+                          })
                         }
 
                         this.serverSsr?.onMatchSettled({
@@ -2612,10 +2606,13 @@ export class RouterCore<
                           match: this.getMatch(matchId)!,
                         })
                       } catch (err) {
+                        batch(() => {
                         updateMatch(matchId, (prev) => ({
                           ...prev,
                           loaderPromise: undefined,
                         }))
+                          executeHead()
+                        })
                         handleRedirectAndNotFound(this.getMatch(matchId)!, err)
                       }
                     }
@@ -2651,6 +2648,12 @@ export class RouterCore<
                       (loaderShouldRunAsync && sync)
                     ) {
                       await runLoader()
+                    }
+                    else {
+                      // if the loader did not run, still update head.
+                      // reason: parent's beforeLoad may have changed the route context
+                      // and only now do we know the route context (and that the loader would not run)
+                      executeHead()
                     }
                   }
                   if (!loaderIsRunningAsync) {


### PR DESCRIPTION
1. execute head also when loader throws
2. don't execute head upon preload
3. execute head also when loader was not executed