### PR TITLE
docs: fix neon bullet points and url

### DIFF
--- a/docs/start/framework/react/databases.md
+++ b/docs/start/framework/react/databases.md
@@ -57,9 +57,10 @@ Key features that make Neon stand out:
 - Point-in-time restore
 - Web-based SQL editor
 - Bottomless storage
-
+  <br />
+  <br />
 - To learn more about Neon, visit the [Neon website](https://neon.tech?utm_source=tanstack)
-- To sign up, visit the [Neon dashboard](https://console.neon.tech/sign_up?utm_source=tanstack)
+- To sign up, visit the [Neon dashboard](https://console.neon.tech/signup?utm_source=tanstack)
 
 ## What is Convex?
 


### PR DESCRIPTION
The markdown list wasn't shown properly and I noticed the signup link was broken

Before
![image](https://github.com/user-attachments/assets/9efd3f90-3ed1-42af-823a-edb4fdd39770)


After
![image](https://github.com/user-attachments/assets/bc43b4ee-30b4-4eb8-ace2-6cd9ca77c2d9)
