### PR TITLE
docs(router): add `route.tsx` in directory vs flat routing guide

### DIFF
--- a/docs/router/framework/react/routing/file-based-routing.md
+++ b/docs/router/framework/react/routing/file-based-routing.md
@@ -47,7 +47,7 @@ See the example below:
 | ┄ ʦ `route-b.tsx`       | `/route-b`                | `<Root><PathlessLayout><RouteB>`  |
 | 📂 `files`              |                           |                                   |
 | ┄ ʦ `$.tsx`             | `/files/$`                | `<Root><Files>`                   |
-| 📂 `account`            |                           |                                   |   
+| 📂 `account`            |                           |                                   |
 | ┄ ʦ `route.tsx`         | `/account`                | `<Root><Account>`                 |
 | ┄ ʦ `overview.tsx`      | `/account/overview`       | `<Root><Account><Overview>`       |
 

--- a/docs/router/framework/react/routing/file-based-routing.md
+++ b/docs/router/framework/react/routing/file-based-routing.md
@@ -75,6 +75,8 @@ See the example below:
 | ʦ `_pathlessLayout.route-a.tsx` | `/route-a`                | `<Root><PathlessLayout><RouteA>`  |
 | ʦ `_pathlessLayout.route-b.tsx` | `/route-b`                | `<Root><PathlessLayout><RouteB>`  |
 | ʦ `files.$.tsx`                 | `/files/$`                | `<Root><Files>`                   |
+| ʦ `account.tsx`                 | `/account`                | `<Root><Account>`                 |
+| ʦ `account.overview.tsx`        | `/account/overview`       | `<Root><Account><Overview>`       |
 
 ## Mixed Flat and Directory Routes
 
@@ -95,6 +97,8 @@ See the example below:
 | ʦ `settings.tsx`               | `/settings`               | `<Root><Settings>`                |
 | ʦ `settings.profile.tsx`       | `/settings/profile`       | `<Root><Settings><Profile>`       |
 | ʦ `settings.notifications.tsx` | `/settings/notifications` | `<Root><Settings><Notifications>` |
+| ʦ `account.tsx`                | `/account`                | `<Root><Account>`                 |
+| ʦ `account.overview.tsx`       | `/account/overview`       | `<Root><Account><Overview>`       |
 
 Both flat and directory routes can be mixed together to create a route tree that uses the best of both worlds where it makes sense.
 

--- a/docs/router/framework/react/routing/file-based-routing.md
+++ b/docs/router/framework/react/routing/file-based-routing.md
@@ -47,6 +47,9 @@ See the example below:
 | ┄ ʦ `route-b.tsx`       | `/route-b`                | `<Root><PathlessLayout><RouteB>`  |
 | 📂 `files`              |                           |                                   |
 | ┄ ʦ `$.tsx`             | `/files/$`                | `<Root><Files>`                   |
+| 📂 `account`            |                           |                                   |   
+| ┄ ʦ `route.tsx`         | `/account`                | `<Root><Account>`                 |
+| ┄ ʦ `overview.tsx`      | `/account/overview`       | `<Root><Account><Overview>`       |
 
 ## Flat Routes
 


### PR DESCRIPTION
The official docs do not currently demonstrate that naming a file as `route.tsx` will automatically have it treated as a layout route for that route.

i.e. 
```
| ʦ `posts.tsx`           | `/posts`                  | `<Root><Posts>`                   |
| 📂 `posts`              |                           |                                   |
| ┄ ʦ `$postId.tsx`       | `/posts/$postId`          | `<Root><Posts><Post>`             |
```

is also the same as 
```
| 📂 `posts`              |                           |                                   |
| ʦ `route.tsx`           | `/posts`                  | `<Root><Posts>`                   |
| ┄ ʦ `$postId.tsx`       | `/posts/$postId`          | `<Root><Posts><Post>`             |
```

This PR adds in a new route in the examples of the `file-based-routing` page -  `account` which reflects this behaviour visually.
