### PR TITLE
Added Prisma as a partner in relevant places

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Enjoy this library? Try the entire [TanStack](https://tanstack.com)! [TanStack Q
   <img alt="Neon" src="https://raw.githubusercontent.com/tannerlinsley/files/master/partners/neon.svg" height="40"
 </a></div><br />
 <div><a href="https://www.prisma.io?utm_source=tanstack&via=tanstack">
-  <img alt="Prisma" src="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/prisma-light.svg" height="40"
+  <img alt="Prisma" src="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/prisma-light.svg" height="40">
 </a></div><br />  
 <div><a href="https://convex.dev?utm_source=tanstack">
   <img alt="Convex" src="https://raw.githubusercontent.com/tannerlinsley/files/master/partners/convex.svg" height="40"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Enjoy this library? Try the entire [TanStack](https://tanstack.com)! [TanStack Q
 <div><a href="https://neon.tech?utm_source=tanstack">
   <img alt="Neon" src="https://raw.githubusercontent.com/tannerlinsley/files/master/partners/neon.svg" height="40"
 </a></div><br />
+<div><a href="https://www.prisma.io?utm_source=tanstack&via=tanstack">
+  <img alt="Prisma" src="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/prisma-light.svg" height="40"
+</a></div><br />  
 <div><a href="https://convex.dev?utm_source=tanstack">
   <img alt="Convex" src="https://raw.githubusercontent.com/tannerlinsley/files/master/partners/convex.svg" height="40"
 </a></div><br />

--- a/docs/start/framework/react/databases.md
+++ b/docs/start/framework/react/databases.md
@@ -62,6 +62,23 @@ Key features that make Neon stand out:
 - To learn more about Neon, visit the [Neon website](https://neon.tech?utm_source=tanstack)
 - To sign up, visit the [Neon dashboard](https://console.neon.tech/signup?utm_source=tanstack)
 
+## What is Convex?
+
+<a href="https://convex.dev?utm_source=tanstack" alt="Convex Logo">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/convex-white.svg" width="280">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/convex-color.svg" width="280">
+    <img alt="Convex logo" src="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/convex-color.svg" width="280">
+  </picture>
+</a>
+
+Convex is a powerful, serverless database platform that simplifies the process of managing your application's data. With Convex, you can build full-stack applications without the need to manually manage database servers or write complex queries. Convex provides a real-time, scalable, and transactional data backend that seamlessly integrates with TanStack Start, making it an excellent choice for modern web applications.
+
+Convex's declarative data model and automatic conflict resolution ensure that your application remains consistent and responsive, even at scale. It's designed to be developer-friendly, with a focus on simplicity and productivity.
+
+- To learn more about Convex, visit the [Convex website](https://convex.dev?utm_source=tanstack)
+- To sign up, visit the [Convex dashboard](https://dashboard.convex.dev/signup?utm_source=tanstack)
+
 ## What is Prisma Postgres?
 
 <a href="https://www.prisma.io?utm_source=tanstack&via=tanstack" alt="Prisma Logo">
@@ -83,23 +100,6 @@ Instant Postgres, Zero Setup: Get a production-ready Postgres database in second
   <br />
 - To learn more about Prisma Postgres, visit the [Prisma website](https://www.prisma.io?utm_source=tanstack&via=tanstack)
 - To sign up, visit the [Prisma Console](https://console.prisma.io/sign-up?utm_source=tanstack&via=tanstack)
-
-## What is Convex?
-
-<a href="https://convex.dev?utm_source=tanstack" alt="Convex Logo">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/convex-white.svg" width="280">
-    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/convex-color.svg" width="280">
-    <img alt="Convex logo" src="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/convex-color.svg" width="280">
-  </picture>
-</a>
-
-Convex is a powerful, serverless database platform that simplifies the process of managing your application's data. With Convex, you can build full-stack applications without the need to manually manage database servers or write complex queries. Convex provides a real-time, scalable, and transactional data backend that seamlessly integrates with TanStack Start, making it an excellent choice for modern web applications.
-
-Convex's declarative data model and automatic conflict resolution ensure that your application remains consistent and responsive, even at scale. It's designed to be developer-friendly, with a focus on simplicity and productivity.
-
-- To learn more about Convex, visit the [Convex website](https://convex.dev?utm_source=tanstack)
-- To sign up, visit the [Convex dashboard](https://dashboard.convex.dev/signup?utm_source=tanstack)
 
 ## Documentation & APIs
 

--- a/docs/start/framework/react/databases.md
+++ b/docs/start/framework/react/databases.md
@@ -68,7 +68,7 @@ Key features that make Neon stand out:
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/prisma-dark.svg" width="280">
     <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/prisma-light.svg" width="280">
-    <img alt="Neon logo" src="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/prisma-light.svg" width="280">
+    <img alt="Prisma logo" src="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/prisma-light.svg" width="280">
   </picture>
 </a>
 

--- a/docs/start/framework/react/databases.md
+++ b/docs/start/framework/react/databases.md
@@ -62,6 +62,28 @@ Key features that make Neon stand out:
 - To learn more about Neon, visit the [Neon website](https://neon.tech?utm_source=tanstack)
 - To sign up, visit the [Neon dashboard](https://console.neon.tech/signup?utm_source=tanstack)
 
+## What is Prisma Postgres?
+
+<a href="https://www.prisma.io?utm_source=tanstack&via=tanstack" alt="Prisma Logo">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/prisma-dark.svg" width="280">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/prisma-light.svg" width="280">
+    <img alt="Neon logo" src="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/prisma-light.svg" width="280">
+  </picture>
+</a>
+
+Instant Postgres, Zero Setup: Get a production-ready Postgres database in seconds, then dive straight back into code. We handle connections, scaling, and turning knobs so your flow never breaks. Blends perfectly with TanStack Start.
+
+- Edge-optimized: Local region routing means lower latency and fewer hops. Even complex queries are one fast round trip.
+- Fits your stack: Works with your frameworks, libraries, and tools for a smooth DX.
+- Web UI: A hosted interface to inspect, manage, and query data with your team.
+- Auto-scaling: Grows from zero to millions of users without cold starts or manual tuning.
+- Unikernel isolation: Each DB runs as its own unikernel for security, speed, and efficiency.
+  <br />
+  <br />
+- To learn more about Prisma Postgres, visit the [Prisma website](https://www.prisma.io?utm_source=tanstack&via=tanstack)
+- To sign up, visit the [Prisma Console](https://console.prisma.io/sign-up?utm_source=tanstack&via=tanstack)
+
 ## What is Convex?
 
 <a href="https://convex.dev?utm_source=tanstack" alt="Convex Logo">

--- a/docs/start/framework/react/overview.md
+++ b/docs/start/framework/react/overview.md
@@ -94,6 +94,15 @@ TanStack works closely with our partners to provide the best possible developer 
   </picture>
   </a>
   A serverless, autoscaling Postgres solution purpose-built for modern full-stack apps. Neon offers rich integration opportunities with TanStack Start, including server functions and database-backed routing. Together, we’re simplifying the database experience for developers using TanStack.
+- **Prisma**
+  <a href="https://prisma.io?utm_source=tanstack&via=tanstack" alt="Prisma Logo">
+  <picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/prisma-dark.svg" style="height: 60px;">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/prisma-light.svg" style="height: 60px;">
+  <img alt="Prisma logo" src="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/prisma-light.svg" style="height: 60px;">
+  </picture>
+  </a>
+  Skip the database setup, get to building. Prisma Postgres provisions production-ready Postgres databases in seconds—no resource config, no infrastructure planning, no late-night "why is my connection pool maxed out?" debugging sessions. Just connect your TanStack app and start building features that matter. 
 - **Convex**
   <a href="https://convex.dev?utm_source=tanstack" alt="Convex Logo">
   <picture>

--- a/docs/start/framework/react/overview.md
+++ b/docs/start/framework/react/overview.md
@@ -67,15 +67,6 @@ TanStack Start is not for you if:
 
 TanStack works closely with our partners to provide the best possible developer experience while also providing solutions that work anywhere and are vetted by industry experts. Each of our partners plays a unique role in the TanStack ecosystem:
 
-- **Clerk**
-  <a href="https://go.clerk.com/wOwHtuJ" alt="Clerk Logo">
-  <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/clerk-logo-dark.svg" style="height: 40px;">
-  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/clerk-logo-light.svg" style="height: 40px;">
-  <img alt="Clerk logo" src="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/clerk-logo-light.svg" style="height: 40px;">
-  </picture>
-  </a>
-  The best possible authentication experience for modern web applications, including TanStack Start applications. Clerk provides TanStack Start users with first-class integrations and solutions to auth and collaborates closely with the TanStack team to ensure that TanStack Start provides APIs that are up to date with the latest in auth best practices.
 - **Netlify**
   <a href="https://www.netlify.com?utm_source=tanstack" alt="Netlify Logo">
   <picture>
@@ -94,15 +85,15 @@ TanStack works closely with our partners to provide the best possible developer 
   </picture>
   </a>
   A serverless, autoscaling Postgres solution purpose-built for modern full-stack apps. Neon offers rich integration opportunities with TanStack Start, including server functions and database-backed routing. Together, we’re simplifying the database experience for developers using TanStack.
-- **Prisma**
-  <a href="https://prisma.io?utm_source=tanstack&via=tanstack" alt="Prisma Logo">
+- **Clerk**
+  <a href="https://go.clerk.com/wOwHtuJ" alt="Clerk Logo">
   <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/prisma-dark.svg" style="height: 60px;">
-  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/prisma-light.svg" style="height: 60px;">
-  <img alt="Prisma logo" src="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/prisma-light.svg" style="height: 60px;">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/clerk-logo-dark.svg" style="height: 40px;">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/clerk-logo-light.svg" style="height: 40px;">
+  <img alt="Clerk logo" src="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/clerk-logo-light.svg" style="height: 40px;">
   </picture>
   </a>
-  Skip the database setup, get to building. Prisma Postgres provisions production-ready Postgres databases in seconds—no resource config, no infrastructure planning, no late-night "why is my connection pool maxed out?" debugging sessions. Just connect your TanStack app and start building features that matter. 
+  The best possible authentication experience for modern web applications, including TanStack Start applications. Clerk provides TanStack Start users with first-class integrations and solutions to auth and collaborates closely with the TanStack team to ensure that TanStack Start provides APIs that are up to date with the latest in auth best practices.
 - **Convex**
   <a href="https://convex.dev?utm_source=tanstack" alt="Convex Logo">
   <picture>
@@ -121,6 +112,15 @@ TanStack works closely with our partners to provide the best possible developer 
   </picture>
   </a>
   A powerful, full-featured observability platform that integrates seamlessly with TanStack Start. Sentry helps developers monitor and fix crashes in real-time and provides insights into your application's performance and error tracking. Sentry collaborates closely with the TanStack team to ensure that TanStack Start provides APIs that are up to date with the latest in observability best practices.
+- **Prisma**
+  <a href="https://prisma.io?utm_source=tanstack&via=tanstack" alt="Prisma Logo">
+  <picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/prisma-dark.svg" style="height: 60px;">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/prisma-light.svg" style="height: 60px;">
+  <img alt="Prisma logo" src="https://raw.githubusercontent.com/tanstack/tanstack.com/main/src/images/prisma-light.svg" style="height: 60px;">
+  </picture>
+  </a>
+  Skip the database setup, get to building. Prisma Postgres provisions production-ready Postgres databases in seconds—no resource config, no infrastructure planning, no late-night "why is my connection pool maxed out?" debugging sessions. Just connect your TanStack app and start building features that matter. 
 
 ## Ready to get started?
 


### PR DESCRIPTION
Inserted relevant logo files and/or blurbs re: Prisma Postgres in the relevant places. Please review and edit as you see fit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added a Prisma partner tile to the Partners section, linking to prisma.io with tracking parameters and logo.
  - Introduced a Prisma Postgres subsection in the React databases guide with dark/light logos, feature highlights (edge-optimized, fits your stack, web UI, auto-scaling, unikernel isolation), and CTAs; placed after Neon.
  - Added Prisma to the TanStack Start funded partners overview with logo and description, positioned between Neon and Convex.
  - No functional or API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->