### PR TITLE
fix(router-plugin): show warning for non-splittable items

### DIFF
--- a/docs/router/framework/react/guide/automatic-code-splitting.md
+++ b/docs/router/framework/react/guide/automatic-code-splitting.md
@@ -78,9 +78,33 @@ This means that it creates three separate lazy-loaded chunks for each route. Res
 
 For automatic code splitting to work, there are some rules in-place to make sure that this process can reliably and predictably happen.
 
-1. **Do not export route properties**: Route properties like `component`, `loader`, etc., should not be exported from the route file. Exporting these properties results in them being bundled into the main application bundle, which means that they will not be code-split.
+#### Do not export route properties
 
-2. **That's it!** There are no other restrictions. You can use any other JavaScript or TypeScript features in your route files as you normally would. If you run into any issues, please [open an issue](https://github.com/tanstack/router/issues) on GitHub.
+Route properties like `component`, `loader`, etc., should not be exported from the route file. Exporting these properties results in them being bundled into the main application bundle, which means that they will not be code-split.
+
+```tsx
+import { createRoute } from '@tanstack/react-router'
+
+export const Route = createRoute('/posts')({
+  // ...
+  notFoundComponent: PostsNotFoundComponent,
+})
+
+// ❌ Do NOT do this!
+// Exporting the notFoundComponent will prevent it from being code-split
+// and will be included in the main bundle.
+export function PostsNotFoundComponent() {
+  // ❌
+  // ...
+}
+
+function PostsNotFoundComponent() {
+  // ✅
+  // ...
+}
+```
+
+**That's it!** There are no other restrictions. You can use any other JavaScript or TypeScript features in your route files as you normally would. If you run into any issues, please [open an issue](https://github.com/tanstack/router/issues) on GitHub.
 
 ## Granular control
 

--- a/docs/router/framework/react/guide/automatic-code-splitting.md
+++ b/docs/router/framework/react/guide/automatic-code-splitting.md
@@ -74,6 +74,14 @@ This means that it creates three separate lazy-loaded chunks for each route. Res
 - One for the error component
 - And one for the not-found component.
 
+### Rules of Splitting
+
+For automatic code splitting to work, there are some rules in-place to make sure that this process can reliably and predictably happen.
+
+1. **Do not export route properties**: Route properties like `component`, `loader`, etc., should not be exported from the route file. Exporting these properties results in them being bundled into the main application bundle, which means that they will not be code-split.
+
+2. **That's it!** There are no other restrictions. You can use any other JavaScript or TypeScript features in your route files as you normally would. If you run into any issues, please [open an issue](https://github.com/tanstack/router/issues) on GitHub.
+
 ## Granular control
 
 For most applications, the default behavior of using `autoCodeSplitting: true` is sufficient. However, TanStack Router provides several options to customize how your routes are split into chunks, allowing you to optimize for specific use cases or performance needs.

--- a/packages/router-plugin/src/core/code-splitter/compilers.ts
+++ b/packages/router-plugin/src/core/code-splitter/compilers.ts
@@ -254,12 +254,13 @@ export function compileCodeSplitReferenceRoute(
                           // since they are already being imported
                           // and need to be retained in the compiled file
                           const isExported = hasExport(ast, value)
+                          if (isExported) {
+                            knownExportedIdents.add(value.name)
+                          }
                           shouldSplit = !isExported
 
                           if (shouldSplit) {
                             removeIdentifierLiteral(path, value)
-                          } else {
-                            knownExportedIdents.add(value.name)
                           }
                         }
 
@@ -325,12 +326,13 @@ export function compileCodeSplitReferenceRoute(
                           // since they are already being imported
                           // and need to be retained in the compiled file
                           const isExported = hasExport(ast, value)
+                          if (isExported) {
+                            knownExportedIdents.add(value.name)
+                          }
                           shouldSplit = !isExported
 
                           if (shouldSplit) {
                             removeIdentifierLiteral(path, value)
-                          } else {
-                            knownExportedIdents.add(value.name)
                           }
                         }
 

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component-and-normal-notFound.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component-and-normal-notFound.tsx
@@ -1,3 +1,4 @@
+console.warn("[tanstack-router] These exports from \"export-default-component-and-normal-notFound.tsx\" will not be code-split and will increase your bundle size:\n- Home\nFor the best optimization, these items should either have their export statements removed, or be imported from another location that is not a route file.");
 const $$splitNotFoundComponentImporter = () => import('export-default-component-and-normal-notFound.tsx?tsr-split=notFoundComponent');
 import { lazyRouteComponent } from '@tanstack/react-router';
 import React, { useState } from 'react';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component-and-normal-notFound@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component-and-normal-notFound@component.tsx
@@ -1,3 +1,2 @@
-console.warn("These exports from \"export-default-component-and-normal-notFound.tsx?component\" are not being code-split and will increase your bundle size: \n- Home\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import React from 'react';
 import { Route } from "export-default-component-and-normal-notFound.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component-and-normal-notFound@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component-and-normal-notFound@errorComponent.tsx
@@ -1,3 +1,2 @@
-console.warn("These exports from \"export-default-component-and-normal-notFound.tsx?errorComponent\" are not being code-split and will increase your bundle size: \n- Home\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import React from 'react';
 import { Route } from "export-default-component-and-normal-notFound.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component-and-normal-notFound@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component-and-normal-notFound@notFoundComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"export-default-component-and-normal-notFound.tsx?notFoundComponent\" are not being code-split and will increase your bundle size: \n- Home\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import React from 'react';
 import { Route } from "export-default-component-and-normal-notFound.tsx";
 function NotFoundComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component.tsx
@@ -1,3 +1,4 @@
+console.warn("[tanstack-router] These exports from \"export-default-component.tsx\" will not be code-split and will increase your bundle size:\n- Home\nFor the best optimization, these items should either have their export statements removed, or be imported from another location that is not a route file.");
 import React, { useState } from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/home')({

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component@component.tsx
@@ -1,3 +1,2 @@
-console.warn("These exports from \"export-default-component.tsx?component\" are not being code-split and will increase your bundle size: \n- Home\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import React from 'react';
 import { Route } from "export-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component@errorComponent.tsx
@@ -1,3 +1,2 @@
-console.warn("These exports from \"export-default-component.tsx?errorComponent\" are not being code-split and will increase your bundle size: \n- Home\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import React from 'react';
 import { Route } from "export-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/export-default-component@notFoundComponent.tsx
@@ -1,3 +1,2 @@
-console.warn("These exports from \"export-default-component.tsx?notFoundComponent\" are not being code-split and will increase your bundle size: \n- Home\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import React from 'react';
 import { Route } from "export-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-export-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-export-component.tsx
@@ -1,3 +1,4 @@
+console.warn("[tanstack-router] These exports from \"retain-export-component.tsx\" will not be code-split and will increase your bundle size:\n- Layout\nFor the best optimization, these items should either have their export statements removed, or be imported from another location that is not a route file.");
 import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent, importedLoader } from '../../shared/imported';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-export-component@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-export-component@component.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-export-component.tsx?component\" are not being code-split and will increase your bundle size: \n- Layout\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Route } from "retain-export-component.tsx";
 import { SIDEBAR_WIDTH } from "retain-export-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-export-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-export-component@errorComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-export-component.tsx?errorComponent\" are not being code-split and will increase your bundle size: \n- Layout\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Route } from "retain-export-component.tsx";
 import { SIDEBAR_WIDTH } from "retain-export-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-export-component@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-export-component@notFoundComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-export-component.tsx?notFoundComponent\" are not being code-split and will increase your bundle size: \n- Layout\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Route } from "retain-export-component.tsx";
 import { SIDEBAR_WIDTH } from "retain-export-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-const.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-const.tsx
@@ -1,3 +1,4 @@
+console.warn("[tanstack-router] These exports from \"retain-exports-const.tsx\" will not be code-split and will increase your bundle size:\n- Layout\nFor the best optimization, these items should either have their export statements removed, or be imported from another location that is not a route file.");
 import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent, importedLoader } from '../../shared/imported';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-const@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-const@component.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-exports-const.tsx?component\" are not being code-split and will increase your bundle size: \n- Layout\n- loaderFn\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Route } from "retain-exports-const.tsx";
 import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-const@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-const@errorComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-exports-const.tsx?errorComponent\" are not being code-split and will increase your bundle size: \n- Layout\n- loaderFn\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Route } from "retain-exports-const.tsx";
 import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-const@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-const@notFoundComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-exports-const.tsx?notFoundComponent\" are not being code-split and will increase your bundle size: \n- Layout\n- loaderFn\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Route } from "retain-exports-const.tsx";
 import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-function.tsx
@@ -1,3 +1,4 @@
+console.warn("[tanstack-router] These exports from \"retain-exports-function.tsx\" will not be code-split and will increase your bundle size:\n- Layout\nFor the best optimization, these items should either have their export statements removed, or be imported from another location that is not a route file.");
 import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent, importedLoader } from '../../shared/imported';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-function@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-function@component.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-exports-function.tsx?component\" are not being code-split and will increase your bundle size: \n- Layout\n- loaderFn\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Route } from "retain-exports-function.tsx";
 import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-function@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-function@errorComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-exports-function.tsx?errorComponent\" are not being code-split and will increase your bundle size: \n- Layout\n- loaderFn\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Route } from "retain-exports-function.tsx";
 import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-function@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-function@notFoundComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-exports-function.tsx?notFoundComponent\" are not being code-split and will increase your bundle size: \n- Layout\n- loaderFn\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Route } from "retain-exports-function.tsx";
 import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-loader@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-loader@component.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-exports-loader.tsx?component\" are not being code-split and will increase your bundle size: \n- loaderFn\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent } from '../../shared/imported';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-loader@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-loader@errorComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-exports-loader.tsx?errorComponent\" are not being code-split and will increase your bundle size: \n- loaderFn\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Route } from "retain-exports-loader.tsx";
 import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-loader@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/retain-exports-loader@notFoundComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-exports-loader.tsx?notFoundComponent\" are not being code-split and will increase your bundle size: \n- loaderFn\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Route } from "retain-exports-loader.tsx";
 import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/useStateDestructure.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/useStateDestructure.tsx
@@ -1,3 +1,4 @@
+console.warn("[tanstack-router] These exports from \"useStateDestructure.tsx\" will not be code-split and will increase your bundle size:\n- VersionIndex\nFor the best optimization, these items should either have their export statements removed, or be imported from another location that is not a route file.");
 import * as React from 'react';
 import { CgCornerUpLeft, CgSpinner } from 'react-icons/cg';
 import { FaBolt, FaBook, FaCheckCircle, FaCogs, FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/useStateDestructure@component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/useStateDestructure@component.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"useStateDestructure.tsx?component\" are not being code-split and will increase your bundle size: \n- VersionIndex\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import { FaBolt, FaBook, FaCheckCircle, FaCogs } from 'react-icons/fa';
 import { VscPreview, VscWand } from 'react-icons/vsc';
 import { Route } from "useStateDestructure.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/useStateDestructure@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/useStateDestructure@errorComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"useStateDestructure.tsx?errorComponent\" are not being code-split and will increase your bundle size: \n- VersionIndex\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import { FaBolt, FaBook, FaCheckCircle, FaCogs } from 'react-icons/fa';
 import { VscPreview, VscWand } from 'react-icons/vsc';
 import { Route } from "useStateDestructure.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/useStateDestructure@notFoundComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/1-default/useStateDestructure@notFoundComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"useStateDestructure.tsx?notFoundComponent\" are not being code-split and will increase your bundle size: \n- VersionIndex\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import { FaBolt, FaBook, FaCheckCircle, FaCogs } from 'react-icons/fa';
 import { VscPreview, VscWand } from 'react-icons/vsc';
 import { Route } from "useStateDestructure.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/export-default-component-and-normal-notFound.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/export-default-component-and-normal-notFound.tsx
@@ -1,3 +1,4 @@
+console.warn("[tanstack-router] These exports from \"export-default-component-and-normal-notFound.tsx\" will not be code-split and will increase your bundle size:\n- Home\nFor the best optimization, these items should either have their export statements removed, or be imported from another location that is not a route file.");
 const $$splitNotFoundComponentImporter = () => import('export-default-component-and-normal-notFound.tsx?tsr-split=component---errorComponent---notFoundComponent---pendingComponent');
 import { lazyRouteComponent } from '@tanstack/react-router';
 import React, { useState } from 'react';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/export-default-component-and-normal-notFound@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/export-default-component-and-normal-notFound@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"export-default-component-and-normal-notFound.tsx?component---errorComponent---notFoundComponent---pendingComponent\" are not being code-split and will increase your bundle size: \n- Home\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import React from 'react';
 import { Route } from "export-default-component-and-normal-notFound.tsx";
 function NotFoundComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/export-default-component-and-normal-notFound@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/export-default-component-and-normal-notFound@loader.tsx
@@ -1,3 +1,2 @@
-console.warn("These exports from \"export-default-component-and-normal-notFound.tsx?loader\" are not being code-split and will increase your bundle size: \n- Home\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import React from 'react';
 import { Route } from "export-default-component-and-normal-notFound.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/export-default-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/export-default-component.tsx
@@ -1,3 +1,4 @@
+console.warn("[tanstack-router] These exports from \"export-default-component.tsx\" will not be code-split and will increase your bundle size:\n- Home\nFor the best optimization, these items should either have their export statements removed, or be imported from another location that is not a route file.");
 import React, { useState } from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/home')({

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/export-default-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/export-default-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,2 @@
-console.warn("These exports from \"export-default-component.tsx?component---errorComponent---notFoundComponent---pendingComponent\" are not being code-split and will increase your bundle size: \n- Home\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import React from 'react';
 import { Route } from "export-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/export-default-component@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/export-default-component@loader.tsx
@@ -1,3 +1,2 @@
-console.warn("These exports from \"export-default-component.tsx?loader\" are not being code-split and will increase your bundle size: \n- Home\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import React from 'react';
 import { Route } from "export-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-export-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-export-component.tsx
@@ -1,3 +1,4 @@
+console.warn("[tanstack-router] These exports from \"retain-export-component.tsx\" will not be code-split and will increase your bundle size:\n- Layout\nFor the best optimization, these items should either have their export statements removed, or be imported from another location that is not a route file.");
 const $$splitLoaderImporter = () => import('retain-export-component.tsx?tsr-split=loader');
 import { lazyFn } from '@tanstack/react-router';
 import * as React from 'react';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-export-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-export-component@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-export-component.tsx?component---errorComponent---notFoundComponent---pendingComponent\" are not being code-split and will increase your bundle size: \n- Layout\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Route } from "retain-export-component.tsx";
 import { SIDEBAR_WIDTH } from "retain-export-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-export-component@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-export-component@loader.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-export-component.tsx?loader\" are not being code-split and will increase your bundle size: \n- Layout\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { importedLoader } from '../../shared/imported';
 import { Route } from "retain-export-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-const.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-const.tsx
@@ -1,3 +1,4 @@
+console.warn("[tanstack-router] These exports from \"retain-exports-const.tsx\" will not be code-split and will increase your bundle size:\n- Layout\n- loaderFn\nFor the best optimization, these items should either have their export statements removed, or be imported from another location that is not a route file.");
 import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent, importedLoader } from '../../shared/imported';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-const@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-const@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-exports-const.tsx?component---errorComponent---notFoundComponent---pendingComponent\" are not being code-split and will increase your bundle size: \n- Layout\n- loaderFn\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Route } from "retain-exports-const.tsx";
 import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-const@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-const@loader.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-exports-const.tsx?loader\" are not being code-split and will increase your bundle size: \n- Layout\n- loaderFn\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Route } from "retain-exports-const.tsx";
 import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-function.tsx
@@ -1,3 +1,4 @@
+console.warn("[tanstack-router] These exports from \"retain-exports-function.tsx\" will not be code-split and will increase your bundle size:\n- Layout\n- loaderFn\nFor the best optimization, these items should either have their export statements removed, or be imported from another location that is not a route file.");
 import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent, importedLoader } from '../../shared/imported';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-function@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-function@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-exports-function.tsx?component---errorComponent---notFoundComponent---pendingComponent\" are not being code-split and will increase your bundle size: \n- Layout\n- loaderFn\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Route } from "retain-exports-function.tsx";
 import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-function@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-function@loader.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-exports-function.tsx?loader\" are not being code-split and will increase your bundle size: \n- Layout\n- loaderFn\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Route } from "retain-exports-function.tsx";
 import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-loader.tsx
@@ -1,3 +1,4 @@
+console.warn("[tanstack-router] These exports from \"retain-exports-loader.tsx\" will not be code-split and will increase your bundle size:\n- loaderFn\nFor the best optimization, these items should either have their export statements removed, or be imported from another location that is not a route file.");
 const $$splitComponentImporter = () => import('retain-exports-loader.tsx?tsr-split=component---errorComponent---notFoundComponent---pendingComponent');
 import { lazyRouteComponent } from '@tanstack/react-router';
 import * as React from 'react';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-loader@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-loader@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-exports-loader.tsx?component---errorComponent---notFoundComponent---pendingComponent\" are not being code-split and will increase your bundle size: \n- loaderFn\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent } from '../../shared/imported';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-loader@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/retain-exports-loader@loader.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-exports-loader.tsx?loader\" are not being code-split and will increase your bundle size: \n- loaderFn\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Route } from "retain-exports-loader.tsx";
 import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/useStateDestructure.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/useStateDestructure.tsx
@@ -1,3 +1,4 @@
+console.warn("[tanstack-router] These exports from \"useStateDestructure.tsx\" will not be code-split and will increase your bundle size:\n- VersionIndex\nFor the best optimization, these items should either have their export statements removed, or be imported from another location that is not a route file.");
 import * as React from 'react';
 import { CgCornerUpLeft, CgSpinner } from 'react-icons/cg';
 import { FaBolt, FaBook, FaCheckCircle, FaCogs, FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/useStateDestructure@component---errorComponent---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/useStateDestructure@component---errorComponent---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"useStateDestructure.tsx?component---errorComponent---notFoundComponent---pendingComponent\" are not being code-split and will increase your bundle size: \n- VersionIndex\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import { FaBolt, FaBook, FaCheckCircle, FaCogs } from 'react-icons/fa';
 import { VscPreview, VscWand } from 'react-icons/vsc';
 import { Route } from "useStateDestructure.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/useStateDestructure@loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/2-components-combined-loader-separate/useStateDestructure@loader.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"useStateDestructure.tsx?loader\" are not being code-split and will increase your bundle size: \n- VersionIndex\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import { FaBolt, FaBook, FaCheckCircle, FaCogs } from 'react-icons/fa';
 import { VscPreview, VscWand } from 'react-icons/vsc';
 import { Route } from "useStateDestructure.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/export-default-component-and-normal-notFound.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/export-default-component-and-normal-notFound.tsx
@@ -1,3 +1,4 @@
+console.warn("[tanstack-router] These exports from \"export-default-component-and-normal-notFound.tsx\" will not be code-split and will increase your bundle size:\n- Home\nFor the best optimization, these items should either have their export statements removed, or be imported from another location that is not a route file.");
 const $$splitNotFoundComponentImporter = () => import('export-default-component-and-normal-notFound.tsx?tsr-split=component---loader---notFoundComponent---pendingComponent');
 import { lazyRouteComponent } from '@tanstack/react-router';
 import React, { useState } from 'react';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/export-default-component-and-normal-notFound@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/export-default-component-and-normal-notFound@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"export-default-component-and-normal-notFound.tsx?component---loader---notFoundComponent---pendingComponent\" are not being code-split and will increase your bundle size: \n- Home\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import React from 'react';
 import { Route } from "export-default-component-and-normal-notFound.tsx";
 function NotFoundComponent() {

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/export-default-component-and-normal-notFound@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/export-default-component-and-normal-notFound@errorComponent.tsx
@@ -1,3 +1,2 @@
-console.warn("These exports from \"export-default-component-and-normal-notFound.tsx?errorComponent\" are not being code-split and will increase your bundle size: \n- Home\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import React from 'react';
 import { Route } from "export-default-component-and-normal-notFound.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/export-default-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/export-default-component.tsx
@@ -1,3 +1,4 @@
+console.warn("[tanstack-router] These exports from \"export-default-component.tsx\" will not be code-split and will increase your bundle size:\n- Home\nFor the best optimization, these items should either have their export statements removed, or be imported from another location that is not a route file.");
 import React, { useState } from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/home')({

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/export-default-component@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/export-default-component@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,3 +1,2 @@
-console.warn("These exports from \"export-default-component.tsx?component---loader---notFoundComponent---pendingComponent\" are not being code-split and will increase your bundle size: \n- Home\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import React from 'react';
 import { Route } from "export-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/export-default-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/export-default-component@errorComponent.tsx
@@ -1,3 +1,2 @@
-console.warn("These exports from \"export-default-component.tsx?errorComponent\" are not being code-split and will increase your bundle size: \n- Home\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import React from 'react';
 import { Route } from "export-default-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-export-component.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-export-component.tsx
@@ -1,3 +1,4 @@
+console.warn("[tanstack-router] These exports from \"retain-export-component.tsx\" will not be code-split and will increase your bundle size:\n- Layout\nFor the best optimization, these items should either have their export statements removed, or be imported from another location that is not a route file.");
 const $$splitLoaderImporter = () => import('retain-export-component.tsx?tsr-split=component---loader---notFoundComponent---pendingComponent');
 import { lazyFn } from '@tanstack/react-router';
 import * as React from 'react';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-export-component@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-export-component@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-export-component.tsx?component---loader---notFoundComponent---pendingComponent\" are not being code-split and will increase your bundle size: \n- Layout\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { importedLoader } from '../../shared/imported';
 import { Route } from "retain-export-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-export-component@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-export-component@errorComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-export-component.tsx?errorComponent\" are not being code-split and will increase your bundle size: \n- Layout\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Route } from "retain-export-component.tsx";
 import { SIDEBAR_WIDTH } from "retain-export-component.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-const.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-const.tsx
@@ -1,3 +1,4 @@
+console.warn("[tanstack-router] These exports from \"retain-exports-const.tsx\" will not be code-split and will increase your bundle size:\n- Layout\n- loaderFn\nFor the best optimization, these items should either have their export statements removed, or be imported from another location that is not a route file.");
 import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent, importedLoader } from '../../shared/imported';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-const@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-const@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-exports-const.tsx?component---loader---notFoundComponent---pendingComponent\" are not being code-split and will increase your bundle size: \n- Layout\n- loaderFn\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Route } from "retain-exports-const.tsx";
 import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-const@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-const@errorComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-exports-const.tsx?errorComponent\" are not being code-split and will increase your bundle size: \n- Layout\n- loaderFn\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Route } from "retain-exports-const.tsx";
 import { SIDEBAR_WIDTH } from "retain-exports-const.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-function.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-function.tsx
@@ -1,3 +1,4 @@
+console.warn("[tanstack-router] These exports from \"retain-exports-function.tsx\" will not be code-split and will increase your bundle size:\n- Layout\n- loaderFn\nFor the best optimization, these items should either have their export statements removed, or be imported from another location that is not a route file.");
 import * as React from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent, importedLoader } from '../../shared/imported';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-function@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-function@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-exports-function.tsx?component---loader---notFoundComponent---pendingComponent\" are not being code-split and will increase your bundle size: \n- Layout\n- loaderFn\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Route } from "retain-exports-function.tsx";
 import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-function@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-function@errorComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-exports-function.tsx?errorComponent\" are not being code-split and will increase your bundle size: \n- Layout\n- loaderFn\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Route } from "retain-exports-function.tsx";
 import { SIDEBAR_WIDTH } from "retain-exports-function.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-loader.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-loader.tsx
@@ -1,3 +1,4 @@
+console.warn("[tanstack-router] These exports from \"retain-exports-loader.tsx\" will not be code-split and will increase your bundle size:\n- loaderFn\nFor the best optimization, these items should either have their export statements removed, or be imported from another location that is not a route file.");
 const $$splitComponentImporter = () => import('retain-exports-loader.tsx?tsr-split=component---loader---notFoundComponent---pendingComponent');
 import { lazyRouteComponent } from '@tanstack/react-router';
 import * as React from 'react';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-loader@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-loader@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-exports-loader.tsx?component---loader---notFoundComponent---pendingComponent\" are not being code-split and will increase your bundle size: \n- loaderFn\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Outlet } from '@tanstack/react-router';
 import { importedComponent as ImportedComponent } from '../../shared/imported';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-loader@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/retain-exports-loader@errorComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"retain-exports-loader.tsx?errorComponent\" are not being code-split and will increase your bundle size: \n- loaderFn\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import * as React from 'react';
 import { Route } from "retain-exports-loader.tsx";
 import { SIDEBAR_WIDTH } from "retain-exports-loader.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/useStateDestructure.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/useStateDestructure.tsx
@@ -1,3 +1,4 @@
+console.warn("[tanstack-router] These exports from \"useStateDestructure.tsx\" will not be code-split and will increase your bundle size:\n- VersionIndex\nFor the best optimization, these items should either have their export statements removed, or be imported from another location that is not a route file.");
 import * as React from 'react';
 import { CgCornerUpLeft, CgSpinner } from 'react-icons/cg';
 import { FaBolt, FaBook, FaCheckCircle, FaCogs, FaDiscord, FaGithub, FaTshirt, FaTwitter } from 'react-icons/fa';

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/useStateDestructure@component---loader---notFoundComponent---pendingComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/useStateDestructure@component---loader---notFoundComponent---pendingComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"useStateDestructure.tsx?component---loader---notFoundComponent---pendingComponent\" are not being code-split and will increase your bundle size: \n- VersionIndex\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import { FaBolt, FaBook, FaCheckCircle, FaCogs } from 'react-icons/fa';
 import { VscPreview, VscWand } from 'react-icons/vsc';
 import { Route } from "useStateDestructure.tsx";

--- a/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/useStateDestructure@errorComponent.tsx
+++ b/packages/router-plugin/tests/code-splitter/snapshots/react/3-all-combined-errorComponent-separate/useStateDestructure@errorComponent.tsx
@@ -1,4 +1,3 @@
-console.warn("These exports from \"useStateDestructure.tsx?errorComponent\" are not being code-split and will increase your bundle size: \n- VersionIndex\nThese should either have their export statements removed or be imported from another file that is not a route.");
 import { FaBolt, FaBook, FaCheckCircle, FaCogs } from 'react-icons/fa';
 import { VscPreview, VscWand } from 'react-icons/vsc';
 import { Route } from "useStateDestructure.tsx";


### PR DESCRIPTION
At some point in the refactors, the warning shown about the non-splittable exports was broken. This PR adds it back in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added clear runtime warnings when route files export values that prevent automatic code-splitting, with guidance to optimize bundle size.

- Documentation
  - Introduced “Rules of Splitting” to the React automatic code-splitting guide, outlining constraints and linking to report issues.

- Tests
  - Updated test snapshots to reflect the new warning behavior and its relocation, ensuring consistency with the improved developer feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->