### PR TITLE
fix: always include the file scheme for the server entrypoint

### DIFF
--- a/packages/start-plugin-core/src/nitro-plugin/prerender.ts
+++ b/packages/start-plugin-core/src/nitro-plugin/prerender.ts
@@ -1,4 +1,5 @@
 import { promises as fsp } from 'node:fs'
+import { pathToFileURL } from 'node:url'
 import os from 'node:os'
 import path from 'node:path'
 import { getRollupConfig } from 'nitropack/rollup'
@@ -22,7 +23,7 @@ export async function prerender({
   builder: ViteBuilder
 }) {
   const logger = createLogger('prerender')
-  logger.info('Prendering pages...')
+  logger.info('Prerendering pages...')
 
   // If prerender is enabled but no pages are provided, default to prerendering the root page
   if (options.prerender?.enabled && !options.pages.length) {
@@ -84,9 +85,9 @@ export async function prerender({
       ? nodeNitroRollupOptions.output.entryFileNames
       : 'index.mjs'
 
-  const serverEntrypoint = path.resolve(
-    path.join(nodeNitro.options.output.serverDir, serverFilename),
-  )
+  const serverEntrypoint = pathToFileURL(
+    path.resolve(path.join(nodeNitro.options.output.serverDir, serverFilename)),
+  ).toString()
 
   const { closePrerenderer, localFetch } = (await import(serverEntrypoint)) as {
     closePrerenderer: () => void


### PR DESCRIPTION
Fixes #4416

On Windows, dynamic `import()` in Node.js confuses the drive letter with the protocol. Common drive letters, such as C and D, which are not part of the [supported schemes](https://nodejs.org/api/errors.html#err_unsupported_esm_url_scheme), cause the build to fail.