### PR TITLE
refactor(router-core): router getMatch doesnt create an array

### DIFF
--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -2078,11 +2078,12 @@ export class RouterCore<
   }
 
   getMatch: GetMatchFn = (matchId: string) => {
-    return [
-      ...this.state.cachedMatches,
-      ...(this.state.pendingMatches ?? []),
-      ...this.state.matches,
-    ].find((d) => d.id === matchId)
+    const findFn = (d: { id: string }) => d.id === matchId
+    return (
+      this.state.cachedMatches.find(findFn) ??
+      this.state.pendingMatches?.find(findFn) ??
+      this.state.matches.find(findFn)
+    )
   }
 
   loadMatches = async ({


### PR DESCRIPTION
`router` > `getMatch` doesn't need to create an array to find the match by id. This function gets called a lot, so it's better if we can avoid accumulating short lived objects that need garbage collection when using it.