### PR TITLE
fix(start-plugin-core): always install nitro dev middleware

### DIFF
--- a/packages/start-plugin-core/src/dev-server-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/dev-server-plugin/plugin.ts
@@ -59,12 +59,8 @@ export function devServerPlugin({
               return
             }
 
-            // do not install middleware if SSR env in case another plugin already did
-            if (
-              !isRunnableDevEnvironment(serverEnv) ||
-              // do not check via `isFetchableDevEnvironment` since nitro does implement the `FetchableDevEnvironment` interface but not via inheritance (which this helper checks)
-              'dispatchFetch' in serverEnv
-            ) {
+            // only install middleware when the SSR environment can run requests itself
+            if (!isRunnableDevEnvironment(serverEnv)) {
               return
             }
           }
@@ -101,7 +97,7 @@ export function devServerPlugin({
               console.error(e)
               try {
                 viteDevServer.ssrFixStacktrace(e as Error)
-              } catch (_e) {}
+              } catch {}
 
               if (
                 webReq.headers.get('content-type')?.includes('application/json')


### PR DESCRIPTION
The guard in the dev plugin assumed that if a Vite server environment exposed a `dispatchFetch` method, another plugin had already installed the request middleware.

Nitro v3’s dev environment now exposes `dispatchFetch` by default, so the guard skipped installing TanStack Start’s middleware entirely (without which any redirects coming from Start handlers were followed internally by Nitro instead of being sent back to the browser).

Fixes #5220