### PR TITLE
fix(router-core): replaceEqualDeep works w/ null prototype objects

### DIFF
--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -203,6 +203,8 @@ export function functionalUpdate<TPrevious, TResult = TPrevious>(
   return updater
 }
 
+const hasOwn = Object.prototype.hasOwnProperty
+
 /**
  * This function returns `prev` if `_next` is deeply equal.
  * If not, it will replace any deeply equal children of `b` with those of `a`.
@@ -237,7 +239,7 @@ export function replaceEqualDeep<T>(prev: any, _next: T): T {
 
     if (p === n) {
       copy[key] = p
-      if (array ? i < prevSize : prev.hasOwnProperty(key)) equalItems++
+      if (array ? i < prevSize : hasOwn.call(prev, key)) equalItems++
       continue
     }
 
@@ -463,7 +465,7 @@ export function shallow<T>(objA: T, objB: T) {
 
   for (const item of keysA) {
     if (
-      !Object.prototype.hasOwnProperty.call(objB, item) ||
+      !hasOwn.call(objB, item) ||
       !Object.is(objA[item as keyof T], objB[item as keyof T])
     ) {
       return false

--- a/packages/router-core/tests/utils.test.ts
+++ b/packages/router-core/tests/utils.test.ts
@@ -326,6 +326,18 @@ describe('replaceEqualDeep', () => {
 
     expect(next).toBe(current)
   })
+
+  it('works w/ null prototype objects', () => {
+    const current = Object.create(null)
+    const next = Object.create(null)
+
+    current.foo = 'bar'
+    next.foo = 'bar'
+    expect(replaceEqualDeep(current, next)).toBe(current)
+
+    next.foo = 'baz'
+    expect(replaceEqualDeep(current, next)).toEqual(next)
+  })
 })
 
 describe('isPlainArray', () => {


### PR DESCRIPTION
Fix https://github.com/TanStack/router/issues/5078

I had not pushed this before because ESLint was angry w/ me, and now stuff breaks :'( 