### PR TITLE
refactor(router-core): slightly faster replaceEqualDeep

### DIFF
--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -231,7 +231,7 @@ export function replaceEqualDeep<T>(prev: any, _next: T): T {
       const key = array ? i : (nextItems[i] as any)
       const p = prev[key]
       if (
-        (array || Object.prototype.hasOwnProperty.call(prev, key)) &&
+        (array || prevItems.includes(key)) &&
         p === undefined &&
         next[key] === undefined
       ) {

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -231,7 +231,7 @@ export function replaceEqualDeep<T>(prev: any, _next: T): T {
       const key = array ? i : (nextItems[i] as any)
       const p = prev[key]
       if (
-        (array || Object.prototype.hasOwnProperty.call(prev, key)) &&
+        (array || prev.hasOwnProperty(key)) &&
         p === undefined &&
         next[key] === undefined
       ) {

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -217,52 +217,59 @@ export function replaceEqualDeep<T>(prev: any, _next: T): T {
   const next = _next as any
 
   const array = isPlainArray(prev) && isPlainArray(next)
+  const object = !array && isPlainObject(prev) && isPlainObject(next)
 
-  if (array || (isSimplePlainObject(prev) && isSimplePlainObject(next))) {
-    const prevItems = array ? prev : Reflect.ownKeys(prev)
-    const prevSize = prevItems.length
-    const nextItems = array ? next : Reflect.ownKeys(next)
-    const nextSize = nextItems.length
-    const copy: any = array ? new Array(nextSize) : {}
+  if (!array && !object) return next
 
-    let equalItems = 0
+  const prevItems = array ? prev : getEnumerableOwnKeys(prev)
+  if (!prevItems) return next
+  const nextItems = array ? next : getEnumerableOwnKeys(next)
+  if (!nextItems) return next
+  const prevSize = prevItems.length
+  const nextSize = nextItems.length
+  const copy: any = array ? new Array(nextSize) : {}
 
-    for (let i = 0; i < nextSize; i++) {
-      const key = array ? i : (nextItems[i] as any)
-      const p = prev[key]
-      if (
-        (array || prev.hasOwnProperty(key)) &&
-        p === undefined &&
-        next[key] === undefined
-      ) {
-        copy[key] = undefined
+  let equalItems = 0
+
+  for (let i = 0; i < nextSize; i++) {
+    const key = array ? i : (nextItems[i] as any)
+    const p = prev[key]
+    if (
+      (array || prev.hasOwnProperty(key)) &&
+      p === undefined &&
+      next[key] === undefined
+    ) {
+      copy[key] = undefined
+      equalItems++
+    } else {
+      const value = replaceEqualDeep(p, next[key])
+      copy[key] = value
+      if (value === p && p !== undefined) {
         equalItems++
-      } else {
-        const value = replaceEqualDeep(p, next[key])
-        copy[key] = value
-        if (value === p && p !== undefined) {
-          equalItems++
-        }
       }
     }
-
-    return prevSize === nextSize && equalItems === prevSize ? prev : copy
   }
 
-  return next
+  return prevSize === nextSize && equalItems === prevSize ? prev : copy
 }
 
 /**
- * A wrapper around `isPlainObject` with additional checks to ensure that it is not
- * only a plain object, but also one that is "clone-friendly" (doesn't have any
- * non-enumerable properties).
+ * Equivalent to `Reflect.ownKeys`, but ensures that objects are "clone-friendly":
+ * will return false if object has any non-enumerable properties.
  */
-function isSimplePlainObject(o: any) {
-  return (
-    // all the checks from isPlainObject are more likely to hit so we perform them first
-    isPlainObject(o) &&
-    Object.getOwnPropertyNames(o).length === Object.keys(o).length
-  )
+function getEnumerableOwnKeys(o: object) {
+  const keys = []
+  const names = Object.getOwnPropertyNames(o)
+  for (const name of names) {
+    if (!Object.prototype.propertyIsEnumerable.call(o, name)) return false
+    keys.push(name)
+  }
+  const symbols = Object.getOwnPropertySymbols(o)
+  for (const symbol of symbols) {
+    if (!Object.prototype.propertyIsEnumerable.call(o, symbol)) return false
+    keys.push(symbol)
+  }
+  return keys
 }
 
 // Copied from: https://github.com/jonschlinkert/is-plain-object

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -223,7 +223,7 @@ export function replaceEqualDeep<T>(prev: any, _next: T): T {
     const prevSize = prevItems.length
     const nextItems = array ? next : Reflect.ownKeys(next)
     const nextSize = nextItems.length
-    const copy: any = array ? [] : {}
+    const copy: any = array ? new Array(nextSize) : {}
 
     let equalItems = 0
 
@@ -231,7 +231,7 @@ export function replaceEqualDeep<T>(prev: any, _next: T): T {
       const key = array ? i : (nextItems[i] as any)
       const p = prev[key]
       if (
-        (array || prevItems.includes(key)) &&
+        (array || Object.prototype.hasOwnProperty.call(prev, key)) &&
         p === undefined &&
         next[key] === undefined
       ) {

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -221,15 +221,11 @@ export function replaceEqualDeep<T>(prev: any, _next: T): T {
   if (array || (isSimplePlainObject(prev) && isSimplePlainObject(next))) {
     const prevItems = array
       ? prev
-      : (Object.keys(prev) as Array<unknown>).concat(
-          Object.getOwnPropertySymbols(prev),
-        )
+      : Reflect.ownKeys(prev)
     const prevSize = prevItems.length
     const nextItems = array
       ? next
-      : (Object.keys(next) as Array<unknown>).concat(
-          Object.getOwnPropertySymbols(next),
-        )
+      : Reflect.ownKeys(next)
     const nextSize = nextItems.length
     const copy: any = array ? [] : {}
 
@@ -238,7 +234,7 @@ export function replaceEqualDeep<T>(prev: any, _next: T): T {
     for (let i = 0; i < nextSize; i++) {
       const key = array ? i : (nextItems[i] as any)
       if (
-        ((!array && prevItems.includes(key)) || array) &&
+        (array || prevItems.includes(key)) &&
         prev[key] === undefined &&
         next[key] === undefined
       ) {

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -231,7 +231,7 @@ export function replaceEqualDeep<T>(prev: any, _next: T): T {
       const key = array ? i : (nextItems[i] as any)
       const p = prev[key]
       if (
-        (array || prevItems.includes(key)) &&
+        (array || Object.prototype.hasOwnProperty.call(prev, key)) &&
         p === undefined &&
         next[key] === undefined
       ) {

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -219,13 +219,9 @@ export function replaceEqualDeep<T>(prev: any, _next: T): T {
   const array = isPlainArray(prev) && isPlainArray(next)
 
   if (array || (isSimplePlainObject(prev) && isSimplePlainObject(next))) {
-    const prevItems = array
-      ? prev
-      : Reflect.ownKeys(prev)
+    const prevItems = array ? prev : Reflect.ownKeys(prev)
     const prevSize = prevItems.length
-    const nextItems = array
-      ? next
-      : Reflect.ownKeys(next)
+    const nextItems = array ? next : Reflect.ownKeys(next)
     const nextSize = nextItems.length
     const copy: any = array ? [] : {}
 

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -229,16 +229,18 @@ export function replaceEqualDeep<T>(prev: any, _next: T): T {
 
     for (let i = 0; i < nextSize; i++) {
       const key = array ? i : (nextItems[i] as any)
+      const p = prev[key]
       if (
         (array || prevItems.includes(key)) &&
-        prev[key] === undefined &&
+        p === undefined &&
         next[key] === undefined
       ) {
         copy[key] = undefined
         equalItems++
       } else {
-        copy[key] = replaceEqualDeep(prev[key], next[key])
-        if (copy[key] === prev[key] && prev[key] !== undefined) {
+        const value = replaceEqualDeep(p, next[key])
+        copy[key] = value
+        if (value === p && p !== undefined) {
           equalItems++
         }
       }


### PR DESCRIPTION
## Description

Improve performance of this function that gets called a lot for structural sharing. Main improvements are
- avoid creating object when possible (`Object.keys().concat(Object.getOwnPropertySymbols())` creates 3 arrays, when we only want 1)
- instantiating array to the correct size avoids a lot of memory management under the hood (prefer `new Array(size)` over `[]`)
- avoid reading the same value many times on an object, store is as a const

More minor changes (not 100% sure I can measure it, but I think so):
- using `keys.includes(k)` is slower than `Object.hasOwnProperty.call(obj, k)` or `obj.hasOwnProperty(k)`

## benchmark

TL;DR: consistently 1.3x faster implementation

```ts
describe('replaceEqualDeep', () => {
  bench('old implementation', () => {
    replaceEqualDeepOld({ a: 1, b: [2, 3] }, { a: 1, b: [2, 3] })
    replaceEqualDeepOld({ a: 1, b: [2, 3] }, { a: 2, b: [2] })
  })

  bench('new implementation', () => {
    replaceEqualDeep({ a: 1, b: [2, 3] }, { a: 1, b: [2, 3] })
    replaceEqualDeep({ a: 1, b: [2, 3] }, { a: 2, b: [2] })
  })
})
```
```sh
 ✓  @tanstack/router-core  tests/utils.bench.ts > replaceEqualDeep 1540ms
     name                          hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · old implementation  1,040,201.62  0.0008  0.7638  0.0010  0.0010  0.0013  0.0016  0.0022  ±0.33%   520101
   · new implementation  1,347,988.70  0.0006  2.4037  0.0007  0.0007  0.0010  0.0010  0.0013  ±0.95%   673995   fastest

 BENCH  Summary

   @tanstack/router-core  new implementation - tests/utils.bench.ts > replaceEqualDeep
    1.30x faster than old implementation
```

---

The `replaceEqualDeep` implementation before this PR handles Symbol keys, and non-enumerable keys (see https://github.com/TanStack/router/pull/4237), but **not** keys that are both a Symbol and non-enumerable.

This PR fixes this issue. But if we also fix it in the previous implementation before comparing performance we get a bigger perf diff
```sh
 ✓  @tanstack/router-core  tests/utils.bench.ts > replaceEqualDeep 1471ms
     name                          hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · old implementation    713,964.88  0.0012  0.7880  0.0014  0.0014  0.0019  0.0023  0.0050  ±0.35%   356983
   · new implementation  1,319,003.07  0.0006  5.0000  0.0008  0.0007  0.0010  0.0016  0.0050  ±1.96%   659502   fastest

 BENCH  Summary

   @tanstack/router-core  new implementation - tests/utils.bench.ts > replaceEqualDeep
    1.85x faster than old implementation
```


---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Change detection now includes symbol-keyed properties, treats undefined/missing entries consistently, and avoids processing objects with non-enumerable own properties to prevent incorrect updates.
  * No public API changes.

* **Performance**
  * Equality/merge logic reuses unchanged values more reliably and improves array update handling by allocating appropriately, reducing unnecessary work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->