### PR TITLE
fix(react-router): make head function scripts load properly in SPA environment

### DIFF
--- a/packages/react-router/src/Asset.tsx
+++ b/packages/react-router/src/Asset.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import type { RouterManagedTag } from '@tanstack/router-core'
 
 export function Asset({ tag, attrs, children }: RouterManagedTag): any {
@@ -20,21 +21,51 @@ export function Asset({ tag, attrs, children }: RouterManagedTag): any {
         />
       )
     case 'script':
-      if ((attrs as any) && (attrs as any).src) {
-        return <script {...attrs} suppressHydrationWarning />
-      }
-      if (typeof children === 'string')
-        return (
-          <script
-            {...attrs}
-            dangerouslySetInnerHTML={{
-              __html: children,
-            }}
-            suppressHydrationWarning
-          />
-        )
-      return null
+      return <ScriptAsset attrs={attrs} children={children} />
     default:
       return null
   }
+}
+
+function ScriptAsset({ attrs, children }: { attrs: any; children?: string }) {
+  React.useEffect(() => {
+    if (attrs?.src) {
+      const script = document.createElement('script')
+      
+      Object.keys(attrs).forEach(key => {
+        if (key !== 'suppressHydrationWarning') {
+          script.setAttribute(key, attrs[key])
+        }
+      })
+      
+      document.head.appendChild(script)
+      
+      return () => {
+        if (script.parentNode) {
+          script.parentNode.removeChild(script)
+        }
+      }
+    } else if (typeof children === 'string') {
+      const script = document.createElement('script')
+      script.textContent = children
+      
+      if (attrs) {
+        Object.keys(attrs).forEach(key => {
+          if (key !== 'suppressHydrationWarning') {
+            script.setAttribute(key, attrs[key])
+          }
+        })
+      }
+      
+      document.head.appendChild(script)
+      
+      return () => {
+        if (script.parentNode) {
+          script.parentNode.removeChild(script)
+        }
+      }
+    }
+  }, [attrs, children])
+
+  return null
 }


### PR DESCRIPTION
#3687 

Scripts returned from the head function in createFileRoute only get properly inserted and loaded when they have an async attribute. Scripts without the async attribute are not inserted at all.

Fixed the issue by modifying the ScriptAsset component in Asset.tsx to properly handle script loading through direct DOM manipulation.