### PR TITLE
Fix: add (de)hydration options to tanstack query integration

### DIFF
--- a/packages/router-ssr-query-core/src/index.ts
+++ b/packages/router-ssr-query-core/src/index.ts
@@ -5,6 +5,8 @@ import {
 import { isRedirect } from '@tanstack/router-core'
 import type { AnyRouter } from '@tanstack/router-core'
 import type {
+  DehydrateOptions,
+  HydrateOptions,
   QueryClient,
   DehydratedState as QueryDehydratedState,
 } from '@tanstack/query-core'
@@ -20,6 +22,8 @@ export type RouterSsrQueryOptions<TRouter extends AnyRouter> = {
    * @link [Guide](https://tanstack.com/router/latest/docs/framework/react/api/router/redirectFunction)
    */
   handleRedirects?: boolean
+  hydrateOptions?: Omit<HydrateOptions, 'shouldDehydrateQuery'>
+  dehydrateOptions?: DehydrateOptions
 }
 
 type DehydratedRouterQueryState = {
@@ -31,6 +35,8 @@ export function setupCoreRouterSsrQueryIntegration<TRouter extends AnyRouter>({
   router,
   queryClient,
   handleRedirects = true,
+  dehydrateOptions,
+  hydrateOptions,
 }: RouterSsrQueryOptions<TRouter>) {
   const ogHydrate = router.options.hydrate
   const ogDehydrate = router.options.dehydrate
@@ -50,7 +56,10 @@ export function setupCoreRouterSsrQueryIntegration<TRouter extends AnyRouter>({
           queryStream: queryStream.stream,
         }
 
-        const dehydratedQueryClient = queryDehydrate(queryClient)
+        const dehydratedQueryClient = queryDehydrate(
+          queryClient,
+          dehydrateOptions,
+        )
         if (dehydratedQueryClient.queries.length > 0) {
           dehydratedQueryClient.queries.forEach((query) => {
             sentQueries.add(query.queryHash)
@@ -93,6 +102,7 @@ export function setupCoreRouterSsrQueryIntegration<TRouter extends AnyRouter>({
       sentQueries.add(event.query.queryHash)
       queryStream.enqueue(
         queryDehydrate(queryClient, {
+          ...dehydrateOptions,
           shouldDehydrateQuery: (query) => {
             if (query.queryHash === event.query.queryHash) {
               return (
@@ -110,7 +120,11 @@ export function setupCoreRouterSsrQueryIntegration<TRouter extends AnyRouter>({
       await ogHydrate?.(dehydrated)
       // hydrate the query client with the dehydrated data (if it was dehydrated on the server)
       if (dehydrated.dehydratedQueryClient) {
-        queryHydrate(queryClient, dehydrated.dehydratedQueryClient)
+        queryHydrate(
+          queryClient,
+          dehydrated.dehydratedQueryClient,
+          hydrateOptions,
+        )
       }
 
       // read the query stream and hydrate the queries as they come in
@@ -118,7 +132,7 @@ export function setupCoreRouterSsrQueryIntegration<TRouter extends AnyRouter>({
       reader
         .read()
         .then(async function handle({ done, value }) {
-          queryHydrate(queryClient, value)
+          queryHydrate(queryClient, value, hydrateOptions)
           if (done) {
             return
           }


### PR DESCRIPTION
I tried to add [Tanstack Query integration](https://tanstack.com/router/v1/docs/integrations/query) to Tanstack Start and it failed with Seroval's error (also crashed the whole app!)
```
Error reading routerStream: g [Error]: The value [object Object] of type "object" cannot be parsed/serialized.
```

Before that I had my own implementation of Tanstack Query integration and it didn't fail because I (de)serialized data, but with integration that's not an option.
This PR adds such an option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional SSR hydration and dehydration configuration (server and client) for finer control over how query state is serialized and restored.
  * Streaming updates now include per-item hydration configuration to ensure consistent behavior during incremental rendering.
  * Client hydration respects these options for both initial load and streamed updates.
  * Defaults unchanged so existing setups continue to work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->