### PR TITLE
fix: don't add all @tanstack packages to noExternal

### DIFF
--- a/packages/start-plugin-core/src/plugin.ts
+++ b/packages/start-plugin-core/src/plugin.ts
@@ -165,7 +165,7 @@ export function TanStackStartVitePluginCore(
               'tanstack-start-router-manifest:v',
               'tanstack-start-server-fn-manifest:v',
               'nitropack',
-              '@tanstack/**',
+              '@tanstack/**start**',
             ],
           },
           optimizeDeps: {


### PR DESCRIPTION
this fixes the issue where a third-party dependency tries to access the router from react via the router context, but vite bundles this dependency with its own version of router and hence the router context is null.

the following error occurs then

```
useRouter must be used inside a <RouterProvider> component!
```

by only adding start packages to `noExternal` we prevent this mismatch