### PR TITLE
docs: improve wording for LLM assistance support in installation.md

### DIFF
--- a/docs/router/framework/react/installation.md
+++ b/docs/router/framework/react/installation.md
@@ -34,9 +34,9 @@ TypeScript is _optional_, but **HIGHLY** recommended! If you are using it, pleas
 > [!IMPORTANT]
 > We aim to support the last five minor versions of TypeScript. If you are using an older version, you may run into issues. Please upgrade to the latest version of TypeScript to ensure compatibility. We may drop support for older versions of TypeScript, outside of the range mentioned above, without warning in a minor or patch release.
 
-### Vibe Coding Support
+### LLM Assistance Support
 
-All of our documentation for TanStack React Router is integrated into the NPM module and can be easily installed as Vibe coding rules. You can integrate Vibe coding rules into the editor of your choice using [vibe-rules](https://www.npmjs.com/package/vibe-rules).
+All of our documentation for TanStack React Router is integrated into the NPM module and can be easily installed as LLM rules. You can integrate LLM rules into the editor of your choice using [vibe-rules](https://www.npmjs.com/package/vibe-rules).
 
 ```bash
 pnpm add -g vibe-rules


### PR DESCRIPTION
Taking into consideration that "vibe coding" has a specific meaning, for some people even a negative one, I think the way this section is currently written does it a disservice. 

So I switched the "vibe coding" description to refer to "LLM assistance", because that's what this is, in essence: LLM assistance, whether you are vibe coding or not.

