### PR TITLE
fix: export OptionalFetcher and RequiredFetcher types

### DIFF
--- a/packages/react-start-client/src/index.tsx
+++ b/packages/react-start-client/src/index.tsx
@@ -25,6 +25,8 @@ export {
   type CompiledFetcherFnOptions,
   type CompiledFetcherFn,
   type Fetcher,
+  type OptionalFetcher,
+  type RequiredFetcher,
   type RscStream,
   type FetcherData,
   type FetcherBaseOptions,

--- a/packages/solid-start-client/src/index.tsx
+++ b/packages/solid-start-client/src/index.tsx
@@ -25,6 +25,8 @@ export {
   type CompiledFetcherFnOptions,
   type CompiledFetcherFn,
   type Fetcher,
+  type OptionalFetcher,
+  type RequiredFetcher,
   type RscStream,
   type FetcherData,
   type FetcherBaseOptions,

--- a/packages/start-client-core/src/index.tsx
+++ b/packages/start-client-core/src/index.tsx
@@ -76,6 +76,7 @@ export type {
   Method,
   StaticCachedResult,
   OptionalFetcher,
+  RequiredFetcher,
 } from './createServerFn'
 export {
   applyMiddleware,


### PR DESCRIPTION
I hit a similar issue to #4001 (ts(2742)) but on pnpm, which requires exporting the types all the way to the module that gets directly imported by the application according to https://github.com/microsoft/TypeScript/issues/47663#issuecomment-1519138189.
This fix resolves this issue.