### PR TITLE
docs(react-router): update custom-link guide for react-aria

### DIFF
--- a/docs/router/framework/react/guide/custom-link.md
+++ b/docs/router/framework/react/guide/custom-link.md
@@ -60,14 +60,14 @@ import { createLink } from '@tanstack/react-router'
 import { Link as RACLink, MenuItem } from 'react-aria-components'
 
 export const Link = createLink(RACLink)
-export const MenuItemLink = createLink(MenuItem);
+export const MenuItemLink = createLink(MenuItem)
 ```
 
 To use React Aria's render props, including the `className`, `style`, and `children` functions, create a wrapper component and pass that to `createLink`.
 
 ```tsx
-import { createLink } from '@tanstack/react-router';
-import { Link as RACLink, type LinkProps } from 'react-aria-components';
+import { createLink } from '@tanstack/react-router'
+import { Link as RACLink, type LinkProps } from 'react-aria-components'
 
 interface MyLinkProps extends LinkProps {
   // your props
@@ -81,10 +81,10 @@ function MyLink(props: MyLinkProps) {
         color: isHovered ? 'red' : 'blue',
       })}
     />
-  );
+  )
 }
 
-export const Link = createLink(MyLink);
+export const Link = createLink(MyLink)
 ```
 
 ### Chakra UI example

--- a/docs/router/framework/react/guide/custom-link.md
+++ b/docs/router/framework/react/guide/custom-link.md
@@ -53,17 +53,38 @@ Here are some examples of how you can use `createLink` with third-party librarie
 
 ### React Aria Components example
 
-React Aria Components v1.11.0 and later works with TanStack Router's `preload (intent)` prop.
+React Aria Components v1.11.0 and later works with TanStack Router's `preload (intent)` prop. Use `createLink` to wrap each React Aria component that you use as a link.
 
 ```tsx
-import { createLink, LinkComponent } from '@tanstack/react-router'
-import { Link as RACLink } from 'react-aria-components'
+import { createLink } from '@tanstack/react-router'
+import { Link as RACLink, MenuItem } from 'react-aria-components'
 
-const CreatedLinkComponent = createLink(RACLink)
+export const Link = createLink(RACLink)
+export const MenuItemLink = createLink(MenuItem);
+```
 
-export const CustomLink: LinkComponent<typeof RACLink> = (props) => {
-  return <CreatedLinkComponent preload={'intent'} {...props} />
+To use React Aria's render props, including the `className`, `style`, and `children` functions, create a wrapper component and pass that to `createLink`.
+
+```tsx
+import { createLink } from '@tanstack/react-router';
+import { Link as RACLink, type LinkProps } from 'react-aria-components';
+
+interface MyLinkProps extends LinkProps {
+  // your props
 }
+
+function MyLink(props: MyLinkProps) {
+  return (
+    <RACLink
+      {...props}
+      style={({ isHovered }) => ({
+        color: isHovered ? 'red' : 'blue',
+      })}
+    />
+  );
+}
+
+export const Link = createLink(MyLink);
 ```
 
 ### Chakra UI example
@@ -101,7 +122,9 @@ export const CustomLink: LinkComponent<typeof ChakraLinkComponent> = (
   )
 }
 ```
-
+export const CustomLink: LinkComponent<typeof RACLink> = (props) => {
+  return <CreatedLinkComponent preload={'intent'} {...props} />
+}
 ### MUI example
 
 There is an [example](https://github.com/TanStack/router/tree/main/examples/react/start-material-ui) available which uses these patterns.

--- a/docs/router/framework/react/guide/custom-link.md
+++ b/docs/router/framework/react/guide/custom-link.md
@@ -53,57 +53,15 @@ Here are some examples of how you can use `createLink` with third-party librarie
 
 ### React Aria Components example
 
-React Aria Components'
-[Link](https://react-spectrum.adobe.com/react-aria/Link.html) component does not support the standard `onMouseEnter` and `onMouseLeave` events.
-Therefore, you cannot use it directly with TanStack Router's `preload (intent)` prop.
-
-Explanation for this can be found here:
-
-- [https://react-spectrum.adobe.com/react-aria/interactions.html](https://react-spectrum.adobe.com/react-aria/interactions.html)
-- [https://react-spectrum.adobe.com/blog/building-a-button-part-2.html](https://react-spectrum.adobe.com/blog/building-a-button-part-2.html)
-
-It is possible to work around this by using the [useLink](https://react-spectrum.adobe.com/react-aria/useLink.html) hook from [React Aria Hooks](https://react-spectrum.adobe.com/react-aria/hooks.html) with a standard anchor element.
+React Aria Components v1.11.0 and later works with TanStack Router's `preload (intent)` prop.
 
 ```tsx
-import * as React from 'react'
 import { createLink, LinkComponent } from '@tanstack/react-router'
-import {
-  mergeProps,
-  useFocusRing,
-  useHover,
-  useLink,
-  useObjectRef,
-} from 'react-aria'
-import type { AriaLinkOptions } from 'react-aria'
+import { Link as RACLink } from 'react-aria-components';
 
-interface RACLinkProps extends Omit<AriaLinkOptions, 'href'> {
-  children?: React.ReactNode
-}
+const CreatedLinkComponent = createLink(RACLink)
 
-const RACLinkComponent = React.forwardRef<HTMLAnchorElement, RACLinkProps>(
-  (props, forwardedRef) => {
-    const ref = useObjectRef(forwardedRef)
-
-    const { isPressed, linkProps } = useLink(props, ref)
-    const { isHovered, hoverProps } = useHover(props)
-    const { isFocusVisible, isFocused, focusProps } = useFocusRing(props)
-
-    return (
-      <a
-        {...mergeProps(linkProps, hoverProps, focusProps, props)}
-        ref={ref}
-        data-hovered={isHovered || undefined}
-        data-pressed={isPressed || undefined}
-        data-focus-visible={isFocusVisible || undefined}
-        data-focused={isFocused || undefined}
-      />
-    )
-  },
-)
-
-const CreatedLinkComponent = createLink(RACLinkComponent)
-
-export const CustomLink: LinkComponent<typeof RACLinkComponent> = (props) => {
+export const CustomLink: LinkComponent<typeof RACLink> = (props) => {
   return <CreatedLinkComponent preload={'intent'} {...props} />
 }
 ```

--- a/docs/router/framework/react/guide/custom-link.md
+++ b/docs/router/framework/react/guide/custom-link.md
@@ -57,7 +57,7 @@ React Aria Components v1.11.0 and later works with TanStack Router's `preload (i
 
 ```tsx
 import { createLink, LinkComponent } from '@tanstack/react-router'
-import { Link as RACLink } from 'react-aria-components';
+import { Link as RACLink } from 'react-aria-components'
 
 const CreatedLinkComponent = createLink(RACLink)
 

--- a/docs/router/framework/react/guide/custom-link.md
+++ b/docs/router/framework/react/guide/custom-link.md
@@ -122,9 +122,7 @@ export const CustomLink: LinkComponent<typeof ChakraLinkComponent> = (
   )
 }
 ```
-export const CustomLink: LinkComponent<typeof RACLink> = (props) => {
-  return <CreatedLinkComponent preload={'intent'} {...props} />
-}
+
 ### MUI example
 
 There is an [example](https://github.com/TanStack/router/tree/main/examples/react/start-material-ui) available which uses these patterns.


### PR DESCRIPTION
As of [React Aria Components v1.11.0](https://react-spectrum.adobe.com/releases/2025-07-22.html), we now pass through DOM events, so it's no longer necessary to use hooks to create a custom link component. You can just use `createLink` with the React Aria component directly.

[Demo](https://stackblitz.com/edit/stackblitz-starters-qc66mmzn?file=src%2FLink.tsx)