### PR TITLE
fix(router-core): on navigate (with preload), route component isn't rendered with undefined context if beforeLoad is pending

### DIFF
--- a/packages/router-core/src/load-matches.ts
+++ b/packages/router-core/src/load-matches.ts
@@ -369,7 +369,7 @@ const executeBeforeLoad = (
   const parentMatchContext =
     parentMatch?.context ?? inner.router.options.context ?? undefined
 
-  const context = { ...parentMatchContext, ...match.__routeContext }
+  const context = { ...match.__beforeLoadContext, ...parentMatchContext, ...match.__routeContext }
 
   let isPending = false
   const pending = () => {


### PR DESCRIPTION
Fixes #4998 