### PR TITLE
alpha: expose underlying nitro configuration in vite plugin

### DIFF
--- a/packages/start-plugin-core/src/nitro/nitro-plugin.ts
+++ b/packages/start-plugin-core/src/nitro/nitro-plugin.ts
@@ -83,6 +83,7 @@ export function nitroPlugin(
                 rollupConfig: {
                   plugins: [virtualBundlePlugin(getSsrBundle())],
                 },
+                ...options.nitro,
               }
 
               const nitro = await createNitro(nitroConfig)

--- a/packages/start-plugin-core/src/schema.ts
+++ b/packages/start-plugin-core/src/schema.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 import { existsSync } from 'node:fs'
 import { z } from 'zod'
 import { configSchema, getConfig } from '@tanstack/router-generator'
-import type { NitroConfig } from 'nitropack'
+import { NitroConfig } from 'nitropack'
 
 const tsrConfig = configSchema.partial().extend({
   srcDirectory: z.string().optional().default('src'),
@@ -130,6 +130,7 @@ export function createTanStackStartOptionsSchema(
         .and(pagePrerenderOptionsSchema.optional())
         .optional(),
       spa: spaSchema.optional(),
+      nitro: z.custom<NitroConfig>().optional(),
     })
     .optional()
     .default({})

--- a/packages/start-plugin-core/src/schema.ts
+++ b/packages/start-plugin-core/src/schema.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 import { existsSync } from 'node:fs'
 import { z } from 'zod'
 import { configSchema, getConfig } from '@tanstack/router-generator'
-import { NitroConfig } from 'nitropack'
+import type { NitroConfig } from 'nitropack'
 
 const tsrConfig = configSchema.partial().extend({
   srcDirectory: z.string().optional().default('src'),


### PR DESCRIPTION
I was having some build issues across multiple platforms - I figured I'd have a better chance of resolving them if the nitro config was exposed.

Any edge cases I might be missing here? Wondering why this was omitted in the first place.