### PR TITLE
Fix loader function for posts route example

### DIFF
--- a/docs/router/framework/react/guide/external-data-loading.md
+++ b/docs/router/framework/react/guide/external-data-loading.md
@@ -75,7 +75,7 @@ Let's take a look at a more realistic example using TanStack Query.
 
 ```tsx
 // src/routes/posts.tsx
-const queryClient = new QueryClient();
+const queryClient = new QueryClient()
 
 const postsQueryOptions = queryOptions({
   queryKey: ['posts'],
@@ -84,7 +84,7 @@ const postsQueryOptions = queryOptions({
 
 export const Route = createFileRoute('/posts')({
   // Use the `loader` option to ensure that the data is loaded
-  loader: () => queryClient.ensureQueryData(postsQueryOptions), 
+  loader: () => queryClient.ensureQueryData(postsQueryOptions),
   component: () => {
     // Read the data from the cache and subscribe to updates
     const {

--- a/docs/router/framework/react/guide/external-data-loading.md
+++ b/docs/router/framework/react/guide/external-data-loading.md
@@ -75,6 +75,8 @@ Let's take a look at a more realistic example using TanStack Query.
 
 ```tsx
 // src/routes/posts.tsx
+const queryClient = new QueryClient();
+
 const postsQueryOptions = queryOptions({
   queryKey: ['posts'],
   queryFn: () => fetchPosts(),
@@ -82,7 +84,7 @@ const postsQueryOptions = queryOptions({
 
 export const Route = createFileRoute('/posts')({
   // Use the `loader` option to ensure that the data is loaded
-  loader: () => queryClient.ensureQueryData(postsQueryOptions),
+  loader: () => queryClient.ensureQueryData(postsQueryOptions), 
   component: () => {
     // Read the data from the cache and subscribe to updates
     const {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the React external data loading guide to include a concrete QueryClient instance in the TanStack Query example.
  * Ensures the loader and suspense query usage reference a real client and shared cache in the snippet.
  * Improves clarity and correctness of the example without altering any APIs or behavior.
  * No other content changes; examples remain functionally consistent with prior guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->