### PR TITLE
feat(router-generator): add option to format with specified tab width

### DIFF
--- a/docs/router/api/file-based-routing.md
+++ b/docs/router/api/file-based-routing.md
@@ -17,6 +17,7 @@ The following options are available for configuring the file-based routing:
 - [`routeToken`](#routetoken)
 - [`quoteStyle`](#quotestyle)
 - [`semicolons`](#semicolons)
+- [`tabWidth`](#tabwidth)
 - [`apiBase`](#apibase)
 - [`autoCodeSplitting`](#autocodesplitting)
 - [`disableTypes`](#disabletypes)
@@ -128,6 +129,15 @@ By default, this value is set to `single`.
 When your generated route tree is generated and when you first create a new route, those files will be formatted with semicolons if this option is set to `true`.
 
 By default, this value is set to `false`.
+
+> [!TIP]
+> You should ignore the path of your generated route tree file from your linter and formatter to avoid conflicts.
+
+### `tabWidth`
+
+When your generated route tree is generated and when you first create a new route, those files will be formatted with the tab width you specify here.
+
+By default, this value is set to `2`.
 
 > [!TIP]
 > You should ignore the path of your generated route tree file from your linter and formatter to avoid conflicts.

--- a/e2e/solid-router/basic-file-based-code-splitting/src/routeTree.gen.ts
+++ b/e2e/solid-router/basic-file-based-code-splitting/src/routeTree.gen.ts
@@ -291,3 +291,66 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRoute
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+/* ROUTE_MANIFEST_START
+{
+  "routes": {
+    "__root__": {
+      "filePath": "__root.tsx",
+      "children": [
+        "/",
+        "/_layout",
+        "/posts",
+        "/viewport-test",
+        "/without-loader"
+      ]
+    },
+    "/": {
+      "filePath": "index.tsx"
+    },
+    "/_layout": {
+      "filePath": "_layout.tsx",
+      "children": [
+        "/_layout/_layout-2"
+      ]
+    },
+    "/posts": {
+      "filePath": "posts.tsx",
+      "children": [
+        "/posts/$postId",
+        "/posts/"
+      ]
+    },
+    "/viewport-test": {
+      "filePath": "viewport-test.tsx"
+    },
+    "/without-loader": {
+      "filePath": "without-loader.tsx"
+    },
+    "/_layout/_layout-2": {
+      "filePath": "_layout/_layout-2.tsx",
+      "parent": "/_layout",
+      "children": [
+        "/_layout/_layout-2/layout-a",
+        "/_layout/_layout-2/layout-b"
+      ]
+    },
+    "/posts/$postId": {
+      "filePath": "posts.$postId.tsx",
+      "parent": "/posts"
+    },
+    "/posts/": {
+      "filePath": "posts.index.tsx",
+      "parent": "/posts"
+    },
+    "/_layout/_layout-2/layout-a": {
+      "filePath": "_layout/_layout-2/layout-a.tsx",
+      "parent": "/_layout/_layout-2"
+    },
+    "/_layout/_layout-2/layout-b": {
+      "filePath": "_layout/_layout-2/layout-b.tsx",
+      "parent": "/_layout/_layout-2"
+    }
+  }
+}
+ROUTE_MANIFEST_END */

--- a/e2e/solid-router/basic-virtual-file-based/src/routeTree.gen.ts
+++ b/e2e/solid-router/basic-virtual-file-based/src/routeTree.gen.ts
@@ -343,3 +343,79 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRoute
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+/* ROUTE_MANIFEST_START
+{
+  "routes": {
+    "__root__": {
+      "filePath": "root.tsx",
+      "children": [
+        "/",
+        "/_first",
+        "/posts",
+        "/classic/hello"
+      ]
+    },
+    "/": {
+      "filePath": "home.tsx"
+    },
+    "/_first": {
+      "filePath": "layout/first-layout.tsx",
+      "children": [
+        "/_first/_second"
+      ]
+    },
+    "/posts": {
+      "filePath": "posts/posts.tsx",
+      "children": [
+        "/posts/",
+        "/posts/$postId"
+      ]
+    },
+    "/classic/hello": {
+      "filePath": "file-based-subtree/hello/route.tsx",
+      "children": [
+        "/classic/hello/universe",
+        "/classic/hello/world",
+        "/classic/hello/"
+      ]
+    },
+    "/posts/": {
+      "filePath": "posts/posts-home.tsx",
+      "parent": "/posts"
+    },
+    "/_first/_second": {
+      "filePath": "layout/second-layout.tsx",
+      "parent": "/_first",
+      "children": [
+        "/_first/_second/layout-a",
+        "/_first/_second/layout-b"
+      ]
+    },
+    "/posts/$postId": {
+      "filePath": "posts/posts-detail.tsx",
+      "parent": "/posts"
+    },
+    "/_first/_second/layout-a": {
+      "filePath": "a.tsx",
+      "parent": "/_first/_second"
+    },
+    "/_first/_second/layout-b": {
+      "filePath": "b.tsx",
+      "parent": "/_first/_second"
+    },
+    "/classic/hello/universe": {
+      "filePath": "file-based-subtree/hello/universe.tsx",
+      "parent": "/classic/hello"
+    },
+    "/classic/hello/world": {
+      "filePath": "file-based-subtree/hello/world.tsx",
+      "parent": "/classic/hello"
+    },
+    "/classic/hello/": {
+      "filePath": "file-based-subtree/hello/index.tsx",
+      "parent": "/classic/hello"
+    }
+  }
+}
+ROUTE_MANIFEST_END */

--- a/packages/router-generator/src/config.ts
+++ b/packages/router-generator/src/config.ts
@@ -13,6 +13,7 @@ export const configSchema = z.object({
   generatedRouteTree: z.string().optional().default('./src/routeTree.gen.ts'),
   quoteStyle: z.enum(['single', 'double']).optional().default('single'),
   semicolons: z.boolean().optional().default(false),
+  tabWidth: z.number().min(1).optional().default(2),
   disableTypes: z.boolean().optional().default(false),
   addExtensions: z.boolean().optional().default(false),
   disableLogging: z.boolean().optional().default(false),

--- a/packages/router-generator/src/utils.ts
+++ b/packages/router-generator/src/utils.ts
@@ -155,6 +155,7 @@ export async function format(source: string, config: Config): Promise<string> {
   const prettierOptions: prettier.Config = {
     semi: config.semicolons,
     singleQuote: config.quoteStyle === 'single',
+    tabWidth: config.tabWidth,
     parser: 'typescript',
   }
   return prettier.format(source, prettierOptions)


### PR DESCRIPTION
First of, I know that there is a declined pull request which, among other things, implemented this: https://github.com/TanStack/router/pull/1817

That being said, this is really more about the format of newly created route files from templates, rather than the route tree (that one Is just ignored in my Biome config).

Right now, route files are always created with two spaces, even if you set a custom scaffolding for the templates with the right number of spaces. This would eventually be fixed by Biome (which I do run in commit hooks), but until then, an IDE like WebStorm will detect that the file has two spaces and thus default to that for anything you write.

This is just a minor inconvenience, but one nonetheless, as after each file creation the first thing I have to do is to click on "2 spaces" and then "reformat as 4 spaces".

An alternative to this would be to be able to set an alternate formatter command in the plugin options. Though that is a lot more involved, it would allow the user to have full control over formatting of new files.