### PR TITLE
docs(router): update NotFoundError type

### DIFF
--- a/docs/router/framework/react/api/router/NotFoundErrorType.md
+++ b/docs/router/framework/react/api/router/NotFoundErrorType.md
@@ -11,6 +11,7 @@ export type NotFoundError = {
   data?: any
   throw?: boolean
   routeId?: string
+  headers?: HeadersInit
 }
 ```
 
@@ -18,17 +19,23 @@ export type NotFoundError = {
 
 The `NotFoundError` object accepts/contains the following properties:
 
+### `global` property (⚠️ deprecated, use `routeId: rootRouteId` instead)
+
+- Type: `boolean`
+- Optional - `default: false`
+- If true, the not-found error will be handled by the `notFoundComponent` of the root route instead of bubbling up from the route that threw it. This has the same behavior as importing the root route and calling `RootRoute.notFound()`.
+
 ### `data` property
 
 - Type: `any`
 - Optional
 - Custom data that is passed into to `notFoundComponent` when the not-found error is handled
 
-### `global` property
+### `throw` property
 
 - Type: `boolean`
 - Optional - `default: false`
-- If true, the not-found error will be handled by the `notFoundComponent` of the root route instead of bubbling up from the route that threw it. This has the same behavior as importing the root route and calling `RootRoute.notFound()`.
+- If provided, will throw the not-found object instead of returning it. This can be useful in places where `throwing` in a function might cause it to have a return type of `never`. In that case, you can use `notFound({ throw: true })` to throw the not-found object instead of returning it.
 
 ### `route` property
 
@@ -36,8 +43,8 @@ The `NotFoundError` object accepts/contains the following properties:
 - Optional
 - The ID of the route that will attempt to handle the not-found error. If the route does not have a `notFoundComponent`, the error will bubble up to the parent route (and be handled by the root route if necessary). By default, TanStack Router will attempt to handle the not-found error with the route that threw it.
 
-### `throw` property
+### `headers` property
 
-- Type: `boolean`
-- Optional - `default: false`
-- If provided, will throw the not-found object instead of returning it. This can be useful in places where `throwing` in a function might cause it to have a return type of `never`. In that case, you can use `notFound({ throw: true })` to throw the not-found object instead of returning it.
+- Type: `HeadersInit`
+- Optional
+- HTTP headers to be included when the not-found error is handled on the server side.


### PR DESCRIPTION
- Mark the `global` property of `NotFoundError` as deprecated
- Add a description for `headers`
- Sort the properties in order