### PR TITLE
feat(router-core) Path: performance improvements [PoC]

### DIFF
--- a/packages/react-router/tests/link.bench.tsx
+++ b/packages/react-router/tests/link.bench.tsx
@@ -75,117 +75,121 @@ describe.each([
   //   matchedParamId: 9999, // range from 0 to numberOfRoutes-1
   //   numberOfLinks: 15000,
   // },
-])('$name', { concurrent: false, sequential: true }, ({ numberOfRoutes, numberOfLinks, matchedParamId }) => {
-  const renderRouter = createRouterRenderer(numberOfRoutes)
+])(
+  '$name',
+  { concurrent: false, sequential: true },
+  ({ numberOfRoutes, numberOfLinks, matchedParamId }) => {
+    const renderRouter = createRouterRenderer(numberOfRoutes)
 
-  bench(
-    'hardcoded href',
-    () => {
-      const router = renderRouter(
-        Array.from({ length: numberOfLinks }).map((_, i) => (
-          <a key={i} href={`/params/${i}`}>
-            {i}
-          </a>
-        )),
-      )
-      render(<RouterProvider router={router} />)
-    },
-    { warmupIterations: 1 },
-  )
+    bench(
+      'hardcoded href',
+      () => {
+        const router = renderRouter(
+          Array.from({ length: numberOfLinks }).map((_, i) => (
+            <a key={i} href={`/params/${i}`}>
+              {i}
+            </a>
+          )),
+        )
+        render(<RouterProvider router={router} />)
+      },
+      { warmupIterations: 1 },
+    )
 
-  bench(
-    'interpolate path',
-    () => {
-      const router = renderRouter(
-        Array.from({ length: numberOfLinks }).map((_, i) => (
-          <InterpolatePathLink
-            key={i}
-            to={`/params/$param${Math.min(i, matchedParamId)}`}
-            params={{ [`param${Math.min(i, matchedParamId)}`]: i }}
-          >
-            {i}
-          </InterpolatePathLink>
-        )),
-      )
-      render(<RouterProvider router={router} />)
-    },
-    { warmupIterations: 1 },
-  )
+    bench(
+      'interpolate path',
+      () => {
+        const router = renderRouter(
+          Array.from({ length: numberOfLinks }).map((_, i) => (
+            <InterpolatePathLink
+              key={i}
+              to={`/params/$param${Math.min(i, matchedParamId)}`}
+              params={{ [`param${Math.min(i, matchedParamId)}`]: i }}
+            >
+              {i}
+            </InterpolatePathLink>
+          )),
+        )
+        render(<RouterProvider router={router} />)
+      },
+      { warmupIterations: 1 },
+    )
 
-  bench(
-    'build location',
-    () => {
-      const router = renderRouter(
-        Array.from({ length: numberOfLinks }).map((_, i) => (
-          <BuildLocationLink
-            key={i}
-            to={`/params/$param${Math.min(i, matchedParamId)}`}
-            params={{ [`param${Math.min(i, matchedParamId)}`]: i }}
-          >
-            {i}
-          </BuildLocationLink>
-        )),
-      )
-      render(<RouterProvider router={router} />)
-    },
-    { warmupIterations: 1 },
-  )
+    bench(
+      'build location',
+      () => {
+        const router = renderRouter(
+          Array.from({ length: numberOfLinks }).map((_, i) => (
+            <BuildLocationLink
+              key={i}
+              to={`/params/$param${Math.min(i, matchedParamId)}`}
+              params={{ [`param${Math.min(i, matchedParamId)}`]: i }}
+            >
+              {i}
+            </BuildLocationLink>
+          )),
+        )
+        render(<RouterProvider router={router} />)
+      },
+      { warmupIterations: 1 },
+    )
 
-  bench(
-    'link to absolute path',
-    () => {
-      const router = renderRouter(
-        Array.from({ length: numberOfLinks }).map((_, i) => (
-          <Link
-            key={i}
-            to={`/params/$param${Math.min(i, matchedParamId)}`}
-            params={{ [`param${Math.min(i, matchedParamId)}`]: i }}
-          >
-            {i}
-          </Link>
-        )),
-      )
-      render(<RouterProvider router={router} />)
-    },
-    { warmupIterations: 1 },
-  )
-
-  bench(
-    'link to relative path',
-    () => {
-      const router = renderRouter(
-        Array.from({ length: numberOfLinks }).map((_, i) => {
-          const to = `./params/$param${Math.min(i, matchedParamId)}`
-
-          return (
+    bench(
+      'link to absolute path',
+      () => {
+        const router = renderRouter(
+          Array.from({ length: numberOfLinks }).map((_, i) => (
             <Link
               key={i}
-              from="/"
-              to={to}
+              to={`/params/$param${Math.min(i, matchedParamId)}`}
               params={{ [`param${Math.min(i, matchedParamId)}`]: i }}
             >
               {i}
             </Link>
-          )
-        }),
-      )
-      render(<RouterProvider router={router} />)
-    },
-    { warmupIterations: 1 },
-  )
+          )),
+        )
+        render(<RouterProvider router={router} />)
+      },
+      { warmupIterations: 1 },
+    )
 
-  bench(
-    'link to current path',
-    () => {
-      const router = renderRouter(
-        Array.from({ length: numberOfLinks }).map((_, i) => (
-          <Link key={i} from="/" search={{ param: i }}>
-            {i}
-          </Link>
-        )),
-      )
-      render(<RouterProvider router={router} />)
-    },
-    { warmupIterations: 1 },
-  )
-})
+    bench(
+      'link to relative path',
+      () => {
+        const router = renderRouter(
+          Array.from({ length: numberOfLinks }).map((_, i) => {
+            const to = `./params/$param${Math.min(i, matchedParamId)}`
+
+            return (
+              <Link
+                key={i}
+                from="/"
+                to={to}
+                params={{ [`param${Math.min(i, matchedParamId)}`]: i }}
+              >
+                {i}
+              </Link>
+            )
+          }),
+        )
+        render(<RouterProvider router={router} />)
+      },
+      { warmupIterations: 1 },
+    )
+
+    bench(
+      'link to current path',
+      () => {
+        const router = renderRouter(
+          Array.from({ length: numberOfLinks }).map((_, i) => (
+            <Link key={i} from="/" search={{ param: i }}>
+              {i}
+            </Link>
+          )),
+        )
+        render(<RouterProvider router={router} />)
+      },
+      { warmupIterations: 1 },
+    )
+  },
+)

--- a/packages/react-router/tests/link.bench.tsx
+++ b/packages/react-router/tests/link.bench.tsx
@@ -10,7 +10,7 @@ import {
   interpolatePath,
   useRouter,
 } from '../src'
-import type { LinkProps } from '../src'
+import type { AnyRouter, LinkProps } from '../src'
 
 const createRouterRenderer =
   (routesCount: number) => (children: React.ReactNode) => {
@@ -37,8 +37,9 @@ const InterpolatePathLink = ({
   to,
   params,
   children,
-}: React.PropsWithChildren<LinkProps>) => {
-  const href = interpolatePath({ path: to, params }).interpolatedPath
+  router,
+}: React.PropsWithChildren<LinkProps> & { router: AnyRouter }) => {
+  const href = interpolatePath({ path: to, params, encodePathParam: router.encodePathParam }).interpolatedPath
   return <a href={href}>{children}</a>
 }
 
@@ -97,6 +98,7 @@ describe.each([
             key={i}
             to={`/params/$param${Math.min(i, matchedParamId)}`}
             params={{ [`param${Math.min(i, matchedParamId)}`]: i }}
+            router={router}
           >
             {i}
           </InterpolatePathLink>

--- a/packages/react-router/tests/link.bench.tsx
+++ b/packages/react-router/tests/link.bench.tsx
@@ -10,7 +10,7 @@ import {
   interpolatePath,
   useRouter,
 } from '../src'
-import type { AnyRouter, LinkProps } from '../src'
+import type { LinkProps } from '../src'
 
 const createRouterRenderer =
   (routesCount: number) => (children: React.ReactNode) => {
@@ -37,8 +37,8 @@ const InterpolatePathLink = ({
   to,
   params,
   children,
-  router,
-}: React.PropsWithChildren<LinkProps> & { router: AnyRouter }) => {
+}: React.PropsWithChildren<LinkProps>) => {
+  const router = useRouter()
   const href = interpolatePath({
     path: to,
     params,
@@ -75,7 +75,7 @@ describe.each([
   //   matchedParamId: 9999, // range from 0 to numberOfRoutes-1
   //   numberOfLinks: 15000,
   // },
-])('$name', ({ numberOfRoutes, numberOfLinks, matchedParamId }) => {
+])('$name', { concurrent: false, sequential: true }, ({ numberOfRoutes, numberOfLinks, matchedParamId }) => {
   const renderRouter = createRouterRenderer(numberOfRoutes)
 
   bench(
@@ -102,7 +102,6 @@ describe.each([
             key={i}
             to={`/params/$param${Math.min(i, matchedParamId)}`}
             params={{ [`param${Math.min(i, matchedParamId)}`]: i }}
-            router={router}
           >
             {i}
           </InterpolatePathLink>

--- a/packages/react-router/tests/link.bench.tsx
+++ b/packages/react-router/tests/link.bench.tsx
@@ -39,7 +39,11 @@ const InterpolatePathLink = ({
   children,
   router,
 }: React.PropsWithChildren<LinkProps> & { router: AnyRouter }) => {
-  const href = interpolatePath({ path: to, params, encodePathParam: router.encodePathParam }).interpolatedPath
+  const href = interpolatePath({
+    path: to,
+    params,
+    encodePathParam: router.encodePathParam,
+  }).interpolatedPath
   return <a href={href}>{children}</a>
 }
 

--- a/packages/router-core/src/index.ts
+++ b/packages/router-core/src/index.ts
@@ -96,7 +96,7 @@ export {
   removeTrailingSlash,
   exactPathTest,
   resolvePath,
-  parsePathname,
+  cachedParsePathname as parsePathname,
   interpolatePath,
   matchPathname,
   removeBasepath,

--- a/packages/router-core/src/path.ts
+++ b/packages/router-core/src/path.ts
@@ -9,10 +9,10 @@ export const SEGMENT_TYPE_OPTIONAL_PARAM = 3
 
 export interface Segment {
   type:
-  | typeof SEGMENT_TYPE_PATHNAME
-  | typeof SEGMENT_TYPE_PARAM
-  | typeof SEGMENT_TYPE_WILDCARD
-  | typeof SEGMENT_TYPE_OPTIONAL_PARAM
+    | typeof SEGMENT_TYPE_PATHNAME
+    | typeof SEGMENT_TYPE_PARAM
+    | typeof SEGMENT_TYPE_WILDCARD
+    | typeof SEGMENT_TYPE_OPTIONAL_PARAM
   value: string
   prefixSegment?: string
   suffixSegment?: string
@@ -323,9 +323,9 @@ export function parsePathname(pathname?: string): Array<Segment> {
         type: SEGMENT_TYPE_PATHNAME,
         value: part.includes('%25')
           ? part
-            .split('%25')
-            .map((segment) => decodeURI(segment))
-            .join('%25')
+              .split('%25')
+              .map((segment) => decodeURI(segment))
+              .join('%25')
           : decodeURI(part),
       }
     }),
@@ -364,7 +364,7 @@ interface InterpolatePathOptions {
   /**
    * Defaults to `encodeURIComponent`.
    * Using `pathParamsAllowedCharacters` will result in this function keeping some characters un-encoded in path params (e.g. '%40' -> '@')
-   * 
+   *
    * The router will use `router.encodePathParam` as the default `encodePathParam` function.
    */
   encodePathParam: (value: string) => string
@@ -479,7 +479,8 @@ export function interpolatePath({
 export function compileEncodePathParam(
   pathParamsAllowedCharacters?: Array<string>,
 ): (value: string) => string {
-  if (!pathParamsAllowedCharacters || pathParamsAllowedCharacters.length === 0) return encodeURIComponent
+  if (!pathParamsAllowedCharacters || pathParamsAllowedCharacters.length === 0)
+    return encodeURIComponent
   return new Function(
     'value',
     `return encodeURIComponent(value).${pathParamsAllowedCharacters.map((char) => `replaceAll('${encodeURIComponent(char)}', '${char}')`).join('.')}`,

--- a/packages/router-core/src/path.ts
+++ b/packages/router-core/src/path.ts
@@ -9,10 +9,10 @@ export const SEGMENT_TYPE_OPTIONAL_PARAM = 3
 
 export interface Segment {
   type:
-    | typeof SEGMENT_TYPE_PATHNAME
-    | typeof SEGMENT_TYPE_PARAM
-    | typeof SEGMENT_TYPE_WILDCARD
-    | typeof SEGMENT_TYPE_OPTIONAL_PARAM
+  | typeof SEGMENT_TYPE_PATHNAME
+  | typeof SEGMENT_TYPE_PARAM
+  | typeof SEGMENT_TYPE_WILDCARD
+  | typeof SEGMENT_TYPE_OPTIONAL_PARAM
   value: string
   prefixSegment?: string
   suffixSegment?: string
@@ -323,9 +323,9 @@ export function parsePathname(pathname?: string): Array<Segment> {
         type: SEGMENT_TYPE_PATHNAME,
         value: part.includes('%25')
           ? part
-              .split('%25')
-              .map((segment) => decodeURI(segment))
-              .join('%25')
+            .split('%25')
+            .map((segment) => decodeURI(segment))
+            .join('%25')
           : decodeURI(part),
       }
     }),
@@ -361,7 +361,12 @@ interface InterpolatePathOptions {
   params: Record<string, unknown>
   leaveWildcards?: boolean
   leaveParams?: boolean
-  // Defaults to `encodeURIComponent`. Using `pathParamsAllowedCharacters` will result in this function keeping some characters un-encoded in path params (e.g. '%40' -> '@')
+  /**
+   * Defaults to `encodeURIComponent`.
+   * Using `pathParamsAllowedCharacters` will result in this function keeping some characters un-encoded in path params (e.g. '%40' -> '@')
+   * 
+   * The router will use `router.encodePathParam` as the default `encodePathParam` function.
+   */
   encodePathParam: (value: string) => string
 }
 
@@ -472,12 +477,12 @@ export function interpolatePath({
 }
 
 export function compileEncodePathParam(
-  decodeCharMap?: Array<string>,
+  pathParamsAllowedCharacters?: Array<string>,
 ): (value: string) => string {
-  if (!decodeCharMap || decodeCharMap.length === 0) return encodeURIComponent
+  if (!pathParamsAllowedCharacters || pathParamsAllowedCharacters.length === 0) return encodeURIComponent
   return new Function(
     'value',
-    `return encodeURIComponent(value).${decodeCharMap.map((char) => `replaceAll('${encodeURIComponent(char)}', '${char}')`).join('.')}`,
+    `return encodeURIComponent(value).${pathParamsAllowedCharacters.map((char) => `replaceAll('${encodeURIComponent(char)}', '${char}')`).join('.')}`,
   ) as (value: string) => string
 }
 

--- a/packages/router-core/src/path.ts
+++ b/packages/router-core/src/path.ts
@@ -9,10 +9,10 @@ export const SEGMENT_TYPE_OPTIONAL_PARAM = 3
 
 export interface Segment {
   type:
-  | typeof SEGMENT_TYPE_PATHNAME
-  | typeof SEGMENT_TYPE_PARAM
-  | typeof SEGMENT_TYPE_WILDCARD
-  | typeof SEGMENT_TYPE_OPTIONAL_PARAM
+    | typeof SEGMENT_TYPE_PATHNAME
+    | typeof SEGMENT_TYPE_PARAM
+    | typeof SEGMENT_TYPE_WILDCARD
+    | typeof SEGMENT_TYPE_OPTIONAL_PARAM
   value: string
   prefixSegment?: string
   suffixSegment?: string
@@ -323,9 +323,9 @@ export function parsePathname(pathname?: string): Array<Segment> {
         type: SEGMENT_TYPE_PATHNAME,
         value: part.includes('%25')
           ? part
-            .split('%25')
-            .map((segment) => decodeURI(segment))
-            .join('%25')
+              .split('%25')
+              .map((segment) => decodeURI(segment))
+              .join('%25')
           : decodeURI(part),
       }
     }),
@@ -550,7 +550,11 @@ export function removeBasepath(
 export function matchByPath(
   basepath: string,
   from: string,
-  { to, fuzzy, caseSensitive }: Pick<MatchLocation, 'to' | 'caseSensitive' | 'fuzzy'>,
+  {
+    to,
+    fuzzy,
+    caseSensitive,
+  }: Pick<MatchLocation, 'to' | 'caseSensitive' | 'fuzzy'>,
 ): Record<string, string> | undefined {
   // check basepath first
   if (basepath !== '/' && !from.startsWith(basepath)) {
@@ -562,7 +566,9 @@ export function matchByPath(
   to = removeBasepath(basepath, `${to ?? '$'}`, caseSensitive)
 
   // Parse the from and to
-  const baseSegments = cachedParsePathname(from.startsWith('/') ? from : `/${from}`)
+  const baseSegments = cachedParsePathname(
+    from.startsWith('/') ? from : `/${from}`,
+  )
   const routeSegments = cachedParsePathname(to.startsWith('/') ? to : `/${to}`)
 
   const params: Record<string, string> = {}
@@ -588,10 +594,7 @@ function isMatch(
   let baseIndex = 0
   let routeIndex = 0
 
-  while (
-    baseIndex < baseSegments.length ||
-    routeIndex < routeSegments.length
-  ) {
+  while (baseIndex < baseSegments.length || routeIndex < routeSegments.length) {
     const baseSegment = baseSegments[baseIndex]
     const routeSegment = routeSegments[routeIndex]
 
@@ -614,17 +617,14 @@ function isMatch(
             return false
           }
         } else if (
-          routeSegment.value.toLowerCase() !==
-          baseSegment.value.toLowerCase()
+          routeSegment.value.toLowerCase() !== baseSegment.value.toLowerCase()
         ) {
           return false
         }
         baseIndex++
         routeIndex++
         continue
-      }
-
-      else if (routeSegment.type === SEGMENT_TYPE_PARAM) {
+      } else if (routeSegment.type === SEGMENT_TYPE_PARAM) {
         if (!baseSegment) {
           return false
         }
@@ -655,10 +655,7 @@ function isMatch(
             paramValue = paramValue.slice(prefix.length)
           }
           if (suffix && paramValue.endsWith(suffix)) {
-            paramValue = paramValue.slice(
-              0,
-              paramValue.length - suffix.length,
-            )
+            paramValue = paramValue.slice(0, paramValue.length - suffix.length)
           }
 
           _paramValue = decodeURIComponent(paramValue)
@@ -676,9 +673,7 @@ function isMatch(
 
         routeIndex++
         continue
-      }
-
-      else if (routeSegment.type === SEGMENT_TYPE_WILDCARD) {
+      } else if (routeSegment.type === SEGMENT_TYPE_WILDCARD) {
         // Capture all remaining segments for a wildcard
         const remainingBaseSegments = baseSegments.slice(baseIndex)
 
@@ -734,9 +729,7 @@ function isMatch(
         params['*'] = _splat
         params['_splat'] = _splat
         return true
-      }
-
-      else if (routeSegment.type === SEGMENT_TYPE_OPTIONAL_PARAM) {
+      } else if (routeSegment.type === SEGMENT_TYPE_OPTIONAL_PARAM) {
         // Optional parameters can be missing - don't fail the match
         if (!baseSegment) {
           // No base segment for optional param - skip this route segment
@@ -834,18 +827,12 @@ function isMatch(
     }
 
     // If we have base segments left but no route segments, it's not a match
-    if (
-      baseIndex < baseSegments.length &&
-      routeIndex >= routeSegments.length
-    ) {
+    if (baseIndex < baseSegments.length && routeIndex >= routeSegments.length) {
       return false
     }
 
     // If we have route segments left but no base segments, check if remaining are optional
-    if (
-      routeIndex < routeSegments.length &&
-      baseIndex >= baseSegments.length
-    ) {
+    if (routeIndex < routeSegments.length && baseIndex >= baseSegments.length) {
       // Check if all remaining route segments are optional
       for (let i = routeIndex; i < routeSegments.length; i++) {
         if (routeSegments[i]?.type !== SEGMENT_TYPE_OPTIONAL_PARAM) {

--- a/packages/router-core/src/path.ts
+++ b/packages/router-core/src/path.ts
@@ -388,7 +388,7 @@ export function interpolatePath({
     const value = params[key]
     const isValueString = typeof value === 'string'
 
-    if (['*', '_splat'].includes(key)) {
+    if (key === '*' || key === '_splat') {
       // the splat/catch-all routes shouldn't have the '/' encoded out
       return isValueString ? encodeURI(value) : value
     } else {
@@ -403,6 +403,10 @@ export function interpolatePath({
   const usedParams: Record<string, unknown> = {}
   const interpolatedPath = joinPaths(
     interpolatedPathSegments.map((segment) => {
+      if (segment.type === SEGMENT_TYPE_PATHNAME) {
+        return segment.value
+      }
+
       if (segment.type === SEGMENT_TYPE_WILDCARD) {
         usedParams._splat = params._splat
         const segmentPrefix = segment.prefixSegment || ''

--- a/packages/router-core/src/path.ts
+++ b/packages/router-core/src/path.ts
@@ -8,7 +8,11 @@ export const SEGMENT_TYPE_WILDCARD = 2
 export const SEGMENT_TYPE_OPTIONAL_PARAM = 3
 
 export interface Segment {
-  type: typeof SEGMENT_TYPE_PATHNAME | typeof SEGMENT_TYPE_PARAM | typeof SEGMENT_TYPE_WILDCARD | typeof SEGMENT_TYPE_OPTIONAL_PARAM
+  type:
+    | typeof SEGMENT_TYPE_PATHNAME
+    | typeof SEGMENT_TYPE_PARAM
+    | typeof SEGMENT_TYPE_WILDCARD
+    | typeof SEGMENT_TYPE_OPTIONAL_PARAM
   value: string
   prefixSegment?: string
   suffixSegment?: string
@@ -319,9 +323,9 @@ export function parsePathname(pathname?: string): Array<Segment> {
         type: SEGMENT_TYPE_PATHNAME,
         value: part.includes('%25')
           ? part
-            .split('%25')
-            .map((segment) => decodeURI(segment))
-            .join('%25')
+              .split('%25')
+              .map((segment) => decodeURI(segment))
+              .join('%25')
           : decodeURI(part),
       }
     }),
@@ -338,8 +342,13 @@ export function parsePathname(pathname?: string): Array<Segment> {
   return segments
 }
 
-const parsedPathnameCache = new Map<string | undefined, ReadonlyArray<Readonly<Segment>>>
-export function cachedParsePathname(pathname?: string): ReadonlyArray<Readonly<Segment>> {
+const parsedPathnameCache = new Map<
+  string | undefined,
+  ReadonlyArray<Readonly<Segment>>
+>()
+export function cachedParsePathname(
+  pathname?: string,
+): ReadonlyArray<Readonly<Segment>> {
   const cached = parsedPathnameCache.get(pathname)
   if (cached) return cached
   const computed = parsePathname(pathname)
@@ -462,11 +471,13 @@ export function interpolatePath({
   return { usedParams, interpolatedPath, isMissingParams }
 }
 
-export function compileEncodePathParam(decodeCharMap?: Array<string>): (value: string) => string {
+export function compileEncodePathParam(
+  decodeCharMap?: Array<string>,
+): (value: string) => string {
   if (!decodeCharMap || decodeCharMap.length === 0) return encodeURIComponent
   return new Function(
     'value',
-    `return encodeURIComponent(value).${decodeCharMap.map(char => `replaceAll('${encodeURIComponent(char)}', '${char}')`).join('.')}`
+    `return encodeURIComponent(value).${decodeCharMap.map((char) => `replaceAll('${encodeURIComponent(char)}', '${char}')`).join('.')}`,
   ) as (value: string) => string
 }
 
@@ -549,17 +560,23 @@ export function matchByPath(
   let routeSegments = cachedParsePathname(to)
 
   if (!from.startsWith('/')) {
-    baseSegments = [{
-      type: SEGMENT_TYPE_PATHNAME,
-      value: '/',
-    }, ...baseSegments]
+    baseSegments = [
+      {
+        type: SEGMENT_TYPE_PATHNAME,
+        value: '/',
+      },
+      ...baseSegments,
+    ]
   }
 
   if (!to.startsWith('/')) {
-    routeSegments = [{
-      type: SEGMENT_TYPE_PATHNAME,
-      value: '/',
-    }, ...routeSegments]
+    routeSegments = [
+      {
+        type: SEGMENT_TYPE_PATHNAME,
+        value: '/',
+      },
+      ...routeSegments,
+    ]
   }
 
   const params: Record<string, string> = {}

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -14,20 +14,19 @@ import {
   replaceEqualDeep,
 } from './utils'
 import {
+  SEGMENT_TYPE_OPTIONAL_PARAM,
+  SEGMENT_TYPE_PARAM,
+  SEGMENT_TYPE_WILDCARD,
+  cachedParsePathname,
   cleanPath,
+  compileEncodePathParam,
   interpolatePath,
   joinPaths,
   matchPathname,
-  cachedParsePathname,
   resolvePath,
   trimPath,
   trimPathLeft,
   trimPathRight,
-  SEGMENT_TYPE_PATHNAME,
-  SEGMENT_TYPE_PARAM,
-  SEGMENT_TYPE_WILDCARD,
-  SEGMENT_TYPE_OPTIONAL_PARAM,
-  compileEncodePathParam
 } from './path'
 import { isNotFound } from './not-found'
 import { setupScrollRestoration } from './scroll-restoration'
@@ -848,7 +847,7 @@ export class RouterCore<
 
     this.isServer = this.options.isServer ?? typeof document === 'undefined'
 
-    this.encodePathParam = compileEncodePAthParams(this.options.pathParamsAllowedCharacters)
+    this.encodePathParam = compileEncodePathParam(this.options.pathParamsAllowedCharacters)
 
     if (
       !this.basepath ||
@@ -1461,6 +1460,7 @@ export class RouterCore<
       const interpolatedNextTo = interpolatePath({
         path: nextTo,
         params: nextParams ?? {},
+        encodePathParam: this.encodePathParam,
       }).interpolatedPath
 
       const destRoutes = this.matchRoutes(

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -920,6 +920,9 @@ export class RouterCore<
       pathname: string,
       routePathname: string | undefined,
     ) => {
+      if (routePathname !== undefined && !this.routesByPath[routePathname]) {
+        routePathname = undefined
+      }
       if (!routePathname) {
         const cached = getMatchedRoutesCache.get(pathname)
         if (cached) return cached

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -847,7 +847,9 @@ export class RouterCore<
 
     this.isServer = this.options.isServer ?? typeof document === 'undefined'
 
-    this.encodePathParam = compileEncodePathParam(this.options.pathParamsAllowedCharacters)
+    this.encodePathParam = compileEncodePathParam(
+      this.options.pathParamsAllowedCharacters,
+    )
 
     if (
       !this.basepath ||
@@ -3317,12 +3319,14 @@ export function processRouteTree<TRouteLike extends RouteLike>({
       if (a.scores.length !== b.scores.length) {
         // Count optional parameters in each route
         const aOptionalCount = a.parsed.reduce(
-          (count, seg) => seg.type === SEGMENT_TYPE_OPTIONAL_PARAM ? count + 1 : count,
-          0
+          (count, seg) =>
+            seg.type === SEGMENT_TYPE_OPTIONAL_PARAM ? count + 1 : count,
+          0,
         )
         const bOptionalCount = b.parsed.reduce(
-          (count, seg) => seg.type === SEGMENT_TYPE_OPTIONAL_PARAM ? count + 1 : count,
-          0
+          (count, seg) =>
+            seg.type === SEGMENT_TYPE_OPTIONAL_PARAM ? count + 1 : count,
+          0,
         )
 
         // If different number of optional parameters, fewer optional parameters wins (more specific)

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -3240,7 +3240,7 @@ export function processRouteTree<TRouteLike extends RouteLike>({
 
     // Removes the leading slash if it is not the only remaining segment
     let skip = 0
-    while (skip < parsed.length && parsed[skip]?.value === '/') {
+    while (parsed.length > skip + 1 && parsed[skip]?.value === '/') {
       skip++
     }
     if (skip > 0) parsed = parsed.slice(skip)

--- a/packages/router-core/tests/optional-path-params-clean.test.ts
+++ b/packages/router-core/tests/optional-path-params-clean.test.ts
@@ -50,6 +50,7 @@ describe('Optional Path Parameters - Clean Comprehensive Tests', () => {
         const result = interpolatePath({
           path: '/posts/{-$category}',
           params: { category: 'tech' },
+          encodePathParam: encodeURIComponent
         })
         expect(result.interpolatedPath).toBe('/posts/tech')
       })
@@ -58,6 +59,7 @@ describe('Optional Path Parameters - Clean Comprehensive Tests', () => {
         const result = interpolatePath({
           path: '/posts/{-$category}',
           params: {},
+          encodePathParam: encodeURIComponent
         })
         expect(result.interpolatedPath).toBe('/posts')
       })
@@ -66,18 +68,21 @@ describe('Optional Path Parameters - Clean Comprehensive Tests', () => {
         const result1 = interpolatePath({
           path: '/posts/{-$category}/{-$slug}',
           params: { category: 'tech', slug: 'hello' },
+          encodePathParam: encodeURIComponent
         })
         expect(result1.interpolatedPath).toBe('/posts/tech/hello')
 
         const result2 = interpolatePath({
           path: '/posts/{-$category}/{-$slug}',
           params: { category: 'tech' },
+          encodePathParam: encodeURIComponent
         })
         expect(result2.interpolatedPath).toBe('/posts/tech')
 
         const result3 = interpolatePath({
           path: '/posts/{-$category}/{-$slug}',
           params: {},
+          encodePathParam: encodeURIComponent
         })
         expect(result3.interpolatedPath).toBe('/posts')
       })
@@ -86,12 +91,14 @@ describe('Optional Path Parameters - Clean Comprehensive Tests', () => {
         const result = interpolatePath({
           path: '/posts/{-$category}/user/$id',
           params: { category: 'tech', id: '123' },
+          encodePathParam: encodeURIComponent
         })
         expect(result.interpolatedPath).toBe('/posts/tech/user/123')
 
         const result2 = interpolatePath({
           path: '/posts/{-$category}/user/$id',
           params: { id: '123' },
+          encodePathParam: encodeURIComponent
         })
         expect(result2.interpolatedPath).toBe('/posts/user/123')
       })
@@ -148,12 +155,14 @@ describe('Optional Path Parameters - Clean Comprehensive Tests', () => {
       const result = interpolatePath({
         path: '/docs/{-$version}/$',
         params: { version: 'v1', _splat: 'guide/intro' },
+        encodePathParam: encodeURIComponent
       })
       expect(result.interpolatedPath).toBe('/docs/v1/guide/intro')
 
       const result2 = interpolatePath({
         path: '/docs/{-$version}/$',
         params: { _splat: 'guide/intro' },
+        encodePathParam: encodeURIComponent
       })
       expect(result2.interpolatedPath).toBe('/docs/guide/intro')
     })
@@ -165,6 +174,7 @@ describe('Optional Path Parameters - Clean Comprehensive Tests', () => {
       const result1 = interpolatePath({
         path: pattern,
         params: { env: 'prod', version: 'v2', id: '123', tab: 'settings' },
+        encodePathParam: encodeURIComponent
       })
       expect(result1.interpolatedPath).toBe(
         '/app/prod/api/v2/users/123/settings',
@@ -174,6 +184,7 @@ describe('Optional Path Parameters - Clean Comprehensive Tests', () => {
       const result2 = interpolatePath({
         path: pattern,
         params: { id: '123' },
+        encodePathParam: encodeURIComponent
       })
       expect(result2.interpolatedPath).toBe('/app/api/users/123')
 
@@ -181,6 +192,7 @@ describe('Optional Path Parameters - Clean Comprehensive Tests', () => {
       const result3 = interpolatePath({
         path: pattern,
         params: { env: 'dev', id: '456', tab: 'profile' },
+        encodePathParam: encodeURIComponent
       })
       expect(result3.interpolatedPath).toBe('/app/dev/api/users/456/profile')
     })

--- a/packages/router-core/tests/optional-path-params-clean.test.ts
+++ b/packages/router-core/tests/optional-path-params-clean.test.ts
@@ -50,7 +50,7 @@ describe('Optional Path Parameters - Clean Comprehensive Tests', () => {
         const result = interpolatePath({
           path: '/posts/{-$category}',
           params: { category: 'tech' },
-          encodePathParam: encodeURIComponent
+          encodePathParam: encodeURIComponent,
         })
         expect(result.interpolatedPath).toBe('/posts/tech')
       })
@@ -59,7 +59,7 @@ describe('Optional Path Parameters - Clean Comprehensive Tests', () => {
         const result = interpolatePath({
           path: '/posts/{-$category}',
           params: {},
-          encodePathParam: encodeURIComponent
+          encodePathParam: encodeURIComponent,
         })
         expect(result.interpolatedPath).toBe('/posts')
       })
@@ -68,21 +68,21 @@ describe('Optional Path Parameters - Clean Comprehensive Tests', () => {
         const result1 = interpolatePath({
           path: '/posts/{-$category}/{-$slug}',
           params: { category: 'tech', slug: 'hello' },
-          encodePathParam: encodeURIComponent
+          encodePathParam: encodeURIComponent,
         })
         expect(result1.interpolatedPath).toBe('/posts/tech/hello')
 
         const result2 = interpolatePath({
           path: '/posts/{-$category}/{-$slug}',
           params: { category: 'tech' },
-          encodePathParam: encodeURIComponent
+          encodePathParam: encodeURIComponent,
         })
         expect(result2.interpolatedPath).toBe('/posts/tech')
 
         const result3 = interpolatePath({
           path: '/posts/{-$category}/{-$slug}',
           params: {},
-          encodePathParam: encodeURIComponent
+          encodePathParam: encodeURIComponent,
         })
         expect(result3.interpolatedPath).toBe('/posts')
       })
@@ -91,14 +91,14 @@ describe('Optional Path Parameters - Clean Comprehensive Tests', () => {
         const result = interpolatePath({
           path: '/posts/{-$category}/user/$id',
           params: { category: 'tech', id: '123' },
-          encodePathParam: encodeURIComponent
+          encodePathParam: encodeURIComponent,
         })
         expect(result.interpolatedPath).toBe('/posts/tech/user/123')
 
         const result2 = interpolatePath({
           path: '/posts/{-$category}/user/$id',
           params: { id: '123' },
-          encodePathParam: encodeURIComponent
+          encodePathParam: encodeURIComponent,
         })
         expect(result2.interpolatedPath).toBe('/posts/user/123')
       })
@@ -155,14 +155,14 @@ describe('Optional Path Parameters - Clean Comprehensive Tests', () => {
       const result = interpolatePath({
         path: '/docs/{-$version}/$',
         params: { version: 'v1', _splat: 'guide/intro' },
-        encodePathParam: encodeURIComponent
+        encodePathParam: encodeURIComponent,
       })
       expect(result.interpolatedPath).toBe('/docs/v1/guide/intro')
 
       const result2 = interpolatePath({
         path: '/docs/{-$version}/$',
         params: { _splat: 'guide/intro' },
-        encodePathParam: encodeURIComponent
+        encodePathParam: encodeURIComponent,
       })
       expect(result2.interpolatedPath).toBe('/docs/guide/intro')
     })
@@ -174,7 +174,7 @@ describe('Optional Path Parameters - Clean Comprehensive Tests', () => {
       const result1 = interpolatePath({
         path: pattern,
         params: { env: 'prod', version: 'v2', id: '123', tab: 'settings' },
-        encodePathParam: encodeURIComponent
+        encodePathParam: encodeURIComponent,
       })
       expect(result1.interpolatedPath).toBe(
         '/app/prod/api/v2/users/123/settings',
@@ -184,7 +184,7 @@ describe('Optional Path Parameters - Clean Comprehensive Tests', () => {
       const result2 = interpolatePath({
         path: pattern,
         params: { id: '123' },
-        encodePathParam: encodeURIComponent
+        encodePathParam: encodeURIComponent,
       })
       expect(result2.interpolatedPath).toBe('/app/api/users/123')
 
@@ -192,7 +192,7 @@ describe('Optional Path Parameters - Clean Comprehensive Tests', () => {
       const result3 = interpolatePath({
         path: pattern,
         params: { env: 'dev', id: '456', tab: 'profile' },
-        encodePathParam: encodeURIComponent
+        encodePathParam: encodeURIComponent,
       })
       expect(result3.interpolatedPath).toBe('/app/dev/api/users/456/profile')
     })

--- a/packages/router-core/tests/optional-path-params-clean.test.ts
+++ b/packages/router-core/tests/optional-path-params-clean.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { interpolatePath, matchPathname, parsePathname, SEGMENT_TYPE_PATHNAME, SEGMENT_TYPE_OPTIONAL_PARAM } from '../src/path'
+import {
+  interpolatePath,
+  matchPathname,
+  parsePathname,
+  SEGMENT_TYPE_PATHNAME,
+  SEGMENT_TYPE_OPTIONAL_PARAM,
+} from '../src/path'
 
 describe('Optional Path Parameters - Clean Comprehensive Tests', () => {
   describe('Optional Dynamic Parameters {-$param}', () => {

--- a/packages/router-core/tests/optional-path-params-clean.test.ts
+++ b/packages/router-core/tests/optional-path-params-clean.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { interpolatePath, matchPathname, parsePathname } from '../src/path'
+import { interpolatePath, matchPathname, parsePathname, SEGMENT_TYPE_PATHNAME, SEGMENT_TYPE_OPTIONAL_PARAM } from '../src/path'
 
 describe('Optional Path Parameters - Clean Comprehensive Tests', () => {
   describe('Optional Dynamic Parameters {-$param}', () => {
@@ -7,34 +7,34 @@ describe('Optional Path Parameters - Clean Comprehensive Tests', () => {
       it('should parse single optional dynamic param', () => {
         const result = parsePathname('/posts/{-$category}')
         expect(result).toEqual([
-          { type: 'pathname', value: '/' },
-          { type: 'pathname', value: 'posts' },
-          { type: 'optional-param', value: '$category' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: 'posts' },
+          { type: SEGMENT_TYPE_OPTIONAL_PARAM, value: '$category' },
         ])
       })
 
       it('should parse multiple optional dynamic params', () => {
         const result = parsePathname('/posts/{-$category}/{-$slug}')
         expect(result).toEqual([
-          { type: 'pathname', value: '/' },
-          { type: 'pathname', value: 'posts' },
-          { type: 'optional-param', value: '$category' },
-          { type: 'optional-param', value: '$slug' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: 'posts' },
+          { type: SEGMENT_TYPE_OPTIONAL_PARAM, value: '$category' },
+          { type: SEGMENT_TYPE_OPTIONAL_PARAM, value: '$slug' },
         ])
       })
 
       it('should handle prefix/suffix with optional dynamic params', () => {
         const result = parsePathname('/api/v{-$version}/data')
         expect(result).toEqual([
-          { type: 'pathname', value: '/' },
-          { type: 'pathname', value: 'api' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: 'api' },
           {
-            type: 'optional-param',
+            type: SEGMENT_TYPE_OPTIONAL_PARAM,
             value: '$version',
             prefixSegment: 'v',
             suffixSegment: undefined,
           },
-          { type: 'pathname', value: 'data' },
+          { type: SEGMENT_TYPE_PATHNAME, value: 'data' },
         ])
       })
     })

--- a/packages/router-core/tests/optional-path-params.test.ts
+++ b/packages/router-core/tests/optional-path-params.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { interpolatePath, matchPathname, parsePathname } from '../src/path'
+import { interpolatePath, matchPathname, parsePathname, SEGMENT_TYPE_PATHNAME, SEGMENT_TYPE_OPTIONAL_PARAM, SEGMENT_TYPE_PARAM, SEGMENT_TYPE_WILDCARD } from '../src/path'
 import type { Segment as PathSegment } from '../src/path'
 
 describe('Optional Path Parameters', () => {
@@ -15,17 +15,17 @@ describe('Optional Path Parameters', () => {
         name: 'regular optional param',
         to: '/{-$slug}',
         expected: [
-          { type: 'pathname', value: '/' },
-          { type: 'optional-param', value: '$slug' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_OPTIONAL_PARAM, value: '$slug' },
         ],
       },
       {
         name: 'optional param with prefix',
         to: '/prefix{-$slug}',
         expected: [
-          { type: 'pathname', value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
           {
-            type: 'optional-param',
+            type: SEGMENT_TYPE_OPTIONAL_PARAM,
             value: '$slug',
             prefixSegment: 'prefix',
           },
@@ -35,9 +35,9 @@ describe('Optional Path Parameters', () => {
         name: 'optional param with suffix',
         to: '/{-$slug}suffix',
         expected: [
-          { type: 'pathname', value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
           {
-            type: 'optional-param',
+            type: SEGMENT_TYPE_OPTIONAL_PARAM,
             value: '$slug',
             suffixSegment: 'suffix',
           },
@@ -47,9 +47,9 @@ describe('Optional Path Parameters', () => {
         name: 'optional param with prefix and suffix',
         to: '/prefix{-$slug}suffix',
         expected: [
-          { type: 'pathname', value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
           {
-            type: 'optional-param',
+            type: SEGMENT_TYPE_OPTIONAL_PARAM,
             value: '$slug',
             prefixSegment: 'prefix',
             suffixSegment: 'suffix',
@@ -60,70 +60,70 @@ describe('Optional Path Parameters', () => {
         name: 'multiple optional params',
         to: '/posts/{-$category}/{-$slug}',
         expected: [
-          { type: 'pathname', value: '/' },
-          { type: 'pathname', value: 'posts' },
-          { type: 'optional-param', value: '$category' },
-          { type: 'optional-param', value: '$slug' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: 'posts' },
+          { type: SEGMENT_TYPE_OPTIONAL_PARAM, value: '$category' },
+          { type: SEGMENT_TYPE_OPTIONAL_PARAM, value: '$slug' },
         ],
       },
       {
         name: 'mixed required and optional params',
         to: '/users/$id/{-$tab}',
         expected: [
-          { type: 'pathname', value: '/' },
-          { type: 'pathname', value: 'users' },
-          { type: 'param', value: '$id' },
-          { type: 'optional-param', value: '$tab' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: 'users' },
+          { type: SEGMENT_TYPE_PARAM, value: '$id' },
+          { type: SEGMENT_TYPE_OPTIONAL_PARAM, value: '$tab' },
         ],
       },
       {
         name: 'optional param followed by required param',
         to: '/{-$category}/$slug',
         expected: [
-          { type: 'pathname', value: '/' },
-          { type: 'optional-param', value: '$category' },
-          { type: 'param', value: '$slug' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_OPTIONAL_PARAM, value: '$category' },
+          { type: SEGMENT_TYPE_PARAM, value: '$slug' },
         ],
       },
       {
         name: 'optional param with wildcard',
         to: '/docs/{-$version}/$',
         expected: [
-          { type: 'pathname', value: '/' },
-          { type: 'pathname', value: 'docs' },
-          { type: 'optional-param', value: '$version' },
-          { type: 'wildcard', value: '$' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: 'docs' },
+          { type: SEGMENT_TYPE_OPTIONAL_PARAM, value: '$version' },
+          { type: SEGMENT_TYPE_WILDCARD, value: '$' },
         ],
       },
       {
         name: 'complex path with all param types',
         to: '/api/{-$version}/users/$id/{-$tab}/$',
         expected: [
-          { type: 'pathname', value: '/' },
-          { type: 'pathname', value: 'api' },
-          { type: 'optional-param', value: '$version' },
-          { type: 'pathname', value: 'users' },
-          { type: 'param', value: '$id' },
-          { type: 'optional-param', value: '$tab' },
-          { type: 'wildcard', value: '$' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: 'api' },
+          { type: SEGMENT_TYPE_OPTIONAL_PARAM, value: '$version' },
+          { type: SEGMENT_TYPE_PATHNAME, value: 'users' },
+          { type: SEGMENT_TYPE_PARAM, value: '$id' },
+          { type: SEGMENT_TYPE_OPTIONAL_PARAM, value: '$tab' },
+          { type: SEGMENT_TYPE_WILDCARD, value: '$' },
         ],
       },
       {
         name: 'optional param at root',
         to: '/{-$slug}',
         expected: [
-          { type: 'pathname', value: '/' },
-          { type: 'optional-param', value: '$slug' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_OPTIONAL_PARAM, value: '$slug' },
         ],
       },
       {
         name: 'multiple consecutive optional params',
         to: '/{-$year}/{-$month}/{-$day}',
         expected: [
-          { type: 'pathname', value: '/' },
-          { type: 'optional-param', value: '$year' },
-          { type: 'optional-param', value: '$month' },
-          { type: 'optional-param', value: '$day' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_OPTIONAL_PARAM, value: '$year' },
+          { type: SEGMENT_TYPE_OPTIONAL_PARAM, value: '$month' },
+          { type: SEGMENT_TYPE_OPTIONAL_PARAM, value: '$day' },
         ],
       },
     ] satisfies ParsePathnameTestScheme)('$name', ({ to, expected }) => {

--- a/packages/router-core/tests/optional-path-params.test.ts
+++ b/packages/router-core/tests/optional-path-params.test.ts
@@ -292,7 +292,7 @@ describe('Optional Path Parameters', () => {
         result: '/posts/42',
       },
     ])('$name', ({ path, params, result }) => {
-      expect(interpolatePath({ path, params }).interpolatedPath).toBe(result)
+      expect(interpolatePath({ path, params, encodePathParam: encodeURIComponent }).interpolatedPath).toBe(result)
     })
   })
 
@@ -400,7 +400,7 @@ describe('Optional Path Parameters', () => {
       // This test will be expanded when we implement params.parse for optional params
       const path = '/posts/{-$category}'
       const params = { category: 'tech' }
-      expect(interpolatePath({ path, params }).interpolatedPath).toBe(
+      expect(interpolatePath({ path, params, encodePathParam: encodeURIComponent }).interpolatedPath).toBe(
         '/posts/tech',
       )
     })

--- a/packages/router-core/tests/optional-path-params.test.ts
+++ b/packages/router-core/tests/optional-path-params.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest'
-import { interpolatePath, matchPathname, parsePathname, SEGMENT_TYPE_PATHNAME, SEGMENT_TYPE_OPTIONAL_PARAM, SEGMENT_TYPE_PARAM, SEGMENT_TYPE_WILDCARD } from '../src/path'
+import {
+  interpolatePath,
+  matchPathname,
+  parsePathname,
+  SEGMENT_TYPE_PATHNAME,
+  SEGMENT_TYPE_OPTIONAL_PARAM,
+  SEGMENT_TYPE_PARAM,
+  SEGMENT_TYPE_WILDCARD,
+} from '../src/path'
 import type { Segment as PathSegment } from '../src/path'
 
 describe('Optional Path Parameters', () => {

--- a/packages/router-core/tests/optional-path-params.test.ts
+++ b/packages/router-core/tests/optional-path-params.test.ts
@@ -292,7 +292,10 @@ describe('Optional Path Parameters', () => {
         result: '/posts/42',
       },
     ])('$name', ({ path, params, result }) => {
-      expect(interpolatePath({ path, params, encodePathParam: encodeURIComponent }).interpolatedPath).toBe(result)
+      expect(
+        interpolatePath({ path, params, encodePathParam: encodeURIComponent })
+          .interpolatedPath,
+      ).toBe(result)
     })
   })
 
@@ -400,9 +403,10 @@ describe('Optional Path Parameters', () => {
       // This test will be expanded when we implement params.parse for optional params
       const path = '/posts/{-$category}'
       const params = { category: 'tech' }
-      expect(interpolatePath({ path, params, encodePathParam: encodeURIComponent }).interpolatedPath).toBe(
-        '/posts/tech',
-      )
+      expect(
+        interpolatePath({ path, params, encodePathParam: encodeURIComponent })
+          .interpolatedPath,
+      ).toBe('/posts/tech')
     })
 
     it('should handle multiple consecutive optional parameters correctly', () => {

--- a/packages/router-core/tests/path.test.ts
+++ b/packages/router-core/tests/path.test.ts
@@ -432,15 +432,18 @@ describe('interpolatePath', () => {
         params: { _splat: 'sean/cassiere' },
         result: '/users/sean/cassiere',
       },
-    ])('$name', ({ path, params, encodePathParam = encodeURIComponent, result }) => {
-      expect(
-        interpolatePath({
-          path,
-          params,
-          encodePathParam,
-        }).interpolatedPath,
-      ).toBe(result)
-    })
+    ])(
+      '$name',
+      ({ path, params, encodePathParam = encodeURIComponent, result }) => {
+        expect(
+          interpolatePath({
+            path,
+            params,
+            encodePathParam,
+          }).interpolatedPath,
+        ).toBe(result)
+      },
+    )
   })
 
   describe('wildcard (prefix + suffix)', () => {

--- a/packages/router-core/tests/path.test.ts
+++ b/packages/router-core/tests/path.test.ts
@@ -8,6 +8,10 @@ import {
   removeTrailingSlash,
   resolvePath,
   trimPathLeft,
+  SEGMENT_TYPE_PATHNAME,
+  SEGMENT_TYPE_PARAM,
+  SEGMENT_TYPE_WILDCARD,
+  SEGMENT_TYPE_OPTIONAL_PARAM,
 } from '../src/path'
 import type { Segment as PathSegment } from '../src/path'
 
@@ -852,89 +856,89 @@ describe('parsePathname', () => {
       {
         name: 'should handle pathname at root',
         to: '/',
-        expected: [{ type: 'pathname', value: '/' }],
+        expected: [{ type: SEGMENT_TYPE_PATHNAME, value: '/' }],
       },
       {
         name: 'should handle pathname with a single segment',
         to: '/foo',
         expected: [
-          { type: 'pathname', value: '/' },
-          { type: 'pathname', value: 'foo' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: 'foo' },
         ],
       },
       {
         name: 'should handle pathname with multiple segments',
         to: '/foo/bar/baz',
         expected: [
-          { type: 'pathname', value: '/' },
-          { type: 'pathname', value: 'foo' },
-          { type: 'pathname', value: 'bar' },
-          { type: 'pathname', value: 'baz' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: 'foo' },
+          { type: SEGMENT_TYPE_PATHNAME, value: 'bar' },
+          { type: SEGMENT_TYPE_PATHNAME, value: 'baz' },
         ],
       },
       {
         name: 'should handle pathname with a trailing slash',
         to: '/foo/',
         expected: [
-          { type: 'pathname', value: '/' },
-          { type: 'pathname', value: 'foo' },
-          { type: 'pathname', value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: 'foo' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
         ],
       },
       {
         name: 'should handle named params',
         to: '/foo/$bar',
         expected: [
-          { type: 'pathname', value: '/' },
-          { type: 'pathname', value: 'foo' },
-          { type: 'param', value: '$bar' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: 'foo' },
+          { type: SEGMENT_TYPE_PARAM, value: '$bar' },
         ],
       },
       {
         name: 'should handle named params at the root',
         to: '/$bar',
         expected: [
-          { type: 'pathname', value: '/' },
-          { type: 'param', value: '$bar' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_PARAM, value: '$bar' },
         ],
       },
       {
         name: 'should handle named params followed by a segment',
         to: '/foo/$bar/baz',
         expected: [
-          { type: 'pathname', value: '/' },
-          { type: 'pathname', value: 'foo' },
-          { type: 'param', value: '$bar' },
-          { type: 'pathname', value: 'baz' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: 'foo' },
+          { type: SEGMENT_TYPE_PARAM, value: '$bar' },
+          { type: SEGMENT_TYPE_PATHNAME, value: 'baz' },
         ],
       },
       {
         name: 'should handle multiple named params',
         to: '/foo/$bar/$baz/qux/$quux',
         expected: [
-          { type: 'pathname', value: '/' },
-          { type: 'pathname', value: 'foo' },
-          { type: 'param', value: '$bar' },
-          { type: 'param', value: '$baz' },
-          { type: 'pathname', value: 'qux' },
-          { type: 'param', value: '$quux' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: 'foo' },
+          { type: SEGMENT_TYPE_PARAM, value: '$bar' },
+          { type: SEGMENT_TYPE_PARAM, value: '$baz' },
+          { type: SEGMENT_TYPE_PATHNAME, value: 'qux' },
+          { type: SEGMENT_TYPE_PARAM, value: '$quux' },
         ],
       },
       {
         name: 'should handle splat params',
         to: '/foo/$',
         expected: [
-          { type: 'pathname', value: '/' },
-          { type: 'pathname', value: 'foo' },
-          { type: 'wildcard', value: '$' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: 'foo' },
+          { type: SEGMENT_TYPE_WILDCARD, value: '$' },
         ],
       },
       {
         name: 'should handle splat params at the root',
         to: '/$',
         expected: [
-          { type: 'pathname', value: '/' },
-          { type: 'wildcard', value: '$' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_WILDCARD, value: '$' },
         ],
       },
     ] satisfies ParsePathnameTestScheme)('$name', ({ to, expected }) => {
@@ -949,25 +953,25 @@ describe('parsePathname', () => {
         name: 'regular',
         to: '/$',
         expected: [
-          { type: 'pathname', value: '/' },
-          { type: 'wildcard', value: '$' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_WILDCARD, value: '$' },
         ],
       },
       {
         name: 'regular curly braces',
         to: '/{$}',
         expected: [
-          { type: 'pathname', value: '/' },
-          { type: 'wildcard', value: '$' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_WILDCARD, value: '$' },
         ],
       },
       {
         name: 'with prefix (regular text)',
         to: '/foo{$}',
         expected: [
-          { type: 'pathname', value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
           {
-            type: 'wildcard',
+            type: SEGMENT_TYPE_WILDCARD,
             value: '$',
             prefixSegment: 'foo',
           },
@@ -977,9 +981,9 @@ describe('parsePathname', () => {
         name: 'with prefix + followed by special character',
         to: '/foo.{$}',
         expected: [
-          { type: 'pathname', value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
           {
-            type: 'wildcard',
+            type: SEGMENT_TYPE_WILDCARD,
             value: '$',
             prefixSegment: 'foo.',
           },
@@ -989,9 +993,9 @@ describe('parsePathname', () => {
         name: 'with suffix',
         to: '/{$}-foo',
         expected: [
-          { type: 'pathname', value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
           {
-            type: 'wildcard',
+            type: SEGMENT_TYPE_WILDCARD,
             value: '$',
             suffixSegment: '-foo',
           },
@@ -1001,9 +1005,9 @@ describe('parsePathname', () => {
         name: 'with prefix + suffix',
         to: '/foo{$}-bar',
         expected: [
-          { type: 'pathname', value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
           {
-            type: 'wildcard',
+            type: SEGMENT_TYPE_WILDCARD,
             value: '$',
             prefixSegment: 'foo',
             suffixSegment: '-bar',
@@ -1014,13 +1018,13 @@ describe('parsePathname', () => {
         name: 'with prefix + followed by special character and a segment',
         to: '/foo.{$}/bar',
         expected: [
-          { type: 'pathname', value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
           {
-            type: 'wildcard',
+            type: SEGMENT_TYPE_WILDCARD,
             value: '$',
             prefixSegment: 'foo.',
           },
-          { type: 'pathname', value: 'bar' },
+          { type: SEGMENT_TYPE_PATHNAME, value: 'bar' },
         ],
       },
     ] satisfies ParsePathnameTestScheme)('$name', ({ to, expected }) => {
@@ -1035,25 +1039,25 @@ describe('parsePathname', () => {
         name: 'regular',
         to: '/$bar',
         expected: [
-          { type: 'pathname', value: '/' },
-          { type: 'param', value: '$bar' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_PARAM, value: '$bar' },
         ],
       },
       {
         name: 'regular curly braces',
         to: '/{$bar}',
         expected: [
-          { type: 'pathname', value: '/' },
-          { type: 'param', value: '$bar' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
+          { type: SEGMENT_TYPE_PARAM, value: '$bar' },
         ],
       },
       {
         name: 'with prefix (regular text)',
         to: '/foo{$bar}',
         expected: [
-          { type: 'pathname', value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
           {
-            type: 'param',
+            type: SEGMENT_TYPE_PARAM,
             value: '$bar',
             prefixSegment: 'foo',
           },
@@ -1063,9 +1067,9 @@ describe('parsePathname', () => {
         name: 'with prefix + followed by special character',
         to: '/foo.{$bar}',
         expected: [
-          { type: 'pathname', value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
           {
-            type: 'param',
+            type: SEGMENT_TYPE_PARAM,
             value: '$bar',
             prefixSegment: 'foo.',
           },
@@ -1075,9 +1079,9 @@ describe('parsePathname', () => {
         name: 'with suffix',
         to: '/{$bar}.foo',
         expected: [
-          { type: 'pathname', value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
           {
-            type: 'param',
+            type: SEGMENT_TYPE_PARAM,
             value: '$bar',
             suffixSegment: '.foo',
           },
@@ -1087,9 +1091,9 @@ describe('parsePathname', () => {
         name: 'with suffix + started by special character',
         to: '/{$bar}.foo',
         expected: [
-          { type: 'pathname', value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
           {
-            type: 'param',
+            type: SEGMENT_TYPE_PARAM,
             value: '$bar',
             suffixSegment: '.foo',
           },
@@ -1099,22 +1103,22 @@ describe('parsePathname', () => {
         name: 'with suffix + started by special character and followed by segment',
         to: '/{$bar}.foo/baz',
         expected: [
-          { type: 'pathname', value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
           {
-            type: 'param',
+            type: SEGMENT_TYPE_PARAM,
             value: '$bar',
             suffixSegment: '.foo',
           },
-          { type: 'pathname', value: 'baz' },
+          { type: SEGMENT_TYPE_PATHNAME, value: 'baz' },
         ],
       },
       {
         name: 'with suffix + prefix',
         to: '/foo{$bar}.baz',
         expected: [
-          { type: 'pathname', value: '/' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '/' },
           {
-            type: 'param',
+            type: SEGMENT_TYPE_PARAM,
             value: '$bar',
             prefixSegment: 'foo',
             suffixSegment: '.baz',

--- a/packages/router-core/tests/path.test.ts
+++ b/packages/router-core/tests/path.test.ts
@@ -12,6 +12,7 @@ import {
   SEGMENT_TYPE_PARAM,
   SEGMENT_TYPE_WILDCARD,
   SEGMENT_TYPE_OPTIONAL_PARAM,
+  compileEncodePathParam,
 } from '../src/path'
 import type { Segment as PathSegment } from '../src/path'
 
@@ -394,9 +395,7 @@ describe('interpolatePath', () => {
         path: '/users/$id',
         params: { id: '?#@john+smith' },
         result: '/users/%3F%23@john+smith',
-        decodeCharMap: new Map(
-          ['@', '+'].map((char) => [encodeURIComponent(char), char]),
-        ),
+        encodePathParam: compileEncodePathParam(['@', '+']),
       },
       {
         name: 'should interpolate the path with the splat param at the end',
@@ -433,12 +432,12 @@ describe('interpolatePath', () => {
         params: { _splat: 'sean/cassiere' },
         result: '/users/sean/cassiere',
       },
-    ])('$name', ({ path, params, decodeCharMap, result }) => {
+    ])('$name', ({ path, params, encodePathParam = encodeURIComponent, result }) => {
       expect(
         interpolatePath({
           path,
           params,
-          decodeCharMap,
+          encodePathParam,
         }).interpolatedPath,
       ).toBe(result)
     })
@@ -481,6 +480,7 @@ describe('interpolatePath', () => {
         interpolatePath({
           path: to,
           params,
+          encodePathParam: encodeURIComponent,
         }).interpolatedPath,
       ).toBe(result)
     })
@@ -523,6 +523,7 @@ describe('interpolatePath', () => {
         interpolatePath({
           path: to,
           params,
+          encodePathParam: encodeURIComponent,
         }).interpolatedPath,
       ).toBe(result)
     })
@@ -564,6 +565,7 @@ describe('interpolatePath', () => {
       const result = interpolatePath({
         path,
         params,
+        encodePathParam: encodeURIComponent,
       })
       expect(result.interpolatedPath).toBe(expectedResult)
       expect(result.isMissingParams).toBe(true)

--- a/packages/router-devtools-core/src/BaseTanStackRouterDevtoolsPanel.tsx
+++ b/packages/router-devtools-core/src/BaseTanStackRouterDevtoolsPanel.tsx
@@ -163,7 +163,7 @@ function RouteComp({
       params: allParams,
       leaveWildcards: false,
       leaveParams: false,
-      decodeCharMap: router().pathParamsDecodeCharMap,
+      encodePathParam: router().encodePathParam,
     })
 
     // only if `interpolated` is not missing params, return the path since this

--- a/packages/solid-router/tests/link.bench.tsx
+++ b/packages/solid-router/tests/link.bench.tsx
@@ -10,7 +10,7 @@ import {
   interpolatePath,
   useRouter,
 } from '../src'
-import type { LinkProps } from '../src'
+import type { AnyRouter, LinkProps } from '../src'
 import type * as Solid from 'solid-js'
 
 const createRouterRenderer =
@@ -38,8 +38,9 @@ const InterpolatePathLink = ({
   to,
   params,
   children,
-}: Solid.PropsWithChildren<LinkProps>) => {
-  const href = interpolatePath({ path: to, params }).interpolatedPath
+  router,
+}: Solid.PropsWithChildren<LinkProps> & { router: AnyRouter }) => {
+  const href = interpolatePath({ path: to, params, encodePathParam: router.encodePathParam }).interpolatedPath
   return <a href={href}>{children}</a>
 }
 
@@ -95,6 +96,7 @@ describe.each([
           <InterpolatePathLink
             to={`/params/$param${Math.min(i, matchedParamId)}`}
             params={{ [`param${Math.min(i, matchedParamId)}`]: i }}
+            router={router}
           >
             {i}
           </InterpolatePathLink>

--- a/packages/solid-router/tests/link.bench.tsx
+++ b/packages/solid-router/tests/link.bench.tsx
@@ -40,7 +40,11 @@ const InterpolatePathLink = ({
   children,
   router,
 }: Solid.PropsWithChildren<LinkProps> & { router: AnyRouter }) => {
-  const href = interpolatePath({ path: to, params, encodePathParam: router.encodePathParam }).interpolatedPath
+  const href = interpolatePath({
+    path: to,
+    params,
+    encodePathParam: router.encodePathParam,
+  }).interpolatedPath
   return <a href={href}>{children}</a>
 }
 


### PR DESCRIPTION
Main changes in `router-core/src/path.ts`:
1. use integers instead of strings for `Segment.type`
2. `parsePathname` caches all parses as readonly in a `Map`
3. `encodePathParam` is now pre-compiled based on `pathParamsAllowedCharacters` during router initialization
4. `getMatchedRoutes` caches all calls without a 2nd argument. This is the case w/ the most complexity (`flatRoutes.find((r) => getMatchedParams(r)`), and this ensures the cache doesn't explode because of all the combinations.
5. `resolvePathWithBase` caches all calls (it's only string -> string, so even a big cache should be ok)


API changes:
- `interpolatePath` requires `encodePathParam` in its options => maybe we could make this optional, like `decodeCharMap` was optional