### PR TITLE
test(react-router) link: add re-render test for preload='viewport' IntersectionObserver

### DIFF
--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -4049,20 +4049,21 @@ describe('Link', () => {
 
   test('Router.preload="viewport", should trigger the IntersectionObserver\'s observe and disconnect methods', async () => {
     const rootRoute = createRootRoute()
+    const RouteComponent = () => {
+      const [count, setCount] = React.useState(0)
+      return (
+        <>
+          <h1>Index Heading</h1>
+          <output>{count}</output>
+          <button onClick={() => setCount((c) => c + 1)}>Render</button>
+          <Link to="/">Index Link</Link>
+        </>
+      )
+    }
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
       path: '/',
-      component: () => {
-        const [count, setCount] = React.useState(0)
-        return (
-          <>
-            <h1>Index Heading</h1>
-            <output>{count}</output>
-            <button onClick={() => setCount((c) => c + 1)}>Render</button>
-            <Link to="/">Index Link</Link>
-          </>
-        )
-      },
+      component: RouteComponent,
     })
 
     const router = createRouter({

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -4058,7 +4058,7 @@ describe('Link', () => {
           <>
             <h1>Index Heading</h1>
             <output>{count}</output>
-            <button onClick={() => setCount(c => c + 1)}>Render</button>
+            <button onClick={() => setCount((c) => c + 1)}>Render</button>
             <Link to="/">Index Link</Link>
           </>
         )

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -4052,12 +4052,17 @@ describe('Link', () => {
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
       path: '/',
-      component: () => (
-        <>
-          <h1>Index Heading</h1>
-          <Link to="/">Index Link</Link>
-        </>
-      ),
+      component: () => {
+        const [count, setCount] = React.useState(0)
+        return (
+          <>
+            <h1>Index Heading</h1>
+            <output>{count}</output>
+            <button onClick={() => setCount(c => c + 1)}>Render</button>
+            <Link to="/">Index Link</Link>
+          </>
+        )
+      },
     })
 
     const router = createRouter({
@@ -4076,6 +4081,17 @@ describe('Link', () => {
 
     expect(ioDisconnectMock).toBeCalled()
     expect(ioDisconnectMock).toBeCalledTimes(1) // since React.StrictMode is enabled it should have disconnected
+
+    const output = screen.getByRole('status')
+    expect(output).toHaveTextContent('0')
+
+    const button = screen.getByRole('button', { name: 'Render' })
+    fireEvent.click(button)
+    await waitFor(() => {
+      expect(output).toHaveTextContent('1')
+    })
+    expect(ioObserveMock).toBeCalledTimes(2) // it should not observe again
+    expect(ioDisconnectMock).toBeCalledTimes(1) // it should not disconnect again
   })
 
   test("Router.preload='render', should trigger the route loader on render", async () => {


### PR DESCRIPTION
This PR adds a test that would fail without https://github.com/TanStack/router/pull/4668

It doesn't test performance, but it does ensure `useIntersectionObserver` doesn't re-create an `IntersectionObserver` on every re-render. This already tests a lot of the memoization.

Dependency chain:

```
doPreload > preloadViewportIoCallback > useIntersectionObserver > useEffect
```