### PR TITLE
docs(build-from-scratch): added missing dev dependency

### DIFF
--- a/docs/start/framework/react/build-from-scratch.md
+++ b/docs/start/framework/react/build-from-scratch.md
@@ -64,7 +64,7 @@ npm i react react-dom
 and some TypeScript:
 
 ```shell
-npm i -D typescript @types/react @types/react-dom vite-tsconfig-paths
+npm i -D typescript @types/react @types/react-dom vite-tsconfig-paths @vitejs/plugin-react
 ```
 
 ## Update Configuration Files


### PR DESCRIPTION
currently, @vitejs/plugin-react is referenced in the following code snippet, but isn't installed, so vscode throws a "cannot find module" error; to fix this error, i added the plugin to the previously-run command to install dev dependencies.