### PR TITLE
refactor(router-core): add LRU cache in front of parsePathname

### DIFF
--- a/packages/router-core/src/lru-cache.ts
+++ b/packages/router-core/src/lru-cache.ts
@@ -1,0 +1,71 @@
+export function createLRUCache<T>(max: number) {
+  const cache = new Map<string, T>()
+  type Node = { before?: Node; after?: Node; key: string }
+  const doublyLinkedList = new Map<string, Node>()
+  let oldest: Node | undefined
+  let newest: Node | undefined
+
+  const touch = (entry: Node) => {
+    if (!entry.before) {
+      if (entry.after) {
+        entry.after.before = undefined
+        oldest = entry.after
+        entry.after = undefined
+      }
+      if (newest) {
+        entry.before = newest
+        newest.after = entry
+      }
+    } else {
+      entry.before.after = entry.after
+      if (entry.after) {
+        entry.after.before = entry.before
+        entry.after = undefined
+      }
+      if (newest) {
+        newest.after = entry
+        entry.before = newest
+      }
+    }
+    newest = entry
+  }
+
+  return {
+    get(key: string): T | undefined {
+      if (!cache.has(key)) {
+        return undefined
+      }
+      const value = cache.get(key)
+      const entry = doublyLinkedList.get(key)
+      if (entry?.after) {
+        touch(entry)
+      }
+      return value
+    },
+    set(key: string, value: T): void {
+      if (cache.size >= max && oldest) {
+        const toDelete = oldest
+        cache.delete(toDelete.key)
+        doublyLinkedList.delete(toDelete.key)
+        if (toDelete.after) {
+          oldest = toDelete.after
+          toDelete.after.before = undefined
+        }
+        if (toDelete === newest) {
+          newest = undefined
+        }
+      }
+      cache.set(key, value)
+      const existing = doublyLinkedList.get(key)
+      if (existing) {
+        touch(existing)
+      } else {
+        const entry: Node = { key, before: newest }
+        if (newest) newest.after = entry
+        newest = entry
+        if (!oldest) oldest = entry
+        doublyLinkedList.set(key, entry)
+      }
+    },
+  }
+}

--- a/packages/router-core/tests/lru.test.ts
+++ b/packages/router-core/tests/lru.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { createLRUCache } from '../src/lru-cache'
+
+describe('LRU Cache', () => {
+  it('evicts oldest set', () => {
+    const cache = createLRUCache<number>(3)
+    cache.set('a', 1)
+    cache.set('b', 2)
+    cache.set('c', 3)
+    cache.set('d', 4) // 'a' should be evicted
+    expect(cache.get('a')).toBeUndefined()
+    expect(cache.get('b')).toBe(2)
+  })
+  it('evicts oldest used', () => {
+    const cache = createLRUCache<number>(3)
+    cache.set('a', 1)
+    cache.set('b', 2)
+    cache.set('c', 3)
+    cache.get('a') // 'a' is now the most recently used
+    cache.set('d', 4) // 'b' should be evicted
+    expect(cache.get('b')).toBeUndefined()
+    expect(cache.get('a')).toBe(1)
+  })
+})


### PR DESCRIPTION
This PR proposes a basic least-recently-used cache implementation (the performance of that data structure is about the same as a `Map` according to benchmark, but it uses more memory).

We can add caching to `parsePathname` now that what it returns is readonly (https://github.com/TanStack/router/pull/4705), which should improve the performance of this bottleneck.

The cache is set to a size of 1000. 


When benchmarking `matchPathname` with and without the cache, we notice a ~7x increase in throughput with the cache.
```
  name             hz     min     max    mean     p75     p99    p995    p999     rme  samples
· cached   13,846.82  0.0645  0.2253  0.0722  0.0729  0.0951  0.1216  0.1635  ±0.24%     6924
· original  1,800.37  0.5097  0.6939  0.5554  0.5607  0.6182  0.6481  0.6939  ±0.20%      901

7.69x faster than original
```