### PR TITLE
Fix clearExpiredCache/AgeTicker on removed routes

### DIFF
--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -2259,9 +2259,9 @@ export class RouterCore<
   clearExpiredCache = () => {
     // This is where all of the garbage collection magic happens
     const filter = (d: MakeRouteMatch<TRouteTree>) => {
-      const route = this.looseRoutesById[d.routeId]!
+      const route = this.looseRoutesById[d.routeId]
 
-      if (!route.options.loader) {
+      if (!route?.options.loader) {
         return true
       }
 

--- a/packages/router-devtools-core/src/AgeTicker.tsx
+++ b/packages/router-devtools-core/src/AgeTicker.tsx
@@ -35,9 +35,9 @@ export function AgeTicker({
     return null
   }
 
-  const route = router().looseRoutesById[match.routeId]!
+  const route = router().looseRoutesById[match.routeId]
 
-  if (!route.options.loader) {
+  if (!route?.options.loader) {
     return null
   }
 


### PR DESCRIPTION
I am working on a application where we update the `routeTree` as new parts of the application is loaded (Module Federation architecture). When a new route is registered, these functions error out since the previous route no longer exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved router stability by safely handling missing routes during loader checks, preventing rare crashes when a route is undefined.
  * Updated devtools AgeTicker to gracefully handle absent routes, avoiding null-reference errors and returning no output when appropriate.
  * Overall, reduces runtime exceptions in edge cases involving unresolved or missing routes, enhancing reliability in both runtime and devtools views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->