### PR TITLE
fix(router-core): allow Route.to access before router initialization

### DIFF
--- a/packages/react-router/tests/route-to-getter.test.tsx
+++ b/packages/react-router/tests/route-to-getter.test.tsx
@@ -190,4 +190,44 @@ describe('Route.to getter early access', () => {
     expect(navigation[1]?.to).toBe('/about')
     expect(navigation[2]?.to).toBe('/contact')
   })
+
+  test('Pathless parent routes should not affect child path', () => {
+    const rootRoute = createRootRoute({})
+
+    const layoutRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      id: '_layout',
+    })
+
+    const childRoute = createRoute({
+      getParentRoute: () => layoutRoute,
+      path: '/child',
+    })
+
+    expect(childRoute.to).toBe('/child')
+
+    const routeTree = rootRoute.addChildren([
+      layoutRoute.addChildren([childRoute]),
+    ])
+
+    createRouter({
+      routeTree,
+      history: createMemoryHistory(),
+    })
+
+    expect(childRoute.to).toBe('/child')
+  })
+
+  test('Root route should always return "/" for to getter', () => {
+    const rootRoute = createRootRoute({})
+
+    expect(rootRoute.to).toBe('/')
+
+    createRouter({
+      routeTree: rootRoute,
+      history: createMemoryHistory(),
+    })
+
+    expect(rootRoute.to).toBe('/')
+  })
 })

--- a/packages/react-router/tests/route-to-getter.test.tsx
+++ b/packages/react-router/tests/route-to-getter.test.tsx
@@ -1,0 +1,193 @@
+import { describe, expect, test } from 'vitest'
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+
+describe('Route.to getter early access', () => {
+  test('Route.to should be accessible before Router initialization', () => {
+    const rootRoute = createRootRoute({})
+    const aboutRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/about',
+    })
+
+    const menuItems = [{ label: 'About', to: aboutRoute.to }]
+
+    expect(menuItems[0]?.to).toBe('/about')
+    expect(aboutRoute.to).toBe('/about')
+
+    const routeTree = rootRoute.addChildren([aboutRoute])
+    createRouter({
+      routeTree,
+      history: createMemoryHistory(),
+    })
+
+    expect(aboutRoute.to).toBe('/about')
+    expect(menuItems[0]?.to).toBe('/about')
+  })
+
+  test('Nested routes should resolve full path before initialization', () => {
+    const rootRoute = createRootRoute({})
+    const dashboardRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/dashboard',
+    })
+    const settingsRoute = createRoute({
+      getParentRoute: () => dashboardRoute,
+      path: '/settings',
+    })
+    const profileRoute = createRoute({
+      getParentRoute: () => settingsRoute,
+      path: '/profile',
+    })
+
+    expect(dashboardRoute.to).toBe('/dashboard')
+    expect(settingsRoute.to).toBe('/dashboard/settings')
+    expect(profileRoute.to).toBe('/dashboard/settings/profile')
+
+    const routeTree = rootRoute.addChildren([
+      dashboardRoute.addChildren([settingsRoute.addChildren([profileRoute])]),
+    ])
+
+    createRouter({
+      routeTree,
+      history: createMemoryHistory(),
+    })
+
+    expect(dashboardRoute.to).toBe('/dashboard')
+    expect(settingsRoute.to).toBe('/dashboard/settings')
+    expect(profileRoute.to).toBe('/dashboard/settings/profile')
+  })
+
+  test('Index routes should resolve correctly', () => {
+    const rootRoute = createRootRoute({})
+    const dashboardRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/dashboard',
+    })
+    const indexRoute = createRoute({
+      getParentRoute: () => dashboardRoute,
+      path: '/',
+    })
+
+    expect(indexRoute.to).toBe('/dashboard')
+
+    const routeTree = rootRoute.addChildren([
+      dashboardRoute.addChildren([indexRoute]),
+    ])
+
+    createRouter({
+      routeTree,
+      history: createMemoryHistory(),
+    })
+
+    expect(indexRoute.to).toBe('/dashboard/')
+  })
+
+  test('Dynamic routes should preserve parameters', () => {
+    const rootRoute = createRootRoute({})
+    const userRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/users/$userId',
+    })
+    const postRoute = createRoute({
+      getParentRoute: () => userRoute,
+      path: '/posts/$postId',
+    })
+
+    expect(userRoute.to).toBe('/users/$userId')
+    expect(postRoute.to).toBe('/users/$userId/posts/$postId')
+
+    const routeTree = rootRoute.addChildren([
+      userRoute.addChildren([postRoute]),
+    ])
+
+    createRouter({
+      routeTree,
+      history: createMemoryHistory(),
+    })
+
+    expect(userRoute.to).toBe('/users/$userId')
+    expect(postRoute.to).toBe('/users/$userId/posts/$postId')
+  })
+
+  test('Optional parameters should be preserved', () => {
+    const rootRoute = createRootRoute({})
+    const productRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/products/$category?/$productId?',
+    })
+
+    expect(productRoute.to).toBe('/products/$category?/$productId?')
+
+    const routeTree = rootRoute.addChildren([productRoute])
+    createRouter({
+      routeTree,
+      history: createMemoryHistory(),
+    })
+
+    expect(productRoute.to).toBe('/products/$category?/$productId?')
+  })
+
+  test('Wildcard routes should work correctly', () => {
+    const rootRoute = createRootRoute({})
+    const filesRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/files/$',
+    })
+
+    expect(filesRoute.to).toBe('/files/$')
+
+    const routeTree = rootRoute.addChildren([filesRoute])
+    createRouter({
+      routeTree,
+      history: createMemoryHistory(),
+    })
+
+    expect(filesRoute.to).toBe('/files/$')
+  })
+
+  test('Static array pattern should capture correct values', () => {
+    const rootRoute = createRootRoute({})
+    const homeRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const aboutRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/about',
+    })
+    const contactRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/contact',
+    })
+
+    const navigation = [
+      { label: 'Home', to: homeRoute.to },
+      { label: 'About', to: aboutRoute.to },
+      { label: 'Contact', to: contactRoute.to },
+    ]
+
+    expect(navigation[0]?.to).toBe('/')
+    expect(navigation[1]?.to).toBe('/about')
+    expect(navigation[2]?.to).toBe('/contact')
+
+    const routeTree = rootRoute.addChildren([
+      homeRoute,
+      aboutRoute,
+      contactRoute,
+    ])
+
+    createRouter({
+      routeTree,
+      history: createMemoryHistory(),
+    })
+
+    expect(navigation[0]?.to).toBe('/')
+    expect(navigation[1]?.to).toBe('/about')
+    expect(navigation[2]?.to).toBe('/contact')
+  })
+})

--- a/packages/router-core/src/route.ts
+++ b/packages/router-core/src/route.ts
@@ -1387,11 +1387,12 @@ export class BaseRoute<
       return this._computedTo as TrimPathRight<TFullPath>
     }
 
-    const collectPaths = (route: any): Array<string> => {
-      if (!route || route.isRoot) return []
+    const collectPaths = (route: any, seen = new Set<any>()): Array<string> => {
+      if (!route || route.isRoot || seen.has(route)) return []
+      seen.add(route)
 
       const parent = route.options?.getParentRoute?.()
-      const parentPaths = parent ? collectPaths(parent) : []
+      const parentPaths = parent ? collectPaths(parent, seen) : []
 
       if (route.options?.path) {
         const trimmed = trimPathLeft(route.options.path)
@@ -1404,7 +1405,7 @@ export class BaseRoute<
     }
 
     const paths = collectPaths(this)
-    const fullPath = '/' + paths.join('/')
+    const fullPath = joinPaths(['/', ...paths])
 
     this._computedTo = fullPath
 
@@ -1566,6 +1567,7 @@ export class BaseRoute<
     this._id = other._id
     this._fullPath = other._fullPath
     this._to = other._to
+    this._computedTo = other._computedTo
     this.options.getParentRoute = other.options.getParentRoute
     this.children = other.children
   }
@@ -1680,6 +1682,7 @@ export class BaseRoute<
     >,
   ): this => {
     Object.assign(this.options, options)
+    this._computedTo = undefined
     return this
   }
 


### PR DESCRIPTION
Fixes #5090 

### Problem

When accessing `Route.to` at module load time (e.g., in static arrays for navigation), it returns `undefined` instead of the expected path string. This occurs despite TypeScript correctly inferring the type (e.g., `AboutRoute.to: "/about"`).

```ts
// Module level
const navigation = [
  { label: 'About', to: AboutRoute.to }, // to is undefined
  { label: 'Contact', to: ContactRoute.to }, // to is undefined
]
```

### Root Cause

Route objects are created at module load time, but their path properties (`_to`, `_path`, etc.) are only initialized when the Router is created and calls `init()` on each route through `processRouteTree()`. This timing gap causes the issue.

The route objects are instantiated when the module is loaded, but their path-related fields (such as _to and _path) are not populated until the router is constructed. During module evaluation, any static arrays or constants that reference Route.to will therefore see it as undefined. Once the router is created, it invokes init() on each route via processRouteTree(), at which point the paths are computed. By the time the component renders, Route.to holds the correct value.

### Solution

The solution was to update the to getter so it computes the full path lazily when it is accessed before initialization. If _to has already been set by the initialization phase, the getter simply returns that value. Otherwise, it walks up the parent chain to assemble the complete path, stores the result, and thereafter serves it from the cache for minimal overhead.

### Changes

- Added lazy path computation to the `to` getter in `BaseRoute` class
- Added `_computedTo` field for caching pre-initialization computed paths
- Maintains backward compatibility - no breaking changes

### Tests

Added comprehensive test suite in `packages/react-router/tests/route-to-getter.test.tsx`
- Simple routes (`/about`)
- Nested routes (`/dashboard/settings/profile`)
- Index routes (`/dashboard/`)
- Dynamic parameters (`/users/$userId/posts/$postId`)
- Optional parameters (`/products/$category?/$productId?`)
- Wildcard routes (`/files/$`)
- Static array pattern (primary use case)

All existing tests pass without modification.

### Example

```ts
// Module level
const navigation = [
  { label: 'Home', to: homeRoute.to },      // '/'
  { label: 'About', to: aboutRoute.to },    // '/about'
  { label: 'Contact', to: contactRoute.to }, // '/contact'
]
```

### Notes

the documentation did not caution against this pattern, and the TypeScript definitions appeared to indicate that it should be supported. This approach is, in fact, a common way to declare navigation in React applications. The proposed solution imposes only a negligible performance cost because results are cached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Route.to now lazily computes full route paths, yielding consistent results for nested, index, dynamic, optional, and wildcard routes with improved trailing-slash behavior.

- Bug Fixes
  - Route.to returns correct values both before and after router initialization; caches are invalidated when routes update so changes propagate.

- Tests
  - Added comprehensive tests validating Route.to resolution across many routing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->