### PR TITLE
fix: Code-splitting for virtual routes outside routesDirectory

### DIFF
--- a/packages/router-plugin/src/core/config.ts
+++ b/packages/router-plugin/src/core/config.ts
@@ -69,6 +69,7 @@ export const configSchema = generatorConfigSchema.extend({
       return codeSplittingOptionsSchema.parse(v)
     })
     .optional(),
+  virtualRouteDirectories: z.array(z.string()).optional(),
 })
 
 export const getConfig = (inlineConfig: Partial<Config>, root: string) => {

--- a/packages/router-plugin/src/core/router-code-splitter-plugin.ts
+++ b/packages/router-plugin/src/core/router-code-splitter-plugin.ts
@@ -17,10 +17,7 @@ import {
   tsrSplit,
 } from './constants'
 import { decodeIdentifier } from './code-splitter/path-ids'
-import {
-  debug,
-  fileIsInRoutesDirectory,
-} from './utils'
+import { debug, fileIsInRoutesDirectory } from './utils'
 import type { CodeSplitGroupings, SplitRouteIdentNodes } from './constants'
 
 import type { Config } from './config'
@@ -64,8 +61,7 @@ plugins: [
 
 const PLUGIN_NAME = 'unplugin:router-code-splitter'
 
-export interface RouterCodeSplitterOptions extends Partial<Config> {
-}
+export interface RouterCodeSplitterOptions extends Partial<Config> {}
 
 export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
   RouterCodeSplitterOptions | undefined
@@ -233,8 +229,6 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
         ROOT = config.root
 
         userConfig = getConfig(options, ROOT)
-
-  
       },
     },
 

--- a/packages/router-plugin/src/core/router-code-splitter-plugin.ts
+++ b/packages/router-plugin/src/core/router-code-splitter-plugin.ts
@@ -20,7 +20,6 @@ import { decodeIdentifier } from './code-splitter/path-ids'
 import {
   debug,
   fileIsInRoutesDirectory,
-  fileIsInVirtualRouteDirectory,
 } from './utils'
 import type { CodeSplitGroupings, SplitRouteIdentNodes } from './constants'
 
@@ -66,7 +65,6 @@ plugins: [
 const PLUGIN_NAME = 'unplugin:router-code-splitter'
 
 export interface RouterCodeSplitterOptions extends Partial<Config> {
-  virtualRouteDirectories?: Array<string>
 }
 
 export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
@@ -197,11 +195,7 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
       }
 
       if (
-        (fileIsInRoutesDirectory(id, userConfig.routesDirectory) ||
-          fileIsInVirtualRouteDirectory(
-            id,
-            userConfig.virtualRouteDirectories,
-          )) &&
+        fileIsInRoutesDirectory(id, userConfig.routesDirectory) &&
         (code.includes('createRoute(') || code.includes('createFileRoute('))
       ) {
         for (const externalPlugin of bannedBeforeExternalPlugins) {
@@ -227,7 +221,6 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
 
       if (
         fileIsInRoutesDirectory(id, userConfig.routesDirectory) ||
-        fileIsInVirtualRouteDirectory(id, userConfig.virtualRouteDirectories) ||
         id.includes(tsrSplit)
       ) {
         return true
@@ -241,13 +234,7 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
 
         userConfig = getConfig(options, ROOT)
 
-        if (options.virtualRouteDirectories?.length) {
-          debug &&
-            console.log(
-              '[TanStack Router] Using virtual route directories from options:',
-              options.virtualRouteDirectories,
-            )
-        }
+  
       },
     },
 

--- a/packages/router-plugin/src/core/types.ts
+++ b/packages/router-plugin/src/core/types.ts
@@ -1,0 +1,10 @@
+export interface RouteInfo {
+  filePath: string
+  routePath: string
+  isVirtual: boolean
+  sourceDir: string
+}
+
+export interface RouteNodes {
+  routes: Record<string, RouteInfo>
+}

--- a/packages/router-plugin/src/core/utils.ts
+++ b/packages/router-plugin/src/core/utils.ts
@@ -16,5 +16,3 @@ export function fileIsInRoutesDirectory(
 
   return path.startsWith(routesDirectoryPath)
 }
-
-

--- a/packages/router-plugin/src/core/utils.ts
+++ b/packages/router-plugin/src/core/utils.ts
@@ -17,21 +17,4 @@ export function fileIsInRoutesDirectory(
   return path.startsWith(routesDirectoryPath)
 }
 
-export function fileIsInVirtualRouteDirectory(
-  filePath: string,
-  virtualRouteDirectories?: Array<string>,
-): boolean {
-  if (!virtualRouteDirectories?.length) {
-    return false
-  }
 
-  const normalizedPath = normalize(filePath)
-  
-  return virtualRouteDirectories.some(dir => {
-    const virtualDirPath = isAbsolute(dir)
-      ? dir
-      : join(process.cwd(), dir)
-      
-    return normalizedPath.startsWith(virtualDirPath)
-  })
-}

--- a/packages/router-plugin/src/core/utils.ts
+++ b/packages/router-plugin/src/core/utils.ts
@@ -16,3 +16,22 @@ export function fileIsInRoutesDirectory(
 
   return path.startsWith(routesDirectoryPath)
 }
+
+export function fileIsInVirtualRouteDirectory(
+  filePath: string,
+  virtualRouteDirectories?: Array<string>,
+): boolean {
+  if (!virtualRouteDirectories?.length) {
+    return false
+  }
+
+  const normalizedPath = normalize(filePath)
+  
+  return virtualRouteDirectories.some(dir => {
+    const virtualDirPath = isAbsolute(dir)
+      ? dir
+      : join(process.cwd(), dir)
+      
+    return normalizedPath.startsWith(virtualDirPath)
+  })
+}

--- a/packages/start-plugin-core/src/route-export.ts
+++ b/packages/start-plugin-core/src/route-export.ts
@@ -8,7 +8,6 @@ let routeNodesInfo: RouteExportInfo | null = null
 
 export interface RouteExportInfo {
   routesDirectory: string
-  virtualRouteDirectories: Array<string>
   routes: Record<string, Record<string, unknown>>
 }
 
@@ -27,15 +26,4 @@ export function getRouteNodesInfo(): RouteExportInfo | null {
   return routeNodesInfo
 }
 
-export function isFileInVirtualRouteDirectories(
-  filePath: string,
-  virtualRouteDirectories: Array<string>,
-): boolean {
-  if (virtualRouteDirectories.length === 0) {
-    return false
-  }
 
-  return virtualRouteDirectories.some((dir) =>
-    filePath.startsWith(dir.replace(/\\/g, '/')),
-  )
-}

--- a/packages/start-plugin-core/src/route-export.ts
+++ b/packages/start-plugin-core/src/route-export.ts
@@ -25,5 +25,3 @@ export function exportRouteNodesInfo(info: RouteExportInfo): void {
 export function getRouteNodesInfo(): RouteExportInfo | null {
   return routeNodesInfo
 }
-
-

--- a/packages/start-plugin-core/src/route-export.ts
+++ b/packages/start-plugin-core/src/route-export.ts
@@ -1,0 +1,41 @@
+/**
+ * Route information export functionality
+ * This file provides functionality to export route information from the start-plugin-core
+ * to be consumed by router-plugin for code splitting
+ */
+
+let routeNodesInfo: RouteExportInfo | null = null
+
+export interface RouteExportInfo {
+  routesDirectory: string
+  virtualRouteDirectories: Array<string>
+  routes: Record<string, Record<string, unknown>>
+}
+
+/**
+ * Export route nodes information for router-plugin to use
+ */
+export function exportRouteNodesInfo(info: RouteExportInfo): void {
+  routeNodesInfo = info
+  console.log('[TanStack Router] Exported route nodes info')
+}
+
+/**
+ * Get exported route nodes information
+ */
+export function getRouteNodesInfo(): RouteExportInfo | null {
+  return routeNodesInfo
+}
+
+export function isFileInVirtualRouteDirectories(
+  filePath: string,
+  virtualRouteDirectories: Array<string>,
+): boolean {
+  if (virtualRouteDirectories.length === 0) {
+    return false
+  }
+
+  return virtualRouteDirectories.some((dir) =>
+    filePath.startsWith(dir.replace(/\\/g, '/')),
+  )
+}

--- a/packages/start-plugin-core/src/schema.ts
+++ b/packages/start-plugin-core/src/schema.ts
@@ -9,6 +9,7 @@ const tsrConfig = configSchema
   .partial()
   .extend({
     srcDirectory: z.string().optional().default('src'),
+    virtualRouteDirectories: z.array(z.string()).optional().default([]),
   })
 
 export function createTanStackConfig<

--- a/packages/start-plugin-core/src/start-manifest-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/start-manifest-plugin/plugin.ts
@@ -145,16 +145,11 @@ export function startManifestPlugin(
             opts.tsr.routesDirectory,
           )
 
-          // Process virtual route directory paths
-          const virtualRouteDirectoriesFromRoot =
-            opts.tsr.virtualRouteDirectories.map((dir) =>
-              path.relative(opts.root, dir),
-            )
+
 
           // Export route nodes information for router-plugin to use
           exportRouteNodesInfo({
             routesDirectory: opts.tsr.routesDirectory,
-            virtualRouteDirectories: opts.tsr.virtualRouteDirectories,
             routes: routeTreeRoutes,
           })
 
@@ -169,23 +164,7 @@ export function startManifestPlugin(
               file = filesByRouteFilePath[defaultRoutePath]
             }
 
-            if (!file && virtualRouteDirectoriesFromRoot.length > 0) {
-              for (const virtualDir of virtualRouteDirectoriesFromRoot) {
-                const virtualFilePath = path.posix.join(
-                  virtualDir,
-                  v.filePath as string,
-                )
-                if (filesByRouteFilePath[virtualFilePath]) {
-                  file = filesByRouteFilePath[virtualFilePath]
 
-                  console.log(
-                    `[TanStack Router] Found virtual route: ${virtualFilePath}`,
-                  )
-
-                  break
-                }
-              }
-            }
 
             if (file) {
               // Map the relevant imports to their route paths,

--- a/packages/start-plugin-core/src/start-manifest-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/start-manifest-plugin/plugin.ts
@@ -5,6 +5,7 @@ import { rootRouteId } from '@tanstack/router-core'
 import { VIRTUAL_MODULES } from '@tanstack/start-server-core'
 import { resolveViteId } from '../utils'
 import { CLIENT_DIST_DIR } from '../constants'
+import { exportRouteNodesInfo } from '../route-export'
 import type {
   PluginOption,
   ResolvedConfig,
@@ -150,21 +151,12 @@ export function startManifestPlugin(
               path.relative(opts.root, dir),
             )
 
-          // Function to check if a file path should be code-split
-          function shouldCodeSplit(filePath: string): boolean {
-            if (filePath.startsWith(path.resolve(opts.tsr.routesDirectory))) {
-              return true
-            }
-
-            // Check if the file is inside any of the virtual route directories
-            for (const virtualDir of opts.tsr.virtualRouteDirectories) {
-              if (filePath.startsWith(path.resolve(virtualDir))) {
-                return true
-              }
-            }
-
-            return false
-          }
+          // Export route nodes information for router-plugin to use
+          exportRouteNodesInfo({
+            routesDirectory: opts.tsr.routesDirectory,
+            virtualRouteDirectories: opts.tsr.virtualRouteDirectories,
+            routes: routeTreeRoutes,
+          })
 
           for (const [routeId, v] of Object.entries(routeTreeRoutes)) {
             let file = null
@@ -186,12 +178,9 @@ export function startManifestPlugin(
                 if (filesByRouteFilePath[virtualFilePath]) {
                   file = filesByRouteFilePath[virtualFilePath]
 
-                  const absolutePath = path.resolve(opts.root, virtualFilePath)
-                  if (shouldCodeSplit(absolutePath)) {
-                    console.log(
-                      `[TanStack Router] Code-splitting virtual route: ${virtualFilePath}`,
-                    )
-                  }
+                  console.log(
+                    `[TanStack Router] Found virtual route: ${virtualFilePath}`,
+                  )
 
                   break
                 }


### PR DESCRIPTION
## Problem

#4331
TanStack Start currently does not support code splitting for Virtual Routes located outside
the configured routesDirectory. This causes all route modules to load simultaneously
during development, resulting in excessive HTTP requests (2500+) and slow initial page load
times (5-10 seconds).

## Solution

- Moving code-splitting logic from start-plugin-core to router-plugin for better architectural separation
- Automatic detection of virtual routes using existing route discovery mechanism
- Extending code-splitting to cover all discovered route files, regardless of location
- No configuration required - works automatically with existing virtual route setup

## Architecture Improvement
Before: start-plugin-core → handles route discovery + code-splitting
After:  start-plugin-core → route discovery + exports route info router-plugin → code-splitting for all discovered routes