### PR TITLE
feat: allow navigation from 404 pages when blocker is active

### DIFF
--- a/packages/react-router/src/useBlocker.tsx
+++ b/packages/react-router/src/useBlocker.tsx
@@ -176,25 +176,38 @@ export function useBlocker(
       function getLocation(
         location: HistoryLocation,
       ): AnyShouldBlockFnLocation {
-        const parsedLocation = router.parseLocation(location)
-        const matchedRoutes = router.getMatchedRoutes(
-          parsedLocation.pathname,
-          undefined,
-        )
+        const pathname = location.pathname
+
+        const matchedRoutes = router.getMatchedRoutes(pathname, undefined)
+
         if (matchedRoutes.foundRoute === undefined) {
-          throw new Error(`No route found for location ${location.href}`)
+          return {
+            routeId: '__notFound__',
+            fullPath: pathname,
+            pathname: pathname,
+            params: matchedRoutes.routeParams || {},
+            search: router.options.parseSearch(location.search),
+          }
         }
+
         return {
           routeId: matchedRoutes.foundRoute.id,
           fullPath: matchedRoutes.foundRoute.fullPath,
-          pathname: parsedLocation.pathname,
+          pathname: pathname,
           params: matchedRoutes.routeParams,
-          search: parsedLocation.search,
+          search: router.options.parseSearch(location.search),
         }
       }
 
       const current = getLocation(blockerFnArgs.currentLocation)
       const next = getLocation(blockerFnArgs.nextLocation)
+
+      if (
+        current.routeId === '__notFound__' &&
+        next.routeId !== '__notFound__'
+      ) {
+        return false
+      }
 
       const shouldBlock = await shouldBlockFn({
         action: blockerFnArgs.action,

--- a/packages/react-router/tests/useBlocker.test.tsx
+++ b/packages/react-router/tests/useBlocker.test.tsx
@@ -440,4 +440,127 @@ describe('useBlocker', () => {
 
     expect(window.location.pathname).toBe('/invoices')
   })
+
+  test('should allow navigation from 404 page when blocker is active', async () => {
+    const rootRoute = createRootRoute({
+      notFoundComponent: () => {
+        const navigate = useNavigate()
+
+        useBlocker({ shouldBlockFn: () => true })
+
+        return (
+          <>
+            <h1>Not Found</h1>
+            <button onClick={() => navigate({ to: '/' })}>Go Home</button>
+            <button onClick={() => navigate({ to: '/posts' })}>
+              Go to Posts
+            </button>
+          </>
+        )
+      },
+    })
+
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => {
+        return (
+          <>
+            <h1>Index</h1>
+          </>
+        )
+      },
+    })
+
+    const postsRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/posts',
+      component: () => {
+        return (
+          <>
+            <h1>Posts</h1>
+          </>
+        )
+      },
+    })
+
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, postsRoute]),
+      history,
+    })
+
+    render(<RouterProvider router={router} />)
+
+    await router.navigate({ to: '/non-existent' as any })
+
+    expect(
+      await screen.findByRole('heading', { name: 'Not Found' }),
+    ).toBeInTheDocument()
+
+    expect(window.location.pathname).toBe('/non-existent')
+
+    const homeButton = await screen.findByRole('button', { name: 'Go Home' })
+    fireEvent.click(homeButton)
+
+    expect(
+      await screen.findByRole('heading', { name: 'Index' }),
+    ).toBeInTheDocument()
+
+    expect(window.location.pathname).toBe('/')
+  })
+
+  test('should handle blocker navigation from 404 to another 404', async () => {
+    const rootRoute = createRootRoute({
+      notFoundComponent: () => {
+        const navigate = useNavigate()
+
+        useBlocker({ shouldBlockFn: () => true })
+
+        return (
+          <>
+            <h1>Not Found</h1>
+            <button onClick={() => navigate({ to: '/another-404' as any })}>
+              Go to Another 404
+            </button>
+          </>
+        )
+      },
+    })
+
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => {
+        return (
+          <>
+            <h1>Index</h1>
+          </>
+        )
+      },
+    })
+
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute]),
+      history,
+    })
+
+    render(<RouterProvider router={router} />)
+
+    await router.navigate({ to: '/non-existent' })
+
+    expect(
+      await screen.findByRole('heading', { name: 'Not Found' }),
+    ).toBeInTheDocument()
+
+    const anotherButton = await screen.findByRole('button', {
+      name: 'Go to Another 404',
+    })
+    fireEvent.click(anotherButton)
+
+    expect(
+      await screen.findByRole('heading', { name: 'Not Found' }),
+    ).toBeInTheDocument()
+
+    expect(window.location.pathname).toBe('/non-existent')
+  })
 })


### PR DESCRIPTION
## Summary

Fixes navigation issues when using [useBlocker](cci:1://file:///Users/leejihoon/Documents/open-source/router/packages/react-router/src/useBlocker.tsx:142:0-148:18) hook on 404 pages. Previously, when a user was on a 404 page with an active blocker, attempting to navigate to any other page would throw an error: `"Error: No route found for location /foo"`.

## Changes

- **Modified [getLocation](cci:1://file:///Users/leejihoon/Documents/open-source/router/packages/react-router/src/useBlocker.tsx:175:6-215:7) function** in [useBlocker.tsx](cci:7://file:///Users/leejihoon/Documents/open-source/router/packages/react-router/src/useBlocker.tsx:0:0-0:0) to handle 404 routes gracefully
- **Added special handling** for routes where `foundRoute` is `undefined` by returning `routeId: '__notFound__'`
- **Implemented logic** to allow navigation from 404 pages to valid routes without blocking
- **Added comprehensive tests** to verify 404 page navigation behavior

## Technical Details

1. **Root Cause**: The blocker was trying to resolve 404 paths as valid routes, causing errors when [getMatchedRoutes](cci:1://file:///Users/leejihoon/Documents/open-source/router/packages/router-core/src/router.ts:3422:0-3504:1) returned `undefined` for `foundRoute`.

2. **Solution**: Instead of throwing errors on 404 routes, the [getLocation](cci:1://file:///Users/leejihoon/Documents/open-source/router/packages/react-router/src/useBlocker.tsx:175:6-215:7) function now
   - Returns a special location object with `routeId: '__notFound__'` for unmatched routes
   - Allows navigation from 404 pages to valid routes by checking route IDs
   - Maintains normal blocking behavior for valid-to-valid route navigation

3. **Test Coverage**: Added tests for:
   - Navigation from 404 page to valid page (should be allowed)
   - Navigation from 404 page to another 404 page (follows normal blocking rules)

## Breaking Changes

None. All existing functionality is preserved.

## Fixes

Closes #4881