### PR TITLE
chore(examples): Pin temporary Clerk version and ssr fix

### DIFF
--- a/examples/react/start-clerk-basic/package.json
+++ b/examples/react/start-clerk-basic/package.json
@@ -9,7 +9,7 @@
     "start": "vite start"
   },
   "dependencies": {
-    "@clerk/tanstack-react-start": "0.12.0",
+    "@clerk/tanstack-react-start": "0.17.0-snapshot.v20250611045520",
     "@tanstack/react-router": "^1.121.0",
     "@tanstack/react-router-devtools": "^1.121.0",
     "@tanstack/react-start": "^1.121.1",

--- a/examples/react/start-clerk-basic/vite.config.ts
+++ b/examples/react/start-clerk-basic/vite.config.ts
@@ -12,4 +12,7 @@ export default defineConfig({
     }),
     tanstackStart(),
   ],
+  ssr: {
+    noExternal: ['@clerk/tanstack-react-start'],
+  },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4542,8 +4542,8 @@ importers:
   examples/react/start-clerk-basic:
     dependencies:
       '@clerk/tanstack-react-start':
-        specifier: 0.12.0
-        version: 0.12.0(@tanstack/react-router@packages+react-router)(@tanstack/react-start@packages+react-start)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 0.17.0-snapshot.v20250611045520
+        version: 0.17.0-snapshot.v20250611045520(@tanstack/react-router@packages+react-router)(@tanstack/react-start@packages+react-start)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -6978,12 +6978,19 @@ packages:
   '@bundled-es-modules/tough-cookie@0.1.6':
     resolution: {integrity: sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==}
 
-  '@clerk/backend@1.25.6':
-    resolution: {integrity: sha512-JxHs9OXhx37RWK5rO3IITh+KP3EYQed9rLZiJKvQxr7A7plYAJhK8BzjNXAE5IXZbCZjkOGFyynmuXnjnyUqaw==}
+  '@clerk/backend@2.0.1-snapshot.v20250611045520':
+    resolution: {integrity: sha512-dllv3pGXMkj+oHIBKxP+JoDNInGey8rvYtgSKbDo+frYEv50Ymprdi3f9EgKh+dyP2sGAFGx5X9y3EC/D11Jzg==}
     engines: {node: '>=18.17.0'}
 
   '@clerk/clerk-react@5.25.3':
     resolution: {integrity: sha512-nSuUzvu/DtiBADx2q0p0syk6NfCT5q4SuVJbQUimNSOPSnGJ7CVfO6QvEXS1oWcVyEKn+8nVlMaZonfDsuaORA==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      react: ^19.0.0
+      react-dom: ^19.0.0
+
+  '@clerk/clerk-react@5.31.10-snapshot.v20250611045520':
+    resolution: {integrity: sha512-35qMgoiuPmrEUOwfukdYV4uIXhUSyNN54X7feIF8GdJw/wNJWEoOcssz+a/MFaXUgoGVkpUyLUoTfszrBQAM/Q==}
     engines: {node: '>=18.17.0'}
     peerDependencies:
       react: ^19.0.0
@@ -7001,8 +7008,20 @@ packages:
       react-dom:
         optional: true
 
-  '@clerk/tanstack-react-start@0.12.0':
-    resolution: {integrity: sha512-QS7uPX5kecedKeX4QgNWBChDd+l/WRlmm1mFVFqM7ZzgxQ198srYxiIAi0njSmwjPRG3lpyHHDJ14Ll2RSTENQ==}
+  '@clerk/shared@3.9.7-snapshot.v20250611045520':
+    resolution: {integrity: sha512-Z64hRJXGRpxJnr234SIKqAzDPQTrKtO6lPyR63R2ak0MHStg3ZyikReczPcVD83QorLXe3ULt+DwwWmDrAJjUA==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      react: ^19.0.0
+      react-dom: ^19.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@clerk/tanstack-react-start@0.17.0-snapshot.v20250611045520':
+    resolution: {integrity: sha512-nLIkzfL7DDD0UvRNld1SZe0B/BvYrWLkt4ZMyY1hxFmfbFPn4PNqznTS/AcMeTLOz5L5IBlq4pReTkcbl+8C0w==}
     engines: {node: '>=18.17.0'}
     peerDependencies:
       '@tanstack/react-router': workspace:*
@@ -7012,6 +7031,10 @@ packages:
 
   '@clerk/types@4.49.2':
     resolution: {integrity: sha512-b4LR3Xsegqe0S6ZkaSJ1skO5a36EIiYRCFBzrJIbJX58vh25FFbOs4VHcK71uCLGJ1Jm1bViPi8QPGYoqYAUuw==}
+    engines: {node: '>=18.17.0'}
+
+  '@clerk/types@4.60.1-snapshot.v20250611045520':
+    resolution: {integrity: sha512-5ZC0+Hu+bP8iaMdhMqCoeSW2sc5V3PiQNh+QQbWhQLhd1NOB1ZpLpLZZykw5zpr97ehVagqBtt1jPpVUfSJaCQ==}
     engines: {node: '>=18.17.0'}
 
   '@cloudflare/kv-asset-handler@0.4.0':
@@ -14355,6 +14378,11 @@ packages:
     peerDependencies:
       react: ^19.0.0
 
+  swr@2.3.3:
+    resolution: {integrity: sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==}
+    peerDependencies:
+      react: ^19.0.0
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -15679,10 +15707,10 @@ snapshots:
       '@types/tough-cookie': 4.0.5
       tough-cookie: 4.1.4
 
-  '@clerk/backend@1.25.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@clerk/backend@2.0.1-snapshot.v20250611045520(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@clerk/shared': 3.2.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@clerk/types': 4.49.2
+      '@clerk/shared': 3.9.7-snapshot.v20250611045520(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@clerk/types': 4.60.1-snapshot.v20250611045520
       cookie: 1.0.2
       snakecase-keys: 8.0.1
       tslib: 2.8.1
@@ -15694,6 +15722,15 @@ snapshots:
     dependencies:
       '@clerk/shared': 3.2.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@clerk/types': 4.49.2
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      tslib: 2.8.1
+    optional: true
+
+  '@clerk/clerk-react@5.31.10-snapshot.v20250611045520(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@clerk/shared': 3.9.7-snapshot.v20250611045520(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@clerk/types': 4.60.1-snapshot.v20250611045520
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       tslib: 2.8.1
@@ -15709,13 +15746,26 @@ snapshots:
     optionalDependencies:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
+    optional: true
 
-  '@clerk/tanstack-react-start@0.12.0(@tanstack/react-router@packages+react-router)(@tanstack/react-start@packages+react-start)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@clerk/shared@3.9.7-snapshot.v20250611045520(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@clerk/backend': 1.25.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@clerk/clerk-react': 5.25.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@clerk/shared': 3.2.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@clerk/types': 4.49.2
+      '@clerk/types': 4.60.1-snapshot.v20250611045520
+      dequal: 2.0.3
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.5
+      std-env: 3.9.0
+      swr: 2.3.3(react@19.0.0)
+    optionalDependencies:
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+
+  '@clerk/tanstack-react-start@0.17.0-snapshot.v20250611045520(@tanstack/react-router@packages+react-router)(@tanstack/react-start@packages+react-start)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@clerk/backend': 2.0.1-snapshot.v20250611045520(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@clerk/clerk-react': 5.31.10-snapshot.v20250611045520(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@clerk/shared': 3.9.7-snapshot.v20250611045520(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@clerk/types': 4.60.1-snapshot.v20250611045520
       '@tanstack/react-router': link:packages/react-router
       '@tanstack/react-start': link:packages/react-start
       react: 19.0.0
@@ -15723,6 +15773,11 @@ snapshots:
       tslib: 2.8.1
 
   '@clerk/types@4.49.2':
+    dependencies:
+      csstype: 3.1.3
+    optional: true
+
+  '@clerk/types@4.60.1-snapshot.v20250611045520':
     dependencies:
       csstype: 3.1.3
 
@@ -23734,6 +23789,13 @@ snapshots:
       webpack: 5.97.1(@swc/core@1.10.15(@swc/helpers@0.5.15))(esbuild@0.25.4)(webpack-cli@5.1.4)
 
   swr@2.3.0(react@19.0.0):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.0.0
+      use-sync-external-store: 1.2.2(react@19.0.0)
+    optional: true
+
+  swr@2.3.3(react@19.0.0):
     dependencies:
       dequal: 2.0.3
       react: 19.0.0


### PR DESCRIPTION
Devinxi is being worked on [here](https://github.com/clerk/javascript/pull/5973) and this PR pins a snapshot version of that PR. This also adds a fix to node_modules dependency scanning issue when using `getEvent()`.

The error being temporarily fixed is:

```ts
No HTTPEvent found in AsyncLocalStorage. Make sure you are using the function within the server runtime.
```