### PR TITLE
fix(router-devtools-core): make solid-js a dependency

### DIFF
--- a/packages/router-devtools-core/package.json
+++ b/packages/router-devtools-core/package.json
@@ -63,10 +63,10 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
-    "goober": "^2.1.16"
+    "goober": "^2.1.16",
+    "solid-js": "^1.9.5"
   },
   "devDependencies": {
-    "solid-js": "^1.9.5",
     "vite-plugin-solid": "^2.11.6"
   },
   "peerDependencies": {

--- a/packages/solid-router-devtools/package.json
+++ b/packages/solid-router-devtools/package.json
@@ -66,10 +66,10 @@
     "node": ">=12"
   },
   "dependencies": {
-    "@tanstack/router-devtools-core": "workspace:^",
-    "solid-js": "^1.9.5"
+    "@tanstack/router-devtools-core": "workspace:^"
   },
   "devDependencies": {
+    "solid-js": "^1.9.5",
     "vite-plugin-solid": "^2.11.6"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,7 +223,7 @@ importers:
         version: 0.5.1
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -275,7 +275,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -327,7 +327,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -437,7 +437,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -541,7 +541,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -596,7 +596,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -856,7 +856,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -960,7 +960,7 @@ importers:
         version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -1140,7 +1140,7 @@ importers:
     dependencies:
       '@babel/plugin-syntax-typescript':
         specifier: ^7.25.9
-        version: 7.25.9(@babel/core@7.27.4)
+        version: 7.27.1(@babel/core@7.27.4)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -1253,7 +1253,7 @@ importers:
         version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -1323,7 +1323,7 @@ importers:
         version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -1393,7 +1393,7 @@ importers:
         version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -1466,7 +1466,7 @@ importers:
         version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -1530,7 +1530,7 @@ importers:
         version: 2.6.0
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -1628,7 +1628,7 @@ importers:
         version: 1.9.5
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -1674,7 +1674,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -1717,7 +1717,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -1849,7 +1849,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -1895,7 +1895,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -1941,7 +1941,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -2082,7 +2082,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -2122,7 +2122,7 @@ importers:
         version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -2211,7 +2211,7 @@ importers:
         version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -2272,7 +2272,7 @@ importers:
         version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -2333,7 +2333,7 @@ importers:
         version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -2394,7 +2394,7 @@ importers:
         version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@playwright/test':
         specifier: ^1.52.0
@@ -2455,7 +2455,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/react':
         specifier: ^19.0.8
@@ -2510,7 +2510,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/react':
         specifier: ^19.0.8
@@ -2602,7 +2602,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/react':
         specifier: ^19.0.8
@@ -2697,7 +2697,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/react':
         specifier: ^19.0.8
@@ -2844,7 +2844,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/react':
         specifier: ^19.0.8
@@ -2896,7 +2896,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/react':
         specifier: ^19.0.8
@@ -2948,7 +2948,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/react':
         specifier: ^19.0.8
@@ -2994,7 +2994,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/react':
         specifier: ^19.0.8
@@ -3043,7 +3043,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/react':
         specifier: ^19.0.8
@@ -3095,7 +3095,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/react':
         specifier: ^19.0.8
@@ -3150,7 +3150,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/react':
         specifier: ^19.0.8
@@ -3208,7 +3208,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/react':
         specifier: ^19.0.8
@@ -3260,7 +3260,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/react':
         specifier: ^19.0.8
@@ -3435,7 +3435,7 @@ importers:
         version: 0.5.1
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/react':
         specifier: ^19.0.8
@@ -3478,7 +3478,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/react':
         specifier: ^19.0.8
@@ -3730,7 +3730,7 @@ importers:
         version: 0.5.1
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@vitejs/plugin-react':
         specifier: ^4.3.4
@@ -3770,7 +3770,7 @@ importers:
         version: 0.5.1
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/react':
         specifier: ^19.0.8
@@ -3979,7 +3979,7 @@ importers:
         version: 0.5.1
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/react':
         specifier: ^19.0.8
@@ -4099,7 +4099,7 @@ importers:
         version: 0.5.1
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/react':
         specifier: ^19.0.8
@@ -4209,7 +4209,7 @@ importers:
         version: 1.0.0-beta.15(typescript@5.8.2)
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.6.3
@@ -4252,7 +4252,7 @@ importers:
         version: 19.0.0(react@19.0.0)
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.0.8
@@ -4301,7 +4301,7 @@ importers:
         version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/node':
         specifier: ^22.5.4
@@ -4445,7 +4445,7 @@ importers:
     dependencies:
       '@babel/plugin-syntax-typescript':
         specifier: ^7.25.9
-        version: 7.25.9(@babel/core@7.27.4)
+        version: 7.27.1(@babel/core@7.27.4)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -4646,7 +4646,7 @@ importers:
         version: 1.3.3
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/react':
         specifier: ^19.0.8
@@ -4793,7 +4793,7 @@ importers:
         version: 19.0.0(react@19.0.0)
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/node':
         specifier: ^22.5.4
@@ -4882,7 +4882,7 @@ importers:
         version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.1.6
@@ -4952,7 +4952,7 @@ importers:
         version: 1.3.3
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/react':
         specifier: ^19.0.8
@@ -5062,7 +5062,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/react':
         specifier: ^19.0.8
@@ -5111,7 +5111,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/react':
         specifier: ^19.0.8
@@ -5169,7 +5169,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/react':
         specifier: ^19.0.8
@@ -5230,7 +5230,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/react':
         specifier: ^19.0.8
@@ -5341,7 +5341,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@tanstack/router-plugin':
         specifier: workspace:*
@@ -5470,7 +5470,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@tanstack/router-plugin':
         specifier: workspace:*
@@ -5513,7 +5513,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@tanstack/router-plugin':
         specifier: workspace:*
@@ -5553,7 +5553,7 @@ importers:
         version: 3.4.17
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@tanstack/router-plugin':
         specifier: workspace:*
@@ -5593,7 +5593,7 @@ importers:
         version: 6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.0.8
@@ -5823,7 +5823,7 @@ importers:
         version: 0.2.57
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
 
   packages/react-router-devtools:
     dependencies:
@@ -5949,7 +5949,7 @@ importers:
         version: link:../start-plugin-core
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@vitejs/plugin-react':
         specifier: ^4.3.4
@@ -6083,13 +6083,13 @@ importers:
       goober:
         specifier: ^2.1.16
         version: 2.1.16(csstype@3.1.3)
+      solid-js:
+        specifier: ^1.9.5
+        version: 1.9.5
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3
     devDependencies:
-      solid-js:
-        specifier: ^1.9.5
-        version: 1.9.5
       vite-plugin-solid:
         specifier: ^2.11.6
         version: 2.11.6(@testing-library/jest-dom@6.6.3)(solid-js@1.9.5)(vite@6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
@@ -6119,7 +6119,7 @@ importers:
         version: 4.19.2
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@tanstack/react-router':
         specifier: workspace:*
@@ -6132,10 +6132,10 @@ importers:
         version: 7.27.4
       '@babel/plugin-syntax-jsx':
         specifier: ^7.25.9
-        version: 7.25.9(@babel/core@7.27.4)
+        version: 7.27.1(@babel/core@7.27.4)
       '@babel/plugin-syntax-typescript':
         specifier: ^7.25.9
-        version: 7.25.9(@babel/core@7.27.4)
+        version: 7.27.1(@babel/core@7.27.4)
       '@babel/template':
         specifier: ^7.26.8
         version: 7.27.2
@@ -6183,7 +6183,7 @@ importers:
         version: 5.97.1(@swc/core@1.10.15(@swc/helpers@0.5.15))(esbuild@0.25.4)
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       '@types/babel__core':
         specifier: ^7.20.5
@@ -6245,10 +6245,10 @@ importers:
         version: 7.27.4
       '@babel/plugin-syntax-jsx':
         specifier: ^7.25.9
-        version: 7.25.9(@babel/core@7.27.4)
+        version: 7.27.1(@babel/core@7.27.4)
       '@babel/plugin-syntax-typescript':
         specifier: ^7.25.9
-        version: 7.25.9(@babel/core@7.27.4)
+        version: 7.27.1(@babel/core@7.27.4)
       '@babel/template':
         specifier: ^7.26.8
         version: 7.27.2
@@ -6334,7 +6334,7 @@ importers:
         version: 2.11.6(@testing-library/jest-dom@6.6.3)(solid-js@1.9.5)(vite@6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
       zod:
         specifier: ^3.23.8
-        version: 3.24.2
+        version: 3.25.57
 
   packages/solid-router-devtools:
     dependencies:
@@ -6344,10 +6344,10 @@ importers:
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../solid-router
+    devDependencies:
       solid-js:
         specifier: ^1.9.5
         version: 1.9.5
-    devDependencies:
       vite-plugin-solid:
         specifier: ^2.11.6
         version: 2.11.6(@testing-library/jest-dom@6.6.3)(solid-js@1.9.5)(vite@6.3.5(@types/node@22.13.4)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
@@ -6433,7 +6433,7 @@ importers:
         version: link:../start-plugin-core
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       vite:
         specifier: 6.3.5
@@ -6567,7 +6567,7 @@ importers:
         version: 3.1.1
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
     devDependencies:
       vite:
         specifier: 6.3.5
@@ -6697,7 +6697,7 @@ importers:
         version: 19.0.0(react@19.0.0)
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.57
 
 packages:
 
@@ -6753,10 +6753,6 @@ packages:
     resolution: {integrity: sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-annotate-as-pure@7.25.9':
-    resolution: {integrity: sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-annotate-as-pure@7.27.3':
     resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
     engines: {node: '>=6.9.0'}
@@ -6765,21 +6761,11 @@ packages:
     resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-create-class-features-plugin@7.25.9':
-    resolution: {integrity: sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
   '@babel/helper-create-class-features-plugin@7.27.1':
     resolution: {integrity: sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
-
-  '@babel/helper-member-expression-to-functions@7.25.9':
-    resolution: {integrity: sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/helper-member-expression-to-functions@7.27.1':
     resolution: {integrity: sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==}
@@ -6799,37 +6785,19 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-optimise-call-expression@7.25.9':
-    resolution: {integrity: sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-optimise-call-expression@7.27.1':
     resolution: {integrity: sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-plugin-utils@7.26.5':
-    resolution: {integrity: sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-plugin-utils@7.27.1':
     resolution: {integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-replace-supers@7.26.5':
-    resolution: {integrity: sha512-bJ6iIVdYX1YooY2X7w1q6VITt+LnUILtNk7zT78ykuwStx8BauCzxvFqFaHjOpW1bVnSUM1PN1f0p5P21wHxvg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
   '@babel/helper-replace-supers@7.27.1':
     resolution: {integrity: sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
-
-  '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
-    resolution: {integrity: sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     resolution: {integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==}
@@ -6868,20 +6836,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-syntax-jsx@7.25.9':
-    resolution: {integrity: sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-syntax-jsx@7.27.1':
     resolution: {integrity: sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-typescript@7.25.9':
-    resolution: {integrity: sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -6894,12 +6850,6 @@ packages:
 
   '@babel/plugin-transform-class-properties@7.25.9':
     resolution: {integrity: sha512-bbMAII8GRSkcd0h0b4X+36GksxuheLFjP65ul9w6C3KgAamI3JqErNgSrosX6ZPj+Mpim5VvEbawXxJCyEUV3Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-modules-commonjs@7.26.3':
-    resolution: {integrity: sha512-MgR55l4q9KddUDITEzEFYn5ZsGDXMSsU9E+kh7fjRXTIC3RHqfCo8RPRbyReYJh44HQ/yomFkqbOFohXvDCiIQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -6922,20 +6872,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-typescript@7.26.8':
-    resolution: {integrity: sha512-bME5J9AC8ChwA7aEPJ6zym3w7aObZULHhbNLU0bKUhKsAkylkzUdq+0kdymh9rzi8nlNFl2bmldFBCKNJBUpuw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-typescript@7.27.1':
     resolution: {integrity: sha512-Q5sT5+O4QUebHdbwKedFBEwRLb02zJ7r4A5Gg2hUoLuU3FjdMcyqcywqUrLCaDsFCxzokf7u9kuy7qz51YUuAg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/preset-typescript@7.26.0':
-    resolution: {integrity: sha512-NMk1IGZ5I/oHhoXEElcm+xUnL/szL6xflkFZmoEU9xj1qSJXpiS7rsspYo92B4DRCDvZn2erT5LdsCeXAKNCkg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -15289,9 +15227,6 @@ packages:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
 
-  zod@3.24.2:
-    resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
-
   zod@3.25.57:
     resolution: {integrity: sha512-6tgzLuwVST5oLUxXTmBqoinKMd3JeesgbgseXeFasKKj8Q1FCZrHnbqJOyiEvr4cVAlbug+CgIsmJ8cl/pU5FA==}
 
@@ -15384,10 +15319,6 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.1.0
 
-  '@babel/helper-annotate-as-pure@7.25.9':
-    dependencies:
-      '@babel/types': 7.27.6
-
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
       '@babel/types': 7.27.6
@@ -15400,19 +15331,6 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.25.9(@babel/core@7.27.4)':
-    dependencies:
-      '@babel/core': 7.27.4
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-member-expression-to-functions': 7.25.9
-      '@babel/helper-optimise-call-expression': 7.25.9
-      '@babel/helper-replace-supers': 7.26.5(@babel/core@7.27.4)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-      '@babel/traverse': 7.27.4
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-create-class-features-plugin@7.27.1(@babel/core@7.27.4)':
     dependencies:
       '@babel/core': 7.27.4
@@ -15423,13 +15341,6 @@ snapshots:
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/traverse': 7.27.4
       semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-member-expression-to-functions@7.25.9':
-    dependencies:
-      '@babel/traverse': 7.27.4
-      '@babel/types': 7.27.6
     transitivePeerDependencies:
       - supports-color
 
@@ -15460,26 +15371,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-optimise-call-expression@7.25.9':
-    dependencies:
-      '@babel/types': 7.27.6
-
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
       '@babel/types': 7.27.6
 
-  '@babel/helper-plugin-utils@7.26.5': {}
-
   '@babel/helper-plugin-utils@7.27.1': {}
-
-  '@babel/helper-replace-supers@7.26.5(@babel/core@7.27.4)':
-    dependencies:
-      '@babel/core': 7.27.4
-      '@babel/helper-member-expression-to-functions': 7.25.9
-      '@babel/helper-optimise-call-expression': 7.25.9
-      '@babel/traverse': 7.27.4
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/helper-replace-supers@7.27.1(@babel/core@7.27.4)':
     dependencies:
@@ -15487,13 +15383,6 @@ snapshots:
       '@babel/helper-member-expression-to-functions': 7.27.1
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/traverse': 7.27.4
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
-    dependencies:
-      '@babel/traverse': 7.27.4
-      '@babel/types': 7.27.6
     transitivePeerDependencies:
       - supports-color
 
@@ -15522,8 +15411,8 @@ snapshots:
   '@babel/plugin-proposal-decorators@7.25.9(@babel/core@7.27.4)':
     dependencies:
       '@babel/core': 7.27.4
-      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.27.4)
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.27.4)
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-decorators': 7.25.9(@babel/core@7.27.4)
     transitivePeerDependencies:
       - supports-color
@@ -15531,22 +15420,12 @@ snapshots:
   '@babel/plugin-syntax-decorators@7.25.9(@babel/core@7.27.4)':
     dependencies:
       '@babel/core': 7.27.4
-      '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.27.4)':
-    dependencies:
-      '@babel/core': 7.27.4
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.27.4)':
     dependencies:
       '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-typescript@7.25.9(@babel/core@7.27.4)':
-    dependencies:
-      '@babel/core': 7.27.4
-      '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.27.4)':
     dependencies:
@@ -15556,16 +15435,8 @@ snapshots:
   '@babel/plugin-transform-class-properties@7.25.9(@babel/core@7.27.4)':
     dependencies:
       '@babel/core': 7.27.4
-      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.27.4)
-      '@babel/helper-plugin-utils': 7.26.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-commonjs@7.26.3(@babel/core@7.27.4)':
-    dependencies:
-      '@babel/core': 7.27.4
-      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.27.4)
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.27.4)
+      '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
@@ -15580,23 +15451,12 @@ snapshots:
   '@babel/plugin-transform-react-jsx-self@7.25.9(@babel/core@7.27.4)':
     dependencies:
       '@babel/core': 7.27.4
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-react-jsx-source@7.25.9(@babel/core@7.27.4)':
     dependencies:
       '@babel/core': 7.27.4
-      '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-transform-typescript@7.26.8(@babel/core@7.27.4)':
-    dependencies:
-      '@babel/core': 7.27.4
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.27.4)
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-      '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.27.4)
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-typescript@7.27.1(@babel/core@7.27.4)':
     dependencies:
@@ -15606,17 +15466,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.27.4)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/preset-typescript@7.26.0(@babel/core@7.27.4)':
-    dependencies:
-      '@babel/core': 7.27.4
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.27.4)
-      '@babel/plugin-transform-modules-commonjs': 7.26.3(@babel/core@7.27.4)
-      '@babel/plugin-transform-typescript': 7.26.8(@babel/core@7.27.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -16963,7 +16812,7 @@ snapshots:
       unixify: 1.0.0
       urlpattern-polyfill: 8.0.2
       yargs: 17.7.2
-      zod: 3.24.2
+      zod: 3.25.57
     transitivePeerDependencies:
       - encoding
       - rollup
@@ -18041,7 +17890,7 @@ snapshots:
       '@babel/core': 7.27.4
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.27.4)
       '@babel/plugin-transform-class-properties': 7.25.9(@babel/core@7.27.4)
-      '@babel/preset-typescript': 7.26.0(@babel/core@7.27.4)
+      '@babel/preset-typescript': 7.27.1(@babel/core@7.27.4)
       '@rsbuild/core': 1.2.4
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
@@ -19691,7 +19540,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.27.4
       '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.27.4)
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.27.4)
       '@babel/types': 7.27.6
       html-entities: 2.3.3
       parse5: 7.3.0
@@ -20496,7 +20345,7 @@ snapshots:
   esbuild-plugin-solid@0.6.0(esbuild@0.25.4)(solid-js@1.9.5):
     dependencies:
       '@babel/core': 7.27.4
-      '@babel/preset-typescript': 7.26.0(@babel/core@7.27.4)
+      '@babel/preset-typescript': 7.27.1(@babel/core@7.27.4)
       babel-preset-solid: 1.9.3(@babel/core@7.27.4)
       esbuild: 0.25.4
       solid-js: 1.9.5
@@ -24729,7 +24578,5 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
-
-  zod@3.24.2: {}
 
   zod@3.25.57: {}


### PR DESCRIPTION
Stemming from issues in https://github.com/TanStack/router/pull/4376.

This change makes it so that `solid-js` is a core dependency of `router-devtools-core` instead of just being a `devDependency`. As such, its consumers (i.e `react-router-devtools` and `solid-router-devtools`) shouldn't need to have `solid-js` be a core dependency it their packages.