### PR TITLE
docs: remove somewhat incorrect statement from docs

### DIFF
--- a/docs/start/framework/react/overview.md
+++ b/docs/start/framework/react/overview.md
@@ -60,7 +60,6 @@ TanStack Start is perfect for you if you want to build a full-stack React applic
 
 TanStack Start is not for you if:
 
-- Your site will be 100% static
 - Your goal is a server-rendered site with zero JS or minimal client-side interactivity
 - You're looking for a React-Server-Component-first framework. (We'll support RSCs soon in our own awesome flavor!)
 


### PR DESCRIPTION
There's absolutely no reason not to use TanStack Start for purely static sites - it works great, and it means that if you then want to transition a codebase to being dynamically SSR, it requires zero work!