### PR TITLE
fix: ensure child routes receive context returned from parent routes' `beforeLoad` functions, even if `invalidate()` is called during another load

### DIFF
--- a/e2e/react-router/basic-auth/.gitignore
+++ b/e2e/react-router/basic-auth/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+.DS_Store
+dist
+dist-hash
+dist-ssr
+*.local
+
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/e2e/react-router/basic-auth/index.html
+++ b/e2e/react-router/basic-auth/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite App</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/e2e/react-router/basic-auth/package.json
+++ b/e2e/react-router/basic-auth/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "tanstack-router-e2e-react-basic-auth",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --port 3000",
+    "dev:e2e": "vite",
+    "build": "vite build && tsc --noEmit",
+    "serve": "vite preview",
+    "start": "vite",
+    "test:e2e": "playwright test --project=chromium"
+  },
+  "dependencies": {
+    "@tanstack/react-router": "workspace:^",
+    "@tanstack/react-router-devtools": "workspace:^",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "redaxios": "^0.5.1",
+    "postcss": "^8.5.1",
+    "autoprefixer": "^10.4.20",
+    "tailwindcss": "^3.4.17"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.50.1",
+    "@tanstack/router-e2e-utils": "workspace:^",
+    "@types/react": "^19.0.8",
+    "@types/react-dom": "^19.0.3",
+    "@vitejs/plugin-react": "^4.3.4",
+    "vite": "^6.1.0"
+  }
+}

--- a/e2e/react-router/basic-auth/playwright.config.ts
+++ b/e2e/react-router/basic-auth/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test'
+import { derivePort } from '@tanstack/router-e2e-utils'
+import packageJson from './package.json' with { type: 'json' }
+
+const PORT = derivePort(packageJson.name)
+const baseURL = `http://localhost:${PORT}`
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests',
+  workers: 1,
+
+  reporter: [['line']],
+
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL,
+  },
+
+  webServer: {
+    command: `VITE_SERVER_PORT=${PORT} pnpm build && VITE_SERVER_PORT=${PORT} pnpm serve --port ${PORT}`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    stdout: 'pipe',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})

--- a/e2e/react-router/basic-auth/postcss.config.mjs
+++ b/e2e/react-router/basic-auth/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/e2e/react-router/basic-auth/src/auth.ts
+++ b/e2e/react-router/basic-auth/src/auth.ts
@@ -1,0 +1,77 @@
+import { useMemo, useState } from 'react'
+
+export type AuthUser = {
+  id: string
+  name: string
+}
+
+export type AuthState =
+  | {
+      type: 'authenticated'
+      user: AuthUser
+    }
+  | {
+      type: 'unauthenticated'
+      hasLoggedIn: boolean
+    }
+
+export type AuthHandle = {
+  login: (userId: string) => Promise<void>
+  logout: () => Promise<void>
+}
+
+export const initialAuthState: AuthState = {
+  type: 'unauthenticated',
+  hasLoggedIn: false,
+}
+
+export const initialAuthHandle: AuthHandle = {
+  login: () => Promise.resolve(),
+  logout: () => Promise.resolve(),
+}
+
+export function useAuth(): readonly [AuthState, AuthHandle] {
+  const [authState, setAuthState] = useState<AuthState>({
+    type: 'unauthenticated',
+    hasLoggedIn: false,
+  })
+
+  const login = async (userId: string) =>
+    new Promise<void>((resolve) => {
+      // Delay the login with a setTimeout to simulate a network request,
+      // and make sure any actions in response are not batched as part of
+      // a React request handler.
+      setTimeout(() => {
+        setAuthState({
+          type: 'authenticated',
+          user: {
+            id: userId,
+            name: `User #${userId}`,
+          },
+        })
+        resolve()
+      }, 500)
+    })
+
+  const logout = async () =>
+    new Promise<void>((resolve) => {
+      setTimeout(() => {
+        setAuthState((currentState) => ({
+          type: 'unauthenticated',
+          hasLoggedIn:
+            currentState.type === 'authenticated' || currentState.hasLoggedIn,
+        }))
+        resolve()
+      })
+    })
+
+  const authHandle = useMemo<AuthHandle>(
+    () => ({
+      login,
+      logout,
+    }),
+    [login, logout],
+  )
+
+  return [authState, authHandle]
+}

--- a/e2e/react-router/basic-auth/src/main.tsx
+++ b/e2e/react-router/basic-auth/src/main.tsx
@@ -1,0 +1,286 @@
+import { useEffect, useMemo } from 'react'
+import ReactDOM from 'react-dom/client'
+import {
+  Link,
+  Outlet,
+  RouterProvider,
+  createRootRouteWithContext,
+  createRoute,
+  createRouter,
+  redirect,
+  useRouter,
+} from '@tanstack/react-router'
+import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
+import './styles.css'
+import { initialAuthHandle, initialAuthState, useAuth } from './auth'
+import type { AuthHandle, AuthState } from './auth'
+
+type RouterContext = {
+  authState: AuthState
+  authHandle: AuthHandle
+}
+
+function Application(props: { router: typeof router }) {
+  const { router } = props
+  const [authState, authHandle] = useAuth()
+  const routerContext = useMemo(
+    () => ({
+      authState,
+      authHandle,
+    }),
+    [authState],
+  )
+
+  useEffect(() => {
+    // Invalidate cache when passing new auth context into the router (but avoid
+    // invalidating the initial unauthenticated state)
+    if (authState.type === 'authenticated' || authState.hasLoggedIn) {
+      router.invalidate()
+    }
+  }, [router, routerContext])
+
+  return <RouterProvider router={router} context={routerContext} />
+}
+
+const rootRoute = createRootRouteWithContext<RouterContext>()({
+  component: RootComponent,
+})
+
+function RootComponent() {
+  return (
+    <>
+      <div className="p-2 flex gap-2 text-lg border-b">
+        <Link
+          to="/"
+          activeProps={{
+            className: 'font-bold',
+          }}
+          activeOptions={{ exact: true }}
+        >
+          Home
+        </Link>{' '}
+        <Link
+          to="/dashboard"
+          search={{
+            organizationId: 'x',
+          }}
+        >
+          Dashboard
+        </Link>
+      </div>
+      <Outlet />
+      <TanStackRouterDevtools position="bottom-right" />
+    </>
+  )
+}
+
+const indexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/',
+  component: IndexComponent,
+})
+
+function IndexComponent() {
+  return (
+    <div className="p-2">
+      <h3>Home</h3>
+    </div>
+  )
+}
+
+const loginRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: 'login',
+  component: LoginComponent,
+  validateSearch: (search): { redirect?: string } => {
+    if (search.redirect) {
+      return {
+        redirect: search.redirect as string,
+      }
+    }
+    return {}
+  },
+})
+
+function LoginComponent() {
+  const router = useRouter()
+  const { authHandle } = loginRoute.useRouteContext()
+  const navigate = loginRoute.useNavigate()
+  const { redirect } = loginRoute.useSearch()
+
+  return (
+    <>
+      <h3>Login Page</h3>
+      <button
+        onClick={async () => {
+          await authHandle.login('123')
+          if (redirect) {
+            router.history.push(redirect)
+          } else {
+            navigate({
+              to: '/dashboard',
+              search: {
+                organizationId: 'x',
+              },
+            })
+          }
+        }}
+      >
+        Log in
+      </button>
+    </>
+  )
+}
+
+async function getIdentity({
+  userId,
+  organizationId,
+}: {
+  userId: string
+  organizationId: string
+}) {
+  if (!userId || !organizationId) {
+    throw new Error('Missing userId or organizationId')
+  }
+
+  return await {
+    organizationName: `Organization #${organizationId}`,
+    userName: `Employee #${userId}`,
+  }
+}
+
+const dashboardRoute = createRoute({
+  getParentRoute: () => organizationLayoutRoute,
+  path: '/dashboard',
+  loader: async ({ context }) => {
+    return await getIdentity({
+      userId: context.user.id,
+      organizationId: context.organizationId,
+    })
+  },
+  component: DashboardComponent,
+})
+
+function DashboardComponent() {
+  const { userName, organizationName } = dashboardRoute.useLoaderData()
+
+  return (
+    <div>
+      <h3>Dashboard</h3>
+      <div>
+        Welcome, {userName} of {organizationName}!
+      </div>
+    </div>
+  )
+}
+
+const authenticatedLayoutRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  id: '_authenticated-layout',
+  beforeLoad: async ({ context, location }) => {
+    const resolvedAuthState = await context.authState
+    if (resolvedAuthState.type !== 'authenticated') {
+      throw redirect({
+        to: '/login',
+        search: {
+          redirect: location.href,
+        },
+      })
+    }
+
+    return {
+      user: resolvedAuthState.user,
+    }
+  },
+  component: AuthenticatedLayoutComponent,
+})
+
+function AuthenticatedLayoutComponent() {
+  const { authHandle } = authenticatedLayoutRoute.useRouteContext()
+
+  return (
+    <div className="p-2">
+      <button
+        onClick={() => {
+          authHandle.logout()
+        }}
+      >
+        Log out
+      </button>
+      <div>
+        <Outlet />
+      </div>
+    </div>
+  )
+}
+
+const organizationLayoutRoute = createRoute({
+  getParentRoute: () => authenticatedLayoutRoute,
+  id: '_organization-layout',
+  beforeLoad: ({ search, location }) => {
+    const organizationId = search.organizationId
+    if (!organizationId) {
+      throw redirect({
+        to: location.pathname,
+        search: {
+          // Use default organizationId if none is provided
+          organizationId: 'x',
+        },
+      })
+    }
+
+    return { organizationId }
+  },
+  loaderDeps: ({ search }) => {
+    return {
+      organizationId: search.organizationId,
+    }
+  },
+  loader: async () => {
+    // An empty loader here caused the test to fail when the test was initially
+    // added.
+  },
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { organizationId: string | undefined } => {
+    const organizationId = search.organizationId
+    if (typeof organizationId === 'string' || organizationId === undefined) {
+      return { organizationId }
+    }
+    throw new Error('Missing organizationId')
+  },
+})
+
+const routeTree = rootRoute.addChildren([
+  loginRoute,
+  authenticatedLayoutRoute.addChildren([
+    organizationLayoutRoute.addChildren([dashboardRoute]),
+  ]),
+  indexRoute,
+])
+
+// Set up a Router instance
+const router = createRouter({
+  routeTree,
+  defaultPreload: 'intent',
+  context: {
+    authState: initialAuthState,
+    authHandle: initialAuthHandle,
+  },
+  scrollRestoration: true,
+})
+
+// Register things for typesafety
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router
+  }
+}
+
+const rootElement = document.getElementById('app')!
+
+if (!rootElement.innerHTML) {
+  const root = ReactDOM.createRoot(rootElement)
+
+  root.render(<Application router={router} />)
+}

--- a/e2e/react-router/basic-auth/src/styles.css
+++ b/e2e/react-router/basic-auth/src/styles.css
@@ -1,0 +1,13 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html {
+  color-scheme: light dark;
+}
+* {
+  @apply border-gray-200 dark:border-gray-800;
+}
+body {
+  @apply bg-gray-50 text-gray-950 dark:bg-gray-900 dark:text-gray-200;
+}

--- a/e2e/react-router/basic-auth/tailwind.config.mjs
+++ b/e2e/react-router/basic-auth/tailwind.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./src/**/*.{js,jsx,ts,tsx}', './index.html'],
+}

--- a/e2e/react-router/basic-auth/tests/app.spec.ts
+++ b/e2e/react-router/basic-auth/tests/app.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/login')
+})
+
+test('Navigate immediately before invalidating context, multiple times', async ({ page }) => {
+  await page.getByRole('button', { name: 'Log in', exact: true }).click()
+  await expect(page.getByRole('heading')).toContainText('Dashboard')
+  await page.getByRole('button', { name: 'Log out', exact: true }).click()
+  await expect(page.getByRole('heading')).toContainText('Login')
+  await page.getByRole('button', { name: 'Log in', exact: true }).click()
+  await expect(page.getByRole('heading')).toContainText('Dashboard')
+})

--- a/e2e/react-router/basic-auth/tsconfig.json
+++ b/e2e/react-router/basic-auth/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "target": "ESNext",
+    "moduleResolution": "Bundler",
+    "module": "ESNext",
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "skipLibCheck": true
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/e2e/react-router/basic-auth/vite.config.js
+++ b/e2e/react-router/basic-auth/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+})

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1963,6 +1963,13 @@ export class RouterCore<
     let redirect: ResolvedRedirect | undefined
     let notFound: NotFoundError | undefined
 
+    // Wait for any in-progress loads to finish before triggering another.
+    while (
+      (this.latestLoadPromise as any)
+    ) {
+      await this.latestLoadPromise
+    }
+
     let loadPromise: Promise<void>
 
     // eslint-disable-next-line prefer-const


### PR DESCRIPTION
Possibly related: 
 
- #3403
- #3578

I've been struggling with an issue where a parent route's context, as returned by `beforeLoad`, is missing (as in completely empty) in a child route, in certain circumstances, particular immediately after logging in. The types suggest this should be impossible, but there are circumstances in where it happens.

This PR adds a failing e2e test that reproduces the issue, and a tentative fix to the router itself.

## Details

To add authentication to the router context, I'm passing a `context` prop into `<RouterProvider>`. This context is stored in React state, contains the current user, and is updated after login.

Also, in order to get ensure that the routes are re-loaded after log out, I've added a call to `router.invalidate()` in an effect within the same component.

```jsx
const [authContext] = useAuth()

useEffect(() => {
  if (notInitialRender) {
    router.invalidate()
  }
}, [authContext])

return (
  <RouterProvider router={router} context={authContext} />
)
```

This works as expected when logging out. However, after logging in, the router is calling the `loader()` function of the new page *without* the context injected by its parent route's `beforeLoad()` function. In my app, this causes an error to be logged to the console on the first run through, and causes the app to crash on the second. This behavior is repeated in the e2e test I've added here.

Adding `console.log()` statements in various places, I've noticed that the `beforeLoad()` function *is* running before the child loader is called, so it's not that the context isn't available, it's just not being passed in.

While debugging, I noticed that `invalidate()` calls `router.load()`, even when the router is already loading, e.g. because of a `navigate()` call being made after login.

https://github.com/TanStack/router/blob/9db424fb5b0c48a3ca87cf44677ad618778277a3/packages/router-core/src/router.ts#L2797-L2827

I noticed that adding a guard to this `router.load()`, so that it is only called if the router is not already loading, fixed my issue, but I worry it would introduce further bugs down the track.

So the fix I ended up arriving on is to use the existing `latestLoadPromise` to wait for previous `router.load()` calls to complete before starting a new one, which resolved the issue for me, and got the new e2e test that I've added passing.