### PR TITLE
fix(react-router): correctly assign createLazyFileRoute on window

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -112,5 +112,5 @@ if (typeof globalThis !== 'undefined') {
   ;(globalThis as any).createLazyFileRoute = createLazyFileRoute
 } else if (typeof window !== 'undefined') {
   ;(window as any).createFileRoute = createFileRoute
-  ;(window as any).createFileRoute = createLazyFileRoute
+  ;(window as any).createLazyFileRoute = createLazyFileRoute
 }


### PR DESCRIPTION
## Summary
In the `window` conditional block of the global assignment, `createFileRoute` was assigned twice, overwriting the first assignment and leaving `createLazyFileRoute` undefined in browser environments.

## Fix
Changed the second assignment to:

```ts
(window as any).createLazyFileRoute = createLazyFileRoute
```

This matches the `globalThis` conditional block behavior and ensures `createLazyFileRoute` is correctly available.

> **Note:**  
> If this was intentional and `createFileRoute` is meant to always reference `createLazyFileRoute` in browser environments, then it might be clearer to directly assign:
> ```ts
> (window as any).createFileRoute = createLazyFileRoute
> ```
> instead of having two consecutive assignments to `createFileRoute`. 
>
> If intentional, adding a short comment explaining this design choice could help future contributors understand the reasoning.