### PR TITLE
feat(react-router): allow to disable formatting of custom scaffolding

### DIFF
--- a/packages/router-generator/src/config.ts
+++ b/packages/router-generator/src/config.ts
@@ -43,6 +43,7 @@ export const configSchema = baseConfigSchema.extend({
     .object({
       routeTemplate: z.string().optional(),
       lazyRouteTemplate: z.string().optional(),
+      disableFormatting: z.boolean().optional(),
     })
     .optional(),
   experimental: z

--- a/packages/router-generator/src/template.ts
+++ b/packages/router-generator/src/template.ts
@@ -12,6 +12,11 @@ export function fillTemplate(
     /%%(\w+)%%/g,
     (_, key) => values[key as TemplateTag] || '',
   )
+
+  if (config.customScaffolding?.disableFormatting) {
+    return replaced
+  }
+
   return format(replaced, config)
 }
 


### PR DESCRIPTION
As #4358 was denied, I'd like to be able to disable formatting, so that the formatting of my custom scaffolding templates stays intact.