### PR TITLE
refactor(router-core): router clearExpiredCache variable naming mistake

### DIFF
--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -2862,8 +2862,8 @@ export class RouterCore<
       const isError = d.status === 'error'
       if (isError) return true
 
-      const isStale = Date.now() - d.updatedAt >= gcTime
-      return isStale
+      const gcEligible = Date.now() - d.updatedAt >= gcTime
+      return gcEligible
     }
     this.clearCache({ filter })
   }


### PR DESCRIPTION
Just correcting a variable naming mistake I made in https://github.com/TanStack/router/pull/4826 because I confused `staleTime` and `gcTime`.