### PR TITLE
feat: create loader deps hash with stringifySearch

### DIFF
--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1189,7 +1189,9 @@ export class RouterCore<
           search: preMatchSearch,
         }) ?? ''
 
-      const loaderDepsHash = loaderDeps ? JSON.stringify(loaderDeps) : ''
+      const loaderDepsHash = loaderDeps
+        ? this.options.stringifySearch(loaderDeps)
+        : ''
 
       const { usedParams, interpolatedPath } = interpolatePath({
         path: route.fullPath,


### PR DESCRIPTION
https://discord.com/channels/719702312431386674/1389585719630102650/1389585719630102650

### My thoughts

`stringifySearch` and `parseSearch` options exit to extend the default behavior of the router to potentially support new data types, such as `bigint`, `Set`, `Map`, etc. Chances are that you'll also want to use these new data types in your loaders (via loaderDeps), so the `JSON.stringify` used in `loaderDepsHash` can be treated as a limitation.

I think there are two solutions to the problem:

1. Leave the problem up to the user, making them do additional work in `loaderDeps` calculation, like
   ```tsx
   validateSearch: z.object({ foo: z.coerce.bigint() }),
   loaderDeps: (deps) => ({ foo: deps.search.foo.toString() }),
   ```
   This would probably require additional docs around `loaderDeps` and `stringifySearch` option.

2. Do the chore for the user by leveraging `stringifySearch` in `loaderDepsHash` like in 56774063b99ef2b5a456a2b597ee35923e305991.