### PR TITLE
Work on next how-to task

### DIFF
--- a/docs/router/framework/react/how-to/README.md
+++ b/docs/router/framework/react/how-to/README.md
@@ -11,7 +11,9 @@ This directory contains focused, step-by-step instructions for common TanStack R
 
 - [Install TanStack Router](./install.md) - Basic installation steps
 - [Deploy to Production](./deploy-to-production.md) - Deploy your app to hosting platforms
-- [Set Up Authentication and Protected Routes](./setup-authentication.md) - Implement auth patterns and route protection
+- [Set Up Basic Authentication](./setup-authentication.md) - Implement basic auth with React Context
+- [Integrate Authentication Providers](./setup-auth-providers.md) - Use Auth0, Clerk, or Supabase
+- [Set Up Role-Based Access Control](./setup-rbac.md) - Add permission-based routing
 
 ## Using These Guides
 

--- a/docs/router/framework/react/how-to/README.md
+++ b/docs/router/framework/react/how-to/README.md
@@ -11,6 +11,7 @@ This directory contains focused, step-by-step instructions for common TanStack R
 
 - [Install TanStack Router](./install.md) - Basic installation steps
 - [Deploy to Production](./deploy-to-production.md) - Deploy your app to hosting platforms
+- [Set Up Authentication and Protected Routes](./setup-authentication.md) - Implement auth patterns and route protection
 
 ## Using These Guides
 

--- a/docs/router/framework/react/how-to/deploy-to-production.md
+++ b/docs/router/framework/react/how-to/deploy-to-production.md
@@ -432,6 +432,8 @@ Before deploying, ensure you have:
 
 After deployment, you might want to:
 
+- [How to Set Up Authentication and Protected Routes](./setup-authentication.md) - Secure your application with auth
+
 <!-- TODO: Uncomment as how-to guides are created
 - [How to Set Up Server-Side Rendering (SSR)](./setup-ssr.md)
 - [How to Optimize Performance](./optimize-performance.md)

--- a/docs/router/framework/react/how-to/deploy-to-production.md
+++ b/docs/router/framework/react/how-to/deploy-to-production.md
@@ -432,7 +432,7 @@ Before deploying, ensure you have:
 
 After deployment, you might want to:
 
-- [How to Set Up Authentication and Protected Routes](./setup-authentication.md) - Secure your application with auth
+- [How to Set Up Basic Authentication](./setup-authentication.md) - Secure your application with auth
 
 <!-- TODO: Uncomment as how-to guides are created
 - [How to Set Up Server-Side Rendering (SSR)](./setup-ssr.md)

--- a/docs/router/framework/react/how-to/setup-auth-providers.md
+++ b/docs/router/framework/react/how-to/setup-auth-providers.md
@@ -1,0 +1,610 @@
+# How to Integrate Authentication Providers
+
+This guide covers integrating popular authentication services (Auth0, Clerk, Supabase) with TanStack Router.
+
+## Quick Start
+
+Choose an authentication provider, install their SDK, wrap your router with their context, and adapt their auth state to work with TanStack Router's context system.
+
+---
+
+## Auth0 Integration
+
+### 1. Install Auth0
+
+```bash
+npm install @auth0/auth0-react
+```
+
+### 2. Set Up Environment Variables
+
+Add to your `.env` file:
+
+```env
+VITE_AUTH0_DOMAIN=your-auth0-domain.auth0.com
+VITE_AUTH0_CLIENT_ID=your_auth0_client_id
+```
+
+### 3. Create Auth0 Wrapper
+
+Create `src/auth/auth0.tsx`:
+
+```tsx
+import { Auth0Provider, useAuth0 } from '@auth0/auth0-react'
+import { createContext, useContext } from 'react'
+
+interface Auth0ContextType {
+  isAuthenticated: boolean
+  user: any
+  login: () => void
+  logout: () => void
+  isLoading: boolean
+}
+
+const Auth0Context = createContext<Auth0ContextType | undefined>(undefined)
+
+export function Auth0Wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <Auth0Provider
+      domain={import.meta.env.VITE_AUTH0_DOMAIN}
+      clientId={import.meta.env.VITE_AUTH0_CLIENT_ID}
+      authorizationParams={{
+        redirect_uri: window.location.origin,
+      }}
+    >
+      <Auth0ContextProvider>{children}</Auth0ContextProvider>
+    </Auth0Provider>
+  )
+}
+
+function Auth0ContextProvider({ children }: { children: React.ReactNode }) {
+  const { isAuthenticated, user, loginWithRedirect, logout, isLoading } = useAuth0()
+
+  const contextValue = {
+    isAuthenticated,
+    user,
+    login: loginWithRedirect,
+    logout: () => logout({ logoutParams: { returnTo: window.location.origin } }),
+    isLoading,
+  }
+
+  return (
+    <Auth0Context.Provider value={contextValue}>
+      {children}
+    </Auth0Context.Provider>
+  )
+}
+
+export function useAuth0Context() {
+  const context = useContext(Auth0Context)
+  if (context === undefined) {
+    throw new Error('useAuth0Context must be used within Auth0Wrapper')
+  }
+  return context
+}
+```
+
+### 4. Update App Configuration
+
+Update `src/App.tsx`:
+
+```tsx
+import { RouterProvider } from '@tanstack/react-router'
+import { Auth0Wrapper, useAuth0Context } from './auth/auth0'
+import { router } from './router'
+
+function InnerApp() {
+  const auth = useAuth0Context()
+  
+  if (auth.isLoading) {
+    return <div className="flex items-center justify-center min-h-screen">Loading...</div>
+  }
+
+  return <RouterProvider router={router} context={{ auth }} />
+}
+
+function App() {
+  return (
+    <Auth0Wrapper>
+      <InnerApp />
+    </Auth0Wrapper>
+  )
+}
+
+export default App
+```
+
+### 5. Create Protected Routes
+
+Create `src/routes/_authenticated.tsx`:
+
+```tsx
+import { createFileRoute, redirect, Outlet } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_authenticated')({
+  beforeLoad: ({ context, location }) => {
+    if (!context.auth.isAuthenticated) {
+      // Auth0 handles login redirects, so just trigger login
+      context.auth.login()
+      return
+    }
+  },
+  component: () => <Outlet />,
+})
+```
+
+---
+
+## Clerk Integration
+
+### 1. Install Clerk
+
+```bash
+npm install @clerk/clerk-react
+```
+
+### 2. Set Up Environment Variables
+
+Add to your `.env` file:
+
+```env
+VITE_CLERK_PUBLISHABLE_KEY=pk_test_your_clerk_key
+```
+
+### 3. Create Clerk Wrapper
+
+Create `src/auth/clerk.tsx`:
+
+```tsx
+import { ClerkProvider, useUser, useAuth } from '@clerk/clerk-react'
+
+export function ClerkWrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <ClerkProvider publishableKey={import.meta.env.VITE_CLERK_PUBLISHABLE_KEY}>
+      {children}
+    </ClerkProvider>
+  )
+}
+
+export function useClerkAuth() {
+  const { isSignedIn, isLoaded } = useAuth()
+  const { user } = useUser()
+
+  return {
+    isAuthenticated: isSignedIn,
+    user: user ? {
+      id: user.id,
+      username: user.username || user.primaryEmailAddress?.emailAddress || '',
+      email: user.primaryEmailAddress?.emailAddress || '',
+    } : null,
+    isLoading: !isLoaded,
+    login: () => {
+      // Clerk handles login through components
+      window.location.href = '/sign-in'
+    },
+    logout: () => {
+      // Clerk handles logout through components
+      window.location.href = '/sign-out'
+    },
+  }
+}
+```
+
+### 4. Create Clerk Auth Routes
+
+Create `src/routes/sign-in.tsx`:
+
+```tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { SignIn } from '@clerk/clerk-react'
+
+export const Route = createFileRoute('/sign-in')({
+  component: () => (
+    <div className="flex items-center justify-center min-h-screen">
+      <SignIn 
+        redirectUrl="/dashboard" 
+        signUpUrl="/sign-up"
+      />
+    </div>
+  ),
+})
+```
+
+Create `src/routes/sign-up.tsx`:
+
+```tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { SignUp } from '@clerk/clerk-react'
+
+export const Route = createFileRoute('/sign-up')({
+  component: () => (
+    <div className="flex items-center justify-center min-h-screen">
+      <SignUp 
+        redirectUrl="/dashboard" 
+        signInUrl="/sign-in"
+      />
+    </div>
+  ),
+})
+```
+
+### 5. Update App Configuration
+
+Update `src/App.tsx`:
+
+```tsx
+import { RouterProvider } from '@tanstack/react-router'
+import { ClerkWrapper, useClerkAuth } from './auth/clerk'
+import { router } from './router'
+
+function InnerApp() {
+  const auth = useClerkAuth()
+  
+  if (auth.isLoading) {
+    return <div className="flex items-center justify-center min-h-screen">Loading...</div>
+  }
+
+  return <RouterProvider router={router} context={{ auth }} />
+}
+
+function App() {
+  return (
+    <ClerkWrapper>
+      <InnerApp />
+    </ClerkWrapper>
+  )
+}
+
+export default App
+```
+
+### 6. Create Protected Routes
+
+Create `src/routes/_authenticated.tsx`:
+
+```tsx
+import { createFileRoute, redirect, Outlet } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_authenticated')({
+  beforeLoad: ({ context, location }) => {
+    if (!context.auth.isAuthenticated) {
+      throw redirect({
+        to: '/sign-in',
+        search: {
+          redirect: location.href,
+        },
+      })
+    }
+  },
+  component: () => <Outlet />,
+})
+```
+
+---
+
+## Supabase Integration
+
+### 1. Install Supabase
+
+```bash
+npm install @supabase/supabase-js
+```
+
+### 2. Set Up Environment Variables
+
+Add to your `.env` file:
+
+```env
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
+```
+
+### 3. Create Supabase Client
+
+Create `src/auth/supabase.tsx`:
+
+```tsx
+import { createClient } from '@supabase/supabase-js'
+import { createContext, useContext, useEffect, useState } from 'react'
+
+const supabase = createClient(
+  import.meta.env.VITE_SUPABASE_URL,
+  import.meta.env.VITE_SUPABASE_ANON_KEY
+)
+
+interface SupabaseAuthState {
+  isAuthenticated: boolean
+  user: any
+  login: (email: string, password: string) => Promise<void>
+  logout: () => Promise<void>
+  isLoading: boolean
+}
+
+const SupabaseAuthContext = createContext<SupabaseAuthState | undefined>(undefined)
+
+export function SupabaseAuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState(null)
+  const [isAuthenticated, setIsAuthenticated] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    // Get initial session
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setUser(session?.user ?? null)
+      setIsAuthenticated(!!session?.user)
+      setIsLoading(false)
+    })
+
+    // Listen for auth changes
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(
+      (_event, session) => {
+        setUser(session?.user ?? null)
+        setIsAuthenticated(!!session?.user)
+        setIsLoading(false)
+      }
+    )
+
+    return () => subscription.unsubscribe()
+  }, [])
+
+  const login = async (email: string, password: string) => {
+    const { error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    })
+    if (error) throw error
+  }
+
+  const logout = async () => {
+    const { error } = await supabase.auth.signOut()
+    if (error) throw error
+  }
+
+  return (
+    <SupabaseAuthContext.Provider value={{ 
+      isAuthenticated, 
+      user, 
+      login, 
+      logout, 
+      isLoading 
+    }}>
+      {children}
+    </SupabaseAuthContext.Provider>
+  )
+}
+
+export function useSupabaseAuth() {
+  const context = useContext(SupabaseAuthContext)
+  if (context === undefined) {
+    throw new Error('useSupabaseAuth must be used within SupabaseAuthProvider')
+  }
+  return context
+}
+```
+
+### 4. Create Login Component
+
+Create `src/routes/login.tsx`:
+
+```tsx
+import { createFileRoute, redirect } from '@tanstack/react-router'
+import { useState } from 'react'
+
+export const Route = createFileRoute('/login')({
+  validateSearch: (search) => ({
+    redirect: (search.redirect as string) || '/dashboard',
+  }),
+  beforeLoad: ({ context, search }) => {
+    if (context.auth.isAuthenticated) {
+      throw redirect({ to: search.redirect })
+    }
+  },
+  component: LoginComponent,
+})
+
+function LoginComponent() {
+  const { auth } = Route.useRouteContext()
+  const { redirect } = Route.useSearch()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsLoading(true)
+    setError('')
+
+    try {
+      await auth.login(email, password)
+      // Supabase auth will automatically update context
+      window.location.href = redirect
+    } catch (err: any) {
+      setError(err.message || 'Login failed')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <form onSubmit={handleSubmit} className="max-w-md w-full space-y-4 p-6 border rounded-lg">
+        <h1 className="text-2xl font-bold text-center">Sign In</h1>
+        
+        {error && (
+          <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
+            {error}
+          </div>
+        )}
+
+        <div>
+          <label htmlFor="email" className="block text-sm font-medium mb-1">
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+
+        <div>
+          <label htmlFor="password" className="block text-sm font-medium mb-1">
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="w-full bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 disabled:opacity-50"
+        >
+          {isLoading ? 'Signing in...' : 'Sign In'}
+        </button>
+      </form>
+    </div>
+  )
+}
+```
+
+### 5. Update App Configuration
+
+Update `src/App.tsx`:
+
+```tsx
+import { RouterProvider } from '@tanstack/react-router'
+import { SupabaseAuthProvider, useSupabaseAuth } from './auth/supabase'
+import { router } from './router'
+
+function InnerApp() {
+  const auth = useSupabaseAuth()
+  
+  if (auth.isLoading) {
+    return <div className="flex items-center justify-center min-h-screen">Loading...</div>
+  }
+
+  return <RouterProvider router={router} context={{ auth }} />
+}
+
+function App() {
+  return (
+    <SupabaseAuthProvider>
+      <InnerApp />
+    </SupabaseAuthProvider>
+  )
+}
+
+export default App
+```
+
+---
+
+## Provider Comparison
+
+| Feature | Auth0 | Clerk | Supabase |
+|---------|-------|-------|----------|
+| **Setup Complexity** | Medium | Low | Medium |
+| **UI Components** | Basic | Excellent | None |
+| **Customization** | High | Medium | High |
+| **Pricing** | Freemium | Freemium | Freemium |
+| **Social Login** | ✅ | ✅ | ✅ |
+| **Enterprise Features** | ✅ | ✅ | ✅ |
+| **Database Included** | ❌ | ❌ | ✅ |
+
+### When to Choose Each:
+
+- **Auth0**: Complex enterprise requirements, extensive customization
+- **Clerk**: Quick setup with beautiful UI components
+- **Supabase**: Full-stack solution with database and real-time features
+
+---
+
+## Common Problems
+
+### Provider Context Not Available
+
+**Problem:** Auth context is undefined in components.
+
+**Solution:** Ensure the provider wrapper is above `RouterProvider`:
+
+```tsx
+// ✅ Correct order
+<AuthProvider>
+  <InnerApp>
+    <RouterProvider />
+  </InnerApp>
+</AuthProvider>
+
+// ❌ Wrong order
+<RouterProvider>
+  <AuthProvider />
+</RouterProvider>
+```
+
+### Infinite Loading States
+
+**Problem:** App stuck on loading screen.
+
+**Solution:** Check if auth provider properly sets `isLoading` to `false`:
+
+```tsx
+// Add timeout fallback
+useEffect(() => {
+  const timeout = setTimeout(() => {
+    if (isLoading) {
+      setIsLoading(false)
+    }
+  }, 5000)
+  return () => clearTimeout(timeout)
+}, [isLoading])
+```
+
+### Redirect Loops with Auth0
+
+**Problem:** Continuous redirects between login and protected routes.
+
+**Solution:** Handle Auth0's automatic redirects properly:
+
+```tsx
+export const Route = createFileRoute('/_authenticated')({
+  beforeLoad: ({ context }) => {
+    if (!context.auth.isAuthenticated && !context.auth.isLoading) {
+      context.auth.login()
+      // Don't throw redirect, let Auth0 handle it
+      return
+    }
+  },
+  component: () => <Outlet />,
+})
+```
+
+---
+
+## Common Next Steps
+
+After integrating authentication providers, you might want to:
+
+- [How to Set Up Role-Based Access Control](./setup-rbac.md) - Add permission-based routing
+- [How to Set Up Basic Authentication](./setup-authentication.md) - Custom auth implementation
+
+<!-- TODO: Uncomment as how-to guides are created
+- [How to Handle User Sessions](./handle-user-sessions.md)
+- [How to Set Up Social Login](./setup-social-login.md)
+-->
+
+## Related Resources
+
+- [Auth0 React SDK](https://auth0.com/docs/libraries/auth0-react) - Official Auth0 documentation
+- [Clerk React SDK](https://clerk.com/docs/references/react/overview) - Official Clerk documentation  
+- [Supabase Auth](https://supabase.com/docs/guides/auth) - Official Supabase auth guide

--- a/docs/router/framework/react/how-to/setup-auth-providers.md
+++ b/docs/router/framework/react/how-to/setup-auth-providers.md
@@ -58,13 +58,15 @@ export function Auth0Wrapper({ children }: { children: React.ReactNode }) {
 }
 
 function Auth0ContextProvider({ children }: { children: React.ReactNode }) {
-  const { isAuthenticated, user, loginWithRedirect, logout, isLoading } = useAuth0()
+  const { isAuthenticated, user, loginWithRedirect, logout, isLoading } =
+    useAuth0()
 
   const contextValue = {
     isAuthenticated,
     user,
     login: loginWithRedirect,
-    logout: () => logout({ logoutParams: { returnTo: window.location.origin } }),
+    logout: () =>
+      logout({ logoutParams: { returnTo: window.location.origin } }),
     isLoading,
   }
 
@@ -95,9 +97,13 @@ import { router } from './router'
 
 function InnerApp() {
   const auth = useAuth0Context()
-  
+
   if (auth.isLoading) {
-    return <div className="flex items-center justify-center min-h-screen">Loading...</div>
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        Loading...
+      </div>
+    )
   }
 
   return <RouterProvider router={router} context={{ auth }} />
@@ -172,11 +178,14 @@ export function useClerkAuth() {
 
   return {
     isAuthenticated: isSignedIn,
-    user: user ? {
-      id: user.id,
-      username: user.username || user.primaryEmailAddress?.emailAddress || '',
-      email: user.primaryEmailAddress?.emailAddress || '',
-    } : null,
+    user: user
+      ? {
+          id: user.id,
+          username:
+            user.username || user.primaryEmailAddress?.emailAddress || '',
+          email: user.primaryEmailAddress?.emailAddress || '',
+        }
+      : null,
     isLoading: !isLoaded,
     login: () => {
       // Clerk handles login through components
@@ -201,10 +210,7 @@ import { SignIn } from '@clerk/clerk-react'
 export const Route = createFileRoute('/sign-in')({
   component: () => (
     <div className="flex items-center justify-center min-h-screen">
-      <SignIn 
-        redirectUrl="/dashboard" 
-        signUpUrl="/sign-up"
-      />
+      <SignIn redirectUrl="/dashboard" signUpUrl="/sign-up" />
     </div>
   ),
 })
@@ -219,10 +225,7 @@ import { SignUp } from '@clerk/clerk-react'
 export const Route = createFileRoute('/sign-up')({
   component: () => (
     <div className="flex items-center justify-center min-h-screen">
-      <SignUp 
-        redirectUrl="/dashboard" 
-        signInUrl="/sign-in"
-      />
+      <SignUp redirectUrl="/dashboard" signInUrl="/sign-in" />
     </div>
   ),
 })
@@ -239,9 +242,13 @@ import { router } from './router'
 
 function InnerApp() {
   const auth = useClerkAuth()
-  
+
   if (auth.isLoading) {
-    return <div className="flex items-center justify-center min-h-screen">Loading...</div>
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        Loading...
+      </div>
+    )
   }
 
   return <RouterProvider router={router} context={{ auth }} />
@@ -309,7 +316,7 @@ import { createContext, useContext, useEffect, useState } from 'react'
 
 const supabase = createClient(
   import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_ANON_KEY
+  import.meta.env.VITE_SUPABASE_ANON_KEY,
 )
 
 interface SupabaseAuthState {
@@ -320,9 +327,15 @@ interface SupabaseAuthState {
   isLoading: boolean
 }
 
-const SupabaseAuthContext = createContext<SupabaseAuthState | undefined>(undefined)
+const SupabaseAuthContext = createContext<SupabaseAuthState | undefined>(
+  undefined,
+)
 
-export function SupabaseAuthProvider({ children }: { children: React.ReactNode }) {
+export function SupabaseAuthProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
   const [user, setUser] = useState(null)
   const [isAuthenticated, setIsAuthenticated] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
@@ -336,13 +349,13 @@ export function SupabaseAuthProvider({ children }: { children: React.ReactNode }
     })
 
     // Listen for auth changes
-    const { data: { subscription } } = supabase.auth.onAuthStateChange(
-      (_event, session) => {
-        setUser(session?.user ?? null)
-        setIsAuthenticated(!!session?.user)
-        setIsLoading(false)
-      }
-    )
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null)
+      setIsAuthenticated(!!session?.user)
+      setIsLoading(false)
+    })
 
     return () => subscription.unsubscribe()
   }, [])
@@ -361,13 +374,15 @@ export function SupabaseAuthProvider({ children }: { children: React.ReactNode }
   }
 
   return (
-    <SupabaseAuthContext.Provider value={{ 
-      isAuthenticated, 
-      user, 
-      login, 
-      logout, 
-      isLoading 
-    }}>
+    <SupabaseAuthContext.Provider
+      value={{
+        isAuthenticated,
+        user,
+        login,
+        logout,
+        isLoading,
+      }}
+    >
       {children}
     </SupabaseAuthContext.Provider>
   )
@@ -428,9 +443,12 @@ function LoginComponent() {
 
   return (
     <div className="min-h-screen flex items-center justify-center">
-      <form onSubmit={handleSubmit} className="max-w-md w-full space-y-4 p-6 border rounded-lg">
+      <form
+        onSubmit={handleSubmit}
+        className="max-w-md w-full space-y-4 p-6 border rounded-lg"
+      >
         <h1 className="text-2xl font-bold text-center">Sign In</h1>
-        
+
         {error && (
           <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
             {error}
@@ -489,9 +507,13 @@ import { router } from './router'
 
 function InnerApp() {
   const auth = useSupabaseAuth()
-  
+
   if (auth.isLoading) {
-    return <div className="flex items-center justify-center min-h-screen">Loading...</div>
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        Loading...
+      </div>
+    )
   }
 
   return <RouterProvider router={router} context={{ auth }} />
@@ -512,15 +534,15 @@ export default App
 
 ## Provider Comparison
 
-| Feature | Auth0 | Clerk | Supabase |
-|---------|-------|-------|----------|
-| **Setup Complexity** | Medium | Low | Medium |
-| **UI Components** | Basic | Excellent | None |
-| **Customization** | High | Medium | High |
-| **Pricing** | Freemium | Freemium | Freemium |
-| **Social Login** | ✅ | ✅ | ✅ |
-| **Enterprise Features** | ✅ | ✅ | ✅ |
-| **Database Included** | ❌ | ❌ | ✅ |
+| Feature                 | Auth0    | Clerk     | Supabase |
+| ----------------------- | -------- | --------- | -------- |
+| **Setup Complexity**    | Medium   | Low       | Medium   |
+| **UI Components**       | Basic    | Excellent | None     |
+| **Customization**       | High     | Medium    | High     |
+| **Pricing**             | Freemium | Freemium  | Freemium |
+| **Social Login**        | ✅       | ✅        | ✅       |
+| **Enterprise Features** | ✅       | ✅        | ✅       |
+| **Database Included**   | ❌       | ❌        | ✅       |
 
 ### When to Choose Each:
 
@@ -606,5 +628,5 @@ After integrating authentication providers, you might want to:
 ## Related Resources
 
 - [Auth0 React SDK](https://auth0.com/docs/libraries/auth0-react) - Official Auth0 documentation
-- [Clerk React SDK](https://clerk.com/docs/references/react/overview) - Official Clerk documentation  
+- [Clerk React SDK](https://clerk.com/docs/references/react/overview) - Official Clerk documentation
 - [Supabase Auth](https://supabase.com/docs/guides/auth) - Official Supabase auth guide

--- a/docs/router/framework/react/how-to/setup-authentication.md
+++ b/docs/router/framework/react/how-to/setup-authentication.md
@@ -1,0 +1,781 @@
+# How to Set Up Authentication and Protected Routes
+
+This guide covers implementing authentication patterns and protecting routes in TanStack Router applications.
+
+## Quick Start
+
+Set up authentication by creating a context-aware router, implementing auth state management, and using `beforeLoad` for route protection. Choose between redirect-based authentication (traditional login pages) or inline authentication (modals/overlays).
+
+---
+
+## React Context Authentication
+
+### 1. Create Authentication Context
+
+Create `src/auth.tsx`:
+
+```tsx
+import React, { createContext, useContext, useState } from 'react'
+
+interface User {
+  id: string
+  username: string
+  email: string
+}
+
+interface AuthState {
+  isAuthenticated: boolean
+  user: User | null
+  login: (username: string, password: string) => Promise<void>
+  logout: () => void
+}
+
+const AuthContext = createContext<AuthState | undefined>(undefined)
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [isAuthenticated, setIsAuthenticated] = useState(false)
+
+  const login = async (username: string, password: string) => {
+    // Replace with your authentication logic
+    const response = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    })
+
+    if (response.ok) {
+      const userData = await response.json()
+      setUser(userData)
+      setIsAuthenticated(true)
+    } else {
+      throw new Error('Authentication failed')
+    }
+  }
+
+  const logout = () => {
+    setUser(null)
+    setIsAuthenticated(false)
+    // Clear any stored tokens
+    localStorage.removeItem('auth-token')
+  }
+
+  return (
+    <AuthContext.Provider value={{ isAuthenticated, user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext)
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
+}
+```
+
+### 2. Set Up Router Context
+
+Update `src/routes/__root.tsx`:
+
+```tsx
+import { createRootRouteWithContext, Outlet } from '@tanstack/react-router'
+import { TanStackRouterDevtools } from '@tanstack/router-devtools'
+
+interface AuthState {
+  isAuthenticated: boolean
+  user: { id: string; username: string; email: string } | null
+  login: (username: string, password: string) => Promise<void>
+  logout: () => void
+}
+
+interface MyRouterContext {
+  auth: AuthState
+}
+
+export const Route = createRootRouteWithContext<MyRouterContext>()({
+  component: () => (
+    <div>
+      <Outlet />
+      <TanStackRouterDevtools />
+    </div>
+  ),
+})
+```
+
+### 3. Configure Router
+
+Update `src/router.tsx`:
+
+```tsx
+import { createRouter } from '@tanstack/react-router'
+import { routeTree } from './routeTree.gen'
+
+export const router = createRouter({
+  routeTree,
+  context: {
+    // auth will be passed down from App component
+    auth: undefined!,
+  },
+})
+
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router
+  }
+}
+```
+
+### 4. Connect App with Authentication
+
+Update `src/App.tsx`:
+
+```tsx
+import { RouterProvider } from '@tanstack/react-router'
+import { AuthProvider, useAuth } from './auth'
+import { router } from './router'
+
+function InnerApp() {
+  const auth = useAuth()
+  return <RouterProvider router={router} context={{ auth }} />
+}
+
+function App() {
+  return (
+    <AuthProvider>
+      <InnerApp />
+    </AuthProvider>
+  )
+}
+
+export default App
+```
+
+---
+
+## Protected Routes with Redirects
+
+### 1. Create Authentication Layout Route
+
+Create `src/routes/_authenticated.tsx`:
+
+```tsx
+import { createFileRoute, redirect, Outlet } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_authenticated')({
+  beforeLoad: ({ context, location }) => {
+    if (!context.auth.isAuthenticated) {
+      throw redirect({
+        to: '/login',
+        search: {
+          // Save current location for redirect after login
+          redirect: location.href,
+        },
+      })
+    }
+  },
+  component: () => <Outlet />,
+})
+```
+
+### 2. Create Login Route
+
+Create `src/routes/login.tsx`:
+
+```tsx
+import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router'
+import { useState } from 'react'
+
+export const Route = createFileRoute('/login')({
+  validateSearch: (search) => ({
+    redirect: (search.redirect as string) || '/',
+  }),
+  beforeLoad: ({ context, search }) => {
+    // Redirect to dashboard if already authenticated
+    if (context.auth.isAuthenticated) {
+      throw redirect({ to: search.redirect })
+    }
+  },
+  component: LoginComponent,
+})
+
+function LoginComponent() {
+  const navigate = useNavigate()
+  const { auth } = Route.useRouteContext()
+  const { redirect } = Route.useSearch()
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsLoading(true)
+    setError('')
+
+    try {
+      await auth.login(username, password)
+      // Use router.history.push for full URL navigation
+      window.location.href = redirect
+    } catch (err) {
+      setError('Invalid username or password')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <form onSubmit={handleSubmit} className="max-w-md w-full space-y-4">
+        <h1 className="text-2xl font-bold">Login</h1>
+        
+        {error && (
+          <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
+            {error}
+          </div>
+        )}
+
+        <div>
+          <label htmlFor="username" className="block text-sm font-medium">
+            Username
+          </label>
+          <input
+            id="username"
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm"
+            required
+          />
+        </div>
+
+        <div>
+          <label htmlFor="password" className="block text-sm font-medium">
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm"
+            required
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="w-full bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 disabled:opacity-50"
+        >
+          {isLoading ? 'Signing in...' : 'Sign in'}
+        </button>
+      </form>
+    </div>
+  )
+}
+```
+
+### 3. Create Protected Routes
+
+Create `src/routes/_authenticated/dashboard.tsx`:
+
+```tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_authenticated/dashboard')({
+  component: DashboardComponent,
+})
+
+function DashboardComponent() {
+  const { auth } = Route.useRouteContext()
+
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <p>Welcome, {auth.user?.username}!</p>
+      <button
+        onClick={auth.logout}
+        className="bg-red-600 text-white px-4 py-2 rounded"
+      >
+        Logout
+      </button>
+    </div>
+  )
+}
+```
+
+---
+
+## Inline Authentication (No Redirects)
+
+### 1. Create Layout with Conditional Rendering
+
+Create `src/routes/_authenticated.tsx`:
+
+```tsx
+import { createFileRoute, Outlet } from '@tanstack/react-router'
+import { LoginModal } from '../components/LoginModal'
+
+export const Route = createFileRoute('/_authenticated')({
+  component: AuthenticatedLayout,
+})
+
+function AuthenticatedLayout() {
+  const { auth } = Route.useRouteContext()
+
+  if (!auth.isAuthenticated) {
+    return <LoginModal />
+  }
+
+  return <Outlet />
+}
+```
+
+### 2. Create Login Modal Component
+
+Create `src/components/LoginModal.tsx`:
+
+```tsx
+import { useState } from 'react'
+import { useRouter } from '@tanstack/react-router'
+
+interface LoginModalProps {
+  onClose?: () => void
+}
+
+export function LoginModal({ onClose }: LoginModalProps) {
+  const router = useRouter()
+  const auth = router.options.context.auth
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsLoading(true)
+    setError('')
+
+    try {
+      await auth.login(username, password)
+      onClose?.()
+    } catch (err) {
+      setError('Invalid username or password')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white p-8 rounded-lg shadow-lg max-w-md w-full mx-4">
+        <h2 className="text-2xl font-bold mb-6">Please sign in to continue</h2>
+        
+        {error && (
+          <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="username" className="block text-sm font-medium">
+              Username
+            </label>
+            <input
+              id="username"
+              type="text"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm"
+              required
+            />
+          </div>
+
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium">
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm"
+              required
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="w-full bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 disabled:opacity-50"
+          >
+            {isLoading ? 'Signing in...' : 'Sign in'}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}
+```
+
+---
+
+## Popular Authentication Providers
+
+### Auth0 Integration
+
+```bash
+npm install @auth0/auth0-react
+```
+
+Create `src/auth/auth0.tsx`:
+
+```tsx
+import { Auth0Provider, useAuth0 } from '@auth0/auth0-react'
+import { createContext, useContext } from 'react'
+
+interface Auth0ContextType {
+  isAuthenticated: boolean
+  user: any
+  login: () => void
+  logout: () => void
+}
+
+const Auth0Context = createContext<Auth0ContextType | undefined>(undefined)
+
+export function Auth0Wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <Auth0Provider
+      domain={import.meta.env.VITE_AUTH0_DOMAIN}
+      clientId={import.meta.env.VITE_AUTH0_CLIENT_ID}
+      authorizationParams={{
+        redirect_uri: window.location.origin,
+      }}
+    >
+      <Auth0ContextProvider>{children}</Auth0ContextProvider>
+    </Auth0Provider>
+  )
+}
+
+function Auth0ContextProvider({ children }: { children: React.ReactNode }) {
+  const { isAuthenticated, user, loginWithRedirect, logout } = useAuth0()
+
+  const contextValue = {
+    isAuthenticated,
+    user,
+    login: loginWithRedirect,
+    logout: () => logout({ logoutParams: { returnTo: window.location.origin } }),
+  }
+
+  return (
+    <Auth0Context.Provider value={contextValue}>
+      {children}
+    </Auth0Context.Provider>
+  )
+}
+
+export function useAuth0Context() {
+  const context = useContext(Auth0Context)
+  if (context === undefined) {
+    throw new Error('useAuth0Context must be used within Auth0Wrapper')
+  }
+  return context
+}
+```
+
+### Clerk Integration
+
+```bash
+npm install @clerk/clerk-react
+```
+
+Create `src/auth/clerk.tsx`:
+
+```tsx
+import { ClerkProvider, useUser, useAuth } from '@clerk/clerk-react'
+
+export function ClerkWrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <ClerkProvider publishableKey={import.meta.env.VITE_CLERK_PUBLISHABLE_KEY}>
+      {children}
+    </ClerkProvider>
+  )
+}
+
+export function useClerkAuth() {
+  const { isSignedIn } = useAuth()
+  const { user } = useUser()
+
+  return {
+    isAuthenticated: isSignedIn,
+    user: user ? {
+      id: user.id,
+      username: user.username || user.primaryEmailAddress?.emailAddress || '',
+      email: user.primaryEmailAddress?.emailAddress || '',
+    } : null,
+    login: () => {
+      // Clerk handles login through components like <SignIn />
+    },
+    logout: () => {
+      // Clerk handles logout through components like <UserButton />
+    },
+  }
+}
+```
+
+### Supabase Integration
+
+```bash
+npm install @supabase/supabase-js
+```
+
+Create `src/auth/supabase.tsx`:
+
+```tsx
+import { createClient } from '@supabase/supabase-js'
+import { createContext, useContext, useEffect, useState } from 'react'
+
+const supabase = createClient(
+  import.meta.env.VITE_SUPABASE_URL,
+  import.meta.env.VITE_SUPABASE_ANON_KEY
+)
+
+interface SupabaseAuthState {
+  isAuthenticated: boolean
+  user: any
+  login: (email: string, password: string) => Promise<void>
+  logout: () => Promise<void>
+}
+
+const SupabaseAuthContext = createContext<SupabaseAuthState | undefined>(undefined)
+
+export function SupabaseAuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState(null)
+  const [isAuthenticated, setIsAuthenticated] = useState(false)
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setUser(session?.user ?? null)
+      setIsAuthenticated(!!session?.user)
+    })
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(
+      (_event, session) => {
+        setUser(session?.user ?? null)
+        setIsAuthenticated(!!session?.user)
+      }
+    )
+
+    return () => subscription.unsubscribe()
+  }, [])
+
+  const login = async (email: string, password: string) => {
+    const { error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    })
+    if (error) throw error
+  }
+
+  const logout = async () => {
+    const { error } = await supabase.auth.signOut()
+    if (error) throw error
+  }
+
+  return (
+    <SupabaseAuthContext.Provider value={{ isAuthenticated, user, login, logout }}>
+      {children}
+    </SupabaseAuthContext.Provider>
+  )
+}
+
+export function useSupabaseAuth() {
+  const context = useContext(SupabaseAuthContext)
+  if (context === undefined) {
+    throw new Error('useSupabaseAuth must be used within SupabaseAuthProvider')
+  }
+  return context
+}
+```
+
+---
+
+## Role-Based Access Control
+
+### 1. Extend Authentication Context
+
+Update your auth context to include roles:
+
+```tsx
+interface User {
+  id: string
+  username: string
+  email: string
+  roles: string[]
+}
+
+interface AuthState {
+  isAuthenticated: boolean
+  user: User | null
+  hasRole: (role: string) => boolean
+  hasAnyRole: (roles: string[]) => boolean
+  login: (username: string, password: string) => Promise<void>
+  logout: () => void
+}
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [isAuthenticated, setIsAuthenticated] = useState(false)
+
+  const hasRole = (role: string) => {
+    return user?.roles.includes(role) ?? false
+  }
+
+  const hasAnyRole = (roles: string[]) => {
+    return roles.some(role => user?.roles.includes(role)) ?? false
+  }
+
+  // ... login, logout logic
+
+  return (
+    <AuthContext.Provider value={{ 
+      isAuthenticated, 
+      user, 
+      hasRole, 
+      hasAnyRole, 
+      login, 
+      logout 
+    }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+```
+
+### 2. Create Role-Protected Routes
+
+Create `src/routes/_authenticated/_admin.tsx`:
+
+```tsx
+import { createFileRoute, redirect, Outlet } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_authenticated/_admin')({
+  beforeLoad: ({ context, location }) => {
+    if (!context.auth.hasRole('admin')) {
+      throw redirect({
+        to: '/unauthorized',
+        search: {
+          redirect: location.href,
+        },
+      })
+    }
+  },
+  component: () => <Outlet />,
+})
+```
+
+---
+
+## Production Checklist
+
+Before deploying authentication, ensure you have:
+
+- [ ] Secured API endpoints with proper authentication middleware
+- [ ] Set up HTTPS in production (required for secure cookies)
+- [ ] Configured environment variables for auth providers
+- [ ] Implemented proper session management and token refresh
+- [ ] Added CSRF protection for form-based authentication
+- [ ] Set up proper CORS configuration for your API
+- [ ] Tested all authentication flows (login, logout, refresh)
+- [ ] Implemented proper error handling for auth failures
+- [ ] Added loading states for auth operations
+
+---
+
+## Common Problems
+
+### Authentication Context Not Available
+
+**Problem:** `useAuth must be used within an AuthProvider` error.
+
+**Cause:** Trying to use auth context outside the provider or incorrect provider setup.
+
+**Solutions:**
+- Ensure `AuthProvider` wraps your entire app
+- Check that `RouterProvider` is inside the auth provider
+- Verify context is properly passed to router
+
+### Infinite Redirect Loops
+
+**Problem:** Page keeps redirecting between login and protected routes.
+
+**Cause:** Authentication state not properly initialized or checking auth in wrong lifecycle.
+
+**Solutions:**
+- Add loading state while auth initializes:
+  ```tsx
+  if (isLoading) return <div>Loading...</div>
+  ```
+- Use `beforeLoad` instead of component for auth checks
+- Ensure auth state is properly persisted
+
+### User Logged Out on Page Refresh
+
+**Problem:** Authentication state resets when page refreshes.
+
+**Cause:** Auth state not persisted between sessions.
+
+**Solutions:**
+- Store tokens in localStorage/sessionStorage:
+  ```tsx
+  useEffect(() => {
+    const token = localStorage.getItem('auth-token')
+    if (token) {
+      validateAndSetUser(token)
+    }
+  }, [])
+  ```
+- Use HTTP-only cookies for better security
+- Implement token refresh logic
+
+### Protected Route Flashing Before Redirect
+
+**Problem:** Protected content briefly shows before redirecting to login.
+
+**Cause:** Authentication check happening in component instead of `beforeLoad`.
+
+**Solution:** Move auth checks to `beforeLoad`:
+```tsx
+export const Route = createFileRoute('/_authenticated/dashboard')({
+  beforeLoad: ({ context }) => {
+    if (!context.auth.isAuthenticated) {
+      throw redirect({ to: '/login' })
+    }
+  },
+  component: DashboardComponent,
+})
+```
+
+---
+
+## Common Next Steps
+
+After setting up authentication, you might want to:
+
+<!-- TODO: Uncomment as how-to guides are created
+- [How to Set Up Authorization and Permissions](./setup-authorization.md)
+- [How to Implement Multi-Factor Authentication](./setup-mfa.md)
+- [How to Handle User Sessions](./handle-user-sessions.md)
+- [How to Set Up Social Login](./setup-social-login.md)
+-->
+
+## Related Resources
+
+- [Authenticated Routes Guide](../guide/authenticated-routes.md) - Detailed conceptual guide
+- [Router Context Guide](../guide/router-context.md) - Understanding context in TanStack Router
+- [Authentication Examples](https://github.com/TanStack/router/tree/main/examples/react/authenticated-routes) - Complete working examples

--- a/docs/router/framework/react/how-to/setup-authentication.md
+++ b/docs/router/framework/react/how-to/setup-authentication.md
@@ -43,8 +43,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       fetch('/api/validate-token', {
         headers: { Authorization: `Bearer ${token}` },
       })
-        .then(response => response.json())
-        .then(userData => {
+        .then((response) => response.json())
+        .then((userData) => {
           if (userData.valid) {
             setUser(userData.user)
             setIsAuthenticated(true)
@@ -65,7 +65,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   // Show loading state while checking auth
   if (isLoading) {
-    return <div className="flex items-center justify-center min-h-screen">Loading...</div>
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        Loading...
+      </div>
+    )
   }
 
   const login = async (username: string, password: string) => {
@@ -264,9 +268,12 @@ function LoginComponent() {
 
   return (
     <div className="min-h-screen flex items-center justify-center">
-      <form onSubmit={handleSubmit} className="max-w-md w-full space-y-4 p-6 border rounded-lg">
+      <form
+        onSubmit={handleSubmit}
+        className="max-w-md w-full space-y-4 p-6 border rounded-lg"
+      >
         <h1 className="text-2xl font-bold text-center">Sign In</h1>
-        
+
         {error && (
           <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
             {error}
@@ -339,15 +346,14 @@ function DashboardComponent() {
           Sign Out
         </button>
       </div>
-      
+
       <div className="bg-white p-6 rounded-lg shadow">
         <h2 className="text-xl font-semibold mb-2">Welcome back!</h2>
         <p className="text-gray-600">
-          Hello, <strong>{auth.user?.username}</strong>! You are successfully authenticated.
+          Hello, <strong>{auth.user?.username}</strong>! You are successfully
+          authenticated.
         </p>
-        <p className="text-sm text-gray-500 mt-2">
-          Email: {auth.user?.email}
-        </p>
+        <p className="text-sm text-gray-500 mt-2">Email: {auth.user?.email}</p>
       </div>
     </div>
   )
@@ -374,8 +380,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       fetch('/api/validate-token', {
         headers: { Authorization: `Bearer ${token}` },
       })
-        .then(response => response.json())
-        .then(userData => {
+        .then((response) => response.json())
+        .then((userData) => {
           if (userData.valid) {
             setUser(userData.user)
             setIsAuthenticated(true)
@@ -396,7 +402,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   // Show loading state while checking auth
   if (isLoading) {
-    return <div className="flex items-center justify-center min-h-screen">Loading...</div>
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        Loading...
+      </div>
+    )
   }
 
   // ... rest of the provider logic

--- a/docs/router/framework/react/how-to/setup-rbac.md
+++ b/docs/router/framework/react/how-to/setup-rbac.md
@@ -1,0 +1,698 @@
+# How to Set Up Role-Based Access Control
+
+This guide covers implementing role-based access control (RBAC) and permission-based routing in TanStack Router applications.
+
+## Quick Start
+
+Extend your authentication context to include roles and permissions, create role-protected layout routes, and use `beforeLoad` to check user permissions before rendering routes.
+
+---
+
+## Extend Authentication Context
+
+### 1. Add Roles to User Type
+
+Update your authentication context to include roles:
+
+```tsx
+// src/auth.tsx
+import React, { createContext, useContext, useState } from 'react'
+
+interface User {
+  id: string
+  username: string
+  email: string
+  roles: string[]
+  permissions: string[]
+}
+
+interface AuthState {
+  isAuthenticated: boolean
+  user: User | null
+  hasRole: (role: string) => boolean
+  hasAnyRole: (roles: string[]) => boolean
+  hasPermission: (permission: string) => boolean
+  hasAnyPermission: (permissions: string[]) => boolean
+  login: (username: string, password: string) => Promise<void>
+  logout: () => void
+}
+
+const AuthContext = createContext<AuthState | undefined>(undefined)
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [isAuthenticated, setIsAuthenticated] = useState(false)
+
+  const hasRole = (role: string) => {
+    return user?.roles.includes(role) ?? false
+  }
+
+  const hasAnyRole = (roles: string[]) => {
+    return roles.some(role => user?.roles.includes(role)) ?? false
+  }
+
+  const hasPermission = (permission: string) => {
+    return user?.permissions.includes(permission) ?? false
+  }
+
+  const hasAnyPermission = (permissions: string[]) => {
+    return permissions.some(permission => user?.permissions.includes(permission)) ?? false
+  }
+
+  const login = async (username: string, password: string) => {
+    const response = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    })
+
+    if (response.ok) {
+      const userData = await response.json()
+      setUser(userData)
+      setIsAuthenticated(true)
+    } else {
+      throw new Error('Authentication failed')
+    }
+  }
+
+  const logout = () => {
+    setUser(null)
+    setIsAuthenticated(false)
+  }
+
+  return (
+    <AuthContext.Provider value={{ 
+      isAuthenticated, 
+      user, 
+      hasRole, 
+      hasAnyRole, 
+      hasPermission, 
+      hasAnyPermission, 
+      login, 
+      logout 
+    }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext)
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
+}
+```
+
+### 2. Update Router Context Types
+
+Update `src/routes/__root.tsx`:
+
+```tsx
+import { createRootRouteWithContext, Outlet } from '@tanstack/react-router'
+
+interface AuthState {
+  isAuthenticated: boolean
+  user: {
+    id: string
+    username: string
+    email: string
+    roles: string[]
+    permissions: string[]
+  } | null
+  hasRole: (role: string) => boolean
+  hasAnyRole: (roles: string[]) => boolean
+  hasPermission: (permission: string) => boolean
+  hasAnyPermission: (permissions: string[]) => boolean
+  login: (username: string, password: string) => Promise<void>
+  logout: () => void
+}
+
+interface MyRouterContext {
+  auth: AuthState
+}
+
+export const Route = createRootRouteWithContext<MyRouterContext>()({
+  component: () => (
+    <div>
+      <Outlet />
+    </div>
+  ),
+})
+```
+
+---
+
+## Create Role-Protected Routes
+
+### 1. Admin-Only Routes
+
+Create `src/routes/_authenticated/_admin.tsx`:
+
+```tsx
+import { createFileRoute, redirect, Outlet } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_authenticated/_admin')({
+  beforeLoad: ({ context, location }) => {
+    if (!context.auth.hasRole('admin')) {
+      throw redirect({
+        to: '/unauthorized',
+        search: {
+          redirect: location.href,
+        },
+      })
+    }
+  },
+  component: AdminLayout,
+})
+
+function AdminLayout() {
+  return (
+    <div>
+      <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
+        <strong>Admin Area:</strong> You have administrative privileges.
+      </div>
+      <Outlet />
+    </div>
+  )
+}
+```
+
+### 2. Multiple Role Access
+
+Create `src/routes/_authenticated/_moderator.tsx`:
+
+```tsx
+import { createFileRoute, redirect, Outlet } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_authenticated/_moderator')({
+  beforeLoad: ({ context, location }) => {
+    const allowedRoles = ['admin', 'moderator']
+    if (!context.auth.hasAnyRole(allowedRoles)) {
+      throw redirect({
+        to: '/unauthorized',
+        search: {
+          redirect: location.href,
+          reason: 'insufficient_role',
+        },
+      })
+    }
+  },
+  component: ModeratorLayout,
+})
+
+function ModeratorLayout() {
+  const { auth } = Route.useRouteContext()
+  
+  return (
+    <div>
+      <div className="bg-blue-100 border border-blue-400 text-blue-700 px-4 py-3 rounded mb-4">
+        <strong>Moderator Area:</strong> Role: {auth.user?.roles.join(', ')}
+      </div>
+      <Outlet />
+    </div>
+  )
+}
+```
+
+### 3. Permission-Based Routes
+
+Create `src/routes/_authenticated/_users.tsx`:
+
+```tsx
+import { createFileRoute, redirect, Outlet } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_authenticated/_users')({
+  beforeLoad: ({ context, location }) => {
+    const requiredPermissions = ['users:read', 'users:write']
+    if (!context.auth.hasAnyPermission(requiredPermissions)) {
+      throw redirect({
+        to: '/unauthorized',
+        search: {
+          redirect: location.href,
+          reason: 'insufficient_permissions',
+        },
+      })
+    }
+  },
+  component: () => <Outlet />,
+})
+```
+
+---
+
+## Create Specific Protected Pages
+
+### 1. Admin Dashboard
+
+Create `src/routes/_authenticated/_admin/dashboard.tsx`:
+
+```tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_authenticated/_admin/dashboard')({
+  component: AdminDashboard,
+})
+
+function AdminDashboard() {
+  const { auth } = Route.useRouteContext()
+
+  return (
+    <div className="p-6">
+      <h1 className="text-3xl font-bold mb-6">Admin Dashboard</h1>
+      
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="bg-white p-6 rounded-lg shadow">
+          <h2 className="text-xl font-semibold mb-2">User Management</h2>
+          <p className="text-gray-600">Manage all users in the system</p>
+          <button className="mt-4 bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
+            View Users
+          </button>
+        </div>
+        
+        <div className="bg-white p-6 rounded-lg shadow">
+          <h2 className="text-xl font-semibold mb-2">System Settings</h2>
+          <p className="text-gray-600">Configure system-wide settings</p>
+          <button className="mt-4 bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700">
+            Open Settings
+          </button>
+        </div>
+        
+        <div className="bg-white p-6 rounded-lg shadow">
+          <h2 className="text-xl font-semibold mb-2">Reports</h2>
+          <p className="text-gray-600">View system reports and analytics</p>
+          <button className="mt-4 bg-purple-600 text-white px-4 py-2 rounded hover:bg-purple-700">
+            View Reports
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-8 bg-gray-100 p-4 rounded">
+        <h3 className="font-semibold">Your Info:</h3>
+        <p>Username: {auth.user?.username}</p>
+        <p>Roles: {auth.user?.roles.join(', ')}</p>
+        <p>Permissions: {auth.user?.permissions.join(', ')}</p>
+      </div>
+    </div>
+  )
+}
+```
+
+### 2. User Management Page
+
+Create `src/routes/_authenticated/_users/manage.tsx`:
+
+```tsx
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_authenticated/_users/manage')({
+  beforeLoad: ({ context }) => {
+    // Additional permission check at the page level
+    if (!context.auth.hasPermission('users:write')) {
+      throw new Error('You need write permissions to manage users')
+    }
+  },
+  component: UserManagement,
+})
+
+function UserManagement() {
+  const { auth } = Route.useRouteContext()
+
+  const canEdit = auth.hasPermission('users:write')
+  const canDelete = auth.hasPermission('users:delete')
+
+  return (
+    <div className="p-6">
+      <h1 className="text-3xl font-bold mb-6">User Management</h1>
+      
+      <div className="bg-white rounded-lg shadow overflow-hidden">
+        <table className="min-w-full">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Email</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Role</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            <tr>
+              <td className="px-6 py-4 whitespace-nowrap">John Doe</td>
+              <td className="px-6 py-4 whitespace-nowrap">john@example.com</td>
+              <td className="px-6 py-4 whitespace-nowrap">
+                <span className="inline-flex px-2 py-1 text-xs font-semibold rounded-full bg-green-100 text-green-800">
+                  User
+                </span>
+              </td>
+              <td className="px-6 py-4 whitespace-nowrap text-sm">
+                {canEdit && (
+                  <button className="text-blue-600 hover:text-blue-900 mr-4">
+                    Edit
+                  </button>
+                )}
+                {canDelete && (
+                  <button className="text-red-600 hover:text-red-900">
+                    Delete
+                  </button>
+                )}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-6 p-4 bg-blue-50 rounded">
+        <h3 className="font-semibold text-blue-800">Your Permissions:</h3>
+        <ul className="text-blue-700 text-sm">
+          {auth.user?.permissions.map(permission => (
+            <li key={permission}>✓ {permission}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}
+```
+
+---
+
+## Create Unauthorized Page
+
+Create `src/routes/unauthorized.tsx`:
+
+```tsx
+import { createFileRoute, Link } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/unauthorized')({
+  validateSearch: (search) => ({
+    redirect: (search.redirect as string) || '/dashboard',
+    reason: (search.reason as string) || 'insufficient_permissions',
+  }),
+  component: UnauthorizedPage,
+})
+
+function UnauthorizedPage() {
+  const { redirect, reason } = Route.useSearch()
+  const { auth } = Route.useRouteContext()
+
+  const reasonMessages = {
+    insufficient_role: 'You do not have the required role to access this page.',
+    insufficient_permissions: 'You do not have the required permissions to access this page.',
+    default: 'You are not authorized to access this page.',
+  }
+
+  const message = reasonMessages[reason as keyof typeof reasonMessages] || reasonMessages.default
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="max-w-md w-full bg-white shadow-lg rounded-lg p-8 text-center">
+        <div className="mb-6">
+          <div className="mx-auto w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
+            <svg className="w-8 h-8 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z" />
+            </svg>
+          </div>
+        </div>
+        
+        <h1 className="text-2xl font-bold text-gray-900 mb-4">Access Denied</h1>
+        <p className="text-gray-600 mb-6">{message}</p>
+        
+        <div className="mb-6 text-sm text-gray-500">
+          <p><strong>Your roles:</strong> {auth.user?.roles.join(', ') || 'None'}</p>
+          <p><strong>Your permissions:</strong> {auth.user?.permissions.join(', ') || 'None'}</p>
+        </div>
+        
+        <div className="space-y-3">
+          <Link
+            to="/dashboard"
+            className="block w-full bg-blue-600 text-white py-2 px-4 rounded hover:bg-blue-700 transition-colors"
+          >
+            Go to Dashboard
+          </Link>
+          
+          <Link
+            to={redirect}
+            className="block w-full bg-gray-200 text-gray-800 py-2 px-4 rounded hover:bg-gray-300 transition-colors"
+          >
+            Try Again
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+---
+
+## Component-Level Permission Checks
+
+### 1. Conditional Rendering Hook
+
+Create `src/hooks/usePermissions.ts`:
+
+```tsx
+import { useRouter } from '@tanstack/react-router'
+
+export function usePermissions() {
+  const router = useRouter()
+  const auth = router.options.context.auth
+
+  return {
+    hasRole: auth.hasRole,
+    hasAnyRole: auth.hasAnyRole,
+    hasPermission: auth.hasPermission,
+    hasAnyPermission: auth.hasAnyPermission,
+    user: auth.user,
+  }
+}
+```
+
+### 2. Permission Guard Component
+
+Create `src/components/PermissionGuard.tsx`:
+
+```tsx
+interface PermissionGuardProps {
+  children: React.ReactNode
+  roles?: string[]
+  permissions?: string[]
+  requireAll?: boolean
+  fallback?: React.ReactNode
+}
+
+export function PermissionGuard({
+  children,
+  roles = [],
+  permissions = [],
+  requireAll = false,
+  fallback = null,
+}: PermissionGuardProps) {
+  const { hasAnyRole, hasAnyPermission, hasRole, hasPermission } = usePermissions()
+
+  const hasRequiredRoles = roles.length === 0 || (
+    requireAll 
+      ? roles.every(role => hasRole(role))
+      : hasAnyRole(roles)
+  )
+
+  const hasRequiredPermissions = permissions.length === 0 || (
+    requireAll 
+      ? permissions.every(permission => hasPermission(permission))
+      : hasAnyPermission(permissions)
+  )
+
+  if (hasRequiredRoles && hasRequiredPermissions) {
+    return <>{children}</>
+  }
+
+  return <>{fallback}</>
+}
+```
+
+### 3. Using Permission Guards
+
+```tsx
+import { PermissionGuard } from '../components/PermissionGuard'
+
+function SomeComponent() {
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      
+      <PermissionGuard roles={['admin']}>
+        <button className="bg-red-600 text-white px-4 py-2 rounded">
+          Admin Only Button
+        </button>
+      </PermissionGuard>
+      
+      <PermissionGuard 
+        permissions={['users:write']}
+        fallback={<p className="text-gray-500">You cannot edit users</p>}
+      >
+        <button className="bg-blue-600 text-white px-4 py-2 rounded">
+          Edit Users
+        </button>
+      </PermissionGuard>
+      
+      <PermissionGuard 
+        roles={['admin', 'moderator']}
+        permissions={['content:moderate']}
+        requireAll={true}
+      >
+        <button className="bg-yellow-600 text-white px-4 py-2 rounded">
+          Moderate Content (Admin/Mod + Permission)
+        </button>
+      </PermissionGuard>
+    </div>
+  )
+}
+```
+
+---
+
+## Advanced Permission Patterns
+
+### 1. Resource-Based Permissions
+
+```tsx
+// Check if user can edit a specific resource
+function canEditResource(auth: AuthState, resourceId: string, ownerId: string) {
+  // Admin can edit anything
+  if (auth.hasRole('admin')) return true
+  
+  // Owner can edit their own resources
+  if (auth.user?.id === ownerId && auth.hasPermission('resource:edit:own')) return true
+  
+  // Moderators can edit with permission
+  if (auth.hasRole('moderator') && auth.hasPermission('resource:edit:any')) return true
+  
+  return false
+}
+
+// Usage in component
+function ResourceEditor({ resource }) {
+  const { auth } = Route.useRouteContext()
+  
+  if (!canEditResource(auth, resource.id, resource.ownerId)) {
+    return <div>You cannot edit this resource</div>
+  }
+  
+  return <EditForm resource={resource} />
+}
+```
+
+### 2. Time-Based Permissions
+
+```tsx
+function hasTimeBasedPermission(auth: AuthState, permission: string) {
+  const userPermissions = auth.user?.permissions || []
+  const hasPermission = userPermissions.includes(permission)
+  
+  // Check if permission has time restrictions
+  const timeRestricted = userPermissions.find(p => 
+    p.startsWith(`${permission}:time:`)
+  )
+  
+  if (timeRestricted) {
+    const [, , startHour, endHour] = timeRestricted.split(':')
+    const currentHour = new Date().getHours()
+    return currentHour >= parseInt(startHour) && currentHour <= parseInt(endHour)
+  }
+  
+  return hasPermission
+}
+```
+
+---
+
+## Common Problems
+
+### Role/Permission Data Not Loading
+
+**Problem:** User roles/permissions are undefined in routes.
+
+**Solution:** Ensure your authentication API returns complete user data:
+
+```tsx
+const login = async (username: string, password: string) => {
+  const response = await fetch('/api/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password }),
+  })
+
+  if (response.ok) {
+    const userData = await response.json()
+    // Ensure userData includes roles and permissions
+    console.log('User data:', userData) // Debug log
+    setUser(userData)
+    setIsAuthenticated(true)
+  }
+}
+```
+
+### Permission Checks Too Restrictive
+
+**Problem:** Users locked out of areas they should access.
+
+**Solution:** Use hierarchical permissions and role inheritance:
+
+```tsx
+const roleHierarchy = {
+  admin: ['admin', 'moderator', 'user'],
+  moderator: ['moderator', 'user'],
+  user: ['user']
+}
+
+const hasRole = (requiredRole: string) => {
+  const userRoles = user?.roles || []
+  return userRoles.some(userRole => 
+    roleHierarchy[userRole]?.includes(requiredRole)
+  )
+}
+```
+
+### Performance Issues with Many Permission Checks
+
+**Problem:** Too many permission checks slowing down renders.
+
+**Solution:** Memoize permission computations:
+
+```tsx
+import { useMemo } from 'react'
+
+function usePermissions() {
+  const { auth } = Route.useRouteContext()
+  
+  const permissions = useMemo(() => ({
+    canEditUsers: auth.hasPermission('users:write'),
+    canDeleteUsers: auth.hasPermission('users:delete'),
+    isAdmin: auth.hasRole('admin'),
+    isModerator: auth.hasAnyRole(['admin', 'moderator']),
+  }), [auth.user?.roles, auth.user?.permissions])
+  
+  return permissions
+}
+```
+
+---
+
+## Common Next Steps
+
+After setting up RBAC, you might want to:
+
+- [How to Set Up Basic Authentication](./setup-authentication.md) - Core auth implementation
+- [How to Integrate Authentication Providers](./setup-auth-providers.md) - Use external auth services
+
+<!-- TODO: Uncomment as how-to guides are created
+- [How to Implement Dynamic Permissions](./setup-dynamic-permissions.md)
+- [How to Audit User Actions](./setup-audit-logging.md)
+-->
+
+## Related Resources
+
+- [Authenticated Routes Guide](../guide/authenticated-routes.md) - Core authentication concepts
+- [Router Context Guide](../guide/router-context.md) - Understanding router context
+- [RBAC Best Practices](https://auth0.com/docs/manage-users/access-control/rbac) - General RBAC principles

--- a/docs/router/framework/react/how-to/setup-rbac.md
+++ b/docs/router/framework/react/how-to/setup-rbac.md
@@ -48,7 +48,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }
 
   const hasAnyRole = (roles: string[]) => {
-    return roles.some(role => user?.roles.includes(role)) ?? false
+    return roles.some((role) => user?.roles.includes(role)) ?? false
   }
 
   const hasPermission = (permission: string) => {
@@ -56,7 +56,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }
 
   const hasAnyPermission = (permissions: string[]) => {
-    return permissions.some(permission => user?.permissions.includes(permission)) ?? false
+    return (
+      permissions.some((permission) =>
+        user?.permissions.includes(permission),
+      ) ?? false
+    )
   }
 
   const login = async (username: string, password: string) => {
@@ -81,16 +85,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <AuthContext.Provider value={{ 
-      isAuthenticated, 
-      user, 
-      hasRole, 
-      hasAnyRole, 
-      hasPermission, 
-      hasAnyPermission, 
-      login, 
-      logout 
-    }}>
+    <AuthContext.Provider
+      value={{
+        isAuthenticated,
+        user,
+        hasRole,
+        hasAnyRole,
+        hasPermission,
+        hasAnyPermission,
+        login,
+        logout,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   )
@@ -204,7 +210,7 @@ export const Route = createFileRoute('/_authenticated/_moderator')({
 
 function ModeratorLayout() {
   const { auth } = Route.useRouteContext()
-  
+
   return (
     <div>
       <div className="bg-blue-100 border border-blue-400 text-blue-700 px-4 py-3 rounded mb-4">
@@ -261,7 +267,7 @@ function AdminDashboard() {
   return (
     <div className="p-6">
       <h1 className="text-3xl font-bold mb-6">Admin Dashboard</h1>
-      
+
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         <div className="bg-white p-6 rounded-lg shadow">
           <h2 className="text-xl font-semibold mb-2">User Management</h2>
@@ -270,7 +276,7 @@ function AdminDashboard() {
             View Users
           </button>
         </div>
-        
+
         <div className="bg-white p-6 rounded-lg shadow">
           <h2 className="text-xl font-semibold mb-2">System Settings</h2>
           <p className="text-gray-600">Configure system-wide settings</p>
@@ -278,7 +284,7 @@ function AdminDashboard() {
             Open Settings
           </button>
         </div>
-        
+
         <div className="bg-white p-6 rounded-lg shadow">
           <h2 className="text-xl font-semibold mb-2">Reports</h2>
           <p className="text-gray-600">View system reports and analytics</p>
@@ -325,15 +331,23 @@ function UserManagement() {
   return (
     <div className="p-6">
       <h1 className="text-3xl font-bold mb-6">User Management</h1>
-      
+
       <div className="bg-white rounded-lg shadow overflow-hidden">
         <table className="min-w-full">
           <thead className="bg-gray-50">
             <tr>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Email</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Role</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                Name
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                Email
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                Role
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                Actions
+              </th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-200">
@@ -365,7 +379,7 @@ function UserManagement() {
       <div className="mt-6 p-4 bg-blue-50 rounded">
         <h3 className="font-semibold text-blue-800">Your Permissions:</h3>
         <ul className="text-blue-700 text-sm">
-          {auth.user?.permissions.map(permission => (
+          {auth.user?.permissions.map((permission) => (
             <li key={permission}>✓ {permission}</li>
           ))}
         </ul>
@@ -398,31 +412,49 @@ function UnauthorizedPage() {
 
   const reasonMessages = {
     insufficient_role: 'You do not have the required role to access this page.',
-    insufficient_permissions: 'You do not have the required permissions to access this page.',
+    insufficient_permissions:
+      'You do not have the required permissions to access this page.',
     default: 'You are not authorized to access this page.',
   }
 
-  const message = reasonMessages[reason as keyof typeof reasonMessages] || reasonMessages.default
+  const message =
+    reasonMessages[reason as keyof typeof reasonMessages] ||
+    reasonMessages.default
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50">
       <div className="max-w-md w-full bg-white shadow-lg rounded-lg p-8 text-center">
         <div className="mb-6">
           <div className="mx-auto w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
-            <svg className="w-8 h-8 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z" />
+            <svg
+              className="w-8 h-8 text-red-600"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"
+              />
             </svg>
           </div>
         </div>
-        
+
         <h1 className="text-2xl font-bold text-gray-900 mb-4">Access Denied</h1>
         <p className="text-gray-600 mb-6">{message}</p>
-        
+
         <div className="mb-6 text-sm text-gray-500">
-          <p><strong>Your roles:</strong> {auth.user?.roles.join(', ') || 'None'}</p>
-          <p><strong>Your permissions:</strong> {auth.user?.permissions.join(', ') || 'None'}</p>
+          <p>
+            <strong>Your roles:</strong> {auth.user?.roles.join(', ') || 'None'}
+          </p>
+          <p>
+            <strong>Your permissions:</strong>{' '}
+            {auth.user?.permissions.join(', ') || 'None'}
+          </p>
         </div>
-        
+
         <div className="space-y-3">
           <Link
             to="/dashboard"
@@ -430,7 +462,7 @@ function UnauthorizedPage() {
           >
             Go to Dashboard
           </Link>
-          
+
           <Link
             to={redirect}
             className="block w-full bg-gray-200 text-gray-800 py-2 px-4 rounded hover:bg-gray-300 transition-colors"
@@ -489,19 +521,18 @@ export function PermissionGuard({
   requireAll = false,
   fallback = null,
 }: PermissionGuardProps) {
-  const { hasAnyRole, hasAnyPermission, hasRole, hasPermission } = usePermissions()
+  const { hasAnyRole, hasAnyPermission, hasRole, hasPermission } =
+    usePermissions()
 
-  const hasRequiredRoles = roles.length === 0 || (
-    requireAll 
-      ? roles.every(role => hasRole(role))
-      : hasAnyRole(roles)
-  )
+  const hasRequiredRoles =
+    roles.length === 0 ||
+    (requireAll ? roles.every((role) => hasRole(role)) : hasAnyRole(roles))
 
-  const hasRequiredPermissions = permissions.length === 0 || (
-    requireAll 
-      ? permissions.every(permission => hasPermission(permission))
-      : hasAnyPermission(permissions)
-  )
+  const hasRequiredPermissions =
+    permissions.length === 0 ||
+    (requireAll
+      ? permissions.every((permission) => hasPermission(permission))
+      : hasAnyPermission(permissions))
 
   if (hasRequiredRoles && hasRequiredPermissions) {
     return <>{children}</>
@@ -520,14 +551,14 @@ function SomeComponent() {
   return (
     <div>
       <h1>Dashboard</h1>
-      
+
       <PermissionGuard roles={['admin']}>
         <button className="bg-red-600 text-white px-4 py-2 rounded">
           Admin Only Button
         </button>
       </PermissionGuard>
-      
-      <PermissionGuard 
+
+      <PermissionGuard
         permissions={['users:write']}
         fallback={<p className="text-gray-500">You cannot edit users</p>}
       >
@@ -535,8 +566,8 @@ function SomeComponent() {
           Edit Users
         </button>
       </PermissionGuard>
-      
-      <PermissionGuard 
+
+      <PermissionGuard
         roles={['admin', 'moderator']}
         permissions={['content:moderate']}
         requireAll={true}
@@ -561,24 +592,26 @@ function SomeComponent() {
 function canEditResource(auth: AuthState, resourceId: string, ownerId: string) {
   // Admin can edit anything
   if (auth.hasRole('admin')) return true
-  
+
   // Owner can edit their own resources
-  if (auth.user?.id === ownerId && auth.hasPermission('resource:edit:own')) return true
-  
+  if (auth.user?.id === ownerId && auth.hasPermission('resource:edit:own'))
+    return true
+
   // Moderators can edit with permission
-  if (auth.hasRole('moderator') && auth.hasPermission('resource:edit:any')) return true
-  
+  if (auth.hasRole('moderator') && auth.hasPermission('resource:edit:any'))
+    return true
+
   return false
 }
 
 // Usage in component
 function ResourceEditor({ resource }) {
   const { auth } = Route.useRouteContext()
-  
+
   if (!canEditResource(auth, resource.id, resource.ownerId)) {
     return <div>You cannot edit this resource</div>
   }
-  
+
   return <EditForm resource={resource} />
 }
 ```
@@ -589,18 +622,20 @@ function ResourceEditor({ resource }) {
 function hasTimeBasedPermission(auth: AuthState, permission: string) {
   const userPermissions = auth.user?.permissions || []
   const hasPermission = userPermissions.includes(permission)
-  
+
   // Check if permission has time restrictions
-  const timeRestricted = userPermissions.find(p => 
-    p.startsWith(`${permission}:time:`)
+  const timeRestricted = userPermissions.find((p) =>
+    p.startsWith(`${permission}:time:`),
   )
-  
+
   if (timeRestricted) {
     const [, , startHour, endHour] = timeRestricted.split(':')
     const currentHour = new Date().getHours()
-    return currentHour >= parseInt(startHour) && currentHour <= parseInt(endHour)
+    return (
+      currentHour >= parseInt(startHour) && currentHour <= parseInt(endHour)
+    )
   }
-  
+
   return hasPermission
 }
 ```
@@ -643,13 +678,13 @@ const login = async (username: string, password: string) => {
 const roleHierarchy = {
   admin: ['admin', 'moderator', 'user'],
   moderator: ['moderator', 'user'],
-  user: ['user']
+  user: ['user'],
 }
 
 const hasRole = (requiredRole: string) => {
   const userRoles = user?.roles || []
-  return userRoles.some(userRole => 
-    roleHierarchy[userRole]?.includes(requiredRole)
+  return userRoles.some((userRole) =>
+    roleHierarchy[userRole]?.includes(requiredRole),
   )
 }
 ```
@@ -665,14 +700,17 @@ import { useMemo } from 'react'
 
 function usePermissions() {
   const { auth } = Route.useRouteContext()
-  
-  const permissions = useMemo(() => ({
-    canEditUsers: auth.hasPermission('users:write'),
-    canDeleteUsers: auth.hasPermission('users:delete'),
-    isAdmin: auth.hasRole('admin'),
-    isModerator: auth.hasAnyRole(['admin', 'moderator']),
-  }), [auth.user?.roles, auth.user?.permissions])
-  
+
+  const permissions = useMemo(
+    () => ({
+      canEditUsers: auth.hasPermission('users:write'),
+      canDeleteUsers: auth.hasPermission('users:delete'),
+      isAdmin: auth.hasRole('admin'),
+      isModerator: auth.hasAnyRole(['admin', 'moderator']),
+    }),
+    [auth.user?.roles, auth.user?.permissions],
+  )
+
   return permissions
 }
 ```

--- a/how-to-guides-implementation-plan.md
+++ b/how-to-guides-implementation-plan.md
@@ -5,7 +5,12 @@ This document outlines the multi-PR process for implementing the remaining how-t
 ## Progress Tracking
 
 - ✅ **Guide #1: Deploy to Production** - COMPLETED in docs/router/framework/react/how-to/deploy-to-production.md
-- ⏳ **Guides #2-11** - Pending implementation
+- ⏳ **Guide #2: Setup SSR** - IN PROGRESS (existing branch work)
+- ⏳ **Guide #3: Migrate from React Router** - IN PROGRESS (existing branch work)
+- ⏳ **Guide #4: Fix Build Issues** - PENDING
+- ⏳ **Guide #5: Integrate UI Libraries** - IN PROGRESS (existing branch work)
+- ✅ **Guide #6: Setup Authentication** - COMPLETED in docs/router/framework/react/how-to/setup-authentication.md
+- ⏳ **Guides #7-11** - Pending implementation
 
 ## Implementation Process
 
@@ -197,11 +202,11 @@ Update this section as guides are completed:
 
 ```
 ✅ Guide #1: Deploy to Production - COMPLETED
-⏳ Guide #2: Setup SSR - IN PROGRESS
-⏳ Guide #3: Migrate from React Router - PENDING
+⏳ Guide #2: Setup SSR - IN PROGRESS (existing branch work)
+⏳ Guide #3: Migrate from React Router - IN PROGRESS (existing branch work)
 ⏳ Guide #4: Fix Build Issues - PENDING
-⏳ Guide #5: Integrate UI Libraries - PENDING
-⏳ Guide #6: Setup Authentication - PENDING
+⏳ Guide #5: Integrate UI Libraries - IN PROGRESS (existing branch work)
+✅ Guide #6: Setup Authentication - COMPLETED
 ⏳ Guide #7: Debug Router Issues - PENDING
 ⏳ Guide #8: Setup Testing - PENDING
 ⏳ Guide #9: Setup Dev Environment - PENDING


### PR DESCRIPTION
Split the comprehensive authentication how-to guide into three focused guides to improve readability and maintainability.

The original authentication guide was too large and covered too many distinct topics (basic setup, provider integration, RBAC). This PR breaks it down into `setup-authentication.md`, `setup-auth-providers.md`, and `setup-rbac.md`, making each guide more digestible, easier to navigate, and allowing users to focus on specific authentication needs.