### PR TITLE
test(router-core): fix flakiness of store-updates 'preload then navigate' test

### DIFF
--- a/packages/react-router/tests/store-updates-during-navigation.test.tsx
+++ b/packages/react-router/tests/store-updates-during-navigation.test.tsx
@@ -189,7 +189,7 @@ describe("Store doesn't update *too many* times during navigation", () => {
   test('hover preload, then navigate, w/ async loaders', async () => {
     const { select } = setup({
       beforeLoad: () => Promise.resolve({ foo: 'bar' }),
-      loader: () => Promise.resolve({ hello: 'world' }),
+      loader: () => resolveAfter(100, { hello: 'world' }),
     })
 
     const link = await waitFor(() =>
@@ -197,6 +197,7 @@ describe("Store doesn't update *too many* times during navigation", () => {
     )
     const before = select.mock.calls.length
     fireEvent.focus(link)
+    await new Promise((resolve) => setTimeout(resolve, 50))
     fireEvent.click(link)
     const title = await waitFor(() =>
       screen.getByRole('heading', { name: /Title$/ }),
@@ -208,6 +209,6 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBe(15)
+    expect(updates).toBe(14)
   })
 })


### PR DESCRIPTION
It turns out the 'hover preload, then navigate, w/ async loaders' test in `packages/react-router/tests/store-updates-during-navigation.test.tsx` was sometimes (but very rarely) yielding 16 updates instead of the expected 15. This PR makes minimal changes to this test so that it's now reliably 14.

I'm not exactly sure where we lost that 1 update, so we might not be measuring exactly the same thing. But it's still worth it to have a robust test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of hover preloading and navigation behavior tests by introducing realistic loader delays and aligning interaction timing, reducing flakiness.
  * Updated assertions for store updates during navigation to reflect observed behavior, ensuring more stable and predictable test outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->