### PR TITLE
refactor(router-core): flatten loadMatches

### DIFF
--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -2283,6 +2283,7 @@ export class RouterCore<
         ssr: match.ssr,
       })),
     }
+
     const tempSsr = route.options.ssr(ssrFnContext)
     if (isPromise(tempSsr)) {
       return tempSsr.then((ssr) => {
@@ -2455,7 +2456,7 @@ export class RouterCore<
         matches: innerLoadContext.matches,
       }
 
-      const then = (beforeLoadContext: any) => {
+      const updateContext = (beforeLoadContext: any) => {
         if (isRedirect(beforeLoadContext) || isNotFound(beforeLoadContext)) {
           this.handleSerialError(
             innerLoadContext,
@@ -2480,13 +2481,13 @@ export class RouterCore<
       const beforeLoadContext = route.options.beforeLoad?.(beforeLoadFnContext)
       if (isPromise(beforeLoadContext)) {
         return beforeLoadContext
-          .then(then)
+          .then(updateContext)
           .catch((err) => {
             this.handleSerialError(innerLoadContext, index, err, 'BEFORE_LOAD')
           })
           .then(resolve)
       } else {
-        then(beforeLoadContext)
+        updateContext(beforeLoadContext)
       }
     } catch (err) {
       this.handleSerialError(innerLoadContext, index, err, 'BEFORE_LOAD')

--- a/packages/solid-router/tests/Transitioner.test.tsx
+++ b/packages/solid-router/tests/Transitioner.test.tsx
@@ -30,13 +30,12 @@ describe('Transitioner', () => {
     // Mock router.load() to verify it gets called
     const loadSpy = vi.spyOn(router, 'load')
 
-    await router.load()
-
     render(() => <RouterProvider router={router} />)
+    await router.latestLoadPromise
 
     // Wait for the createRenderEffect to run and call router.load()
     await waitFor(() => {
-      expect(loadSpy).toHaveBeenCalledTimes(2)
+      expect(loadSpy).toHaveBeenCalledTimes(1)
       expect(loader).toHaveBeenCalledTimes(1)
     })
 


### PR DESCRIPTION
This PR *should* be a no-op. Just restructuring the code to have all the functions used by `loadMatches` at the same level, instead of nested callbacks. In order to still have access to the data that was previously in scope because of nesting, we use a `innerLoadContext` object, which is basically just the arguments of `loadMatches`, and a few mutables.

However, in order to do so, we have to rearrange promises in an area that is sensitive to any microtask order change, and we did change some of them. So this is not *really* a no-op, even though this does not attempt any optimization. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Smoother navigations with predictable pending states and minimum display durations.
  - More consistent head/meta updates after route loading.
- Bug Fixes
  - More reliable redirects and 404 handling, including during preloading and SSR.
  - Reduced UI flicker by refining pending and preloading behavior.
- Refactor
  - Reworked the routing load pipeline for improved performance, stability, and SSR behavior.
  - Streamlined before-load steps for clearer, more consistent execution.
- Tests
  - Updated tests to reflect the new loading flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->