### PR TITLE
refactor(router-core,react-router,solid-router): avoid copying arrays just to .reverse() them

### DIFF
--- a/packages/react-router/src/HeadContent.tsx
+++ b/packages/react-router/src/HeadContent.tsx
@@ -17,9 +17,11 @@ export const useTags = () => {
     const resultMeta: Array<RouterManagedTag> = []
     const metaByAttribute: Record<string, true> = {}
     let title: RouterManagedTag | undefined
-    ;[...routeMeta].reverse().forEach((metas) => {
-      ;[...metas].reverse().forEach((m) => {
-        if (!m) return
+    for (let i = routeMeta.length - 1; i >= 0; i--) {
+      const metas = routeMeta[i]!
+      for (let j = metas.length - 1; j >= 0; j--) {
+        const m = metas[j]
+        if (!m) continue
 
         if (m.title) {
           if (!title) {
@@ -32,7 +34,7 @@ export const useTags = () => {
           const attribute = m.name ?? m.property
           if (attribute) {
             if (metaByAttribute[attribute]) {
-              return
+              continue
             } else {
               metaByAttribute[attribute] = true
             }
@@ -45,8 +47,8 @@ export const useTags = () => {
             },
           })
         }
-      })
-    })
+      }
+    }
 
     if (title) {
       resultMeta.push(title)

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -8,6 +8,7 @@ import invariant from 'tiny-invariant'
 import {
   createControlledPromise,
   deepEqual,
+  findLast,
   functionalUpdate,
   last,
   pick,
@@ -1441,13 +1442,11 @@ export class RouterCore<
             undefined,
           ).matchedRoutes
 
-          const matchedFrom = [...allCurrentLocationMatches]
-            .reverse()
-            .find((d) => {
-              return comparePaths(d.fullPath, fromPath)
-            })
+          const matchedFrom = findLast(allCurrentLocationMatches, (d) => {
+            return comparePaths(d.fullPath, fromPath)
+          })
 
-          const matchedCurrent = [...allFromMatches].reverse().find((d) => {
+          const matchedCurrent = findLast(allFromMatches, (d) => {
             return comparePaths(d.fullPath, currentLocation.pathname)
           })
 

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -485,13 +485,12 @@ export function isPromise<T>(
 }
 
 export function findLast<T>(
-  array: Array<T>,
+  array: ReadonlyArray<T>,
   predicate: (item: T) => boolean,
 ): T | undefined {
   for (let i = array.length - 1; i >= 0; i--) {
-    if (predicate(array[i]!)) {
-      return array[i]!
-    }
+    const item = array[i]!
+    if (predicate(item)) return item
   }
   return undefined
 }

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -483,3 +483,12 @@ export function isPromise<T>(
       typeof (value as Promise<T>).then === 'function',
   )
 }
+
+export function findLast<T>(array: Array<T>, predicate: (item: T) => boolean): T | undefined {
+  for (let i = array.length - 1; i >= 0; i--) {
+    if (predicate(array[i]!)) {
+      return array[i]!;
+    }
+  }
+  return undefined;
+}

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -484,11 +484,14 @@ export function isPromise<T>(
   )
 }
 
-export function findLast<T>(array: Array<T>, predicate: (item: T) => boolean): T | undefined {
+export function findLast<T>(
+  array: Array<T>,
+  predicate: (item: T) => boolean,
+): T | undefined {
   for (let i = array.length - 1; i >= 0; i--) {
     if (predicate(array[i]!)) {
-      return array[i]!;
+      return array[i]!
     }
   }
-  return undefined;
+  return undefined
 }

--- a/packages/solid-router/src/HeadContent.tsx
+++ b/packages/solid-router/src/HeadContent.tsx
@@ -18,9 +18,12 @@ export const useTags = () => {
     const resultMeta: Array<RouterManagedTag> = []
     const metaByAttribute: Record<string, true> = {}
     let title: RouterManagedTag | undefined
-    ;[...routeMeta()].reverse().forEach((metas) => {
-      ;[...metas].reverse().forEach((m) => {
-        if (!m) return
+    const routeMetasArray = routeMeta()
+    for (let i = routeMetasArray.length - 1; i >= 0; i--) {
+      const metas = routeMetasArray[i]!
+      for (let j = metas.length - 1; j >= 0; j--) {
+        const m = metas[j]
+        if (!m) continue
 
         if (m.title) {
           if (!title) {
@@ -33,7 +36,7 @@ export const useTags = () => {
           const attribute = m.name ?? m.property
           if (attribute) {
             if (metaByAttribute[attribute]) {
-              return
+              continue
             } else {
               metaByAttribute[attribute] = true
             }
@@ -46,8 +49,8 @@ export const useTags = () => {
             },
           })
         }
-      })
-    })
+      }
+    }
 
     if (title) {
       resultMeta.push(title)


### PR DESCRIPTION
The pattern of copying an array just to `.reverse()` it and iterate it from the end ends up creating a transient object (a copy of the array) that needs to be garbage collected.

For example:
```ts
[...array].reverse().find(() => {/*...*/})
```
or
```ts
[...array].reverse().forEach(() => {/*...*/})
```

Instead we can use a regular `for` loop to iterate it from the end. This will be mostly beneficial in `router-core > router > buildLocation` that gets called pretty often.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved head metadata processing in React and Solid routers to be more efficient and readable, reducing work for large route metadata sets.
  - Simplified route matching logic to consistently pick the last relevant match, improving clarity and maintainability.

- **Chores**
  - Added a utility to locate the last list item meeting a condition, supporting cleaner routing internals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->