### PR TITLE
fix(react-start-client): useServerFn returns a stable reference

### DIFF
--- a/packages/react-start-client/src/useServerFn.ts
+++ b/packages/react-start-client/src/useServerFn.ts
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import { isRedirect } from '@tanstack/router-core'
 import { useRouter } from '@tanstack/react-router'
 
@@ -6,22 +7,25 @@ export function useServerFn<T extends (...deps: Array<any>) => Promise<any>>(
 ): (...args: Parameters<T>) => ReturnType<T> {
   const router = useRouter()
 
-  return (async (...args: Array<any>) => {
-    try {
-      const res = await serverFn(...args)
+  return React.useCallback(
+    async (...args: Array<any>) => {
+      try {
+        const res = await serverFn(...args)
 
-      if (isRedirect(res)) {
-        throw res
+        if (isRedirect(res)) {
+          throw res
+        }
+
+        return res
+      } catch (err) {
+        if (isRedirect(err)) {
+          err.options._fromLocation = router.state.location
+          return router.navigate(router.resolveRedirect(err).options)
+        }
+
+        throw err
       }
-
-      return res
-    } catch (err) {
-      if (isRedirect(err)) {
-        err.options._fromLocation = router.state.location
-        return router.navigate(router.resolveRedirect(err).options)
-      }
-
-      throw err
-    }
-  }) as any
+    },
+    [router, serverFn],
+  ) as any
 }


### PR DESCRIPTION
Previously, `react-start-client`'s `useServerFn` would return a new handler function on every render. The handler is now wrapped in `useCallback`.

Returning a new handler function can lead to excessive re-renders. Developers usually expect hooks like this to return a stable value, so the behavior is surprising.

[Discussion in discord](https://discord.com/channels/719702312431386674/1393921652798001213/1393986769061675108) confirms we don't need to make an equivalent update to the solid client.

My first PR here, so I'm not sure if I followed conventions properly -- not sure if I need to make an issue to close here, or if this warrants an e2e or something. Just let me know :) 