### PR TITLE
Fix hydration mismatch in production builds when using the Tailwind 4 Integration Guide

### DIFF
--- a/docs/start/framework/react/tailwind-integration.md
+++ b/docs/start/framework/react/tailwind-integration.md
@@ -44,7 +44,7 @@ You need to create a CSS file to configure Tailwind CSS instead of the configura
 
 ```css
 /* src/styles/app.css */
-@import 'tailwindcss';
+@import 'tailwindcss' source('../');
 ```
 
 ## Import the CSS file in your `__root.tsx` file


### PR DESCRIPTION
Fix hydration mismatch in production builds when using the Tailwind 4 Integration Guide

Added `source("../")` to the Tailwind import to explicitly set the base path for class detection.

### Problem
- Dev server runs from project root, production build runs from a different working directory
- This causes Tailwind to scan different file sets, generating different CSS content
- Different CSS content = different content hash = hydration mismatch

### Solution
```css
@import "tailwindcss" source("../");
```

The `source()` directive tells Tailwind to always scan from `../` relative to the CSS file location, regardless of the current working directory during build.

### What it points to
- In the Tailwind integration guide the path is relative to the CSS file location (`app/styles/app.css` → `app/src/`)

### References
- [Tailwind v4 - Setting your base path](https://tailwindcss.com/docs/detecting-classes-in-source-files#setting-your-base-path)
- [TanStack Start - Tailwind Integration](https://tanstack.com/start/latest/docs/framework/react/tailwind-integration/)
- [shadcn/ui - TanStack Start](https://ui.shadcn.com/docs/installation/tanstack)

Without this explicit path, builds from different working directories (CI/CD, Docker, monorepo tools) will produce inconsistent CSS output.

Mentioned in https://discord.com/channels/719702312431386674/1390062434038845521