### PR TITLE
fix(solid-router): correctly assign createLazyFileRoute on window

### DIFF
--- a/packages/solid-router/src/router.ts
+++ b/packages/solid-router/src/router.ts
@@ -108,5 +108,5 @@ if (typeof globalThis !== 'undefined') {
   ;(globalThis as any).createLazyFileRoute = createLazyFileRoute
 } else if (typeof window !== 'undefined') {
   ;(window as any).createFileRoute = createFileRoute
-  ;(window as any).createFileRoute = createLazyFileRoute
+  ;(window as any).createLazyFileRoute = createLazyFileRoute
 }


### PR DESCRIPTION
_This PR applies the same fix as in [#4948](https://github.com/TanStack/router/pull/4948), but for the `solid-router` package._


## Summary
In the `window` conditional block of the global assignment, `createFileRoute` was assigned twice, overwriting the first assignment and leaving `createLazyFileRoute` undefined in browser environments.

## Fix
Changed the second assignment to:

```ts
(window as any).createLazyFileRoute = createLazyFileRoute
```

This matches the `globalThis` conditional block behavior and ensures `createLazyFileRoute` is correctly available.