### PR TITLE
fix: dynamically import virtual modules

### DIFF
--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -106,7 +106,7 @@ export function createStartHandler<TRouter extends AnyRouter>({
       const router = createRouter()
 
       // Attach the server-side SSR utils to the client-side router
-      attachRouterServerSsrUtils(router, getStartManifest())
+      attachRouterServerSsrUtils(router, await getStartManifest())
 
       // Update the client-side router with the history and context
       router.update({

--- a/packages/start-server-core/src/router-manifest.ts
+++ b/packages/start-server-core/src/router-manifest.ts
@@ -1,4 +1,3 @@
-import { tsrStartManifest } from 'tanstack-start-router-manifest:v'
 import { rootRouteId } from '@tanstack/router-core'
 
 declare global {
@@ -12,7 +11,8 @@ declare global {
  * special assets that are needed for the client. It does not include relationships
  * between routes or any other data that is not needed for the client.
  */
-export function getStartManifest() {
+export async function getStartManifest() {
+  const { tsrStartManifest } = await import('tanstack-start-router-manifest:v')
   const startManifest = tsrStartManifest()
 
   const rootRoute = (startManifest.routes[rootRouteId] =

--- a/packages/start-server-core/src/server-functions-handler.ts
+++ b/packages/start-server-core/src/server-functions-handler.ts
@@ -1,18 +1,7 @@
 import { isNotFound } from '@tanstack/router-core'
 import invariant from 'tiny-invariant'
 import { startSerializer } from '@tanstack/start-client-core'
-// @ts-expect-error
-import _serverFnManifest from 'tanstack-start-server-fn-manifest:v'
 import { getEvent, getResponseStatus } from './h3'
-
-const serverFnManifest = _serverFnManifest as Record<
-  string,
-  {
-    functionName: string
-    extractedFilename: string
-    importer: () => Promise<any>
-  }
->
 
 function sanitizeBase(base: string | undefined) {
   if (!base) {
@@ -53,6 +42,19 @@ export const handleServerAction = async ({ request }: { request: Request }) => {
     throw new Error('Invalid server action param for serverFnId: ' + serverFnId)
   }
 
+  const { default: _serverFnManifest } = await import(
+    // @ts-expect-error
+    'tanstack-start-server-fn-manifest:v'
+  )
+
+  const serverFnManifest = _serverFnManifest as Record<
+    string,
+    {
+      functionName: string
+      extractedFilename: string
+      importer: () => Promise<any>
+    }
+  >
   const serverFnInfo = serverFnManifest[serverFnId]
 
   if (!serverFnInfo) {


### PR DESCRIPTION
otherwise other packages that import start (e.g. clerk) for which noExternal is not set will not properly transform those virtual modules during dev