### PR TITLE
fix: remove solid-js dependency from react-router-devtools

### DIFF
--- a/packages/react-router-devtools/package.json
+++ b/packages/react-router-devtools/package.json
@@ -62,8 +62,7 @@
     "node": ">=12"
   },
   "dependencies": {
-    "@tanstack/router-devtools-core": "workspace:^",
-    "solid-js": "^1.9.5"
+    "@tanstack/router-devtools-core": "workspace:^"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.4",

--- a/packages/react-router-devtools/src/TanStackRouterDevtools.tsx
+++ b/packages/react-router-devtools/src/TanStackRouterDevtools.tsx
@@ -1,9 +1,9 @@
 import { TanStackRouterDevtoolsCore } from '@tanstack/router-devtools-core'
 import { Fragment, useEffect, useRef, useState } from 'react'
 import { useRouter, useRouterState } from '@tanstack/react-router'
+import type { ButtonHTMLAttributes, HTMLAttributes } from 'react'
 import type { AnyRouter } from '@tanstack/react-router'
 import type React from 'react'
-import type { JSX } from 'solid-js'
 
 interface DevtoolsOptions {
   /**
@@ -13,15 +13,15 @@ interface DevtoolsOptions {
   /**
    * Use this to add props to the panel. For example, you can add className, style (merge and override default style), etc.
    */
-  panelProps?: JSX.HTMLAttributes<HTMLDivElement>
+  panelProps?: HTMLAttributes<HTMLDivElement>
   /**
    * Use this to add props to the close button. For example, you can add className, style (merge and override default style), onClick (extend default handler), etc.
    */
-  closeButtonProps?: JSX.ButtonHTMLAttributes<HTMLButtonElement>
+  closeButtonProps?: ButtonHTMLAttributes<HTMLButtonElement>
   /**
    * Use this to add props to the toggle button. For example, you can add className, style (merge and override default style), onClick (extend default handler), etc.
    */
-  toggleButtonProps?: JSX.ButtonHTMLAttributes<HTMLButtonElement>
+  toggleButtonProps?: ButtonHTMLAttributes<HTMLButtonElement>
   /**
    * The position of the TanStack Router logo to open and close the devtools panel.
    * Defaults to 'bottom-left'.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5833,9 +5833,6 @@ importers:
       '@tanstack/router-devtools-core':
         specifier: workspace:^
         version: link:../router-devtools-core
-      solid-js:
-        specifier: ^1.9.5
-        version: 1.9.5
     devDependencies:
       '@vitejs/plugin-react':
         specifier: ^4.3.4


### PR DESCRIPTION
We don't need to depend on solid-js to import JSX types in react-router-devtools package