### PR TITLE
fix(router-core): avoid infinite serializer recursion for arrays

### DIFF
--- a/packages/router-core/src/ssr/serializer/transformer.ts
+++ b/packages/router-core/src/ssr/serializer/transformer.ts
@@ -191,12 +191,21 @@ export type ValidateSerializableResult<T, TSerializable> =
   T extends TSerializable
     ? T
     : T extends ReadonlyArray<any>
-      ? ValidateSerializableArray<T, TSerializable>
+      ? ValidateSerializableResultArray<T, TSerializable>
       : unknown extends SerializerExtensions['ReadableStream']
         ? { [K in keyof T]: ValidateSerializableResult<T[K], TSerializable> }
         : T extends SerializerExtensions['ReadableStream']
           ? ReadableStream
           : { [K in keyof T]: ValidateSerializableResult<T[K], TSerializable> }
+
+type ValidateSerializableResultArray<
+  T extends ReadonlyArray<any>,
+  TSerializable,
+> = IsTuple<T> extends true
+  ? { [K in keyof T]: ValidateSerializableResult<T[K], TSerializable> }
+  : T extends Array<infer U>
+    ? Array<ValidateSerializableResult<U, TSerializable>>
+    : ReadonlyArray<ValidateSerializableResult<T[number], TSerializable>>
 
 export type RegisteredSSROption<TRegister> =
   unknown extends RegisteredConfigType<TRegister, 'defaultSsr'>

--- a/packages/router-core/src/ssr/serializer/transformer.ts
+++ b/packages/router-core/src/ssr/serializer/transformer.ts
@@ -30,24 +30,23 @@ export interface CreateSerializationAdapterOptions<TInput, TOutput> {
   fromSerializable: (value: TOutput) => TInput
 }
 
-export type ValidateSerializable<T, TSerializable> =
-  T extends unknown
-    ? T extends TSerializable
-      ? T
-      : T extends ReadonlyArray<any>
-        ? ValidateSerializableArray<T, TSerializable>
-        : T extends (...args: Array<any>) => any
-          ? 'Function is not serializable'
-          : T extends Promise<any>
-            ? ValidateSerializablePromise<T, TSerializable>
-            : T extends ReadableStream<any>
-              ? ValidateReadableStream<T, TSerializable>
-              : T extends Set<any>
-                ? ValidateSerializableSet<T, TSerializable>
-                : T extends Map<any, any>
-                  ? ValidateSerializableMap<T, TSerializable>
-                  : { [K in keyof T]: ValidateSerializable<T[K], TSerializable> }
-    : never
+export type ValidateSerializable<T, TSerializable> = T extends unknown
+  ? T extends TSerializable
+    ? T
+    : T extends ReadonlyArray<any>
+      ? ValidateSerializableArray<T, TSerializable>
+      : T extends (...args: Array<any>) => any
+        ? 'Function is not serializable'
+        : T extends Promise<any>
+          ? ValidateSerializablePromise<T, TSerializable>
+          : T extends ReadableStream<any>
+            ? ValidateReadableStream<T, TSerializable>
+            : T extends Set<any>
+              ? ValidateSerializableSet<T, TSerializable>
+              : T extends Map<any, any>
+                ? ValidateSerializableMap<T, TSerializable>
+                : { [K in keyof T]: ValidateSerializable<T[K], TSerializable> }
+  : never
 
 export type ValidateSerializablePromise<T, TSerializable> =
   T extends Promise<infer TAwaited>
@@ -188,27 +187,27 @@ export type RegisteredSerializationAdapters<TRegister> = RegisteredConfigType<
 export type ValidateSerializableInputResult<TRegister, T> =
   ValidateSerializableResult<T, RegisteredSerializableInput<TRegister>>
 
-export type ValidateSerializableResult<T, TSerializable> =
-  T extends unknown
-    ? T extends TSerializable
-      ? T
-      : T extends ReadonlyArray<any>
-        ? ValidateSerializableResultArray<T, TSerializable>
-        : unknown extends SerializerExtensions['ReadableStream']
-          ? { [K in keyof T]: ValidateSerializableResult<T[K], TSerializable> }
-          : T extends SerializerExtensions['ReadableStream']
-            ? ReadableStream
-            : { [K in keyof T]: ValidateSerializableResult<T[K], TSerializable> }
-    : never
+export type ValidateSerializableResult<T, TSerializable> = T extends unknown
+  ? T extends TSerializable
+    ? T
+    : T extends ReadonlyArray<any>
+      ? ValidateSerializableResultArray<T, TSerializable>
+      : unknown extends SerializerExtensions['ReadableStream']
+        ? { [K in keyof T]: ValidateSerializableResult<T[K], TSerializable> }
+        : T extends SerializerExtensions['ReadableStream']
+          ? ReadableStream
+          : { [K in keyof T]: ValidateSerializableResult<T[K], TSerializable> }
+  : never
 
 type ValidateSerializableResultArray<
   T extends ReadonlyArray<any>,
   TSerializable,
-> = IsTuple<T> extends true
-  ? { [K in keyof T]: ValidateSerializableResult<T[K], TSerializable> }
-  : T extends Array<infer U>
-    ? Array<ValidateSerializableResult<U, TSerializable>>
-    : ReadonlyArray<ValidateSerializableResult<T[number], TSerializable>>
+> =
+  IsTuple<T> extends true
+    ? { [K in keyof T]: ValidateSerializableResult<T[K], TSerializable> }
+    : T extends Array<infer U>
+      ? Array<ValidateSerializableResult<U, TSerializable>>
+      : ReadonlyArray<ValidateSerializableResult<T[number], TSerializable>>
 
 export type RegisteredSSROption<TRegister> =
   unknown extends RegisteredConfigType<TRegister, 'defaultSsr'>

--- a/packages/router-core/src/ssr/serializer/transformer.ts
+++ b/packages/router-core/src/ssr/serializer/transformer.ts
@@ -79,13 +79,9 @@ type ApplyArrayValidation<
   ? ValidateSerializable<TValue, TSerializable>
   : ValidateSerializableResult<TValue, TSerializable>
 
-type IsTuple<T extends ReadonlyArray<unknown>> = T extends readonly []
-  ? true
-  : T extends readonly [unknown, ...infer TRest]
-    ? TRest extends ReadonlyArray<unknown>
-      ? true
-      : false
-    : false
+type IsTuple<T extends ReadonlyArray<unknown>> = number extends T['length']
+  ? false
+  : true
 
 type ValidateSerializableArrayCore<
   T extends ReadonlyArray<unknown>,

--- a/packages/router-core/src/ssr/serializer/transformer.ts
+++ b/packages/router-core/src/ssr/serializer/transformer.ts
@@ -31,10 +31,10 @@ export interface CreateSerializationAdapterOptions<TInput, TOutput> {
 }
 
 export type ValidateSerializable<T, TSerializable> = T extends unknown
-  ? T extends TSerializable
-    ? T
-    : T extends ReadonlyArray<unknown>
-      ? ValidateSerializableArray<T, TSerializable>
+  ? T extends ReadonlyArray<unknown>
+    ? ValidateSerializableArray<T, TSerializable>
+    : T extends TSerializable
+      ? T
       : T extends (...args: Array<any>) => any
         ? 'Function is not serializable'
         : T extends Promise<any>
@@ -83,23 +83,18 @@ type ValidateSerializableArrayCore<
   T extends ReadonlyArray<unknown>,
   TSerializable,
   TKind extends 'input' | 'result',
-> =
-  IsTuple<T> extends true
-    ? { [K in keyof T]: ApplyArrayValidation<T[K], TSerializable, TKind> }
-    : T extends Array<infer U>
+> = T extends any
+  ? number extends T['length']
+    ? T extends Array<infer U>
       ? Array<ApplyArrayValidation<U, TSerializable, TKind>>
       : ReadonlyArray<ApplyArrayValidation<T[number], TSerializable, TKind>>
+    : { [K in keyof T]: ApplyArrayValidation<T[K], TSerializable, TKind> }
+  : never
 
 type ValidateSerializableArray<
   T extends ReadonlyArray<unknown>,
   TSerializable,
 > = ValidateSerializableArrayCore<T, TSerializable, 'input'>
-
-type IsTuple<T extends ReadonlyArray<unknown>> = T extends readonly []
-  ? true
-  : T extends readonly [unknown, ...Array<unknown>]
-    ? true
-    : false
 
 export type RegisteredReadableStream =
   unknown extends SerializerExtensions['ReadableStream']
@@ -205,10 +200,10 @@ export type ValidateSerializableInputResult<TRegister, T> =
   ValidateSerializableResult<T, RegisteredSerializableInput<TRegister>>
 
 export type ValidateSerializableResult<T, TSerializable> = T extends unknown
-  ? T extends TSerializable
-    ? T
-    : T extends ReadonlyArray<unknown>
-      ? ValidateSerializableResultArray<T, TSerializable>
+  ? T extends ReadonlyArray<unknown>
+    ? ValidateSerializableResultArray<T, TSerializable>
+    : T extends TSerializable
+      ? T
       : unknown extends SerializerExtensions['ReadableStream']
         ? { [K in keyof T]: ValidateSerializableResult<T[K], TSerializable> }
         : T extends SerializerExtensions['ReadableStream']

--- a/packages/router-core/src/ssr/serializer/transformer.ts
+++ b/packages/router-core/src/ssr/serializer/transformer.ts
@@ -79,20 +79,16 @@ type ApplyArrayValidation<
   ? ValidateSerializable<TValue, TSerializable>
   : ValidateSerializableResult<TValue, TSerializable>
 
-type IsTuple<T extends ReadonlyArray<unknown>> = number extends T['length']
-  ? false
-  : true
-
 type ValidateSerializableArrayCore<
   T extends ReadonlyArray<unknown>,
   TSerializable,
   TKind extends 'input' | 'result',
 > = T extends any
-  ? IsTuple<T> extends true
-    ? { [K in keyof T]: ApplyArrayValidation<T[K], TSerializable, TKind> }
-    : T extends Array<infer U>
+  ? number extends T['length']
+    ? T extends Array<infer U>
       ? Array<ApplyArrayValidation<U, TSerializable, TKind>>
       : ReadonlyArray<ApplyArrayValidation<T[number], TSerializable, TKind>>
+    : { [K in keyof T]: ApplyArrayValidation<T[K], TSerializable, TKind> }
   : never
 
 type ValidateSerializableArray<

--- a/packages/router-core/src/ssr/serializer/transformer.ts
+++ b/packages/router-core/src/ssr/serializer/transformer.ts
@@ -71,12 +71,29 @@ export type ValidateSerializableMap<T, TSerializable> =
       >
     : never
 
-type ValidateSerializableArray<T extends ReadonlyArray<any>, TSerializable> =
+type ApplyArrayValidation<
+  TValue,
+  TSerializable,
+  TKind extends 'input' | 'result',
+> = TKind extends 'input'
+  ? ValidateSerializable<TValue, TSerializable>
+  : ValidateSerializableResult<TValue, TSerializable>
+
+type ValidateSerializableArrayCore<
+  T extends ReadonlyArray<any>,
+  TSerializable,
+  TKind extends 'input' | 'result',
+> =
   IsTuple<T> extends true
-    ? { [K in keyof T]: ValidateSerializable<T[K], TSerializable> }
+    ? { [K in keyof T]: ApplyArrayValidation<T[K], TSerializable, TKind> }
     : T extends Array<infer U>
-      ? Array<ValidateSerializable<U, TSerializable>>
-      : ReadonlyArray<ValidateSerializable<T[number], TSerializable>>
+      ? Array<ApplyArrayValidation<U, TSerializable, TKind>>
+      : ReadonlyArray<ApplyArrayValidation<T[number], TSerializable, TKind>>
+
+type ValidateSerializableArray<
+  T extends ReadonlyArray<any>,
+  TSerializable,
+> = ValidateSerializableArrayCore<T, TSerializable, 'input'>
 
 type IsTuple<T extends ReadonlyArray<any>> = T extends readonly []
   ? true
@@ -202,12 +219,7 @@ export type ValidateSerializableResult<T, TSerializable> = T extends unknown
 type ValidateSerializableResultArray<
   T extends ReadonlyArray<any>,
   TSerializable,
-> =
-  IsTuple<T> extends true
-    ? { [K in keyof T]: ValidateSerializableResult<T[K], TSerializable> }
-    : T extends Array<infer U>
-      ? Array<ValidateSerializableResult<U, TSerializable>>
-      : ReadonlyArray<ValidateSerializableResult<T[number], TSerializable>>
+> = ValidateSerializableArrayCore<T, TSerializable, 'result'>
 
 export type RegisteredSSROption<TRegister> =
   unknown extends RegisteredConfigType<TRegister, 'defaultSsr'>

--- a/packages/router-core/src/ssr/serializer/transformer.ts
+++ b/packages/router-core/src/ssr/serializer/transformer.ts
@@ -30,23 +30,24 @@ export interface CreateSerializationAdapterOptions<TInput, TOutput> {
   fromSerializable: (value: TOutput) => TInput
 }
 
-export type ValidateSerializable<T, TSerializable> = T extends TSerializable
-  ? T
-  : T extends ReadonlyArray<any>
-    ? ValidateSerializableArray<T, TSerializable>
-    : T extends (...args: Array<any>) => any
-      ? 'Function is not serializable'
-      : T extends Promise<any>
-        ? ValidateSerializablePromise<T, TSerializable>
-        : T extends ReadableStream<any>
-          ? ValidateReadableStream<T, TSerializable>
-          : T extends Set<any>
-            ? ValidateSerializableSet<T, TSerializable>
-            : T extends Map<any, any>
-              ? ValidateSerializableMap<T, TSerializable>
-              : {
-                  [K in keyof T]: ValidateSerializable<T[K], TSerializable>
-                }
+export type ValidateSerializable<T, TSerializable> =
+  T extends unknown
+    ? T extends TSerializable
+      ? T
+      : T extends ReadonlyArray<any>
+        ? ValidateSerializableArray<T, TSerializable>
+        : T extends (...args: Array<any>) => any
+          ? 'Function is not serializable'
+          : T extends Promise<any>
+            ? ValidateSerializablePromise<T, TSerializable>
+            : T extends ReadableStream<any>
+              ? ValidateReadableStream<T, TSerializable>
+              : T extends Set<any>
+                ? ValidateSerializableSet<T, TSerializable>
+                : T extends Map<any, any>
+                  ? ValidateSerializableMap<T, TSerializable>
+                  : { [K in keyof T]: ValidateSerializable<T[K], TSerializable> }
+    : never
 
 export type ValidateSerializablePromise<T, TSerializable> =
   T extends Promise<infer TAwaited>
@@ -188,15 +189,17 @@ export type ValidateSerializableInputResult<TRegister, T> =
   ValidateSerializableResult<T, RegisteredSerializableInput<TRegister>>
 
 export type ValidateSerializableResult<T, TSerializable> =
-  T extends TSerializable
-    ? T
-    : T extends ReadonlyArray<any>
-      ? ValidateSerializableResultArray<T, TSerializable>
-      : unknown extends SerializerExtensions['ReadableStream']
-        ? { [K in keyof T]: ValidateSerializableResult<T[K], TSerializable> }
-        : T extends SerializerExtensions['ReadableStream']
-          ? ReadableStream
-          : { [K in keyof T]: ValidateSerializableResult<T[K], TSerializable> }
+  T extends unknown
+    ? T extends TSerializable
+      ? T
+      : T extends ReadonlyArray<any>
+        ? ValidateSerializableResultArray<T, TSerializable>
+        : unknown extends SerializerExtensions['ReadableStream']
+          ? { [K in keyof T]: ValidateSerializableResult<T[K], TSerializable> }
+          : T extends SerializerExtensions['ReadableStream']
+            ? ReadableStream
+            : { [K in keyof T]: ValidateSerializableResult<T[K], TSerializable> }
+    : never
 
 type ValidateSerializableResultArray<
   T extends ReadonlyArray<any>,

--- a/packages/router-core/src/ssr/serializer/transformer.ts
+++ b/packages/router-core/src/ssr/serializer/transformer.ts
@@ -223,8 +223,8 @@ type ResolveArrayShape<
   TMode extends 'input' | 'result',
 > = number extends T['length']
   ? T extends Array<infer U>
-    ? Array<ResolveArrayElement<U, TSerializable, TMode>>
-    : ReadonlyArray<ResolveArrayElement<T[number], TSerializable, TMode>>
+    ? Array<ArrayModeResult<TMode, U, TSerializable>>
+    : ReadonlyArray<ArrayModeResult<TMode, T[number], TSerializable>>
   : ResolveTupleShape<T, TSerializable, TMode>
 
 type ResolveTupleShape<
@@ -233,19 +233,15 @@ type ResolveTupleShape<
   TMode extends 'input' | 'result',
 > = T extends readonly [infer THead, ...infer TTail]
   ? readonly [
-      ResolveArrayElement<THead, TSerializable, TMode>,
-      ...ResolveTupleShape<
-        TTail extends ReadonlyArray<unknown> ? TTail : [],
-        TSerializable,
-        TMode
-      >,
+      ArrayModeResult<TMode, THead, TSerializable>,
+      ...ResolveTupleShape<Readonly<TTail>, TSerializable, TMode>,
     ]
   : T
 
-type ResolveArrayElement<
+type ArrayModeResult<
+  TMode extends 'input' | 'result',
   TValue,
   TSerializable,
-  TMode extends 'input' | 'result',
 > = TMode extends 'input'
   ? ValidateSerializable<TValue, TSerializable>
   : ValidateSerializableResult<TValue, TSerializable>

--- a/packages/router-core/src/ssr/serializer/transformer.ts
+++ b/packages/router-core/src/ssr/serializer/transformer.ts
@@ -33,7 +33,7 @@ export interface CreateSerializationAdapterOptions<TInput, TOutput> {
 export type ValidateSerializable<T, TSerializable> = T extends unknown
   ? T extends TSerializable
     ? T
-    : T extends ReadonlyArray<any>
+    : T extends ReadonlyArray<unknown>
       ? ValidateSerializableArray<T, TSerializable>
       : T extends (...args: Array<any>) => any
         ? 'Function is not serializable'
@@ -80,7 +80,7 @@ type ApplyArrayValidation<
   : ValidateSerializableResult<TValue, TSerializable>
 
 type ValidateSerializableArrayCore<
-  T extends ReadonlyArray<any>,
+  T extends ReadonlyArray<unknown>,
   TSerializable,
   TKind extends 'input' | 'result',
 > =
@@ -91,13 +91,13 @@ type ValidateSerializableArrayCore<
       : ReadonlyArray<ApplyArrayValidation<T[number], TSerializable, TKind>>
 
 type ValidateSerializableArray<
-  T extends ReadonlyArray<any>,
+  T extends ReadonlyArray<unknown>,
   TSerializable,
 > = ValidateSerializableArrayCore<T, TSerializable, 'input'>
 
-type IsTuple<T extends ReadonlyArray<any>> = T extends readonly []
+type IsTuple<T extends ReadonlyArray<unknown>> = T extends readonly []
   ? true
-  : T extends readonly [any, ...infer _Rest]
+  : T extends readonly [unknown, ...Array<unknown>]
     ? true
     : false
 
@@ -207,7 +207,7 @@ export type ValidateSerializableInputResult<TRegister, T> =
 export type ValidateSerializableResult<T, TSerializable> = T extends unknown
   ? T extends TSerializable
     ? T
-    : T extends ReadonlyArray<any>
+    : T extends ReadonlyArray<unknown>
       ? ValidateSerializableResultArray<T, TSerializable>
       : unknown extends SerializerExtensions['ReadableStream']
         ? { [K in keyof T]: ValidateSerializableResult<T[K], TSerializable> }
@@ -217,7 +217,7 @@ export type ValidateSerializableResult<T, TSerializable> = T extends unknown
   : never
 
 type ValidateSerializableResultArray<
-  T extends ReadonlyArray<any>,
+  T extends ReadonlyArray<unknown>,
   TSerializable,
 > = ValidateSerializableArrayCore<T, TSerializable, 'result'>
 

--- a/packages/router-core/tests/serializer-recursion.test-d.ts
+++ b/packages/router-core/tests/serializer-recursion.test-d.ts
@@ -2,10 +2,32 @@ import { describe, expectTypeOf, it } from 'vitest'
 
 import type {
   Serializable,
+  ValidateSerializable,
   ValidateSerializableResult,
 } from '../src/ssr/serializer/transformer'
 
-describe('ValidateSerializableResult recursion', () => {
+describe('ValidateSerializable array handling', () => {
+  it('preserves nested array payloads for input validation', () => {
+    type Input = Array<{ value: string; nested: Array<{ id: number }> }>
+    expectTypeOf<
+      ValidateSerializable<Input, Serializable>
+    >().branded.toEqualTypeOf<Input>()
+  })
+
+  it('preserves tuple structure for input validation', () => {
+    type InputTuple = readonly [{ name: string }, { count: number }]
+    expectTypeOf<
+      ValidateSerializable<InputTuple, Serializable>
+    >().branded.toEqualTypeOf<InputTuple>()
+  })
+
+  it('preserves readonly array structure for input validation', () => {
+    type InputReadonlyArray = ReadonlyArray<{ value: string }>
+    expectTypeOf<
+      ValidateSerializable<InputReadonlyArray, Serializable>
+    >().branded.toEqualTypeOf<InputReadonlyArray>()
+  })
+
   it('should preserve recursive payload without infinite expansion', () => {
     type Result = Array<Result> | { [key: string]: Result }
     expectTypeOf<
@@ -16,7 +38,7 @@ describe('ValidateSerializableResult recursion', () => {
   it('should preserve recursive tuples without infinite expansion', () => {
     type ResultTuple = readonly [
       ReadonlyArray<ResultTuple>,
-      { [key: string]: ResultTuple }
+      { [key: string]: ResultTuple },
     ]
     expectTypeOf<
       ValidateSerializableResult<ResultTuple, Serializable>

--- a/packages/router-core/tests/serializer-recursion.test-d.ts
+++ b/packages/router-core/tests/serializer-recursion.test-d.ts
@@ -12,4 +12,23 @@ describe('ValidateSerializableResult recursion', () => {
       ValidateSerializableResult<Result, Serializable>
     >().branded.toEqualTypeOf<Result>()
   })
+
+  it('should preserve recursive tuples without infinite expansion', () => {
+    type ResultTuple = readonly [
+      ReadonlyArray<ResultTuple>,
+      { [key: string]: ResultTuple }
+    ]
+    expectTypeOf<
+      ValidateSerializableResult<ResultTuple, Serializable>
+    >().branded.toEqualTypeOf<ResultTuple>()
+  })
+
+  it('should preserve readonly recursive arrays without infinite expansion', () => {
+    type ResultReadonlyArray = ReadonlyArray<
+      ResultReadonlyArray | { [key: string]: ResultReadonlyArray }
+    >
+    expectTypeOf<
+      ValidateSerializableResult<ResultReadonlyArray, Serializable>
+    >().branded.toEqualTypeOf<ResultReadonlyArray>()
+  })
 })

--- a/packages/router-core/tests/serializer-recursion.test-d.ts
+++ b/packages/router-core/tests/serializer-recursion.test-d.ts
@@ -1,0 +1,15 @@
+import { describe, expectTypeOf, it } from 'vitest'
+
+import type {
+  Serializable,
+  ValidateSerializableResult,
+} from '../src/ssr/serializer/transformer'
+
+describe('ValidateSerializableResult recursion', () => {
+  it('should preserve recursive payload without infinite expansion', () => {
+    type Result = Array<Result> | { [key: string]: Result }
+    expectTypeOf<
+      ValidateSerializableResult<Result, Serializable>
+    >().branded.toEqualTypeOf<Result>()
+  })
+})

--- a/packages/router-core/tests/serializer-recursion.test-d.ts
+++ b/packages/router-core/tests/serializer-recursion.test-d.ts
@@ -28,6 +28,30 @@ describe('ValidateSerializable array handling', () => {
     >().branded.toEqualTypeOf<InputReadonlyArray>()
   })
 
+  it('preserves recursive payloads wrapped in Promise for input validation', () => {
+    type Recursive = { value: number; next?: Recursive }
+    type InputPromise = Promise<Recursive>
+    expectTypeOf<
+      ValidateSerializable<InputPromise, Serializable>
+    >().branded.toEqualTypeOf<InputPromise>()
+  })
+
+  it('preserves recursive payloads wrapped in Promise<Array> for input validation', () => {
+    type Recursive = { value: number; children?: Array<Recursive> }
+    type InputPromiseArray = Promise<Array<Recursive>>
+    expectTypeOf<
+      ValidateSerializable<InputPromiseArray, Serializable>
+    >().branded.toEqualTypeOf<InputPromiseArray>()
+  })
+
+  it('preserves recursive payloads wrapped in ReadableStream for input validation', () => {
+    type Recursive = { value: number; next?: Recursive }
+    type InputStream = ReadableStream<Recursive>
+    expectTypeOf<
+      ValidateSerializable<InputStream, Serializable>
+    >().branded.toEqualTypeOf<InputStream>()
+  })
+
   it('should preserve recursive payload without infinite expansion', () => {
     type Result = Array<Result> | { [key: string]: Result }
     expectTypeOf<


### PR DESCRIPTION
Fixes some issues I was having with https://conform.guide (also fixes https://github.com/TanStack/router/issues/4533)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compile-time serialization validation now recognizes readonly arrays and tuples for inputs and results, preserving tuple shapes and improving type inference and editor experience; no runtime changes.

* **Tests**
  * Added type-level tests covering recursive, nested, readonly array and tuple scenarios to verify compile-time validation and type propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->