### PR TITLE
refactor: consistent virtual module naming and resolve using Rollup conventions

### DIFF
--- a/packages/react-start-server/vite.config.ts
+++ b/packages/react-start-server/vite.config.ts
@@ -22,6 +22,7 @@ export default mergeConfig(
     externalDeps: [
       'tanstack-start-server-fn-manifest:v',
       'tanstack-start-router-manifest:v',
+      'tanstack-start-server-routes-manifest:v',
     ],
   }),
 )

--- a/packages/react-start-server/vite.config.ts
+++ b/packages/react-start-server/vite.config.ts
@@ -19,6 +19,9 @@ export default mergeConfig(
   tanstackViteConfig({
     srcDir: './src',
     entry: './src/index.tsx',
-    externalDeps: ['tanstack:server-fn-manifest', 'tanstack:start-manifest'],
+    externalDeps: [
+      'tanstack-server-fn-manifest:module',
+      'tanstack:start-manifest',
+    ],
   }),
 )

--- a/packages/react-start-server/vite.config.ts
+++ b/packages/react-start-server/vite.config.ts
@@ -20,7 +20,7 @@ export default mergeConfig(
     srcDir: './src',
     entry: './src/index.tsx',
     externalDeps: [
-      'tanstack-server-fn-manifest:module',
+      'tanstack-start-server-fn-manifest:v',
       'tanstack-start-router-manifest:v',
     ],
   }),

--- a/packages/react-start-server/vite.config.ts
+++ b/packages/react-start-server/vite.config.ts
@@ -21,7 +21,7 @@ export default mergeConfig(
     entry: './src/index.tsx',
     externalDeps: [
       'tanstack-server-fn-manifest:module',
-      'tanstack:start-manifest',
+      'tanstack-start-router-manifest:v',
     ],
   }),
 )

--- a/packages/server-functions-plugin/src/index.ts
+++ b/packages/server-functions-plugin/src/index.ts
@@ -141,9 +141,17 @@ export function createTanStackServerFnPlugin(opts: ServerFnPluginOpts): {
         // so the manifest is like a serialized state from the client build to the server build
         name: 'tanstack-start-server-fn-vite-plugin-manifest-server',
         enforce: 'pre',
-        resolveId: (id) => (id === opts.manifestVirtualImportId ? id : null),
+        resolveId(id) {
+          if (id === opts.manifestVirtualImportId) {
+            return resolveViteId(id)
+          }
+
+          return undefined
+        },
         load(id) {
-          if (id !== opts.manifestVirtualImportId) return null
+          if (id !== resolveViteId(opts.manifestVirtualImportId)) {
+            return undefined
+          }
 
           // In development, we **can** use the in-memory manifest, and we should
           // since it will be incrementally updated as we use the app and dynamic
@@ -255,7 +263,6 @@ export function TanStackServerFnPluginEnv(
   const directiveLabel = 'Server Function'
 
   return [
-    // client: [
     // The client plugin is used to compile the client directives
     // and save them so we can create a manifest
     TanStackDirectiveFunctionsPluginEnv({
@@ -325,9 +332,17 @@ export function TanStackServerFnPluginEnv(
       // applyToEnvironment(environment) {
       //   return environment.name === opts.server.envName
       // },
-      resolveId: (id) => (id === opts.manifestVirtualImportId ? id : null),
+      resolveId(id) {
+        if (id === opts.manifestVirtualImportId) {
+          return resolveViteId(id)
+        }
+
+        return undefined
+      },
       load(id) {
-        if (id !== opts.manifestVirtualImportId) return null
+        if (id !== resolveViteId(opts.manifestVirtualImportId)) {
+          return undefined
+        }
 
         // In development, we **can** use the in-memory manifest, and we should
         // since it will be incrementally updated as we use the app and dynamic
@@ -360,6 +375,9 @@ export function TanStackServerFnPluginEnv(
         return manifestWithImports
       },
     },
-    // ],
   ]
+}
+
+function resolveViteId(id: string) {
+  return `\0${id}`
 }

--- a/packages/solid-start-server/vite.config.ts
+++ b/packages/solid-start-server/vite.config.ts
@@ -23,7 +23,7 @@ export default mergeConfig(
     srcDir: './src',
     entry: './src/index.tsx',
     externalDeps: [
-      'tanstack-server-fn-manifest:module',
+      'tanstack-start-server-fn-manifest:v',
       'tanstack-start-router-manifest:v',
     ],
   }),

--- a/packages/solid-start-server/vite.config.ts
+++ b/packages/solid-start-server/vite.config.ts
@@ -22,6 +22,9 @@ export default mergeConfig(
   tanstackViteConfig({
     srcDir: './src',
     entry: './src/index.tsx',
-    externalDeps: ['tanstack:server-fn-manifest', 'tanstack:start-manifest'],
+    externalDeps: [
+      'tanstack-server-fn-manifest:module',
+      'tanstack:start-manifest',
+    ],
   }),
 )

--- a/packages/solid-start-server/vite.config.ts
+++ b/packages/solid-start-server/vite.config.ts
@@ -25,6 +25,7 @@ export default mergeConfig(
     externalDeps: [
       'tanstack-start-server-fn-manifest:v',
       'tanstack-start-router-manifest:v',
+      'tanstack-start-server-routes-manifest:v',
     ],
   }),
 )

--- a/packages/solid-start-server/vite.config.ts
+++ b/packages/solid-start-server/vite.config.ts
@@ -24,7 +24,7 @@ export default mergeConfig(
     entry: './src/index.tsx',
     externalDeps: [
       'tanstack-server-fn-manifest:module',
-      'tanstack:start-manifest',
+      'tanstack-start-router-manifest:v',
     ],
   }),
 )

--- a/packages/start-plugin-core/src/index.ts
+++ b/packages/start-plugin-core/src/index.ts
@@ -5,3 +5,4 @@ export {
 } from './schema'
 
 export { TanStackStartVitePluginCore } from './plugin'
+export { resolveViteId } from './utils'

--- a/packages/start-plugin-core/src/plugin.ts
+++ b/packages/start-plugin-core/src/plugin.ts
@@ -141,7 +141,7 @@ export function TanStackStartVitePluginCore(
               '@tanstack/start-router-manifest',
               '@tanstack/start-config',
               '@tanstack/server-functions-plugin',
-              'tanstack:start-manifest',
+              'tanstack-start-router-manifest:v',
               'tanstack-server-fn-manifest:module',
               'nitropack',
               '@tanstack/**',

--- a/packages/start-plugin-core/src/plugin.ts
+++ b/packages/start-plugin-core/src/plugin.ts
@@ -142,7 +142,7 @@ export function TanStackStartVitePluginCore(
               '@tanstack/start-config',
               '@tanstack/server-functions-plugin',
               'tanstack:start-manifest',
-              'tanstack:server-fn-manifest',
+              'tanstack-server-fn-manifest:module',
               'nitropack',
               '@tanstack/**',
             ],
@@ -166,7 +166,7 @@ export function TanStackStartVitePluginCore(
     TanStackServerFnPluginEnv({
       // This is the ID that will be available to look up and import
       // our server function manifest and resolve its module
-      manifestVirtualImportId: 'tanstack:server-fn-manifest',
+      manifestVirtualImportId: 'tanstack-server-fn-manifest:module',
       client: {
         getRuntimeCode: () =>
           `import { createClientRpc } from '@tanstack/${opts.framework}-start/server-functions-client'`,

--- a/packages/start-plugin-core/src/plugin.ts
+++ b/packages/start-plugin-core/src/plugin.ts
@@ -142,7 +142,7 @@ export function TanStackStartVitePluginCore(
               '@tanstack/start-config',
               '@tanstack/server-functions-plugin',
               'tanstack-start-router-manifest:v',
-              'tanstack-server-fn-manifest:module',
+              'tanstack-start-server-fn-manifest:v',
               'nitropack',
               '@tanstack/**',
             ],
@@ -166,7 +166,7 @@ export function TanStackStartVitePluginCore(
     TanStackServerFnPluginEnv({
       // This is the ID that will be available to look up and import
       // our server function manifest and resolve its module
-      manifestVirtualImportId: 'tanstack-server-fn-manifest:module',
+      manifestVirtualImportId: 'tanstack-start-server-fn-manifest:v',
       client: {
         getRuntimeCode: () =>
           `import { createClientRpc } from '@tanstack/${opts.framework}-start/server-functions-client'`,

--- a/packages/start-plugin-core/src/routesManifestPlugin.ts
+++ b/packages/start-plugin-core/src/routesManifestPlugin.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { joinURL } from 'ufo'
 import { rootRouteId } from '@tanstack/router-core'
+import { resolveViteId } from './utils'
 import type {
   PluginOption,
   ResolvedConfig,
@@ -16,6 +17,9 @@ export function startManifestPlugin(
 ): PluginOption {
   let config: ResolvedConfig
 
+  const moduleId = 'tanstack-start-router-manifest:v'
+  const resolvedModuleId = resolveViteId(moduleId)
+
   return {
     name: 'tsr-routes-manifest',
     enforce: 'pre',
@@ -27,13 +31,13 @@ export function startManifestPlugin(
     //   config = envConfig.
     // },
     resolveId(id) {
-      if (id === 'tanstack:start-manifest') {
-        return id
+      if (id === moduleId) {
+        return resolvedModuleId
       }
       return
     },
     load(id) {
-      if (id === 'tanstack:start-manifest') {
+      if (id === resolvedModuleId) {
         if (this.environment.config.consumer !== 'server') {
           // this will ultimately fail the build if the plugin is used outside the server environment
           // TODO: do we need special handling for `serve`?

--- a/packages/start-plugin-core/src/start-server-routes-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/start-server-routes-plugin/plugin.ts
@@ -30,6 +30,7 @@ const setLock = (bool: boolean) => {
 
 export function TanStackStartServerRoutesVite(config: Config): Plugin {
   let ROOT: string = process.cwd()
+  const moduleId = 'tanstack-start-server-routes-manifest:v'
 
   const getRoutesDirectoryPath = () => {
     return isAbsolute(config.routesDirectory)
@@ -80,7 +81,7 @@ export function TanStackStartServerRoutesVite(config: Config): Plugin {
     },
     sharedDuringBuild: true,
     resolveId(id) {
-      if (id === 'tanstack:server-routes') {
+      if (id === moduleId) {
         const generatedRouteTreePath = getGeneratedRouteTreePath(ROOT)
         return generatedRouteTreePath
       }

--- a/packages/start-plugin-core/src/utils.ts
+++ b/packages/start-plugin-core/src/utils.ts
@@ -1,0 +1,3 @@
+export function resolveViteId(id: string) {
+  return `\0${id}`
+}

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -135,10 +135,10 @@ export function createStartHandler<TRouter extends AnyRouter>({
           // Then move on to attempting to load server routes
           const serverRouteTreeModule = await (async () => {
             try {
-              // @ts-expect-error
-              return (await import('tanstack:server-routes')) as {
-                routeTree: AnyServerRoute
-              }
+              return (await import(
+                // @ts-expect-error
+                'tanstack-start-server-routes-manifest:v'
+              )) as { routeTree: AnyServerRoute }
             } catch (e) {
               console.log(e)
               return undefined
@@ -347,7 +347,7 @@ async function handleServerRoutes({
 function handlerToMiddleware(
   handler: AnyServerRouteWithTypes['options']['methods'][string],
 ) {
-  return async ({ next, ...rest }: TODO) => ({
+  return async ({ next: _next, ...rest }: TODO) => ({
     response: await handler(rest),
   })
 }

--- a/packages/start-server-core/src/router-manifest.ts
+++ b/packages/start-server-core/src/router-manifest.ts
@@ -1,4 +1,4 @@
-import { tsrStartManifest } from 'tanstack:start-manifest'
+import { tsrStartManifest } from 'tanstack-start-router-manifest:v'
 import { rootRouteId } from '@tanstack/router-core'
 
 declare global {

--- a/packages/start-server-core/src/server-functions-handler.ts
+++ b/packages/start-server-core/src/server-functions-handler.ts
@@ -1,18 +1,8 @@
 import { isNotFound } from '@tanstack/router-core'
 import invariant from 'tiny-invariant'
 import { startSerializer } from '@tanstack/start-client-core'
-// @ts-expect-error
-import _serverFnManifest from 'tanstack:server-fn-manifest'
+import serverFnManifest from 'tanstack-server-fn-manifest:module'
 import { getEvent, getResponseStatus } from './h3'
-
-const serverFnManifest = _serverFnManifest as Record<
-  string,
-  {
-    functionName: string
-    extractedFilename: string
-    importer: () => Promise<any>
-  }
->
 
 function sanitizeBase(base: string | undefined) {
   if (!base) {

--- a/packages/start-server-core/src/server-functions-handler.ts
+++ b/packages/start-server-core/src/server-functions-handler.ts
@@ -1,8 +1,18 @@
 import { isNotFound } from '@tanstack/router-core'
 import invariant from 'tiny-invariant'
 import { startSerializer } from '@tanstack/start-client-core'
-import serverFnManifest from 'tanstack-start-server-fn-manifest:v'
+// @ts-expect-error
+import _serverFnManifest from 'tanstack-start-server-fn-manifest:v'
 import { getEvent, getResponseStatus } from './h3'
+
+const serverFnManifest = _serverFnManifest as Record<
+  string,
+  {
+    functionName: string
+    extractedFilename: string
+    importer: () => Promise<any>
+  }
+>
 
 function sanitizeBase(base: string | undefined) {
   if (!base) {

--- a/packages/start-server-core/src/server-functions-handler.ts
+++ b/packages/start-server-core/src/server-functions-handler.ts
@@ -1,7 +1,7 @@
 import { isNotFound } from '@tanstack/router-core'
 import invariant from 'tiny-invariant'
 import { startSerializer } from '@tanstack/start-client-core'
-import serverFnManifest from 'tanstack-server-fn-manifest:module'
+import serverFnManifest from 'tanstack-start-server-fn-manifest:v'
 import { getEvent, getResponseStatus } from './h3'
 
 function sanitizeBase(base: string | undefined) {

--- a/packages/start-server-core/src/tanstack-start.d.ts
+++ b/packages/start-server-core/src/tanstack-start.d.ts
@@ -5,7 +5,7 @@ declare module 'tanstack-start-router-manifest:v' {
 }
 
 declare module 'tanstack-start-server-fn-manifest:v' {
-  export default {} as Record<
+  const manifest: Record<
     string,
     {
       functionName: string
@@ -13,4 +13,6 @@ declare module 'tanstack-start-server-fn-manifest:v' {
       importer: () => Promise<any>
     }
   >
+
+  export default manifest
 }

--- a/packages/start-server-core/src/tanstack-start.d.ts
+++ b/packages/start-server-core/src/tanstack-start.d.ts
@@ -4,7 +4,7 @@ declare module 'tanstack-start-router-manifest:v' {
   export const tsrStartManifest: () => Manifest
 }
 
-declare module 'tanstack-server-fn-manifest:module' {
+declare module 'tanstack-start-server-fn-manifest:v' {
   export default {} as Record<
     string,
     {

--- a/packages/start-server-core/src/tanstack-start.d.ts
+++ b/packages/start-server-core/src/tanstack-start.d.ts
@@ -3,3 +3,14 @@ declare module 'tanstack:start-manifest' {
 
   export const tsrStartManifest: () => Manifest
 }
+
+declare module 'tanstack-server-fn-manifest:module' {
+  export default {} as Record<
+    string,
+    {
+      functionName: string
+      extractedFilename: string
+      importer: () => Promise<any>
+    }
+  >
+}

--- a/packages/start-server-core/src/tanstack-start.d.ts
+++ b/packages/start-server-core/src/tanstack-start.d.ts
@@ -1,4 +1,4 @@
-declare module 'tanstack:start-manifest' {
+declare module 'tanstack-start-router-manifest:v' {
   import type { Manifest } from '@tanstack/router-core'
 
   export const tsrStartManifest: () => Manifest

--- a/packages/start-server-core/src/tanstack-start.d.ts
+++ b/packages/start-server-core/src/tanstack-start.d.ts
@@ -3,16 +3,3 @@ declare module 'tanstack-start-router-manifest:v' {
 
   export const tsrStartManifest: () => Manifest
 }
-
-declare module 'tanstack-start-server-fn-manifest:v' {
-  const manifest: Record<
-    string,
-    {
-      functionName: string
-      extractedFilename: string
-      importer: () => Promise<any>
-    }
-  >
-
-  export default manifest
-}

--- a/packages/start-server-core/vite.config.ts
+++ b/packages/start-server-core/vite.config.ts
@@ -20,7 +20,7 @@ export default mergeConfig(
     srcDir: './src',
     entry: './src/index.tsx',
     externalDeps: [
-      'tanstack-server-fn-manifest:module',
+      'tanstack-start-server-fn-manifest:v',
       'tanstack-start-router-manifest:v',
       'tanstack:server-routes',
     ],

--- a/packages/start-server-core/vite.config.ts
+++ b/packages/start-server-core/vite.config.ts
@@ -22,7 +22,7 @@ export default mergeConfig(
     externalDeps: [
       'tanstack-start-server-fn-manifest:v',
       'tanstack-start-router-manifest:v',
-      'tanstack:server-routes',
+      'tanstack-start-server-routes-manifest:v',
     ],
   }),
 )

--- a/packages/start-server-core/vite.config.ts
+++ b/packages/start-server-core/vite.config.ts
@@ -20,7 +20,7 @@ export default mergeConfig(
     srcDir: './src',
     entry: './src/index.tsx',
     externalDeps: [
-      'tanstack:server-fn-manifest',
+      'tanstack-server-fn-manifest:module',
       'tanstack:start-manifest',
       'tanstack:server-routes',
     ],

--- a/packages/start-server-core/vite.config.ts
+++ b/packages/start-server-core/vite.config.ts
@@ -21,7 +21,7 @@ export default mergeConfig(
     entry: './src/index.tsx',
     externalDeps: [
       'tanstack-server-fn-manifest:module',
-      'tanstack:start-manifest',
+      'tanstack-start-router-manifest:v',
       'tanstack:server-routes',
     ],
   }),


### PR DESCRIPTION
Renames the following virtual modules as such to have them be both consistent and more easily readable should there be an error when importing them.

| Before | After |
|--------|--------|
| `tanstack:server-fn-manifest` | `tanstack-start-server-fn-manifest:v` |
| `tanstack:start-manifest` | `tanstack-start-router-manifest:v` |
| `tanstack:server-rotues` | `tanstack-start-server-routes-manifest:v` | 

Additionally, the [Rollup convention for resolving virtual modules](https://vite.dev/guide/api-plugin#virtual-modules-convention) is being applied to these modules.