### PR TITLE
refactor(router-core): shouldExecuteBeforeLoad is always true

### DIFF
--- a/packages/router-core/src/load-matches.ts
+++ b/packages/router-core/src/load-matches.ts
@@ -489,14 +489,8 @@ const handleBeforeLoad = (
 
   const queueExecution = () => {
     if (shouldSkipLoader(inner, matchId)) return
-    const result = preBeforeLoadSetup(
-      inner,
-      matchId,
-      route,
-    )
-    return isPromise(result)
-      ? result.then(execute)
-      : execute()
+    const result = preBeforeLoadSetup(inner, matchId, route)
+    return isPromise(result) ? result.then(execute) : execute()
   }
 
   const execute = () => executeBeforeLoad(inner, matchId, index, route)


### PR DESCRIPTION
Fix https://github.com/TanStack/router/pull/4971#discussion_r2282953542

With the code now simplified by previous PRs, we noticed that the `shouldExecuteBeforeLoad` guard is always true, so we can clean it up.

In a follow up PR, we'll revise the conditions under which a `beforeLoad` should be called or skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined pre-load checks and execution flow, reducing branching and improving consistency across client and server rendering.
  * Unified orchestration of the before-load phase to simplify control flow and improve maintainability.

* **Bug Fixes**
  * More reliable handling of redirects and “not found” states during preloading, preventing unintended execution paths and improving navigation stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->