### PR TITLE
fix: SSR invariant dehydration errors with bun

### DIFF
--- a/packages/start-server-core/src/transformStreamWithRouter.ts
+++ b/packages/start-server-core/src/transformStreamWithRouter.ts
@@ -171,8 +171,6 @@ export function transformStreamWithRouter(
       const text = decodeChunk(chunk.value)
 
       let chunkString = leftover + text
-      const bodyEndMatch = chunkString.match(patternBodyEnd)
-      const htmlEndMatch = chunkString.match(patternHtmlEnd)
 
       if (!bodyStarted) {
         const bodyStartMatch = chunkString.match(patternBodyStart)
@@ -201,6 +199,9 @@ export function transformStreamWithRouter(
         leftover = ''
         return
       }
+
+      const bodyEndMatch = chunkString.match(patternBodyEnd)
+      const htmlEndMatch = chunkString.match(patternHtmlEnd)
 
       // If either the body end or html end is in the chunk,
       // We need to get all of our data in asap


### PR DESCRIPTION
Related: https://github.com/TanStack/router/issues/3989

The script assigned to `\_\_TSR_SSR\_\_.dehydrated` appears outside the `</html>` tag. When the entry script `/_build/assets/client-BJoNZ2zg.js` is cached locally by the browser, even if the entry script is async, the script outside the html may still be executed after the entry script.

https://github.com/TanStack/router/blob/72ffeb4d4ae23a30859b9c7b8a3164535d5f2b85/packages/start-server-core/src/transformStreamWithRouter.ts#L171

Problems occur when `text` is complete HTML

https://github.com/TanStack/router/blob/72ffeb4d4ae23a30859b9c7b8a3164535d5f2b85/packages/start-server-core/src/transformStreamWithRouter.ts#L174-L175

https://github.com/TanStack/router/blob/72ffeb4d4ae23a30859b9c7b8a3164535d5f2b85/packages/start-server-core/src/transformStreamWithRouter.ts#L190

`bodyEndMatch` is assigned before the `!headStarted` branch processes chunkString.

https://github.com/TanStack/router/blob/72ffeb4d4ae23a30859b9c7b8a3164535d5f2b85/packages/start-server-core/src/transformStreamWithRouter.ts#L216

The length of `bodyEndIndex` obtained here will exceed the length of the modified `chunkString`, resulting in `<script>` being appended after `</html>`

![Image](https://github.com/user-attachments/assets/4fb5b36d-0dd3-43fe-8c50-3dd731b0361d)

The solution is to move `bodyEndMatch` and `htmlEndMatch` to after the `chunkString` change.