### PR TITLE
Added missing triple-slash directive for css imports

### DIFF
--- a/docs/start/framework/react/build-from-scratch.md
+++ b/docs/start/framework/react/build-from-scratch.md
@@ -155,6 +155,7 @@ Finally, we need to create the root of our application. This is the entry point 
 
 ```tsx
 // src/routes/__root.tsx
+/// <reference types="vite/client" />
 import type { ReactNode } from 'react'
 import {
   Outlet,


### PR DESCRIPTION
I added the missing triple-slash directive (present in examples but not on this page) to eliminate the error when importing CSS files. 