### PR TITLE
fix(start-server-functions-server): add base path to the RPC URL

### DIFF
--- a/e2e/react-start/custom-basepath/src/routeTree.gen.ts
+++ b/e2e/react-start/custom-basepath/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { createServerRootRoute } from '@tanstack/react-start/server'
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as UsersRouteImport } from './routes/users'
 import { Route as PostsRouteImport } from './routes/posts'
+import { Route as LogoutRouteImport } from './routes/logout'
 import { Route as DeferredRouteImport } from './routes/deferred'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as UsersIndexRouteImport } from './routes/users.index'
@@ -33,6 +34,11 @@ const UsersRoute = UsersRouteImport.update({
 const PostsRoute = PostsRouteImport.update({
   id: '/posts',
   path: '/posts',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LogoutRoute = LogoutRouteImport.update({
+  id: '/logout',
+  path: '/logout',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DeferredRoute = DeferredRouteImport.update({
@@ -84,6 +90,7 @@ const ApiUsersIdServerRoute = ApiUsersIdServerRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/deferred': typeof DeferredRoute
+  '/logout': typeof LogoutRoute
   '/posts': typeof PostsRouteWithChildren
   '/users': typeof UsersRouteWithChildren
   '/posts/$postId': typeof PostsPostIdRoute
@@ -95,6 +102,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/deferred': typeof DeferredRoute
+  '/logout': typeof LogoutRoute
   '/posts/$postId': typeof PostsPostIdRoute
   '/users/$userId': typeof UsersUserIdRoute
   '/posts': typeof PostsIndexRoute
@@ -105,6 +113,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/deferred': typeof DeferredRoute
+  '/logout': typeof LogoutRoute
   '/posts': typeof PostsRouteWithChildren
   '/users': typeof UsersRouteWithChildren
   '/posts/$postId': typeof PostsPostIdRoute
@@ -118,6 +127,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/deferred'
+    | '/logout'
     | '/posts'
     | '/users'
     | '/posts/$postId'
@@ -129,6 +139,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/deferred'
+    | '/logout'
     | '/posts/$postId'
     | '/users/$userId'
     | '/posts'
@@ -138,6 +149,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/deferred'
+    | '/logout'
     | '/posts'
     | '/users'
     | '/posts/$postId'
@@ -150,6 +162,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   DeferredRoute: typeof DeferredRoute
+  LogoutRoute: typeof LogoutRoute
   PostsRoute: typeof PostsRouteWithChildren
   UsersRoute: typeof UsersRouteWithChildren
   PostsPostIdDeepRoute: typeof PostsPostIdDeepRoute
@@ -193,6 +206,13 @@ declare module '@tanstack/react-router' {
       path: '/posts'
       fullPath: '/posts'
       preLoaderRoute: typeof PostsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/logout': {
+      id: '/logout'
+      path: '/logout'
+      fullPath: '/logout'
+      preLoaderRoute: typeof LogoutRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/deferred': {
@@ -304,6 +324,7 @@ const ApiUsersServerRouteWithChildren = ApiUsersServerRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   DeferredRoute: DeferredRoute,
+  LogoutRoute: LogoutRoute,
   PostsRoute: PostsRouteWithChildren,
   UsersRoute: UsersRouteWithChildren,
   PostsPostIdDeepRoute: PostsPostIdDeepRoute,

--- a/e2e/react-start/custom-basepath/src/routes/logout.tsx
+++ b/e2e/react-start/custom-basepath/src/routes/logout.tsx
@@ -1,0 +1,32 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+import { createServerFn } from '@tanstack/react-start'
+
+const logoutFn = createServerFn({
+  method: 'POST',
+}).handler(async () => {
+  // do logout stuff here
+  throw redirect({
+    to: '/',
+  })
+})
+
+export const Route = createFileRoute('/logout')({
+  component: Home,
+})
+
+function Home() {
+  return (
+    <div className="p-2">
+      <h3>Logout Page</h3>
+      <p>
+        This form tests that server function URLs correctly include the app's
+        basepath. The form action should be '/custom/basepath/_serverFn/...' not
+        just '/_serverFn/...'
+      </p>
+      <form action={logoutFn.url} method="POST">
+        <input type="hidden" name="csrfToken" value="123abc" />
+        <button type="submit">Logout</button>
+      </form>
+    </div>
+  )
+}

--- a/e2e/react-start/custom-basepath/tests/navigation.spec.ts
+++ b/e2e/react-start/custom-basepath/tests/navigation.spec.ts
@@ -32,3 +32,16 @@ test('Should change title on client side navigation', async ({ page }) => {
 
   await expect(page).toHaveTitle('Posts page')
 })
+
+test('Server function URLs correctly include app basepath', async ({
+  page,
+}) => {
+  await page.goto('/logout')
+
+  const form = page.locator('form')
+  const actionUrl = await form.getAttribute('action')
+
+  expect(actionUrl).toBe(
+    '/custom/basepath/_serverFn/src_routes_logout_tsx--logoutFn_createServerFn_handler',
+  )
+})

--- a/packages/start-server-functions-server/src/index.ts
+++ b/packages/start-server-functions-server/src/index.ts
@@ -15,7 +15,10 @@ export const createServerRpc: CreateRpcFn = (
     '🚨splitImportFn required for the server functions server runtime, but was not provided.',
   )
 
-  const url = `/${sanitizeBase(serverBase)}/${functionId}`
+  const sanitizedAppBase = sanitizeBase(process.env.TSS_APP_BASE || '/')
+  const sanitizedServerBase = sanitizeBase(serverBase)
+
+  const url = `${sanitizedAppBase ? `/${sanitizedAppBase}` : ``}/${sanitizedServerBase}/${functionId}`
 
   return Object.assign(splitImportFn, {
     url,


### PR DESCRIPTION
Hi! This PR fixes a bug where server function urls are incorrect when the app uses a basePath.

## The Problem:

The `createServerRpc` function (on the server) was creating URLs without the base path. However, the `createClientRpc`
function (on the client) was including it.


https://github.com/TanStack/router/blob/b9f88c5426f3221ef5b43b11df35f8ba7d61042c/packages/start-server-functions-server/src/index.ts#L18

https://github.com/TanStack/router/blob/b9f88c5426f3221ef5b43b11df35f8ba7d61042c/packages/start-server-functions-client/src/index.ts#L9-L12


For example, with a base path of '/app':

- Server URL: /_serverFn/<function_id>
- Client URL: /app/_serverFn/<function_id>


`<form action={loginFn.url} method="POST">`
hydration error:
```
  <LoginPage>
    <div>
      <h1>
        <form
+         action="/app/_serverFn/src_routes_auth_login_tsx--loginFn_createServerFn_handler"
-         action="/_serverFn/src_routes_auth_login_tsx--loginFn_createServerFn_handler"
           method="POST"
        >
```

This difference caused two main problems:
- A hydration error
- Broken forms, because submitting a form would go to the wrong URL (without the /app prefix).


## The Solution:

I've updated `createServerRpc` to also use the base path when it creates the URL, just like the client version does.


File changed: packages/start-server-functions-server/src/index.ts


```ts
// Before
const url = `/${sanitizeBase(serverBase)}/${functionId}`

// After
const sanitizedAppBase = sanitizeBase(process.env.TSS_APP_BASE || '/')
const sanitizedServerBase = sanitizeBase(serverBase)

const url = `${sanitizedAppBase ? `/${sanitizedAppBase}` : ``}/${sanitizedServerBase}/${functionId}`
```


Now, both the client and server create the same correct URL.