### PR TITLE
docs: Update tsr.config.json options link

### DIFF
--- a/docs/router/framework/react/migrate-from-react-location.md
+++ b/docs/router/framework/react/migrate-from-react-location.md
@@ -70,7 +70,7 @@ Create a `tsr.config.json` file in the root of your project with the following c
 }
 ```
 
-You can find the full list of options for the `tsr.config.json` file [here](../routing/file-based-routing.md#options).
+You can find the full list of options for the `tsr.config.json` file [here](../../../api/file-based-routing.md).
 
 ### Step 4: Create the routes directory
 


### PR DESCRIPTION
The link at for tsr.config.json found [in this section](https://tanstack.com/router/latest/docs/framework/react/migrate-from-react-location#differences-between-react-location-and-tanstack-router) points to [this page about file routing styles in the docs](https://tanstack.com/router/latest/docs/framework/react/routing/file-based-routing#options)

That doesn't seem right, when the `tsr.config.json` options are [found here](https://tanstack.com/router/latest/docs/api/file-based-routing)

I've followed the docs in the `tanstack.com` page and checked this link works as expected 😌


