### PR TITLE
[Docs] Fix link to Server Entry Point in server-routes.md

### DIFF
--- a/docs/start/framework/react/server-routes.md
+++ b/docs/start/framework/react/server-routes.md
@@ -110,7 +110,7 @@ Server route requests are handled by Start automatically by default or by Start'
 
 The start handler is responsible for matching an incoming request to a server route and executing the appropriate middleware and handler.
 
-If you need to customize the server handler, you can do so by creating a custom handler and then passing the event to the start handler. See [The Server Entry Point](../server-entry-point).
+If you need to customize the server handler, you can do so by creating a custom handler and then passing the event to the start handler. See [The Server Entry Point](./server-entry-point).
 
 ## Defining a Server Route
 

--- a/docs/start/framework/react/server-routes.md
+++ b/docs/start/framework/react/server-routes.md
@@ -110,7 +110,7 @@ Server route requests are handled by Start automatically by default or by Start'
 
 The start handler is responsible for matching an incoming request to a server route and executing the appropriate middleware and handler.
 
-If you need to customize the server handler, you can do so by creating a custom handler and then passing the event to the start handler. See [The Server Entry Point](../learn-the-basics#the-server-entry-point-optional).
+If you need to customize the server handler, you can do so by creating a custom handler and then passing the event to the start handler. See [The Server Entry Point](../server-entry-point).
 
 ## Defining a Server Route
 


### PR DESCRIPTION
Updated link in documentation for server handler customization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Server Entry Point link in “Handling Server Route Requests” to point to the correct page, improving navigation accuracy.
  * Documentation-only update; no functional or public/API changes were made in this PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->