### PR TITLE
fix(router-devtools-core): allow styling of TanStackRouterDevtoolsPanel

### DIFF
--- a/examples/react/basic-devtools-panel/src/main.tsx
+++ b/examples/react/basic-devtools-panel/src/main.tsx
@@ -12,6 +12,7 @@ import {
   createRootRoute,
 } from '@tanstack/react-router'
 import { TanStackRouterDevtoolsPanel } from '@tanstack/react-router-devtools'
+import './styles.css'
 
 const rootRoute = createRootRoute({
   component: () => (

--- a/packages/router-devtools-core/src/TanStackRouterDevtoolsPanelCore.tsx
+++ b/packages/router-devtools-core/src/TanStackRouterDevtoolsPanelCore.tsx
@@ -49,7 +49,14 @@ class TanStackRouterDevtoolsPanelCore {
   #Component: any
 
   constructor(config: TanStackRouterDevtoolsPanelCoreOptions) {
-    const { router, routerState, shadowDOMTarget, setIsOpen, style, className } = config
+    const {
+      router,
+      routerState,
+      shadowDOMTarget,
+      setIsOpen,
+      style,
+      className,
+    } = config
 
     this.#router = createSignal(router)
     this.#routerState = createSignal(routerState)
@@ -145,7 +152,7 @@ class TanStackRouterDevtoolsPanelCore {
     if (options.style !== undefined) {
       this.setStyle(options.style)
     }
-    
+
     if (options.className !== undefined) {
       this.setClassName(options.className)
     }

--- a/packages/router-devtools-core/src/TanStackRouterDevtoolsPanelCore.tsx
+++ b/packages/router-devtools-core/src/TanStackRouterDevtoolsPanelCore.tsx
@@ -40,6 +40,8 @@ interface TanStackRouterDevtoolsPanelCoreOptions {
 class TanStackRouterDevtoolsPanelCore {
   #router: any
   #routerState: any
+  #style: any
+  #className: any
   #shadowDOMTarget?: ShadowRoot
   #isMounted = false
   #setIsOpen?: (isOpen: boolean) => void
@@ -47,10 +49,12 @@ class TanStackRouterDevtoolsPanelCore {
   #Component: any
 
   constructor(config: TanStackRouterDevtoolsPanelCoreOptions) {
-    const { router, routerState, shadowDOMTarget, setIsOpen } = config
+    const { router, routerState, shadowDOMTarget, setIsOpen, style, className } = config
 
     this.#router = createSignal(router)
     this.#routerState = createSignal(routerState)
+    this.#style = createSignal(style)
+    this.#className = createSignal(className)
     this.#shadowDOMTarget = shadowDOMTarget
     this.#setIsOpen = setIsOpen
   }
@@ -63,6 +67,8 @@ class TanStackRouterDevtoolsPanelCore {
     const dispose = render(() => {
       const [router] = this.#router
       const [routerState] = this.#routerState
+      const [style] = this.#style
+      const [className] = this.#className
       const shadowDOMTarget = this.#shadowDOMTarget
       const setIsOpen = this.#setIsOpen
 
@@ -89,6 +95,8 @@ class TanStackRouterDevtoolsPanelCore {
               routerState={routerState}
               shadowDOMTarget={shadowDOMTarget}
               setIsOpen={setIsOpen}
+              style={style}
+              className={className}
             />
           </DevtoolsOnCloseContext.Provider>
         </ShadowDomTargetContext.Provider>
@@ -115,6 +123,14 @@ class TanStackRouterDevtoolsPanelCore {
     this.#routerState[1](routerState)
   }
 
+  setStyle(style: any) {
+    this.#style[1](style)
+  }
+
+  setClassName(className: any) {
+    this.#className[1](className)
+  }
+
   setOptions(options: Partial<TanStackRouterDevtoolsPanelCoreOptions>) {
     if (options.shadowDOMTarget !== undefined) {
       this.#shadowDOMTarget = options.shadowDOMTarget
@@ -124,6 +140,14 @@ class TanStackRouterDevtoolsPanelCore {
     }
     if (options.routerState !== undefined) {
       this.setRouterState(options.routerState)
+    }
+
+    if (options.style !== undefined) {
+      this.setStyle(options.style)
+    }
+    
+    if (options.className !== undefined) {
+      this.setClassName(options.className)
     }
   }
 }


### PR DESCRIPTION
fixes #4670

It seems that style and className were not passed down to the underlying components in TanStackRouterDevtoolsPanelCore, preventing users from customizing the style of the panel