### PR TITLE
chore(examples): remove unnecessary opts.deps to clear confusion

### DIFF
--- a/examples/react/kitchen-sink-react-query-file-based/src/routes/dashboard.users.route.tsx
+++ b/examples/react/kitchen-sink-react-query-file-based/src/routes/dashboard.users.route.tsx
@@ -30,7 +30,7 @@ export const Route = createFileRoute('/dashboard/users')({
     middlewares: [retainSearchParams(['usersView'])],
   },
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(usersQueryOptions(opts.deps)),
+    opts.context.queryClient.ensureQueryData(usersQueryOptions({})),
   component: UsersComponent,
 })
 


### PR DESCRIPTION
I think opts.deps is creating confusion here because there is no loader deps there. 