### PR TITLE
fix(router-plugin): initialise generator within webpack plugin

### DIFF
--- a/packages/router-plugin/src/core/router-generator-plugin.ts
+++ b/packages/router-plugin/src/core/router-generator-plugin.ts
@@ -113,7 +113,7 @@ export const unpluginRouterGeneratorFactory: UnpluginFactory<
       })
     },
     webpack(compiler) {
-      initConfigAndGenerator();
+      initConfigAndGenerator()
 
       let handle: FSWatcher | null = null
 

--- a/packages/router-plugin/src/core/router-generator-plugin.ts
+++ b/packages/router-plugin/src/core/router-generator-plugin.ts
@@ -113,7 +113,7 @@ export const unpluginRouterGeneratorFactory: UnpluginFactory<
       })
     },
     webpack(compiler) {
-      userConfig = getConfig(options, ROOT)
+      initConfigAndGenerator();
 
       let handle: FSWatcher | null = null
 


### PR DESCRIPTION
hi,

init of config and generator was changed in 25c1369726f8550f12a3f13556e42d9cd615e7eb part of #4337.

The webpack plugin needs a fix to incorporate init changes.

Use the same init method as other plugins for webpack.

Thanks,
Valentin