### PR TITLE
Adding note regarding yarn workspace usage

### DIFF
--- a/docs/router/framework/react/installation.md
+++ b/docs/router/framework/react/installation.md
@@ -51,3 +51,12 @@ vibe-rules install cursor
 ```
 
 But you can also use `windsurf`, `claude-code`, etc. Check the [vibe-rules](https://www.npmjs.com/package/vibe-rules) documentation for more information.
+
+### Usage with yarn workspaces
+
+When using yarn workspaces, you will need to add the following config to the `.yarnrc.yml` of the application using TanStack Router
+
+```yml
+pnpFallbackMode: all
+pnpMode: loose
+```


### PR DESCRIPTION
This adds a note which will resolve the issue referenced [here ](https://github.com/TanStack/router/issues/3778) when using TanStack Router from within a yarn workspace



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Usage with Yarn workspaces” section to the React Router installation guide.
  * Provides guidance for Yarn Plug’n’Play (PnP) configuration in .yarnrc.yml, including:
    * pnpFallbackMode: all
    * pnpMode: loose
  * Clarifies setup for monorepos using Yarn workspaces to improve install reliability and reduce missing module errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->