### PR TITLE
fix: tanstack start workos example

### DIFF
--- a/examples/react/start-workos/src/routes/callback.tsx
+++ b/examples/react/start-workos/src/routes/callback.tsx
@@ -1,9 +1,9 @@
 import { createServerFileRoute } from '@tanstack/react-start/server';
-import { getConfig } from '../../../authkit/ssr/config';
-import { saveSession } from '../../../authkit/ssr/session';
-import { getWorkOS } from '../../../authkit/ssr/workos';
+import { getConfig } from '../authkit/ssr/config';
+import { saveSession } from '../authkit/ssr/session';
+import { getWorkOS } from '../authkit/ssr/workos';
 
-export const ServerRoute = createServerFileRoute('/api/auth/callback').methods({
+export const ServerRoute = createServerFileRoute('/callback').methods({
   GET: async ({ request }) => {
     const url = new URL(request.url);
     const code = url.searchParams.get('code');


### PR DESCRIPTION
The example README suggests you set your `WORKOS_REDIRECT_URI` to `localhost:3000/callback`, but then defines the actual callback route at `/api/auth/callback`. This breaks the redirect back from authentication on WorkOS Authkit.

There were two solutions, really:

1. Update the README to suggest the env be `localhost:3000/api/auth/callback`
2. Update the route location

Given that WorkOS's default value / the value in their docs is `/callback`, that seemed like the better route to take (pun intended).

The example now works for me.

