### PR TITLE
refactor(react-router,solid-router): Minor simplification of MatchInner match logic in select

### DIFF
--- a/packages/react-router/src/Match.tsx
+++ b/packages/react-router/src/Match.tsx
@@ -189,8 +189,7 @@ export const MatchInner = React.memo(function MatchInnerImpl({
 
   const { match, key, routeId } = useRouterState({
     select: (s) => {
-      const matchIndex = s.matches.findIndex((d) => d.id === matchId)
-      const match = s.matches[matchIndex]!
+      const match = s.matches.find((d) => d.id === matchId)!
       const routeId = match.routeId as string
 
       const remountFn =

--- a/packages/solid-router/src/Match.tsx
+++ b/packages/solid-router/src/Match.tsx
@@ -185,8 +185,7 @@ export const MatchInner = (props: { matchId: string }): any => {
 
   const matchState = useRouterState({
     select: (s) => {
-      const matchIndex = s.matches.findIndex((d) => d.id === props.matchId)
-      const match = s.matches[matchIndex]!
+      const match = s.matches.find((d) => d.id === props.matchId)!
       const routeId = match.routeId as string
 
       const remountFn =


### PR DESCRIPTION
We don't need the `matchIndex` in `Match > MatchInner > useRouterState > select`. It must have been left after a previous refactor.