### PR TITLE
fix(router-generator): use the tmpDir when genearting a temporary filename

### DIFF
--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -1090,7 +1090,7 @@ ${acc.routeTree.map((child) => `${child.variableName}${exportName}: typeof ${get
       mkdirSync(this.config.tmpDir, { recursive: true })
       this.sessionId = crypto.randomBytes(4).toString('hex')
     }
-    return `${this.sessionId}-${hash}`
+    return path.join(this.config.tmpDir, `${this.sessionId}-${hash}`)
   }
 
   private async isRouteFileCacheFresh(node: RouteNode): Promise<


### PR DESCRIPTION
When upgrading to the latest version, in my Docker setup I started getting errors like:

```
Error: EXDEV: cross-device link not permitted, rename 'b13b6193-a621cd78c46b3a318f72a46c63be0ef6' -> '/app/src/app/routes/route.tsx'
```

It appears it's due to the change at https://github.com/TanStack/router/pull/4860/files#diff-a903efbcea6827ab7d7262d62ec3cc012831364e98ebcafcfa4885eeb634f91eL1092 where `getTempFileName` no longer returns includes the `path.join` with the temporary directory.

This PR brings back the `path.join`.