### PR TITLE
fix(solid-router): prevent client effects running on server

### DIFF
--- a/packages/react-router/src/Matches.tsx
+++ b/packages/react-router/src/Matches.tsx
@@ -54,7 +54,7 @@ export function Matches() {
 
   const inner = (
     <ResolvedSuspense fallback={pendingElement}>
-      <Transitioner />
+      {!router.isServer && <Transitioner />}
       <MatchesInner />
     </ResolvedSuspense>
   )

--- a/packages/react-router/src/Transitioner.tsx
+++ b/packages/react-router/src/Transitioner.tsx
@@ -30,14 +30,12 @@ export function Transitioner() {
   const isPagePending = isLoading || hasPendingMatches
   const previousIsPagePending = usePrevious(isPagePending)
 
-  if (!router.isServer) {
-    router.startTransition = (fn: () => void) => {
-      setIsTransitioning(true)
-      React.startTransition(() => {
-        fn()
-        setIsTransitioning(false)
-      })
-    }
+  router.startTransition = (fn: () => void) => {
+    setIsTransitioning(true)
+    React.startTransition(() => {
+      fn()
+      setIsTransitioning(false)
+    })
   }
 
   // Subscribe to location changes

--- a/packages/solid-router/package.json
+++ b/packages/solid-router/package.json
@@ -33,7 +33,7 @@
     "test:types:ts56": "node ../../node_modules/typescript56/lib/tsc.js -p tsconfig.legacy.json",
     "test:types:ts57": "node ../../node_modules/typescript57/lib/tsc.js -p tsconfig.legacy.json",
     "test:types:ts58": "tsc -p tsconfig.legacy.json",
-    "test:unit": "vitest",
+    "test:unit": "vitest && vitest --mode server",
     "test:unit:dev": "pnpm run test:unit --watch --hideSkippedTests",
     "test:perf": "vitest bench",
     "test:perf:dev": "pnpm run test:perf --watch --hideSkippedTests",

--- a/packages/solid-router/src/Matches.tsx
+++ b/packages/solid-router/src/Matches.tsx
@@ -50,7 +50,7 @@ export function Matches() {
 
   const inner = (
     <ResolvedSuspense fallback={pendingElement}>
-      <Transitioner />
+      {!router.isServer && <Transitioner />}
       <MatchesInner />
     </ResolvedSuspense>
   )

--- a/packages/solid-router/src/Transitioner.tsx
+++ b/packages/solid-router/src/Transitioner.tsx
@@ -30,12 +30,10 @@ export function Transitioner() {
   const isPagePending = () => isLoading() || hasPendingMatches()
   const previousIsPagePending = usePrevious(isPagePending)
 
-  if (!router.isServer) {
-    router.startTransition = async (fn: () => void | Promise<void>) => {
-      setIsTransitioning(true)
-      await fn()
-      setIsTransitioning(false)
-    }
+  router.startTransition = async (fn: () => void | Promise<void>) => {
+    setIsTransitioning(true)
+    await fn()
+    setIsTransitioning(false)
   }
 
   // Subscribe to location changes
@@ -66,7 +64,6 @@ export function Transitioner() {
 
   // Try to load the initial location
   Solid.createRenderEffect(() => {
-    if (router.isServer) return
     Solid.untrack(() => {
       if (
         // if we are hydrating from SSR, loading is triggered in ssr-client
@@ -100,6 +97,7 @@ export function Transitioner() {
       },
     ),
   )
+
   Solid.createRenderEffect(
     Solid.on(
       [isPagePending, previousIsPagePending],

--- a/packages/solid-router/tests/server/Transitioner.test.tsx
+++ b/packages/solid-router/tests/server/Transitioner.test.tsx
@@ -1,15 +1,15 @@
 import { describe, expect, it, vi } from 'vitest'
-import { render, waitFor } from '@solidjs/testing-library'
+import { renderToStringAsync } from 'solid-js/web'
 import {
   createMemoryHistory,
   createRootRoute,
   createRoute,
   createRouter,
-} from '../src'
-import { RouterProvider } from '../src/RouterProvider'
+} from '../../src'
+import { RouterProvider } from '../../src/RouterProvider'
 
-describe('Transitioner', () => {
-  it('should call router.load() when Transitioner mounts on the client', async () => {
+describe('Transitioner (server)', () => {
+  it('should call router.load() only once when on the server', async () => {
     const loader = vi.fn()
     const rootRoute = createRootRoute()
     const indexRoute = createRoute({
@@ -25,6 +25,7 @@ describe('Transitioner', () => {
       history: createMemoryHistory({
         initialEntries: ['/'],
       }),
+      isServer: true,
     })
 
     // Mock router.load() to verify it gets called
@@ -32,13 +33,10 @@ describe('Transitioner', () => {
 
     await router.load()
 
-    render(() => <RouterProvider router={router} />)
+    await renderToStringAsync(() => <RouterProvider router={router} />)
 
-    // Wait for the createRenderEffect to run and call router.load()
-    await waitFor(() => {
-      expect(loadSpy).toHaveBeenCalledTimes(2)
-      expect(loader).toHaveBeenCalledTimes(1)
-    })
+    expect(loadSpy).toHaveBeenCalledTimes(1)
+    expect(loader).toHaveBeenCalledTimes(1)
 
     loadSpy.mockRestore()
   })

--- a/packages/solid-router/vite.config.ts
+++ b/packages/solid-router/vite.config.ts
@@ -4,22 +4,40 @@ import solid from 'vite-plugin-solid'
 import packageJson from './package.json'
 import type { ViteUserConfig } from 'vitest/config'
 
-const config = defineConfig({
-  plugins: [solid()] as ViteUserConfig['plugins'],
-  test: {
-    name: packageJson.name,
-    dir: './tests',
-    watch: false,
-    environment: 'jsdom',
-    typecheck: { enabled: true },
-    setupFiles: ['./tests/setupTests.tsx'],
-  },
+const config = defineConfig(({ mode }) => {
+  if (mode === 'server') {
+    return {
+      plugins: [solid({ ssr: true })] as ViteUserConfig['plugins'],
+      test: {
+        name: `${packageJson.name} (server)`,
+        dir: './tests/server',
+        watch: false,
+        environment: 'node',
+        typecheck: { enabled: true },
+      },
+    }
+  }
+
+  return {
+    plugins: [solid()] as ViteUserConfig['plugins'],
+    test: {
+      name: packageJson.name,
+      dir: './tests',
+      exclude: ['server'],
+      watch: false,
+      environment: 'jsdom',
+      typecheck: { enabled: true },
+      setupFiles: ['./tests/setupTests.tsx'],
+    },
+  }
 })
 
-export default mergeConfig(
-  config,
-  tanstackViteConfig({
-    entry: ['./src/index.tsx', './src/ssr/client.ts', './src/ssr/server.ts'],
-    srcDir: './src',
-  }),
+export default defineConfig((env) =>
+  mergeConfig(
+    config(env),
+    tanstackViteConfig({
+      entry: ['./src/index.tsx', './src/ssr/client.ts', './src/ssr/server.ts'],
+      srcDir: './src',
+    }),
+  ),
 )


### PR DESCRIPTION
This is exploration of the comment I posted on https://github.com/TanStack/router/pull/4574#issuecomment-3038862345.

Using `Solid.createRenderEffect` in SSR will execute the effects after the render takes place. To prevent server from doing meaningless work, we can use the `useLayoutEffect` utility function, which will make the server use `Solid.createEffect` instead, preventing such effects from being ran on server. Client side there are no differences as `Solid.createRenderEffect` is still used. This is closer to how it works in React version today.

To properly test this, we need true SSR with `environment: 'node'` and  `solidPlugin({ ssr: true })` in Vite, because:
1) `jsdom` environment provides `window`, which causes wrong branch in `useLayoutEffect` to be chosen. This is fixable by replacing `typeof window !== 'undefined'` check with `isServer` from `solid-js/web`, resulting in a marginally smaller client bundle, too (This was decided against in order to keep the code as similar to react-router). 
2) Without `ssr: true`, we do not have access to `renderToString`.

For now I added the SSR config to the same vite config via `--mode` switch. However I am unhappy with the way how now `package.json` script needs to launch vitest twice: `"test:unit": "vitest && vitest --mode server"`. Suggestions on better format or alternatives would be most welcome.