### PR TITLE
fix(react-router): ensure consistent disabled prop handling across Link variants

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -536,12 +536,6 @@ export const Link: LinkComponent<'a'> = React.forwardRef<Element, any>(
           })
         : rest.children
 
-    if (_asChild === undefined) {
-      // the ReturnType of useLinkProps returns the correct type for a <a> element, not a general component that has a disabled prop
-      // @ts-expect-error
-      delete linkProps.disabled
-    }
-
     return React.createElement(
       _asChild ? _asChild : 'a',
       {


### PR DESCRIPTION
Hi TanStack Router Team,

**Problem**
- Like Ant Design provide CSS styles that target disabled anchor elements using selectors like a[disabled]. 
- However, TanStack Router's current Link component implementation removes the disabled prop when rendering default <a> elements, breaking compatibility with these UI library styles
<img width="1605" height="710" alt="image" src="https://github.com/user-attachments/assets/73cdcb97-322e-4883-b4d8-487d55ba8bf1" />


**Current behavior**:
- `Link` component: disabled prop gets deleted
- `createLink` with custom components: disabled prop is preserved
=> This inconsistency means developers must use createLink to get proper disabled styling from UI libraries, creating an inconsistent developer experience.

**Reproduce codebase**

```tsx
// Bug reproduction scenario  
function BugReproduction() {  
  // Case 1: Default Link (disabled prop gets deleted)  
  const DefaultLink = () => (  
    <Link to="/test" disabled={true}>  
      Default Link - disabled prop will be removed  
    </Link>  
  )  
    
  // Case 2: Custom Link (disabled prop is preserved)  
  const CustomButton = createLink('a')  
  const CustomLink = () => (  
    <CustomButton to="/test" disabled={true}>  
      Custom Link - disabled prop will be kept  
    </CustomButton>  
  )  
    
  // Expected: Both should handle disabled consistently  
  // Actual: Only CustomLink preserves the disabled prop  
}
```
