### PR TITLE
refactor(router-core): loadMatches extra microtask

### DIFF
--- a/packages/react-router/tests/store-updates-during-navigation.test.tsx
+++ b/packages/react-router/tests/store-updates-during-navigation.test.tsx
@@ -183,7 +183,7 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBe(8)
+    expect(updates).toBe(7)
   })
 
   test('hover preload, then navigate, w/ async loaders', async () => {

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -2930,33 +2930,23 @@ export class RouterCore<
     }
 
     try {
-      await new Promise<void>((resolveAll, rejectAll) => {
-        ;(async () => {
-          try {
-            // Execute all beforeLoads one by one
-            for (let i = 0; i < innerLoadContext.matches.length; i++) {
-              const beforeLoad = this.handleBeforeLoad(innerLoadContext, i)
-              if (isPromise(beforeLoad)) await beforeLoad
-            }
+      // Execute all beforeLoads one by one
+      for (let i = 0; i < innerLoadContext.matches.length; i++) {
+        const beforeLoad = this.handleBeforeLoad(innerLoadContext, i)
+        if (isPromise(beforeLoad)) await beforeLoad
+      }
 
-            // Execute all loaders in parallel
-            const max =
-              innerLoadContext.firstBadMatchIndex ??
-              innerLoadContext.matches.length
-            for (let i = 0; i < max; i++) {
-              innerLoadContext.matchPromises.push(
-                this.loadRouteMatch(innerLoadContext, i),
-              )
-            }
+      // Execute all loaders in parallel
+      const max =
+        innerLoadContext.firstBadMatchIndex ??
+        innerLoadContext.matches.length
+      for (let i = 0; i < max; i++) {
+        innerLoadContext.matchPromises.push(
+          this.loadRouteMatch(innerLoadContext, i),
+        )
+      }
+      await Promise.all(innerLoadContext.matchPromises)
 
-            await Promise.all(innerLoadContext.matchPromises)
-
-            resolveAll()
-          } catch (err) {
-            rejectAll(err)
-          }
-        })()
-      })
       const readyPromise = this.triggerOnReady(innerLoadContext)
       if (isPromise(readyPromise)) await readyPromise
     } catch (err) {

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -2938,8 +2938,7 @@ export class RouterCore<
 
       // Execute all loaders in parallel
       const max =
-        innerLoadContext.firstBadMatchIndex ??
-        innerLoadContext.matches.length
+        innerLoadContext.firstBadMatchIndex ?? innerLoadContext.matches.length
       for (let i = 0; i < max; i++) {
         innerLoadContext.matchPromises.push(
           this.loadRouteMatch(innerLoadContext, i),


### PR DESCRIPTION
The `loadMatches` has an unnecessary complicated async setup, probably due to how complicated the function was before recent cleanups:

```ts
async function loadMatches() {
  try {
    await new Promise((resolve, reject) => {
      ;(async () => {
        try {
          // the logic
          resolve()
        } catch (err) {
          reject(err)
        }
      })()
    })
    // after promise
  } catch (err) {
    // error handling
  }
}
```

Aside from some scheduling differences due to unnecessary promises in the above example, this can be simplified down to this:
```ts
async function loadMatches() {
  try {
    // the logic
    // after promise
  } catch (err) {
    // error handling
  }
}
```

This is what this PR does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes.

- Refactor
  - Simplified internal async flow for route loading, removing redundant promise wrapping.
  - Maintains existing behavior and public API; no action required from users.
  - More consistent error handling and slightly reduced overhead during parallel loads.
  - Improves maintainability and prepares the codebase for future enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->