### PR TITLE
refactor(router-core): make parsePathnameCache internal

### DIFF
--- a/packages/router-core/src/path.ts
+++ b/packages/router-core/src/path.ts
@@ -203,10 +203,11 @@ export function resolvePath({
   return joined
 }
 
-const parsePathnameCache: LRUCache<string, ReadonlyArray<Segment>> = createLRUCache(1000)
-export const parsePathname = (
-  pathname?: string,
-): ReadonlyArray<Segment> => {
+const parsePathnameCache: LRUCache<
+  string,
+  ReadonlyArray<Segment>
+> = createLRUCache(1000)
+export const parsePathname = (pathname?: string): ReadonlyArray<Segment> => {
   if (!pathname) return []
   const cached = parsePathnameCache.get(pathname)
   if (cached) return cached
@@ -490,11 +491,7 @@ export function matchPathname(
   currentPathname: string,
   matchLocation: Pick<MatchLocation, 'to' | 'fuzzy' | 'caseSensitive'>,
 ): AnyPathParams | undefined {
-  const pathParams = matchByPath(
-    basepath,
-    currentPathname,
-    matchLocation,
-  )
+  const pathParams = matchByPath(basepath, currentPathname, matchLocation)
   // const searchMatched = matchBySearch(location.search, matchLocation)
 
   if (matchLocation.to && !pathParams) {
@@ -564,12 +561,8 @@ export function matchByPath(
   to = removeBasepath(basepath, `${to ?? '$'}`, caseSensitive)
 
   // Parse the from and to
-  const baseSegments = parsePathname(
-    from.startsWith('/') ? from : `/${from}`,
-  )
-  const routeSegments = parsePathname(
-    to.startsWith('/') ? to : `/${to}`,
-  )
+  const baseSegments = parsePathname(from.startsWith('/') ? from : `/${from}`)
+  const routeSegments = parsePathname(to.startsWith('/') ? to : `/${to}`)
 
   const params: Record<string, string> = {}
 

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1567,15 +1567,11 @@ export class RouterCore<
         let params = {}
 
         const foundMask = this.options.routeMasks?.find((d) => {
-          const match = matchPathname(
-            this.basepath,
-            next.pathname,
-            {
-              to: d.from,
-              caseSensitive: false,
-              fuzzy: false,
-            },
-          )
+          const match = matchPathname(this.basepath, next.pathname, {
+            to: d.from,
+            caseSensitive: false,
+            fuzzy: false,
+          })
 
           if (match) {
             params = match
@@ -2975,14 +2971,10 @@ export class RouterCore<
       ? this.latestLocation
       : this.state.resolvedLocation || this.state.location
 
-    const match = matchPathname(
-      this.basepath,
-      baseLocation.pathname,
-      {
-        ...opts,
-        to: next.pathname,
-      },
-    ) as any
+    const match = matchPathname(this.basepath, baseLocation.pathname, {
+      ...opts,
+      to: next.pathname,
+    }) as any
 
     if (!match) {
       return false
@@ -3388,16 +3380,12 @@ export function getMatchedRoutes<TRouteLike extends RouteLike>({
   let routeParams: Record<string, string> = {}
   const trimmedPath = trimPathRight(pathname)
   const getMatchedParams = (route: TRouteLike) => {
-    const result = matchPathname(
-      basepath,
-      trimmedPath,
-      {
-        to: route.fullPath,
-        caseSensitive: route.options?.caseSensitive ?? caseSensitive,
-        // we need fuzzy matching for `notFoundMode: 'fuzzy'`
-        fuzzy: true,
-      },
-    )
+    const result = matchPathname(basepath, trimmedPath, {
+      to: route.fullPath,
+      caseSensitive: route.options?.caseSensitive ?? caseSensitive,
+      // we need fuzzy matching for `notFoundMode: 'fuzzy'`
+      fuzzy: true,
+    })
     return result
   }
 

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -33,8 +33,7 @@ import { setupScrollRestoration } from './scroll-restoration'
 import { defaultParseSearch, defaultStringifySearch } from './searchParams'
 import { rootRouteId } from './root'
 import { isRedirect, redirect } from './redirect'
-import { createLRUCache } from './lru-cache'
-import type { ParsePathnameCache, Segment } from './path'
+import type { Segment } from './path'
 import type { SearchParser, SearchSerializer } from './searchParams'
 import type { AnyRedirect, ResolvedRedirect } from './redirect'
 import type {
@@ -1015,7 +1014,6 @@ export class RouterCore<
       to: cleanPath(path),
       trailingSlash: this.options.trailingSlash,
       caseSensitive: this.options.caseSensitive,
-      parseCache: this.parsePathnameCache,
     })
     return resolvedPath
   }
@@ -1197,7 +1195,6 @@ export class RouterCore<
           params: routeParams,
           leaveWildcards: true,
           decodeCharMap: this.pathParamsDecodeCharMap,
-          parseCache: this.parsePathnameCache,
         }).interpolatedPath + loaderDepsHash
 
       // Waste not, want not. If we already have a match for this route,
@@ -1336,9 +1333,6 @@ export class RouterCore<
     return matches
   }
 
-  /** a cache for `parsePathname` */
-  private parsePathnameCache: ParsePathnameCache = createLRUCache(1000)
-
   getMatchedRoutes: GetMatchRoutesFn = (
     pathname: string,
     routePathname: string | undefined,
@@ -1351,7 +1345,6 @@ export class RouterCore<
       routesByPath: this.routesByPath,
       routesById: this.routesById,
       flatRoutes: this.flatRoutes,
-      parseCache: this.parsePathnameCache,
     })
   }
 
@@ -1459,7 +1452,6 @@ export class RouterCore<
       const interpolatedNextTo = interpolatePath({
         path: nextTo,
         params: nextParams ?? {},
-        parseCache: this.parsePathnameCache,
       }).interpolatedPath
 
       const destRoutes = this.matchRoutes(
@@ -1492,7 +1484,6 @@ export class RouterCore<
         leaveWildcards: false,
         leaveParams: opts.leaveParams,
         decodeCharMap: this.pathParamsDecodeCharMap,
-        parseCache: this.parsePathnameCache,
       }).interpolatedPath
 
       // Resolve the next search
@@ -1584,7 +1575,6 @@ export class RouterCore<
               caseSensitive: false,
               fuzzy: false,
             },
-            this.parsePathnameCache,
           )
 
           if (match) {
@@ -2992,7 +2982,6 @@ export class RouterCore<
         ...opts,
         to: next.pathname,
       },
-      this.parsePathnameCache,
     ) as any
 
     if (!match) {
@@ -3387,7 +3376,6 @@ export function getMatchedRoutes<TRouteLike extends RouteLike>({
   routesByPath,
   routesById,
   flatRoutes,
-  parseCache,
 }: {
   pathname: string
   routePathname?: string
@@ -3396,7 +3384,6 @@ export function getMatchedRoutes<TRouteLike extends RouteLike>({
   routesByPath: Record<string, TRouteLike>
   routesById: Record<string, TRouteLike>
   flatRoutes: Array<TRouteLike>
-  parseCache?: ParsePathnameCache
 }) {
   let routeParams: Record<string, string> = {}
   const trimmedPath = trimPathRight(pathname)
@@ -3410,7 +3397,6 @@ export function getMatchedRoutes<TRouteLike extends RouteLike>({
         // we need fuzzy matching for `notFoundMode: 'fuzzy'`
         fuzzy: true,
       },
-      parseCache,
     )
     return result
   }


### PR DESCRIPTION
REF: https://github.com/TanStack/router/pull/4752

It introduced the LRU ache for parsePathname. However, it exposed the internal cache, making it the caller's responsibility to pass the cache. This could defeat the purpose if the parameter is missing.

I'd suggest it's better to keep the cache internal and transparent to the caller. This reduces the burden of passing the cache around and keeps the API cleaner, the bundle size would be smaller as well.