### PR TITLE
refactor(router-core): slightly faster deepEqual

### DIFF
--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -307,9 +307,12 @@ export function isPlainArray(value: unknown): value is Array<unknown> {
 }
 
 function getObjectKeys(obj: any, ignoreUndefined: boolean) {
-  let keys = Object.keys(obj)
-  if (ignoreUndefined) {
-    keys = keys.filter((key) => obj[key] !== undefined)
+  if (!ignoreUndefined) return Object.keys(obj)
+  const keys = []
+  for (const key in obj) {
+    if (obj[key] !== undefined) {
+      keys.push(key)
+    }
   }
   return keys
 }
@@ -336,14 +339,25 @@ export function deepEqual(
       return false
     }
 
-    return bKeys.every((key) => deepEqual(a[key], b[key], opts))
+    for (let i = 0, l = bKeys.length; i < l; i++) {
+      const key = bKeys[i]!
+      if (!deepEqual(a[key], b[key], opts)) {
+        return false
+      }
+    }
+    return true
   }
 
   if (Array.isArray(a) && Array.isArray(b)) {
     if (a.length !== b.length) {
       return false
     }
-    return !a.some((item, index) => !deepEqual(item, b[index], opts))
+    for (let i = 0, l = a.length; i < l; i++) {
+      if (!deepEqual(a[i], b[i], opts)) {
+        return false
+      }
+    }
+    return true
   }
 
   return false

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -322,8 +322,7 @@ export function deepEqual(
   if (Array.isArray(a) && Array.isArray(b)) {
     if (a.length !== b.length) return false
     for (let i = 0, l = a.length; i < l; i++) {
-      if (!deepEqual(a[i], b[i], opts))
-        return false
+      if (!deepEqual(a[i], b[i], opts)) return false
     }
     return true
   }
@@ -334,8 +333,7 @@ export function deepEqual(
     if (opts?.partial) {
       for (const k in b) {
         if (!ignoreUndefined || b[k] !== undefined) {
-          if (!deepEqual(a[k], b[k], opts))
-            return false
+          if (!deepEqual(a[k], b[k], opts)) return false
         }
       }
       return true
@@ -346,8 +344,7 @@ export function deepEqual(
       aCount = Object.keys(a).length
     } else {
       for (const k in a) {
-        if (a[k] !== undefined)
-          aCount++
+        if (a[k] !== undefined) aCount++
       }
     }
 
@@ -355,8 +352,7 @@ export function deepEqual(
     for (const k in b) {
       if (!ignoreUndefined || b[k] !== undefined) {
         bCount++
-        if (bCount > aCount || !deepEqual(a[k], b[k], opts))
-          return false
+        if (bCount > aCount || !deepEqual(a[k], b[k], opts)) return false
       }
     }
 

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -332,11 +332,13 @@ export function deepEqual(
 
   if (isPlainObject(a) && isPlainObject(b)) {
     const ignoreUndefined = opts?.ignoreUndefined ?? true
-    const aKeys = getObjectKeys(a, ignoreUndefined)
     const bKeys = getObjectKeys(b, ignoreUndefined)
-
-    if (!opts?.partial && aKeys.length !== bKeys.length) {
-      return false
+    
+    if (!opts?.partial) {
+      const aKeys = getObjectKeys(a, ignoreUndefined)
+      if (aKeys.length !== bKeys.length) {
+        return false
+      }
     }
 
     for (let i = 0, l = bKeys.length; i < l; i++) {

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -333,7 +333,7 @@ export function deepEqual(
   if (isPlainObject(a) && isPlainObject(b)) {
     const ignoreUndefined = opts?.ignoreUndefined ?? true
     const bKeys = getObjectKeys(b, ignoreUndefined)
-    
+
     if (!opts?.partial) {
       const aKeys = getObjectKeys(a, ignoreUndefined)
       if (aKeys.length !== bKeys.length) {

--- a/packages/router-core/tests/utils.test.ts
+++ b/packages/router-core/tests/utils.test.ts
@@ -436,12 +436,15 @@ describe('deepEqual', () => {
   })
 
   describe('augmented object prototype fail case (no one should do this anyway)', () => {
-    it.fails('should not compare objects with augmented prototype properties', () => {
-      // @ts-expect-error -- typescript is right to complain here, don't do this!
-      Object.prototype.x = 'x'
-      const a = { a: 1 }
-      const b = { a: 1 }
-      expect(deepEqual(a, b, { ignoreUndefined: false })).toEqual(true)
-    })
+    it.fails(
+      'should not compare objects with augmented prototype properties',
+      () => {
+        // @ts-expect-error -- typescript is right to complain here, don't do this!
+        Object.prototype.x = 'x'
+        const a = { a: 1 }
+        const b = { a: 1 }
+        expect(deepEqual(a, b, { ignoreUndefined: false })).toEqual(true)
+      },
+    )
   })
 })

--- a/packages/router-core/tests/utils.test.ts
+++ b/packages/router-core/tests/utils.test.ts
@@ -434,4 +434,14 @@ describe('deepEqual', () => {
       expect(deepEqual(b, a, { partial: true })).toEqual(false)
     })
   })
+
+  describe('augmented object prototype fail case (no one should do this anyway)', () => {
+    it.fails('should not compare objects with augmented prototype properties', () => {
+      // @ts-expect-error -- typescript is right to complain here, don't do this!
+      Object.prototype.x = 'x'
+      const a = { a: 1 }
+      const b = { a: 1 }
+      expect(deepEqual(a, b, { ignoreUndefined: false })).toEqual(true)
+    })
+  })
 })

--- a/packages/router-core/tests/utils.test.ts
+++ b/packages/router-core/tests/utils.test.ts
@@ -435,6 +435,31 @@ describe('deepEqual', () => {
     })
   })
 
+  // This might not be what we want, but this test documents how things are now
+  describe('symbol and non-enumerable properties are not handled', () => {
+    it.fails(
+      'should return `false` for unequal objects with symbol properties',
+      () => {
+        const key = Symbol('foo')
+        const a = { [key]: 1 }
+        const b = { [key]: 2 }
+        expect(deepEqual(a, b)).toEqual(false)
+      },
+    )
+
+    it.fails(
+      'should return `false` for unequal objects with non-enumerable properties',
+      () => {
+        const a = {}
+        Object.defineProperty(a, 'prop', { value: 1, enumerable: false })
+        const b = {}
+        Object.defineProperty(b, 'prop', { value: 2, enumerable: false })
+        expect(deepEqual(a, b)).toEqual(false)
+      },
+    )
+  })
+
+  // We voluntarily fail in this case, because users should not do it, and ignoring it enables some performance improvements
   describe('augmented object prototype fail case (no one should do this anyway)', () => {
     it.fails(
       'should not compare objects with augmented prototype properties',

--- a/packages/router-core/tests/utils.test.ts
+++ b/packages/router-core/tests/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { deepEqual, isPlainArray, replaceEqualDeep } from '../src/utils'
 
 describe('replaceEqualDeep', () => {
@@ -446,5 +446,12 @@ describe('deepEqual', () => {
         expect(deepEqual(a, b, { ignoreUndefined: false })).toEqual(true)
       },
     )
+
+    afterEach(() => {
+      // it's probably not necessary to clean this up because vitest isolates tests
+      // but just in case isolation ever gets disabled, we clean the prototype to avoid disturbing other tests
+      // @ts-expect-error
+      delete Object.prototype.x
+    })
   })
 })


### PR DESCRIPTION
## description
- inline `getObjectKeys` as regular control flow inside `deepEqual` to be able to skip as much work as possible, and create fewer objects
- using a regular `for` loop for the array case to skip the overhead of using native array iterators w/ the `.every()` or `.some()` methods
- check `Array.isArray` before `isPlainObject` because this check is cheaper
- `opts.partial` is a special case that allows us to skip a bunch of work, so we give it its own branch

## benchmark

TL;DR: consistently 1.7x faster implementation

```ts
describe.only('deepEqual', () => {
  bench('old implementation', () => {
    deepEqualOld({ a: 1, b: [2, 3] }, { a: 1, b: [2, 3] }, {partial: true})
    deepEqualOld({ a: 1, b: [2, 3] }, { a: 2, b: [2] })
  })

  bench('new implementation', () => {
    deepEqual({ a: 1, b: [2, 3] }, { a: 1, b: [2, 3] }, {partial: true})
    deepEqual({ a: 1, b: [2, 3] }, { a: 2, b: [2] })
  })
})
```

```sh
 ✓  @tanstack/router-core  tests/utils.bench.ts > deepEqual 2484ms
     name                          hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · old implementation  3,806,354.20  0.0002  4.3084  0.0003  0.0003  0.0005  0.0007  0.0013  ±1.78%  1903178
   · new implementation  6,978,154.05  0.0001  0.1937  0.0001  0.0002  0.0002  0.0002  0.0003  ±0.15%  3489078   fastest

 BENCH  Summary

   @tanstack/router-core  new implementation - tests/utils.bench.ts > deepEqual
    1.83x faster than old implementation
```

----

This PR also adds test cases for using `deepEqual` w/ objects containing Symbol and non-enumerable keys. The behavior for those was not changed in this PR, we're just documenting it: they are simply ignored.

----

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deep-equality checks for arrays and object comparisons; ignore-undefined handling clarified and made more consistent.

* **Refactor**
  * Iteration and comparison logic reorganized for earlier short-circuiting; behavior around enumerable (including inherited) keys adjusted; no public API changes.

* **Tests**
  * Added tests demonstrating edge cases with symbol/non-enumerable properties and prototype augmentation (marked as expected failures).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->