### PR TITLE
fix: normalize router filepath

### DIFF
--- a/packages/start-plugin-core/src/plugin.ts
+++ b/packages/start-plugin-core/src/plugin.ts
@@ -237,10 +237,8 @@ function resolveVirtualEntriesPlugin(
       return undefined
     },
     load(id) {
-      const routerFilepath = path.resolve(
-        startConfig.root,
-        startConfig.tsr.srcDirectory,
-        'router',
+      const routerFilepath = vite.normalizePath(
+        path.resolve(startConfig.root, startConfig.tsr.srcDirectory, 'router'),
       )
 
       if (id === '/~start/server-entry.tsx') {


### PR DESCRIPTION
Fixes #4243

There's a subtle difference between the [`routerImportPath`](https://github.com/TanStack/router/pull/4238/files#diff-a6e4ac58c8c6c3471a9b07a5b161709f0f70e9a761b1528d0cb7b88fdc4d15b3L48) before and [`routerFilepath`](https://github.com/TanStack/router/pull/4238/files#diff-bdd2c7efd081403fb4f53a6d4b441db0904b3e860ceff5dbd7d9721e4e0ce89aR240) after #4238. The former uses `JSON.stringify()`, which generates a path with double backslashes, while the latter uses the return value from `path.resolve()` directly, which uses a single backslash as the separator. This is similar to #4180, but for the router. Using `normalizePath()` to turn all backslashes to forward slashes fixes the import error caused by the malformed path.