### PR TITLE
docs: update RouteMatch type to include more properties based on Matches.d.ts

### DIFF
--- a/docs/router/framework/react/api/router/RouteMatchType.md
+++ b/docs/router/framework/react/api/router/RouteMatchType.md
@@ -9,6 +9,8 @@ The `RouteMatch` type represents a route match in TanStack Router.
 interface RouteMatch {
   id: string
   routeId: string
+  fullPath: string
+  index: number
   pathname: string
   params: Route['allParams']
   status: 'pending' | 'success' | 'error' | 'redirected' | 'notFound'
@@ -24,7 +26,13 @@ interface RouteMatch {
   search: Route['fullSearchSchema']
   fetchedAt: number
   abortController: AbortController
-  cause: 'enter' | 'stay'
+  cause: 'preload' | 'enter' | 'stay'
+  fetchCount: number
+  preload: boolean
+  invalid: boolean
+  headers?: Record<string, string>
+  globalNotFound?: boolean
   ssr?: boolean | 'data-only'
+  displayPendingPromise?: Promise<void>
 }
 ```


### PR DESCRIPTION
I only added ones with a "clear" typing (no generic arguments, no fields starting with `_`). I initially only wanted to document the `fullPath` but then I saw there are more. 