### PR TITLE
fix(router-core): optional-path-param usage variations

### DIFF
--- a/docs/router/framework/react/guide/path-params.md
+++ b/docs/router/framework/react/guide/path-params.md
@@ -235,7 +235,12 @@ Optional parameters create flexible URL patterns:
 
 - `/posts/{-$category}` matches both `/posts` and `/posts/tech`
 - `/posts/{-$category}/{-$slug}` matches `/posts`, `/posts/tech`, and `/posts/tech/hello-world`
+- `/posts/{-$category}/{-$slug}/list` matches `/posts/list`, `/posts/tech/list`, and `/posts/tech/hello-world/list`
 - `/users/$id/{-$tab}` matches `/users/123` and `/users/123/settings`
+- `/users/{-$category}/$id/{-$tab}` matches `/users/123`, `/users/admin/123` and `/users/admin/123/settings`
+- `/users/{-$category}/$id/$slug/{-$tab}` matches `/users/123/slug`, `/users/admin/123/slug` and `/users/admin/123/slug/settings`
+- `/users/{-$category}/$id/{-$tab}/$slug` matches `/users/123/slug`, `/users/admin/123/slug` and `/users/admin/123/settings/slug`
+- `/users/{-$category}/$id/edit/{-$tab}` matches `/users/123/edit`, `/users/admin/123/edit`, `/users/123/edit/settings` and `/users/admin/123/edit/settings`
 
 When an optional parameter is not present in the URL, its value will be `undefined` in your route handlers and components.
 

--- a/e2e/react-router/basic-file-based/src/routeTree.gen.ts
+++ b/e2e/react-router/basic-file-based/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as ComponentTypesTestRouteImport } from './routes/component-types
 import { Route as AnchorRouteImport } from './routes/anchor'
 import { Route as LayoutRouteImport } from './routes/_layout'
 import { Route as SearchParamsRouteRouteImport } from './routes/search-params/route'
+import { Route as OptionalParamsRouteRouteImport } from './routes/optional-params/route'
 import { Route as NonNestedRouteRouteImport } from './routes/non-nested/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SearchParamsIndexRouteImport } from './routes/search-params/index'
@@ -73,14 +74,21 @@ import { Route as RelativeUseNavigateNestedIndexRouteImport } from './routes/rel
 import { Route as RelativeLinkWithSearchIndexRouteImport } from './routes/relative/link/with-search/index'
 import { Route as RelativeLinkPathIndexRouteImport } from './routes/relative/link/path/index'
 import { Route as RelativeLinkNestedIndexRouteImport } from './routes/relative/link/nested/index'
+import { Route as OptionalParamsSimpleChar123IdChar125IndexRouteImport } from './routes/optional-params/simple/{-$id}.index'
 import { Route as ParamsPsNonNestedFooBarRouteImport } from './routes/params-ps/non-nested/$foo_/$bar'
+import { Route as OptionalParamsSimpleChar123IdChar125PathRouteImport } from './routes/optional-params/simple/{-$id}.path'
 import { Route as NonNestedBazBazidEditRouteImport } from './routes/non-nested/baz_.$bazid.edit'
 import { Route as ParamsPsNamedFooBarRouteRouteImport } from './routes/params-ps/named/$foo/$bar.route'
 import { Route as RelativeUseNavigatePathPathIndexRouteImport } from './routes/relative/useNavigate/path/$path/index'
 import { Route as RelativeUseNavigateNestedDeepIndexRouteImport } from './routes/relative/useNavigate/nested/deep/index'
 import { Route as RelativeLinkPathPathIndexRouteImport } from './routes/relative/link/path/$path/index'
 import { Route as RelativeLinkNestedDeepIndexRouteImport } from './routes/relative/link/nested/deep/index'
+import { Route as OptionalParamsWithIndexChar123IdChar125CategoryIndexRouteImport } from './routes/optional-params/withIndex/{-$id}.$category.index'
 import { Route as ParamsPsNamedFooBarBazRouteImport } from './routes/params-ps/named/$foo/$bar.$baz'
+import { Route as OptionalParamsWithIndexChar123IdChar125CategoryPathIndexRouteImport } from './routes/optional-params/withIndex/{-$id}.$category.path.index'
+import { Route as OptionalParamsWithRequiredParamChar123IdChar125CategoryChar123SlugChar125InfoRouteImport } from './routes/optional-params/withRequiredParam/{-$id}.$category.{-$slug}.info'
+import { Route as OptionalParamsWithRequiredInBetweenChar123IdChar125CategoryPathChar123SlugChar125RouteImport } from './routes/optional-params/withRequiredInBetween/{-$id}.$category.path.{-$slug}'
+import { Route as OptionalParamsConsecutiveChar123IdChar125Char123SlugChar125CategoryInfoRouteImport } from './routes/optional-params/consecutive/{-$id}.{-$slug}.$category.info'
 
 const groupRouteImport = createFileRoute('/(group)')()
 
@@ -136,6 +144,11 @@ const LayoutRoute = LayoutRouteImport.update({
 const SearchParamsRouteRoute = SearchParamsRouteRouteImport.update({
   id: '/search-params',
   path: '/search-params',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OptionalParamsRouteRoute = OptionalParamsRouteRouteImport.update({
+  id: '/optional-params',
+  path: '/optional-params',
   getParentRoute: () => rootRouteImport,
 } as any)
 const NonNestedRouteRoute = NonNestedRouteRouteImport.update({
@@ -415,11 +428,23 @@ const RelativeLinkNestedIndexRoute = RelativeLinkNestedIndexRouteImport.update({
   path: '/nested/',
   getParentRoute: () => RelativeLinkRouteRoute,
 } as any)
+const OptionalParamsSimpleChar123IdChar125IndexRoute =
+  OptionalParamsSimpleChar123IdChar125IndexRouteImport.update({
+    id: '/simple/{-$id}/',
+    path: '/simple/{-$id}/',
+    getParentRoute: () => OptionalParamsRouteRoute,
+  } as any)
 const ParamsPsNonNestedFooBarRoute = ParamsPsNonNestedFooBarRouteImport.update({
   id: '/$bar',
   path: '/$bar',
   getParentRoute: () => ParamsPsNonNestedFooRouteRoute,
 } as any)
+const OptionalParamsSimpleChar123IdChar125PathRoute =
+  OptionalParamsSimpleChar123IdChar125PathRouteImport.update({
+    id: '/simple/{-$id}/path',
+    path: '/simple/{-$id}/path',
+    getParentRoute: () => OptionalParamsRouteRoute,
+  } as any)
 const NonNestedBazBazidEditRoute = NonNestedBazBazidEditRouteImport.update({
   id: '/baz_/$bazid/edit',
   path: '/baz/$bazid/edit',
@@ -455,15 +480,52 @@ const RelativeLinkNestedDeepIndexRoute =
     path: '/nested/deep/',
     getParentRoute: () => RelativeLinkRouteRoute,
   } as any)
+const OptionalParamsWithIndexChar123IdChar125CategoryIndexRoute =
+  OptionalParamsWithIndexChar123IdChar125CategoryIndexRouteImport.update({
+    id: '/withIndex/{-$id}/$category/',
+    path: '/withIndex/{-$id}/$category/',
+    getParentRoute: () => OptionalParamsRouteRoute,
+  } as any)
 const ParamsPsNamedFooBarBazRoute = ParamsPsNamedFooBarBazRouteImport.update({
   id: '/$baz',
   path: '/$baz',
   getParentRoute: () => ParamsPsNamedFooBarRouteRoute,
 } as any)
+const OptionalParamsWithIndexChar123IdChar125CategoryPathIndexRoute =
+  OptionalParamsWithIndexChar123IdChar125CategoryPathIndexRouteImport.update({
+    id: '/withIndex/{-$id}/$category/path/',
+    path: '/withIndex/{-$id}/$category/path/',
+    getParentRoute: () => OptionalParamsRouteRoute,
+  } as any)
+const OptionalParamsWithRequiredParamChar123IdChar125CategoryChar123SlugChar125InfoRoute =
+  OptionalParamsWithRequiredParamChar123IdChar125CategoryChar123SlugChar125InfoRouteImport.update(
+    {
+      id: '/withRequiredParam/{-$id}/$category/{-$slug}/info',
+      path: '/withRequiredParam/{-$id}/$category/{-$slug}/info',
+      getParentRoute: () => OptionalParamsRouteRoute,
+    } as any,
+  )
+const OptionalParamsWithRequiredInBetweenChar123IdChar125CategoryPathChar123SlugChar125Route =
+  OptionalParamsWithRequiredInBetweenChar123IdChar125CategoryPathChar123SlugChar125RouteImport.update(
+    {
+      id: '/withRequiredInBetween/{-$id}/$category/path/{-$slug}',
+      path: '/withRequiredInBetween/{-$id}/$category/path/{-$slug}',
+      getParentRoute: () => OptionalParamsRouteRoute,
+    } as any,
+  )
+const OptionalParamsConsecutiveChar123IdChar125Char123SlugChar125CategoryInfoRoute =
+  OptionalParamsConsecutiveChar123IdChar125Char123SlugChar125CategoryInfoRouteImport.update(
+    {
+      id: '/consecutive/{-$id}/{-$slug}/$category/info',
+      path: '/consecutive/{-$id}/{-$slug}/$category/info',
+      getParentRoute: () => OptionalParamsRouteRoute,
+    } as any,
+  )
 
 export interface FileRoutesByFullPath {
   '/': typeof groupLayoutRouteWithChildren
   '/non-nested': typeof NonNestedRouteRouteWithChildren
+  '/optional-params': typeof OptionalParamsRouteRouteWithChildren
   '/search-params': typeof SearchParamsRouteRouteWithChildren
   '/anchor': typeof AnchorRoute
   '/component-types-test': typeof ComponentTypesTestRoute
@@ -517,7 +579,9 @@ export interface FileRoutesByFullPath {
   '/redirect/$target/': typeof RedirectTargetIndexRoute
   '/params-ps/named/$foo/$bar': typeof ParamsPsNamedFooBarRouteRouteWithChildren
   '/non-nested/baz/$bazid/edit': typeof NonNestedBazBazidEditRoute
+  '/optional-params/simple/{-$id}/path': typeof OptionalParamsSimpleChar123IdChar125PathRoute
   '/params-ps/non-nested/$foo/$bar': typeof ParamsPsNonNestedFooBarRoute
+  '/optional-params/simple/{-$id}': typeof OptionalParamsSimpleChar123IdChar125IndexRoute
   '/relative/link/nested': typeof RelativeLinkNestedIndexRoute
   '/relative/link/path': typeof RelativeLinkPathIndexRoute
   '/relative/link/with-search': typeof RelativeLinkWithSearchIndexRoute
@@ -525,14 +589,20 @@ export interface FileRoutesByFullPath {
   '/relative/useNavigate/path': typeof RelativeUseNavigatePathIndexRoute
   '/relative/useNavigate/with-search': typeof RelativeUseNavigateWithSearchIndexRoute
   '/params-ps/named/$foo/$bar/$baz': typeof ParamsPsNamedFooBarBazRoute
+  '/optional-params/withIndex/{-$id}/$category': typeof OptionalParamsWithIndexChar123IdChar125CategoryIndexRoute
   '/relative/link/nested/deep': typeof RelativeLinkNestedDeepIndexRoute
   '/relative/link/path/$path': typeof RelativeLinkPathPathIndexRoute
   '/relative/useNavigate/nested/deep': typeof RelativeUseNavigateNestedDeepIndexRoute
   '/relative/useNavigate/path/$path': typeof RelativeUseNavigatePathPathIndexRoute
+  '/optional-params/consecutive/{-$id}/{-$slug}/$category/info': typeof OptionalParamsConsecutiveChar123IdChar125Char123SlugChar125CategoryInfoRoute
+  '/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}': typeof OptionalParamsWithRequiredInBetweenChar123IdChar125CategoryPathChar123SlugChar125Route
+  '/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info': typeof OptionalParamsWithRequiredParamChar123IdChar125CategoryChar123SlugChar125InfoRoute
+  '/optional-params/withIndex/{-$id}/$category/path': typeof OptionalParamsWithIndexChar123IdChar125CategoryPathIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof groupLayoutRouteWithChildren
   '/non-nested': typeof NonNestedRouteRouteWithChildren
+  '/optional-params': typeof OptionalParamsRouteRouteWithChildren
   '/anchor': typeof AnchorRoute
   '/component-types-test': typeof ComponentTypesTestRoute
   '/editing-a': typeof EditingARoute
@@ -583,7 +653,9 @@ export interface FileRoutesByTo {
   '/redirect/$target': typeof RedirectTargetIndexRoute
   '/params-ps/named/$foo/$bar': typeof ParamsPsNamedFooBarRouteRouteWithChildren
   '/non-nested/baz/$bazid/edit': typeof NonNestedBazBazidEditRoute
+  '/optional-params/simple/{-$id}/path': typeof OptionalParamsSimpleChar123IdChar125PathRoute
   '/params-ps/non-nested/$foo/$bar': typeof ParamsPsNonNestedFooBarRoute
+  '/optional-params/simple/{-$id}': typeof OptionalParamsSimpleChar123IdChar125IndexRoute
   '/relative/link/nested': typeof RelativeLinkNestedIndexRoute
   '/relative/link/path': typeof RelativeLinkPathIndexRoute
   '/relative/link/with-search': typeof RelativeLinkWithSearchIndexRoute
@@ -591,15 +663,21 @@ export interface FileRoutesByTo {
   '/relative/useNavigate/path': typeof RelativeUseNavigatePathIndexRoute
   '/relative/useNavigate/with-search': typeof RelativeUseNavigateWithSearchIndexRoute
   '/params-ps/named/$foo/$bar/$baz': typeof ParamsPsNamedFooBarBazRoute
+  '/optional-params/withIndex/{-$id}/$category': typeof OptionalParamsWithIndexChar123IdChar125CategoryIndexRoute
   '/relative/link/nested/deep': typeof RelativeLinkNestedDeepIndexRoute
   '/relative/link/path/$path': typeof RelativeLinkPathPathIndexRoute
   '/relative/useNavigate/nested/deep': typeof RelativeUseNavigateNestedDeepIndexRoute
   '/relative/useNavigate/path/$path': typeof RelativeUseNavigatePathPathIndexRoute
+  '/optional-params/consecutive/{-$id}/{-$slug}/$category/info': typeof OptionalParamsConsecutiveChar123IdChar125Char123SlugChar125CategoryInfoRoute
+  '/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}': typeof OptionalParamsWithRequiredInBetweenChar123IdChar125CategoryPathChar123SlugChar125Route
+  '/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info': typeof OptionalParamsWithRequiredParamChar123IdChar125CategoryChar123SlugChar125InfoRoute
+  '/optional-params/withIndex/{-$id}/$category/path': typeof OptionalParamsWithIndexChar123IdChar125CategoryPathIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/non-nested': typeof NonNestedRouteRouteWithChildren
+  '/optional-params': typeof OptionalParamsRouteRouteWithChildren
   '/search-params': typeof SearchParamsRouteRouteWithChildren
   '/_layout': typeof LayoutRouteWithChildren
   '/anchor': typeof AnchorRoute
@@ -657,7 +735,9 @@ export interface FileRoutesById {
   '/redirect/$target/': typeof RedirectTargetIndexRoute
   '/params-ps/named/$foo/$bar': typeof ParamsPsNamedFooBarRouteRouteWithChildren
   '/non-nested/baz_/$bazid/edit': typeof NonNestedBazBazidEditRoute
+  '/optional-params/simple/{-$id}/path': typeof OptionalParamsSimpleChar123IdChar125PathRoute
   '/params-ps/non-nested/$foo_/$bar': typeof ParamsPsNonNestedFooBarRoute
+  '/optional-params/simple/{-$id}/': typeof OptionalParamsSimpleChar123IdChar125IndexRoute
   '/relative/link/nested/': typeof RelativeLinkNestedIndexRoute
   '/relative/link/path/': typeof RelativeLinkPathIndexRoute
   '/relative/link/with-search/': typeof RelativeLinkWithSearchIndexRoute
@@ -665,16 +745,22 @@ export interface FileRoutesById {
   '/relative/useNavigate/path/': typeof RelativeUseNavigatePathIndexRoute
   '/relative/useNavigate/with-search/': typeof RelativeUseNavigateWithSearchIndexRoute
   '/params-ps/named/$foo/$bar/$baz': typeof ParamsPsNamedFooBarBazRoute
+  '/optional-params/withIndex/{-$id}/$category/': typeof OptionalParamsWithIndexChar123IdChar125CategoryIndexRoute
   '/relative/link/nested/deep/': typeof RelativeLinkNestedDeepIndexRoute
   '/relative/link/path/$path/': typeof RelativeLinkPathPathIndexRoute
   '/relative/useNavigate/nested/deep/': typeof RelativeUseNavigateNestedDeepIndexRoute
   '/relative/useNavigate/path/$path/': typeof RelativeUseNavigatePathPathIndexRoute
+  '/optional-params/consecutive/{-$id}/{-$slug}/$category/info': typeof OptionalParamsConsecutiveChar123IdChar125Char123SlugChar125CategoryInfoRoute
+  '/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}': typeof OptionalParamsWithRequiredInBetweenChar123IdChar125CategoryPathChar123SlugChar125Route
+  '/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info': typeof OptionalParamsWithRequiredParamChar123IdChar125CategoryChar123SlugChar125InfoRoute
+  '/optional-params/withIndex/{-$id}/$category/path/': typeof OptionalParamsWithIndexChar123IdChar125CategoryPathIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
     | '/non-nested'
+    | '/optional-params'
     | '/search-params'
     | '/anchor'
     | '/component-types-test'
@@ -728,7 +814,9 @@ export interface FileRouteTypes {
     | '/redirect/$target/'
     | '/params-ps/named/$foo/$bar'
     | '/non-nested/baz/$bazid/edit'
+    | '/optional-params/simple/{-$id}/path'
     | '/params-ps/non-nested/$foo/$bar'
+    | '/optional-params/simple/{-$id}'
     | '/relative/link/nested'
     | '/relative/link/path'
     | '/relative/link/with-search'
@@ -736,14 +824,20 @@ export interface FileRouteTypes {
     | '/relative/useNavigate/path'
     | '/relative/useNavigate/with-search'
     | '/params-ps/named/$foo/$bar/$baz'
+    | '/optional-params/withIndex/{-$id}/$category'
     | '/relative/link/nested/deep'
     | '/relative/link/path/$path'
     | '/relative/useNavigate/nested/deep'
     | '/relative/useNavigate/path/$path'
+    | '/optional-params/consecutive/{-$id}/{-$slug}/$category/info'
+    | '/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}'
+    | '/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info'
+    | '/optional-params/withIndex/{-$id}/$category/path'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/non-nested'
+    | '/optional-params'
     | '/anchor'
     | '/component-types-test'
     | '/editing-a'
@@ -794,7 +888,9 @@ export interface FileRouteTypes {
     | '/redirect/$target'
     | '/params-ps/named/$foo/$bar'
     | '/non-nested/baz/$bazid/edit'
+    | '/optional-params/simple/{-$id}/path'
     | '/params-ps/non-nested/$foo/$bar'
+    | '/optional-params/simple/{-$id}'
     | '/relative/link/nested'
     | '/relative/link/path'
     | '/relative/link/with-search'
@@ -802,14 +898,20 @@ export interface FileRouteTypes {
     | '/relative/useNavigate/path'
     | '/relative/useNavigate/with-search'
     | '/params-ps/named/$foo/$bar/$baz'
+    | '/optional-params/withIndex/{-$id}/$category'
     | '/relative/link/nested/deep'
     | '/relative/link/path/$path'
     | '/relative/useNavigate/nested/deep'
     | '/relative/useNavigate/path/$path'
+    | '/optional-params/consecutive/{-$id}/{-$slug}/$category/info'
+    | '/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}'
+    | '/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info'
+    | '/optional-params/withIndex/{-$id}/$category/path'
   id:
     | '__root__'
     | '/'
     | '/non-nested'
+    | '/optional-params'
     | '/search-params'
     | '/_layout'
     | '/anchor'
@@ -867,7 +969,9 @@ export interface FileRouteTypes {
     | '/redirect/$target/'
     | '/params-ps/named/$foo/$bar'
     | '/non-nested/baz_/$bazid/edit'
+    | '/optional-params/simple/{-$id}/path'
     | '/params-ps/non-nested/$foo_/$bar'
+    | '/optional-params/simple/{-$id}/'
     | '/relative/link/nested/'
     | '/relative/link/path/'
     | '/relative/link/with-search/'
@@ -875,15 +979,21 @@ export interface FileRouteTypes {
     | '/relative/useNavigate/path/'
     | '/relative/useNavigate/with-search/'
     | '/params-ps/named/$foo/$bar/$baz'
+    | '/optional-params/withIndex/{-$id}/$category/'
     | '/relative/link/nested/deep/'
     | '/relative/link/path/$path/'
     | '/relative/useNavigate/nested/deep/'
     | '/relative/useNavigate/path/$path/'
+    | '/optional-params/consecutive/{-$id}/{-$slug}/$category/info'
+    | '/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}'
+    | '/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info'
+    | '/optional-params/withIndex/{-$id}/$category/path/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   NonNestedRouteRoute: typeof NonNestedRouteRouteWithChildren
+  OptionalParamsRouteRoute: typeof OptionalParamsRouteRouteWithChildren
   SearchParamsRouteRoute: typeof SearchParamsRouteRouteWithChildren
   LayoutRoute: typeof LayoutRouteWithChildren
   AnchorRoute: typeof AnchorRoute
@@ -996,6 +1106,13 @@ declare module '@tanstack/react-router' {
       path: '/search-params'
       fullPath: '/search-params'
       preLoaderRoute: typeof SearchParamsRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/optional-params': {
+      id: '/optional-params'
+      path: '/optional-params'
+      fullPath: '/optional-params'
+      preLoaderRoute: typeof OptionalParamsRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/non-nested': {
@@ -1362,12 +1479,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof RelativeLinkNestedIndexRouteImport
       parentRoute: typeof RelativeLinkRouteRoute
     }
+    '/optional-params/simple/{-$id}/': {
+      id: '/optional-params/simple/{-$id}/'
+      path: '/simple/{-$id}'
+      fullPath: '/optional-params/simple/{-$id}'
+      preLoaderRoute: typeof OptionalParamsSimpleChar123IdChar125IndexRouteImport
+      parentRoute: typeof OptionalParamsRouteRoute
+    }
     '/params-ps/non-nested/$foo_/$bar': {
       id: '/params-ps/non-nested/$foo_/$bar'
       path: '/$bar'
       fullPath: '/params-ps/non-nested/$foo/$bar'
       preLoaderRoute: typeof ParamsPsNonNestedFooBarRouteImport
       parentRoute: typeof ParamsPsNonNestedFooRouteRoute
+    }
+    '/optional-params/simple/{-$id}/path': {
+      id: '/optional-params/simple/{-$id}/path'
+      path: '/simple/{-$id}/path'
+      fullPath: '/optional-params/simple/{-$id}/path'
+      preLoaderRoute: typeof OptionalParamsSimpleChar123IdChar125PathRouteImport
+      parentRoute: typeof OptionalParamsRouteRoute
     }
     '/non-nested/baz_/$bazid/edit': {
       id: '/non-nested/baz_/$bazid/edit'
@@ -1411,12 +1542,47 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof RelativeLinkNestedDeepIndexRouteImport
       parentRoute: typeof RelativeLinkRouteRoute
     }
+    '/optional-params/withIndex/{-$id}/$category/': {
+      id: '/optional-params/withIndex/{-$id}/$category/'
+      path: '/withIndex/{-$id}/$category'
+      fullPath: '/optional-params/withIndex/{-$id}/$category'
+      preLoaderRoute: typeof OptionalParamsWithIndexChar123IdChar125CategoryIndexRouteImport
+      parentRoute: typeof OptionalParamsRouteRoute
+    }
     '/params-ps/named/$foo/$bar/$baz': {
       id: '/params-ps/named/$foo/$bar/$baz'
       path: '/$baz'
       fullPath: '/params-ps/named/$foo/$bar/$baz'
       preLoaderRoute: typeof ParamsPsNamedFooBarBazRouteImport
       parentRoute: typeof ParamsPsNamedFooBarRouteRoute
+    }
+    '/optional-params/withIndex/{-$id}/$category/path/': {
+      id: '/optional-params/withIndex/{-$id}/$category/path/'
+      path: '/withIndex/{-$id}/$category/path'
+      fullPath: '/optional-params/withIndex/{-$id}/$category/path'
+      preLoaderRoute: typeof OptionalParamsWithIndexChar123IdChar125CategoryPathIndexRouteImport
+      parentRoute: typeof OptionalParamsRouteRoute
+    }
+    '/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info': {
+      id: '/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info'
+      path: '/withRequiredParam/{-$id}/$category/{-$slug}/info'
+      fullPath: '/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info'
+      preLoaderRoute: typeof OptionalParamsWithRequiredParamChar123IdChar125CategoryChar123SlugChar125InfoRouteImport
+      parentRoute: typeof OptionalParamsRouteRoute
+    }
+    '/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}': {
+      id: '/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}'
+      path: '/withRequiredInBetween/{-$id}/$category/path/{-$slug}'
+      fullPath: '/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}'
+      preLoaderRoute: typeof OptionalParamsWithRequiredInBetweenChar123IdChar125CategoryPathChar123SlugChar125RouteImport
+      parentRoute: typeof OptionalParamsRouteRoute
+    }
+    '/optional-params/consecutive/{-$id}/{-$slug}/$category/info': {
+      id: '/optional-params/consecutive/{-$id}/{-$slug}/$category/info'
+      path: '/consecutive/{-$id}/{-$slug}/$category/info'
+      fullPath: '/optional-params/consecutive/{-$id}/{-$slug}/$category/info'
+      preLoaderRoute: typeof OptionalParamsConsecutiveChar123IdChar125Char123SlugChar125CategoryInfoRouteImport
+      parentRoute: typeof OptionalParamsRouteRoute
     }
   }
 }
@@ -1446,6 +1612,36 @@ const NonNestedRouteRouteChildren: NonNestedRouteRouteChildren = {
 const NonNestedRouteRouteWithChildren = NonNestedRouteRoute._addFileChildren(
   NonNestedRouteRouteChildren,
 )
+
+interface OptionalParamsRouteRouteChildren {
+  OptionalParamsSimpleChar123IdChar125PathRoute: typeof OptionalParamsSimpleChar123IdChar125PathRoute
+  OptionalParamsSimpleChar123IdChar125IndexRoute: typeof OptionalParamsSimpleChar123IdChar125IndexRoute
+  OptionalParamsWithIndexChar123IdChar125CategoryIndexRoute: typeof OptionalParamsWithIndexChar123IdChar125CategoryIndexRoute
+  OptionalParamsConsecutiveChar123IdChar125Char123SlugChar125CategoryInfoRoute: typeof OptionalParamsConsecutiveChar123IdChar125Char123SlugChar125CategoryInfoRoute
+  OptionalParamsWithRequiredInBetweenChar123IdChar125CategoryPathChar123SlugChar125Route: typeof OptionalParamsWithRequiredInBetweenChar123IdChar125CategoryPathChar123SlugChar125Route
+  OptionalParamsWithRequiredParamChar123IdChar125CategoryChar123SlugChar125InfoRoute: typeof OptionalParamsWithRequiredParamChar123IdChar125CategoryChar123SlugChar125InfoRoute
+  OptionalParamsWithIndexChar123IdChar125CategoryPathIndexRoute: typeof OptionalParamsWithIndexChar123IdChar125CategoryPathIndexRoute
+}
+
+const OptionalParamsRouteRouteChildren: OptionalParamsRouteRouteChildren = {
+  OptionalParamsSimpleChar123IdChar125PathRoute:
+    OptionalParamsSimpleChar123IdChar125PathRoute,
+  OptionalParamsSimpleChar123IdChar125IndexRoute:
+    OptionalParamsSimpleChar123IdChar125IndexRoute,
+  OptionalParamsWithIndexChar123IdChar125CategoryIndexRoute:
+    OptionalParamsWithIndexChar123IdChar125CategoryIndexRoute,
+  OptionalParamsConsecutiveChar123IdChar125Char123SlugChar125CategoryInfoRoute:
+    OptionalParamsConsecutiveChar123IdChar125Char123SlugChar125CategoryInfoRoute,
+  OptionalParamsWithRequiredInBetweenChar123IdChar125CategoryPathChar123SlugChar125Route:
+    OptionalParamsWithRequiredInBetweenChar123IdChar125CategoryPathChar123SlugChar125Route,
+  OptionalParamsWithRequiredParamChar123IdChar125CategoryChar123SlugChar125InfoRoute:
+    OptionalParamsWithRequiredParamChar123IdChar125CategoryChar123SlugChar125InfoRoute,
+  OptionalParamsWithIndexChar123IdChar125CategoryPathIndexRoute:
+    OptionalParamsWithIndexChar123IdChar125CategoryPathIndexRoute,
+}
+
+const OptionalParamsRouteRouteWithChildren =
+  OptionalParamsRouteRoute._addFileChildren(OptionalParamsRouteRouteChildren)
 
 interface SearchParamsRouteRouteChildren {
   SearchParamsDefaultRoute: typeof SearchParamsDefaultRoute
@@ -1653,6 +1849,7 @@ const ParamsPsNamedFooRouteRouteWithChildren =
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   NonNestedRouteRoute: NonNestedRouteRouteWithChildren,
+  OptionalParamsRouteRoute: OptionalParamsRouteRouteWithChildren,
   SearchParamsRouteRoute: SearchParamsRouteRouteWithChildren,
   LayoutRoute: LayoutRouteWithChildren,
   AnchorRoute: AnchorRoute,

--- a/e2e/react-router/basic-file-based/src/routes/optional-params/consecutive/{-$id}.{-$slug}.$category.info.tsx
+++ b/e2e/react-router/basic-file-based/src/routes/optional-params/consecutive/{-$id}.{-$slug}.$category.info.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute(
+  '/optional-params/consecutive/{-$id}/{-$slug}/$category/info',
+)({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const params = Route.useParams()
+  return (
+    <>
+      <div data-testid="consecutive-heading">
+        Hello "/optional-params/consecutive/-$id/-$slug/$category/info"!
+      </div>
+      <div>
+        params:{' '}
+        <span data-testid="consecutive-id-slug-category-info-params">
+          {JSON.stringify(params)}
+        </span>
+      </div>
+    </>
+  )
+}

--- a/e2e/react-router/basic-file-based/src/routes/optional-params/route.tsx
+++ b/e2e/react-router/basic-file-based/src/routes/optional-params/route.tsx
@@ -1,0 +1,243 @@
+import { Link, Outlet, createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/optional-params')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  return (
+    <div>
+      <h3 className="pb-2">optional path params</h3>
+      <ul className="grid mb-2">
+        <div>simple optional path param usage</div>
+        <div className="ml-5">
+          <li>
+            <Link
+              data-testid="l-to-simple-index"
+              to="/optional-params/simple/{-$id}"
+              params={{
+                id: undefined,
+              }}
+            >
+              /optionals/simple
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-simple-id-index"
+              to="/optional-params/simple/{-$id}"
+              params={{ id: 'id' }}
+            >
+              /optionals/simple/id
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-simple-path"
+              to="/optional-params/simple/{-$id}/path"
+              params={{ id: undefined }}
+            >
+              /optionals/simple/path
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-simple-id-path"
+              to="/optional-params/simple/{-$id}/path"
+              params={{ id: 'id' }}
+            >
+              /optionals/simple/id/path
+            </Link>
+          </li>
+        </div>
+        <hr />
+        <div>With path params and index page</div>
+        <div className="ml-5">
+          <li>
+            <Link
+              data-testid="l-to-withIndex-category-index"
+              to="/optional-params/withIndex/{-$id}/$category"
+              params={{
+                id: undefined,
+                category: 'category',
+              }}
+            >
+              /optionals/withIndex/category
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-withIndex-id-category-index"
+              to="/optional-params/withIndex/{-$id}/$category"
+              params={{
+                id: 'id',
+                category: 'category',
+              }}
+            >
+              /optionals/withIndex/id/category
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-withIndex-category-path"
+              to="/optional-params/withIndex/{-$id}/$category/path"
+              params={{
+                id: undefined,
+                category: 'category',
+              }}
+            >
+              /optionals/withIndex/category/path
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-withIndex-id-category-path"
+              to="/optional-params/withIndex/{-$id}/$category/path"
+              params={{
+                id: 'id',
+                category: 'category',
+              }}
+            >
+              /optionals/withIndex/id/category/path
+            </Link>{' '}
+          </li>
+        </div>
+        <hr />
+        <div>Consecutive path params</div>
+        <div className="ml-5">
+          <li>
+            <Link
+              data-testid="l-to-consecutive-category-info"
+              to="/optional-params/consecutive/{-$id}/{-$slug}/$category/info"
+              params={{
+                id: undefined,
+                slug: undefined,
+                category: 'category',
+              }}
+            >
+              /optionals/consecutive/category/info
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-consecutive-id-category-info"
+              to="/optional-params/consecutive/{-$id}/{-$slug}/$category/info"
+              params={{ id: 'id', slug: undefined, category: 'category' }}
+            >
+              /optionals/consecutive/id1/category/info
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-consecutive-slug-category-info"
+              to="/optional-params/consecutive/{-$id}/{-$slug}/$category/info"
+              params={{ id: undefined, slug: 'slug', category: 'category' }}
+            >
+              /optionals/consecutive/slug/category/info
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-consecutive-id-slug-category-info"
+              to="/optional-params/consecutive/{-$id}/{-$slug}/$category/info"
+              params={{ id: 'id', slug: 'slug', category: 'category' }}
+            >
+              /optionals/consecutive/id1/slug/category/info
+            </Link>
+          </li>
+        </div>
+        <hr />
+        <div>Required path in between optional and path params</div>
+        <div className="ml-5">
+          <li>
+            <Link
+              data-testid="l-to-withRequiredInBetween-category"
+              to="/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}"
+              params={{
+                id: undefined,
+                slug: undefined,
+                category: 'category',
+              }}
+            >
+              /optionals/withRequiredInBetween/category/path
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-withRequiredInBetween-id-category"
+              to="/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}"
+              params={{ id: 'id', slug: undefined, category: 'category' }}
+            >
+              /optionals/withRequiredInBetween/id/category/path
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-withRequiredInBetween-category-slug"
+              to="/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}"
+              params={{ id: undefined, slug: 'slug', category: 'category' }}
+            >
+              /optionals/withRequiredInBetween/category/path/slug
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-withRequiredInBetween-id-category-slug"
+              to="/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}"
+              params={{ id: 'id', slug: 'slug', category: 'category' }}
+            >
+              /optionals/withRequiredInBetween/id/category/path/slug
+            </Link>
+          </li>
+        </div>
+
+        <hr />
+        <div>Required Param in between optional path params</div>
+        <div className="ml-5">
+          <li>
+            <Link
+              data-testid="l-to-withRequiredParam-category"
+              to="/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info"
+              params={{
+                id: undefined,
+                slug: undefined,
+                category: 'category',
+              }}
+            >
+              /optionals/withRequiredParam/category/info
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-withRequiredParam-id-category"
+              to="/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info"
+              params={{ id: 'id', slug: undefined, category: 'category' }}
+            >
+              /optionals/withRequiredParam/id1/category/info
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-withRequiredParam-category-slug"
+              to="/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info"
+              params={{ id: undefined, slug: 'slug', category: 'category' }}
+            >
+              /optionals/withRequiredParam/category/slug/info
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-withRequiredParam-id-category-slug"
+              to="/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info"
+              params={{ id: 'id', slug: 'slug', category: 'category' }}
+            >
+              /optionals/withRequiredParam/id1/category/slug/info
+            </Link>
+          </li>
+        </div>
+      </ul>
+      <hr />
+      <Outlet />
+    </div>
+  )
+}

--- a/e2e/react-router/basic-file-based/src/routes/optional-params/simple/{-$id}.index.tsx
+++ b/e2e/react-router/basic-file-based/src/routes/optional-params/simple/{-$id}.index.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/optional-params/simple/{-$id}/')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const params = Route.useParams()
+
+  return (
+    <div data-testid="simple-index-heading">
+      Hello "/optional-params/simple/-$id/"!
+      <span data-testid="simple-index-params">{JSON.stringify(params)}</span>
+    </div>
+  )
+}

--- a/e2e/react-router/basic-file-based/src/routes/optional-params/simple/{-$id}.path.tsx
+++ b/e2e/react-router/basic-file-based/src/routes/optional-params/simple/{-$id}.path.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/optional-params/simple/{-$id}/path')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const params = Route.useParams()
+  return (
+    <div data-testid="simple-path-heading">
+      Hello "/optional-params/simple/-$id/path"!
+      <span data-testid="simple-path-params">{JSON.stringify(params)}</span>
+    </div>
+  )
+}

--- a/e2e/react-router/basic-file-based/src/routes/optional-params/withIndex/{-$id}.$category.index.tsx
+++ b/e2e/react-router/basic-file-based/src/routes/optional-params/withIndex/{-$id}.$category.index.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute(
+  '/optional-params/withIndex/{-$id}/$category/',
+)({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const params = Route.useParams()
+  return (
+    <div data-testid="withIndex-index-heading">
+      Hello "/optional-params/withIndex/-$id/$category/"!
+      <span data-testid="withIndex-index-params">{JSON.stringify(params)}</span>
+    </div>
+  )
+}

--- a/e2e/react-router/basic-file-based/src/routes/optional-params/withIndex/{-$id}.$category.path.index.tsx
+++ b/e2e/react-router/basic-file-based/src/routes/optional-params/withIndex/{-$id}.$category.path.index.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute(
+  '/optional-params/withIndex/{-$id}/$category/path/',
+)({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const params = Route.useParams()
+  return (
+    <div data-testid="withIndex-path-heading">
+      Hello "/optional-params/withIndex/-$id/$category/path"!
+      <span data-testid="withIndex-path-params">{JSON.stringify(params)}</span>
+    </div>
+  )
+}

--- a/e2e/react-router/basic-file-based/src/routes/optional-params/withRequiredInBetween/{-$id}.$category.path.{-$slug}.tsx
+++ b/e2e/react-router/basic-file-based/src/routes/optional-params/withRequiredInBetween/{-$id}.$category.path.{-$slug}.tsx
@@ -1,0 +1,26 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute(
+  '/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}',
+)({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const params = Route.useParams()
+
+  return (
+    <>
+      <div data-testid="withRequiredInBetween-heading">
+        Hello
+        "/optional-params/withRequiredInBetween/-$id/$category/path/$slug"!
+      </div>
+      <div>
+        params:{' '}
+        <span data-testid="withRequiredInBetween-id-category-path-slug-params">
+          {JSON.stringify(params)}
+        </span>
+      </div>
+    </>
+  )
+}

--- a/e2e/react-router/basic-file-based/src/routes/optional-params/withRequiredParam/{-$id}.$category.{-$slug}.info.tsx
+++ b/e2e/react-router/basic-file-based/src/routes/optional-params/withRequiredParam/{-$id}.$category.{-$slug}.info.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute(
+  '/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info',
+)({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const params = Route.useParams()
+  return (
+    <>
+      <div data-testid="withRequiredParam-heading">
+        Hello "/optional-params/-$id/$category/-$slug/info"! aaaa
+      </div>
+      <div>
+        params:{' '}
+        <span data-testid="withRequiredParam-id-category-slug-info-params">
+          {JSON.stringify(params)}
+        </span>
+      </div>
+    </>
+  )
+}

--- a/e2e/react-router/basic-file-based/tests/optionalParams.spec.ts
+++ b/e2e/react-router/basic-file-based/tests/optionalParams.spec.ts
@@ -1,0 +1,430 @@
+import { expect, test } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/')
+})
+
+test.describe('ensure paths with optional params are resolved correctly', () => {
+  test('simple optional param usage', async ({ page }) => {
+    await page.goto('/optional-params')
+    let pagePathname = ''
+
+    const simpleIndexLink = page.getByTestId('l-to-simple-index')
+    const simpleIdIndexLink = page.getByTestId('l-to-simple-id-index')
+    const simplePathLink = page.getByTestId('l-to-simple-path')
+    const simpleIdPathLink = page.getByTestId('l-to-simple-id-path')
+
+    await expect(simpleIndexLink).toHaveAttribute(
+      'href',
+      '/optional-params/simple',
+    )
+    await expect(simpleIdIndexLink).toHaveAttribute(
+      'href',
+      '/optional-params/simple/id',
+    )
+    await expect(simplePathLink).toHaveAttribute(
+      'href',
+      '/optional-params/simple/path',
+    )
+    await expect(simpleIdPathLink).toHaveAttribute(
+      'href',
+      '/optional-params/simple/id/path',
+    )
+
+    await simpleIndexLink.click()
+    await page.waitForURL('/optional-params/simple')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe('/optional-params/simple')
+    await expect(page.getByTestId('simple-index-heading')).toBeInViewport()
+    expect(await page.getByTestId('simple-index-params').innerText()).toEqual(
+      JSON.stringify({}),
+    )
+
+    await simpleIdIndexLink.click()
+    await page.waitForURL('/optional-params/simple/id')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe('/optional-params/simple/id')
+    await expect(page.getByTestId('simple-index-heading')).toBeInViewport()
+    expect(await page.getByTestId('simple-index-params').innerText()).toEqual(
+      JSON.stringify({ id: 'id' }),
+    )
+
+    await simplePathLink.click()
+    await page.waitForURL('/optional-params/simple/path')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe('/optional-params/simple/path')
+    await expect(page.getByTestId('simple-path-heading')).toBeInViewport()
+    expect(await page.getByTestId('simple-path-params').innerText()).toEqual(
+      JSON.stringify({}),
+    )
+
+    await simpleIdPathLink.click()
+    await page.waitForURL('/optional-params/simple/id/path')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe('/optional-params/simple/id/path')
+    await expect(page.getByTestId('simple-path-heading')).toBeInViewport()
+    expect(await page.getByTestId('simple-path-params').innerText()).toEqual(
+      JSON.stringify({ id: 'id' }),
+    )
+  })
+
+  test('with index pages, path params and optional params', async ({
+    page,
+  }) => {
+    await page.goto('/optional-params')
+    let pagePathname = ''
+
+    const withIndexCategoryLink = page.getByTestId(
+      'l-to-withIndex-category-index',
+    )
+    const withIndexIdCategoryLink = page.getByTestId(
+      'l-to-withIndex-id-category-index',
+    )
+    const withIndexCategoryPathLink = page.getByTestId(
+      'l-to-withIndex-category-path',
+    )
+    const withIndexIdCategoryPathLink = page.getByTestId(
+      'l-to-withIndex-id-category-path',
+    )
+
+    await expect(withIndexCategoryLink).toHaveAttribute(
+      'href',
+      '/optional-params/withIndex/category',
+    )
+    await expect(withIndexIdCategoryLink).toHaveAttribute(
+      'href',
+      '/optional-params/withIndex/id/category',
+    )
+    await expect(withIndexCategoryPathLink).toHaveAttribute(
+      'href',
+      '/optional-params/withIndex/category/path',
+    )
+    await expect(withIndexIdCategoryPathLink).toHaveAttribute(
+      'href',
+      '/optional-params/withIndex/id/category/path',
+    )
+
+    await withIndexCategoryLink.click()
+    await page.waitForURL('/optional-params/withIndex/category')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe('/optional-params/withIndex/category')
+    await expect(page.getByTestId('withIndex-index-heading')).toBeInViewport()
+    expect(
+      await page.getByTestId('withIndex-index-params').innerText(),
+    ).toEqual(JSON.stringify({ category: 'category' }))
+
+    await withIndexIdCategoryLink.click()
+    await page.waitForURL('/optional-params/withIndex/id/category')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe('/optional-params/withIndex/id/category')
+    await expect(page.getByTestId('withIndex-index-heading')).toBeInViewport()
+    expect(
+      await page.getByTestId('withIndex-index-params').innerText(),
+    ).toEqual(JSON.stringify({ id: 'id', category: 'category' }))
+
+    await withIndexCategoryPathLink.click()
+    await page.waitForURL('/optional-params/withIndex/category/path')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe('/optional-params/withIndex/category/path')
+    await expect(page.getByTestId('withIndex-path-heading')).toBeInViewport()
+    expect(await page.getByTestId('withIndex-path-params').innerText()).toEqual(
+      JSON.stringify({ category: 'category' }),
+    )
+
+    await withIndexIdCategoryPathLink.click()
+    await page.waitForURL('/optional-params/withIndex/id/category/path')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe('/optional-params/withIndex/id/category/path')
+    await expect(page.getByTestId('withIndex-path-heading')).toBeInViewport()
+    expect(await page.getByTestId('withIndex-path-params').innerText()).toEqual(
+      JSON.stringify({ id: 'id', category: 'category' }),
+    )
+  })
+
+  test('with consecutive optional params', async ({ page }) => {
+    await page.goto('/optional-params')
+    let pagePathname = ''
+
+    const withNoOptionalsLink = page.getByTestId(
+      'l-to-consecutive-category-info',
+    )
+    const withOptionalIdLink = page.getByTestId(
+      'l-to-consecutive-id-category-info',
+    )
+    const withOptionalSlugLink = page.getByTestId(
+      'l-to-consecutive-slug-category-info',
+    )
+    const withOptionalIdSlugLink = page.getByTestId(
+      'l-to-consecutive-id-slug-category-info',
+    )
+
+    await expect(withNoOptionalsLink).toHaveAttribute(
+      'href',
+      '/optional-params/consecutive/category/info',
+    )
+    await expect(withOptionalIdLink).toHaveAttribute(
+      'href',
+      '/optional-params/consecutive/id/category/info',
+    )
+    await expect(withOptionalSlugLink).toHaveAttribute(
+      'href',
+      '/optional-params/consecutive/slug/category/info',
+    )
+    await expect(withOptionalIdSlugLink).toHaveAttribute(
+      'href',
+      '/optional-params/consecutive/id/slug/category/info',
+    )
+
+    await withNoOptionalsLink.click()
+    await page.waitForURL('/optional-params/consecutive/category/info')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe('/optional-params/consecutive/category/info')
+    await expect(page.getByTestId('consecutive-heading')).toBeInViewport()
+    expect(
+      await page
+        .getByTestId('consecutive-id-slug-category-info-params')
+        .innerText(),
+    ).toEqual(JSON.stringify({ category: 'category' }))
+
+    await withOptionalIdLink.click()
+    await page.waitForURL('/optional-params/consecutive/id/category/info')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe('/optional-params/consecutive/id/category/info')
+    await expect(page.getByTestId('consecutive-heading')).toBeInViewport()
+    expect(
+      await page
+        .getByTestId('consecutive-id-slug-category-info-params')
+        .innerText(),
+    ).toEqual(JSON.stringify({ id: 'id', category: 'category' }))
+
+    await withOptionalSlugLink.click()
+    await page.waitForURL('/optional-params/consecutive/slug/category/info')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe('/optional-params/consecutive/slug/category/info')
+    await expect(page.getByTestId('consecutive-heading')).toBeInViewport()
+    expect(
+      await page
+        .getByTestId('consecutive-id-slug-category-info-params')
+        .innerText(),
+    ).not.toEqual(JSON.stringify({ slug: 'slug', category: 'category' }))
+
+    expect(
+      await page
+        .getByTestId('consecutive-id-slug-category-info-params')
+        .innerText(),
+    ).toEqual(JSON.stringify({ id: 'slug', category: 'category' }))
+
+    await withOptionalIdSlugLink.click()
+    await page.waitForURL('/optional-params/consecutive/id/slug/category/info')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe(
+      '/optional-params/consecutive/id/slug/category/info',
+    )
+    await expect(page.getByTestId('consecutive-heading')).toBeInViewport()
+    expect(
+      await page
+        .getByTestId('consecutive-id-slug-category-info-params')
+        .innerText(),
+    ).toEqual(JSON.stringify({ id: 'id', slug: 'slug', category: 'category' }))
+  })
+
+  test('with required path between optional params', async ({ page }) => {
+    await page.goto('/optional-params')
+    let pagePathname = ''
+
+    const withNoOptionalsLink = page.getByTestId(
+      'l-to-withRequiredInBetween-category',
+    )
+    const withOptionalIdLink = page.getByTestId(
+      'l-to-withRequiredInBetween-id-category',
+    )
+    const withOptionalSlugLink = page.getByTestId(
+      'l-to-withRequiredInBetween-category-slug',
+    )
+    const withOptionalIdSlugLink = page.getByTestId(
+      'l-to-withRequiredInBetween-id-category-slug',
+    )
+
+    await expect(withNoOptionalsLink).toHaveAttribute(
+      'href',
+      '/optional-params/withRequiredInBetween/category/path',
+    )
+    await expect(withOptionalIdLink).toHaveAttribute(
+      'href',
+      '/optional-params/withRequiredInBetween/id/category/path',
+    )
+    await expect(withOptionalSlugLink).toHaveAttribute(
+      'href',
+      '/optional-params/withRequiredInBetween/category/path/slug',
+    )
+    await expect(withOptionalIdSlugLink).toHaveAttribute(
+      'href',
+      '/optional-params/withRequiredInBetween/id/category/path/slug',
+    )
+
+    await withNoOptionalsLink.click()
+    await page.waitForURL(
+      '/optional-params/withRequiredInBetween/category/path',
+    )
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe(
+      '/optional-params/withRequiredInBetween/category/path',
+    )
+    await expect(
+      page.getByTestId('withRequiredInBetween-heading'),
+    ).toBeInViewport()
+    expect(
+      await page
+        .getByTestId('withRequiredInBetween-id-category-path-slug-params')
+        .innerText(),
+    ).toEqual(JSON.stringify({ category: 'category' }))
+
+    await withOptionalIdLink.click()
+    await page.waitForURL(
+      '/optional-params/withRequiredInBetween/id/category/path',
+    )
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe(
+      '/optional-params/withRequiredInBetween/id/category/path',
+    )
+    await expect(
+      page.getByTestId('withRequiredInBetween-heading'),
+    ).toBeInViewport()
+    expect(
+      await page
+        .getByTestId('withRequiredInBetween-id-category-path-slug-params')
+        .innerText(),
+    ).toEqual(JSON.stringify({ id: 'id', category: 'category' }))
+
+    await withOptionalSlugLink.click()
+    await page.waitForURL(
+      '/optional-params/withRequiredInBetween/category/path/slug',
+    )
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe(
+      '/optional-params/withRequiredInBetween/category/path/slug',
+    )
+    await expect(
+      page.getByTestId('withRequiredInBetween-heading'),
+    ).toBeInViewport()
+    expect(
+      await page
+        .getByTestId('withRequiredInBetween-id-category-path-slug-params')
+        .innerText(),
+    ).toEqual(JSON.stringify({ category: 'category', slug: 'slug' }))
+
+    await withOptionalIdSlugLink.click()
+    await page.waitForURL(
+      '/optional-params/withRequiredInBetween/id/category/path/slug',
+    )
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe(
+      '/optional-params/withRequiredInBetween/id/category/path/slug',
+    )
+    await expect(
+      page.getByTestId('withRequiredInBetween-heading'),
+    ).toBeInViewport()
+    expect(
+      await page
+        .getByTestId('withRequiredInBetween-id-category-path-slug-params')
+        .innerText(),
+    ).toEqual(JSON.stringify({ id: 'id', category: 'category', slug: 'slug' }))
+  })
+
+  test('with required params between optional params', async ({ page }) => {
+    await page.goto('/optional-params')
+    let pagePathname = ''
+
+    const withNoOptionalsLink = page.getByTestId(
+      'l-to-withRequiredParam-category',
+    )
+    const withOptionalIdLink = page.getByTestId(
+      'l-to-withRequiredParam-id-category',
+    )
+    const withOptionalSlugLink = page.getByTestId(
+      'l-to-withRequiredParam-category-slug',
+    )
+    const withOptionalIdSlugLink = page.getByTestId(
+      'l-to-withRequiredParam-id-category-slug',
+    )
+
+    await expect(withNoOptionalsLink).toHaveAttribute(
+      'href',
+      '/optional-params/withRequiredParam/category/info',
+    )
+    await expect(withOptionalIdLink).toHaveAttribute(
+      'href',
+      '/optional-params/withRequiredParam/id/category/info',
+    )
+    await expect(withOptionalSlugLink).toHaveAttribute(
+      'href',
+      '/optional-params/withRequiredParam/category/slug/info',
+    )
+    await expect(withOptionalIdSlugLink).toHaveAttribute(
+      'href',
+      '/optional-params/withRequiredParam/id/category/slug/info',
+    )
+
+    await withNoOptionalsLink.click()
+    await page.waitForURL('/optional-params/withRequiredParam/category/info')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe(
+      '/optional-params/withRequiredParam/category/info',
+    )
+    await expect(page.getByTestId('withRequiredParam-heading')).toBeInViewport()
+    expect(
+      await page
+        .getByTestId('withRequiredParam-id-category-slug-info-params')
+        .innerText(),
+    ).toEqual(JSON.stringify({ category: 'category' }))
+
+    await withOptionalIdLink.click()
+    await page.waitForURL('/optional-params/withRequiredParam/id/category/info')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe(
+      '/optional-params/withRequiredParam/id/category/info',
+    )
+    await expect(page.getByTestId('withRequiredParam-heading')).toBeInViewport()
+    expect(
+      await page
+        .getByTestId('withRequiredParam-id-category-slug-info-params')
+        .innerText(),
+    ).toEqual(JSON.stringify({ id: 'id', category: 'category' }))
+
+    await withOptionalSlugLink.click()
+    await page.waitForURL(
+      '/optional-params/withRequiredParam/category/slug/info',
+    )
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe(
+      '/optional-params/withRequiredParam/category/slug/info',
+    )
+    await expect(page.getByTestId('withRequiredParam-heading')).toBeInViewport()
+    expect(
+      await page
+        .getByTestId('withRequiredParam-id-category-slug-info-params')
+        .innerText(),
+    ).not.toEqual(JSON.stringify({ category: 'category', slug: 'slug' }))
+
+    expect(
+      await page
+        .getByTestId('withRequiredParam-id-category-slug-info-params')
+        .innerText(),
+    ).toEqual(JSON.stringify({ id: 'category', category: 'slug' }))
+
+    await withOptionalIdSlugLink.click()
+    await page.waitForURL(
+      '/optional-params/withRequiredParam/id/category/slug/info',
+    )
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe(
+      '/optional-params/withRequiredParam/id/category/slug/info',
+    )
+    await expect(page.getByTestId('withRequiredParam-heading')).toBeInViewport()
+    expect(
+      await page
+        .getByTestId('withRequiredParam-id-category-slug-info-params')
+        .innerText(),
+    ).toEqual(JSON.stringify({ id: 'id', category: 'category', slug: 'slug' }))
+  })
+})

--- a/e2e/solid-router/basic-file-based/src/routeTree.gen.ts
+++ b/e2e/solid-router/basic-file-based/src/routeTree.gen.ts
@@ -20,6 +20,7 @@ import { Route as ComponentTypesTestRouteImport } from './routes/component-types
 import { Route as AnchorRouteImport } from './routes/anchor'
 import { Route as LayoutRouteImport } from './routes/_layout'
 import { Route as SearchParamsRouteRouteImport } from './routes/search-params/route'
+import { Route as OptionalParamsRouteRouteImport } from './routes/optional-params/route'
 import { Route as NonNestedRouteRouteImport } from './routes/non-nested/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SearchParamsIndexRouteImport } from './routes/search-params/index'
@@ -64,14 +65,21 @@ import { Route as RelativeUseNavigateNestedIndexRouteImport } from './routes/rel
 import { Route as RelativeLinkWithSearchIndexRouteImport } from './routes/relative/link/with-search/index'
 import { Route as RelativeLinkPathIndexRouteImport } from './routes/relative/link/path/index'
 import { Route as RelativeLinkNestedIndexRouteImport } from './routes/relative/link/nested/index'
+import { Route as OptionalParamsSimpleChar123IdChar125IndexRouteImport } from './routes/optional-params/simple/{-$id}.index'
 import { Route as ParamsPsNonNestedFooBarRouteImport } from './routes/params-ps/non-nested/$foo_/$bar'
+import { Route as OptionalParamsSimpleChar123IdChar125PathRouteImport } from './routes/optional-params/simple/{-$id}.path'
 import { Route as NonNestedBazBazidEditRouteImport } from './routes/non-nested/baz_.$bazid.edit'
 import { Route as ParamsPsNamedFooBarRouteRouteImport } from './routes/params-ps/named/$foo/$bar.route'
 import { Route as RelativeUseNavigatePathPathIndexRouteImport } from './routes/relative/useNavigate/path/$path/index'
 import { Route as RelativeUseNavigateNestedDeepIndexRouteImport } from './routes/relative/useNavigate/nested/deep/index'
 import { Route as RelativeLinkPathPathIndexRouteImport } from './routes/relative/link/path/$path/index'
 import { Route as RelativeLinkNestedDeepIndexRouteImport } from './routes/relative/link/nested/deep/index'
+import { Route as OptionalParamsWithIndexChar123IdChar125CategoryIndexRouteImport } from './routes/optional-params/withIndex/{-$id}.$category.index'
 import { Route as ParamsPsNamedFooBarBazRouteImport } from './routes/params-ps/named/$foo/$bar.$baz'
+import { Route as OptionalParamsWithIndexChar123IdChar125CategoryPathIndexRouteImport } from './routes/optional-params/withIndex/{-$id}.$category.path.index'
+import { Route as OptionalParamsWithRequiredParamChar123IdChar125CategoryChar123SlugChar125InfoRouteImport } from './routes/optional-params/withRequiredParam/{-$id}.$category.{-$slug}.info'
+import { Route as OptionalParamsWithRequiredInBetweenChar123IdChar125CategoryPathChar123SlugChar125RouteImport } from './routes/optional-params/withRequiredInBetween/{-$id}.$category.path.{-$slug}'
+import { Route as OptionalParamsConsecutiveChar123IdChar125Char123SlugChar125CategoryInfoRouteImport } from './routes/optional-params/consecutive/{-$id}.{-$slug}.$category.info'
 
 const groupRouteImport = createFileRoute('/(group)')()
 
@@ -121,6 +129,11 @@ const LayoutRoute = LayoutRouteImport.update({
 const SearchParamsRouteRoute = SearchParamsRouteRouteImport.update({
   id: '/search-params',
   path: '/search-params',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OptionalParamsRouteRoute = OptionalParamsRouteRouteImport.update({
+  id: '/optional-params',
+  path: '/optional-params',
   getParentRoute: () => rootRouteImport,
 } as any)
 const NonNestedRouteRoute = NonNestedRouteRouteImport.update({
@@ -355,11 +368,23 @@ const RelativeLinkNestedIndexRoute = RelativeLinkNestedIndexRouteImport.update({
   path: '/nested/',
   getParentRoute: () => RelativeLinkRouteRoute,
 } as any)
+const OptionalParamsSimpleChar123IdChar125IndexRoute =
+  OptionalParamsSimpleChar123IdChar125IndexRouteImport.update({
+    id: '/simple/{-$id}/',
+    path: '/simple/{-$id}/',
+    getParentRoute: () => OptionalParamsRouteRoute,
+  } as any)
 const ParamsPsNonNestedFooBarRoute = ParamsPsNonNestedFooBarRouteImport.update({
   id: '/$bar',
   path: '/$bar',
   getParentRoute: () => ParamsPsNonNestedFooRouteRoute,
 } as any)
+const OptionalParamsSimpleChar123IdChar125PathRoute =
+  OptionalParamsSimpleChar123IdChar125PathRouteImport.update({
+    id: '/simple/{-$id}/path',
+    path: '/simple/{-$id}/path',
+    getParentRoute: () => OptionalParamsRouteRoute,
+  } as any)
 const NonNestedBazBazidEditRoute = NonNestedBazBazidEditRouteImport.update({
   id: '/baz_/$bazid/edit',
   path: '/baz/$bazid/edit',
@@ -395,15 +420,52 @@ const RelativeLinkNestedDeepIndexRoute =
     path: '/nested/deep/',
     getParentRoute: () => RelativeLinkRouteRoute,
   } as any)
+const OptionalParamsWithIndexChar123IdChar125CategoryIndexRoute =
+  OptionalParamsWithIndexChar123IdChar125CategoryIndexRouteImport.update({
+    id: '/withIndex/{-$id}/$category/',
+    path: '/withIndex/{-$id}/$category/',
+    getParentRoute: () => OptionalParamsRouteRoute,
+  } as any)
 const ParamsPsNamedFooBarBazRoute = ParamsPsNamedFooBarBazRouteImport.update({
   id: '/$baz',
   path: '/$baz',
   getParentRoute: () => ParamsPsNamedFooBarRouteRoute,
 } as any)
+const OptionalParamsWithIndexChar123IdChar125CategoryPathIndexRoute =
+  OptionalParamsWithIndexChar123IdChar125CategoryPathIndexRouteImport.update({
+    id: '/withIndex/{-$id}/$category/path/',
+    path: '/withIndex/{-$id}/$category/path/',
+    getParentRoute: () => OptionalParamsRouteRoute,
+  } as any)
+const OptionalParamsWithRequiredParamChar123IdChar125CategoryChar123SlugChar125InfoRoute =
+  OptionalParamsWithRequiredParamChar123IdChar125CategoryChar123SlugChar125InfoRouteImport.update(
+    {
+      id: '/withRequiredParam/{-$id}/$category/{-$slug}/info',
+      path: '/withRequiredParam/{-$id}/$category/{-$slug}/info',
+      getParentRoute: () => OptionalParamsRouteRoute,
+    } as any,
+  )
+const OptionalParamsWithRequiredInBetweenChar123IdChar125CategoryPathChar123SlugChar125Route =
+  OptionalParamsWithRequiredInBetweenChar123IdChar125CategoryPathChar123SlugChar125RouteImport.update(
+    {
+      id: '/withRequiredInBetween/{-$id}/$category/path/{-$slug}',
+      path: '/withRequiredInBetween/{-$id}/$category/path/{-$slug}',
+      getParentRoute: () => OptionalParamsRouteRoute,
+    } as any,
+  )
+const OptionalParamsConsecutiveChar123IdChar125Char123SlugChar125CategoryInfoRoute =
+  OptionalParamsConsecutiveChar123IdChar125Char123SlugChar125CategoryInfoRouteImport.update(
+    {
+      id: '/consecutive/{-$id}/{-$slug}/$category/info',
+      path: '/consecutive/{-$id}/{-$slug}/$category/info',
+      getParentRoute: () => OptionalParamsRouteRoute,
+    } as any,
+  )
 
 export interface FileRoutesByFullPath {
   '/': typeof groupLayoutRouteWithChildren
   '/non-nested': typeof NonNestedRouteRouteWithChildren
+  '/optional-params': typeof OptionalParamsRouteRouteWithChildren
   '/search-params': typeof SearchParamsRouteRouteWithChildren
   '/anchor': typeof AnchorRoute
   '/component-types-test': typeof ComponentTypesTestRoute
@@ -448,7 +510,9 @@ export interface FileRoutesByFullPath {
   '/redirect/$target/': typeof RedirectTargetIndexRoute
   '/params-ps/named/$foo/$bar': typeof ParamsPsNamedFooBarRouteRouteWithChildren
   '/non-nested/baz/$bazid/edit': typeof NonNestedBazBazidEditRoute
+  '/optional-params/simple/{-$id}/path': typeof OptionalParamsSimpleChar123IdChar125PathRoute
   '/params-ps/non-nested/$foo/$bar': typeof ParamsPsNonNestedFooBarRoute
+  '/optional-params/simple/{-$id}': typeof OptionalParamsSimpleChar123IdChar125IndexRoute
   '/relative/link/nested': typeof RelativeLinkNestedIndexRoute
   '/relative/link/path': typeof RelativeLinkPathIndexRoute
   '/relative/link/with-search': typeof RelativeLinkWithSearchIndexRoute
@@ -456,14 +520,20 @@ export interface FileRoutesByFullPath {
   '/relative/useNavigate/path': typeof RelativeUseNavigatePathIndexRoute
   '/relative/useNavigate/with-search': typeof RelativeUseNavigateWithSearchIndexRoute
   '/params-ps/named/$foo/$bar/$baz': typeof ParamsPsNamedFooBarBazRoute
+  '/optional-params/withIndex/{-$id}/$category': typeof OptionalParamsWithIndexChar123IdChar125CategoryIndexRoute
   '/relative/link/nested/deep': typeof RelativeLinkNestedDeepIndexRoute
   '/relative/link/path/$path': typeof RelativeLinkPathPathIndexRoute
   '/relative/useNavigate/nested/deep': typeof RelativeUseNavigateNestedDeepIndexRoute
   '/relative/useNavigate/path/$path': typeof RelativeUseNavigatePathPathIndexRoute
+  '/optional-params/consecutive/{-$id}/{-$slug}/$category/info': typeof OptionalParamsConsecutiveChar123IdChar125Char123SlugChar125CategoryInfoRoute
+  '/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}': typeof OptionalParamsWithRequiredInBetweenChar123IdChar125CategoryPathChar123SlugChar125Route
+  '/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info': typeof OptionalParamsWithRequiredParamChar123IdChar125CategoryChar123SlugChar125InfoRoute
+  '/optional-params/withIndex/{-$id}/$category/path': typeof OptionalParamsWithIndexChar123IdChar125CategoryPathIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof groupLayoutRouteWithChildren
   '/non-nested': typeof NonNestedRouteRouteWithChildren
+  '/optional-params': typeof OptionalParamsRouteRouteWithChildren
   '/anchor': typeof AnchorRoute
   '/component-types-test': typeof ComponentTypesTestRoute
   '/editing-a': typeof EditingARoute
@@ -505,7 +575,9 @@ export interface FileRoutesByTo {
   '/redirect/$target': typeof RedirectTargetIndexRoute
   '/params-ps/named/$foo/$bar': typeof ParamsPsNamedFooBarRouteRouteWithChildren
   '/non-nested/baz/$bazid/edit': typeof NonNestedBazBazidEditRoute
+  '/optional-params/simple/{-$id}/path': typeof OptionalParamsSimpleChar123IdChar125PathRoute
   '/params-ps/non-nested/$foo/$bar': typeof ParamsPsNonNestedFooBarRoute
+  '/optional-params/simple/{-$id}': typeof OptionalParamsSimpleChar123IdChar125IndexRoute
   '/relative/link/nested': typeof RelativeLinkNestedIndexRoute
   '/relative/link/path': typeof RelativeLinkPathIndexRoute
   '/relative/link/with-search': typeof RelativeLinkWithSearchIndexRoute
@@ -513,15 +585,21 @@ export interface FileRoutesByTo {
   '/relative/useNavigate/path': typeof RelativeUseNavigatePathIndexRoute
   '/relative/useNavigate/with-search': typeof RelativeUseNavigateWithSearchIndexRoute
   '/params-ps/named/$foo/$bar/$baz': typeof ParamsPsNamedFooBarBazRoute
+  '/optional-params/withIndex/{-$id}/$category': typeof OptionalParamsWithIndexChar123IdChar125CategoryIndexRoute
   '/relative/link/nested/deep': typeof RelativeLinkNestedDeepIndexRoute
   '/relative/link/path/$path': typeof RelativeLinkPathPathIndexRoute
   '/relative/useNavigate/nested/deep': typeof RelativeUseNavigateNestedDeepIndexRoute
   '/relative/useNavigate/path/$path': typeof RelativeUseNavigatePathPathIndexRoute
+  '/optional-params/consecutive/{-$id}/{-$slug}/$category/info': typeof OptionalParamsConsecutiveChar123IdChar125Char123SlugChar125CategoryInfoRoute
+  '/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}': typeof OptionalParamsWithRequiredInBetweenChar123IdChar125CategoryPathChar123SlugChar125Route
+  '/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info': typeof OptionalParamsWithRequiredParamChar123IdChar125CategoryChar123SlugChar125InfoRoute
+  '/optional-params/withIndex/{-$id}/$category/path': typeof OptionalParamsWithIndexChar123IdChar125CategoryPathIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/non-nested': typeof NonNestedRouteRouteWithChildren
+  '/optional-params': typeof OptionalParamsRouteRouteWithChildren
   '/search-params': typeof SearchParamsRouteRouteWithChildren
   '/_layout': typeof LayoutRouteWithChildren
   '/anchor': typeof AnchorRoute
@@ -570,7 +648,9 @@ export interface FileRoutesById {
   '/redirect/$target/': typeof RedirectTargetIndexRoute
   '/params-ps/named/$foo/$bar': typeof ParamsPsNamedFooBarRouteRouteWithChildren
   '/non-nested/baz_/$bazid/edit': typeof NonNestedBazBazidEditRoute
+  '/optional-params/simple/{-$id}/path': typeof OptionalParamsSimpleChar123IdChar125PathRoute
   '/params-ps/non-nested/$foo_/$bar': typeof ParamsPsNonNestedFooBarRoute
+  '/optional-params/simple/{-$id}/': typeof OptionalParamsSimpleChar123IdChar125IndexRoute
   '/relative/link/nested/': typeof RelativeLinkNestedIndexRoute
   '/relative/link/path/': typeof RelativeLinkPathIndexRoute
   '/relative/link/with-search/': typeof RelativeLinkWithSearchIndexRoute
@@ -578,16 +658,22 @@ export interface FileRoutesById {
   '/relative/useNavigate/path/': typeof RelativeUseNavigatePathIndexRoute
   '/relative/useNavigate/with-search/': typeof RelativeUseNavigateWithSearchIndexRoute
   '/params-ps/named/$foo/$bar/$baz': typeof ParamsPsNamedFooBarBazRoute
+  '/optional-params/withIndex/{-$id}/$category/': typeof OptionalParamsWithIndexChar123IdChar125CategoryIndexRoute
   '/relative/link/nested/deep/': typeof RelativeLinkNestedDeepIndexRoute
   '/relative/link/path/$path/': typeof RelativeLinkPathPathIndexRoute
   '/relative/useNavigate/nested/deep/': typeof RelativeUseNavigateNestedDeepIndexRoute
   '/relative/useNavigate/path/$path/': typeof RelativeUseNavigatePathPathIndexRoute
+  '/optional-params/consecutive/{-$id}/{-$slug}/$category/info': typeof OptionalParamsConsecutiveChar123IdChar125Char123SlugChar125CategoryInfoRoute
+  '/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}': typeof OptionalParamsWithRequiredInBetweenChar123IdChar125CategoryPathChar123SlugChar125Route
+  '/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info': typeof OptionalParamsWithRequiredParamChar123IdChar125CategoryChar123SlugChar125InfoRoute
+  '/optional-params/withIndex/{-$id}/$category/path/': typeof OptionalParamsWithIndexChar123IdChar125CategoryPathIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
     | '/non-nested'
+    | '/optional-params'
     | '/search-params'
     | '/anchor'
     | '/component-types-test'
@@ -632,7 +718,9 @@ export interface FileRouteTypes {
     | '/redirect/$target/'
     | '/params-ps/named/$foo/$bar'
     | '/non-nested/baz/$bazid/edit'
+    | '/optional-params/simple/{-$id}/path'
     | '/params-ps/non-nested/$foo/$bar'
+    | '/optional-params/simple/{-$id}'
     | '/relative/link/nested'
     | '/relative/link/path'
     | '/relative/link/with-search'
@@ -640,14 +728,20 @@ export interface FileRouteTypes {
     | '/relative/useNavigate/path'
     | '/relative/useNavigate/with-search'
     | '/params-ps/named/$foo/$bar/$baz'
+    | '/optional-params/withIndex/{-$id}/$category'
     | '/relative/link/nested/deep'
     | '/relative/link/path/$path'
     | '/relative/useNavigate/nested/deep'
     | '/relative/useNavigate/path/$path'
+    | '/optional-params/consecutive/{-$id}/{-$slug}/$category/info'
+    | '/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}'
+    | '/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info'
+    | '/optional-params/withIndex/{-$id}/$category/path'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/non-nested'
+    | '/optional-params'
     | '/anchor'
     | '/component-types-test'
     | '/editing-a'
@@ -689,7 +783,9 @@ export interface FileRouteTypes {
     | '/redirect/$target'
     | '/params-ps/named/$foo/$bar'
     | '/non-nested/baz/$bazid/edit'
+    | '/optional-params/simple/{-$id}/path'
     | '/params-ps/non-nested/$foo/$bar'
+    | '/optional-params/simple/{-$id}'
     | '/relative/link/nested'
     | '/relative/link/path'
     | '/relative/link/with-search'
@@ -697,14 +793,20 @@ export interface FileRouteTypes {
     | '/relative/useNavigate/path'
     | '/relative/useNavigate/with-search'
     | '/params-ps/named/$foo/$bar/$baz'
+    | '/optional-params/withIndex/{-$id}/$category'
     | '/relative/link/nested/deep'
     | '/relative/link/path/$path'
     | '/relative/useNavigate/nested/deep'
     | '/relative/useNavigate/path/$path'
+    | '/optional-params/consecutive/{-$id}/{-$slug}/$category/info'
+    | '/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}'
+    | '/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info'
+    | '/optional-params/withIndex/{-$id}/$category/path'
   id:
     | '__root__'
     | '/'
     | '/non-nested'
+    | '/optional-params'
     | '/search-params'
     | '/_layout'
     | '/anchor'
@@ -753,7 +855,9 @@ export interface FileRouteTypes {
     | '/redirect/$target/'
     | '/params-ps/named/$foo/$bar'
     | '/non-nested/baz_/$bazid/edit'
+    | '/optional-params/simple/{-$id}/path'
     | '/params-ps/non-nested/$foo_/$bar'
+    | '/optional-params/simple/{-$id}/'
     | '/relative/link/nested/'
     | '/relative/link/path/'
     | '/relative/link/with-search/'
@@ -761,15 +865,21 @@ export interface FileRouteTypes {
     | '/relative/useNavigate/path/'
     | '/relative/useNavigate/with-search/'
     | '/params-ps/named/$foo/$bar/$baz'
+    | '/optional-params/withIndex/{-$id}/$category/'
     | '/relative/link/nested/deep/'
     | '/relative/link/path/$path/'
     | '/relative/useNavigate/nested/deep/'
     | '/relative/useNavigate/path/$path/'
+    | '/optional-params/consecutive/{-$id}/{-$slug}/$category/info'
+    | '/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}'
+    | '/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info'
+    | '/optional-params/withIndex/{-$id}/$category/path/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   NonNestedRouteRoute: typeof NonNestedRouteRouteWithChildren
+  OptionalParamsRouteRoute: typeof OptionalParamsRouteRouteWithChildren
   SearchParamsRouteRoute: typeof SearchParamsRouteRouteWithChildren
   LayoutRoute: typeof LayoutRouteWithChildren
   AnchorRoute: typeof AnchorRoute
@@ -866,6 +976,13 @@ declare module '@tanstack/solid-router' {
       path: '/search-params'
       fullPath: '/search-params'
       preLoaderRoute: typeof SearchParamsRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/optional-params': {
+      id: '/optional-params'
+      path: '/optional-params'
+      fullPath: '/optional-params'
+      preLoaderRoute: typeof OptionalParamsRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/non-nested': {
@@ -1176,12 +1293,26 @@ declare module '@tanstack/solid-router' {
       preLoaderRoute: typeof RelativeLinkNestedIndexRouteImport
       parentRoute: typeof RelativeLinkRouteRoute
     }
+    '/optional-params/simple/{-$id}/': {
+      id: '/optional-params/simple/{-$id}/'
+      path: '/simple/{-$id}'
+      fullPath: '/optional-params/simple/{-$id}'
+      preLoaderRoute: typeof OptionalParamsSimpleChar123IdChar125IndexRouteImport
+      parentRoute: typeof OptionalParamsRouteRoute
+    }
     '/params-ps/non-nested/$foo_/$bar': {
       id: '/params-ps/non-nested/$foo_/$bar'
       path: '/$bar'
       fullPath: '/params-ps/non-nested/$foo/$bar'
       preLoaderRoute: typeof ParamsPsNonNestedFooBarRouteImport
       parentRoute: typeof ParamsPsNonNestedFooRouteRoute
+    }
+    '/optional-params/simple/{-$id}/path': {
+      id: '/optional-params/simple/{-$id}/path'
+      path: '/simple/{-$id}/path'
+      fullPath: '/optional-params/simple/{-$id}/path'
+      preLoaderRoute: typeof OptionalParamsSimpleChar123IdChar125PathRouteImport
+      parentRoute: typeof OptionalParamsRouteRoute
     }
     '/non-nested/baz_/$bazid/edit': {
       id: '/non-nested/baz_/$bazid/edit'
@@ -1225,12 +1356,47 @@ declare module '@tanstack/solid-router' {
       preLoaderRoute: typeof RelativeLinkNestedDeepIndexRouteImport
       parentRoute: typeof RelativeLinkRouteRoute
     }
+    '/optional-params/withIndex/{-$id}/$category/': {
+      id: '/optional-params/withIndex/{-$id}/$category/'
+      path: '/withIndex/{-$id}/$category'
+      fullPath: '/optional-params/withIndex/{-$id}/$category'
+      preLoaderRoute: typeof OptionalParamsWithIndexChar123IdChar125CategoryIndexRouteImport
+      parentRoute: typeof OptionalParamsRouteRoute
+    }
     '/params-ps/named/$foo/$bar/$baz': {
       id: '/params-ps/named/$foo/$bar/$baz'
       path: '/$baz'
       fullPath: '/params-ps/named/$foo/$bar/$baz'
       preLoaderRoute: typeof ParamsPsNamedFooBarBazRouteImport
       parentRoute: typeof ParamsPsNamedFooBarRouteRoute
+    }
+    '/optional-params/withIndex/{-$id}/$category/path/': {
+      id: '/optional-params/withIndex/{-$id}/$category/path/'
+      path: '/withIndex/{-$id}/$category/path'
+      fullPath: '/optional-params/withIndex/{-$id}/$category/path'
+      preLoaderRoute: typeof OptionalParamsWithIndexChar123IdChar125CategoryPathIndexRouteImport
+      parentRoute: typeof OptionalParamsRouteRoute
+    }
+    '/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info': {
+      id: '/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info'
+      path: '/withRequiredParam/{-$id}/$category/{-$slug}/info'
+      fullPath: '/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info'
+      preLoaderRoute: typeof OptionalParamsWithRequiredParamChar123IdChar125CategoryChar123SlugChar125InfoRouteImport
+      parentRoute: typeof OptionalParamsRouteRoute
+    }
+    '/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}': {
+      id: '/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}'
+      path: '/withRequiredInBetween/{-$id}/$category/path/{-$slug}'
+      fullPath: '/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}'
+      preLoaderRoute: typeof OptionalParamsWithRequiredInBetweenChar123IdChar125CategoryPathChar123SlugChar125RouteImport
+      parentRoute: typeof OptionalParamsRouteRoute
+    }
+    '/optional-params/consecutive/{-$id}/{-$slug}/$category/info': {
+      id: '/optional-params/consecutive/{-$id}/{-$slug}/$category/info'
+      path: '/consecutive/{-$id}/{-$slug}/$category/info'
+      fullPath: '/optional-params/consecutive/{-$id}/{-$slug}/$category/info'
+      preLoaderRoute: typeof OptionalParamsConsecutiveChar123IdChar125Char123SlugChar125CategoryInfoRouteImport
+      parentRoute: typeof OptionalParamsRouteRoute
     }
   }
 }
@@ -1260,6 +1426,36 @@ const NonNestedRouteRouteChildren: NonNestedRouteRouteChildren = {
 const NonNestedRouteRouteWithChildren = NonNestedRouteRoute._addFileChildren(
   NonNestedRouteRouteChildren,
 )
+
+interface OptionalParamsRouteRouteChildren {
+  OptionalParamsSimpleChar123IdChar125PathRoute: typeof OptionalParamsSimpleChar123IdChar125PathRoute
+  OptionalParamsSimpleChar123IdChar125IndexRoute: typeof OptionalParamsSimpleChar123IdChar125IndexRoute
+  OptionalParamsWithIndexChar123IdChar125CategoryIndexRoute: typeof OptionalParamsWithIndexChar123IdChar125CategoryIndexRoute
+  OptionalParamsConsecutiveChar123IdChar125Char123SlugChar125CategoryInfoRoute: typeof OptionalParamsConsecutiveChar123IdChar125Char123SlugChar125CategoryInfoRoute
+  OptionalParamsWithRequiredInBetweenChar123IdChar125CategoryPathChar123SlugChar125Route: typeof OptionalParamsWithRequiredInBetweenChar123IdChar125CategoryPathChar123SlugChar125Route
+  OptionalParamsWithRequiredParamChar123IdChar125CategoryChar123SlugChar125InfoRoute: typeof OptionalParamsWithRequiredParamChar123IdChar125CategoryChar123SlugChar125InfoRoute
+  OptionalParamsWithIndexChar123IdChar125CategoryPathIndexRoute: typeof OptionalParamsWithIndexChar123IdChar125CategoryPathIndexRoute
+}
+
+const OptionalParamsRouteRouteChildren: OptionalParamsRouteRouteChildren = {
+  OptionalParamsSimpleChar123IdChar125PathRoute:
+    OptionalParamsSimpleChar123IdChar125PathRoute,
+  OptionalParamsSimpleChar123IdChar125IndexRoute:
+    OptionalParamsSimpleChar123IdChar125IndexRoute,
+  OptionalParamsWithIndexChar123IdChar125CategoryIndexRoute:
+    OptionalParamsWithIndexChar123IdChar125CategoryIndexRoute,
+  OptionalParamsConsecutiveChar123IdChar125Char123SlugChar125CategoryInfoRoute:
+    OptionalParamsConsecutiveChar123IdChar125Char123SlugChar125CategoryInfoRoute,
+  OptionalParamsWithRequiredInBetweenChar123IdChar125CategoryPathChar123SlugChar125Route:
+    OptionalParamsWithRequiredInBetweenChar123IdChar125CategoryPathChar123SlugChar125Route,
+  OptionalParamsWithRequiredParamChar123IdChar125CategoryChar123SlugChar125InfoRoute:
+    OptionalParamsWithRequiredParamChar123IdChar125CategoryChar123SlugChar125InfoRoute,
+  OptionalParamsWithIndexChar123IdChar125CategoryPathIndexRoute:
+    OptionalParamsWithIndexChar123IdChar125CategoryPathIndexRoute,
+}
+
+const OptionalParamsRouteRouteWithChildren =
+  OptionalParamsRouteRoute._addFileChildren(OptionalParamsRouteRouteChildren)
 
 interface SearchParamsRouteRouteChildren {
   SearchParamsDefaultRoute: typeof SearchParamsDefaultRoute
@@ -1467,6 +1663,7 @@ const ParamsPsNamedFooRouteRouteWithChildren =
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   NonNestedRouteRoute: NonNestedRouteRouteWithChildren,
+  OptionalParamsRouteRoute: OptionalParamsRouteRouteWithChildren,
   SearchParamsRouteRoute: SearchParamsRouteRouteWithChildren,
   LayoutRoute: LayoutRouteWithChildren,
   AnchorRoute: AnchorRoute,

--- a/e2e/solid-router/basic-file-based/src/routes/optional-params/consecutive/{-$id}.{-$slug}.$category.info.tsx
+++ b/e2e/solid-router/basic-file-based/src/routes/optional-params/consecutive/{-$id}.{-$slug}.$category.info.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute } from '@tanstack/solid-router'
+
+export const Route = createFileRoute(
+  '/optional-params/consecutive/{-$id}/{-$slug}/$category/info',
+)({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const params = Route.useParams()
+  return (
+    <>
+      <div data-testid="consecutive-heading">
+        Hello "/optional-params/consecutive/-$id/-$slug/$category/info"!
+      </div>
+      <div>
+        params:{' '}
+        <span data-testid="consecutive-id-slug-category-info-params">
+          {JSON.stringify(params())}
+        </span>
+      </div>
+    </>
+  )
+}

--- a/e2e/solid-router/basic-file-based/src/routes/optional-params/route.tsx
+++ b/e2e/solid-router/basic-file-based/src/routes/optional-params/route.tsx
@@ -1,0 +1,243 @@
+import { Link, Outlet, createFileRoute } from '@tanstack/solid-router'
+
+export const Route = createFileRoute('/optional-params')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  return (
+    <div>
+      <h3 class="pb-2">optional path params</h3>
+      <ul class="grid mb-2">
+        <div>simple optional path param usage</div>
+        <div class="ml-5">
+          <li>
+            <Link
+              data-testid="l-to-simple-index"
+              to="/optional-params/simple/{-$id}"
+              params={{
+                id: undefined,
+              }}
+            >
+              /optionals/simple
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-simple-id-index"
+              to="/optional-params/simple/{-$id}"
+              params={{ id: 'id' }}
+            >
+              /optionals/simple/id
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-simple-path"
+              to="/optional-params/simple/{-$id}/path"
+              params={{ id: undefined }}
+            >
+              /optionals/simple/path
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-simple-id-path"
+              to="/optional-params/simple/{-$id}/path"
+              params={{ id: 'id' }}
+            >
+              /optionals/simple/id/path
+            </Link>
+          </li>
+        </div>
+        <hr />
+        <div>With path params and index page</div>
+        <div class="ml-5">
+          <li>
+            <Link
+              data-testid="l-to-withIndex-category-index"
+              to="/optional-params/withIndex/{-$id}/$category"
+              params={{
+                id: undefined,
+                category: 'category',
+              }}
+            >
+              /optionals/withIndex/category
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-withIndex-id-category-index"
+              to="/optional-params/withIndex/{-$id}/$category"
+              params={{
+                id: 'id',
+                category: 'category',
+              }}
+            >
+              /optionals/withIndex/id/category
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-withIndex-category-path"
+              to="/optional-params/withIndex/{-$id}/$category/path"
+              params={{
+                id: undefined,
+                category: 'category',
+              }}
+            >
+              /optionals/withIndex/category/path
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-withIndex-id-category-path"
+              to="/optional-params/withIndex/{-$id}/$category/path"
+              params={{
+                id: 'id',
+                category: 'category',
+              }}
+            >
+              /optionals/withIndex/id/category/path
+            </Link>{' '}
+          </li>
+        </div>
+        <hr />
+        <div>Consecutive path params</div>
+        <div class="ml-5">
+          <li>
+            <Link
+              data-testid="l-to-consecutive-category-info"
+              to="/optional-params/consecutive/{-$id}/{-$slug}/$category/info"
+              params={{
+                id: undefined,
+                slug: undefined,
+                category: 'category',
+              }}
+            >
+              /optionals/consecutive/category/info
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-consecutive-id-category-info"
+              to="/optional-params/consecutive/{-$id}/{-$slug}/$category/info"
+              params={{ id: 'id', slug: undefined, category: 'category' }}
+            >
+              /optionals/consecutive/id1/category/info
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-consecutive-slug-category-info"
+              to="/optional-params/consecutive/{-$id}/{-$slug}/$category/info"
+              params={{ id: undefined, slug: 'slug', category: 'category' }}
+            >
+              /optionals/consecutive/slug/category/info
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-consecutive-id-slug-category-info"
+              to="/optional-params/consecutive/{-$id}/{-$slug}/$category/info"
+              params={{ id: 'id', slug: 'slug', category: 'category' }}
+            >
+              /optionals/consecutive/id1/slug/category/info
+            </Link>
+          </li>
+        </div>
+        <hr />
+        <div>Required path in between optional and path params</div>
+        <div class="ml-5">
+          <li>
+            <Link
+              data-testid="l-to-withRequiredInBetween-category"
+              to="/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}"
+              params={{
+                id: undefined,
+                slug: undefined,
+                category: 'category',
+              }}
+            >
+              /optionals/withRequiredInBetween/category/path
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-withRequiredInBetween-id-category"
+              to="/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}"
+              params={{ id: 'id', slug: undefined, category: 'category' }}
+            >
+              /optionals/withRequiredInBetween/id/category/path
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-withRequiredInBetween-category-slug"
+              to="/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}"
+              params={{ id: undefined, slug: 'slug', category: 'category' }}
+            >
+              /optionals/withRequiredInBetween/category/path/slug
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-withRequiredInBetween-id-category-slug"
+              to="/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}"
+              params={{ id: 'id', slug: 'slug', category: 'category' }}
+            >
+              /optionals/withRequiredInBetween/id/category/path/slug
+            </Link>
+          </li>
+        </div>
+
+        <hr />
+        <div>Required Param in between optional path params</div>
+        <div class="ml-5">
+          <li>
+            <Link
+              data-testid="l-to-withRequiredParam-category"
+              to="/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info"
+              params={{
+                id: undefined,
+                slug: undefined,
+                category: 'category',
+              }}
+            >
+              /optionals/withRequiredParam/category/info
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-withRequiredParam-id-category"
+              to="/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info"
+              params={{ id: 'id', slug: undefined, category: 'category' }}
+            >
+              /optionals/withRequiredParam/id1/category/info
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-withRequiredParam-category-slug"
+              to="/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info"
+              params={{ id: undefined, slug: 'slug', category: 'category' }}
+            >
+              /optionals/withRequiredParam/category/slug/info
+            </Link>{' '}
+          </li>
+          <li>
+            <Link
+              data-testid="l-to-withRequiredParam-id-category-slug"
+              to="/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info"
+              params={{ id: 'id', slug: 'slug', category: 'category' }}
+            >
+              /optionals/withRequiredParam/id1/category/slug/info
+            </Link>
+          </li>
+        </div>
+      </ul>
+      <hr />
+      <Outlet />
+    </div>
+  )
+}

--- a/e2e/solid-router/basic-file-based/src/routes/optional-params/simple/{-$id}.index.tsx
+++ b/e2e/solid-router/basic-file-based/src/routes/optional-params/simple/{-$id}.index.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from '@tanstack/solid-router'
+
+export const Route = createFileRoute('/optional-params/simple/{-$id}/')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const params = Route.useParams()
+
+  return (
+    <div data-testid="simple-index-heading">
+      Hello "/optional-params/simple/-$id/"!
+      <span data-testid="simple-index-params">{JSON.stringify(params())}</span>
+    </div>
+  )
+}

--- a/e2e/solid-router/basic-file-based/src/routes/optional-params/simple/{-$id}.path.tsx
+++ b/e2e/solid-router/basic-file-based/src/routes/optional-params/simple/{-$id}.path.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute } from '@tanstack/solid-router'
+
+export const Route = createFileRoute('/optional-params/simple/{-$id}/path')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const params = Route.useParams()
+  return (
+    <div data-testid="simple-path-heading">
+      Hello "/optional-params/simple/-$id/path"!
+      <span data-testid="simple-path-params">{JSON.stringify(params())}</span>
+    </div>
+  )
+}

--- a/e2e/solid-router/basic-file-based/src/routes/optional-params/withIndex/{-$id}.$category.index.tsx
+++ b/e2e/solid-router/basic-file-based/src/routes/optional-params/withIndex/{-$id}.$category.index.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from '@tanstack/solid-router'
+
+export const Route = createFileRoute(
+  '/optional-params/withIndex/{-$id}/$category/',
+)({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const params = Route.useParams()
+  return (
+    <div data-testid="withIndex-index-heading">
+      Hello "/optional-params/withIndex/-$id/$category/"!
+      <span data-testid="withIndex-index-params">
+        {JSON.stringify(params())}
+      </span>
+    </div>
+  )
+}

--- a/e2e/solid-router/basic-file-based/src/routes/optional-params/withIndex/{-$id}.$category.path.index.tsx
+++ b/e2e/solid-router/basic-file-based/src/routes/optional-params/withIndex/{-$id}.$category.path.index.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from '@tanstack/solid-router'
+
+export const Route = createFileRoute(
+  '/optional-params/withIndex/{-$id}/$category/path/',
+)({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const params = Route.useParams()
+  return (
+    <div data-testid="withIndex-path-heading">
+      Hello "/optional-params/withIndex/-$id/$category/path"!
+      <span data-testid="withIndex-path-params">
+        {JSON.stringify(params())}
+      </span>
+    </div>
+  )
+}

--- a/e2e/solid-router/basic-file-based/src/routes/optional-params/withRequiredInBetween/{-$id}.$category.path.{-$slug}.tsx
+++ b/e2e/solid-router/basic-file-based/src/routes/optional-params/withRequiredInBetween/{-$id}.$category.path.{-$slug}.tsx
@@ -1,0 +1,26 @@
+import { createFileRoute } from '@tanstack/solid-router'
+
+export const Route = createFileRoute(
+  '/optional-params/withRequiredInBetween/{-$id}/$category/path/{-$slug}',
+)({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const params = Route.useParams()
+
+  return (
+    <>
+      <div data-testid="withRequiredInBetween-heading">
+        Hello
+        "/optional-params/withRequiredInBetween/-$id/$category/path/$slug"!
+      </div>
+      <div>
+        params:{' '}
+        <span data-testid="withRequiredInBetween-id-category-path-slug-params">
+          {JSON.stringify(params())}
+        </span>
+      </div>
+    </>
+  )
+}

--- a/e2e/solid-router/basic-file-based/src/routes/optional-params/withRequiredParam/{-$id}.$category.{-$slug}.info.tsx
+++ b/e2e/solid-router/basic-file-based/src/routes/optional-params/withRequiredParam/{-$id}.$category.{-$slug}.info.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute } from '@tanstack/solid-router'
+
+export const Route = createFileRoute(
+  '/optional-params/withRequiredParam/{-$id}/$category/{-$slug}/info',
+)({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const params = Route.useParams()
+  return (
+    <>
+      <div data-testid="withRequiredParam-heading">
+        Hello "/optional-params/-$id/$category/-$slug/info"! aaaa
+      </div>
+      <div>
+        params:{' '}
+        <span data-testid="withRequiredParam-id-category-slug-info-params">
+          {JSON.stringify(params())}
+        </span>
+      </div>
+    </>
+  )
+}

--- a/e2e/solid-router/basic-file-based/tests/optionalParams.spec.ts
+++ b/e2e/solid-router/basic-file-based/tests/optionalParams.spec.ts
@@ -1,0 +1,430 @@
+import { expect, test } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/')
+})
+
+test.describe('ensure paths with optional params are resolved correctly', () => {
+  test('simple optional param usage', async ({ page }) => {
+    await page.goto('/optional-params')
+    let pagePathname = ''
+
+    const simpleIndexLink = page.getByTestId('l-to-simple-index')
+    const simpleIdIndexLink = page.getByTestId('l-to-simple-id-index')
+    const simplePathLink = page.getByTestId('l-to-simple-path')
+    const simpleIdPathLink = page.getByTestId('l-to-simple-id-path')
+
+    await expect(simpleIndexLink).toHaveAttribute(
+      'href',
+      '/optional-params/simple',
+    )
+    await expect(simpleIdIndexLink).toHaveAttribute(
+      'href',
+      '/optional-params/simple/id',
+    )
+    await expect(simplePathLink).toHaveAttribute(
+      'href',
+      '/optional-params/simple/path',
+    )
+    await expect(simpleIdPathLink).toHaveAttribute(
+      'href',
+      '/optional-params/simple/id/path',
+    )
+
+    await simpleIndexLink.click()
+    await page.waitForURL('/optional-params/simple')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe('/optional-params/simple')
+    await expect(page.getByTestId('simple-index-heading')).toBeInViewport()
+    expect(await page.getByTestId('simple-index-params').innerText()).toEqual(
+      JSON.stringify({}),
+    )
+
+    await simpleIdIndexLink.click()
+    await page.waitForURL('/optional-params/simple/id')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe('/optional-params/simple/id')
+    await expect(page.getByTestId('simple-index-heading')).toBeInViewport()
+    expect(await page.getByTestId('simple-index-params').innerText()).toEqual(
+      JSON.stringify({ id: 'id' }),
+    )
+
+    await simplePathLink.click()
+    await page.waitForURL('/optional-params/simple/path')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe('/optional-params/simple/path')
+    await expect(page.getByTestId('simple-path-heading')).toBeInViewport()
+    expect(await page.getByTestId('simple-path-params').innerText()).toEqual(
+      JSON.stringify({}),
+    )
+
+    await simpleIdPathLink.click()
+    await page.waitForURL('/optional-params/simple/id/path')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe('/optional-params/simple/id/path')
+    await expect(page.getByTestId('simple-path-heading')).toBeInViewport()
+    expect(await page.getByTestId('simple-path-params').innerText()).toEqual(
+      JSON.stringify({ id: 'id' }),
+    )
+  })
+
+  test('with index pages, path params and optional params', async ({
+    page,
+  }) => {
+    await page.goto('/optional-params')
+    let pagePathname = ''
+
+    const withIndexCategoryLink = page.getByTestId(
+      'l-to-withIndex-category-index',
+    )
+    const withIndexIdCategoryLink = page.getByTestId(
+      'l-to-withIndex-id-category-index',
+    )
+    const withIndexCategoryPathLink = page.getByTestId(
+      'l-to-withIndex-category-path',
+    )
+    const withIndexIdCategoryPathLink = page.getByTestId(
+      'l-to-withIndex-id-category-path',
+    )
+
+    await expect(withIndexCategoryLink).toHaveAttribute(
+      'href',
+      '/optional-params/withIndex/category',
+    )
+    await expect(withIndexIdCategoryLink).toHaveAttribute(
+      'href',
+      '/optional-params/withIndex/id/category',
+    )
+    await expect(withIndexCategoryPathLink).toHaveAttribute(
+      'href',
+      '/optional-params/withIndex/category/path',
+    )
+    await expect(withIndexIdCategoryPathLink).toHaveAttribute(
+      'href',
+      '/optional-params/withIndex/id/category/path',
+    )
+
+    await withIndexCategoryLink.click()
+    await page.waitForURL('/optional-params/withIndex/category')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe('/optional-params/withIndex/category')
+    await expect(page.getByTestId('withIndex-index-heading')).toBeInViewport()
+    expect(
+      await page.getByTestId('withIndex-index-params').innerText(),
+    ).toEqual(JSON.stringify({ category: 'category' }))
+
+    await withIndexIdCategoryLink.click()
+    await page.waitForURL('/optional-params/withIndex/id/category')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe('/optional-params/withIndex/id/category')
+    await expect(page.getByTestId('withIndex-index-heading')).toBeInViewport()
+    expect(
+      await page.getByTestId('withIndex-index-params').innerText(),
+    ).toEqual(JSON.stringify({ id: 'id', category: 'category' }))
+
+    await withIndexCategoryPathLink.click()
+    await page.waitForURL('/optional-params/withIndex/category/path')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe('/optional-params/withIndex/category/path')
+    await expect(page.getByTestId('withIndex-path-heading')).toBeInViewport()
+    expect(await page.getByTestId('withIndex-path-params').innerText()).toEqual(
+      JSON.stringify({ category: 'category' }),
+    )
+
+    await withIndexIdCategoryPathLink.click()
+    await page.waitForURL('/optional-params/withIndex/id/category/path')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe('/optional-params/withIndex/id/category/path')
+    await expect(page.getByTestId('withIndex-path-heading')).toBeInViewport()
+    expect(await page.getByTestId('withIndex-path-params').innerText()).toEqual(
+      JSON.stringify({ id: 'id', category: 'category' }),
+    )
+  })
+
+  test('with consecutive optional params', async ({ page }) => {
+    await page.goto('/optional-params')
+    let pagePathname = ''
+
+    const withNoOptionalsLink = page.getByTestId(
+      'l-to-consecutive-category-info',
+    )
+    const withOptionalIdLink = page.getByTestId(
+      'l-to-consecutive-id-category-info',
+    )
+    const withOptionalSlugLink = page.getByTestId(
+      'l-to-consecutive-slug-category-info',
+    )
+    const withOptionalIdSlugLink = page.getByTestId(
+      'l-to-consecutive-id-slug-category-info',
+    )
+
+    await expect(withNoOptionalsLink).toHaveAttribute(
+      'href',
+      '/optional-params/consecutive/category/info',
+    )
+    await expect(withOptionalIdLink).toHaveAttribute(
+      'href',
+      '/optional-params/consecutive/id/category/info',
+    )
+    await expect(withOptionalSlugLink).toHaveAttribute(
+      'href',
+      '/optional-params/consecutive/slug/category/info',
+    )
+    await expect(withOptionalIdSlugLink).toHaveAttribute(
+      'href',
+      '/optional-params/consecutive/id/slug/category/info',
+    )
+
+    await withNoOptionalsLink.click()
+    await page.waitForURL('/optional-params/consecutive/category/info')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe('/optional-params/consecutive/category/info')
+    await expect(page.getByTestId('consecutive-heading')).toBeInViewport()
+    expect(
+      await page
+        .getByTestId('consecutive-id-slug-category-info-params')
+        .innerText(),
+    ).toEqual(JSON.stringify({ category: 'category' }))
+
+    await withOptionalIdLink.click()
+    await page.waitForURL('/optional-params/consecutive/id/category/info')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe('/optional-params/consecutive/id/category/info')
+    await expect(page.getByTestId('consecutive-heading')).toBeInViewport()
+    expect(
+      await page
+        .getByTestId('consecutive-id-slug-category-info-params')
+        .innerText(),
+    ).toEqual(JSON.stringify({ id: 'id', category: 'category' }))
+
+    await withOptionalSlugLink.click()
+    await page.waitForURL('/optional-params/consecutive/slug/category/info')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe('/optional-params/consecutive/slug/category/info')
+    await expect(page.getByTestId('consecutive-heading')).toBeInViewport()
+    expect(
+      await page
+        .getByTestId('consecutive-id-slug-category-info-params')
+        .innerText(),
+    ).not.toEqual(JSON.stringify({ slug: 'slug', category: 'category' }))
+
+    expect(
+      await page
+        .getByTestId('consecutive-id-slug-category-info-params')
+        .innerText(),
+    ).toEqual(JSON.stringify({ id: 'slug', category: 'category' }))
+
+    await withOptionalIdSlugLink.click()
+    await page.waitForURL('/optional-params/consecutive/id/slug/category/info')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe(
+      '/optional-params/consecutive/id/slug/category/info',
+    )
+    await expect(page.getByTestId('consecutive-heading')).toBeInViewport()
+    expect(
+      await page
+        .getByTestId('consecutive-id-slug-category-info-params')
+        .innerText(),
+    ).toEqual(JSON.stringify({ id: 'id', slug: 'slug', category: 'category' }))
+  })
+
+  test('with required path between optional params', async ({ page }) => {
+    await page.goto('/optional-params')
+    let pagePathname = ''
+
+    const withNoOptionalsLink = page.getByTestId(
+      'l-to-withRequiredInBetween-category',
+    )
+    const withOptionalIdLink = page.getByTestId(
+      'l-to-withRequiredInBetween-id-category',
+    )
+    const withOptionalSlugLink = page.getByTestId(
+      'l-to-withRequiredInBetween-category-slug',
+    )
+    const withOptionalIdSlugLink = page.getByTestId(
+      'l-to-withRequiredInBetween-id-category-slug',
+    )
+
+    await expect(withNoOptionalsLink).toHaveAttribute(
+      'href',
+      '/optional-params/withRequiredInBetween/category/path',
+    )
+    await expect(withOptionalIdLink).toHaveAttribute(
+      'href',
+      '/optional-params/withRequiredInBetween/id/category/path',
+    )
+    await expect(withOptionalSlugLink).toHaveAttribute(
+      'href',
+      '/optional-params/withRequiredInBetween/category/path/slug',
+    )
+    await expect(withOptionalIdSlugLink).toHaveAttribute(
+      'href',
+      '/optional-params/withRequiredInBetween/id/category/path/slug',
+    )
+
+    await withNoOptionalsLink.click()
+    await page.waitForURL(
+      '/optional-params/withRequiredInBetween/category/path',
+    )
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe(
+      '/optional-params/withRequiredInBetween/category/path',
+    )
+    await expect(
+      page.getByTestId('withRequiredInBetween-heading'),
+    ).toBeInViewport()
+    expect(
+      await page
+        .getByTestId('withRequiredInBetween-id-category-path-slug-params')
+        .innerText(),
+    ).toEqual(JSON.stringify({ category: 'category' }))
+
+    await withOptionalIdLink.click()
+    await page.waitForURL(
+      '/optional-params/withRequiredInBetween/id/category/path',
+    )
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe(
+      '/optional-params/withRequiredInBetween/id/category/path',
+    )
+    await expect(
+      page.getByTestId('withRequiredInBetween-heading'),
+    ).toBeInViewport()
+    expect(
+      await page
+        .getByTestId('withRequiredInBetween-id-category-path-slug-params')
+        .innerText(),
+    ).toEqual(JSON.stringify({ id: 'id', category: 'category' }))
+
+    await withOptionalSlugLink.click()
+    await page.waitForURL(
+      '/optional-params/withRequiredInBetween/category/path/slug',
+    )
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe(
+      '/optional-params/withRequiredInBetween/category/path/slug',
+    )
+    await expect(
+      page.getByTestId('withRequiredInBetween-heading'),
+    ).toBeInViewport()
+    expect(
+      await page
+        .getByTestId('withRequiredInBetween-id-category-path-slug-params')
+        .innerText(),
+    ).toEqual(JSON.stringify({ category: 'category', slug: 'slug' }))
+
+    await withOptionalIdSlugLink.click()
+    await page.waitForURL(
+      '/optional-params/withRequiredInBetween/id/category/path/slug',
+    )
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe(
+      '/optional-params/withRequiredInBetween/id/category/path/slug',
+    )
+    await expect(
+      page.getByTestId('withRequiredInBetween-heading'),
+    ).toBeInViewport()
+    expect(
+      await page
+        .getByTestId('withRequiredInBetween-id-category-path-slug-params')
+        .innerText(),
+    ).toEqual(JSON.stringify({ id: 'id', category: 'category', slug: 'slug' }))
+  })
+
+  test('with required params between optional params', async ({ page }) => {
+    await page.goto('/optional-params')
+    let pagePathname = ''
+
+    const withNoOptionalsLink = page.getByTestId(
+      'l-to-withRequiredParam-category',
+    )
+    const withOptionalIdLink = page.getByTestId(
+      'l-to-withRequiredParam-id-category',
+    )
+    const withOptionalSlugLink = page.getByTestId(
+      'l-to-withRequiredParam-category-slug',
+    )
+    const withOptionalIdSlugLink = page.getByTestId(
+      'l-to-withRequiredParam-id-category-slug',
+    )
+
+    await expect(withNoOptionalsLink).toHaveAttribute(
+      'href',
+      '/optional-params/withRequiredParam/category/info',
+    )
+    await expect(withOptionalIdLink).toHaveAttribute(
+      'href',
+      '/optional-params/withRequiredParam/id/category/info',
+    )
+    await expect(withOptionalSlugLink).toHaveAttribute(
+      'href',
+      '/optional-params/withRequiredParam/category/slug/info',
+    )
+    await expect(withOptionalIdSlugLink).toHaveAttribute(
+      'href',
+      '/optional-params/withRequiredParam/id/category/slug/info',
+    )
+
+    await withNoOptionalsLink.click()
+    await page.waitForURL('/optional-params/withRequiredParam/category/info')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe(
+      '/optional-params/withRequiredParam/category/info',
+    )
+    await expect(page.getByTestId('withRequiredParam-heading')).toBeInViewport()
+    expect(
+      await page
+        .getByTestId('withRequiredParam-id-category-slug-info-params')
+        .innerText(),
+    ).toEqual(JSON.stringify({ category: 'category' }))
+
+    await withOptionalIdLink.click()
+    await page.waitForURL('/optional-params/withRequiredParam/id/category/info')
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe(
+      '/optional-params/withRequiredParam/id/category/info',
+    )
+    await expect(page.getByTestId('withRequiredParam-heading')).toBeInViewport()
+    expect(
+      await page
+        .getByTestId('withRequiredParam-id-category-slug-info-params')
+        .innerText(),
+    ).toEqual(JSON.stringify({ id: 'id', category: 'category' }))
+
+    await withOptionalSlugLink.click()
+    await page.waitForURL(
+      '/optional-params/withRequiredParam/category/slug/info',
+    )
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe(
+      '/optional-params/withRequiredParam/category/slug/info',
+    )
+    await expect(page.getByTestId('withRequiredParam-heading')).toBeInViewport()
+    expect(
+      await page
+        .getByTestId('withRequiredParam-id-category-slug-info-params')
+        .innerText(),
+    ).not.toEqual(JSON.stringify({ category: 'category', slug: 'slug' }))
+
+    expect(
+      await page
+        .getByTestId('withRequiredParam-id-category-slug-info-params')
+        .innerText(),
+    ).toEqual(JSON.stringify({ id: 'category', category: 'slug' }))
+
+    await withOptionalIdSlugLink.click()
+    await page.waitForURL(
+      '/optional-params/withRequiredParam/id/category/slug/info',
+    )
+    pagePathname = new URL(page.url()).pathname
+    expect(pagePathname).toBe(
+      '/optional-params/withRequiredParam/id/category/slug/info',
+    )
+    await expect(page.getByTestId('withRequiredParam-heading')).toBeInViewport()
+    expect(
+      await page
+        .getByTestId('withRequiredParam-id-category-slug-info-params')
+        .innerText(),
+    ).toEqual(JSON.stringify({ id: 'id', category: 'category', slug: 'slug' }))
+  })
+})

--- a/packages/router-core/src/path.ts
+++ b/packages/router-core/src/path.ts
@@ -838,6 +838,12 @@ function isMatch(
             // where consecutive optional params are used, we can break early.
             // preference is given to the first optional param
             if (futureRouteSegment?.type === SEGMENT_TYPE_OPTIONAL_PARAM) {
+              if (
+                routeSegmentLength - optionalCount + processedOptionals >=
+                baseSegments.length
+              ) {
+                shouldMatchOptional = false
+              }
               break
             }
 
@@ -858,8 +864,8 @@ function isMatch(
                 followingRouteSegment &&
                 (followingRouteSegment.type === SEGMENT_TYPE_PATHNAME ||
                   (followingRouteSegment.type === SEGMENT_TYPE_OPTIONAL_PARAM &&
-                    followingRouteSegment.prefixSegment) ||
-                  followingRouteSegment.suffixSegment)
+                    (followingRouteSegment.prefixSegment ||
+                      followingRouteSegment.suffixSegment)))
               ) {
                 const remainingRouteSegments = routeSegments.slice(
                   lookAhead + 1,

--- a/packages/router-core/tests/match-by-path.test.ts
+++ b/packages/router-core/tests/match-by-path.test.ts
@@ -257,6 +257,30 @@ describe('default path matching', () => {
       '/a/{-$id}/{-$other}/b/{-$d}/c/$e/',
       { id: '2', d: '3', e: '4' },
     ],
+    ['/a/b/c', '/a/{-$id}/{-$other}/$b/{-$d}/c', { b: 'b' }],
+    ['/a/b/c', '/a/{-$id}/{-$other}/$b/{-$d}/c/', { b: 'b' }],
+    ['/a/1/b/c', '/a/{-$id}/{-$other}/$b/{-$d}/c', { id: '1', b: 'b' }],
+    ['/a/1/b/c', '/a/{-$id}/{-$other}/$b/{-$d}/c/', { id: '1', b: 'b' }],
+    [
+      '/a/1/other/b/c',
+      '/a/{-$id}/{-$other}/$b/{-$d}/c',
+      { id: '1', other: 'other', b: 'b' },
+    ],
+    [
+      '/a/1/other/b/c',
+      '/a/{-$id}/{-$other}/$b/{-$d}/c/',
+      { id: '1', other: 'other', b: 'b' },
+    ],
+    [
+      '/a/1/other/b/d/c',
+      '/a/{-$id}/{-$other}/$b/{-$d}/c',
+      { id: '1', other: 'other', b: 'b', d: 'd' },
+    ],
+    [
+      '/a/1/other/b/d/c',
+      '/a/{-$id}/{-$other}/$b/{-$d}/c/',
+      { id: '1', other: 'other', b: 'b', d: 'd' },
+    ],
   ])('consecutive optionals %s => %s', (from, to, result) => {
     expect(
       matchByPath('/', from, { to, caseSensitive: true, fuzzy: false }),

--- a/packages/router-core/tests/match-by-path.test.ts
+++ b/packages/router-core/tests/match-by-path.test.ts
@@ -52,10 +52,15 @@ describe('default path matching', () => {
     ['/a/1', '/a/{-$id}', { id: '1' }],
     ['/a', '/a/{-$id}', {}],
     ['/a/1/b', '/a/{-$id}/b', { id: '1' }],
+    ['/a/1/b', '/a/{-$id}/b/', { id: '1' }],
     ['/a/b', '/a/{-$id}/b', {}],
+    ['/a/b', '/a/{-$id}/b/', {}],
     ['/a/1/b/2', '/a/{-$id}/b/{-$other}', { id: '1', other: '2' }],
+    ['/a/1/b/2', '/a/{-$id}/b/{-$other}/', { id: '1', other: '2' }],
     ['/a/b/2', '/a/{-$id}/b/{-$other}', { other: '2' }],
+    ['/a/b/2', '/a/{-$id}/b/{-$other}/', { other: '2' }],
     ['/a/1/b', '/a/{-$id}/b/{-$other}', { id: '1' }],
+    ['/a/1/b', '/a/{-$id}/b/{-$other}/', { id: '1' }],
     ['/a/b', '/a/{-$id}/b/{-$other}', {}],
     ['/a/1/b/2', '/a/{-$id}/b/{-$id}', { id: '2' }],
   ])('optional %s => %s', (from, to, result) => {
@@ -70,6 +75,189 @@ describe('default path matching', () => {
     ['/a', '/a/$', { _splat: '', '*': '' }],
     ['/a/b/c', '/a/$/foo', { _splat: 'b/c', '*': 'b/c' }],
   ])('wildcard %s => %s', (from, to, result) => {
+    expect(
+      matchByPath('/', from, { to, caseSensitive: true, fuzzy: false }),
+    ).toEqual(result)
+  })
+
+  it.each([
+    ['/a/1/b/2', '/a/{-$id}/b/$other', { id: '1', other: '2' }],
+    ['/a/1/b/2', '/a/{-$id}/b/$other/', { id: '1', other: '2' }],
+    ['/a/1/b/2/c', '/a/{-$id}/b/$other/c', { id: '1', other: '2' }],
+    ['/a/1/b/2/c', '/a/{-$id}/b/$other/c/', { id: '1', other: '2' }],
+    [
+      '/a/1/b/2/c/3',
+      '/a/{-$id}/b/$other/c/$d',
+      { id: '1', other: '2', d: '3' },
+    ],
+    [
+      '/a/1/b/2/c/3',
+      '/a/{-$id}/b/$other/c/$d/',
+      { id: '1', other: '2', d: '3' },
+    ],
+
+    ['/a/1/2/3/c', '/a/{-$id}/$other/{-$d}/c', { id: '1', other: '2', d: '3' }],
+    [
+      '/a/1/2/3/c',
+      '/a/{-$id}/$other/{-$d}/c/',
+      { id: '1', other: '2', d: '3' },
+    ],
+    ['/a/2', '/a/{-$id}/$other/{-$d}', { other: '2' }],
+    ['/a/2', '/a/{-$id}/$other/{-$d}/', { other: '2' }],
+    ['/a/2/c', '/a/{-$id}/$other/{-$d}/c', { other: '2' }],
+    ['/a/2/c', '/a/{-$id}/$other/{-$d}/c/', { other: '2' }],
+    ['/a/1/2', '/a/{-$id}/$other/{-$d}', { id: '1', other: '2' }],
+    ['/a/1/2', '/a/{-$id}/$other/{-$d}/', { id: '1', other: '2' }],
+    ['/a/2/e', '/a/{-$id}/$other/{-$d}/$e', { other: '2', e: 'e' }],
+    ['/a/2/e', '/a/{-$id}/$other/{-$d}/$e/', { other: '2', e: 'e' }],
+    ['/a/1/2/e', '/a/{-$id}/$other/{-$d}/$e', { id: '1', other: '2', e: 'e' }],
+    ['/a/1/2/e', '/a/{-$id}/$other/{-$d}/$e/', { id: '1', other: '2', e: 'e' }],
+    [
+      '/a/1/2/d/e',
+      '/a/{-$id}/$other/{-$d}/$e',
+      { id: '1', other: '2', d: 'd', e: 'e' },
+    ],
+    [
+      '/a/1/2/d/e',
+      '/a/{-$id}/$other/{-$d}/$e/',
+      { id: '1', other: '2', d: 'd', e: 'e' },
+    ],
+    ['/a/1/2/c', '/a/{-$id}/$other/{-$d}/c', { id: '1', other: '2' }],
+    ['/a/1/2/c', '/a/{-$id}/$other/{-$d}/c/', { id: '1', other: '2' }],
+    ['/a/1/2/c', '/a/{-$id}/$other/c/{-$d}', { id: '1', other: '2' }],
+    ['/a/1/2/c', '/a/{-$id}/$other/c/{-$d}/', { id: '1', other: '2' }],
+    ['/a/1/2/c/3', '/a/{-$id}/$other/c/{-$d}', { id: '1', other: '2', d: '3' }],
+    [
+      '/a/1/2/c/3',
+      '/a/{-$id}/$other/c/{-$d}/',
+      { id: '1', other: '2', d: '3' },
+    ],
+    ['/a/2/c/3', '/a/{-$id}/$other/c/{-$d}', { other: '2', d: '3' }],
+    ['/a/2/c/3', '/a/{-$id}/$other/c/{-$d}/', { other: '2', d: '3' }],
+    ['/a/2/c', '/a/{-$id}/$other/c/{-$d}', { other: '2' }],
+    ['/a/2/c', '/a/{-$id}/$other/c/{-$d}/', { other: '2' }],
+    ['/a/1/2/c', '/a/{-$id}/$other/$c/{-$d}', { id: '1', other: '2', c: 'c' }],
+    ['/a/1/2/c', '/a/{-$id}/$other/$c/{-$d}/', { id: '1', other: '2', c: 'c' }],
+    [
+      '/a/1/2/c/3',
+      '/a/{-$id}/$other/$c/{-$d}',
+      { id: '1', other: '2', c: 'c', d: '3' },
+    ],
+    [
+      '/a/1/2/c/3',
+      '/a/{-$id}/$other/$c/{-$d}/',
+      { id: '1', other: '2', c: 'c', d: '3' },
+    ],
+    [
+      '/a/1/2/c/e',
+      '/a/{-$id}/$other/$c/e/{-$d}',
+      { id: '1', other: '2', c: 'c' },
+    ],
+    [
+      '/a/1/2/c/e',
+      '/a/{-$id}/$other/$c/e/{-$d}/',
+      { id: '1', other: '2', c: 'c' },
+    ],
+    [
+      '/a/1/2/c/e/3',
+      '/a/{-$id}/$other/$c/e/{-$d}',
+      { id: '1', other: '2', c: 'c', d: '3' },
+    ],
+    [
+      '/a/1/2/c/e/3',
+      '/a/{-$id}/$other/$c/e/{-$d}/',
+      { id: '1', other: '2', c: 'c', d: '3' },
+    ],
+    [
+      '/a/1/b/2/c/3',
+      '/a/{-$id}/b/$other/c/{-$d}',
+      { id: '1', other: '2', d: '3' },
+    ],
+    [
+      '/a/1/b/2/c/3',
+      '/a/{-$id}/b/$other/c/{-$d}/',
+      { id: '1', other: '2', d: '3' },
+    ],
+    [
+      '/a/1/b/2/c/3/4',
+      '/a/{-$id}/b/$other/c/{-$d}/$e',
+      { id: '1', other: '2', d: '3', e: '4' },
+    ],
+    [
+      '/a/1/b/2/c/3/4',
+      '/a/{-$id}/b/$other/c/{-$d}/$e/',
+      { id: '1', other: '2', d: '3', e: '4' },
+    ],
+    ['/a/b/2', '/a/{-$id}/b/$other', { other: '2' }],
+    ['/a/b/2', '/a/{-$id}/b/$other/', { other: '2' }],
+    ['/a/b/2/c', '/a/{-$id}/b/$other/c', { other: '2' }],
+    ['/a/b/2/c', '/a/{-$id}/b/$other/c/', { other: '2' }],
+    ['/a/b/2/c/3', '/a/{-$id}/b/$other/c/$d', { other: '2', d: '3' }],
+    ['/a/b/2/c/3', '/a/{-$id}/b/$other/c/$d/', { other: '2', d: '3' }],
+    ['/a/b/2/c/3', '/a/{-$id}/b/$other/c/{-$d}', { other: '2', d: '3' }],
+    ['/a/b/2/c/3', '/a/{-$id}/b/$other/c/{-$d}/', { other: '2', d: '3' }],
+    [
+      '/a/b/2/c/3/4',
+      '/a/{-$id}/b/$other/c/{-$d}/$e',
+      { other: '2', d: '3', e: '4' },
+    ],
+    [
+      '/a/b/2/c/3/4',
+      '/a/{-$id}/b/$other/c/{-$d}/$e/',
+      { other: '2', d: '3', e: '4' },
+    ],
+    ['/a/1/b/2/c', '/a/{-$id}/b/$other/c/{-$d}', { id: '1', other: '2' }],
+    ['/a/1/b/2/c', '/a/{-$id}/b/$other/c/{-$d}/', { id: '1', other: '2' }],
+    [
+      '/a/1/b/2/c/4',
+      '/a/{-$id}/b/$other/c/{-$d}/$e',
+      { id: '1', other: '2', e: '4' },
+    ],
+    [
+      '/a/1/b/2/c/4',
+      '/a/{-$id}/b/$other/c/{-$d}/$e/',
+      { id: '1', other: '2', e: '4' },
+    ],
+    ['/a/b/2/c', '/a/{-$id}/b/$other/c/{-$d}', { other: '2' }],
+    ['/a/b/2/c', '/a/{-$id}/b/$other/c/{-$d}/', { other: '2' }],
+    ['/a/b/2/c/4', '/a/{-$id}/b/$other/c/{-$d}/$e', { other: '2', e: '4' }],
+    ['/a/b/2/c/4', '/a/{-$id}/b/$other/c/{-$d}/$e/', { other: '2', e: '4' }],
+    [
+      '/a/2/c/3',
+      '/a/{-$id}/$other/c{-$cid}/{-$d}',
+      { cid: '', other: '2', d: '3' },
+    ],
+    [
+      '/a/2/c4/3',
+      '/a/{-$id}/$other/c{-$cid}/{-$d}/',
+      { other: '2', cid: '4', d: '3' },
+    ],
+  ])('complex optional usage %s => %s', (from, to, result) => {
+    expect(
+      matchByPath('/', from, { to, caseSensitive: true, fuzzy: false }),
+    ).toEqual(result)
+  })
+
+  it.each([
+    ['/a/2', '/a/{-$id}/{-$other}', { id: '2' }],
+    ['/a/2', '/a/{-$id}/{-$other}/', { id: '2' }],
+    ['/a/2/b', '/a/{-$id}/{-$other}/b', { id: '2' }],
+    ['/a/2/b', '/a/{-$id}/{-$other}/b/', { id: '2' }],
+    ['/a/2/b/c', '/a/{-$id}/{-$other}/b/{-$d}/c', { id: '2' }],
+    ['/a/2/b/c', '/a/{-$id}/{-$other}/b/{-$d}/c/', { id: '2' }],
+    ['/a/2/b/3/c', '/a/{-$id}/{-$other}/b/{-$d}/c', { id: '2', d: '3' }],
+    ['/a/2/b/3/c', '/a/{-$id}/{-$other}/b/{-$d}/c/', { id: '2', d: '3' }],
+    [
+      '/a/2/b/3/c/4',
+      '/a/{-$id}/{-$other}/b/{-$d}/c/$e',
+      { id: '2', d: '3', e: '4' },
+    ],
+    [
+      '/a/2/b/3/c/4',
+      '/a/{-$id}/{-$other}/b/{-$d}/c/$e/',
+      { id: '2', d: '3', e: '4' },
+    ],
+  ])('consecutive optionals %s => %s', (from, to, result) => {
     expect(
       matchByPath('/', from, { to, caseSensitive: true, fuzzy: false }),
     ).toEqual(result)
@@ -110,11 +298,11 @@ describe('case insensitive path matching', () => {
     ['/a/1', '/A/{-$id}', { id: '1' }],
     ['/a', '/A/{-$id}', {}],
     ['/a/1/b', '/A/{-$id}/B', { id: '1' }],
-    // ['/a/b', '/A/{-$id}/B', {}],
+    ['/a/b', '/A/{-$id}/B', {}],
     ['/a/1/b/2', '/A/{-$id}/B/{-$other}', { id: '1', other: '2' }],
-    // ['/a/b/2', '/A/{-$id}/B/{-$other}', { other: '2' }],
+    ['/a/b/2', '/A/{-$id}/B/{-$other}', { other: '2' }],
     ['/a/1/b', '/A/{-$id}/B/{-$other}', { id: '1' }],
-    // ['/a/b', '/A/{-$id}/B/{-$other}', {}],
+    ['/a/b', '/A/{-$id}/B/{-$other}', {}],
     ['/a/1/b/2', '/A/{-$id}/B/{-$id}', { id: '2' }],
   ])('optional %s => %s', (from, to, result) => {
     expect(
@@ -128,6 +316,81 @@ describe('case insensitive path matching', () => {
     ['/a', '/A/$', { _splat: '', '*': '' }],
     ['/a/b/c', '/A/$/foo', { _splat: 'b/c', '*': 'b/c' }],
   ])('wildcard %s => %s', (from, to, result) => {
+    expect(
+      matchByPath('/', from, { to, caseSensitive: false, fuzzy: false }),
+    ).toEqual(result)
+  })
+
+  it.each([
+    ['/a/1/b/2', '/A/{-$id}/B/$other', { id: '1', other: '2' }],
+    ['/a/1/b/2', '/A/{-$id}/B/$other/', { id: '1', other: '2' }],
+    ['/a/1/b/2/c', '/A/{-$id}/B/$other/C', { id: '1', other: '2' }],
+    ['/a/1/b/2/c', '/A/{-$id}/B/$other/C/', { id: '1', other: '2' }],
+    [
+      '/a/1/b/2/c/3',
+      '/A/{-$id}/B/$other/C/$d',
+      { id: '1', other: '2', d: '3' },
+    ],
+    [
+      '/a/1/b/2/c/3',
+      '/A/{-$id}/B/$other/C/$d/',
+      { id: '1', other: '2', d: '3' },
+    ],
+    [
+      '/a/1/b/2/c/3',
+      '/A/{-$id}/B/$other/C/{-$d}',
+      { id: '1', other: '2', d: '3' },
+    ],
+    [
+      '/a/1/b/2/c/3',
+      '/A/{-$id}/B/$other/C/{-$d}/',
+      { id: '1', other: '2', d: '3' },
+    ],
+    [
+      '/a/1/b/2/c/3/4',
+      '/A/{-$id}/B/$other/C/{-$d}/$e',
+      { id: '1', other: '2', d: '3', e: '4' },
+    ],
+    [
+      '/a/1/b/2/c/3/4',
+      '/A/{-$id}/B/$other/C/{-$d}/$e/',
+      { id: '1', other: '2', d: '3', e: '4' },
+    ],
+    ['/a/b/2', '/A/{-$id}/B/$other', { other: '2' }],
+    ['/a/b/2', '/A/{-$id}/B/$other/', { other: '2' }],
+    ['/a/b/2/c', '/A/{-$id}/B/$other/C', { other: '2' }],
+    ['/a/b/2/c', '/A/{-$id}/B/$other/C/', { other: '2' }],
+    ['/a/b/2/c/3', '/A/{-$id}/B/$other/C/$d', { other: '2', d: '3' }],
+    ['/a/b/2/c/3', '/A/{-$id}/B/$other/C/$d/', { other: '2', d: '3' }],
+    ['/a/b/2/c/3', '/A/{-$id}/B/$other/C/{-$d}', { other: '2', d: '3' }],
+    ['/a/b/2/c/3', '/A/{-$id}/B/$other/C/{-$d}/', { other: '2', d: '3' }],
+    [
+      '/a/b/2/c/3/4',
+      '/A/{-$id}/B/$other/C/{-$d}/$e',
+      { other: '2', d: '3', e: '4' },
+    ],
+    [
+      '/a/b/2/c/3/4',
+      '/A/{-$id}/B/$other/C/{-$d}/$e/',
+      { other: '2', d: '3', e: '4' },
+    ],
+    ['/a/1/b/2/c', '/A/{-$id}/B/$other/C/{-$d}', { id: '1', other: '2' }],
+    ['/a/1/b/2/c', '/A/{-$id}/B/$other/C/{-$d}/', { id: '1', other: '2' }],
+    [
+      '/a/1/b/2/c/4',
+      '/A/{-$id}/B/$other/C/{-$d}/$e',
+      { id: '1', other: '2', e: '4' },
+    ],
+    [
+      '/a/1/b/2/c/4',
+      '/A/{-$id}/B/$other/C/{-$d}/$e/',
+      { id: '1', other: '2', e: '4' },
+    ],
+    ['/a/b/2/c', '/A/{-$id}/B/$other/C/{-$d}', { other: '2' }],
+    ['/a/b/2/c', '/A/{-$id}/B/$other/C/{-$d}/', { other: '2' }],
+    ['/a/b/2/c/4', '/A/{-$id}/B/$other/C/{-$d}/$e', { other: '2', e: '4' }],
+    ['/a/b/2/c/4', '/A/{-$id}/B/$other/C/{-$d}/$e/', { other: '2', e: '4' }],
+  ])('optional preceding wildcard %s => %s', (from, to, result) => {
     expect(
       matchByPath('/', from, { to, caseSensitive: false, fuzzy: false }),
     ).toEqual(result)


### PR DESCRIPTION
#4933 highlighted a case where index routes would not resolve when an optional param is followed by a required path param.

apart from this specific issue, this PR unlocks some more variations in the usage of optional params including:

{-$optional}.$pathParam.index
{-$optional}.{-$optional}.$pathParam.path (with and without index)
{-$optional}.$pathParam.{-$optional}.path (with and without index)
{-$optional}.path.{-$optional}.$pathParam (with and without index)
{-$optional}.path.$pathParam.{-$optional} (with and without index)

bunch of unit tests added to match-path tests to test various variations and completions.
also added e2e tests on react and solid to test functionality of this. not all variations are covered here since they are covered in the unit test. this is just to ensure findings from unit tests carry over to e2e. 