### PR TITLE
Correct file reference in `build-from-scratch.md`

### DIFF
--- a/docs/start/framework/react/build-from-scratch.md
+++ b/docs/start/framework/react/build-from-scratch.md
@@ -137,7 +137,7 @@ from the default [preloading functionality](/router/latest/docs/framework/react/
 > You won't have a `routeTree.gen.ts` file yet. This file will be generated when you run TanStack Start for the first time.
 
 ```tsx
-// src/start.tsx
+// src/router.tsx
 import { createRouter } from '@tanstack/react-router'
 import { routeTree } from './routeTree.gen'
 


### PR DESCRIPTION
The file tree above, and in all examples uses `src/router.tsx` but this currently references `src/start.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the React “build from scratch” guide to reference the correct router configuration filename in the code example.
  * Aligned examples with current project structure; no changes to imports, logic, or usage patterns.
  * Clarifies setup steps and reduces confusion for new projects; no functional impact on existing implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->