### PR TITLE
fix: use package alias for h3

### DIFF
--- a/packages/start-server-core/package.json
+++ b/packages/start-server-core/package.json
@@ -68,7 +68,7 @@
     "@tanstack/router-core": "workspace:*",
     "@tanstack/start-client-core": "workspace:*",
     "@tanstack/start-storage-context": "workspace:*",
-    "h3": "2.0.0-beta.4",
+    "h3-v2": "npm:h3@2.0.0-beta.4",
     "seroval": "^1.3.2",
     "tiny-invariant": "^1.3.3"
   },

--- a/packages/start-server-core/src/request-response.ts
+++ b/packages/start-server-core/src/request-response.ts
@@ -19,7 +19,7 @@ import {
   unsealSession as h3_unsealSession,
   updateSession as h3_updateSession,
   useSession as h3_useSession,
-} from 'h3'
+} from 'h3-v2'
 import type {
   RequestHeaderMap,
   RequestHeaderName,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7406,9 +7406,9 @@ importers:
       '@tanstack/start-storage-context':
         specifier: workspace:*
         version: link:../start-storage-context
-      h3:
-        specifier: 2.0.0-beta.4
-        version: 2.0.0-beta.4
+      h3-v2:
+        specifier: npm:h3@2.0.0-beta.4
+        version: h3@2.0.0-beta.4
       seroval:
         specifier: ^1.3.2
         version: 1.3.2


### PR DESCRIPTION
this should help compatibility with npm and the vite nitro v2 plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated an internal dependency by switching to an aliased package name while keeping the same version (2.0.0-beta.4); no functional or API changes are expected.
  - No other dependencies, public interfaces, or runtime behaviors were modified; installation, compatibility, and build/deploy workflows remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->