### PR TITLE
Add support for setting <html lang> attribute in TanStack Router (React)

### DIFF
--- a/packages/react-router/src/ssr/renderRouterToString.tsx
+++ b/packages/react-router/src/ssr/renderRouterToString.tsx
@@ -13,6 +13,25 @@ export const renderRouterToString = async ({
 }) => {
   try {
     let html = ReactDOMServer.renderToString(children)
+
+    // Collect HTML attributes from all route matches
+    const htmlAttributes: Record<string, string> = {}
+    for (const match of router.state.matches) {
+      if (match.html) {
+        Object.assign(htmlAttributes, match.html)
+      }
+    }
+
+    // Convert HTML attributes to string
+    const htmlAttrsString = Object.entries(htmlAttributes)
+      .map(([key, value]) => `${key}="${value}"`)
+      .join(' ')
+
+    // Apply HTML attributes to the html element
+    if (htmlAttrsString) {
+      html = html.replace(/<html([^>]*)>/, `<html$1 ${htmlAttrsString}>`)
+    }
+
     const injectedHtml = await Promise.all(router.serverSsr!.injectedHtml).then(
       (htmls) => htmls.join(''),
     )

--- a/packages/router-core/src/Matches.ts
+++ b/packages/router-core/src/Matches.ts
@@ -110,6 +110,7 @@ export interface DefaultRouteMatchExtensions {
   headScripts?: unknown
   meta?: unknown
   styles?: unknown
+  html?: unknown
 }
 
 export interface RouteMatchExtensions extends DefaultRouteMatchExtensions {}

--- a/packages/router-core/src/load-matches.ts
+++ b/packages/router-core/src/load-matches.ts
@@ -505,7 +505,7 @@ const executeHead = (
 ): void | Promise<
   Pick<
     AnyRouteMatch,
-    'meta' | 'links' | 'headScripts' | 'headers' | 'scripts' | 'styles'
+    'meta' | 'links' | 'headScripts' | 'headers' | 'scripts' | 'styles' | 'html'
   >
 > => {
   const match = inner.router.getMatch(matchId)
@@ -513,7 +513,7 @@ const executeHead = (
   if (!match) {
     return
   }
-  if (!route.options.head && !route.options.scripts && !route.options.headers) {
+  if (!route.options.head && !route.options.scripts && !route.options.headers && !route.options.html) {
     return
   }
   const assetContext = {
@@ -527,11 +527,13 @@ const executeHead = (
     route.options.head?.(assetContext),
     route.options.scripts?.(assetContext),
     route.options.headers?.(assetContext),
-  ]).then(([headFnContent, scripts, headers]) => {
+    route.options.html?.(assetContext),
+  ]).then(([headFnContent, scripts, headers, html]) => {
     const meta = headFnContent?.meta
     const links = headFnContent?.links
     const headScripts = headFnContent?.scripts
     const styles = headFnContent?.styles
+    const html = headFnContent?.html
 
     return {
       meta,
@@ -540,6 +542,7 @@ const executeHead = (
       headers,
       scripts,
       styles,
+      html,
     }
   })
 }

--- a/packages/router-core/src/route.ts
+++ b/packages/router-core/src/route.ts
@@ -792,7 +792,7 @@ export type BeforeLoadFn<
 export type FileBaseRouteOptions<
   TParentRoute extends AnyRoute = AnyRoute,
   TId extends string = string,
-  TPath extends string = string,
+  TPath extends string = '',
   TSearchValidator = undefined,
   TParams = {},
   TLoaderDeps extends Record<string, any> = {},
@@ -1161,6 +1161,24 @@ export interface UpdatableRouteOptions<
     scripts?: AnyRouteMatch['headScripts']
     meta?: AnyRouteMatch['meta']
     styles?: AnyRouteMatch['styles']
+  }>
+  html?: (
+    ctx: AssetFnContextOptions<
+      TRouteId,
+      TFullPath,
+      TParentRoute,
+      TParams,
+      TSearchValidator,
+      TLoaderFn,
+      TRouterContext,
+      TRouteContextFn,
+      TBeforeLoadFn,
+      TLoaderDeps
+    >,
+  ) => Awaitable<{
+    lang?: string
+    dir?: string
+    [key: string]: string | undefined
   }>
   scripts?: (
     ctx: AssetFnContextOptions<


### PR DESCRIPTION
Currently, TanStack Router provides a way to set head attributes such as <title> and <meta> tags. While building my website, I encountered a use case where I needed to set the lang attribute on the root <html> element.

This attribute is not currently supported by the router, so I’ve attempted to add support for it in the React adapter.

Key notes:

Introduces initial support for setting lang on <html>

The current code may or may not fully work as intended

Looking for feedback and guidance from maintainers/contributors to finish the job and align the approach with the project’s standards

I’m happy to refine the implementation based on any suggestions or alternative design ideas.