### PR TITLE
refactor(router-core): router clearExpiredCache DeMorgan's simplification

### DIFF
--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -2867,7 +2867,11 @@ export class RouterCore<
           : (route.options.gcTime ?? this.options.defaultGcTime)) ??
         5 * 60 * 1000
 
-      return !(d.status !== 'error' && Date.now() - d.updatedAt < gcTime)
+      const isError = d.status === 'error'
+      if (isError) return true
+
+      const isStale = Date.now() - d.updatedAt >= gcTime
+      return isStale
     }
     this.clearCache({ filter })
   }


### PR DESCRIPTION
Use De Morgan's contrapositive to cleanup the return condition of the `clearExpiredCache` filter function. This should be a no-op and is mathematically equivalent to what was written before, just more readable for future refactoring.