### PR TITLE
fix: tell router that rendering finished when rendering to string

### DIFF
--- a/packages/react-router/src/ssr/renderRouterToString.tsx
+++ b/packages/react-router/src/ssr/renderRouterToString.tsx
@@ -13,6 +13,7 @@ export const renderRouterToString = async ({
 }) => {
   try {
     let html = ReactDOMServer.renderToString(children)
+    router.serverSsr!.setRenderFinished()
     const injectedHtml = await Promise.all(router.serverSsr!.injectedHtml).then(
       (htmls) => htmls.join(''),
     )

--- a/packages/solid-router/src/ssr/renderRouterToString.tsx
+++ b/packages/solid-router/src/ssr/renderRouterToString.tsx
@@ -13,6 +13,7 @@ export const renderRouterToString = async ({
 }) => {
   try {
     let html = Solid.renderToString(children)
+    router.serverSsr!.setRenderFinished()
     const injectedHtml = await Promise.all(router.serverSsr!.injectedHtml).then(
       (htmls) => htmls.join(''),
     )


### PR DESCRIPTION
fixes #5155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side rendering stability by correctly finalizing the initial render before injecting additional HTML, preventing rare hangs or incomplete pages.
  * Applies to both React and Solid router SSR paths.

* **Performance**
  * Slightly reduces SSR latency by signaling render completion earlier in the pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->