### PR TITLE
docs: Use named component in react quick-start

### DIFF
--- a/docs/router/framework/react/quick-start.md
+++ b/docs/router/framework/react/quick-start.md
@@ -76,23 +76,23 @@ Create the following files:
 import { createRootRoute, Link, Outlet } from '@tanstack/react-router'
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
 
-export const Route = createRootRoute({
-  component: () => (
-    <>
-      <div className="p-2 flex gap-2">
-        <Link to="/" className="[&.active]:font-bold">
-          Home
-        </Link>{' '}
-        <Link to="/about" className="[&.active]:font-bold">
-          About
-        </Link>
-      </div>
-      <hr />
-      <Outlet />
-      <TanStackRouterDevtools />
-    </>
-  ),
-})
+const RootLayout = () => (
+  <>
+    <div className="p-2 flex gap-2">
+      <Link to="/" className="[&.active]:font-bold">
+        Home
+      </Link>{' '}
+      <Link to="/about" className="[&.active]:font-bold">
+        About
+      </Link>
+    </div>
+    <hr />
+    <Outlet />
+    <TanStackRouterDevtools />
+  </>
+)
+
+export const Route = createRootRoute({ component: RootLayout });
 ```
 
 #### `src/routes/index.tsx`


### PR DESCRIPTION
When using an anonymous component, Vite's hot reloading doesn't always immediately pick up changes made to the component. This can be confusing to someone testing out the router.

By extracting a named component, Vite seems to be able to match updates to the component to the mounted instance and apply hot reloading as expected.