### PR TITLE
fix: Preload assets on windows

### DIFF
--- a/packages/start-plugin-core/src/start-routes-manifest-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/start-routes-manifest-plugin/plugin.ts
@@ -153,7 +153,9 @@ export function startRoutesManifestPlugin(
         Object.entries(routeTreeRoutes).forEach(([routeId, v]) => {
           const file =
             filesByRouteFilePath[
-              path.join(routesDirectoryFromRoot, v.filePath as string).replaceAll('\\', '/')
+              path
+                .join(routesDirectoryFromRoot, v.filePath as string)
+                .replaceAll('\\', '/')
             ]
 
           if (file) {

--- a/packages/start-plugin-core/src/start-routes-manifest-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/start-routes-manifest-plugin/plugin.ts
@@ -153,9 +153,7 @@ export function startRoutesManifestPlugin(
         Object.entries(routeTreeRoutes).forEach(([routeId, v]) => {
           const file =
             filesByRouteFilePath[
-              path
-                .join(routesDirectoryFromRoot, v.filePath as string)
-                .replaceAll('\\', '/')
+              path.posix.join(routesDirectoryFromRoot, v.filePath as string)
             ]
 
           if (file) {

--- a/packages/start-plugin-core/src/start-routes-manifest-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/start-routes-manifest-plugin/plugin.ts
@@ -153,7 +153,7 @@ export function startRoutesManifestPlugin(
         Object.entries(routeTreeRoutes).forEach(([routeId, v]) => {
           const file =
             filesByRouteFilePath[
-              path.join(routesDirectoryFromRoot, v.filePath as string)
+              path.join(routesDirectoryFromRoot, v.filePath as string).replaceAll('\\', '/')
             ]
 
           if (file) {


### PR DESCRIPTION
This wasn't working correctly on Windows.

In `filesByRouteFilePath`, the paths are formatted using `/`, but `path.join` on Windows uses `\`, which caused a mismatch. As a result, asset preloading was broken. This change fixes that issue.

That said, there might still be a problem. I added a log to check for missing files in `filesByRouteFilePath`, and I'm still seeing `not found src\routes\__root.tsx`. I don't see a corresponding key like `__root.tsx` in `filesByRouteFilePath`. However, CSS and JS files are now preloading correctly on Windows.
