### PR TITLE
fix(router-core): set default value for TTo in UseNavigateResult type

### DIFF
--- a/packages/router-core/src/useNavigate.ts
+++ b/packages/router-core/src/useNavigate.ts
@@ -3,7 +3,7 @@ import type { RegisteredRouter } from './router'
 
 export type UseNavigateResult<TDefaultFrom extends string> = <
   TRouter extends RegisteredRouter,
-  TTo extends string | undefined,
+  TTo extends string | undefined = '.',
   TFrom extends string = TDefaultFrom,
   TMaskFrom extends string = TFrom,
   TMaskTo extends string = '',


### PR DESCRIPTION
fixes #5203 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated navigation API typings to include a default destination when none is specified, improving TypeScript inference and reducing the need for explicit generics. This results in fewer editor warnings and a smoother development experience. Existing code continues to work without changes.
- Chores
  - Internal type cleanup only; no runtime or user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->