### PR TITLE
fix(alpha): Recursively import CSS assets

### DIFF
--- a/examples/react/start-bare/src/routes/__root.tsx
+++ b/examples/react/start-bare/src/routes/__root.tsx
@@ -1,13 +1,13 @@
+import * as React from 'react'
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
 import {
-  createRootRoute,
   HeadContent,
   Link,
   Outlet,
   Scripts,
+  createRootRoute,
 } from '@tanstack/react-router'
 import appCss from '~/styles/app.css?url'
-import * as React from 'react'
 
 export const Route = createRootRoute({
   head: () => ({

--- a/examples/react/start-bare/src/routes/about.tsx
+++ b/examples/react/start-bare/src/routes/about.tsx
@@ -1,3 +1,5 @@
+import Counter from "~/components/Counter"
+
 export const Route = createFileRoute({
   component: RouteComponent,
 })
@@ -6,6 +8,7 @@ function RouteComponent() {
   return (
     <main>
       <h1>About</h1>
+      <Counter />
     </main>
   )
 }

--- a/examples/react/start-bare/src/routes/about.tsx
+++ b/examples/react/start-bare/src/routes/about.tsx
@@ -1,4 +1,4 @@
-import Counter from "~/components/Counter"
+import Counter from '~/components/Counter'
 
 export const Route = createFileRoute({
   component: RouteComponent,

--- a/examples/react/start-bare/src/routes/index.tsx
+++ b/examples/react/start-bare/src/routes/index.tsx
@@ -1,4 +1,3 @@
-import Counter from '~/components/Counter'
 export const Route = createFileRoute({
   component: RouteComponent,
 })
@@ -7,7 +6,6 @@ function RouteComponent() {
   return (
     <main>
       <h1 className="text-3xl text-blue-500 mb-5">Hello world!</h1>
-      <Counter />
     </main>
   )
 }

--- a/packages/start-plugin-core/src/routesManifestPlugin.ts
+++ b/packages/start-plugin-core/src/routesManifestPlugin.ts
@@ -12,7 +12,10 @@ import type {
 import type { Manifest, RouterManagedTag } from '@tanstack/router-core'
 import type { TanStackStartOutputConfig } from './plugin'
 
-const getCSSRecursively = (file: ViteManifestChunk, filesByRouteFilePath: ViteManifest) => {
+const getCSSRecursively = (
+  file: ViteManifestChunk,
+  filesByRouteFilePath: ViteManifest,
+) => {
   const result: Array<RouterManagedTag> = []
 
   // Get all css imports from the file
@@ -29,14 +32,14 @@ const getCSSRecursively = (file: ViteManifestChunk, filesByRouteFilePath: ViteMa
 
   // Recursively get CSS from imports
   for (const imp of file.imports ?? []) {
-    const importInfo = filesByRouteFilePath[imp];
+    const importInfo = filesByRouteFilePath[imp]
     if (importInfo) {
-      result.push(...getCSSRecursively(importInfo, filesByRouteFilePath));
+      result.push(...getCSSRecursively(importInfo, filesByRouteFilePath))
     }
   }
 
-  return result;
-};
+  return result
+}
 
 export function startManifestPlugin(
   opts: TanStackStartOutputConfig,
@@ -141,7 +144,7 @@ export function startManifestPlugin(
         Object.entries(routes).forEach(([k, v]) => {
           const file =
             filesByRouteFilePath[
-            path.join(routesDirectoryFromRoot, v.filePath as string)
+              path.join(routesDirectoryFromRoot, v.filePath as string)
             ]
 
           if (file) {
@@ -153,7 +156,7 @@ export function startManifestPlugin(
               preloads.unshift(path.join('/', file.file))
             }
 
-            const cssAssetsList = getCSSRecursively(file, filesByRouteFilePath);
+            const cssAssetsList = getCSSRecursively(file, filesByRouteFilePath)
 
             routes[k] = {
               ...v,
@@ -173,7 +176,10 @@ export function startManifestPlugin(
 
           // Gather all the CSS files from the entry file in
           // the `css` key and add them to the root route
-          const entryCssAssetsList = getCSSRecursively(entryFile, filesByRouteFilePath)
+          const entryCssAssetsList = getCSSRecursively(
+            entryFile,
+            filesByRouteFilePath,
+          )
 
           routes[rootRouteId]!.assets = [
             ...(routes[rootRouteId]!.assets || []),


### PR DESCRIPTION
This PR resolves an issue where not all CSS files needed to render a route were included in the SSR response. The root cause was that only CSS directly imported by the main route was being requested, leaving out styles from nested components.

The fix ensures CSS is now recursively imported, so all necessary styles—regardless of where they’re required—are properly included.

Before
![image](https://github.com/user-attachments/assets/ea03cb23-cd24-43c4-8779-14108c7a9c24)
After
![image](https://github.com/user-attachments/assets/4f9ffc46-aef7-41a4-b16c-95232241e06f)


I also updated the start bare example importing the counter compontent from the about page to show the error and the fix, and ensure this is not a problem in the future.

This is my first PR in this repo, im not sure if this breaks anything else but for my testing this works as expected and solves the issue!