### PR TITLE
refactor(start-plugin-core): omit `autoCodeSplitting` configuration option in `tsr`

### DIFF
--- a/packages/router-plugin/src/core/config.ts
+++ b/packages/router-plugin/src/core/config.ts
@@ -78,3 +78,5 @@ export const getConfig = (inlineConfig: Partial<Config>, root: string) => {
 }
 
 export type Config = z.infer<typeof configSchema>
+export type ConfigInput = z.input<typeof configSchema>
+export type ConfigOutput = z.output<typeof configSchema>

--- a/packages/router-plugin/src/index.ts
+++ b/packages/router-plugin/src/index.ts
@@ -1,4 +1,4 @@
-export { configSchema } from './core/config'
+export { configSchema, getConfig } from './core/config'
 export { unpluginRouterCodeSplitterFactory } from './core/router-code-splitter-plugin'
 export { unpluginRouterGeneratorFactory } from './core/router-generator-plugin'
 export type { Config, ConfigInput, ConfigOutput } from './core/config'

--- a/packages/router-plugin/src/index.ts
+++ b/packages/router-plugin/src/index.ts
@@ -1,4 +1,4 @@
 export { configSchema } from './core/config'
 export { unpluginRouterCodeSplitterFactory } from './core/router-code-splitter-plugin'
 export { unpluginRouterGeneratorFactory } from './core/router-generator-plugin'
-export type { Config } from './core/config'
+export type { Config, ConfigInput, ConfigOutput } from './core/config'

--- a/packages/start-plugin-core/src/schema.ts
+++ b/packages/start-plugin-core/src/schema.ts
@@ -84,7 +84,7 @@ export function createTanStackStartOptionsSchema(
       root: z.string().optional().default(process.cwd()),
       target: z.custom<NitroConfig['preset']>().optional(),
       ...frameworkPlugin,
-      tsr: tsrConfig.optional().default({}),
+      tsr: tsrConfig.omit({ autoCodeSplitting: true }).optional().default({}),
       client: z
         .object({
           entry: z.string().optional(),

--- a/packages/start-plugin-core/src/schema.ts
+++ b/packages/start-plugin-core/src/schema.ts
@@ -4,9 +4,12 @@ import { z } from 'zod'
 import { configSchema, getConfig } from '@tanstack/router-generator'
 import type { NitroConfig } from 'nitropack'
 
-const tsrConfig = configSchema.partial().extend({
-  srcDirectory: z.string().optional().default('src'),
-})
+const tsrConfig = configSchema
+  .omit({ autoCodeSplitting: true })
+  .partial()
+  .extend({
+    srcDirectory: z.string().optional().default('src'),
+  })
 
 export function createTanStackConfig<
   TFrameworkPlugin extends Record<string, unknown>,
@@ -84,7 +87,7 @@ export function createTanStackStartOptionsSchema(
       root: z.string().optional().default(process.cwd()),
       target: z.custom<NitroConfig['preset']>().optional(),
       ...frameworkPlugin,
-      tsr: tsrConfig.omit({ autoCodeSplitting: true }).optional().default({}),
+      tsr: tsrConfig.optional().default({}),
       client: z
         .object({
           entry: z.string().optional(),


### PR DESCRIPTION
At the moment, no changes made by the user regarding these options will change what happens.

This change will hide these options from users.