### PR TITLE
docs: Update RouteOptionsType doc to reflect correct Loader opts

### DIFF
--- a/docs/router/framework/react/api/router/RouteOptionsType.md
+++ b/docs/router/framework/react/api/router/RouteOptionsType.md
@@ -124,15 +124,15 @@ type beforeLoad = (
 ```tsx
 type loader = (
   opts: RouteMatch & {
-    search: TFullSearchSchema
     abortController: AbortController
-    preload: boolean
-    params: TAllParams
-    context: TAllContext
-    location: ParsedLocation
-    navigate: NavigateFn<AnyRoute> // @deprecated
-    buildLocation: BuildLocationFn<AnyRoute>
     cause: 'enter' | 'stay'
+    context: TAllContext
+    deps: TLoaderDeps
+    location: ParsedLocation
+    params: TAllParams
+    preload: boolean
+    parentMatchPromise: Promise<MakeRouteMatchFromRoute<TParentRoute>>
+    navigate: NavigateFn<AnyRoute> // @deprecated
   },
 ) => Promise<TLoaderData> | TLoaderData | void
 ```
@@ -142,6 +142,7 @@ type loader = (
 - This async function is called when a route is matched and passed the route's match object. If an error is thrown here, the route will be put into an error state and the error will be thrown during render. If thrown during a navigation, the navigation will be canceled and the error will be passed to the `onError` function. If thrown during a preload event, the error will be logged to the console and the preload will fail.
 - If this function returns a promise, the route will be put into a pending state and cause rendering to suspend until the promise resolves. If this route's pendingMs threshold is reached, the `pendingComponent` will be shown until it resolves. If the promise rejects, the route will be put into an error state and the error will be thrown during render.
 - If this function returns a `TLoaderData` object, that object will be stored on the route match until the route match is no longer active. It can be accessed using the `useLoaderData` hook in any component that is a child of the route match before another `<Outlet />` is rendered.
+- Deps must be returned by your `loaderDeps` function in order to appear.
 
 > 🚧 `opts.navigate` has been deprecated and will be removed in the next major release. Use `throw redirect({ to: '/somewhere' })` instead. Read more about the `redirect` function [here](../redirectFunction.md).
 
@@ -292,7 +293,7 @@ interface RemountDepsOptions<
 - The return value needs to be JSON serializable.
 - By default, a route component will not be remounted if it stays active after a navigation.
 
-Example:  
+Example:
 If you want to configure to remount a route component upon `params` change, use:
 
 ```tsx


### PR DESCRIPTION
The loader section of the RouteOptions Type docs page currently shows opts properties that have been removed. This PR cleans those up and updates the list to reflect what is actually available. 

**Removed:**
- `search`
- `buildLocation`

**Changed:**
- Sorted alpha to match the [loader params page](https://tanstack.com/router/latest/docs/framework/react/guide/data-loading#loader-parameters)