### PR TITLE
Fix double decoding of query parameters in QSS.ts

### DIFF
--- a/packages/router-core/src/qss.ts
+++ b/packages/router-core/src/qss.ts
@@ -7,7 +7,6 @@
  * (namely URLSearchParams) and TypeScript while still
  * maintaining the original functionality and interface.
  */
-import { hasUriEncodedChars } from './utils'
 
 /**
  * Encodes an object into a query string.
@@ -42,11 +41,8 @@ export function encode(obj: any, pfx?: string) {
  * // Example input: toValue("123")
  * // Expected output: 123
  */
-function toValue(mix: any) {
-  if (!mix) return ''
-  const str = hasUriEncodedChars(mix)
-    ? decodeURIComponent(mix)
-    : decodeURIComponent(encodeURIComponent(mix))
+function toValue(str: unknown) {
+  if (!str) return ''
 
   if (str === 'false') return false
   if (str === 'true') return true

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -446,20 +446,3 @@ export function shallow<T>(objA: T, objB: T) {
   }
   return true
 }
-
-/**
- * Checks if a string contains URI-encoded special characters (e.g., %3F, %20).
- *
- * @param {string} inputString The string to check.
- * @returns {boolean} True if the string contains URI-encoded characters, false otherwise.
- * @example
- * ```typescript
- * const str1 = "foo%3Fbar";
- * const hasEncodedChars = hasUriEncodedChars(str1); // returns true
- * ```
- */
-export function hasUriEncodedChars(inputString: string): boolean {
-  // This regex looks for a percent sign followed by two hexadecimal digits
-  const pattern = /%[0-9A-Fa-f]{2}/
-  return pattern.test(inputString)
-}

--- a/packages/router-core/tests/qss.test.ts
+++ b/packages/router-core/tests/qss.test.ts
@@ -104,4 +104,10 @@ describe('decode function', () => {
     const decodedObj = decode(queryString)
     expect(decodedObj).toEqual({ q: 'red+yellow orange' })
   })
+
+  it('should decode once percent characters (%) encoded twice', () => {
+    const queryString = 'q=%2540'
+    const decodedObj = decode(queryString)
+    expect(decodedObj).toEqual({ q: '%40' })
+  })
 })


### PR DESCRIPTION
### Related Package
router-core

### Issue

#4294

Navigating to URLs with percent-encoded query values (e.g. `/?foo=bar%2540domain.com`) results in double decoding. Instead of decoding once to `bar%40domain.com`, the router produces `bar@domain.com`, breaking use cases where encoded characters are expected to persist after the initial decode.

### Root Cause
In `qss.ts`, query parameters were being decoded twice:
Once implicitly by the `URLSearchParams` constructor.
A second time manually via `decodeURIComponent`.

### Fix
Removed the redundant `decodeURIComponent` call to ensure that each parameter is decoded exactly once, matching expected behavior.