### PR TITLE
docs: use correct syntax for createFileRoute

### DIFF
--- a/docs/router/eslint/create-route-property-order.md
+++ b/docs/router/eslint/create-route-property-order.md
@@ -29,7 +29,7 @@ Examples of **incorrect** code for this rule:
 /* eslint "@tanstack/router/create-route-property-order": "warn" */
 import { createFileRoute } from '@tanstack/react-router'
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/path')({
   loader: async ({context}) => {
     await context.queryClient.ensureQueryData(getQueryOptions(context.hello)),
   },
@@ -43,7 +43,7 @@ Examples of **correct** code for this rule:
 /* eslint "@tanstack/router/create-route-property-order": "warn" */
 import { createFileRoute } from '@tanstack/react-router'
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/path')({
   beforeLoad: () => ({hello: 'world'}),
   loader: async ({context}) => {
     await context.queryClient.ensureQueryData(getQueryOptions(context.hello)),

--- a/docs/router/framework/react/api/router/createFileRouteFunction.md
+++ b/docs/router/framework/react/api/router/createFileRouteFunction.md
@@ -26,7 +26,7 @@ A new function that accepts a single argument of type [`RouteOptions`](../RouteO
 ```tsx
 import { createFileRoute } from '@tanstack/react-router'
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/')({
   loader: () => {
     return 'Hello World'
   },

--- a/docs/router/framework/react/api/router/retainSearchParamsFunction.md
+++ b/docs/router/framework/react/api/router/retainSearchParamsFunction.md
@@ -39,7 +39,7 @@ const searchSchema = z.object({
   two: z.string().optional(),
 })
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/')({
   validateSearch: zodValidator(searchSchema),
   search: {
     middlewares: [retainSearchParams(true)],

--- a/docs/router/framework/react/api/router/stripSearchParamsFunction.md
+++ b/docs/router/framework/react/api/router/stripSearchParamsFunction.md
@@ -30,7 +30,7 @@ const searchSchema = z.object({
   two: z.string().default(defaultValues.two),
 })
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/')({
   validateSearch: zodValidator(searchSchema),
   search: {
     // strip default values
@@ -68,7 +68,7 @@ const searchSchema = z.object({
   two: z.string().default('xyz'),
 })
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/')({
   validateSearch: zodValidator(searchSchema),
   search: {
     // remove all search params

--- a/docs/router/framework/react/decisions-on-dx.md
+++ b/docs/router/framework/react/decisions-on-dx.md
@@ -225,7 +225,7 @@ Let's take a look at how the route configuration for the previous example would 
 // src/routes/posts/index.ts
 import { createFileRoute } from '@tanstack/react-router'
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/posts/')({
   component: () => 'Posts index component goes here!!!',
 })
 ```

--- a/docs/router/framework/react/guide/external-data-loading.md
+++ b/docs/router/framework/react/guide/external-data-loading.md
@@ -48,7 +48,7 @@ Here is a naive illustration (don't do this) of using a Route's `loader` option 
 // src/routes/posts.tsx
 let postsCache = []
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/posts')({
   loader: async () => {
     postsCache = await fetchPosts()
   },
@@ -80,7 +80,7 @@ const postsQueryOptions = queryOptions({
   queryFn: () => fetchPosts(),
 })
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/posts')({
   // Use the `loader` option to ensure that the data is loaded
   loader: () => queryClient.ensureQueryData(postsQueryOptions),
   component: () => {
@@ -105,7 +105,7 @@ export const Route = createFileRoute({
 When an error occurs while using `suspense` with `Tanstack Query`, you'll need to let queries know that you want to try again when re-rendering. This can be done by using the `reset` function provided by the `useQueryErrorResetBoundary` hook. We can invoke this function in an effect as soon as the error component mounts. This will make sure that the query is reset and will try to fetch data again when the route component is rendered again. This will also cover cases where users navigate away from our route instead of clicking the `retry` button.
 
 ```tsx
-export const Route = createFileRoute({
+export const Route = createFileRoute('/')({
   loader: () => queryClient.ensureQueryData(postsQueryOptions),
   errorComponent: ({ error, reset }) => {
     const router = useRouter()

--- a/docs/router/framework/react/guide/router-context.md
+++ b/docs/router/framework/react/guide/router-context.md
@@ -92,7 +92,7 @@ Once you have defined the router context type, you can use it in your route defi
 
 ```tsx
 // src/routes/todos.tsx
-export const Route = createFileRoute({
+export const Route = createFileRoute('/todos')({
   component: Todos,
   loader: ({ context }) => fetchTodosByUserId(context.user.id),
 })
@@ -122,7 +122,7 @@ Then, in your route:
 
 ```tsx
 // src/routes/todos.tsx
-export const Route = createFileRoute({
+export const Route = createFileRoute('/todos')({
   component: Todos,
   loader: ({ context }) => context.fetchTodosByUserId(context.userId),
 })
@@ -158,7 +158,7 @@ Then, in your route:
 
 ```tsx
 // src/routes/todos.tsx
-export const Route = createFileRoute({
+export const Route = createFileRoute('/todos')({
   component: Todos,
   loader: async ({ context }) => {
     await context.queryClient.ensureQueryData({
@@ -234,7 +234,7 @@ So, now in our route's `loader` function, we can access the `networkStrength` ho
 ```tsx
 import { createFileRoute } from '@tanstack/react-router'
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/posts')({
   component: Posts,
   loader: ({ context }) => {
     if (context.networkStrength === 'STRONG') {
@@ -282,7 +282,7 @@ const router = createRouter({
 ```tsx
 import { createFileRoute } from '@tanstack/react-router'
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/todos')({
   component: Todos,
   beforeLoad: () => {
     return {

--- a/docs/router/framework/react/migrate-from-react-location.md
+++ b/docs/router/framework/react/migrate-from-react-location.md
@@ -112,7 +112,7 @@ export const Route = createRootRoute({
 // src/routes/index.tsx
 import { createFileRoute } from '@tanstack/react-router'
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/')({
   component: Index,
 })
 ```
@@ -125,7 +125,7 @@ export const Route = createFileRoute({
 // src/routes/posts.tsx
 import { createFileRoute, Link, Outlet } from '@tanstack/react-router'
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/posts')({
   component: Posts,
   loader: async () => {
     const posts = await fetchPosts()
@@ -164,7 +164,7 @@ function Posts() {
 // src/routes/posts.index.tsx
 import { createFileRoute } from '@tanstack/react-router'
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/posts/')({
   component: PostsIndex,
 })
 ```
@@ -177,7 +177,7 @@ export const Route = createFileRoute({
 // src/routes/posts.$postId.tsx
 import { createFileRoute } from '@tanstack/react-router'
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/posts/$postId')({
   component: PostsId,
   loader: async ({ params: { postId } }) => {
     const post = await fetchPost(postId)

--- a/docs/router/framework/react/routing/routing-concepts.md
+++ b/docs/router/framework/react/routing/routing-concepts.md
@@ -13,7 +13,7 @@ All other routes, other than the [Root Route](#the-root-route), are configured u
 ```tsx
 import { createFileRoute } from '@tanstack/react-router'
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/')({
   component: PostsComponent,
 })
 ```
@@ -71,7 +71,7 @@ Let's take a look at an `/about` route:
 // about.tsx
 import { createFileRoute } from '@tanstack/react-router'
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/about')({
   component: AboutComponent,
 })
 
@@ -93,7 +93,7 @@ Let's take a look at an index route for a `/posts` URL:
 import { createFileRoute } from '@tanstack/react-router'
 
 // Note the trailing slash, which is used to target index routes
-export const Route = createFileRoute({
+export const Route = createFileRoute('/posts/')({
   component: PostsIndexComponent,
 })
 
@@ -113,7 +113,7 @@ These params are then usable in your route's configuration and components! Let's
 ```tsx
 import { createFileRoute } from '@tanstack/react-router'
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/posts/$postId')({
   // In a loader
   loader: ({ params }) => fetchPost(params.postId),
   // Or in a component
@@ -172,7 +172,7 @@ This tree structure is used to wrap the child routes with a layout component:
 ```tsx
 import { Outlet, createFileRoute } from '@tanstack/react-router'
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/app')({
   component: AppLayoutComponent,
 })
 
@@ -243,7 +243,7 @@ The `_pathlessLayout.tsx` route is used to wrap the child routes with a Pathless
 ```tsx
 import { Outlet, createFileRoute } from '@tanstack/react-router'
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/_pathlessLayout')({
   component: PathlessLayoutComponent,
 })
 

--- a/docs/start/framework/react/migrate-from-next-js.md
+++ b/docs/start/framework/react/migrate-from-next-js.md
@@ -187,7 +187,7 @@ Instead of `page.tsx`, create an `index.tsx` file for the `/` route.
 
 ```tsx
 - export default function Home() { // [!code --]
-+ export const Route = createFileRoute({ // [!code ++]
++ export const Route = createFileRoute('/')({ // [!code ++]
 +   component: Home, // [!code ++]
 + }) // [!code ++]
 
@@ -283,7 +283,7 @@ Retrieving dynamic route parameters in TanStack Start is straightforward.
 - }: { // [!code --]
 -   params: Promise<{ slug: string }> // [!code --]
 - }) { // [!code --]
-+ export const Route = createFileRoute({ // [!code ++]
++ export const Route = createFileRoute('/app/posts/$slug')({ // [!code ++]
 +   component: Page, // [!code ++]
 + }) // [!code ++]
 
@@ -384,7 +384,7 @@ Add the following to `src/app/globals.css`:
 
 ```tsx
 - export default async function Page() { // [!code --]
-+ export const Route = createFileRoute({ // [!code ++]
++ export const Route = createFileRoute('/')({ // [!code ++]
 +   component: Page, // [!code ++]
 +   loader: async () => { // [!code ++]
 +     const res = await fetch('https://api.vercel.app/blog') // [!code ++]

--- a/docs/start/framework/react/server-routes.md
+++ b/docs/start/framework/react/server-routes.md
@@ -35,7 +35,7 @@ export const ServerRoute = createServerFileRoute().methods({
   },
 })
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/hello')({
   component: HelloComponent,
 })
 

--- a/docs/start/framework/solid/build-from-scratch.md
+++ b/docs/start/framework/solid/build-from-scratch.md
@@ -220,7 +220,7 @@ const updateCount = createServerFn({ method: 'POST' })
     await fs.promises.writeFile(filePath, `${count + data}`)
   })
 
-export const Route = createFileRoute({
+export const Route = createFileRoute('/')({
   component: Home,
   loader: async () => await getCount(),
 })


### PR DESCRIPTION
Some of the documentation was missing the path parameter for `createFileRoute`, which is required by default.

This PR adds those paths back, and tries to make it as relevant to the surrounding context as possible.

Fixes #4372