### PR TITLE
fix: replace backslashes in full paths when generating route nodes

### DIFF
--- a/packages/router-generator/src/filesystem/physical/getRouteNodes.ts
+++ b/packages/router-generator/src/filesystem/physical/getRouteNodes.ts
@@ -115,7 +115,7 @@ export async function getRouteNodes(
 
     await Promise.all(
       dirList.map(async (dirent) => {
-        const fullPath = path.posix.join(fullDir, dirent.name)
+        const fullPath = replaceBackslash(path.join(fullDir, dirent.name))
         const relativePath = path.posix.join(dir, dirent.name)
 
         if (dirent.isDirectory()) {

--- a/packages/router-generator/src/filesystem/virtual/getRouteNodes.ts
+++ b/packages/router-generator/src/filesystem/virtual/getRouteNodes.ts
@@ -3,6 +3,7 @@ import {
   removeExt,
   removeLeadingSlash,
   removeTrailingSlash,
+  replaceBackslash,
   routePathToVariable,
 } from '../../utils'
 import { getRouteNodes as getRouteNodesPhysical } from '../physical/getRouteNodes'
@@ -70,7 +71,7 @@ export async function getRouteNodes(
   const allNodes = flattenTree({
     children,
     filePath: virtualRouteConfig.file,
-    fullPath: join(fullDir, virtualRouteConfig.file),
+    fullPath: replaceBackslash(join(fullDir, virtualRouteConfig.file)),
     variableName: 'root',
     routePath: `/${rootPathId}`,
     _fsRouteType: '__root',
@@ -163,7 +164,7 @@ export async function getRouteNodesRecursive(
       function getFile(file: string) {
         const filePath = file
         const variableName = routePathToVariable(removeExt(filePath))
-        const fullPath = join(fullDir, filePath)
+        const fullPath = replaceBackslash(join(fullDir, filePath))
         return { filePath, variableName, fullPath }
       }
       const parentRoutePath = removeTrailingSlash(parent?.routePath ?? '/')


### PR DESCRIPTION
Fixes https://github.com/TanStack/router/issues/4428

`path.posix.join` is not sufficient when the first argument is a path containing backslashes, for instance, joining `D:\\path` with `filename` results in `D:\\path/filename`.

**start-basic**
Before:
```
.tanstack/start/build/client-dist/.vite/manifest.json        0.38 kB │ gzip:  0.20 kB
.tanstack/start/build/client-dist/assets/app-DACsPwZv.css    7.33 kB │ gzip:  2.10 kB
.tanstack/start/build/client-dist/assets/main-C896_Nb9.js  283.11 kB │ gzip: 90.49 kB
```

After:
```
.tanstack/start/build/client-dist/.vite/manifest.json                       6.80 kB │ gzip:  0.85 kB
.tanstack/start/build/client-dist/assets/app-DACsPwZv.css                   7.33 kB │ gzip:  2.10 kB
.tanstack/start/build/client-dist/assets/posts._postId-zPBcgaYs.js          0.11 kB │ gzip:  0.12 kB
.tanstack/start/build/client-dist/assets/posts_._postId.deep-EeRi2084.js    0.11 kB │ gzip:  0.12 kB
.tanstack/start/build/client-dist/assets/PostError-DDivhtBO.js              0.11 kB │ gzip:  0.11 kB
.tanstack/start/build/client-dist/assets/route-b-JZ50lMR2.js                0.12 kB │ gzip:  0.14 kB
.tanstack/start/build/client-dist/assets/route-a-BR6e2HVr.js                0.12 kB │ gzip:  0.14 kB
.tanstack/start/build/client-dist/assets/users._userId-BlXFTeC_.js          0.13 kB │ gzip:  0.14 kB
.tanstack/start/build/client-dist/assets/posts._postId-TIIP_wcq.js          0.13 kB │ gzip:  0.14 kB
.tanstack/start/build/client-dist/assets/posts.index-jechJlPM.js            0.13 kB │ gzip:  0.14 kB
.tanstack/start/build/client-dist/assets/users._userId-CuFCnY0m.js          0.13 kB │ gzip:  0.13 kB
.tanstack/start/build/client-dist/assets/index-CUl_qRyG.js                  0.17 kB │ gzip:  0.16 kB
.tanstack/start/build/client-dist/assets/_pathlessLayout-BmL-VOG7.js        0.24 kB │ gzip:  0.19 kB
.tanstack/start/build/client-dist/assets/users.index-FELXzoue.js            0.25 kB │ gzip:  0.22 kB
.tanstack/start/build/client-dist/assets/posts_._postId.deep-XaANUuD8.js    0.41 kB │ gzip:  0.29 kB
.tanstack/start/build/client-dist/assets/users._userId-KCL7sOWj.js          0.44 kB │ gzip:  0.28 kB
.tanstack/start/build/client-dist/assets/_nested-layout-CVK6kKP9.js         0.44 kB │ gzip:  0.25 kB
.tanstack/start/build/client-dist/assets/posts._postId-BKotR883.js          0.49 kB │ gzip:  0.32 kB
.tanstack/start/build/client-dist/assets/users-D3dFUtdi.js                  0.60 kB │ gzip:  0.39 kB
.tanstack/start/build/client-dist/assets/posts-cTz7c0d1.js                  0.60 kB │ gzip:  0.39 kB
.tanstack/start/build/client-dist/assets/deferred-UX5XHwZ1.js               0.82 kB │ gzip:  0.39 kB
.tanstack/start/build/client-dist/assets/main-BPKm1-5B.js                 281.86 kB │ gzip: 90.63 kB
```

**basic-virtual-file-based**
Before:
```
dist/index.html                   0.39 kB │ gzip:  0.27 kB
dist/assets/index-CQTDupZg.css    6.10 kB │ gzip:  1.80 kB
dist/assets/index-DO5uNxpI.js   264.38 kB │ gzip: 84.32 kB
```

After:
```
dist/index.html                          0.39 kB │ gzip:  0.26 kB
dist/assets/index-CQTDupZg.css           6.10 kB │ gzip:  1.80 kB
dist/assets/index-CXBrw_JR.js            0.12 kB │ gzip:  0.13 kB
dist/assets/world-D9fNVQmH.js            0.13 kB │ gzip:  0.14 kB
dist/assets/b-C99UymLD.js                0.13 kB │ gzip:  0.14 kB
dist/assets/a-7m4UKESZ.js                0.13 kB │ gzip:  0.14 kB
dist/assets/posts-home-gDtMaVGa.js       0.13 kB │ gzip:  0.14 kB
dist/assets/universe-4ZnthVNa.js         0.13 kB │ gzip:  0.14 kB
dist/assets/posts-detail-Lnq84mbu.js     0.16 kB │ gzip:  0.14 kB
dist/assets/home-DDjv6BaC.js             0.17 kB │ gzip:  0.16 kB
dist/assets/posts-detail-CagXeWfG.js     0.20 kB │ gzip:  0.17 kB
dist/assets/first-layout-BQq53G4l.js     0.24 kB │ gzip:  0.19 kB
dist/assets/posts-detail-DLYR3d4T.js     0.37 kB │ gzip:  0.26 kB
dist/assets/route-DXjJZLwn.js            0.38 kB │ gzip:  0.23 kB
dist/assets/second-layout-DypPv_V3.js    0.48 kB │ gzip:  0.26 kB
dist/assets/posts-H1io-iFu.js            0.60 kB │ gzip:  0.39 kB
dist/assets/index-Bc0nKp7X.js          265.41 kB │ gzip: 85.11 kB
```