### PR TITLE
fix(history): add ignoreBlocker support to go method (#4867)

### DIFF
--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -101,7 +101,7 @@ export function createHistory(opts: {
   getLength: () => number
   pushState: (path: string, state: any) => void
   replaceState: (path: string, state: any) => void
-  go: (n: number) => void
+  go: (n: number, ignoreBlocker: boolean) => void
   back: (ignoreBlocker: boolean) => void
   forward: (ignoreBlocker: boolean) => void
   createHref: (path: string) => string
@@ -204,7 +204,7 @@ export function createHistory(opts: {
     go: (index, navigateOpts) => {
       tryNavigation({
         task: () => {
-          opts.go(index)
+          opts.go(index, navigateOpts?.ignoreBlocker ?? false)
           handleIndexChange({ type: 'GO', index })
         },
         navigateOpts,
@@ -500,7 +500,8 @@ export function createBrowserHistory(opts?: {
       ignoreNextBeforeUnload = true
       win.history.forward()
     },
-    go: (n) => {
+    go: (n, ignoreBlocker) => {
+      if (ignoreBlocker) skipBlockerNextPop = true
       nextPopIsGo = true
       win.history.go(n)
     },

--- a/packages/history/tests/ignoreBlocker.test.ts
+++ b/packages/history/tests/ignoreBlocker.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test, vi } from 'vitest'
 import { createBrowserHistory } from '../src'
 
 describe('ignoreBlocker functionality', () => {
-  test('ignoreBlocker should work with browser history', () => {
+  test('go method should respect ignoreBlocker option', () => {
     const mockWindow = {
       history: {
         pushState: vi.fn(),
@@ -27,8 +27,70 @@ describe('ignoreBlocker functionality', () => {
 
     const unblock = history.block({ blockerFn: blocker })
 
-    history.go(-1, { ignoreBlocker: true })
-    expect(mockWindow.history.go).toHaveBeenCalledWith(-1)
+    history.go(-2, { ignoreBlocker: true })
+    expect(mockWindow.history.go).toHaveBeenCalledWith(-2)
+
+    unblock()
+  })
+
+  test('back method should respect ignoreBlocker option', () => {
+    const mockWindow = {
+      history: {
+        pushState: vi.fn(),
+        replaceState: vi.fn(),
+        go: vi.fn(),
+        back: vi.fn(),
+        forward: vi.fn(),
+        length: 3,
+        state: { __TSR_index: 2 },
+      },
+      location: {
+        pathname: '/a',
+        search: '',
+        hash: '',
+      },
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }
+
+    const history = createBrowserHistory({ window: mockWindow })
+    const blocker = vi.fn(() => true)
+
+    const unblock = history.block({ blockerFn: blocker })
+
+    history.back({ ignoreBlocker: true })
+    expect(mockWindow.history.back).toHaveBeenCalled()
+
+    unblock()
+  })
+
+  test('forward method should respect ignoreBlocker option', () => {
+    const mockWindow = {
+      history: {
+        pushState: vi.fn(),
+        replaceState: vi.fn(),
+        go: vi.fn(),
+        back: vi.fn(),
+        forward: vi.fn(),
+        length: 3,
+        state: { __TSR_index: 2 },
+      },
+      location: {
+        pathname: '/a',
+        search: '',
+        hash: '',
+      },
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }
+
+    const history = createBrowserHistory({ window: mockWindow })
+    const blocker = vi.fn(() => true)
+
+    const unblock = history.block({ blockerFn: blocker })
+
+    history.forward({ ignoreBlocker: true })
+    expect(mockWindow.history.forward).toHaveBeenCalled()
 
     unblock()
   })

--- a/packages/history/tests/ignoreBlocker.test.ts
+++ b/packages/history/tests/ignoreBlocker.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test, vi } from 'vitest'
+import { createBrowserHistory } from '../src'
+
+describe('ignoreBlocker functionality', () => {
+  test('ignoreBlocker should work with browser history', () => {
+    const mockWindow = {
+      history: {
+        pushState: vi.fn(),
+        replaceState: vi.fn(),
+        go: vi.fn(),
+        back: vi.fn(),
+        forward: vi.fn(),
+        length: 3,
+        state: { __TSR_index: 2 },
+      },
+      location: {
+        pathname: '/a',
+        search: '',
+        hash: '',
+      },
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }
+
+    const history = createBrowserHistory({ window: mockWindow })
+    const blocker = vi.fn(() => true)
+
+    const unblock = history.block({ blockerFn: blocker })
+
+    history.go(-1, { ignoreBlocker: true })
+    expect(mockWindow.history.go).toHaveBeenCalledWith(-1)
+
+    unblock()
+  })
+})


### PR DESCRIPTION
## Description

Fixes GitHub issue #4867 - `history.go` does not respect `ignoreBlocker` option.

Currently, when using TanStack Router with `BrowserHistory`, the `ignoreBlocker` option works as expected for `history.back` and `history.forward`, but does not work for `history.go`. This means that navigation blockers are still triggered even when `ignoreBlocker: true` is passed to `history.go`.

## Changes

### Core Fix
- **`packages/history/src/index.ts`**: 
  - Add `ignoreBlocker` parameter to `go` method in `createBrowserHistory`
  - Update `createHistory` to pass `ignoreBlocker` to underlying `go` implementation
  - Ensure consistent behavior across `back`, `forward`, and `go` methods

### Testing
- **`packages/history/tests/ignoreBlocker.test.ts`**: 
  - Test all navigation methods (`back`, `forward`, `go`) with `ignoreBlocker` option in `createBrowserHistory`