### PR TITLE
fix: basepath rewrite to match with or without trailing slash

### DIFF
--- a/packages/router-core/src/rewrite.ts
+++ b/packages/router-core/src/rewrite.ts
@@ -24,7 +24,7 @@ export function rewriteBasepath(opts: {
 }) {
   const trimmedBasepath = trimPath(opts.basepath)
   const regex = new RegExp(
-    `^/${trimmedBasepath}/`,
+    `^/${trimmedBasepath}(?:/|$)`,
     opts.caseSensitive ? '' : 'i',
   )
   return {


### PR DESCRIPTION
## Summary

This PR fixes the basepath rewrite logic to correctly match routes with or without a trailing slash.

## Problem

The rewrite logic didn’t consider basepaths without a trailing slash. For example, if you define a basepath like `/myapp` and try to access the root page at `/myapp`, it would not work unless you added a trailing slash (i.e., `/myapp/`). This caused the root page to be inaccessible without the slash, breaking prerendering in Tanstack Start

## Related Issue

See #5261 for more details


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route matching for base paths to handle URLs with or without a trailing slash, reducing false 404s and ensuring correct resolution.
  * Enhances compatibility across environments where base paths may be configured inconsistently, resulting in more reliable navigation and redirects.
  * Preserves existing case sensitivity behavior with no changes to the public API or configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->