### PR TITLE
fix(router-plugin): respect root configuration when generating routes

### DIFF
--- a/packages/router-plugin/src/core/router-generator-plugin.ts
+++ b/packages/router-plugin/src/core/router-generator-plugin.ts
@@ -34,7 +34,7 @@ export const unpluginRouterGeneratorFactory: UnpluginFactory<
     setLock(true)
 
     try {
-      await generator(userConfig, process.cwd())
+      await generator(userConfig, ROOT)
     } catch (err) {
       console.error(err)
       console.info()


### PR DESCRIPTION
Closes #3624 

This PR fixes a line that reuses `process.cwd()` instead of the provided `ROOT` variable. The side effects are that there can be a desync between features of the router plugins.