### PR TITLE
fix: reset statusCode to 200 on navigation start

### DIFF
--- a/e2e/react-router/basic/src/main.tsx
+++ b/e2e/react-router/basic/src/main.tsx
@@ -8,6 +8,7 @@ import {
   createRoute,
   createRouter,
   redirect,
+  useRouterState,
 } from '@tanstack/react-router'
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
 import { NotFoundError, fetchPost, fetchPosts } from './posts'
@@ -27,6 +28,7 @@ const rootRoute = createRootRoute({
 })
 
 function RootComponent() {
+  const routerState = useRouterState()
   return (
     <>
       <div className="p-2 flex gap-2 text-lg border-b">
@@ -71,6 +73,7 @@ function RootComponent() {
           This Route Does Not Exist
         </Link>
       </div>
+      <div data-testid="status-code">{routerState.statusCode}</div>
       <Outlet />
       <TanStackRouterDevtools position="bottom-right" />
     </>

--- a/e2e/react-router/basic/tests/app.spec.ts
+++ b/e2e/react-router/basic/tests/app.spec.ts
@@ -45,3 +45,14 @@ test('Navigating to a post page with viewTransition types', async ({
   await page.getByRole('link', { name: 'sunt aut facere repe' }).click()
   await expect(page.getByRole('heading')).toContainText('sunt aut facere')
 })
+
+test('StatusCode should reset after visiting 404 route', async ({ page }) => {
+  await page.getByRole('link', { name: 'This Route Does Not Exist' }).click()
+  expect(page.getByTestId('status-code')).toContainText('404')
+
+  await page.getByRole('link', { name: 'Start Over' }).click()
+  expect(page.getByTestId('status-code')).toContainText('200')
+
+  await page.getByRole('link', { name: 'Posts', exact: true }).click()
+  expect(page.getByTestId('status-code')).toContainText('200')
+})

--- a/e2e/solid-router/basic/src/main.tsx
+++ b/e2e/solid-router/basic/src/main.tsx
@@ -8,6 +8,7 @@ import {
   createRootRoute,
   createRoute,
   createRouter,
+  useRouterState,
 } from '@tanstack/solid-router'
 import { TanStackRouterDevtools } from '@tanstack/solid-router-devtools'
 import { NotFoundError, fetchPost, fetchPosts } from './posts'
@@ -27,6 +28,7 @@ const rootRoute = createRootRoute({
 })
 
 function RootComponent() {
+  const routerState = useRouterState()
   return (
     <>
       <HeadContent />
@@ -72,6 +74,7 @@ function RootComponent() {
           This Route Does Not Exist
         </Link>
       </div>
+      <div data-testid="status-code">{routerState().statusCode}</div>
       <Outlet />
       <TanStackRouterDevtools position="bottom-right" />
     </>

--- a/e2e/solid-router/basic/tests/app.spec.ts
+++ b/e2e/solid-router/basic/tests/app.spec.ts
@@ -45,3 +45,14 @@ test('Navigating to a post page with viewTransition types', async ({
   await page.getByRole('link', { name: 'sunt aut facere repe' }).click()
   await expect(page.getByRole('heading')).toContainText('sunt aut facere')
 })
+
+test('StatusCode should reset after visiting 404 route', async ({ page }) => {
+  await page.getByRole('link', { name: 'This Route Does Not Exist' }).click()
+  expect(page.getByTestId('status-code')).toContainText('404')
+
+  await page.getByRole('link', { name: 'Start Over' }).click()
+  expect(page.getByTestId('status-code')).toContainText('200')
+
+  await page.getByRole('link', { name: 'Posts', exact: true }).click()
+  expect(page.getByTestId('status-code')).toContainText('200')
+})

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1796,6 +1796,7 @@ export class RouterCore<
     this.__store.setState((s) => ({
       ...s,
       status: 'pending',
+      statusCode: 200,
       isLoading: true,
       location: this.latestLocation,
       pendingMatches,


### PR DESCRIPTION
fix #4663 

The problem appears to be that statusCode isn't reset to 200 at the beginning of navigation, causing 404 to persist across subsequent navigations.