### PR TITLE
fix: router-plugins correctly handle virtual file routes regardless of their location

### DIFF
--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -4,7 +4,10 @@ import { mkdtempSync } from 'node:fs'
 import crypto from 'node:crypto'
 import { deepEqual, rootRouteId } from '@tanstack/router-core'
 import { logging } from './logger'
-import { getRouteNodes as physicalGetRouteNodes } from './filesystem/physical/getRouteNodes'
+import {
+  isVirtualConfigFile,
+  getRouteNodes as physicalGetRouteNodes,
+} from './filesystem/physical/getRouteNodes'
 import { getRouteNodes as virtualGetRouteNodes } from './filesystem/virtual/getRouteNodes'
 import { rootPathId } from './filesystem/physical/rootPathId'
 import {
@@ -170,6 +173,7 @@ export class Generator {
   // this is just a cache for the transform plugins since we need them for each route file that is to be processed
   private transformPlugins: Array<TransformPlugin> = []
   private routeGroupPatternRegex = /\(.+\)/g
+  private physicalDirectories: Array<string> = []
 
   constructor(opts: { config: Config; root: string; fs?: fs }) {
     this.config = opts.config
@@ -203,17 +207,17 @@ export class Generator {
       : path.resolve(this.root, this.config.routesDirectory)
   }
 
+  public getRouteFileList(): Set<string> {
+    return new Set(this.routeNodeCache.keys())
+  }
+
   public async run(event?: GeneratorEvent): Promise<void> {
-    // we are only interested in FileEvents that affect either the generated route tree or files inside the routes folder
-    if (event && event.type !== 'rerun') {
-      if (
-        !(
-          event.path === this.generatedRouteTreePath ||
-          event.path.startsWith(this.routesDirectoryPath)
-        )
-      ) {
-        return
-      }
+    if (
+      event &&
+      event.type !== 'rerun' &&
+      !this.isFileRelevantForRouteTreeGeneration(event.path)
+    ) {
+      return
     }
     this.fileEventQueue.push(event ?? { type: 'rerun' })
     // only allow a single run at a time
@@ -233,7 +237,7 @@ export class Generator {
           await Promise.all(
             tempQueue.map(async (e) => {
               if (e.type === 'update') {
-                let cacheEntry
+                let cacheEntry: GeneratorCacheEntry | undefined
                 if (e.path === this.generatedRouteTreePath) {
                   cacheEntry = this.routeTreeFileCache
                 } else {
@@ -301,7 +305,11 @@ export class Generator {
       getRouteNodesResult = await physicalGetRouteNodes(this.config, this.root)
     }
 
-    const { rootRouteNode, routeNodes: beforeRouteNodes } = getRouteNodesResult
+    const {
+      rootRouteNode,
+      routeNodes: beforeRouteNodes,
+      physicalDirectories,
+    } = getRouteNodesResult
     if (rootRouteNode === undefined) {
       let errorMessage = `rootRouteNode must not be undefined. Make sure you've added your root route into the route-tree.`
       if (!this.config.virtualRouteConfig) {
@@ -309,6 +317,7 @@ export class Generator {
       }
       throw new Error(errorMessage)
     }
+    this.physicalDirectories = physicalDirectories
 
     writeRouteTreeFile = await this.handleRootNode(rootRouteNode)
 
@@ -1291,5 +1300,43 @@ ${acc.routeTree.map((child) => `${child.variableName}${exportName}: typeof ${get
     }
 
     acc.routeNodes.push(node)
+  }
+
+  // only process files that are relevant for the route tree generation
+  private isFileRelevantForRouteTreeGeneration(filePath: string): boolean {
+    // the generated route tree file
+    if (filePath === this.generatedRouteTreePath) {
+      return true
+    }
+
+    // files inside the routes folder
+    if (filePath.startsWith(this.routesDirectoryPath)) {
+      return true
+    }
+
+    // the virtual route config file passed into `virtualRouteConfig`
+    if (
+      typeof this.config.virtualRouteConfig === 'string' &&
+      filePath === this.config.virtualRouteConfig
+    ) {
+      return true
+    }
+
+    // this covers all files that are mounted via `virtualRouteConfig` or any `__virtual.ts` files
+    if (this.routeNodeCache.has(filePath)) {
+      return true
+    }
+
+    // virtual config files such as`__virtual.ts`
+    if (isVirtualConfigFile(path.basename(filePath))) {
+      return true
+    }
+
+    // route files inside directories mounted via `physical()` inside a virtual route config
+    if (this.physicalDirectories.some((dir) => filePath.startsWith(dir))) {
+      return true
+    }
+
+    return false
   }
 }

--- a/packages/router-generator/src/types.ts
+++ b/packages/router-generator/src/types.ts
@@ -18,6 +18,7 @@ export type RouteNode = {
 export interface GetRouteNodesResult {
   rootRouteNode?: RouteNode
   routeNodes: Array<RouteNode>
+  physicalDirectories: Array<string>
 }
 
 export type FsRouteType =

--- a/packages/router-plugin/src/core/router-code-splitter-plugin.ts
+++ b/packages/router-plugin/src/core/router-code-splitter-plugin.ts
@@ -180,7 +180,10 @@ export const unpluginRouterCodeSplitterFactory: UnpluginFactory<
           code: 'createFileRoute(',
         },
         handler(code, id) {
-          if (globalThis.TSR_ROUTE_FILES?.has(id) && code.includes('createFileRoute(')) {
+          if (
+            globalThis.TSR_ROUTE_FILES?.has(id) &&
+            code.includes('createFileRoute(')
+          ) {
             for (const externalPlugin of bannedBeforeExternalPlugins) {
               if (!externalPlugin.frameworks.includes(framework)) {
                 continue

--- a/packages/router-plugin/src/core/router-composed-plugin.ts
+++ b/packages/router-plugin/src/core/router-composed-plugin.ts
@@ -20,7 +20,13 @@ export const unpluginRouterComposedFactory: UnpluginFactory<
   const routerCodeSplitter = getPlugin(unpluginRouterCodeSplitterFactory)
   const routeAutoImport = getPlugin(unpluginRouteAutoImportFactory)
 
-  const result = [...routerGenerator, ...routerCodeSplitter, ...routeAutoImport]
+  const result = [...routerGenerator]
+  if (options.autoCodeSplitting) {
+    result.push(...routerCodeSplitter)
+  }
+  if (options.verboseFileRoutes === false) {
+    result.push(...routeAutoImport)
+  }
 
   const isProduction = process.env.NODE_ENV === 'production'
 

--- a/packages/router-plugin/src/core/router-generator-plugin.ts
+++ b/packages/router-plugin/src/core/router-generator-plugin.ts
@@ -1,7 +1,8 @@
 import { isAbsolute, join, normalize } from 'node:path'
 import { Generator, resolveConfigPath } from '@tanstack/router-generator'
-
 import { getConfig } from './config'
+
+import type { GeneratorEvent } from '@tanstack/router-generator'
 import type { FSWatcher } from 'chokidar'
 import type { UnpluginFactory } from 'unplugin'
 import type { Config } from './config'
@@ -31,41 +32,39 @@ export const unpluginRouterGeneratorFactory: UnpluginFactory<
     })
   }
 
-  const generate = async () => {
+  const generate = async (opts?: {
+    file: string
+    event: 'create' | 'update' | 'delete'
+  }) => {
     if (routeGenerationDisabled()) {
       return
     }
-    try {
-      await generator.run()
-    } catch (e) {
-      console.error(e)
+    let generatorEvent: GeneratorEvent | undefined = undefined
+    if (opts) {
+      const filePath = normalize(opts.file)
+      if (filePath === resolveConfigPath({ configDirectory: ROOT })) {
+        initConfigAndGenerator()
+        return
+      }
+      generatorEvent = { path: filePath, type: opts.event }
     }
-  }
 
-  const handleFile = async (
-    file: string,
-    event: 'create' | 'update' | 'delete',
-  ) => {
-    const filePath = normalize(file)
-
-    if (filePath === resolveConfigPath({ configDirectory: ROOT })) {
-      initConfigAndGenerator()
-      return
-    }
     try {
-      await generator.run({ path: filePath, type: event })
+      await generator.run(generatorEvent)
+      globalThis.TSR_ROUTE_FILES = generator.getRouteFileList()
     } catch (e) {
       console.error(e)
     }
   }
 
   return {
-    name: 'router-generator-plugin',
+    name: 'tanstack:router-generator',
     enforce: 'pre',
     async watchChange(id, { event }) {
-      if (!routeGenerationDisabled()) {
-        await handleFile(id, event)
-      }
+      await generate({
+        file: id,
+        event,
+      })
     },
     async buildStart() {
       await generate()
@@ -89,7 +88,7 @@ export const unpluginRouterGeneratorFactory: UnpluginFactory<
 
       let handle: FSWatcher | null = null
 
-      compiler.hooks.beforeRun.tapPromise(PLUGIN_NAME, generate)
+      compiler.hooks.beforeRun.tapPromise(PLUGIN_NAME, () => generate())
 
       compiler.hooks.watchRun.tapPromise(PLUGIN_NAME, async () => {
         if (handle) {
@@ -117,7 +116,7 @@ export const unpluginRouterGeneratorFactory: UnpluginFactory<
 
       let handle: FSWatcher | null = null
 
-      compiler.hooks.beforeRun.tapPromise(PLUGIN_NAME, generate)
+      compiler.hooks.beforeRun.tapPromise(PLUGIN_NAME, () => generate())
 
       compiler.hooks.watchRun.tapPromise(PLUGIN_NAME, async () => {
         if (handle) {

--- a/packages/router-plugin/src/core/router-hmr-plugin.ts
+++ b/packages/router-plugin/src/core/router-hmr-plugin.ts
@@ -1,7 +1,7 @@
 import { generateFromAst, logDiff, parseAst } from '@tanstack/router-utils'
 import { getConfig } from './config'
 import { routeHmrStatement } from './route-hmr-statement'
-import { debug, fileIsInRoutesDirectory } from './utils'
+import { debug } from './utils'
 import type { Config } from './config'
 import type { UnpluginFactory } from 'unplugin'
 
@@ -17,32 +17,33 @@ export const unpluginRouterHmrFactory: UnpluginFactory<
   let userConfig = options as Config
 
   return {
-    name: 'router-hmr-plugin',
+    name: 'tanstack-router:hmr',
     enforce: 'pre',
 
-    transform(code, id) {
-      if (!code.includes('export const Route = createFileRoute(')) {
-        return null
-      }
+    transform: {
+      filter: {
+        code: 'createFileRoute(',
+      },
+      handler(code, id) {
+        if (!globalThis.TSR_ROUTE_FILES?.has(id)) {
+          return null
+        }
 
-      if (debug) console.info('Adding HMR handling to route ', id)
+        if (debug) console.info('Adding HMR handling to route ', id)
 
-      const ast = parseAst({ code })
-      ast.program.body.push(routeHmrStatement)
-      const result = generateFromAst(ast, {
-        sourceMaps: true,
-        filename: id,
-        sourceFileName: id,
-      })
-      if (debug) {
-        logDiff(code, result.code)
-        console.log('Output:\n', result.code + '\n\n')
-      }
-      return result
-    },
-
-    transformInclude(id) {
-      return fileIsInRoutesDirectory(id, userConfig.routesDirectory)
+        const ast = parseAst({ code })
+        ast.program.body.push(routeHmrStatement)
+        const result = generateFromAst(ast, {
+          sourceMaps: true,
+          filename: id,
+          sourceFileName: id,
+        })
+        if (debug) {
+          logDiff(code, result.code)
+          console.log('Output:\n', result.code + '\n\n')
+        }
+        return result
+      },
     },
 
     vite: {

--- a/packages/router-plugin/src/core/utils.ts
+++ b/packages/router-plugin/src/core/utils.ts
@@ -1,18 +1,3 @@
-import { isAbsolute, join, normalize } from 'node:path'
-
 export const debug =
   process.env.TSR_VITE_DEBUG &&
   ['true', 'router-plugin'].includes(process.env.TSR_VITE_DEBUG)
-
-export function fileIsInRoutesDirectory(
-  filePath: string,
-  routesDirectory: string,
-): boolean {
-  const routesDirectoryPath = isAbsolute(routesDirectory)
-    ? routesDirectory
-    : join(process.cwd(), routesDirectory)
-
-  const path = normalize(filePath)
-
-  return path.startsWith(routesDirectoryPath)
-}

--- a/packages/router-plugin/src/global.d.ts
+++ b/packages/router-plugin/src/global.d.ts
@@ -1,0 +1,5 @@
+/* eslint-disable no-var */
+declare global {
+  var TSR_ROUTE_FILES: Set<string> | undefined
+}
+export {}


### PR DESCRIPTION
fixes #4331

also switched over to plugin hook filters, see https://rolldown.rs/guide/plugin-development#plugin-hook-filters