### PR TITLE
Docs: Change "target" to "preset" in Nitro v3 example config

### DIFF
--- a/docs/start/framework/react/hosting.md
+++ b/docs/start/framework/react/hosting.md
@@ -168,7 +168,7 @@ export default defineConfig({
     tanstackStart(),
     nitro(/*
       // nitro config goes here, e.g.
-      { config: { target: 'node-server' } }
+      { config: { preset: 'node-server' } }
     */)
     viteReact(),
   ],


### PR DESCRIPTION
"target" has been replaced by "preset"