### PR TITLE
feat(eslint): support the shorter syntax with verboseFileRoutes: false

### DIFF
--- a/packages/eslint-plugin-router/src/__tests__/create-route-property-order.rule.test.ts
+++ b/packages/eslint-plugin-router/src/__tests__/create-route-property-order.rule.test.ts
@@ -193,6 +193,27 @@ const invalidTestCases = invalidTestMatrix.map(
   }),
 )
 
+validTestCases.push({
+  name: 'verboseFileRoutes: false, createFileRoute valid order',
+  code: `export const Route = createFileRoute({
+  loaderDeps: () => null,
+  loader: () => null,
+})`,
+})
+
+invalidTestCases.push({
+  name: 'verboseFileRoutes: false, createFileRoute invalid order',
+  code: `export const Route = createFileRoute({
+  loader: () => null,
+  loaderDeps: () => null,
+})`,
+  errors: [{ messageId: 'invalidOrder' }],
+  output: `export const Route = createFileRoute({
+  loaderDeps: () => null,
+  loader: () => null,
+})`,
+})
+
 ruleTester.run(name, rule, {
   valid: validTestCases,
   invalid: invalidTestCases,

--- a/packages/eslint-plugin-router/src/rules/create-route-property-order/create-route-property-order.rule.ts
+++ b/packages/eslint-plugin-router/src/rules/create-route-property-order/create-route-property-order.rule.ts
@@ -51,7 +51,14 @@ export const rule = createRule({
         let args = node.arguments
         if (createRouteFunctionsIndirect.includes(createRouteFunction as any)) {
           if (node.parent.type === AST_NODE_TYPES.CallExpression) {
+            // Default verboseFileRoutes curried usage: createFileRoute('/path')({ ... })
             args = node.parent.arguments
+          } else if (
+            // verboseFileRoutes: false syntax: createFileRoute({ ... })
+            args[0] &&
+            args[0].type === AST_NODE_TYPES.ObjectExpression
+          ) {
+            // use args as-is
           } else {
             return
           }


### PR DESCRIPTION
Flag `create-route-property-order` also when `verboseFileRoutes` is false and file routes are defined without explicit import, for example in:

```ts
export const Route = createFileRoute({
  component: RouteComponent,
  head: ({}) => ({}),
  loader: ({}) => {},
})
```