### PR TITLE
fix(router): respect `target` attribute on inner component

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -218,11 +218,15 @@ export function useLinkProps<
 
   // The click handler
   const handleClick = (e: React.MouseEvent) => {
+    // Check actual element's target attribute as fallback
+    const elementTarget = (e.currentTarget as HTMLAnchorElement).target
+    const effectiveTarget = target !== undefined ? target : elementTarget
+
     if (
       !disabled &&
       !isCtrlEvent(e) &&
       !e.defaultPrevented &&
-      (!target || target === '_self') &&
+      (!effectiveTarget || effectiveTarget === '_self') &&
       e.button === 0
     ) {
       e.preventDefault()

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -4711,7 +4711,7 @@ describe('createLink', () => {
     const postsRoute = createRoute({
       getParentRoute: () => rootRoute,
       path: '/posts',
-      component: () => <h1>Posts</h1>,
+      component: () => <h1 data-testid="posts-heading">Posts</h1>,
     })
 
     const router = createRouter({
@@ -4738,9 +4738,7 @@ describe('createLink', () => {
       expect(router.state.location.pathname).toBe('/')
     })
 
-    await expect(
-      screen.findByRole('heading', { name: 'Posts' }),
-    ).rejects.toThrow()
+    await expect(screen.findByTestId('posts-heading')).rejects.toThrow()
 
     window.open = originalOpen
   })
@@ -4770,7 +4768,7 @@ describe('createLink', () => {
     const postsRoute = createRoute({
       getParentRoute: () => rootRoute,
       path: '/posts',
-      component: () => <h1>Posts</h1>,
+      component: () => <h1 data-testid="posts-heading">Posts</h1>,
     })
 
     const router = createRouter({
@@ -4792,7 +4790,8 @@ describe('createLink', () => {
       expect(router.state.location.pathname).toBe('/posts')
     })
 
-    await screen.findByRole('heading', { name: 'Posts' })
+    const postsHeading = await screen.findByTestId('posts-heading')
+    expect(postsHeading).toBeInTheDocument()
   })
 })
 

--- a/packages/solid-router/src/link.tsx
+++ b/packages/solid-router/src/link.tsx
@@ -264,11 +264,16 @@ export function useLinkProps<
 
   // The click handler
   const handleClick = (e: MouseEvent) => {
+    // Check actual element's target attribute as fallback
+    const elementTarget = (e.currentTarget as HTMLAnchorElement).target
+    const effectiveTarget =
+      local.target !== undefined ? local.target : elementTarget
+
     if (
       !local.disabled &&
       !isCtrlEvent(e) &&
       !e.defaultPrevented &&
-      (!local.target || local.target === '_self') &&
+      (!effectiveTarget || effectiveTarget === '_self') &&
       e.button === 0
     ) {
       e.preventDefault()

--- a/packages/solid-router/tests/link.test.tsx
+++ b/packages/solid-router/tests/link.test.tsx
@@ -4245,6 +4245,119 @@ describe('createLink', () => {
     const button3 = await screen.findByText('active: no - foo: no - Button3')
     expect(button3.getAttribute('overrideMeIfYouWant')).toBe('Button3')
   })
+
+  it('should respect target attribute set by custom component', async () => {
+    const CustomLinkWithTarget = (props: {
+      href?: string
+      children?: Solid.JSX.Element
+      ref?: (el: HTMLAnchorElement) => void
+    }) => (
+      <a ref={props.ref} {...props} target="_blank" rel="noopener noreferrer" />
+    )
+
+    const CreatedCustomLink = createLink(CustomLinkWithTarget)
+
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => (
+        <>
+          <h1>Index</h1>
+          <CreatedCustomLink to="/posts">
+            Posts (should open in new tab)
+          </CreatedCustomLink>
+        </>
+      ),
+    })
+
+    const postsRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/posts',
+      component: () => <h1 data-testid="posts-heading">Posts</h1>,
+    })
+
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, postsRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    const originalOpen = window.open
+    const openMock = vi.fn()
+    window.open = openMock
+
+    render(() => <RouterProvider router={router} />)
+
+    const postsLink = await screen.findByRole('link', {
+      name: 'Posts (should open in new tab)',
+    })
+
+    expect(postsLink).toHaveAttribute('target', '_blank')
+    expect(postsLink).toHaveAttribute('rel', 'noopener noreferrer')
+
+    fireEvent.click(postsLink)
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/')
+    })
+
+    await expect(screen.findByTestId('posts-heading')).rejects.toThrow()
+
+    window.open = originalOpen
+  })
+
+  it('should allow override of target prop even when custom component sets it', async () => {
+    const CustomLinkWithDefaultTarget = (props: {
+      href?: string
+      children?: Solid.JSX.Element
+      target?: string
+      ref?: (el: HTMLAnchorElement) => void
+    }) => <a ref={props.ref} target="_blank" {...props} />
+
+    const CreatedCustomLink = createLink(CustomLinkWithDefaultTarget)
+
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => (
+        <>
+          <h1>Index</h1>
+          <CreatedCustomLink to="/posts" target="_self">
+            Posts (should navigate internally)
+          </CreatedCustomLink>
+        </>
+      ),
+    })
+
+    const postsRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/posts',
+      component: () => <h1 data-testid="posts-heading">Posts</h1>,
+    })
+
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, postsRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    render(() => <RouterProvider router={router} />)
+
+    const postsLink = await screen.findByRole('link', {
+      name: 'Posts (should navigate internally)',
+    })
+
+    expect(postsLink).toHaveAttribute('target', '_self')
+
+    fireEvent.click(postsLink)
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/posts')
+    })
+
+    const postsHeading = await screen.findByTestId('posts-heading')
+    expect(postsHeading).toBeInTheDocument()
+  })
 })
 
 describe('search middleware', () => {


### PR DESCRIPTION
fixes #5011 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Links now correctly respect the target attribute from rendered anchor elements when not explicitly provided as a prop. Clicks on links with target=_blank are no longer intercepted for client-side navigation, opening in a new tab as expected.
  - Explicit target props still override defaults from custom link components, ensuring predictable behavior.
  - Applies to both React Router and Solid Router link components, improving consistency with custom link implementations and browser defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->