### PR TITLE
docs: resolve invalid relative paths

### DIFF
--- a/docs/router/framework/react/migrate-from-react-location.md
+++ b/docs/router/framework/react/migrate-from-react-location.md
@@ -22,7 +22,7 @@ In this guide we'll go over the process of migrating the [React Location Basic e
 
 ### Step 1: Swap over to TanStack Router's dependencies
 
-First, we need to install the dependencies for TanStack Router. For detailed installation instructions, see our [How to Install TanStack Router](./how-to/install.md) guide.
+First, we need to install the dependencies for TanStack Router. For detailed installation instructions, see our [How to Install TanStack Router](../how-to/install.md) guide.
 
 ```sh
 npm install @tanstack/react-router @tanstack/router-devtools

--- a/docs/router/framework/react/migrate-from-react-router.md
+++ b/docs/router/framework/react/migrate-from-react-router.md
@@ -7,7 +7,7 @@ toc: false
 
 Here is the [example repo](https://github.com/Benanna2019/SickFitsForEveryone/tree/migrate-to-tanstack/router/React-Router)
 
-- [ ] Install Router - `npm i @tanstack/react-router` (see [detailed installation guide](./how-to/install.md))
+- [ ] Install Router - `npm i @tanstack/react-router` (see [detailed installation guide](../how-to/install.md))
 - [ ] **Optional:** Uninstall React Router to get TypeScript errors on imports.
   - At this point I don’t know if you can do a gradual migration, but it seems likely you could have multiple router providers, not desirable.
   - The api’s between React Router and TanStack Router are very similar and could most likely be handled in a sprint cycle or two if that is your companies way of doing things.


### PR DESCRIPTION
paths in "migrate from react location" and "migrate from react-router" to the installation docs form installing Tanstack router returns 404.

This PR fixes the incorrect relative paths.