### PR TITLE
refactor(router-core): defaultParseSearch,defaultStringifySearch better performance w/ early json exit

### DIFF
--- a/packages/router-core/src/searchParams.ts
+++ b/packages/router-core/src/searchParams.ts
@@ -20,6 +20,7 @@ export const defaultStringifySearch = stringifySearchWith(
  * @link https://tanstack.com/router/latest/docs/framework/react/guide/custom-search-param-serialization
  */
 export function parseSearchWith(parser: (str: string) => any) {
+  const isJsonParser = parser === JSON.parse
   return (searchStr: string): AnySchema => {
     if (searchStr[0] === '?') {
       searchStr = searchStr.substring(1)
@@ -30,7 +31,10 @@ export function parseSearchWith(parser: (str: string) => any) {
     // Try to parse any query params that might be json
     for (const key in query) {
       const value = query[key]
-      if (typeof value === 'string') {
+      if (
+        typeof value === 'string' &&
+        (!isJsonParser || looksLikeJson(value))
+      ) {
         try {
           query[key] = parser(value)
         } catch (_err) {
@@ -60,6 +64,7 @@ export function stringifySearchWith(
   parser?: (str: string) => any,
 ) {
   const hasParser = typeof parser === 'function'
+  const isJsonParser = parser === JSON.parse
   function stringifyValue(val: any) {
     if (typeof val === 'object' && val !== null) {
       try {
@@ -67,7 +72,11 @@ export function stringifySearchWith(
       } catch (_err) {
         // silent
       }
-    } else if (hasParser && typeof val === 'string') {
+    } else if (
+      hasParser &&
+      typeof val === 'string' &&
+      (!isJsonParser || looksLikeJson(val))
+    ) {
       try {
         // Check if it's a valid parseable string.
         // If it is, then stringify it again.
@@ -88,3 +97,23 @@ export function stringifySearchWith(
 
 export type SearchSerializer = (searchObj: Record<string, any>) => string
 export type SearchParser = (searchStr: string) => Record<string, any>
+
+/**
+ * Fast check to see if the string is a likely to be a JSON value.
+ * It could return false positives (returned true but wasn't actually a json),
+ * but not false negatives (returned false but was actually a json).
+ */
+function looksLikeJson(str: string): boolean {
+  if (!str) return false
+  const c = str.charCodeAt(0)
+  return (
+    c === 34 || // "
+    c === 123 || // {
+    c === 91 || // [
+    c === 45 || // -
+    (c >= 48 && c <= 57) || // 0-9
+    c === 116 || // t (true)
+    c === 102 || // f (false)
+    c === 110 // n (null)
+  )
+}


### PR DESCRIPTION


Improve performance of `defaultParseSearch` and `defaultStringifySearch` by skipping calling `JSON.parse` if we know from the 1 char that it cannot be a valid JSON string.

```sh
 ✓  @tanstack/router-core  tests/searchParams.bench.ts > defaultStringifySearch 1209ms
     name         hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · new   10,257.92  0.0593  0.7257  0.0975  0.0795  0.3030  0.3619  0.5785  ±1.95%     5130   fastest
   · old    7,636.79  0.0823  0.6418  0.1309  0.1065  0.3945  0.4503  0.5691  ±2.13%     3819

 ✓  @tanstack/router-core  tests/searchParams.bench.ts > defaultParseSearch 1208ms
     name        hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · new   9,709.41  0.0896  0.3881  0.1030  0.1000  0.2121  0.2446  0.2928  ±0.60%     4855   fastest
   · old   7,832.70  0.1157  0.3793  0.1277  0.1280  0.2366  0.2919  0.3616  ±0.50%     3917

 BENCH  Summary

   @tanstack/router-core  new - tests/searchParams.bench.ts > defaultStringifySearch
    1.34x faster than old

   @tanstack/router-core  new - tests/searchParams.bench.ts > defaultParseSearch
    1.24x faster than old
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of search parameter parsing and stringifying.
  - Only treats values as JSON when they appear JSON-like, preventing unintended parsing.
  - Preserves plain strings and reduces unexpected value transformations.
  - Lowers risk of errors or crashes when handling non-JSON values in URLs.
- Refactor
  - Internal logic streamlined to safely apply parsers without altering public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->