### PR TITLE
docs: added missing middleware method chaining in context example

### DIFF
--- a/docs/start/framework/react/middleware.md
+++ b/docs/start/framework/react/middleware.md
@@ -136,12 +136,12 @@ const awesomeMiddleware = createMiddleware({ type: 'function' }).server(
   },
 )
 
-const loggingMiddleware = createMiddleware({ type: 'function' }).server(
-  async ({ next, context }) => {
+const loggingMiddleware = createMiddleware({ type: 'function' })
+  .middleware([awesomeMiddleware])
+  .server(async ({ next, context }) => {
     console.log('Is awesome?', context.isAwesome)
     return next()
-  },
-)
+  })
 ```
 
 ## Client-Side Logic


### PR DESCRIPTION
The example "[Providing context to the next middleware via next](https://tanstack.com/start/latest/docs/framework/react/middleware#providing-context-to-the-next-middleware-via-next)" was missing the middleware method chaining to provide the first middleware context to the second one