### PR TITLE
docs: Rename Link Preloading Timeout to Link Preloading Delay

### DIFF
--- a/docs/router/framework/react/guide/navigation.md
+++ b/docs/router/framework/react/guide/navigation.md
@@ -667,13 +667,13 @@ With preloading enabled and relatively quick asynchronous route dependencies (if
 
 What's even better is that by using a cache-first library like `@tanstack/query`, preloaded routes will stick around and be ready for a stale-while-revalidate experience if the user decides to navigate to the route later on.
 
-### Link Preloading Timeout
+### Link Preloading Delay
 
-Along with preloading is a configurable timeout which determines how long a user must hover over a link to trigger the intent-based preloading. The default timeout is 50 milliseconds, but you can change this by passing a `preloadTimeout` prop to the `Link` component with the number of milliseconds you'd like to wait:
+Along with preloading is a configurable delay which determines how long a user must hover over a link to trigger the intent-based preloading. The default delay is 50 milliseconds, but you can change this by passing a `preloadDelay` prop to the `Link` component with the number of milliseconds you'd like to wait:
 
 ```tsx
 const link = (
-  <Link to="/blog/post/$postId" preload="intent" preloadTimeout={100}>
+  <Link to="/blog/post/$postId" preload="intent" preloadDelay={100}>
     Blog Post
   </Link>
 )


### PR DESCRIPTION
The current `Link` component doesn't have `preloadTimeout` prop as stated in the docs. This PR updates documentation to use the correct `preloadDelay` prop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminology from “Link Preloading Timeout” to “Link Preloading Delay” to improve clarity.
  * Revised examples to use the preloadDelay option instead of preloadTimeout.
  * Clarified that the default delay remains 50 ms.
  * Ensured consistency across headings, descriptions, and code snippets to match the current public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->