### PR TITLE
refactor(router-core): redirect skips creating a URL object if href is not a string

### DIFF
--- a/packages/router-core/src/redirect.ts
+++ b/packages/router-core/src/redirect.ts
@@ -65,9 +65,9 @@ export function redirect<
 ): Redirect<TRouter, TFrom, TTo, TMaskFrom, TMaskTo> {
   opts.statusCode = opts.statusCode || opts.code || 307
 
-  if (!opts.reloadDocument) {
+  if (!opts.reloadDocument && typeof opts.href === 'string') {
     try {
-      new URL(`${opts.href}`)
+      new URL(opts.href)
       opts.reloadDocument = true
     } catch {}
   }
@@ -103,7 +103,7 @@ export function isResolvedRedirect(
 }
 
 export function parseRedirect(obj: any) {
-  if (typeof obj === 'object' && obj.isSerializedRedirect) {
+  if (obj !== null && typeof obj === 'object' && obj.isSerializedRedirect) {
     return redirect(obj)
   }
 


### PR DESCRIPTION
Creating a `URL` object is a little expensive, and we know it's going to throw if `href` is not a string. So we can skip it entirely in that case (which is probably most cases?).