### PR TITLE
refactor(router-core): strip internal types from public build

### DIFF
--- a/packages/router-core/src/Matches.ts
+++ b/packages/router-core/src/Matches.ts
@@ -20,14 +20,14 @@ export type FindValueByIndex<
 
 export type FindValueByKey<TKey, TValue> =
   TValue extends ReadonlyArray<any>
-  ? FindValueByIndex<TKey, TValue>
-  : TValue[TKey & keyof TValue]
+    ? FindValueByIndex<TKey, TValue>
+    : TValue[TKey & keyof TValue]
 
 export type CreateMatchAndValue<TMatch, TValue> = TValue extends any
   ? {
-    match: TMatch
-    value: TValue
-  }
+      match: TMatch
+      value: TValue
+    }
   : never
 
 export type NextMatchAndValue<
@@ -35,19 +35,19 @@ export type NextMatchAndValue<
   TMatchAndValue extends AnyMatchAndValue,
 > = TMatchAndValue extends any
   ? CreateMatchAndValue<
-    TMatchAndValue['match'],
-    FindValueByKey<TKey, TMatchAndValue['value']>
-  >
+      TMatchAndValue['match'],
+      FindValueByKey<TKey, TMatchAndValue['value']>
+    >
   : never
 
 export type IsMatchKeyOf<TValue> =
   TValue extends ReadonlyArray<any>
-  ? number extends TValue['length']
-  ? `${number}`
-  : keyof TValue & `${number}`
-  : TValue extends object
-  ? keyof TValue & string
-  : never
+    ? number extends TValue['length']
+      ? `${number}`
+      : keyof TValue & `${number}`
+    : TValue extends object
+      ? keyof TValue & string
+      : never
 
 export type IsMatchPath<
   TParentPath extends string,
@@ -59,8 +59,8 @@ export type IsMatchResult<
   TMatchAndValue extends AnyMatchAndValue,
 > = TMatchAndValue extends any
   ? TKey extends keyof TMatchAndValue['value']
-  ? TMatchAndValue['match']
-  : never
+    ? TMatchAndValue['match']
+    : never
   : never
 
 export type IsMatchParse<
@@ -69,16 +69,16 @@ export type IsMatchParse<
   TParentPath extends string = '',
 > = TPath extends `${string}.${string}`
   ? TPath extends `${infer TFirst}.${infer TRest}`
-  ? IsMatchParse<
-    TRest,
-    NextMatchAndValue<TFirst, TMatchAndValue>,
-    `${TParentPath}${TFirst}.`
-  >
-  : never
+    ? IsMatchParse<
+        TRest,
+        NextMatchAndValue<TFirst, TMatchAndValue>,
+        `${TParentPath}${TFirst}.`
+      >
+    : never
   : {
-    path: IsMatchPath<TParentPath, TMatchAndValue>
-    result: IsMatchResult<TPath, TMatchAndValue>
-  }
+      path: IsMatchPath<TParentPath, TMatchAndValue>
+      result: IsMatchResult<TPath, TMatchAndValue>
+    }
 
 export type IsMatch<TMatch, TPath> = IsMatchParse<
   TPath,
@@ -179,11 +179,11 @@ export interface PreValidationErrorHandlingRouteMatch<
   index: number
   pathname: string
   search:
-  | { status: 'success'; value: TFullSearchSchema }
-  | { status: 'error'; error: unknown }
+    | { status: 'success'; value: TFullSearchSchema }
+    | { status: 'error'; error: unknown }
   params:
-  | { status: 'success'; value: TAllParams }
-  | { status: 'error'; error: unknown }
+    | { status: 'success'; value: TAllParams }
+    | { status: 'error'; error: unknown }
   staticData: StaticDataRouteOption
   ssr?: boolean | 'data-only'
 }
@@ -193,11 +193,11 @@ export type MakePreValidationErrorHandlingRouteMatchUnion<
   TRoute extends AnyRoute = ParseRoute<TRouter['routeTree']>,
 > = TRoute extends any
   ? PreValidationErrorHandlingRouteMatch<
-    TRoute['id'],
-    TRoute['fullPath'],
-    TRoute['types']['allParams'],
-    TRoute['types']['fullSearchSchema']
-  >
+      TRoute['id'],
+      TRoute['fullPath'],
+      TRoute['types']['allParams'],
+      TRoute['types']['fullSearchSchema']
+    >
   : never
 
 export type MakeRouteMatchFromRoute<TRoute extends AnyRoute> = RouteMatch<
@@ -218,17 +218,17 @@ export type MakeRouteMatch<
   TRouteId,
   RouteById<TRouteTree, TRouteId>['types']['fullPath'],
   TStrict extends false
-  ? AllParams<TRouteTree>
-  : RouteById<TRouteTree, TRouteId>['types']['allParams'],
+    ? AllParams<TRouteTree>
+    : RouteById<TRouteTree, TRouteId>['types']['allParams'],
   TStrict extends false
-  ? FullSearchSchema<TRouteTree>
-  : RouteById<TRouteTree, TRouteId>['types']['fullSearchSchema'],
+    ? FullSearchSchema<TRouteTree>
+    : RouteById<TRouteTree, TRouteId>['types']['fullSearchSchema'],
   TStrict extends false
-  ? AllLoaderData<TRouteTree>
-  : RouteById<TRouteTree, TRouteId>['types']['loaderData'],
+    ? AllLoaderData<TRouteTree>
+    : RouteById<TRouteTree, TRouteId>['types']['loaderData'],
   TStrict extends false
-  ? AllContext<TRouteTree>
-  : RouteById<TRouteTree, TRouteId>['types']['allContext'],
+    ? AllContext<TRouteTree>
+    : RouteById<TRouteTree, TRouteId>['types']['allContext'],
   RouteById<TRouteTree, TRouteId>['types']['loaderDeps']
 >
 
@@ -239,14 +239,14 @@ export type MakeRouteMatchUnion<
   TRoute extends AnyRoute = ParseRoute<TRouter['routeTree']>,
 > = TRoute extends any
   ? RouteMatch<
-    TRoute['id'],
-    TRoute['fullPath'],
-    TRoute['types']['allParams'],
-    TRoute['types']['fullSearchSchema'],
-    TRoute['types']['loaderData'],
-    TRoute['types']['allContext'],
-    TRoute['types']['loaderDeps']
-  >
+      TRoute['id'],
+      TRoute['fullPath'],
+      TRoute['types']['allParams'],
+      TRoute['types']['fullSearchSchema'],
+      TRoute['types']['loaderData'],
+      TRoute['types']['allContext'],
+      TRoute['types']['loaderDeps']
+    >
   : never
 
 /**

--- a/packages/router-core/src/Matches.ts
+++ b/packages/router-core/src/Matches.ts
@@ -20,14 +20,14 @@ export type FindValueByIndex<
 
 export type FindValueByKey<TKey, TValue> =
   TValue extends ReadonlyArray<any>
-    ? FindValueByIndex<TKey, TValue>
-    : TValue[TKey & keyof TValue]
+  ? FindValueByIndex<TKey, TValue>
+  : TValue[TKey & keyof TValue]
 
 export type CreateMatchAndValue<TMatch, TValue> = TValue extends any
   ? {
-      match: TMatch
-      value: TValue
-    }
+    match: TMatch
+    value: TValue
+  }
   : never
 
 export type NextMatchAndValue<
@@ -35,19 +35,19 @@ export type NextMatchAndValue<
   TMatchAndValue extends AnyMatchAndValue,
 > = TMatchAndValue extends any
   ? CreateMatchAndValue<
-      TMatchAndValue['match'],
-      FindValueByKey<TKey, TMatchAndValue['value']>
-    >
+    TMatchAndValue['match'],
+    FindValueByKey<TKey, TMatchAndValue['value']>
+  >
   : never
 
 export type IsMatchKeyOf<TValue> =
   TValue extends ReadonlyArray<any>
-    ? number extends TValue['length']
-      ? `${number}`
-      : keyof TValue & `${number}`
-    : TValue extends object
-      ? keyof TValue & string
-      : never
+  ? number extends TValue['length']
+  ? `${number}`
+  : keyof TValue & `${number}`
+  : TValue extends object
+  ? keyof TValue & string
+  : never
 
 export type IsMatchPath<
   TParentPath extends string,
@@ -59,8 +59,8 @@ export type IsMatchResult<
   TMatchAndValue extends AnyMatchAndValue,
 > = TMatchAndValue extends any
   ? TKey extends keyof TMatchAndValue['value']
-    ? TMatchAndValue['match']
-    : never
+  ? TMatchAndValue['match']
+  : never
   : never
 
 export type IsMatchParse<
@@ -69,16 +69,16 @@ export type IsMatchParse<
   TParentPath extends string = '',
 > = TPath extends `${string}.${string}`
   ? TPath extends `${infer TFirst}.${infer TRest}`
-    ? IsMatchParse<
-        TRest,
-        NextMatchAndValue<TFirst, TMatchAndValue>,
-        `${TParentPath}${TFirst}.`
-      >
-    : never
+  ? IsMatchParse<
+    TRest,
+    NextMatchAndValue<TFirst, TMatchAndValue>,
+    `${TParentPath}${TFirst}.`
+  >
+  : never
   : {
-      path: IsMatchPath<TParentPath, TMatchAndValue>
-      result: IsMatchResult<TPath, TMatchAndValue>
-    }
+    path: IsMatchPath<TParentPath, TMatchAndValue>
+    result: IsMatchResult<TPath, TMatchAndValue>
+  }
 
 export type IsMatch<TMatch, TPath> = IsMatchParse<
   TPath,
@@ -137,10 +137,14 @@ export interface RouteMatch<
   searchError: unknown
   updatedAt: number
   loadPromise?: ControlledPromise<void>
+  /** @internal */
   beforeLoadPromise?: ControlledPromise<void>
+  /** @internal */
   loaderPromise?: ControlledPromise<void>
   loaderData?: TLoaderData
+  /** @internal */
   __routeContext: Record<string, unknown>
+  /** @internal */
   __beforeLoadContext?: Record<string, unknown>
   context: TAllContext
   search: TFullSearchSchema
@@ -175,11 +179,11 @@ export interface PreValidationErrorHandlingRouteMatch<
   index: number
   pathname: string
   search:
-    | { status: 'success'; value: TFullSearchSchema }
-    | { status: 'error'; error: unknown }
+  | { status: 'success'; value: TFullSearchSchema }
+  | { status: 'error'; error: unknown }
   params:
-    | { status: 'success'; value: TAllParams }
-    | { status: 'error'; error: unknown }
+  | { status: 'success'; value: TAllParams }
+  | { status: 'error'; error: unknown }
   staticData: StaticDataRouteOption
   ssr?: boolean | 'data-only'
 }
@@ -189,11 +193,11 @@ export type MakePreValidationErrorHandlingRouteMatchUnion<
   TRoute extends AnyRoute = ParseRoute<TRouter['routeTree']>,
 > = TRoute extends any
   ? PreValidationErrorHandlingRouteMatch<
-      TRoute['id'],
-      TRoute['fullPath'],
-      TRoute['types']['allParams'],
-      TRoute['types']['fullSearchSchema']
-    >
+    TRoute['id'],
+    TRoute['fullPath'],
+    TRoute['types']['allParams'],
+    TRoute['types']['fullSearchSchema']
+  >
   : never
 
 export type MakeRouteMatchFromRoute<TRoute extends AnyRoute> = RouteMatch<
@@ -214,17 +218,17 @@ export type MakeRouteMatch<
   TRouteId,
   RouteById<TRouteTree, TRouteId>['types']['fullPath'],
   TStrict extends false
-    ? AllParams<TRouteTree>
-    : RouteById<TRouteTree, TRouteId>['types']['allParams'],
+  ? AllParams<TRouteTree>
+  : RouteById<TRouteTree, TRouteId>['types']['allParams'],
   TStrict extends false
-    ? FullSearchSchema<TRouteTree>
-    : RouteById<TRouteTree, TRouteId>['types']['fullSearchSchema'],
+  ? FullSearchSchema<TRouteTree>
+  : RouteById<TRouteTree, TRouteId>['types']['fullSearchSchema'],
   TStrict extends false
-    ? AllLoaderData<TRouteTree>
-    : RouteById<TRouteTree, TRouteId>['types']['loaderData'],
+  ? AllLoaderData<TRouteTree>
+  : RouteById<TRouteTree, TRouteId>['types']['loaderData'],
   TStrict extends false
-    ? AllContext<TRouteTree>
-    : RouteById<TRouteTree, TRouteId>['types']['allContext'],
+  ? AllContext<TRouteTree>
+  : RouteById<TRouteTree, TRouteId>['types']['allContext'],
   RouteById<TRouteTree, TRouteId>['types']['loaderDeps']
 >
 
@@ -235,14 +239,14 @@ export type MakeRouteMatchUnion<
   TRoute extends AnyRoute = ParseRoute<TRouter['routeTree']>,
 > = TRoute extends any
   ? RouteMatch<
-      TRoute['id'],
-      TRoute['fullPath'],
-      TRoute['types']['allParams'],
-      TRoute['types']['fullSearchSchema'],
-      TRoute['types']['loaderData'],
-      TRoute['types']['allContext'],
-      TRoute['types']['loaderDeps']
-    >
+    TRoute['id'],
+    TRoute['fullPath'],
+    TRoute['types']['allParams'],
+    TRoute['types']['fullSearchSchema'],
+    TRoute['types']['loaderData'],
+    TRoute['types']['allContext'],
+    TRoute['types']['loaderDeps']
+  >
   : never
 
 /**

--- a/packages/router-core/src/typePrimitives.ts
+++ b/packages/router-core/src/typePrimitives.ts
@@ -36,7 +36,7 @@ export type ValidateParams<
 > = PathParamOptions<TRouter, TFrom, TTo>
 
 /**
- * @internal
+ * @private
  */
 export type InferFrom<
   TOptions,
@@ -48,7 +48,7 @@ export type InferFrom<
   : TDefaultFrom
 
 /**
- * @internal
+ * @private
  */
 export type InferTo<TOptions> = TOptions extends {
   to: infer TTo extends string
@@ -57,7 +57,7 @@ export type InferTo<TOptions> = TOptions extends {
   : undefined
 
 /**
- * @internal
+ * @private
  */
 export type InferMaskTo<TOptions> = TOptions extends {
   mask: { to: infer TTo extends string }
@@ -131,7 +131,7 @@ export type ValidateId<
 > = ConstrainLiteral<TId, RouteIds<TRouter['routeTree']>>
 
 /**
- * @internal
+ * @private
  */
 export type InferStrict<TOptions> = TOptions extends {
   strict: infer TStrict extends boolean
@@ -140,7 +140,7 @@ export type InferStrict<TOptions> = TOptions extends {
   : true
 
 /**
- * @internal
+ * @private
  */
 export type InferShouldThrow<TOptions> = TOptions extends {
   shouldThrow: infer TShouldThrow extends boolean
@@ -149,7 +149,7 @@ export type InferShouldThrow<TOptions> = TOptions extends {
   : true
 
 /**
- * @internal
+ * @private
  */
 export type InferSelected<TOptions> = TOptions extends {
   select: (...args: Array<any>) => infer TSelected

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
+    "stripInternal": true,
     "target": "ES2020"
   },
   "include": ["eslint.config.js", "prettier.config.js", "scripts"]


### PR DESCRIPTION
This PR proposes we use the `@internal` JSDoc tag, and `--stripInternal` typescript compiler option to remove internal keys from the public `.d.ts` files.

Docs for `stripInternal`: https://www.typescriptlang.org/tsconfig/#stripInternal

This helps ensuring internal values aren't considered as part of the *public API surface* by users, allowing us more flexibility in refactoring.

> [!WARNING]
> This PR proposes we add `stripInternal` to the entire repo, not just `router-core`. However there are already some values marked as internal that weren't added by this PR:
> - `InferStructuralSharing` in `react-router`
> - `handleHashScroll` in `router-core > scrollRestoration`
> - many `InferFoo` types in `router-core > typePrimitives`
>
> as a result of this, we might have to switch some of those `@internal` tags to something else (like `@private` maybe?) because they are, in fact, necessary for the build to be correct.

Example:
```ts
export type Foo = {
  a: number,
  /** @internal */
  b: number,
}

/** @internal */
export function hello() {
  return 'world'
}

export const answer = 42
```
gets compiled as `.d.ts` to
```ts
export type Foo = {
  a: number
}
export const answer = 42
```