### PR TITLE
fix: return Headers instead of object

### DIFF
--- a/packages/start-server-core/src/request-response.ts
+++ b/packages/start-server-core/src/request-response.ts
@@ -143,7 +143,7 @@ export function setResponseHeaders(
 
 export function getResponseHeaders(): TypedHeaders<ResponseHeaderMap> {
   const event = getH3Event()
-  return Object.fromEntries(event.res.headers.entries()) as any
+  return event.res.headers
 }
 
 export function getResponseHeader(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Response header access now returns a headers-style map instead of a plain key-value object.
  * Existing behavior and APIs remain the same otherwise.

* **Potential Impact**
  * Integrations expecting a plain object may need adjustments.
  * Consumers can now directly use standard headers iteration and retrieval methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->