### PR TITLE
refactor(router-core): improve router.comparePaths regexp performance

### DIFF
--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1370,7 +1370,7 @@ export class RouterCore<
   }
 
   private comparePaths(path1: string, path2: string) {
-    return path1.replace(/(.+)\/$/, '$1') === path2.replace(/(.+)\/$/, '$1')
+    return path1.replace(/\/$/, '') === path2.replace(/\/$/, '')
   }
 
   buildLocation: BuildLocationFn = (opts) => {


### PR DESCRIPTION
We can improve perf of this function *that gets called a lot* by not grouping the entire string, and only removing the trailing slash.

The entire string is returned by `.replace()`, so we don't ned the group
```
> "/foo/bar/".replace(/\/$/, '')
'/foo/bar'
```

Doing so, we get ~6x performance out of it.

```
 ✓  @tanstack/router-core  tests/other.bench.ts > comparePaths 2183ms
     name                       hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · oldComparePaths  1,300,774.12  0.0006  0.8563  0.0008  0.0008  0.0010  0.0010  0.0017  ±0.35%   650388
   · newComparePaths  7,773,004.63  0.0000  0.2112  0.0001  0.0001  0.0002  0.0002  0.0004  ±0.14%  3886503   fastest

 BENCH  Summary

   @tanstack/router-core  newComparePaths - tests/other.bench.ts > comparePaths
    5.98x faster than oldComparePaths
```
