### PR TITLE
fix: use joinURL for entry routes in manifests

### DIFF
--- a/packages/start-plugin-core/src/start-manifest-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/start-manifest-plugin/plugin.ts
@@ -160,7 +160,7 @@ export function startManifestPlugin(opts: {
                 // Since this is the most important JS entry for the route,
                 // it should be moved to the front of the preloads so that
                 // it has the best chance of being loaded first.
-                preloads.unshift(path.join(APP_BASE, chunk.fileName))
+                preloads.unshift(joinURL(APP_BASE, chunk.fileName))
 
                 const cssAssetsList = getCSSRecursively(
                   chunk,

--- a/packages/start-plugin-core/src/start-manifest-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/start-manifest-plugin/plugin.ts
@@ -1,4 +1,3 @@
-import path from 'node:path'
 import { joinURL } from 'ufo'
 import { rootRouteId } from '@tanstack/router-core'
 import { VIRTUAL_MODULES } from '@tanstack/start-server-core'


### PR DESCRIPTION
The entry JS file is the only one using `path.join` instead of `joinURL` and that breaks if we're passing URLs (instead of paths like `/`) in Vite as `base`.

