### PR TITLE
fix broken link in migrate-from-next-js.md

### DIFF
--- a/docs/start/framework/react/migrate-from-next-js.md
+++ b/docs/start/framework/react/migrate-from-next-js.md
@@ -327,7 +327,7 @@ Learn more about the [Links](../learn-the-basics.md#navigation).
 + }) // [!code ++]
 ```
 
-Learn more about the [Server Functions](./server-functions.md).
+Learn more about the [Server Functions](../server-functions.md).
 
 ### Server Routes ~Handlers~
 
@@ -340,7 +340,7 @@ Learn more about the [Server Functions](./server-functions.md).
 + }) // [!code ++]
 ```
 
-Learn more about the [Server Routes](./server-routes.md).
+Learn more about the [Server Routes](../server-routes.md).
 
 ### Fonts
 


### PR DESCRIPTION
the server function and server route links were not working (missing .)