### PR TITLE
fix: merge `serializationAdapters` from `createStart` `getOptions` and `router.options`

### DIFF
--- a/packages/start-client-core/src/client/hydrateStart.ts
+++ b/packages/start-client-core/src/client/hydrateStart.ts
@@ -25,6 +25,9 @@ export async function hydrateStart(): Promise<AnyRouter> {
   }
 
   serializationAdapters.push(ServerFunctionSerializationAdapter)
+  if (router.options.serializationAdapters) {
+    serializationAdapters.push(...router.options.serializationAdapters)
+  }
 
   router.update({
     basepath: process.env.TSS_ROUTER_BASEPATH,

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -147,7 +147,7 @@ export function createStartHandler<TRegister = Register>(
           defaultSsr: startOptions.defaultSsr,
           serializationAdapters: [
             ...(startOptions.serializationAdapters || []),
-            ...(router.options?.serializationAdapters || []),
+            ...(router.options.serializationAdapters || []),
           ],
         },
         basepath: ROUTER_BASEPATH,

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -145,7 +145,10 @@ export function createStartHandler<TRegister = Register>(
         origin: router.options.origin ?? origin,
         ...{
           defaultSsr: startOptions.defaultSsr,
-          serializationAdapters: startOptions.serializationAdapters,
+          serializationAdapters: [
+            ...(startOptions.serializationAdapters || []),
+            ...(router.options?.serializationAdapters || []),
+          ],
         },
         basepath: ROUTER_BASEPATH,
       })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Serialization adapters are now merged from both app configuration and router-defined options on client and server. This preserves existing adapters and ensures new adapters are applied without overriding user settings. Improves compatibility when using multiple adapters, preventing missing or incorrect serialization during hydration and routing updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->