### PR TITLE
Make useBlocker exception on unknown routes optional

### DIFF
--- a/packages/react-router/src/useBlocker.tsx
+++ b/packages/react-router/src/useBlocker.tsx
@@ -42,7 +42,7 @@ type BlockerResolver<TRouter extends AnyRouter = RegisteredRouter> =
   | {
       status: 'blocked'
       current: MakeShouldBlockFnLocationUnion<TRouter>
-      next: MakeShouldBlockFnLocationUnion<TRouter>
+      next: MakeShouldBlockFnLocationUnion<TRouter> | undefined
       action: HistoryAction
       proceed: () => void
       reset: () => void
@@ -57,8 +57,8 @@ type BlockerResolver<TRouter extends AnyRouter = RegisteredRouter> =
     }
 
 type ShouldBlockFnArgs<TRouter extends AnyRouter = RegisteredRouter> = {
-  current: MakeShouldBlockFnLocationUnion<TRouter> | null
-  next: MakeShouldBlockFnLocationUnion<TRouter> | null
+  current: MakeShouldBlockFnLocationUnion<TRouter>
+  next: MakeShouldBlockFnLocationUnion<TRouter> | undefined
   action: HistoryAction
 }
 
@@ -177,14 +177,14 @@ export function useBlocker(
     const blockerFnComposed = async (blockerFnArgs: BlockerFnArgs) => {
       function getLocation(
         location: HistoryLocation,
-      ): AnyShouldBlockFnLocation|null {
+      ): AnyShouldBlockFnLocation|undefined {
         const parsedLocation = router.parseLocation(undefined, location)
         const matchedRoutes = router.getMatchedRoutes(
           parsedLocation.pathname,
           undefined,
         )
         if (matchedRoutes.foundRoute === undefined) {
-          return null
+          return undefined
         }
         return {
           routeId: matchedRoutes.foundRoute.id,

--- a/packages/react-router/src/useBlocker.tsx
+++ b/packages/react-router/src/useBlocker.tsx
@@ -41,7 +41,7 @@ type MakeShouldBlockFnLocationUnion<
 type BlockerResolver<TRouter extends AnyRouter = RegisteredRouter> =
   | {
       status: 'blocked'
-      current: MakeShouldBlockFnLocationUnion<TRouter>
+      current: MakeShouldBlockFnLocationUnion<TRouter> | undefined
       next: MakeShouldBlockFnLocationUnion<TRouter> | undefined
       action: HistoryAction
       proceed: () => void
@@ -57,7 +57,7 @@ type BlockerResolver<TRouter extends AnyRouter = RegisteredRouter> =
     }
 
 type ShouldBlockFnArgs<TRouter extends AnyRouter = RegisteredRouter> = {
-  current: MakeShouldBlockFnLocationUnion<TRouter>
+  current: MakeShouldBlockFnLocationUnion<TRouter> | undefined
   next: MakeShouldBlockFnLocationUnion<TRouter> | undefined
   action: HistoryAction
 }
@@ -196,7 +196,7 @@ export function useBlocker(
       }
 
       const current = getLocation(blockerFnArgs.currentLocation)
-      if (!current) {
+      if (!current && throwOnUnknownRoute) {
         throw new Error(
           `No route found for location ${blockerFnArgs.currentLocation.href}`,
         )

--- a/packages/react-router/tests/useBlocker.test-d.tsx
+++ b/packages/react-router/tests/useBlocker.test-d.tsx
@@ -109,6 +109,7 @@ test('shouldBlockFn has corrent action', () => {
     .toHaveProperty('shouldBlockFn')
     .parameter(0)
     .toHaveProperty('current')
+    .exclude(undefined)
     .toHaveProperty('routeId')
     .toEqualTypeOf<'__root__' | '/' | '/invoices' | '/invoices/'>()
 

--- a/packages/react-router/tests/useBlocker.test-d.tsx
+++ b/packages/react-router/tests/useBlocker.test-d.tsx
@@ -109,7 +109,6 @@ test('shouldBlockFn has corrent action', () => {
     .toHaveProperty('shouldBlockFn')
     .parameter(0)
     .toHaveProperty('current')
-    .exclude(null)
     .toHaveProperty('routeId')
     .toEqualTypeOf<'__root__' | '/' | '/invoices' | '/invoices/'>()
 
@@ -118,7 +117,7 @@ test('shouldBlockFn has corrent action', () => {
     .toHaveProperty('shouldBlockFn')
     .parameter(0)
     .toHaveProperty('next')
-    .exclude(null)
+    .exclude(undefined)
     .toHaveProperty('routeId')
     .toEqualTypeOf<'__root__' | '/' | '/invoices' | '/invoices/'>()
 })

--- a/packages/react-router/tests/useBlocker.test-d.tsx
+++ b/packages/react-router/tests/useBlocker.test-d.tsx
@@ -109,6 +109,7 @@ test('shouldBlockFn has corrent action', () => {
     .toHaveProperty('shouldBlockFn')
     .parameter(0)
     .toHaveProperty('current')
+    .exclude(null)
     .toHaveProperty('routeId')
     .toEqualTypeOf<'__root__' | '/' | '/invoices' | '/invoices/'>()
 
@@ -117,6 +118,7 @@ test('shouldBlockFn has corrent action', () => {
     .toHaveProperty('shouldBlockFn')
     .parameter(0)
     .toHaveProperty('next')
+    .exclude(null)
     .toHaveProperty('routeId')
     .toEqualTypeOf<'__root__' | '/' | '/invoices' | '/invoices/'>()
 })

--- a/packages/react-router/tests/useBlocker.test.tsx
+++ b/packages/react-router/tests/useBlocker.test.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import '@testing-library/jest-dom/vitest'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import {
-  act,
   cleanup,
   fireEvent,
   render,

--- a/packages/solid-router/src/useBlocker.tsx
+++ b/packages/solid-router/src/useBlocker.tsx
@@ -43,7 +43,7 @@ type BlockerResolver<TRouter extends AnyRouter = RegisteredRouter> =
   | {
       status: 'blocked'
       current: MakeShouldBlockFnLocationUnion<TRouter>
-      next: MakeShouldBlockFnLocationUnion<TRouter>
+      next: MakeShouldBlockFnLocationUnion<TRouter> | undefined
       action: HistoryAction
       proceed: () => void
       reset: () => void
@@ -58,8 +58,8 @@ type BlockerResolver<TRouter extends AnyRouter = RegisteredRouter> =
     }
 
 type ShouldBlockFnArgs<TRouter extends AnyRouter = RegisteredRouter> = {
-  current: MakeShouldBlockFnLocationUnion<TRouter> | null
-  next: MakeShouldBlockFnLocationUnion<TRouter> | null
+  current: MakeShouldBlockFnLocationUnion<TRouter>
+  next: MakeShouldBlockFnLocationUnion<TRouter> | undefined
   action: HistoryAction
 }
 
@@ -186,14 +186,14 @@ export function useBlocker(
     const blockerFnComposed = async (blockerFnArgs: BlockerFnArgs) => {
       function getLocation(
         location: HistoryLocation,
-      ): AnyShouldBlockFnLocation | null {
+      ): AnyShouldBlockFnLocation | undefined {
         const parsedLocation = router.parseLocation(undefined, location)
         const matchedRoutes = router.getMatchedRoutes(
           parsedLocation.pathname,
           undefined,
         )
         if (matchedRoutes.foundRoute === undefined) {
-          return null
+          return undefined
         }
         return {
           routeId: matchedRoutes.foundRoute.id,

--- a/packages/solid-router/src/useBlocker.tsx
+++ b/packages/solid-router/src/useBlocker.tsx
@@ -42,7 +42,7 @@ type MakeShouldBlockFnLocationUnion<
 type BlockerResolver<TRouter extends AnyRouter = RegisteredRouter> =
   | {
       status: 'blocked'
-      current: MakeShouldBlockFnLocationUnion<TRouter>
+      current: MakeShouldBlockFnLocationUnion<TRouter> | undefined
       next: MakeShouldBlockFnLocationUnion<TRouter> | undefined
       action: HistoryAction
       proceed: () => void
@@ -58,7 +58,7 @@ type BlockerResolver<TRouter extends AnyRouter = RegisteredRouter> =
     }
 
 type ShouldBlockFnArgs<TRouter extends AnyRouter = RegisteredRouter> = {
-  current: MakeShouldBlockFnLocationUnion<TRouter>
+  current: MakeShouldBlockFnLocationUnion<TRouter> | undefined
   next: MakeShouldBlockFnLocationUnion<TRouter> | undefined
   action: HistoryAction
 }
@@ -205,7 +205,7 @@ export function useBlocker(
       }
 
       const current = getLocation(blockerFnArgs.currentLocation)
-      if (!current) {
+      if (!current && props.throwOnUnknownRoute) {
         throw new Error(
           `No route found for location ${blockerFnArgs.currentLocation.href}`,
         )

--- a/packages/solid-router/tests/useBlocker.test-d.tsx
+++ b/packages/solid-router/tests/useBlocker.test-d.tsx
@@ -106,7 +106,6 @@ test('shouldBlockFn has corrent action', () => {
     .toHaveProperty('shouldBlockFn')
     .parameter(0)
     .toHaveProperty('current')
-    .exclude(null)
     .toHaveProperty('routeId')
     .toEqualTypeOf<'__root__' | '/' | '/invoices' | '/invoices/'>()
 
@@ -115,7 +114,7 @@ test('shouldBlockFn has corrent action', () => {
     .toHaveProperty('shouldBlockFn')
     .parameter(0)
     .toHaveProperty('next')
-    .exclude(null)
+    .exclude(undefined)
     .toHaveProperty('routeId')
     .toEqualTypeOf<'__root__' | '/' | '/invoices' | '/invoices/'>()
 })

--- a/packages/solid-router/tests/useBlocker.test-d.tsx
+++ b/packages/solid-router/tests/useBlocker.test-d.tsx
@@ -106,6 +106,7 @@ test('shouldBlockFn has corrent action', () => {
     .toHaveProperty('shouldBlockFn')
     .parameter(0)
     .toHaveProperty('current')
+    .exclude(undefined)
     .toHaveProperty('routeId')
     .toEqualTypeOf<'__root__' | '/' | '/invoices' | '/invoices/'>()
 

--- a/packages/solid-router/tests/useBlocker.test-d.tsx
+++ b/packages/solid-router/tests/useBlocker.test-d.tsx
@@ -106,6 +106,7 @@ test('shouldBlockFn has corrent action', () => {
     .toHaveProperty('shouldBlockFn')
     .parameter(0)
     .toHaveProperty('current')
+    .exclude(null)
     .toHaveProperty('routeId')
     .toEqualTypeOf<'__root__' | '/' | '/invoices' | '/invoices/'>()
 
@@ -114,6 +115,7 @@ test('shouldBlockFn has corrent action', () => {
     .toHaveProperty('shouldBlockFn')
     .parameter(0)
     .toHaveProperty('next')
+    .exclude(null)
     .toHaveProperty('routeId')
     .toEqualTypeOf<'__root__' | '/' | '/invoices' | '/invoices/'>()
 })


### PR DESCRIPTION
Adds a `throwOnUnknownRoute` option to the `useBlocker` hook for both React and Solid.

When set to `false`, this option prevents `useBlocker` from throwing an exception if the user navigates to a route that is not recognized by the router. Instead, the navigation is allowed to proceed. This is useful for applications that are progressively adopting the router and may have links that navigate from router-managed pages to non-router-managed pages.

The default value is `true` to maintain the existing behavior. 

I'm not sure the option is really necessary. We could imagine to completely reconsider throwing an exception from this function (I don't see anyway how the user could catch it. Let me know if we already can).