### PR TITLE
feat(server-functions-plugin): make the manifest output path configurable

### DIFF
--- a/packages/server-functions-plugin/README.md
+++ b/packages/server-functions-plugin/README.md
@@ -8,8 +8,8 @@ Create a new instance of the plugin with the following options:
 
 ```ts
 const TanStackServerFnsPlugin = createTanStackServerFnPlugin({
-  // This is the ID that will be available to look up and import
-  // our server function manifest and resolve its module
+  // This is the ID (virtual module) that will be made available to look up
+  // and import our server function manifest and resolve its modules.
   manifestVirtualImportId: 'tanstack:server-fn-manifest',
   client: {
     getRuntimeCode: () =>
@@ -86,5 +86,5 @@ export const handler = async (req: Request) => {
   const args = await req.json()
 
   return await fnModule(...args)
-
+}
 ```

--- a/packages/server-functions-plugin/src/index.ts
+++ b/packages/server-functions-plugin/src/index.ts
@@ -22,15 +22,28 @@ declare global {
 }
 
 export type ServerFnPluginOpts = {
+  /**
+   * The virtual import ID that will be used to import the server function manifest.
+   * This virtual import ID will be used in the server build to import the manifest
+   * and its modules.
+   */
   manifestVirtualImportId: string
+  /**
+   * The path to the manifest file that will be created during the build process.
+   * This file will be used to import the modules for the server functions in your
+   * server handler.
+   *
+   * @default 'node_modules/.tanstack-start/server-functions-manifest.json'
+   */
+  manifestOutputFilename?: string
   client: ServerFnPluginEnvOpts
   ssr: ServerFnPluginEnvOpts
   server: ServerFnPluginEnvOpts
   importer?: (fn: DirectiveFn) => Promise<any>
 }
 
-const manifestFilename =
-  '.tanstack-start/build/server/server-functions-manifest.json'
+const defaultManifestFilename =
+  'node_modules/.tanstack-start/server-functions-manifest.json'
 
 export type ServerFnPluginEnvOpts = {
   getRuntimeCode: () => string
@@ -70,6 +83,9 @@ export function createTanStackServerFnPlugin(opts: ServerFnPluginOpts): {
       ),
     )
   }
+
+  const manifestFilename =
+    opts.manifestOutputFilename || defaultManifestFilename
 
   const directive = 'use server'
   const directiveLabel = 'Server Function'
@@ -201,7 +217,20 @@ export function createTanStackServerFnPlugin(opts: ServerFnPluginOpts): {
 }
 
 export interface TanStackServerFnPluginEnvOpts {
+  /**
+   * The virtual import ID that will be used to import the server function manifest.
+   * This virtual import ID will be used in the server build to import the manifest
+   * and its modules.
+   */
   manifestVirtualImportId: string
+  /**
+   * The path to the manifest file that will be created during the build process.
+   * This file will be used to import the modules for the server functions in your
+   * server handler.
+   *
+   * @default 'node_modules/.tanstack-start/server-functions-manifest.json'
+   */
+  manifestOutputFilename?: string
   client: {
     envName?: string
     getRuntimeCode: () => string
@@ -258,6 +287,9 @@ export function TanStackServerFnPluginEnv(
       ),
     )
   }
+
+  const manifestFilename =
+    opts.manifestOutputFilename || defaultManifestFilename
 
   const directive = 'use server'
   const directiveLabel = 'Server Function'

--- a/packages/start-plugin-core/src/plugin.ts
+++ b/packages/start-plugin-core/src/plugin.ts
@@ -167,6 +167,8 @@ export function TanStackStartVitePluginCore(
       // This is the ID that will be available to look up and import
       // our server function manifest and resolve its module
       manifestVirtualImportId: 'tanstack-start-server-fn-manifest:v',
+      manifestOutputFilename:
+        '.tanstack-start/build/server/server-functions-manifest.json',
       client: {
         getRuntimeCode: () =>
           `import { createClientRpc } from '@tanstack/${opts.framework}-start/server-functions-client'`,


### PR DESCRIPTION
As part of the devinxi changes, the following hard-coded output path of the server functions manifest file was changed.

```diff
- const manifestFilename = 'node_modules/.tanstack-start/server-functions-manifest.json'
+ const manifestFilename = '.tanstack-start/build/server/server-functions-manifest.json'
```

This would have had breaking changes in the user DX for downstream frameworks building upon the `@tanstack/server-functions-plugin` package - (i.e. SolidStart).

---

This change makes the manifest file for `server-functions-plugin` configurable, with it being defaulted to  the old value of `node_modules/.tanstack-start/server-functions-manifest.json`.

It also sets the default for TanStack Start to `.tanstack-start/build/server/server-functions-manifest.json`.