### PR TITLE
Add Pure SPA section to SPA Mode page

### DIFF
--- a/docs/start/framework/react/spa-mode.md
+++ b/docs/start/framework/react/spa-mode.md
@@ -22,6 +22,10 @@ For applications that do not require SSR for either SEO, crawlers, or performanc
 - **Slower time to full content** - Time to full content is longer since all JS must download and execute before anything below the shell can be rendered.
 - **Less SEO friendly** - Robots, crawlers and link unfurlers _may_ have a harder time indexing your application unless they are configured to execute JS and your application can render within a reasonable amount of time.
 
+## Pure SPA
+
+SPA mode does not mean there is no frontend server; it's just a different way for the client to interact with your frontend (i.e., TanSatck Start) server. If you need to do an SPA with no frontend server, then [TanStack Router](https://tanstack.com/router/latest) will be a better fit for your project.
+
 ## How does it work?
 
 After enabling the SPA mode, running a Start build will have an additional prerendering step afterwards to generate the shell. This is done by:

--- a/docs/start/framework/react/spa-mode.md
+++ b/docs/start/framework/react/spa-mode.md
@@ -24,7 +24,7 @@ For applications that do not require SSR for either SEO, crawlers, or performanc
 
 ## Pure SPA
 
-SPA mode does not mean there is no frontend server; it's just a different way for the client to interact with your frontend (i.e., TanSatck Start) server. If you need to do an SPA with no frontend server, then [TanStack Router](https://tanstack.com/router/latest) will be a better fit for your project.
+SPA mode does not mean there is no frontend server; it's just a different way for the client to interact with your frontend (i.e., TanStack Start) server. If you need to do an SPA with no frontend server, then [TanStack Router](https://tanstack.com/router/latest) will be a better fit for your project.
 
 ## How does it work?
 


### PR DESCRIPTION
Let me know if you think this is an alright addition to the SPA Mode page. I spent like a whole day trying to get SPA mode to work without an FE server before asking in the Discord and learning that that is antithetical to the ethos of Start. Something akin to this would have saved me a lot of time by directing me to Router alone much sooner.

After the first sentence, there could also be another sentence added explaining

> Loader functions in your `__root.tsx` file will still run on the server on startup in SPA mode.

I left it out because I didn't know if it was overexplaining.

Another option is maybe adding a sentence in the [Why use Start without SSR?](https://tanstack.com/start/latest/docs/framework/react/spa-mode#why-use-start-without-ssr) section to clarify better. I guess what I'm looking for is something on the SPA docs specifying that Start is an obligate server environment and enabling SPA doesn't opt you out of that, it merely changes how you interact with said server. I.e., if you want to bring your own server, you *must* daisy chain it to the Start server.

My position is that I'm in a company with a large Java backend. They would like us to rewrite the FE, but they don't want to add infra for an FE server. Ergo, I saw SPA mode and thought that I could use Start, but such is not the case. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Pure SPA" section to the SPA mode docs (placed after caveats).
  * Clarifies that SPA mode still involves a frontend server (TanStack Start).
  * Recommends TanStack Router for setups requiring no frontend server, with a link included.
  * Prerendering steps and configuration guidance remain unchanged.
  * No code or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->