### PR TITLE
docs(Start): change cloudflare pages to workers on deployment target list

### DIFF
--- a/docs/start/framework/react/hosting.md
+++ b/docs/start/framework/react/hosting.md
@@ -35,7 +35,7 @@ When a TanStack Start application is being deployed, the `target` value in the T
 
 - [`netlify`](#netlify): Deploy to Netlify
 - [`vercel`](#vercel): Deploy to Vercel
-- [`cloudflare-pages`](#cloudflare-pages): Deploy to Cloudflare Pages
+- [`cloudflare-workers`](#cloudflare-workers): Deploy to Cloudflare Workers
 - [`railway`](#railway): Deploy to Railway
 - [`node-server`](#nodejs): Deploy to a Node.js server
 - [`bun`](#bun): Deploy to a Bun server


### PR DESCRIPTION
Deployment target list was still referencing cloudflare pages instead of workers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated React hosting guide to list Cloudflare Workers as the deployment target instead of Cloudflare Pages.
  * Adjusted in-page anchors and references to match the new deployment option.
  * Confirmed all other deployment targets remain unchanged.
  * Ensures readers are directed to the correct Cloudflare Workers guidance for deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->