### PR TITLE
docs: wrong link to bun server implementation in hosting page

### DIFF
--- a/docs/start/framework/react/hosting.md
+++ b/docs/start/framework/react/hosting.md
@@ -245,7 +245,7 @@ We've created an optimized production server that provides intelligent static as
 
 **Quick Setup:**
 
-1. Copy the [`server.ts`](../../../../examples/react/start-bun/server.ts) file from the example in this repository to your project root
+1. Copy the [`server.ts`](https://github.com/tanstack/router/blob/main/examples/react/start-bun/server.ts) file from the example in this repository to your project root
 
 2. Build your application:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Setup instructions to copy the example server file from a GitHub URL instead of a local relative path.
  * Improves clarity and reduces friction by pointing to a single, canonical source for the example file.
  * No functional or behavioral changes; this is an instructional update only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->