### PR TITLE
fix: Fix devtools when using shadowdom

### DIFF
--- a/packages/router-devtools-core/src/TanStackRouterDevtoolsCore.tsx
+++ b/packages/router-devtools-core/src/TanStackRouterDevtoolsCore.tsx
@@ -4,7 +4,6 @@ import { ShadowDomTargetContext } from './context'
 import type { AnyRouter } from '@tanstack/router-core'
 import type { Signal } from 'solid-js'
 
-
 interface DevtoolsOptions {
   /**
    * Set this true if you want the dev tools to default to being open

--- a/packages/router-devtools-core/src/TanStackRouterDevtoolsCore.tsx
+++ b/packages/router-devtools-core/src/TanStackRouterDevtoolsCore.tsx
@@ -1,7 +1,9 @@
 import { createSignal, lazy } from 'solid-js'
 import { render } from 'solid-js/web'
+import { ShadowDomTargetContext } from './context'
 import type { AnyRouter } from '@tanstack/router-core'
 import type { Signal } from 'solid-js'
+
 
 interface DevtoolsOptions {
   /**
@@ -104,17 +106,19 @@ class TanStackRouterDevtoolsCore {
       }
 
       return (
-        <Devtools
-          position={position}
-          initialIsOpen={initialIsOpen}
-          shadowDOMTarget={shadowDOMTarget}
-          router={router}
-          routerState={routerState}
-          panelProps={panelProps}
-          closeButtonProps={closeButtonProps}
-          toggleButtonProps={toggleButtonProps}
-          containerElement={containerElement}
-        />
+        <ShadowDomTargetContext.Provider value={shadowDOMTarget}>
+          <Devtools
+            position={position}
+            initialIsOpen={initialIsOpen}
+            router={router}
+            routerState={routerState}
+            shadowDOMTarget={shadowDOMTarget}
+            panelProps={panelProps}
+            closeButtonProps={closeButtonProps}
+            toggleButtonProps={toggleButtonProps}
+            containerElement={containerElement}
+          />
+        </ShadowDomTargetContext.Provider>
       )
     }, el)
 


### PR DESCRIPTION
I noticed devtools not rendering correctly after a recent update.  This fix wraps the DevTools component in the shadowdom context.  

Fixes: #4064 
 