### PR TITLE
fix: resolve flaky e2e tests on useServerFn redirect tests

### DIFF
--- a/e2e/react-start/basic/src/routes/redirect/$target/via-beforeLoad.tsx
+++ b/e2e/react-start/basic/src/routes/redirect/$target/via-beforeLoad.tsx
@@ -9,8 +9,7 @@ export const Route = createFileRoute({
       case 'internal':
         throw redirect({ to: '/posts', reloadDocument })
       case 'external':
-        const href = externalHost ?? 'http://example.com'
-        throw redirect({ href })
+        throw redirect({ href: externalHost })
     }
   },
   component: () => <div>{Route.fullPath}</div>,

--- a/e2e/react-start/basic/src/routes/redirect/$target/via-loader.tsx
+++ b/e2e/react-start/basic/src/routes/redirect/$target/via-loader.tsx
@@ -10,8 +10,7 @@ export const Route = createFileRoute({
       case 'internal':
         throw redirect({ to: '/posts', reloadDocument })
       case 'external':
-        const href = externalHost ?? 'http://example.com'
-        throw redirect({ href })
+        throw redirect({ href: externalHost })
     }
   },
   component: () => <div>{Route.fullPath}</div>,

--- a/e2e/react-start/basic/tests/redirect.spec.ts
+++ b/e2e/react-start/basic/tests/redirect.spec.ts
@@ -183,9 +183,13 @@ test.describe('redirects', () => {
     test(`useServerFn redirects to target: ${target}, reloadDocument: ${reloadDocument}`, async ({
       page,
     }) => {
-      await page.goto(
-        `/redirect/${target}/serverFn/via-useServerFn${reloadDocument ? '?reloadDocument=true' : ''}`,
-      )
+      const q = queryString.stringify({
+        externalHost: `http://localhost:${EXTERNAL_HOST_PORT}/`,
+        reloadDocument,
+      })
+
+      await page.goto(`/redirect/${target}/serverFn/via-useServerFn?${q}`)
+
       const button = page.getByTestId('redirect-on-click')
 
       let fullPageLoad = false
@@ -198,7 +202,7 @@ test.describe('redirects', () => {
       const url =
         target === 'internal'
           ? `http://localhost:${PORT}/posts`
-          : 'http://example.com/'
+          : `http://localhost:${EXTERNAL_HOST_PORT}/`
       await page.waitForURL(url)
       expect(page.url()).toBe(url)
       if (target === 'internal') {

--- a/e2e/solid-start/basic/src/routes/redirect/$target/via-beforeLoad.tsx
+++ b/e2e/solid-start/basic/src/routes/redirect/$target/via-beforeLoad.tsx
@@ -9,8 +9,7 @@ export const Route = createFileRoute('/redirect/$target/via-beforeLoad')({
       case 'internal':
         throw redirect({ to: '/posts', reloadDocument })
       case 'external':
-        const href = externalHost ?? 'http://example.com'
-        throw redirect({ href })
+        throw redirect({ href: externalHost })
     }
   },
   component: () => <div>{Route.fullPath}</div>,

--- a/e2e/solid-start/basic/src/routes/redirect/$target/via-loader.tsx
+++ b/e2e/solid-start/basic/src/routes/redirect/$target/via-loader.tsx
@@ -10,8 +10,7 @@ export const Route = createFileRoute('/redirect/$target/via-loader')({
       case 'internal':
         throw redirect({ to: '/posts', reloadDocument })
       case 'external':
-        const href = externalHost ?? 'http://example.com'
-        throw redirect({ href })
+        throw redirect({ href: externalHost })
     }
   },
   component: () => <div>{Route.fullPath}</div>,

--- a/e2e/solid-start/basic/tests/redirect.spec.ts
+++ b/e2e/solid-start/basic/tests/redirect.spec.ts
@@ -183,9 +183,12 @@ test.describe('redirects', () => {
     test(`useServerFn redirects to target: ${target}, reloadDocument: ${reloadDocument}`, async ({
       page,
     }) => {
-      await page.goto(
-        `/redirect/${target}/serverFn/via-useServerFn${reloadDocument ? '?reloadDocument=true' : ''}`,
-      )
+      const q = queryString.stringify({
+        externalHost: `http://localhost:${EXTERNAL_HOST_PORT}/`,
+        reloadDocument,
+      })
+
+      await page.goto(`/redirect/${target}/serverFn/via-useServerFn?${q}`)
 
       const button = page.getByTestId('redirect-on-click')
 
@@ -199,7 +202,7 @@ test.describe('redirects', () => {
       const url =
         target === 'internal'
           ? `http://localhost:${PORT}/posts`
-          : 'http://example.com/'
+          : `http://localhost:${EXTERNAL_HOST_PORT}/`
       await page.waitForURL(url)
       expect(page.url()).toBe(url)
       if (target === 'internal') {


### PR DESCRIPTION
This PR addresses some flaky tests in the redirect e2e tests for react-start and solid start.

Specifically, when testing external redirects use useServerFn it was trying to reach out to http://example.com. This updates it to redirect to the local dummy server. 