### PR TITLE
fix react-basic-ssr-streaming-file-based example

### DIFF
--- a/examples/react/basic-ssr-streaming-file-based/package.disabled.json
+++ b/examples/react/basic-ssr-streaming-file-based/package.disabled.json
@@ -11,10 +11,10 @@
     "debug": "node --inspect-brk server"
   },
   "dependencies": {
-    "@tanstack/react-router": "^1.120.20",
-    "@tanstack/react-router-devtools": "^1.120.20",
-    "@tanstack/router-plugin": "^1.120.20",
-    "@tanstack/react-start": "^1.120.20",
+    "@tanstack/react-router": "^1.121.12",
+    "@tanstack/react-router-devtools": "^1.121.12",
+    "@tanstack/router-plugin": "^1.121.12",
+    "@tanstack/react-start": "^1.121.12",
     "get-port": "^7.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/examples/react/basic-ssr-streaming-file-based/server.js
+++ b/examples/react/basic-ssr-streaming-file-based/server.js
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import express from 'express'
 import getPort, { portNumbers } from 'get-port'
 
@@ -44,19 +45,19 @@ export async function createServer(
     try {
       const url = req.originalUrl
 
-      if (url.includes('.')) {
+      if (path.extname(url) !== '') {
         console.warn(`${url} is not valid router path`)
         res.status(404)
         res.end(`${url} is not valid router path`)
         return
       }
 
-      // Extract the head from vite's index transformation hook
+      // Best effort extraction of the head from vite's index transformation hook
       let viteHead = !isProd
         ? await vite.transformIndexHtml(
-            url,
-            `<html><head></head><body></body></html>`,
-          )
+          url,
+          `<html><head></head><body></body></html>`,
+        )
         : ''
 
       viteHead = viteHead.substring(
@@ -73,7 +74,7 @@ export async function createServer(
       })()
 
       console.info('Rendering: ', url, '...')
-      entry.render({ req, res, url, head: viteHead })
+      entry.render({ req, res, head: viteHead })
     } catch (e) {
       !isProd && vite.ssrFixStacktrace(e)
       console.info(e.stack)

--- a/examples/react/basic-ssr-streaming-file-based/src/entry-server.tsx
+++ b/examples/react/basic-ssr-streaming-file-based/src/entry-server.tsx
@@ -1,22 +1,62 @@
+import { pipeline } from 'node:stream/promises'
 import {
   createRequestHandler,
   defaultStreamHandler,
 } from '@tanstack/react-start/server'
 import { createRouter } from './router'
 import type express from 'express'
-
-// index.js
 import './fetch-polyfill'
 
-export async function render(opts: {
-  url: string
+export async function render({
+                               req,
+                               res,
+                               head,
+                             }: {
   head: string
   req: express.Request
   res: express.Response
 }) {
-  return createRequestHandler({
-    createRouter,
-    req: opts.req,
-    res: opts.res,
-  })(defaultStreamHandler)
+  // Convert the express request to a fetch request
+  const url = new URL(req.originalUrl || req.url, 'https://localhost:3000').href
+
+  const request = new Request(url, {
+    method: req.method,
+    headers: (() => {
+      const headers = new Headers()
+      for (const [key, value] of Object.entries(req.headers)) {
+        headers.set(key, value as any)
+      }
+      return headers
+    })(),
+  })
+
+  // Create a request handler
+  const handler = createRequestHandler({
+    request,
+    createRouter: () => {
+      const router = createRouter()
+
+      // Update each router instance with the head info from vite
+      router.update({
+        context: {
+          ...router.options.context,
+          head: head,
+        },
+      })
+      return router
+    },
+  })
+
+  // Let's use the default stream handler to create the response
+  const response = await handler(defaultStreamHandler)
+
+  // Convert the fetch response back to an express response
+  res.statusMessage = response.statusText
+  res.status(response.status)
+  response.headers.forEach((value, name) => {
+    res.setHeader(name, value)
+  })
+
+  // Stream the response body
+  return pipeline(response.body as any, res)
 }

--- a/examples/react/basic-ssr-streaming-file-based/src/routeTree.gen.ts
+++ b/examples/react/basic-ssr-streaming-file-based/src/routeTree.gen.ts
@@ -8,139 +8,113 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-// Import Routes
-
-import type { FileRoutesByPath, CreateFileRoute } from '@tanstack/react-router'
-import { Route as rootRoute } from './routes/__root'
+import { Route as rootRouteImport } from './routes/__root'
 import { Route as ErrorRouteImport } from './routes/error'
 import { Route as PostsRouteRouteImport } from './routes/posts/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as PostsIndexRouteImport } from './routes/posts/index'
 import { Route as PostsPostIdRouteImport } from './routes/posts/$postId'
 
-// Create/Update Routes
-
 const ErrorRoute = ErrorRouteImport.update({
   id: '/error',
   path: '/error',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
 const PostsRouteRoute = PostsRouteRouteImport.update({
   id: '/posts',
   path: '/posts',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
 const PostsIndexRoute = PostsIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => PostsRouteRoute,
 } as any)
-
 const PostsPostIdRoute = PostsPostIdRouteImport.update({
   id: '/$postId',
   path: '/$postId',
   getParentRoute: () => PostsRouteRoute,
 } as any)
 
-// Populate the FileRoutesByPath interface
+export interface FileRoutesByFullPath {
+  '/': typeof IndexRoute
+  '/posts': typeof PostsRouteRouteWithChildren
+  '/error': typeof ErrorRoute
+  '/posts/$postId': typeof PostsPostIdRoute
+  '/posts/': typeof PostsIndexRoute
+}
+export interface FileRoutesByTo {
+  '/': typeof IndexRoute
+  '/error': typeof ErrorRoute
+  '/posts/$postId': typeof PostsPostIdRoute
+  '/posts': typeof PostsIndexRoute
+}
+export interface FileRoutesById {
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/posts': typeof PostsRouteRouteWithChildren
+  '/error': typeof ErrorRoute
+  '/posts/$postId': typeof PostsPostIdRoute
+  '/posts/': typeof PostsIndexRoute
+}
+export interface FileRouteTypes {
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths: '/' | '/posts' | '/error' | '/posts/$postId' | '/posts/'
+  fileRoutesByTo: FileRoutesByTo
+  to: '/' | '/error' | '/posts/$postId' | '/posts'
+  id: '__root__' | '/' | '/posts' | '/error' | '/posts/$postId' | '/posts/'
+  fileRoutesById: FileRoutesById
+}
+export interface RootRouteChildren {
+  IndexRoute: typeof IndexRoute
+  PostsRouteRoute: typeof PostsRouteRouteWithChildren
+  ErrorRoute: typeof ErrorRoute
+}
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRoute
+    '/error': {
+      id: '/error'
+      path: '/error'
+      fullPath: '/error'
+      preLoaderRoute: typeof ErrorRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/posts': {
       id: '/posts'
       path: '/posts'
       fullPath: '/posts'
       preLoaderRoute: typeof PostsRouteRouteImport
-      parentRoute: typeof rootRoute
+      parentRoute: typeof rootRouteImport
     }
-    '/error': {
-      id: '/error'
-      path: '/error'
-      fullPath: '/error'
-      preLoaderRoute: typeof ErrorRouteImport
-      parentRoute: typeof rootRoute
-    }
-    '/posts/$postId': {
-      id: '/posts/$postId'
-      path: '/$postId'
-      fullPath: '/posts/$postId'
-      preLoaderRoute: typeof PostsPostIdRouteImport
-      parentRoute: typeof PostsRouteRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/posts/': {
       id: '/posts/'
       path: '/'
       fullPath: '/posts/'
       preLoaderRoute: typeof PostsIndexRouteImport
-      parentRoute: typeof PostsRouteRouteImport
+      parentRoute: typeof PostsRouteRoute
+    }
+    '/posts/$postId': {
+      id: '/posts/$postId'
+      path: '/$postId'
+      fullPath: '/posts/$postId'
+      preLoaderRoute: typeof PostsPostIdRouteImport
+      parentRoute: typeof PostsRouteRoute
     }
   }
 }
-
-// Add type-safety to the createFileRoute function across the route tree
-
-declare module './routes/index' {
-  const createFileRoute: CreateFileRoute<
-    '/',
-    FileRoutesByPath['/']['parentRoute'],
-    FileRoutesByPath['/']['id'],
-    FileRoutesByPath['/']['path'],
-    FileRoutesByPath['/']['fullPath']
-  >
-}
-declare module './routes/posts/route' {
-  const createFileRoute: CreateFileRoute<
-    '/posts',
-    FileRoutesByPath['/posts']['parentRoute'],
-    FileRoutesByPath['/posts']['id'],
-    FileRoutesByPath['/posts']['path'],
-    FileRoutesByPath['/posts']['fullPath']
-  >
-}
-declare module './routes/error' {
-  const createFileRoute: CreateFileRoute<
-    '/error',
-    FileRoutesByPath['/error']['parentRoute'],
-    FileRoutesByPath['/error']['id'],
-    FileRoutesByPath['/error']['path'],
-    FileRoutesByPath['/error']['fullPath']
-  >
-}
-declare module './routes/posts/$postId' {
-  const createFileRoute: CreateFileRoute<
-    '/posts/$postId',
-    FileRoutesByPath['/posts/$postId']['parentRoute'],
-    FileRoutesByPath['/posts/$postId']['id'],
-    FileRoutesByPath['/posts/$postId']['path'],
-    FileRoutesByPath['/posts/$postId']['fullPath']
-  >
-}
-declare module './routes/posts/index' {
-  const createFileRoute: CreateFileRoute<
-    '/posts/',
-    FileRoutesByPath['/posts/']['parentRoute'],
-    FileRoutesByPath['/posts/']['id'],
-    FileRoutesByPath['/posts/']['path'],
-    FileRoutesByPath['/posts/']['fullPath']
-  >
-}
-
-// Create and export the route tree
 
 interface PostsRouteRouteChildren {
   PostsPostIdRoute: typeof PostsPostIdRoute
@@ -156,90 +130,11 @@ const PostsRouteRouteWithChildren = PostsRouteRoute._addFileChildren(
   PostsRouteRouteChildren,
 )
 
-export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '/posts': typeof PostsRouteRouteWithChildren
-  '/error': typeof ErrorRoute
-  '/posts/$postId': typeof PostsPostIdRoute
-  '/posts/': typeof PostsIndexRoute
-}
-
-export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/error': typeof ErrorRoute
-  '/posts/$postId': typeof PostsPostIdRoute
-  '/posts': typeof PostsIndexRoute
-}
-
-export interface FileRoutesById {
-  __root__: typeof rootRoute
-  '/': typeof IndexRoute
-  '/posts': typeof PostsRouteRouteWithChildren
-  '/error': typeof ErrorRoute
-  '/posts/$postId': typeof PostsPostIdRoute
-  '/posts/': typeof PostsIndexRoute
-}
-
-export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/posts' | '/error' | '/posts/$postId' | '/posts/'
-  fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/error' | '/posts/$postId' | '/posts'
-  id: '__root__' | '/' | '/posts' | '/error' | '/posts/$postId' | '/posts/'
-  fileRoutesById: FileRoutesById
-}
-
-export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  PostsRouteRoute: typeof PostsRouteRouteWithChildren
-  ErrorRoute: typeof ErrorRoute
-}
-
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   PostsRouteRoute: PostsRouteRouteWithChildren,
   ErrorRoute: ErrorRoute,
 }
-
-export const routeTree = rootRoute
+export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-// @ts-ignore
-import type * as ServerTypes from '../.tanstack-start/server-routes/routeTree.gen.ts'
-
-/* ROUTE_MANIFEST_START
-{
-  "routes": {
-    "__root__": {
-      "filePath": "__root.tsx",
-      "children": [
-        "/",
-        "/posts",
-        "/error"
-      ]
-    },
-    "/": {
-      "filePath": "index.tsx"
-    },
-    "/posts": {
-      "filePath": "posts/route.tsx",
-      "children": [
-        "/posts/$postId",
-        "/posts/"
-      ]
-    },
-    "/error": {
-      "filePath": "error.tsx"
-    },
-    "/posts/$postId": {
-      "filePath": "posts/$postId.tsx",
-      "parent": "/posts"
-    },
-    "/posts/": {
-      "filePath": "posts/index.tsx",
-      "parent": "/posts"
-    }
-  }
-}
-ROUTE_MANIFEST_END */

--- a/examples/react/basic-ssr-streaming-file-based/src/routes/error.tsx
+++ b/examples/react/basic-ssr-streaming-file-based/src/routes/error.tsx
@@ -1,4 +1,4 @@
-import { Await } from '@tanstack/react-router'
+import { Await, createFileRoute } from '@tanstack/react-router'
 import * as React from 'react'
 
 async function loadData() {
@@ -7,7 +7,7 @@ async function loadData() {
   return 'Hello!'
 }
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/error')({
   component: ErrorComponent,
   loader: () => {
     if (Math.random() > 0.5) throw new Error('Random error!')

--- a/examples/react/basic-ssr-streaming-file-based/src/routes/index.tsx
+++ b/examples/react/basic-ssr-streaming-file-based/src/routes/index.tsx
@@ -1,7 +1,7 @@
-import { Await } from '@tanstack/react-router'
+import { Await, createFileRoute } from '@tanstack/react-router'
 import * as React from 'react'
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/')({
   loader: () => ({
     date: new Date(),
     deferred: new Promise<{ date: Date }>((r) =>
@@ -19,7 +19,7 @@ function IndexComponent() {
       <h3>Welcome Home!</h3>
       <p>Data: {data.date.getDate()}</p>
       <Await promise={data.deferred} fallback="Loading...">
-        {(data) => <p>Deferred: {data.date.getDate()}</p>}
+        {(data) => <p>Deferred: {new Date(data.date).getDate()}</p>}
       </Await>
     </div>
   )

--- a/examples/react/basic-ssr-streaming-file-based/src/routes/posts/$postId.tsx
+++ b/examples/react/basic-ssr-streaming-file-based/src/routes/posts/$postId.tsx
@@ -1,4 +1,4 @@
-import { Await, notFound } from '@tanstack/react-router'
+import { Await, notFound, createFileRoute } from '@tanstack/react-router'
 import * as React from 'react'
 import type { PostType } from './route'
 
@@ -32,7 +32,7 @@ async function fetchComments(postId: string) {
   ).then((r) => r.json() as Promise<Array<CommentType>>)
 }
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/posts/$postId')({
   loader: async ({ params: { postId } }) => {
     const commentsPromise = fetchComments(postId)
     const post = await fetchPostById(postId)

--- a/examples/react/basic-ssr-streaming-file-based/src/routes/posts/index.tsx
+++ b/examples/react/basic-ssr-streaming-file-based/src/routes/posts/index.tsx
@@ -1,6 +1,7 @@
+import { createFileRoute } from '@tanstack/react-router'
 import * as React from 'react'
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/posts/')({
   component: PostsIndexComponent,
   wrapInSuspense: true,
   errorComponent: ({ error }) => {

--- a/examples/react/basic-ssr-streaming-file-based/src/routes/posts/route.tsx
+++ b/examples/react/basic-ssr-streaming-file-based/src/routes/posts/route.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Link, Outlet } from '@tanstack/react-router'
+import { Link, Outlet, createFileRoute } from '@tanstack/react-router'
 
 export type PostType = {
   id: string
@@ -7,7 +7,7 @@ export type PostType = {
   body: string
 }
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/posts')({
   loader: async () => {
     console.info('Fetching posts...')
     await new Promise((r) =>


### PR DESCRIPTION
The react basic-ssr-streaming-file-based example is a bit outdated and no longer working.

This fix updates the server.js and entry-server.tsx to match those of the basic-ssr-file-based example as these were using the new createRequestHandler and defaultStreamHandler.

This also addresses an issue with the index route where the deferred value is causing an error when accessing the getDate() function. The value when streamed in is not being transformed back into a date. I assume this will be addressed with the serializer re-write/seroval but until then this at least allows the example to run.