### PR TITLE
fix: set component return type to `any` by default

### DIFF
--- a/examples/react/navigation-blocking/src/main.tsx
+++ b/examples/react/navigation-blocking/src/main.tsx
@@ -130,7 +130,7 @@ const fooRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: 'foo/$id',
   validateSearch: (search) => ({ hello: search.hello }) as { hello: string },
-  component: () => <div>foo {fooRoute.useParams().id}</div>,
+  component: () => <>foo {fooRoute.useParams().id}</>,
 })
 
 const editor1Route = createRoute({
@@ -220,13 +220,6 @@ const router = createRouter({
   defaultPreload: 'intent',
   scrollRestoration: true,
 })
-
-// Register things for typesafety
-declare module '@tanstack/react-router' {
-  interface Register {
-    router: typeof router
-  }
-}
 
 const rootElement = document.getElementById('app')!
 

--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -284,11 +284,12 @@ export {
 } from './route'
 export type {
   AnyRootRoute,
-  SyncRouteComponent,
   AsyncRouteComponent,
   RouteComponent,
   ErrorRouteComponent,
   NotFoundRouteComponent,
+  DefaultRouteTypes,
+  RouteTypes,
 } from './route'
 
 export { createRouter, Router } from './router'

--- a/packages/react-router/src/route.tsx
+++ b/packages/react-router/src/route.tsx
@@ -542,19 +542,22 @@ export function createRouteMask<
   return opts as any
 }
 
-export type SyncRouteComponent<TProps> =
-  | React.FC<TProps>
-  | React.LazyExoticComponent<(props: TProps) => React.ReactNode>
+export interface DefaultRouteTypes<TProps> {
+  component:
+    | ((props: TProps) => any)
+    | React.LazyExoticComponent<(props: TProps) => any>
+}
+export interface RouteTypes<TProps> extends DefaultRouteTypes<TProps> {}
 
-export type AsyncRouteComponent<TProps> = SyncRouteComponent<TProps> & {
+export type AsyncRouteComponent<TProps> = RouteTypes<TProps>['component'] & {
   preload?: () => Promise<void>
 }
 
-export type RouteComponent<TProps = any> = AsyncRouteComponent<TProps>
+export type RouteComponent = AsyncRouteComponent<{}>
 
-export type ErrorRouteComponent = RouteComponent<ErrorComponentProps>
+export type ErrorRouteComponent = AsyncRouteComponent<ErrorComponentProps>
 
-export type NotFoundRouteComponent = SyncRouteComponent<NotFoundRouteProps>
+export type NotFoundRouteComponent = RouteTypes<NotFoundRouteProps>['component']
 
 export class NotFoundRoute<
   TParentRoute extends AnyRootRoute,

--- a/packages/solid-router/src/index.tsx
+++ b/packages/solid-router/src/index.tsx
@@ -291,7 +291,6 @@ export {
 export type {
   AnyRootRoute,
   SolidNode,
-  SyncRouteComponent,
   AsyncRouteComponent,
   RouteComponent,
   ErrorRouteComponent,

--- a/packages/solid-router/src/route.tsx
+++ b/packages/solid-router/src/route.tsx
@@ -488,17 +488,20 @@ export function createRouteMask<
 
 export type SolidNode = Solid.JSX.Element
 
-export type SyncRouteComponent<TProps> = (props: TProps) => Solid.JSX.Element
+export interface DefaultRouteTypes<TProps> {
+  component: (props: TProps) => any
+}
+export interface RouteTypes<TProps> extends DefaultRouteTypes<TProps> {}
 
-export type AsyncRouteComponent<TProps> = SyncRouteComponent<TProps> & {
+export type AsyncRouteComponent<TProps> = RouteTypes<TProps>['component'] & {
   preload?: () => Promise<void>
 }
 
-export type RouteComponent<TProps = any> = AsyncRouteComponent<TProps>
+export type RouteComponent = AsyncRouteComponent<{}>
 
-export type ErrorRouteComponent = RouteComponent<ErrorComponentProps>
+export type ErrorRouteComponent = AsyncRouteComponent<ErrorComponentProps>
 
-export type NotFoundRouteComponent = SyncRouteComponent<NotFoundRouteProps>
+export type NotFoundRouteComponent = RouteTypes<NotFoundRouteProps>['component']
 
 export class NotFoundRoute<
   TParentRoute extends AnyRootRoute,


### PR DESCRIPTION
TypeScript cannot infer the return type of a component if it directly (e.g. inside a fragment) returns route state.

```tsx
const fooRoute = createRoute({
  getParentRoute: () => rootRoute,
  path: 'foo/$id',
  validateSearch: (search) => ({ hello: search.hello }) as { hello: string },
  component: () => <>foo {fooRoute.useParams().id}</>,
})
```

This results in the following compiler error:

> 'component' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.ts(7023)

This commit reverts the change in #4528 that required the return type of a route component to be of `React.ReactNode` and uses `any` again.

Strict typing of the route components can be enabled via module augmentation:

```tsx
declare module '@tanstack/react-router' {
  interface RouteTypes<TProps> {
    component: React.FC<TProps>
  }
}
```

In the strict case, the above example compiles with an explicit return type annotation:

```tsx
const fooRoute = createRoute({
  getParentRoute: () => rootRoute,
  path: 'foo/$id',
  validateSearch: (search) => ({ hello: search.hello }) as { hello: string },
  component: () : React.JSX.Element => <>foo {fooRoute.useParams().id}</>,
})
```

fixes #4560