### PR TITLE
fix: head execution

### DIFF
--- a/packages/react-router/tests/Scripts.test.tsx
+++ b/packages/react-router/tests/Scripts.test.tsx
@@ -123,7 +123,7 @@ describe('ssr HeadContent', () => {
             },
             {
               name: 'description',
-              content: loaderData.description,
+              content: loaderData?.description,
             },
             {
               name: 'image',
@@ -160,7 +160,7 @@ describe('ssr HeadContent', () => {
             },
             {
               name: 'description',
-              content: loaderData.description,
+              content: loaderData?.description,
             },
             {
               name: 'last-modified',

--- a/packages/react-router/tests/route.test.tsx
+++ b/packages/react-router/tests/route.test.tsx
@@ -8,6 +8,7 @@ import {
   createRoute,
   createRouter,
   getRouteApi,
+  notFound,
 } from '../src'
 
 afterEach(() => {
@@ -259,6 +260,85 @@ describe('route.head', () => {
     render(<RouterProvider router={router} />)
     const indexElem = await screen.findByText('Index')
     expect(indexElem).toBeInTheDocument()
+
+    const metaState = router.state.matches.map((m) => m.meta)
+    expect(metaState).toEqual([
+      [
+        { title: 'Root' },
+        {
+          charSet: 'utf-8',
+        },
+      ],
+      [{ title: 'Index' }],
+    ])
+  })
+
+  test('meta is set when loader throws notFound', async () => {
+    const rootRoute = createRootRoute({
+      head: () => ({
+        meta: [
+          { title: 'Root' },
+          {
+            charSet: 'utf-8',
+          },
+        ],
+      }),
+    })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      head: () => ({
+        meta: [{ title: 'Index' }],
+      }),
+      loader: async () => {
+        throw notFound()
+      },
+      component: () => <div>Index</div>,
+    })
+    const routeTree = rootRoute.addChildren([indexRoute])
+    const router = createRouter({ routeTree })
+    render(<RouterProvider router={router} />)
+    expect(await screen.findByText('Not Found')).toBeInTheDocument()
+
+    const metaState = router.state.matches.map((m) => m.meta)
+    expect(metaState).toEqual([
+      [
+        { title: 'Root' },
+        {
+          charSet: 'utf-8',
+        },
+      ],
+      [{ title: 'Index' }],
+    ])
+  })
+
+  test('meta is set when loader throws an error', async () => {
+    const rootRoute = createRootRoute({
+      head: () => ({
+        meta: [
+          { title: 'Root' },
+          {
+            charSet: 'utf-8',
+          },
+        ],
+      }),
+    })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      head: () => ({
+        meta: [{ title: 'Index' }],
+      }),
+      loader: async () => {
+        throw new Error('Fly, you fools!')
+      },
+      component: () => <div>Index</div>,
+    })
+    const routeTree = rootRoute.addChildren([indexRoute])
+    const router = createRouter({ routeTree })
+    render(<RouterProvider router={router} />)
+
+    expect(await screen.findByText('Fly, you fools!')).toBeInTheDocument()
 
     const metaState = router.state.matches.map((m) => m.meta)
     expect(metaState).toEqual([

--- a/packages/router-core/src/route.ts
+++ b/packages/router-core/src/route.ts
@@ -960,7 +960,7 @@ type AssetFnContextOptions<
     TLoaderDeps
   >
   params: ResolveAllParamsFromParent<TParentRoute, TParams>
-  loaderData: ResolveLoaderData<TLoaderFn>
+  loaderData?: ResolveLoaderData<TLoaderFn>
 }
 
 export interface DefaultUpdatableRouteOptionsExtensions {
@@ -1070,9 +1070,20 @@ export interface UpdatableRouteOptions<
       TLoaderDeps
     >,
   ) => void
-  headers?: (ctx: {
-    loaderData: ResolveLoaderData<TLoaderFn>
-  }) => Record<string, string>
+  headers?: (
+    ctx: AssetFnContextOptions<
+      TRouteId,
+      TFullPath,
+      TParentRoute,
+      TParams,
+      TSearchValidator,
+      TLoaderFn,
+      TRouterContext,
+      TRouteContextFn,
+      TBeforeLoadFn,
+      TLoaderDeps
+    >,
+  ) => Record<string, string>
   head?: (
     ctx: AssetFnContextOptions<
       TRouteId,

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1447,26 +1447,6 @@ export class RouterCore<
           ...match.__beforeLoadContext,
         }
       }
-
-      // If it's already a success, update headers and head content
-      // These may get updated again if the match is refreshed
-      // due to being stale
-      if (match.status === 'success') {
-        match.headers = route.options.headers?.({
-          loaderData: match.loaderData,
-        })
-        const assetContext = {
-          matches,
-          match,
-          params: match.params,
-          loaderData: match.loaderData,
-        }
-        const headFnContent = route.options.head?.(assetContext)
-        match.links = headFnContent?.links
-        match.headScripts = headFnContent?.scripts
-        match.meta = headFnContent?.meta
-        match.scripts = route.options.scripts?.(assetContext)
-      }
     })
 
     return matches
@@ -2609,6 +2589,35 @@ export class RouterCore<
                         !this.state.matches.find((d) => d.id === matchId),
                     }))
 
+                    const executeHead = () => {
+                      const match = this.getMatch(matchId)
+                      // in case of a redirecting match during preload, the match does not exist
+                      if (!match) {
+                        return
+                      }
+                      const assetContext = {
+                        matches,
+                        match,
+                        params: match.params,
+                        loaderData: match.loaderData,
+                      }
+                      const headFnContent = route.options.head?.(assetContext)
+                      const meta = headFnContent?.meta
+                      const links = headFnContent?.links
+                      const headScripts = headFnContent?.scripts
+
+                      const scripts = route.options.scripts?.(assetContext)
+                      const headers = route.options.headers?.(assetContext)
+                      updateMatch(matchId, (prev) => ({
+                        ...prev,
+                        meta,
+                        links,
+                        headScripts,
+                        headers,
+                        scripts,
+                      }))
+                    }
+
                     const runLoader = async () => {
                       try {
                         // If the Matches component rendered
@@ -2649,40 +2658,21 @@ export class RouterCore<
 
                           await potentialPendingMinPromise()
 
-                          const assetContext = {
-                            matches,
-                            match: this.getMatch(matchId)!,
-                            params: this.getMatch(matchId)!.params,
-                            loaderData,
-                          }
-                          const headFnContent =
-                            route.options.head?.(assetContext)
-                          const meta = headFnContent?.meta
-                          const links = headFnContent?.links
-                          const headScripts = headFnContent?.scripts
-
-                          const scripts = route.options.scripts?.(assetContext)
-                          const headers = route.options.headers?.({
-                            loaderData,
-                          })
-
                           // Last but not least, wait for the the components
                           // to be preloaded before we resolve the match
                           await route._componentsPromise
 
-                          updateMatch(matchId, (prev) => ({
-                            ...prev,
-                            error: undefined,
-                            status: 'success',
-                            isFetching: false,
-                            updatedAt: Date.now(),
-                            loaderData,
-                            meta,
-                            links,
-                            headScripts,
-                            headers,
-                            scripts,
-                          }))
+                          batch(() => {
+                            updateMatch(matchId, (prev) => ({
+                              ...prev,
+                              error: undefined,
+                              status: 'success',
+                              isFetching: false,
+                              updatedAt: Date.now(),
+                              loaderData,
+                            }))
+                            executeHead()
+                          })
                         } catch (e) {
                           let error = e
 
@@ -2700,12 +2690,15 @@ export class RouterCore<
                             )
                           }
 
-                          updateMatch(matchId, (prev) => ({
-                            ...prev,
-                            error,
-                            status: 'error',
-                            isFetching: false,
-                          }))
+                          batch(() => {
+                            updateMatch(matchId, (prev) => ({
+                              ...prev,
+                              error,
+                              status: 'error',
+                              isFetching: false,
+                            }))
+                            executeHead()
+                          })
                         }
 
                         this.serverSsr?.onMatchSettled({
@@ -2713,10 +2706,13 @@ export class RouterCore<
                           match: this.getMatch(matchId)!,
                         })
                       } catch (err) {
-                        updateMatch(matchId, (prev) => ({
-                          ...prev,
-                          loaderPromise: undefined,
-                        }))
+                        batch(() => {
+                          updateMatch(matchId, (prev) => ({
+                            ...prev,
+                            loaderPromise: undefined,
+                          }))
+                          executeHead()
+                        })
                         handleRedirectAndNotFound(this.getMatch(matchId)!, err)
                       }
                     }
@@ -2752,6 +2748,11 @@ export class RouterCore<
                       (loaderShouldRunAsync && sync)
                     ) {
                       await runLoader()
+                    } else {
+                      // if the loader did not run, still update head.
+                      // reason: parent's beforeLoad may have changed the route context
+                      // and only now do we know the route context (and that the loader would not run)
+                      executeHead()
                     }
                   }
                   if (!loaderIsRunningAsync) {


### PR DESCRIPTION
1. execute head also when loader throws
2. execute head also when loader was not executed, but only after parent's beforeLoad ran

fixes #3657