### PR TITLE
refactor(react-router): Link component composeHandler performance

### DIFF
--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -374,10 +374,11 @@ const intersectionObserverOptions: IntersectionObserverInit = {
 const composeHandlers =
   (handlers: Array<undefined | React.EventHandler<any>>) =>
   (e: React.SyntheticEvent) => {
-    handlers.filter(Boolean).forEach((handler) => {
+    for (const handler of handlers) {
+      if (!handler) continue
       if (e.defaultPrevented) return
-      handler!(e)
-    })
+      handler(e)
+    }
   }
 
 type UseLinkReactProps<TComp> = TComp extends keyof React.JSX.IntrinsicElements


### PR DESCRIPTION
I noticed a slight performance dip during some navigations and the bottom-up call list of the flame graph seemed to point to the `composeHandler`. This seems (surprising and) pretty minor, but I'm measuring a consistent 3ms self-time when the resulting handler is actually being called.

This PR proposes ditching array methods and using a `for-of` loop. This is good-enough™ and preserves the generality and DX of this function for a 25% perf improvement.

```sh
 ✓  @tanstack/react-router  tests/foo.bench.tsx > composeHandlers 10064ms
     name                      hz     min     max    mean     p75     p99    p995    p999     rme   samples
   · array methods  37,152,711.10  0.0000  0.1624  0.0000  0.0000  0.0000  0.0000  0.0002  ±0.14%  18576357
   · for-of         47,029,751.81  0.0000  0.0236  0.0000  0.0000  0.0000  0.0000  0.0001  ±0.07%  23514876   fastest

 BENCH  Summary

   @tanstack/react-router  for-of - tests/foo.bench.tsx > composeHandlers
    1.27x faster than array methods
```

A slightly more performant (~30%) version would be to handle *exactly* 2 handlers instead of an arbitrary number (since `composeHandlers` is only used w/ 2 callbacks) but this does affect the generality and DX of this function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated link event handling to short-circuit when an action is prevented, maintaining existing behavior.
  - Streamlined internal logic for handling user interactions with links for improved efficiency.
- **Performance**
  - Minor efficiency improvements in link interaction handling without altering the public API or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->