### PR TITLE
fix: update state key references from 'key' to '__key'

### DIFF
--- a/docs/router/framework/react/guide/scroll-restoration.md
+++ b/docs/router/framework/react/guide/scroll-restoration.md
@@ -71,7 +71,7 @@ Falling in behind Remix's own Scroll Restoration APIs, you can also customize th
 
 The `getKey` option receives the relevant `Location` state from TanStack Router and expects you to return a string to uniquely identify the scrollable measurements for that state.
 
-The default `getKey` is `(location) => location.state.key!`, where `key` is the unique key generated for each entry in the history.
+The default `getKey` is `(location) => location.state.__key!`, where `__key` is the unique key generated for each entry in the history.
 
 ## Examples
 
@@ -95,7 +95,7 @@ const router = createRouter({
     const paths = ['/', '/chat']
     return paths.includes(location.pathname)
       ? location.pathname
-      : location.state.key!
+      : location.state.__key!
   },
 })
 ```

--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -53,7 +53,7 @@ export interface ParsedPath {
 export interface HistoryState {}
 
 export type ParsedHistoryState = HistoryState & {
-  key?: string
+  __key?: string
   __TSR_index: number
 }
 
@@ -254,7 +254,7 @@ function assignKeyAndIndex(index: number, state: HistoryState | undefined) {
   }
   return {
     ...state,
-    key: createRandomKey(),
+    __key: createRandomKey(),
     [stateIndexKey]: index,
   } as ParsedHistoryState
 }
@@ -302,11 +302,11 @@ export function createBrowserHistory(opts?: {
       ))
 
   // Ensure there is always a key to start
-  if (!win.history.state?.key) {
+  if (!win.history.state?.__key) {
     win.history.replaceState(
       {
         [stateIndexKey]: 0,
-        key: createRandomKey(),
+        __key: createRandomKey(),
       },
       '',
     )
@@ -632,7 +632,7 @@ export function parseHref(
       searchIndex > -1
         ? href.slice(searchIndex, hashIndex === -1 ? undefined : hashIndex)
         : '',
-    state: state || { [stateIndexKey]: 0, key: createRandomKey() },
+    state: state || { [stateIndexKey]: 0, __key: createRandomKey() },
   }
 }
 

--- a/packages/react-router/src/Match.tsx
+++ b/packages/react-router/src/Match.tsx
@@ -139,7 +139,7 @@ function OnRendered() {
 
   return (
     <script
-      key={router.latestLocation.state.key}
+      key={router.latestLocation.state.__key}
       suppressHydrationWarning
       ref={(el) => {
         if (

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1102,7 +1102,7 @@ export class RouterCore<
     if (__tempLocation && (!__tempKey || __tempKey === this.tempLocationKey)) {
       // Sync up the location keys
       const parsedTempLocation = parse(__tempLocation) as any
-      parsedTempLocation.state.key = location.state.key
+      parsedTempLocation.state.__key = location.state.__key
 
       delete parsedTempLocation.state.__tempLocation
 
@@ -1823,7 +1823,7 @@ export class RouterCore<
       // temporarily add the previous values to the next state so they don't affect
       // the comparison
       const ignoredProps = [
-        'key',
+        '__key',
         '__TSR_index',
         '__hashScrollIntoViewOptions',
       ] as const
@@ -1864,7 +1864,7 @@ export class RouterCore<
                 ...nextHistory.state,
                 __tempKey: undefined!,
                 __tempLocation: undefined!,
-                key: undefined!,
+                __key: undefined!,
               },
             },
           },

--- a/packages/router-core/src/scroll-restoration.ts
+++ b/packages/router-core/src/scroll-restoration.ts
@@ -79,7 +79,7 @@ export const scrollRestorationCache = createScrollRestorationCache()
  */
 
 export const defaultGetScrollRestorationKey = (location: ParsedLocation) => {
-  return location.state.key! || location.href
+  return location.state.__key! || location.href
 }
 
 export function getCssSelector(el: any): string {

--- a/packages/solid-router/src/Match.tsx
+++ b/packages/solid-router/src/Match.tsx
@@ -140,7 +140,7 @@ function OnRendered() {
 
   const location = useRouterState({
     select: (s) => {
-      return s.resolvedLocation?.state.key
+      return s.resolvedLocation?.state.__key
     },
   })
   Solid.createEffect(


### PR DESCRIPTION
# Description

Currently, when using TanStack Router, if users define a property named `key` within the navigation state, its value is overridden by the router's internal logic, which assigns a random key.

## For example:

```tsx
const navigate = useNavigate();
navigate({ to: '/', state: { color: 'blue', key: 123 } });

// Defined type
interface HistoryState {
  key?: number;
  otherValue?: string;
}

// On navigation target
const location = useLocation();
console.log(location.state.color); // correctly "blue"
console.log(location.state.key);   // incorrectly overridden by a random string like "p7axhg"
```

# Expected Behavior

When explicitly providing a `key` within the navigation state, it should preserve the user's defined value rather than being overridden by the router's internal random key.

