### PR TITLE
refactor(router-core): remove pick utility in favor of direct object manipulation

### DIFF
--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -25,7 +25,6 @@ export {
   parseSearchWith,
   stringifySearchWith,
   escapeJSON, // SSR
-  pick,
   functionalUpdate,
   replaceEqualDeep,
   isPlainObject,

--- a/packages/router-core/src/index.ts
+++ b/packages/router-core/src/index.ts
@@ -269,7 +269,6 @@ export type { OptionalStructuralSharing } from './structuralSharing'
 export {
   last,
   functionalUpdate,
-  pick,
   replaceEqualDeep,
   isPlainObject,
   isPlainArray,

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -11,7 +11,6 @@ import {
   findLast,
   functionalUpdate,
   last,
-  pick,
   replaceEqualDeep,
 } from './utils'
 import {
@@ -1617,7 +1616,7 @@ export class RouterCore<
         if (foundMask) {
           const { from: _from, ...maskProps } = foundMask
           maskedDest = {
-            ...pick(opts, ['from']),
+            from: opts.from,
             ...maskProps,
             params,
           }
@@ -1635,7 +1634,7 @@ export class RouterCore<
 
     if (opts.mask) {
       return buildWithMatches(opts, {
-        ...pick(opts, ['from']),
+        from: opts.from,
         ...opts.mask,
       })
     }

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -203,16 +203,6 @@ export function functionalUpdate<TPrevious, TResult = TPrevious>(
   return updater
 }
 
-export function pick<TValue, TKey extends keyof TValue>(
-  parent: TValue,
-  keys: Array<TKey>,
-): Pick<TValue, TKey> {
-  return keys.reduce((obj: any, key: TKey) => {
-    obj[key] = parent[key]
-    return obj
-  }, {} as any)
-}
-
 /**
  * This function returns `prev` if `_next` is deeply equal.
  * If not, it will replace any deeply equal children of `b` with those of `a`.

--- a/packages/solid-router/src/index.tsx
+++ b/packages/solid-router/src/index.tsx
@@ -25,7 +25,6 @@ export {
   parseSearchWith,
   stringifySearchWith,
   escapeJSON, // SSR
-  pick,
   functionalUpdate,
   replaceEqualDeep,
   isPlainObject,


### PR DESCRIPTION
Based on the current usage of `pick`, directly addinf the picked keys to the objects will be less overhead with the same result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Simplified internal routing logic related to navigation options; no change to runtime behavior.
- Chores
  - Removed an internal utility no longer used.
- Public API
  - One non-essential utility export was removed from package entry points, slightly reducing the public API surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->