### PR TITLE
fix: Add `optimizeDeps.entries` for `client` and `ssr` environments

### DIFF
--- a/packages/react-start/src/plugin/vite.ts
+++ b/packages/react-start/src/plugin/vite.ts
@@ -65,7 +65,7 @@ export function tanstackStart(
                       ? ['react-dom/client']
                       : ['react-dom/server']),
                     // `@tanstack/react-store` has a dependency on `use-sync-external-store`, which is CJS.
-                    // It therefore needs to included so that it is converted to ESM.
+                    // It therefore needs to be included so that it is converted to ESM.
                     '@tanstack/react-router > @tanstack/react-store',
                   ],
                 }

--- a/packages/react-start/src/plugin/vite.ts
+++ b/packages/react-start/src/plugin/vite.ts
@@ -16,9 +16,9 @@ const defaultEntryDir = path.resolve(
   'default-entry',
 )
 const defaultEntryPaths = {
-  client: path.resolve(defaultEntryDir, 'client'),
-  server: path.resolve(defaultEntryDir, 'server'),
-  start: path.resolve(defaultEntryDir, 'start'),
+  client: path.resolve(defaultEntryDir, 'client.tsx'),
+  server: path.resolve(defaultEntryDir, 'server.ts'),
+  start: path.resolve(defaultEntryDir, 'start.ts'),
 }
 
 const isInsideRouterMonoRepo =

--- a/packages/solid-start/src/plugin/vite.ts
+++ b/packages/solid-start/src/plugin/vite.ts
@@ -16,9 +16,9 @@ const defaultEntryDir = path.resolve(
   'default-entry',
 )
 const defaultEntryPaths = {
-  client: path.resolve(defaultEntryDir, 'client'),
-  server: path.resolve(defaultEntryDir, 'server'),
-  start: path.resolve(defaultEntryDir, 'start'),
+  client: path.resolve(defaultEntryDir, 'client.tsx'),
+  server: path.resolve(defaultEntryDir, 'server.ts'),
+  start: path.resolve(defaultEntryDir, 'start.ts'),
 }
 
 export function tanstackStart(

--- a/packages/start-plugin-core/package.json
+++ b/packages/start-plugin-core/package.json
@@ -76,6 +76,7 @@
     "exsolve": "^1.0.7",
     "pathe": "^2.0.3",
     "srvx": "^0.8.2",
+    "tinyglobby": "^0.2.15",
     "ufo": "^1.5.4",
     "vitefu": "^1.1.1",
     "xmlbuilder2": "^3.1.1",

--- a/packages/start-plugin-core/src/constants.ts
+++ b/packages/start-plugin-core/src/constants.ts
@@ -12,8 +12,8 @@ export type ViteEnvironmentNames =
 // if a user has a custom server/client entry point file, resolve.alias will point to this
 // otherwise it will be aliased to the default entry point in the respective framework plugin
 export const ENTRY_POINTS = {
-  client: 'virtual:tanstack-start-client-entry',
-  server: 'virtual:tanstack-start-server-request-entry',
+  client: '__tanstack-start-client-entry__',
+  server: '__tanstack-start-server-entry__',
   // the start entry point must always be provided by the user
   start: '#tanstack-start-entry',
   router: '#tanstack-router-entry',

--- a/packages/start-plugin-core/src/plugin.ts
+++ b/packages/start-plugin-core/src/plugin.ts
@@ -1,4 +1,3 @@
-import path from 'node:path'
 import { trimPathRight } from '@tanstack/router-core'
 import { VIRTUAL_MODULES } from '@tanstack/start-server-core'
 import { TanStackServerFnPluginEnv } from '@tanstack/server-functions-plugin'
@@ -134,37 +133,25 @@ export function TanStackStartVitePluginCore(
           required: false,
         })
 
-        let clientAlias: string
-        if (clientEntryPath) {
-          clientAlias = vite.normalizePath(
-            path.join('/@fs', path.resolve(root, clientEntryPath)),
-          )
-        } else {
-          clientAlias = corePluginOpts.defaultEntryPaths.client
-        }
-
-        let serverAlias: string
-        if (serverEntryPath) {
-          serverAlias = vite.normalizePath(path.resolve(root, serverEntryPath))
-        } else {
-          serverAlias = corePluginOpts.defaultEntryPaths.server
-        }
-
-        let startAlias: string
-        if (startFilePath) {
-          startAlias = vite.normalizePath(path.resolve(root, startFilePath))
-        } else {
-          startAlias = corePluginOpts.defaultEntryPaths.start
-        }
+        const clientAlias = vite.normalizePath(
+          clientEntryPath ?? corePluginOpts.defaultEntryPaths.client,
+        )
+        const serverAlias = vite.normalizePath(
+          serverEntryPath ?? corePluginOpts.defaultEntryPaths.server,
+        )
+        const startAlias = vite.normalizePath(
+          startFilePath ?? corePluginOpts.defaultEntryPaths.start,
+        )
+        const routerAlias = vite.normalizePath(routerFilePath)
 
         const entryAliasConfiguration: Record<
           (typeof ENTRY_POINTS)[keyof typeof ENTRY_POINTS],
           string
         > = {
-          [ENTRY_POINTS.start]: startAlias,
-          [ENTRY_POINTS.router]: routerFilePath,
           [ENTRY_POINTS.client]: clientAlias,
           [ENTRY_POINTS.server]: serverAlias,
+          [ENTRY_POINTS.start]: startAlias,
+          [ENTRY_POINTS.router]: routerAlias,
         }
 
         const startPackageName =

--- a/packages/start-plugin-core/src/plugin.ts
+++ b/packages/start-plugin-core/src/plugin.ts
@@ -4,6 +4,7 @@ import { TanStackServerFnPluginEnv } from '@tanstack/server-functions-plugin'
 import * as vite from 'vite'
 import { crawlFrameworkPkgs } from 'vitefu'
 import { join } from 'pathe'
+import { escapePath } from 'tinyglobby'
 import { startManifestPlugin } from './start-manifest-plugin/plugin'
 import { startCompilerPlugin } from './start-compiler-plugin/plugin'
 import { ENTRY_POINTS, VITE_ENVIRONMENT_NAMES } from './constants'
@@ -195,7 +196,10 @@ export function TanStackStartVitePluginCore(
               },
               optimizeDeps: {
                 // Ensure user code can be crawled for dependencies
-                entries: [clientAlias, routerAlias],
+                entries: [clientAlias, routerAlias].map((entry) =>
+                  // Entries are treated as `tinyglobby` patterns so need to be escaped
+                  escapePath(entry),
+                ),
               },
             },
             [VITE_ENVIRONMENT_NAMES.server]: {
@@ -217,7 +221,10 @@ export function TanStackStartVitePluginCore(
               },
               optimizeDeps: {
                 // Ensure user code can be crawled for dependencies
-                entries: [serverAlias, startAlias, routerAlias],
+                entries: [serverAlias, startAlias, routerAlias].map((entry) =>
+                  // Entries are treated as `tinyglobby` patterns so need to be escaped
+                  escapePath(entry),
+                ),
               },
             },
           },

--- a/packages/start-plugin-core/src/plugin.ts
+++ b/packages/start-plugin-core/src/plugin.ts
@@ -193,10 +193,13 @@ export function TanStackStartVitePluginCore(
                 },
                 outDir: getClientOutputDirectory(viteConfig),
               },
+              optimizeDeps: {
+                // Ensure user code can be crawled for dependencies
+                entries: [clientAlias, routerAlias],
+              },
             },
             [VITE_ENVIRONMENT_NAMES.server]: {
               consumer: 'server',
-
               build: {
                 ssr: true,
                 rollupOptions: {
@@ -211,6 +214,10 @@ export function TanStackStartVitePluginCore(
                 copyPublicDir:
                   viteConfig.environments?.[VITE_ENVIRONMENT_NAMES.server]
                     ?.build?.copyPublicDir ?? false,
+              },
+              optimizeDeps: {
+                // Ensure user code can be crawled for dependencies
+                entries: [serverAlias, startAlias, routerAlias],
               },
             },
           },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7063,6 +7063,9 @@ importers:
       srvx:
         specifier: ^0.8.2
         version: 0.8.7
+      tinyglobby:
+        specifier: ^0.2.15
+        version: 0.2.15
       ufo:
         specifier: ^1.5.4
         version: 1.6.1
@@ -18254,10 +18257,10 @@ snapshots:
       '@rollup/pluginutils': 5.1.4(rollup@4.52.2)
       commondir: 1.0.1
       estree-walker: 2.0.2
-      fdir: 6.4.4(picomatch@4.0.2)
+      fdir: 6.5.0(picomatch@4.0.3)
       is-reference: 1.2.1
       magic-string: 0.30.19
-      picomatch: 4.0.2
+      picomatch: 4.0.3
     optionalDependencies:
       rollup: 4.52.2
 
@@ -18304,7 +18307,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.7
       estree-walker: 2.0.2
-      picomatch: 4.0.2
+      picomatch: 4.0.3
     optionalDependencies:
       rollup: 4.52.2
 
@@ -19512,7 +19515,7 @@ snapshots:
       glob: 10.4.5
       graceful-fs: 4.2.11
       node-gyp-build: 4.8.4
-      picomatch: 4.0.2
+      picomatch: 4.0.3
       resolve-from: 5.0.0
     transitivePeerDependencies:
       - encoding
@@ -19624,7 +19627,7 @@ snapshots:
       flatted: 3.3.2
       pathe: 2.0.3
       sirv: 3.0.1
-      tinyglobby: 0.2.13
+      tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
       vitest: 3.2.4(@types/node@22.13.4)(@vitest/browser@3.0.6)(@vitest/ui@3.0.6)(jiti@2.6.0)(jsdom@25.0.1)(lightningcss@1.29.2)(msw@2.7.0(@types/node@22.13.4)(typescript@5.9.2))(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.0)
 
@@ -23492,7 +23495,7 @@ snapshots:
   rollup-plugin-visualizer@6.0.3(rollup@4.52.2):
     dependencies:
       open: 8.4.2
-      picomatch: 4.0.2
+      picomatch: 4.0.3
       source-map: 0.7.6
       yargs: 17.7.2
     optionalDependencies:


### PR DESCRIPTION
This adds `optimizeDeps.entries` for the `client` and `ssr` environments so that dependencies are discovered when starting the dev server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Simplified internal entry and route aliasing for more consistent build/dev behavior; entry targets made more explicit (no public API changes).
- Documentation
  - Minor comment clarity improvement.
- Chores
  - Added a small utility dependency to improve file resolution and dependency discovery during development and build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->