### PR TITLE
docs: Integration with Esbuild - update title to reflect "Esbuild"

### DIFF
--- a/docs/router/framework/react/routing/installation-with-esbuild.md
+++ b/docs/router/framework/react/routing/installation-with-esbuild.md
@@ -1,5 +1,5 @@
 ---
-title: Installation with Vite
+title: Installation with Esbuild
 ---
 
 [//]: # 'BundlerConfiguration'


### PR DESCRIPTION
The integration with Esbuild page's title is reflecting as Vite.

This PR updates it to reflect as "Esbuild"