### PR TITLE
fix: restore InferStructuralSharing and handleHashScroll in published .d.ts files

### DIFF
--- a/packages/react-router/src/typePrimitives.ts
+++ b/packages/react-router/src/typePrimitives.ts
@@ -32,7 +32,7 @@ export type ValidateLinkOptions<
 >
 
 /**
- * @internal
+ * @private
  */
 export type InferStructuralSharing<TOptions> = TOptions extends {
   structuralSharing: infer TStructuralSharing

--- a/packages/router-core/src/scroll-restoration.ts
+++ b/packages/router-core/src/scroll-restoration.ts
@@ -346,7 +346,7 @@ export function setupScrollRestoration(router: AnyRouter, force?: boolean) {
 }
 
 /**
- * @internal
+ * @private
  * Handles hash-based scrolling after navigation completes.
  * To be used in framework-specific <Transitioner> components during the onResolved event.
  *


### PR DESCRIPTION
Fixes #5116

### Root Cause
In PR #4907, the TypeScript compiler option `stripInternal` was enabled in tsconfig.json, which causes TypeScript to remove any declarations marked with `@internal` from the published `.d.ts` files.

This resulted in TypeScript compilation errors for library users who have set the TypeScript compiler option `skipLibCheck` to `false`, because the following members were missing:

- `InferStructuralSharing` type in `react-router`
- `handleHashScroll` function in `router-core > scrollRestoration`

### Fix
- This PR replaces the `@internal` annotation with the `@private` annotation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal API annotations in routing packages to mark certain items as private, improving the accuracy of generated developer documentation.
  * No changes to public APIs, behavior, or performance.
  * No user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->