### PR TITLE
Fix: use plugin root override instead of Vite root

### DIFF
--- a/packages/start-plugin-core/src/resolve-virtual-entries-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/resolve-virtual-entries-plugin/plugin.ts
@@ -53,7 +53,10 @@ export function resolveVirtualEntriesPlugin(
           )
             ? startConfig.serverEntryPath
             : vite.normalizePath(
-                path.resolve(resolvedConfig.root, startConfig.serverEntryPath),
+                path.resolve(
+                  startConfig.root || resolvedConfig.root,
+                  startConfig.serverEntryPath,
+                ),
               )
 
           return opts.getVirtualServerRootHandler({


### PR DESCRIPTION
Hello,
I switch to using `vite.root` recently so I had to use plugin's `config.root` as well to match all the paths properly.

My file system is:
```
.
└── apps/
    └── web/
        ├── vite.config.ts
        └── src/
            └── entry/
                ├── client.tsx
                └── server.tsx
```

My `vite.config.ts` (partial):
```ts
const rootDir = path.resolve(__dirname, "../..");
const webDir = path.resolve(rootDir, "apps/web");
const config = defineConfig({
  root: rootDir,
  plugins: [
    tanstackStart({
      root: webDir,
      tsr: {
        srcDirectory: "./src/entry",
      },
    }),
  ],
});
```

On build I've got an error
```
error during build:
[vite]: Rollup failed to resolve import "<projectDir>/src/entry/server.tsx" from "/~start/server-entry.tsx".
```

While debugging, I found out that only Vite root is used while resolving path to the entry, so I patched the package and here's a PR with this small fix.