### PR TITLE
refactor: rename internal functions and limit nitro defaults

### DIFF
--- a/packages/react-start-plugin/src/index.ts
+++ b/packages/react-start-plugin/src/index.ts
@@ -21,10 +21,10 @@ export function TanStackStartVitePlugin(
     TanStackStartVitePluginCore(
       {
         framework: 'react',
-        getVirtualServerHandlerEntry(ctx) {
+        getVirtualServerRootHandler(ctx) {
           return `
 import { toWebRequest, defineEventHandler } from '@tanstack/react-start/server';
-import serverEntry from '${ctx.ssrEntryFilepath}';
+import serverEntry from '${ctx.serverEntryFilepath}';
 
 export default defineEventHandler(function(event) {
   const request = toWebRequest(event);
@@ -49,7 +49,7 @@ startTransition(() => {
   );
 });`
         },
-        getVirtualSsrEntry(ctx) {
+        getVirtualServerEntry(ctx) {
           return `
 import { createStartHandler, defaultStreamHandler } from '@tanstack/react-start/server';
 import { createRouter } from '${ctx.routerFilepath}';

--- a/packages/solid-start-plugin/src/index.ts
+++ b/packages/solid-start-plugin/src/index.ts
@@ -21,10 +21,10 @@ export function TanStackStartVitePlugin(
     TanStackStartVitePluginCore(
       {
         framework: 'solid',
-        getVirtualServerHandlerEntry(ctx) {
+        getVirtualServerRootHandler(ctx) {
           return `
 import { toWebRequest, defineEventHandler } from '@tanstack/solid-start/server';
-import serverEntry from '${ctx.ssrEntryFilepath}';
+import serverEntry from '${ctx.serverEntryFilepath}';
 
 export default defineEventHandler(function(event) {
   const request = toWebRequest(event);
@@ -41,7 +41,7 @@ const router = createRouter();
 
 hydrate(() => <StartClient router={router} />, document.body);`
         },
-        getVirtualSsrEntry(ctx) {
+        getVirtualServerEntry(ctx) {
           return `
 import { createStartHandler, defaultStreamHandler } from '@tanstack/solid-start/server';
 import { createRouter } from '${ctx.routerFilepath}';

--- a/packages/start-plugin-core/src/nitro/nitro-plugin.ts
+++ b/packages/start-plugin-core/src/nitro/nitro-plugin.ts
@@ -72,7 +72,7 @@ export function nitroPlugin(
 
               const nitroConfig: NitroConfig = {
                 dev: false,
-                // TODO do we need this? should this be made configurable?
+                // TODO: do we need this? should this be made configurable?
                 compatibilityDate: '2024-11-19',
                 logLevel: 3,
                 preset: buildPreset,
@@ -86,8 +86,16 @@ export function nitroPlugin(
                 },
                 prerender: undefined,
                 renderer: ssrEntryFile,
+                plugins: [], // Nitro's plugins
+                appConfigFiles: [],
+                scanDirs: [],
+                imports: false, // unjs/unimport for global/magic imports
                 rollupConfig: {
                   plugins: [virtualBundlePlugin(getSsrBundle())],
+                },
+                virtual: {
+                  // This is Nitro's way of defining virtual modules
+                  // Should we define the ones for TanStack Start's here as well?
                 },
               }
 

--- a/packages/start-plugin-core/src/plugin.ts
+++ b/packages/start-plugin-core/src/plugin.ts
@@ -35,11 +35,11 @@ export const ssrEntryFile = 'ssr.mjs'
 
 export interface TanStackStartVitePluginCoreOptions {
   framework: CompileStartFrameworkOptions
-  getVirtualServerHandlerEntry: (ctx: {
+  getVirtualServerRootHandler: (ctx: {
     routerFilepath: string
-    ssrEntryFilepath: string
+    serverEntryFilepath: string
   }) => string
-  getVirtualSsrEntry: (ctx: { routerFilepath: string }) => string
+  getVirtualServerEntry: (ctx: { routerFilepath: string }) => string
   getVirtualClientEntry: (ctx: { routerFilepath: string }) => string
 }
 // this needs to live outside of the TanStackStartVitePluginCore since it will be invoked multiple times by vite
@@ -250,9 +250,9 @@ function resolveVirtualEntriesPlugin(
               path.resolve(resolvedConfig.root, startConfig.serverEntryPath),
             )
 
-        return opts.getVirtualServerHandlerEntry({
+        return opts.getVirtualServerRootHandler({
           routerFilepath,
-          ssrEntryFilepath,
+          serverEntryFilepath: ssrEntryFilepath,
         })
       }
 
@@ -261,7 +261,7 @@ function resolveVirtualEntriesPlugin(
       }
 
       if (id === '/~start/default-server-entry.tsx') {
-        return opts.getVirtualSsrEntry({ routerFilepath })
+        return opts.getVirtualServerEntry({ routerFilepath })
       }
 
       return undefined

--- a/packages/start-server-core/src/server-functions-handler.ts
+++ b/packages/start-server-core/src/server-functions-handler.ts
@@ -42,19 +42,20 @@ export const handleServerAction = async ({ request }: { request: Request }) => {
     throw new Error('Invalid server action param for serverFnId: ' + serverFnId)
   }
 
-  const { default: _serverFnManifest } = await import(
+  const { default: serverFnManifest } = (await import(
     // @ts-expect-error
     'tanstack-start-server-fn-manifest:v'
-  )
+  )) as {
+    default: Record<
+      string,
+      {
+        functionName: string
+        extractedFilename: string
+        importer: () => Promise<any>
+      }
+    >
+  }
 
-  const serverFnManifest = _serverFnManifest as Record<
-    string,
-    {
-      functionName: string
-      extractedFilename: string
-      importer: () => Promise<any>
-    }
-  >
   const serverFnInfo = serverFnManifest[serverFnId]
 
   if (!serverFnInfo) {


### PR DESCRIPTION
- Brings more of the defaults from Vinxi which limits what `createNitro` does.
- Renamed the functions and arguments for getting the entry/handlers for the "server root", "server entry", and "client entry".
- Assigns the type for the `serverFnManifest` import in-place, instead of casting later on.