### PR TITLE
docs: fix external data loading path

### DIFF
--- a/docs/router/integrations/query.md
+++ b/docs/router/integrations/query.md
@@ -4,7 +4,7 @@ title: TanStack Query Integration
 ---
 
 > [!IMPORTANT]
-> This integration automates SSR dehydration/hydration and streaming between TanStack Router and TanStack Query. If you haven't read the standard [External Data Loading](../framework/react/guide/external-data-loading.md) guide, start there.
+> This integration automates SSR dehydration/hydration and streaming between TanStack Router and TanStack Query. If you haven't read the standard [External Data Loading](../../framework/react/guide/external-data-loading.md) guide, start there.
 
 ## What you get
 


### PR DESCRIPTION
The link to External Data Loading on the [Query Integration](https://tanstack.com/router/latest/docs/integrations/query) page currently throws a 404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a link in the Router integrations guide to point to the proper External Data Loading page in the React framework section. This fixes navigation from that note and ensures readers can access the referenced guidance without errors. No functional changes to the product; content remains otherwise unchanged and reduces confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->