### PR TITLE
feat(router-core) path: parsePathname returns a readonly array

### DIFF
--- a/packages/router-core/src/path.ts
+++ b/packages/router-core/src/path.ts
@@ -3,12 +3,12 @@ import type { MatchLocation } from './RouterProvider'
 import type { AnyPathParams } from './route'
 
 export interface Segment {
-  type: 'pathname' | 'param' | 'wildcard' | 'optional-param'
-  value: string
-  prefixSegment?: string
-  suffixSegment?: string
+  readonly type: 'pathname' | 'param' | 'wildcard' | 'optional-param'
+  readonly value: string
+  readonly prefixSegment?: string
+  readonly suffixSegment?: string
   // Indicates if there is a static segment after this required/optional param
-  hasStaticAfter?: boolean
+  readonly hasStaticAfter?: boolean
 }
 
 export function joinPaths(paths: Array<string | undefined>) {
@@ -94,6 +94,48 @@ interface ResolvePathOptions {
   caseSensitive?: boolean
 }
 
+function segmentToString(segment: Segment): string {
+  if (segment.type === 'pathname') {
+    return segment.value
+  }
+
+  if (segment.type === 'param') {
+    const param = segment.value.substring(1)
+    if (segment.prefixSegment && segment.suffixSegment) {
+      return `${segment.prefixSegment}{$${param}}${segment.suffixSegment}`
+    } else if (segment.prefixSegment) {
+      return `${segment.prefixSegment}{$${param}}`
+    } else if (segment.suffixSegment) {
+      return `{$${param}}${segment.suffixSegment}`
+    }
+  }
+  
+  if (segment.type === 'optional-param') {
+    const param = segment.value.substring(1)
+    if (segment.prefixSegment && segment.suffixSegment) {
+      return `${segment.prefixSegment}{-$${param}}${segment.suffixSegment}`
+    } else if (segment.prefixSegment) {
+      return `${segment.prefixSegment}{-$${param}}`
+    } else if (segment.suffixSegment) {
+      return `{-$${param}}${segment.suffixSegment}`
+    }
+    return `{-$${param}}`
+  }
+
+  if (segment.type === 'wildcard') {
+    if (segment.prefixSegment && segment.suffixSegment) {
+      return `${segment.prefixSegment}{$}${segment.suffixSegment}`
+    } else if (segment.prefixSegment) {
+      return `${segment.prefixSegment}{$}`
+    } else if (segment.suffixSegment) {
+      return `{$}${segment.suffixSegment}`
+    }
+  }
+
+  // This case should never happen, should we throw instead?
+  return segment.value
+}
+
 export function resolvePath({
   basepath,
   base,
@@ -104,35 +146,37 @@ export function resolvePath({
   base = removeBasepath(basepath, base, caseSensitive)
   to = removeBasepath(basepath, to, caseSensitive)
 
-  let baseSegments = parsePathname(base)
+  let baseSegments = parsePathname(base).slice()
   const toSegments = parsePathname(to)
 
   if (baseSegments.length > 1 && last(baseSegments)?.value === '/') {
     baseSegments.pop()
   }
 
-  toSegments.forEach((toSegment, index) => {
-    if (toSegment.value === '/') {
+  for (let index = 0, length = toSegments.length; index < length; index++) {
+    const toSegment = toSegments[index]!
+    const value = toSegment.value
+    if (value === '/') {
       if (!index) {
         // Leading slash
         baseSegments = [toSegment]
-      } else if (index === toSegments.length - 1) {
+      } else if (index === length - 1) {
         // Trailing Slash
         baseSegments.push(toSegment)
       } else {
         // ignore inter-slashes
       }
-    } else if (toSegment.value === '..') {
+    } else if (value === '..') {
       baseSegments.pop()
-    } else if (toSegment.value === '.') {
+    } else if (value === '.') {
       // ignore
     } else {
       baseSegments.push(toSegment)
     }
-  })
+  }
 
   if (baseSegments.length > 1) {
-    if (last(baseSegments)?.value === '/') {
+    if (last(baseSegments)!.value === '/') {
       if (trailingSlash === 'never') {
         baseSegments.pop()
       }
@@ -141,42 +185,9 @@ export function resolvePath({
     }
   }
 
-  const segmentValues = baseSegments.map((segment) => {
-    if (segment.type === 'param') {
-      const param = segment.value.substring(1)
-      if (segment.prefixSegment && segment.suffixSegment) {
-        return `${segment.prefixSegment}{$${param}}${segment.suffixSegment}`
-      } else if (segment.prefixSegment) {
-        return `${segment.prefixSegment}{$${param}}`
-      } else if (segment.suffixSegment) {
-        return `{$${param}}${segment.suffixSegment}`
-      }
-    }
-    if (segment.type === 'optional-param') {
-      const param = segment.value.substring(1)
-      if (segment.prefixSegment && segment.suffixSegment) {
-        return `${segment.prefixSegment}{-$${param}}${segment.suffixSegment}`
-      } else if (segment.prefixSegment) {
-        return `${segment.prefixSegment}{-$${param}}`
-      } else if (segment.suffixSegment) {
-        return `{-$${param}}${segment.suffixSegment}`
-      }
-      return `{-$${param}}`
-    }
-
-    if (segment.type === 'wildcard') {
-      if (segment.prefixSegment && segment.suffixSegment) {
-        return `${segment.prefixSegment}{$}${segment.suffixSegment}`
-      } else if (segment.prefixSegment) {
-        return `${segment.prefixSegment}{$}`
-      } else if (segment.suffixSegment) {
-        return `{$}${segment.suffixSegment}`
-      }
-    }
-    return segment.value
-  })
+  const segmentValues = baseSegments.map(segmentToString)
   const joined = joinPaths([basepath, ...segmentValues])
-  return cleanPath(joined)
+  return joined
 }
 
 const PARAM_RE = /^\$.{1,}$/ // $paramName
@@ -204,7 +215,7 @@ const WILDCARD_W_CURLY_BRACES_RE = /^(.*?)\{\$\}(.*)$/ // prefix{$}suffix
  * - `/foo/[$]{$foo} - Dynamic route with a static prefix of `$`
  * - `/foo/{$foo}[$]` - Dynamic route with a static suffix of `$`
  */
-export function parsePathname(pathname?: string): Array<Segment> {
+export function parsePathname(pathname?: string): ReadonlyArray<Segment> {
   if (!pathname) {
     return []
   }
@@ -345,7 +356,7 @@ export function interpolatePath({
     const value = params[key]
     const isValueString = typeof value === 'string'
 
-    if (['*', '_splat'].includes(key)) {
+    if (key === '*' || key === '_splat') {
       // the splat/catch-all routes shouldn't have the '/' encoded out
       return isValueString ? encodeURI(value) : value
     } else {
@@ -360,6 +371,10 @@ export function interpolatePath({
   const usedParams: Record<string, unknown> = {}
   const interpolatedPath = joinPaths(
     interpolatedPathSegments.map((segment) => {
+      if (segment.type === 'pathname') {
+        return segment.value
+      }
+
       if (segment.type === 'wildcard') {
         usedParams._splat = params._splat
         const segmentPrefix = segment.prefixSegment || ''
@@ -502,165 +517,220 @@ export function removeBasepath(
 export function matchByPath(
   basepath: string,
   from: string,
-  matchLocation: Pick<MatchLocation, 'to' | 'caseSensitive' | 'fuzzy'>,
+  {to, fuzzy, caseSensitive}: Pick<MatchLocation, 'to' | 'caseSensitive' | 'fuzzy'>,
 ): Record<string, string> | undefined {
   // check basepath first
   if (basepath !== '/' && !from.startsWith(basepath)) {
     return undefined
   }
   // Remove the base path from the pathname
-  from = removeBasepath(basepath, from, matchLocation.caseSensitive)
+  from = removeBasepath(basepath, from, caseSensitive)
   // Default to to $ (wildcard)
-  const to = removeBasepath(
-    basepath,
-    `${matchLocation.to ?? '$'}`,
-    matchLocation.caseSensitive,
-  )
+  to = removeBasepath(basepath, `${to ?? '$'}`, caseSensitive)
 
   // Parse the from and to
-  const baseSegments = parsePathname(from)
-  const routeSegments = parsePathname(to)
-
-  if (!from.startsWith('/')) {
-    baseSegments.unshift({
-      type: 'pathname',
-      value: '/',
-    })
-  }
-
-  if (!to.startsWith('/')) {
-    routeSegments.unshift({
-      type: 'pathname',
-      value: '/',
-    })
-  }
+  const baseSegments = parsePathname(from.startsWith('/') ? from : `/${from}`)
+  const routeSegments = parsePathname(to.startsWith('/') ? to : `/${to}`)
 
   const params: Record<string, string> = {}
 
-  const isMatch = (() => {
-    let baseIndex = 0
-    let routeIndex = 0
+  const result = isMatch(
+    baseSegments,
+    routeSegments,
+    params,
+    fuzzy,
+    caseSensitive,
+  )
 
-    while (
-      baseIndex < baseSegments.length ||
-      routeIndex < routeSegments.length
-    ) {
-      const baseSegment = baseSegments[baseIndex]
-      const routeSegment = routeSegments[routeIndex]
+  return result ? params : undefined
+}
 
-      const isLastBaseSegment = baseIndex >= baseSegments.length - 1
-      const isLastRouteSegment = routeIndex >= routeSegments.length - 1
+function isMatch(
+  baseSegments: ReadonlyArray<Segment>,
+  routeSegments: ReadonlyArray<Segment>,
+  params: Record<string, string>,
+  fuzzy?: boolean,
+  caseSensitive?: boolean,
+): boolean {
+  let baseIndex = 0
+  let routeIndex = 0
 
-      if (routeSegment) {
-        if (routeSegment.type === 'wildcard') {
-          // Capture all remaining segments for a wildcard
-          const remainingBaseSegments = baseSegments.slice(baseIndex)
+  while (
+    baseIndex < baseSegments.length ||
+    routeIndex < routeSegments.length
+  ) {
+    const baseSegment = baseSegments[baseIndex]
+    const routeSegment = routeSegments[routeIndex]
 
-          let _splat: string
+    const isLastBaseSegment = baseIndex >= baseSegments.length - 1
+    const isLastRouteSegment = routeIndex >= routeSegments.length - 1
 
-          // If this is a wildcard with prefix/suffix, we need to handle the first segment specially
-          if (routeSegment.prefixSegment || routeSegment.suffixSegment) {
-            if (!baseSegment) return false
+    if (routeSegment) {
+      if (routeSegment.type === 'wildcard') {
+        // Capture all remaining segments for a wildcard
+        const remainingBaseSegments = baseSegments.slice(baseIndex)
 
-            const prefix = routeSegment.prefixSegment || ''
-            const suffix = routeSegment.suffixSegment || ''
+        let _splat: string
 
-            // Check if the base segment starts with prefix and ends with suffix
-            const baseValue = baseSegment.value
-            if ('prefixSegment' in routeSegment) {
-              if (!baseValue.startsWith(prefix)) {
-                return false
-              }
+        // If this is a wildcard with prefix/suffix, we need to handle the first segment specially
+        if (routeSegment.prefixSegment || routeSegment.suffixSegment) {
+          if (!baseSegment) return false
+
+          const prefix = routeSegment.prefixSegment || ''
+          const suffix = routeSegment.suffixSegment || ''
+
+          // Check if the base segment starts with prefix and ends with suffix
+          const baseValue = baseSegment.value
+          if ('prefixSegment' in routeSegment) {
+            if (!baseValue.startsWith(prefix)) {
+              return false
             }
-            if ('suffixSegment' in routeSegment) {
-              if (
-                !baseSegments[baseSegments.length - 1]?.value.endsWith(suffix)
-              ) {
-                return false
-              }
-            }
-
-            let rejoinedSplat = decodeURI(
-              joinPaths(remainingBaseSegments.map((d) => d.value)),
-            )
-
-            // Remove the prefix and suffix from the rejoined splat
-            if (prefix && rejoinedSplat.startsWith(prefix)) {
-              rejoinedSplat = rejoinedSplat.slice(prefix.length)
-            }
-
-            if (suffix && rejoinedSplat.endsWith(suffix)) {
-              rejoinedSplat = rejoinedSplat.slice(
-                0,
-                rejoinedSplat.length - suffix.length,
-              )
-            }
-
-            _splat = rejoinedSplat
-          } else {
-            // If no prefix/suffix, just rejoin the remaining segments
-            _splat = decodeURI(
-              joinPaths(remainingBaseSegments.map((d) => d.value)),
-            )
           }
-
-          // TODO: Deprecate *
-          params['*'] = _splat
-          params['_splat'] = _splat
-          return true
-        }
-
-        if (routeSegment.type === 'pathname') {
-          if (routeSegment.value === '/' && !baseSegment?.value) {
-            routeIndex++
-            continue
-          }
-
-          if (baseSegment) {
-            if (matchLocation.caseSensitive) {
-              if (routeSegment.value !== baseSegment.value) {
-                return false
-              }
-            } else if (
-              routeSegment.value.toLowerCase() !==
-              baseSegment.value.toLowerCase()
+          if ('suffixSegment' in routeSegment) {
+            if (
+              !baseSegments[baseSegments.length - 1]?.value.endsWith(suffix)
             ) {
               return false
             }
-            baseIndex++
-            routeIndex++
-            continue
-          } else {
-            return false
           }
+
+          let rejoinedSplat = decodeURI(
+            joinPaths(remainingBaseSegments.map((d) => d.value)),
+          )
+
+          // Remove the prefix and suffix from the rejoined splat
+          if (prefix && rejoinedSplat.startsWith(prefix)) {
+            rejoinedSplat = rejoinedSplat.slice(prefix.length)
+          }
+
+          if (suffix && rejoinedSplat.endsWith(suffix)) {
+            rejoinedSplat = rejoinedSplat.slice(
+              0,
+              rejoinedSplat.length - suffix.length,
+            )
+          }
+
+          _splat = rejoinedSplat
+        } else {
+          // If no prefix/suffix, just rejoin the remaining segments
+          _splat = decodeURI(
+            joinPaths(remainingBaseSegments.map((d) => d.value)),
+          )
         }
 
-        if (routeSegment.type === 'param') {
-          if (!baseSegment) {
+        // TODO: Deprecate *
+        params['*'] = _splat
+        params['_splat'] = _splat
+        return true
+      }
+
+      if (routeSegment.type === 'pathname') {
+        if (routeSegment.value === '/' && !baseSegment?.value) {
+          routeIndex++
+          continue
+        }
+
+        if (baseSegment) {
+          if (caseSensitive) {
+            if (routeSegment.value !== baseSegment.value) {
+              return false
+            }
+          } else if (
+            routeSegment.value.toLowerCase() !==
+            baseSegment.value.toLowerCase()
+          ) {
+            return false
+          }
+          baseIndex++
+          routeIndex++
+          continue
+        } else {
+          return false
+        }
+      }
+
+      if (routeSegment.type === 'param') {
+        if (!baseSegment) {
+          return false
+        }
+
+        if (baseSegment.value === '/') {
+          return false
+        }
+
+        let _paramValue = ''
+        let matched = false
+
+        // If this param has prefix/suffix, we need to extract the actual parameter value
+        if (routeSegment.prefixSegment || routeSegment.suffixSegment) {
+          const prefix = routeSegment.prefixSegment || ''
+          const suffix = routeSegment.suffixSegment || ''
+
+          // Check if the base segment starts with prefix and ends with suffix
+          const baseValue = baseSegment.value
+          if (prefix && !baseValue.startsWith(prefix)) {
+            return false
+          }
+          if (suffix && !baseValue.endsWith(suffix)) {
             return false
           }
 
-          if (baseSegment.value === '/') {
-            return false
+          let paramValue = baseValue
+          if (prefix && paramValue.startsWith(prefix)) {
+            paramValue = paramValue.slice(prefix.length)
+          }
+          if (suffix && paramValue.endsWith(suffix)) {
+            paramValue = paramValue.slice(
+              0,
+              paramValue.length - suffix.length,
+            )
           }
 
-          let _paramValue = ''
-          let matched = false
+          _paramValue = decodeURIComponent(paramValue)
+          matched = true
+        } else {
+          // If no prefix/suffix, just decode the base segment value
+          _paramValue = decodeURIComponent(baseSegment.value)
+          matched = true
+        }
 
-          // If this param has prefix/suffix, we need to extract the actual parameter value
-          if (routeSegment.prefixSegment || routeSegment.suffixSegment) {
-            const prefix = routeSegment.prefixSegment || ''
-            const suffix = routeSegment.suffixSegment || ''
+        if (matched) {
+          params[routeSegment.value.substring(1)] = _paramValue
+          baseIndex++
+        }
 
-            // Check if the base segment starts with prefix and ends with suffix
-            const baseValue = baseSegment.value
-            if (prefix && !baseValue.startsWith(prefix)) {
-              return false
-            }
-            if (suffix && !baseValue.endsWith(suffix)) {
-              return false
-            }
+        routeIndex++
+        continue
+      }
 
+      if (routeSegment.type === 'optional-param') {
+        // Optional parameters can be missing - don't fail the match
+        if (!baseSegment) {
+          // No base segment for optional param - skip this route segment
+          routeIndex++
+          continue
+        }
+
+        if (baseSegment.value === '/') {
+          // Skip slash segments for optional params
+          routeIndex++
+          continue
+        }
+
+        let _paramValue = ''
+        let matched = false
+
+        // If this optional param has prefix/suffix, we need to extract the actual parameter value
+        if (routeSegment.prefixSegment || routeSegment.suffixSegment) {
+          const prefix = routeSegment.prefixSegment || ''
+          const suffix = routeSegment.suffixSegment || ''
+
+          // Check if the base segment starts with prefix and ends with suffix
+          const baseValue = baseSegment.value
+          if (
+            (!prefix || baseValue.startsWith(prefix)) &&
+            (!suffix || baseValue.endsWith(suffix))
+          ) {
             let paramValue = baseValue
             if (prefix && paramValue.startsWith(prefix)) {
               paramValue = paramValue.slice(prefix.length)
@@ -674,146 +744,87 @@ export function matchByPath(
 
             _paramValue = decodeURIComponent(paramValue)
             matched = true
-          } else {
+          }
+        } else {
+          // For optional params without prefix/suffix, we need to check if the current
+          // base segment should match this optional param or a later route segment
+
+          // Look ahead to see if there's a later route segment that matches the current base segment
+          let shouldMatchOptional = true
+          for (
+            let lookAhead = routeIndex + 1;
+            lookAhead < routeSegments.length;
+            lookAhead++
+          ) {
+            const futureRouteSegment = routeSegments[lookAhead]
+            if (
+              futureRouteSegment?.type === 'pathname' &&
+              futureRouteSegment.value === baseSegment.value
+            ) {
+              // The current base segment matches a future pathname segment,
+              // so we should skip this optional parameter
+              shouldMatchOptional = false
+              break
+            }
+
+            // If we encounter a required param or wildcard, stop looking ahead
+            if (
+              futureRouteSegment?.type === 'param' ||
+              futureRouteSegment?.type === 'wildcard'
+            ) {
+              break
+            }
+          }
+
+          if (shouldMatchOptional) {
             // If no prefix/suffix, just decode the base segment value
             _paramValue = decodeURIComponent(baseSegment.value)
             matched = true
           }
-
-          if (matched) {
-            params[routeSegment.value.substring(1)] = _paramValue
-            baseIndex++
-          }
-
-          routeIndex++
-          continue
         }
 
-        if (routeSegment.type === 'optional-param') {
-          // Optional parameters can be missing - don't fail the match
-          if (!baseSegment) {
-            // No base segment for optional param - skip this route segment
-            routeIndex++
-            continue
-          }
+        if (matched) {
+          params[routeSegment.value.substring(1)] = _paramValue
+          baseIndex++
+        }
 
-          if (baseSegment.value === '/') {
-            // Skip slash segments for optional params
-            routeIndex++
-            continue
-          }
+        routeIndex++
+        continue
+      }
+    }
 
-          let _paramValue = ''
-          let matched = false
+    if (!isLastBaseSegment && isLastRouteSegment) {
+      params['**'] = joinPaths(
+        baseSegments.slice(baseIndex + 1).map((d) => d.value),
+      )
+      return !!fuzzy && routeSegment?.value !== '/'
+    }
 
-          // If this optional param has prefix/suffix, we need to extract the actual parameter value
-          if (routeSegment.prefixSegment || routeSegment.suffixSegment) {
-            const prefix = routeSegment.prefixSegment || ''
-            const suffix = routeSegment.suffixSegment || ''
+    // If we have base segments left but no route segments, it's not a match
+    if (
+      baseIndex < baseSegments.length &&
+      routeIndex >= routeSegments.length
+    ) {
+      return false
+    }
 
-            // Check if the base segment starts with prefix and ends with suffix
-            const baseValue = baseSegment.value
-            if (
-              (!prefix || baseValue.startsWith(prefix)) &&
-              (!suffix || baseValue.endsWith(suffix))
-            ) {
-              let paramValue = baseValue
-              if (prefix && paramValue.startsWith(prefix)) {
-                paramValue = paramValue.slice(prefix.length)
-              }
-              if (suffix && paramValue.endsWith(suffix)) {
-                paramValue = paramValue.slice(
-                  0,
-                  paramValue.length - suffix.length,
-                )
-              }
-
-              _paramValue = decodeURIComponent(paramValue)
-              matched = true
-            }
-          } else {
-            // For optional params without prefix/suffix, we need to check if the current
-            // base segment should match this optional param or a later route segment
-
-            // Look ahead to see if there's a later route segment that matches the current base segment
-            let shouldMatchOptional = true
-            for (
-              let lookAhead = routeIndex + 1;
-              lookAhead < routeSegments.length;
-              lookAhead++
-            ) {
-              const futureRouteSegment = routeSegments[lookAhead]
-              if (
-                futureRouteSegment?.type === 'pathname' &&
-                futureRouteSegment.value === baseSegment.value
-              ) {
-                // The current base segment matches a future pathname segment,
-                // so we should skip this optional parameter
-                shouldMatchOptional = false
-                break
-              }
-
-              // If we encounter a required param or wildcard, stop looking ahead
-              if (
-                futureRouteSegment?.type === 'param' ||
-                futureRouteSegment?.type === 'wildcard'
-              ) {
-                break
-              }
-            }
-
-            if (shouldMatchOptional) {
-              // If no prefix/suffix, just decode the base segment value
-              _paramValue = decodeURIComponent(baseSegment.value)
-              matched = true
-            }
-          }
-
-          if (matched) {
-            params[routeSegment.value.substring(1)] = _paramValue
-            baseIndex++
-          }
-
-          routeIndex++
-          continue
+    // If we have route segments left but no base segments, check if remaining are optional
+    if (
+      routeIndex < routeSegments.length &&
+      baseIndex >= baseSegments.length
+    ) {
+      // Check if all remaining route segments are optional
+      for (let i = routeIndex; i < routeSegments.length; i++) {
+        if (routeSegments[i]?.type !== 'optional-param') {
+          return false
         }
       }
-
-      if (!isLastBaseSegment && isLastRouteSegment) {
-        params['**'] = joinPaths(
-          baseSegments.slice(baseIndex + 1).map((d) => d.value),
-        )
-        return !!matchLocation.fuzzy && routeSegment?.value !== '/'
-      }
-
-      // If we have base segments left but no route segments, it's not a match
-      if (
-        baseIndex < baseSegments.length &&
-        routeIndex >= routeSegments.length
-      ) {
-        return false
-      }
-
-      // If we have route segments left but no base segments, check if remaining are optional
-      if (
-        routeIndex < routeSegments.length &&
-        baseIndex >= baseSegments.length
-      ) {
-        // Check if all remaining route segments are optional
-        for (let i = routeIndex; i < routeSegments.length; i++) {
-          if (routeSegments[i]?.type !== 'optional-param') {
-            return false
-          }
-        }
-        // All remaining are optional, so we can finish
-        break
-      }
-
+      // All remaining are optional, so we can finish
       break
     }
 
-    return true
-  })()
+    break
+  }
 
-  return isMatch ? params : undefined
+  return true
 }

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -3246,7 +3246,7 @@ export function processRouteTree<TRouteLike extends RouteLike>({
   const scoredRoutes: Array<{
     child: TRouteLike
     trimmed: string
-    parsed: Array<Segment>
+    parsed: ReadonlyArray<Segment>
     index: number
     scores: Array<number>
     hasStaticAfter: boolean
@@ -3261,12 +3261,14 @@ export function processRouteTree<TRouteLike extends RouteLike>({
     }
 
     const trimmed = trimPathLeft(d.fullPath)
-    const parsed = parsePathname(trimmed)
+    let parsed = parsePathname(trimmed)
 
     // Removes the leading slash if it is not the only remaining segment
-    while (parsed.length > 1 && parsed[0]?.value === '/') {
-      parsed.shift()
+    let skip = 0
+    while (parsed.length > skip + 1 && parsed[skip]?.value === '/') {
+      skip++
     }
+    if (skip > 0) parsed = parsed.slice(skip)
 
     let optionalParamCount = 0
     let hasStaticAfter = false
@@ -3412,8 +3414,9 @@ export function getMatchedRoutes<TRouteLike extends RouteLike>({
 
   while (routeCursor.parentRoute) {
     routeCursor = routeCursor.parentRoute as TRouteLike
-    matchedRoutes.unshift(routeCursor)
+    matchedRoutes.push(routeCursor)
   }
+  matchedRoutes.reverse()
 
   return { matchedRoutes, routeParams, foundRoute }
 }


### PR DESCRIPTION
`parsePathname` should return a `ReadonlyArray` instead of `Array`, and `Segment` should be `readonly` too. This is because if we want to improve perf by either caching at runtime or pre-computing routes at build time, we need to ensure those objects can't be manipulated.

An unrelated change in this PR is also to move some iniline function to module-scoped functions `segmentToString` (from `resolvePath`) and `isMatch` (from `matchByPath`). Those functions are in the hot path so it's nice if the runtime compiler can promote them to optimized functions.