### PR TITLE
Rfc/server routes object handlers

### DIFF
--- a/docs/start/framework/react/middleware.md
+++ b/docs/start/framework/react/middleware.md
@@ -163,7 +163,7 @@ export const Route = createFileRoute('/foo')({
 
 #### Specific Server Route Methods
 
-You can pass middleware to specific server route methods by using the `{ middleware, handler }` form for a method. Example:
+You can pass middleware to specific server route methods by using the object form. Example:
 
 ```tsx
 const loggingMiddleware = createMiddleware().server(() => {

--- a/docs/start/framework/react/middleware.md
+++ b/docs/start/framework/react/middleware.md
@@ -163,7 +163,7 @@ export const Route = createFileRoute('/foo')({
 
 #### Specific Server Route Methods
 
-You can pass middleware to specific server route methods by using the `createHandlers` utility and passing a middleware array to the `middleware` property of the method object.
+You can pass middleware to specific server route methods by using the `{ middleware, handler }` form for a method. Example:
 
 ```tsx
 const loggingMiddleware = createMiddleware().server(() => {
@@ -172,15 +172,14 @@ const loggingMiddleware = createMiddleware().server(() => {
 
 export const Route = createFileRoute('/foo')({
   server: {
-    handlers: ({ createHandlers }) =>
-      createHandlers({
-        GET: {
-          middleware: [loggingMiddleware],
-          handler: () => {
-            //...
-          },
+    handlers: {
+      GET: {
+        middleware: [loggingMiddleware],
+        handler: () => {
+          //...
         },
-      }),
+      },
+    },
   },
 })
 ```

--- a/docs/start/framework/react/server-routes.md
+++ b/docs/start/framework/react/server-routes.md
@@ -140,7 +140,7 @@ export const Route = createFileRoute('/hello')({
 You can define handlers in two ways:
 
 - **Simple handlers**: Provide handler functions directly in a handlers object
-- **Handlers with middleware**: Use the `createHandlers` function to define handlers with middleware
+- **Handlers with middleware**: Use an object to define handlers with middleware
 
 ### Simple handlers
 

--- a/examples/react/start-basic/src/routes/__root.tsx
+++ b/examples/react/start-basic/src/routes/__root.tsx
@@ -61,63 +61,64 @@ export const testGetMiddleware = startInstance
 export const Route = createRootRoute({
   server: {
     middleware: [testServerMw],
+    // handlers: {
+    //   GET: ({ context, next }) => {
+    //     context.fromFetch
+    //     //      ^?
+    //     context.fromServerMw
+    //     //      ^?
+    //     context.fromIndexServerMw
+    //     //      ^?
+    //     return next({
+    //       context: {
+    //         fromGet: true,
+    //       },
+    //     })
+    //   },
+    //   POST: ({ context, next }) => {
+    //     context.fromFetch
+    //     context.fromServerMw
+    //     context.fromIndexServerMw
+    //     return next({
+    //       context: {
+    //         fromPost: true,
+    //       },
+    //     })
+    //   },
+    // },
+
     handlers: {
-      GET: ({ context, next }) => {
-        context.fromFetch
-        //      ^?
-        context.fromServerMw
-        //      ^?
-        context.fromIndexServerMw
-        //      ^?
-        return next({
-          context: {
-            fromGet: true,
+        GET: {
+          middleware: [testGetMiddleware],
+          handler: ({ context, next }) => {
+            context.fromFetch
+            //      ^?
+            context.fromServerMw
+            //      ^?
+            context.fromIndexServerMw
+            //      ^?
+            context.fromGetMiddleware
+            //      ^?
+            console.log({context})
+            return next({
+              context: {
+                fromGet: true,
+                fromPost: false,
+              },
+            })
           },
-        })
-      },
-      POST: ({ context, next }) => {
-        context.fromFetch
-        context.fromServerMw
-        context.fromIndexServerMw
-        return next({
-          context: {
-            fromPost: true,
+        },
+        POST: {
+          handler: ({ next }) => {
+            return next({
+              context: {
+                fromGet: false,
+                fromPost: true,
+              },
+            })
           },
-        })
+        },
       },
-    },
-    // handlers: ({ createHandlers }) =>
-    //   createHandlers({
-    //     GET: {
-    //       middleware: [testGetMiddleware],
-    //       handler: ({ context, next }) => {
-    //         context.fromFetch
-    //         //      ^?
-    //         context.fromServerMw
-    //         //      ^?
-    //         context.fromIndexServerMw
-    //         //      ^?
-    //         context.fromGetMiddleware
-    //         //      ^?
-    //         return next({
-    //           context: {
-    //             fromGet: true,
-    //             fromPost: false,
-    //           },
-    //         })
-    //       },
-    //     },
-    //     POST: {
-    //       handler: ({ next }) => {
-    //         return next({
-    //           context: {
-    //             fromGet: false,
-    //             fromPost: true,
-    //           },
-    //         })
-    //       },
-    //     },
-    //   }),
     test: (test) => {},
   },
   beforeLoad: ({ serverContext }) => {

--- a/packages/start-client-core/src/serverRoute.ts
+++ b/packages/start-client-core/src/serverRoute.ts
@@ -153,29 +153,29 @@ export interface RouteServerOptions<
             TServerMiddlewares,
             any,
             any
+          > 
+          | RouteMethodBuilderOptions<
+           TRegister,
+            TParentRoute,
+            TPath,
+            TServerMiddlewares,
+            any,
+            any
           >
         >
       >
-    | ((
-        opts: HandlersFnOpts<
-          TRegister,
-          TParentRoute,
-          TPath,
-          TServerMiddlewares
-        >,
-      ) => CustomHandlerFunctionsRecord<
+    |  CustomHandlerFunctionsRecord<
         TRegister,
         TParentRoute,
         TPath,
         TServerMiddlewares,
         any,
         any
-      >)
+      >
   >
   test?: (test: Expand<ExtractHandlersContext<THandlers>>) => void
 }
 
-declare const createHandlersSymbol: unique symbol
 
 type CustomHandlerFunctionsRecord<
   TRegister,
@@ -184,9 +184,7 @@ type CustomHandlerFunctionsRecord<
   TServerMiddlewares,
   TMethodMiddlewares,
   TServerContext,
-> = {
-  [createHandlersSymbol]: true
-} & Partial<
+> =  Partial<
   Record<
     RouteMethod,
     RouteMethodHandler<
@@ -200,59 +198,6 @@ type CustomHandlerFunctionsRecord<
   >
 >
 
-export interface HandlersFnOpts<
-  TRegister,
-  TParentRoute extends AnyRoute,
-  TPath extends string,
-  TServerMiddlewares,
-> {
-  createHandlers: CreateHandlersFn<
-    TRegister,
-    TParentRoute,
-    TPath,
-    TServerMiddlewares
-  >
-}
-
-export type CreateHandlersFn<
-  TRegister,
-  TParentRoute extends AnyRoute,
-  TPath extends string,
-  TServerMiddlewares,
-> = <
-  const TMethodAllMiddlewares,
-  const TMethodGetMiddlewares,
-  const TMethodPostMiddlewares,
-  const TMethodPutMiddlewares,
-  const TMethodPatchMiddlewares,
-  const TMethodDeleteMiddlewares,
-  const TMethodOptionsMiddlewares,
-  const TMethodHeadMiddlewares,
-  TServerContext,
->(
-  opts: CreateMethodFnOpts<
-    TRegister,
-    TParentRoute,
-    TPath,
-    TServerMiddlewares,
-    TMethodAllMiddlewares,
-    TMethodGetMiddlewares,
-    TMethodPostMiddlewares,
-    TMethodPutMiddlewares,
-    TMethodPatchMiddlewares,
-    TMethodDeleteMiddlewares,
-    TMethodOptionsMiddlewares,
-    TMethodHeadMiddlewares,
-    TServerContext
-  >,
-) => CustomHandlerFunctionsRecord<
-  TRegister,
-  TParentRoute,
-  TPath,
-  TServerMiddlewares,
-  any,
-  TServerContext
->
 
 export interface CreateMethodFnOpts<
   TRegister,

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -396,10 +396,8 @@ async function handleServerRoutes({
     if (server.handlers) {
       const handlers =
         typeof server.handlers === 'function'
-          ? server.handlers({
-              createHandlers: (d: any) => d,
-            })
-          : server.handlers
+          ? server.handlers()
+          : server.handlers.handler()
 
       const requestMethod = request.method.toLowerCase()
 

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -397,7 +397,7 @@ async function handleServerRoutes({
       const handlers =
         typeof server.handlers === 'function'
           ? server.handlers()
-          : server.handlers.handler()
+          : server.handlers
 
       const requestMethod = request.method.toLowerCase()
 


### PR DESCRIPTION
Removes the need for `createHandlers` and provides an object option for server route handlers with middleware such as

 ```diff
- handlers: ({ createHandlers }) =>
-     createHandlers({
       GET: {
         middleware: [loggerMiddleware],
         handler: async ({ request }) => {
           return new Response('Hello, World! from ' + request.url)
         },
       },
-     }),
+ handlers: {
+   GET: {
     middleware: [validationMiddleware],
     handler: async ({ request }) => {
       const body = await request.json()
       return new Response(`Hello, ${body.name}!`)
     },
   },
+ }
```

- [ ] types
  - [x] remove `createHandlers`
  - [ ] include specified middleware ctx
 - [x] docs
 - [ ] tests
   - [ ] start-basic 