### PR TITLE
feat: full document hydration for solid

### DIFF
--- a/examples/solid/start-bare/src/routes/__root.tsx
+++ b/examples/solid/start-bare/src/routes/__root.tsx
@@ -1,24 +1,50 @@
-import { createRootRoute, Link, Outlet } from '@tanstack/solid-router'
+import {
+  createRootRoute,
+  HeadContent,
+  Link,
+  Outlet,
+  Scripts,
+} from '@tanstack/solid-router'
 import appCss from '~/styles/app.css?url'
 import * as Solid from 'solid-js'
 import { TanStackRouterDevtools } from '@tanstack/solid-router-devtools'
+import { Hydration, HydrationScript, NoHydration } from 'solid-js/web'
 
 export const Route = createRootRoute({
   head: () => ({
     links: [{ rel: 'stylesheet', href: appCss }],
   }),
-  component: RootDocument,
+  component: RootComponent,
 })
+
+function RootComponent() {
+  return (
+    <RootDocument>
+      <Outlet />
+    </RootDocument>
+  )
+}
 
 function RootDocument({ children }: { children: Solid.JSX.Element }) {
   return (
-    <>
-      <div class="p-2 flex gap-2 text-lg">
-        <Link to="/">Index</Link>
-        <Link to="/about">About</Link>
-      </div>
-      <Outlet />
-      <TanStackRouterDevtools position="bottom-right" />
-    </>
+    <NoHydration>
+      <html>
+        <head>
+          <HydrationScript />
+          <HeadContent />
+        </head>
+        <body>
+          <Hydration>
+            <div class="p-2 flex gap-2 text-lg">
+              <Link to="/">Index</Link>
+              <Link to="/about">About</Link>
+            </div>
+            {children}
+            <TanStackRouterDevtools position="bottom-right" />
+            <Scripts />
+          </Hydration>
+        </body>
+      </html>
+    </NoHydration>
   )
 }

--- a/packages/solid-start-client/src/StartClient.tsx
+++ b/packages/solid-start-client/src/StartClient.tsx
@@ -1,4 +1,4 @@
-import { Await, HeadContent, RouterProvider } from '@tanstack/solid-router'
+import { Await, RouterProvider } from '@tanstack/solid-router'
 import { hydrate } from '@tanstack/start-client-core'
 import type { AnyRouter } from '@tanstack/router-core'
 import type { JSXElement } from 'solid-js'
@@ -15,27 +15,11 @@ export function StartClient(props: { router: AnyRouter }) {
       hydrationPromise = Promise.resolve()
     }
   }
+
   return (
     <Await
       promise={hydrationPromise}
-      children={() => (
-        <Dummy>
-          <Dummy>
-            <RouterProvider
-              router={props.router}
-              InnerWrap={(props) => (
-                <Dummy>
-                  <Dummy>
-                    <HeadContent />
-                    {props.children}
-                  </Dummy>
-                  <Dummy />
-                </Dummy>
-              )}
-            />
-          </Dummy>
-        </Dummy>
-      )}
+      children={() => <RouterProvider router={props.router} />}
     />
   )
 }

--- a/packages/solid-start-plugin/src/index.ts
+++ b/packages/solid-start-plugin/src/index.ts
@@ -39,7 +39,7 @@ import { createRouter } from '${ctx.routerFilepath}';
 
 const router = createRouter();
 
-hydrate(() => <StartClient router={router} />, document.body);`
+hydrate(() => <StartClient router={router} />, document);`
         },
         getVirtualServerEntry(ctx) {
           return `

--- a/packages/solid-start-server/src/StartServer.tsx
+++ b/packages/solid-start-server/src/StartServer.tsx
@@ -1,11 +1,5 @@
-import { Asset, RouterProvider, Scripts, useTags } from '@tanstack/solid-router'
-import {
-  Hydration,
-  HydrationScript,
-  NoHydration,
-  ssr,
-  useAssets,
-} from 'solid-js/web'
+import { Asset, RouterProvider, useTags } from '@tanstack/solid-router'
+import { useAssets } from 'solid-js/web'
 import { MetaProvider } from '@solidjs/meta'
 import type { AnyRouter } from '@tanstack/router-core'
 
@@ -23,35 +17,8 @@ export function ServerHeadContent() {
   return null
 }
 
-const docType = ssr('<!DOCTYPE html>')
-
 export function StartServer<TRouter extends AnyRouter>(props: {
   router: TRouter
 }) {
-  return (
-    <NoHydration>
-      {docType as any}
-      <html>
-        <head>
-          <HydrationScript />
-        </head>
-        <body>
-          <Hydration>
-            <RouterProvider
-              router={props.router}
-              InnerWrap={(props) => (
-                <NoHydration>
-                  <MetaProvider>
-                    <ServerHeadContent />
-                    <Hydration>{props.children}</Hydration>
-                    <Scripts />
-                  </MetaProvider>
-                </NoHydration>
-              )}
-            />
-          </Hydration>
-        </body>
-      </html>
-    </NoHydration>
-  )
+  return <RouterProvider router={props.router} />
 }


### PR DESCRIPTION
We've known about this for awhile but we basically hydrate the document.body instead of the entire document.

To be on par with React we would like to give the end user control of the full html document.

This is my attempt at modifying our existing code to support that but I am currently stuck.

> template2 is not a function

![image](https://github.com/user-attachments/assets/ff148757-8090-4088-98f5-bc276d2eccb7)
