### PR TITLE
alpha: export unenv option

### DIFF
--- a/packages/start-plugin-core/src/nitro/nitro-plugin.ts
+++ b/packages/start-plugin-core/src/nitro/nitro-plugin.ts
@@ -18,6 +18,8 @@ export function nitroPlugin(
   const buildPreset =
     process.env['START_TARGET'] ?? (options.target as string | undefined)
 
+  const unenv = options.unenv
+
   return [
     devServerPlugin(),
     {
@@ -80,6 +82,7 @@ export function nitroPlugin(
                 },
                 prerender: undefined,
                 renderer: ssrEntryFile,
+                unenv: unenv,
                 rollupConfig: {
                   plugins: [virtualBundlePlugin(getSsrBundle())],
                 },

--- a/packages/start-plugin-core/src/schema.ts
+++ b/packages/start-plugin-core/src/schema.ts
@@ -83,6 +83,7 @@ export function createTanStackStartOptionsSchema(
     .object({
       root: z.string().optional().default(process.cwd()),
       target: z.custom<NitroConfig['preset']>().optional(),
+      unenv: z.custom<NitroConfig['unenv']>().optional(),
       ...frameworkPlugin,
       tsr: tsrConfig.optional().default({}),
       client: z


### PR DESCRIPTION
I'd like to test alpha with cloudflare workers so I created this PR

This pull request introduces support for a new `unenv` option in the `nitroPlugin` and updates the schema to validate this new option. The changes ensure that the `unenv` configuration is properly passed and handled throughout the plugin.

### Addition of `unenv` option:

* [`packages/start-plugin-core/src/nitro/nitro-plugin.ts`](diffhunk://#diff-bc138cd8b0b75e20caee4e669fa075d5ca7d8f2201a95677da2ff0b40a4628bfR21-R22): Added a new `unenv` option to the `nitroPlugin` function, making it configurable via the `options` parameter. The `unenv` value is also passed to the `prerender` configuration. [[1]](diffhunk://#diff-bc138cd8b0b75e20caee4e669fa075d5ca7d8f2201a95677da2ff0b40a4628bfR21-R22) [[2]](diffhunk://#diff-bc138cd8b0b75e20caee4e669fa075d5ca7d8f2201a95677da2ff0b40a4628bfR85)

### Schema update:

* [`packages/start-plugin-core/src/schema.ts`](diffhunk://#diff-441062ba480be79919ec6780d1750dc0713c33b06a0d2b8b6d03bb5102936b22R86): Updated the schema in `createTanStackStartOptionsSchema` to include the `unenv` option, ensuring it is validated as part of the plugin's configuration.