### PR TITLE
handle Symbol properties and non-enumerable properties in `replaceEqualDeep`

### DIFF
--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -214,9 +214,19 @@ export function replaceEqualDeep<T>(prev: any, _next: T): T {
   const array = isPlainArray(prev) && isPlainArray(next)
 
   if (array || (isPlainObject(prev) && isPlainObject(next))) {
-    const prevItems = array ? prev : Object.keys(prev)
+    const prevItems = array
+      ? prev
+      : [
+          ...Object.getOwnPropertyNames(prev),
+          ...Object.getOwnPropertySymbols(prev),
+        ]
     const prevSize = prevItems.length
-    const nextItems = array ? next : Object.keys(next)
+    const nextItems = array
+      ? next
+      : [
+          ...Object.getOwnPropertyNames(next),
+          ...Object.getOwnPropertySymbols(next),
+        ]
     const nextSize = nextItems.length
     const copy: any = array ? [] : {}
 

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -213,20 +213,18 @@ export function replaceEqualDeep<T>(prev: any, _next: T): T {
 
   const array = isPlainArray(prev) && isPlainArray(next)
 
-  if (array || (isPlainObject(prev) && isPlainObject(next))) {
+  if (array || (isSimplePlainObject(prev) && isSimplePlainObject(next))) {
     const prevItems = array
       ? prev
-      : [
-          ...Object.getOwnPropertyNames(prev),
-          ...Object.getOwnPropertySymbols(prev),
-        ]
+      : (Object.keys(prev) as Array<unknown>).concat(
+          Object.getOwnPropertySymbols(prev),
+        )
     const prevSize = prevItems.length
     const nextItems = array
       ? next
-      : [
-          ...Object.getOwnPropertyNames(next),
-          ...Object.getOwnPropertySymbols(next),
-        ]
+      : (Object.keys(next) as Array<unknown>).concat(
+          Object.getOwnPropertySymbols(next),
+        )
     const nextSize = nextItems.length
     const copy: any = array ? [] : {}
 
@@ -253,6 +251,19 @@ export function replaceEqualDeep<T>(prev: any, _next: T): T {
   }
 
   return next
+}
+
+/**
+ * A wrapper around `isPlainObject` with additional checks to ensure that it is not
+ * only a plain object, but also one that is "clone-friendly" (doesn't have any
+ * non-enumerable properties).
+ */
+function isSimplePlainObject(o: any) {
+  return (
+    // all the checks from isPlainObject are more likely to hit so we perform them first
+    isPlainObject(o) &&
+    Object.getOwnPropertyNames(o).length === Object.keys(o).length
+  )
 }
 
 // Copied from: https://github.com/jonschlinkert/is-plain-object

--- a/packages/router-core/tests/utils.test.ts
+++ b/packages/router-core/tests/utils.test.ts
@@ -54,7 +54,7 @@ describe('replaceEqualDeep', () => {
   })
 
   describe('non-enumerable properties', () => {
-    it('should look at non-enumerable properties in the object comparison', () => {
+    it('should treat objects with non-enumerable properties as non-plain (no need for property comparisons)', () => {
       const obj1: { a: number; b?: number } = { a: 1 }
       Object.defineProperty(obj1, 'b', { enumerable: false, value: 2 })
       const obj2: { a: number; b?: number } = { a: 1 }
@@ -64,11 +64,10 @@ describe('replaceEqualDeep', () => {
       // expect(result).toBe(obj1)
       // expect(result.b).toBe(2)
       // with this PR:
-      expect(result).not.toBe(obj1)
-      expect(result).toStrictEqual({ a: 1, b: 3 })
+      expect(result).toBe(obj2)
     })
 
-    it('should copy over non-enumerable properties when creating a new object', () => {
+    it("should treat objects with non-enumerable properties as non-plain (copying doesn't happen)", () => {
       const obj1: { a: number; b?: number } = { a: 1 }
       Object.defineProperty(obj1, 'b', { enumerable: false, value: 2 })
       const obj2: { a: number; b?: number } = { a: 3 }
@@ -78,7 +77,7 @@ describe('replaceEqualDeep', () => {
       // expect(result).toStrictEqual({ a: 3 })
       // expect(result.b).toBe(undefined)
       // with this PR:
-      expect(result).toStrictEqual({ a: 3, b: 2 })
+      expect(result).toBe(obj2)
     })
   })
 

--- a/packages/router-core/tests/utils.test.ts
+++ b/packages/router-core/tests/utils.test.ts
@@ -35,9 +35,6 @@ describe('replaceEqualDeep', () => {
       const obj1 = { a: 1, [propertyKey]: 2 }
       const obj2 = { a: 1, [propertyKey]: 3 }
       const result = replaceEqualDeep(obj1, obj2)
-      // without this PR:
-      // expect(result).toBe(obj1)
-      // with this PR:
       expect(result).toStrictEqual(obj2)
     })
 
@@ -46,9 +43,6 @@ describe('replaceEqualDeep', () => {
       const obj1 = { a: 1, [propertyKey]: 2 }
       const obj2 = { a: 3, [propertyKey]: 2 }
       const result = replaceEqualDeep(obj1, obj2)
-      // without this PR:
-      // expect(result).toStrictEqual({ a: 3 })
-      // with this PR:
       expect(result).toStrictEqual(obj2)
     })
   })
@@ -60,10 +54,6 @@ describe('replaceEqualDeep', () => {
       const obj2: { a: number; b?: number } = { a: 1 }
       Object.defineProperty(obj2, 'b', { enumerable: false, value: 3 })
       const result = replaceEqualDeep(obj1, obj2)
-      // without this PR:
-      // expect(result).toBe(obj1)
-      // expect(result.b).toBe(2)
-      // with this PR:
       expect(result).toBe(obj2)
     })
 
@@ -73,10 +63,6 @@ describe('replaceEqualDeep', () => {
       const obj2: { a: number; b?: number } = { a: 3 }
       Object.defineProperty(obj2, 'b', { enumerable: false, value: 2 })
       const result = replaceEqualDeep(obj1, obj2)
-      // without this PR:
-      // expect(result).toStrictEqual({ a: 3 })
-      // expect(result.b).toBe(undefined)
-      // with this PR:
       expect(result).toBe(obj2)
     })
   })


### PR DESCRIPTION
Opening this PR for discussion, I'm very open to scope changes.

This PR tackles two problems with `defaultStructuralSharing: true`:

1. symbol properties are not taken into account for "object equality" and are not copied over when creating a new copy
2. non-enumerable properties are not taken into account for "object equality" and are not copied over when creating a new copy

Point 1. actually is causing some of our users a headache, see https://github.com/apollographql/apollo-client/issues/12619 and https://community.apollographql.com/t/preloadquery-with-tanstack-router-loader/9100 .

Users expect that they're able to pass an object with symbol properties over from a loader into components, but when having `defaultStructuralSharing` enabled, from the second object that is passed over, it creates a copy and strips off symbol properties.
That new object without the expected symbol properties will then crash our `useReadQuery` hook.

In other words, the first loader call returns
```js
{
    refObject: { toPromise: Function1, [secretSymbol]: ImplementationDetail1 }
}
```
the component receives
```js
{
    refObject: { toPromise: Function1, [secretSymbol]: ImplementationDetail1 }
}
```
and the second loader call returns
```js
{
    refObject: { toPromise: Function2, [secretSymbol]: ImplementationDetail2 }
}
```
but the component receives
```js
{
    refObject: { toPromise: Function2 }
}
```
`toPromise` is a different function, so it goes into the "clone" path, but skips the `secretSymbol` property.

If we wouldn't have that `toPromise` property on there (and we're considering removing it!), it would even be worse to debug - users would always stay on the first `refObject` and never get the second, since both objects would be considered equal.

On our side, passing these objects from loaders to components is actually an intended pattern, so this is causing quite a bit of problems - see this example from our docs (see [Initiating queries outside React](https://www.apollographql.com/docs/react/data/suspense#initiating-queries-outside-react)):

```ts
import { useLoaderData } from 'react-router-dom';

export function loader() {
  return preloadQuery(GET_DOGS_QUERY);
}

export function RouteComponent() {
  const queryRef = useLoaderData();
  const { data } = useReadQuery(queryRef);

  return (
    // ...
  );
}
```

Problem 2. is purely hypothetical and we haven't encountered it - but it should probably be handled in some way.

Both of these problems can be handled in two ways:

* take these "special properties" into account for comparisons and copy them over (my naive approach here would lose the "non-enumerability" of these properties, more code would be necessary to keep that)
* in `isPlainObject` just return `false` if an object has non-enumerable or symbol properties. This would opt out of structural sharing for these objects (which is probably perfectly fine)

I'd be open for either of those solutions, and also for completely dropping the "non-enumerable" case for simplicity, but I would be very happy if we could get *something* in to help with symbol properties.  
In React Query, these values can be assumed to be serializable JSON, so the current implementation is perfectly fine, but with client-side loaders, users can just pass anything, and here it's causing quite the problem.  
Telling our users to situationally turn off structural sharing would be an educational nightmare. 