### PR TITLE
tests for generator breaking backward compatibility

### DIFF
--- a/packages/router-generator/tests/generator/classes-mixed/routes/__root.tsx
+++ b/packages/router-generator/tests/generator/classes-mixed/routes/__root.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react'
+import { Outlet, RootRoute } from '@tanstack/react-router'
+
+export const Route = new RootRoute({
+  component: RootComponent,
+})
+
+function RootComponent() {
+  return (
+    <React.Fragment>
+      <div>Hello "__root"!</div>
+      <Outlet />
+    </React.Fragment>
+  )
+}

--- a/packages/router-generator/tests/generator/classes-mixed/routes/index.tsx
+++ b/packages/router-generator/tests/generator/classes-mixed/routes/index.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  return <div>Hello "/"!</div>
+}

--- a/packages/router-generator/tests/generator/classes-mixed/routes/posts.tsx
+++ b/packages/router-generator/tests/generator/classes-mixed/routes/posts.tsx
@@ -1,0 +1,9 @@
+import { FileRoute } from '@tanstack/react-router'
+
+export const Route = new FileRoute('/posts').createRoute({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  return <div>Hello "/posts"!</div>
+}

--- a/packages/router-generator/tests/generator/component-extensions/routes/__root.tsx
+++ b/packages/router-generator/tests/generator/component-extensions/routes/__root.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react'
+import { Outlet, createRootRoute } from '@tanstack/react-router'
+
+export const Route = createRootRoute({
+  component: RootComponent,
+})
+
+function RootComponent() {
+  return (
+    <React.Fragment>
+      <div>Hello "__root"!</div>
+      <Outlet />
+    </React.Fragment>
+  )
+}

--- a/packages/router-generator/tests/generator/component-extensions/routes/index.tsx
+++ b/packages/router-generator/tests/generator/component-extensions/routes/index.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  return <div>Hello "/"!</div>
+}

--- a/packages/router-generator/tests/generator/component-extensions/routes/posts.component.tsx
+++ b/packages/router-generator/tests/generator/component-extensions/routes/posts.component.tsx
@@ -1,0 +1,3 @@
+import { MyComponent } from 'wherever'
+
+export const component = MyComponent

--- a/packages/router-generator/tests/generator/component-extensions/routes/posts.errorComponent.tsx
+++ b/packages/router-generator/tests/generator/component-extensions/routes/posts.errorComponent.tsx
@@ -1,0 +1,3 @@
+import { MyErrorComponent } from 'wherever'
+
+export const errorComponent = MyErrorComponent

--- a/packages/router-generator/tests/generator/component-extensions/routes/posts.loader.tsx
+++ b/packages/router-generator/tests/generator/component-extensions/routes/posts.loader.tsx
@@ -1,0 +1,3 @@
+import { myLoader } from 'wherever'
+
+export const loader = myLoader

--- a/packages/router-generator/tests/generator/component-extensions/routes/posts.notFoundComponent.tsx
+++ b/packages/router-generator/tests/generator/component-extensions/routes/posts.notFoundComponent.tsx
@@ -1,0 +1,3 @@
+import { MyNotFoundComponent } from 'wherever'
+
+export const notFoundComponent = MyNotFoundComponent

--- a/packages/router-generator/tests/generator/component-extensions/routes/posts.pendingComponent.tsx
+++ b/packages/router-generator/tests/generator/component-extensions/routes/posts.pendingComponent.tsx
@@ -1,0 +1,3 @@
+import { MyPendingComponent } from 'wherever'
+
+export const pendingComponent = MyPendingComponent


### PR DESCRIPTION
Related to #4778, this adds tests so development can be done to support two workflows which were lost in the generator rewrite.

1. Using extensions, like `src/routes/posts.component.tsx`. 
2. Using Class based Route inits, like `export const Route = new FileRoute('/posts').createRoute({ ... })`.

The test files for `1` lives `packages/router-generator/tests/generator/component-extensions`. These test files do not cause a fail condition, since the logic is outright missing for appending these extensions as lazy imports.

The test files for `2` lives `packages/router-generator/tests/generator/classes-mixed`. These test files mix both function and class based Route inits. The error message is as follows for a route using a class-based init.

```sh
tests/generator.test.ts > generator works > should wire-up the routes for a "classes-mixed" tree
Error: expected identifier to be present in /posts for export Route
 ❯ src/generator.ts:307:19
```