### PR TITLE
removes Tailwind

### DIFF
--- a/examples/react/start-bare/package.json
+++ b/examples/react/start-bare/package.json
@@ -17,11 +17,9 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
-    "@tailwindcss/vite": "^4.0.8",
     "@types/node": "^22.5.4",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
-    "tailwindcss": "^4.0.8",
     "typescript": "^5.7.2",
     "vite": "^6.3.5",
     "vite-tsconfig-paths": "^5.1.4"

--- a/examples/react/start-bare/src/routes/__root.tsx
+++ b/examples/react/start-bare/src/routes/__root.tsx
@@ -32,7 +32,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         <HeadContent />
       </head>
       <body>
-        <div className="p-2 flex gap-2 text-lg">
+        <div>
           <Link to="/">Index</Link>
           <Link to="/about">About</Link>
         </div>

--- a/examples/react/start-bare/src/routes/index.tsx
+++ b/examples/react/start-bare/src/routes/index.tsx
@@ -6,7 +6,7 @@ export const Route = createFileRoute('/')({
 function RouteComponent() {
   return (
     <main>
-      <h1 className="text-3xl text-blue-500 mb-5">Hello world!</h1>
+      <h1>Hello world!</h1>
     </main>
   )
 }

--- a/examples/react/start-bare/src/styles/app.css
+++ b/examples/react/start-bare/src/styles/app.css
@@ -1,5 +1,3 @@
-@import 'tailwindcss';
-
 body {
   font-family:
     Gordita, Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue',


### PR DESCRIPTION
The `start-bare` example includes Tailwind with a broken config (missing `tailwindcss()` in vite.config.ts plugins), which contradicts the 'bare' concept. Since `start-tailwind-v4` already provides a properly configured Tailwind example, this PR removes Tailwind from `start-bare` to make it actually bare.