### PR TITLE
fix(react-router): preserve ref type in createLink with required interface properties

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -400,9 +400,12 @@ const composeHandlers =
     })
   }
 
-type UseLinkReactProps<TComp> = TComp extends React.ElementType
-  ? React.ComponentPropsWithRef<TComp>
-  : never
+type UseLinkReactProps<TComp> = TComp extends keyof React.JSX.IntrinsicElements
+  ? React.JSX.IntrinsicElements[TComp]
+  : TComp extends React.ComponentType<any>
+    ? React.ComponentPropsWithoutRef<TComp> &
+        React.RefAttributes<React.ComponentRef<TComp>>
+    : never
 
 export type UseLinkPropsOptions<
   TRouter extends AnyRouter = RegisteredRouter,

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -400,18 +400,9 @@ const composeHandlers =
     })
   }
 
-type UseLinkReactProps<TComp> = TComp extends keyof React.JSX.IntrinsicElements
-  ? React.JSX.IntrinsicElements[TComp]
-  : React.PropsWithoutRef<
-      TComp extends React.ComponentType<infer TProps> ? TProps : never
-    > &
-      React.RefAttributes<
-        TComp extends
-          | React.FC<{ ref: React.Ref<infer TRef> }>
-          | React.Component<{ ref: React.Ref<infer TRef> }>
-          ? TRef
-          : never
-      >
+type UseLinkReactProps<TComp> = TComp extends React.ElementType
+  ? React.ComponentPropsWithRef<TComp>
+  : never
 
 export type UseLinkPropsOptions<
   TRouter extends AnyRouter = RegisteredRouter,

--- a/packages/react-router/tests/link.test-d.tsx
+++ b/packages/react-router/tests/link.test-d.tsx
@@ -4040,6 +4040,25 @@ test('that createLink refs forward correctly', () => {
     .toEqualTypeOf<Parameters<typeof BasicLinkComponent>[0]['ref']>()
 })
 
+test('createLink should preserve correct ref type with required interface properties', () => {
+  interface MyLinkProps extends React.ComponentPropsWithRef<'a'> {
+    extra: unknown
+  }
+
+  const MyLink = React.forwardRef<HTMLAnchorElement, MyLinkProps>(
+    (props, ref) => {
+      return <a ref={ref} {...props} />
+    },
+  )
+
+  const CreatedLink = createLink(MyLink)
+
+  expectTypeOf(CreatedLink)
+    .parameter(0)
+    .toHaveProperty('ref')
+    .toEqualTypeOf<React.Ref<HTMLAnchorElement> | undefined>()
+})
+
 test('ResolveRelativePath', () => {
   expectTypeOf<ResolveRelativePath<'/', '/posts'>>().toEqualTypeOf<'/posts'>()
 


### PR DESCRIPTION
Fixes #4673

I a bit simplified the `UseLinkReactProps` to make more use of typing from React (and this simplification just fixes the bug)
Also added a test to check that the bug is no longer reproduced