### PR TITLE
docs: Correct optional params docs syntax

### DIFF
--- a/docs/router/framework/react/guide/path-params.md
+++ b/docs/router/framework/react/guide/path-params.md
@@ -594,9 +594,9 @@ function AdvancedLanguageSwitcher() {
 }
 ```
 
-### Advanced i18n with Route Groups
+### Advanced i18n with Optional Parameters
 
-Organize i18n routes using route groups for better structure:
+Organize i18n routes using optional parameters for flexible locale handling:
 
 ```tsx
 // Route structure:

--- a/docs/router/framework/react/guide/path-params.md
+++ b/docs/router/framework/react/guide/path-params.md
@@ -601,15 +601,15 @@ Organize i18n routes using route groups for better structure:
 ```tsx
 // Route structure:
 // routes/
-//   ({-$locale})/
+//   {-$locale}/
 //     index.tsx        // /, /en, /fr
 //     about.tsx        // /about, /en/about, /fr/about
 //     blog/
 //       index.tsx      // /blog, /en/blog, /fr/blog
 //       $slug.tsx      // /blog/post, /en/blog/post, /fr/blog/post
 
-// routes/({-$locale})/index.tsx
-export const Route = createFileRoute('/({-$locale})/')({
+// routes/{-$locale}/index.tsx
+export const Route = createFileRoute('/{-$locale}/')({
   component: HomeComponent,
 })
 
@@ -625,8 +625,8 @@ function HomeComponent() {
   )
 }
 
-// routes/({-$locale})/about.tsx
-export const Route = createFileRoute('/({-$locale})/about')({
+// routes/{-$locale}/about.tsx
+export const Route = createFileRoute('/{-$locale}/about')({
   component: AboutComponent,
 })
 ```


### PR DESCRIPTION
Correct optional parameter syntax in documentation by removing unnecessary parentheses.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-e64937de-18eb-4b0c-8696-c1e1f2eb8a9d) · [Cursor](https://cursor.com/background-agent?bcId=bc-e64937de-18eb-4b0c-8696-c1e1f2eb8a9d)