### PR TITLE
fix(examples): add the required peer deps of @tanstack/router-devtools-core and vite-tsconfig-paths

### DIFF
--- a/examples/react/start-basic/package.json
+++ b/examples/react/start-basic/package.json
@@ -12,6 +12,7 @@
     "@tanstack/react-router": "^1.120.5",
     "@tanstack/react-router-devtools": "^1.120.6",
     "@tanstack/react-start": "^1.120.5",
+    "@tanstack/router-core": "^1.120.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^2.6.0",
@@ -24,7 +25,9 @@
     "autoprefixer": "^10.4.20",
     "postcss": "^8.5.1",
     "tailwindcss": "^3.4.17",
+    "tiny-invariant": "^1.3.3",
     "typescript": "^5.7.2",
+    "vite": "^6.1.0",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }


### PR DESCRIPTION
`@tanstack/router-devtools-core` which is a dependency of `@tanstack/react-router-devtools` have 2 missing peer dependencies in the `start-basic` example:

1. `@tanstack/router-core` I used the version of other `@tanstack/*` deps
2. `tiny-invariant` I used the version that `@tanstack/router-devtools-core` specifies 

`vite-tsconfig-paths` has 1 missing peer dependency: `vite`. I copied the version from react basic example.


I found that while doing a tanstack start POC using the [breakproof repo template](https://github.com/YotpoLtd/breakproof-base-monorepo) where the automatic peer dependency installation is disabled.

I can apply the same/similar fixes for other examples if you OK this.