### PR TITLE
fix: correctly pass 'create' event to generator for rspack/webpack

### DIFF
--- a/packages/router-plugin/src/core/router-generator-plugin.ts
+++ b/packages/router-plugin/src/core/router-generator-plugin.ts
@@ -102,7 +102,7 @@ export const unpluginRouterGeneratorFactory: UnpluginFactory<
         const chokidar = await import('chokidar')
         handle = chokidar
           .watch(routesDirectoryPath, { ignoreInitial: true })
-          .on('add', generate)
+          .on('add', (file) => generate({ file, event: 'create' }))
 
         await generate()
       })
@@ -130,7 +130,7 @@ export const unpluginRouterGeneratorFactory: UnpluginFactory<
         const chokidar = await import('chokidar')
         handle = chokidar
           .watch(routesDirectoryPath, { ignoreInitial: true })
-          .on('add', generate)
+          .on('add', (file) => generate({ file, event: 'create' }))
 
         await generate()
       })


### PR DESCRIPTION
fixes #4437