### PR TITLE
fix(router-core): reduce maskedLocation builds

### DIFF
--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1620,8 +1620,7 @@ export class RouterCore<
       }
 
       if (maskedNext) {
-        const maskedFinal = build(maskedDest)
-        next.maskedLocation = maskedFinal
+        next.maskedLocation = maskedNext
       }
 
       return next


### PR DESCRIPTION
As highlighted by #5062 when using a mask, the location is being built multiple times.

While we need to build the next path as well as the mask, the mask is being built twice. this PR fixes that by using the first build of the mask as the maskedLocation for the next path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized routing logic to avoid redundant work when applying masked destinations, reducing unnecessary computation during navigation. No changes to behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->