### PR TITLE
Update code-splitting.md

### DIFF
--- a/docs/router/framework/react/guide/code-splitting.md
+++ b/docs/router/framework/react/guide/code-splitting.md
@@ -217,7 +217,7 @@ If you are using code-based routing, you can still code-split your routes using 
 Create a lazy route using the `createLazyRoute` function.
 
 ```tsx
-// src/posts.tsx
+// src/posts.lazy.tsx
 export const Route = createLazyRoute('/posts')({
   component: MyComponent,
 })


### PR DESCRIPTION
Fix code-based splitting example.
Change file name from `// src/posts.tsx` to `// src/posts.lazy.tsx`