### PR TITLE
fix: basepath

### DIFF
--- a/examples/react/start-basic/vite.config.ts
+++ b/examples/react/start-basic/vite.config.ts
@@ -4,6 +4,7 @@ import tsConfigPaths from 'vite-tsconfig-paths'
 import viteReact from '@vitejs/plugin-react'
 
 export default defineConfig({
+  base: '/foo/',
   server: {
     port: 3000,
   },

--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -349,7 +349,7 @@ export { Asset } from './Asset'
 export { HeadContent } from './HeadContent'
 export { Scripts } from './Scripts'
 export type * from './ssr/serializer'
-export { rewriteBasepath, composeRewrites } from '@tanstack/router-core'
+export { composeRewrites } from '@tanstack/router-core'
 export type {
   LocationRewrite,
   LocationRewriteFunction,

--- a/packages/react-router/tests/router.test.tsx
+++ b/packages/react-router/tests/router.test.tsx
@@ -2986,7 +2986,7 @@ describe('basepath', () => {
     const router = createRouter({
       routeTree,
       history,
-      basepath: 'my-app'
+      basepath: 'my-app',
     })
 
     render(<RouterProvider router={router} />)

--- a/packages/react-router/tests/router.test.tsx
+++ b/packages/react-router/tests/router.test.tsx
@@ -19,7 +19,6 @@ import {
   createRootRoute,
   createRoute,
   createRouter,
-  rewriteBasepath,
   useNavigate,
 } from '../src'
 import type { StandardSchemaValidator } from '@tanstack/router-core'
@@ -2602,7 +2601,7 @@ describe('Router rewrite functionality', () => {
   })
 })
 
-describe('rewriteBasepath utility', () => {
+describe('basepath', () => {
   it('should handle basic basepath rewriting with input', async () => {
     const rootRoute = createRootRoute({
       component: () => <Outlet />,
@@ -2627,7 +2626,7 @@ describe('rewriteBasepath utility', () => {
       history: createMemoryHistory({
         initialEntries: ['/my-app/about'],
       }),
-      rewrite: rewriteBasepath({ basepath: 'my-app' }),
+      basepath: 'my-app',
     })
 
     render(<RouterProvider router={router} />)
@@ -2640,37 +2639,11 @@ describe('rewriteBasepath utility', () => {
     expect(router.state.location.pathname).toBe('/about')
   })
 
-  it('should handle basepath with leading and trailing slashes', async () => {
-    const rootRoute = createRootRoute({
-      component: () => <Outlet />,
-    })
-
-    const usersRoute = createRoute({
-      getParentRoute: () => rootRoute,
-      path: '/users',
-      component: () => <div data-testid="users">Users</div>,
-    })
-
-    const routeTree = rootRoute.addChildren([usersRoute])
-
-    const router = createRouter({
-      routeTree,
-      history: createMemoryHistory({
-        initialEntries: ['/api/v1/users'],
-      }),
-      rewrite: rewriteBasepath({ basepath: '/api/v1/' }), // With leading and trailing slashes
-    })
-
-    render(<RouterProvider router={router} />)
-
-    await waitFor(() => {
-      expect(screen.getByTestId('users')).toBeInTheDocument()
-    })
-
-    expect(router.state.location.pathname).toBe('/users')
-  })
-
   it.each([
+    {
+      description: 'basepath with leading and trailing slashes',
+      basepath: '/api/v1/',
+    },
     {
       description: 'basepath with leading slash but without trailing slash',
       basepath: '/api/v1',
@@ -2701,7 +2674,7 @@ describe('rewriteBasepath utility', () => {
       history: createMemoryHistory({
         initialEntries: ['/api/v1/users'],
       }),
-      rewrite: rewriteBasepath({ basepath }),
+      basepath,
     })
 
     render(<RouterProvider router={router} />)
@@ -2742,7 +2715,7 @@ describe('rewriteBasepath utility', () => {
         history: createMemoryHistory({
           initialEntries: ['/my-app/'],
         }),
-        rewrite: rewriteBasepath({ basepath }),
+        basepath,
       })
 
       render(<RouterProvider router={router} />)
@@ -2791,7 +2764,7 @@ describe('rewriteBasepath utility', () => {
       const router = createRouter({
         routeTree,
         history,
-        rewrite: rewriteBasepath({ basepath }),
+        basepath,
       })
 
       render(<RouterProvider router={router} />)
@@ -2826,7 +2799,7 @@ describe('rewriteBasepath utility', () => {
       history: createMemoryHistory({
         initialEntries: ['/test'],
       }),
-      rewrite: rewriteBasepath({ basepath: '' }), // Empty basepath
+      basepath: '',
     })
 
     render(<RouterProvider router={router} />)
@@ -2854,19 +2827,16 @@ describe('rewriteBasepath utility', () => {
       history: createMemoryHistory({
         initialEntries: ['/my-app/legacy/api/v1'],
       }),
-      rewrite: composeRewrites([
-        rewriteBasepath({ basepath: 'my-app' }),
-        {
-          // Additional rewrite logic after basepath removal
-          input: ({ url }) => {
-            if (url.pathname === '/legacy/api/v1') {
-              url.pathname = '/api/v2'
-              return url
-            }
-            return undefined
-          },
+      basepath: 'my-app',
+      rewrite: {
+        input: ({ url }) => {
+          if (url.pathname === '/legacy/api/v1') {
+            url.pathname = '/api/v2'
+            return url
+          }
+          return undefined
         },
-      ]),
+      },
     })
 
     render(<RouterProvider router={router} />)
@@ -2876,36 +2846,6 @@ describe('rewriteBasepath utility', () => {
     // Should first remove basepath (/my-app/legacy/api/v1 -> /legacy/api/v1)
     // Then apply additional rewrite (/legacy/api/v1 -> /api/v2)
     expect(router.state.location.pathname).toBe('/api/v2')
-  })
-
-  it('should handle complex basepath with subdomain-style paths', async () => {
-    const rootRoute = createRootRoute({
-      component: () => <Outlet />,
-    })
-
-    const dashboardRoute = createRoute({
-      getParentRoute: () => rootRoute,
-      path: '/dashboard',
-      component: () => <div data-testid="dashboard">Dashboard</div>,
-    })
-
-    const routeTree = rootRoute.addChildren([dashboardRoute])
-
-    const router = createRouter({
-      routeTree,
-      history: createMemoryHistory({
-        initialEntries: ['/tenant-123/dashboard'],
-      }),
-      rewrite: rewriteBasepath({ basepath: 'tenant-123' }),
-    })
-
-    render(<RouterProvider router={router} />)
-
-    await waitFor(() => {
-      expect(screen.getByTestId('dashboard')).toBeInTheDocument()
-    })
-
-    expect(router.state.location.pathname).toBe('/dashboard')
   })
 
   it('should preserve search params and hash when rewriting basepath', async () => {
@@ -2926,7 +2866,7 @@ describe('rewriteBasepath utility', () => {
       history: createMemoryHistory({
         initialEntries: ['/app/search?q=test&filter=all#results'],
       }),
-      rewrite: rewriteBasepath({ basepath: 'app' }),
+      basepath: 'app',
     })
 
     render(<RouterProvider router={router} />)
@@ -2961,8 +2901,8 @@ describe('rewriteBasepath utility', () => {
       history: createMemoryHistory({
         initialEntries: ['/base/legacy/old/path'],
       }),
+      basepath: 'base',
       rewrite: composeRewrites([
-        rewriteBasepath({ basepath: 'base' }),
         {
           input: ({ url }) => {
             // First layer: convert legacy paths
@@ -3046,7 +2986,7 @@ describe('rewriteBasepath utility', () => {
     const router = createRouter({
       routeTree,
       history,
-      rewrite: rewriteBasepath({ basepath: 'my-app' }),
+      basepath: 'my-app'
     })
 
     render(<RouterProvider router={router} />)

--- a/packages/router-core/src/index.ts
+++ b/packages/router-core/src/index.ts
@@ -434,7 +434,6 @@ export {
 export { defaultSerovalPlugins } from './ssr/serializer/seroval-plugins'
 
 export {
-  rewriteBasepath,
   composeRewrites,
   executeRewriteInput,
   executeRewriteOutput,

--- a/packages/solid-router/src/index.tsx
+++ b/packages/solid-router/src/index.tsx
@@ -352,7 +352,7 @@ export { ScriptOnce } from './ScriptOnce'
 export { Asset } from './Asset'
 export { HeadContent, useTags } from './HeadContent'
 export { Scripts } from './Scripts'
-export { rewriteBasepath, composeRewrites } from '@tanstack/router-core'
+export { composeRewrites } from '@tanstack/router-core'
 export type {
   LocationRewrite,
   LocationRewriteFunction,

--- a/packages/start-client-core/src/client-rpc/createClientRpc.ts
+++ b/packages/start-client-core/src/client-rpc/createClientRpc.ts
@@ -1,20 +1,8 @@
 import { TSS_SERVER_FUNCTION } from '../constants'
 import { serverFnFetcher } from './serverFnFetcher'
 
-// make sure this get's hoisted
-// eslint-disable-next-line no-var
-var baseUrl: string
-function sanitizeBase(base: string) {
-  return base.replace(/^\/|\/$/g, '')
-}
-
 export function createClientRpc(functionId: string) {
-  if (!baseUrl) {
-    const sanitizedAppBase = sanitizeBase(process.env.TSS_APP_BASE || '/')
-    const sanitizedServerBase = sanitizeBase(process.env.TSS_SERVER_FN_BASE!)
-    baseUrl = `${sanitizedAppBase ? `/${sanitizedAppBase}` : ''}/${sanitizedServerBase}/`
-  }
-  const url = baseUrl + functionId
+  const url = process.env.TSS_SERVER_FN_BASE + functionId
 
   const clientFn = (...args: Array<any>) => {
     return serverFnFetcher(url, args, fetch)

--- a/packages/start-client-core/src/client/hydrateStart.ts
+++ b/packages/start-client-core/src/client/hydrateStart.ts
@@ -25,8 +25,11 @@ export async function hydrateStart(): Promise<AnyRouter> {
   }
 
   serializationAdapters.push(ServerFunctionSerializationAdapter)
-  router.options.serializationAdapters = serializationAdapters
 
+  router.update({
+    basepath: process.env.TSS_ROUTER_BASEPATH,
+    ...{ serializationAdapters },
+  })
   if (!router.state.matches.length) {
     await hydrate(router)
   }

--- a/packages/start-plugin-core/src/global.d.ts
+++ b/packages/start-plugin-core/src/global.d.ts
@@ -2,7 +2,6 @@ import type { Manifest } from '@tanstack/router-core'
 
 /* eslint-disable no-var */
 declare global {
-  var TSS_APP_BASE: string
   var TSS_ROUTES_MANIFEST: Manifest
 }
 export {}

--- a/packages/start-plugin-core/src/plugin.ts
+++ b/packages/start-plugin-core/src/plugin.ts
@@ -121,6 +121,19 @@ export function TanStackStartVitePluginCore(
           } else {
             startConfig.router.basepath = '/'
           }
+        } else {
+          if (command === 'serve' && !viteConfig.server?.middlewareMode) {
+            // when serving, we must ensure that router basepath and viteAppBase are aligned
+            if (
+              !joinPaths(['/', startConfig.router.basepath, '/']).startsWith(
+                joinPaths(['/', resolvedStartConfig.viteAppBase, '/']),
+              )
+            ) {
+              this.error(
+                '[tanstack-start]: During `vite dev`, `router.basepath` must start with the vite `base` config value',
+              )
+            }
+          }
         }
 
         const TSS_SERVER_FN_BASE = joinPaths([

--- a/packages/start-plugin-core/src/plugin.ts
+++ b/packages/start-plugin-core/src/plugin.ts
@@ -1,4 +1,4 @@
-import { trimPathRight } from '@tanstack/router-core'
+import { joinPaths, trimPathRight } from '@tanstack/router-core'
 import { VIRTUAL_MODULES } from '@tanstack/start-server-core'
 import { TanStackServerFnPluginEnv } from '@tanstack/server-functions-plugin'
 import * as vite from 'vite'
@@ -41,6 +41,7 @@ export interface ResolvedStartConfig {
   startFilePath: string | undefined
   routerFilePath: string
   srcDirectory: string
+  viteAppBase: string
 }
 
 export type GetConfigFn = () => {
@@ -56,6 +57,7 @@ export function TanStackStartVitePluginCore(
     startFilePath: undefined,
     routerFilePath: '',
     srcDirectory: '',
+    viteAppBase: '',
   }
 
   let startConfig: TanStackStartOutputConfig | null
@@ -90,13 +92,25 @@ export function TanStackStartVitePluginCore(
       name: 'tanstack-start-core:config',
       enforce: 'pre',
       async config(viteConfig, { command }) {
-        const viteAppBase = trimPathRight(viteConfig.base || '/')
-        globalThis.TSS_APP_BASE = viteAppBase
-
+        resolvedStartConfig.viteAppBase = trimPathRight(viteConfig.base || '/')
         const root = viteConfig.root || process.cwd()
         resolvedStartConfig.root = root
 
         const { startConfig } = getConfig()
+        if (startConfig.router.basepath === undefined) {
+          startConfig.router.basepath = resolvedStartConfig.viteAppBase
+        }
+        startConfig.router.basepath = startConfig.router.basepath.replace(
+          /^\/|\/$/g,
+          '',
+        )
+
+        const TSS_SERVER_FN_BASE = joinPaths([
+          '/',
+          startConfig.router.basepath,
+          startConfig.serverFns.base,
+          '/',
+        ])
         const resolvedSrcDirectory = join(root, startConfig.srcDirectory)
         resolvedStartConfig.srcDirectory = resolvedSrcDirectory
 
@@ -179,7 +193,6 @@ export function TanStackStartVitePluginCore(
         })
 
         return {
-          base: viteAppBase,
           // see https://vite.dev/config/shared-options.html#apptype
           // this will prevent vite from injecting middlewares that we don't want
           appType: viteConfig.appType ?? 'custom',
@@ -246,9 +259,9 @@ export function TanStackStartVitePluginCore(
             // i.e: __FRAMEWORK_NAME__ can be replaced with JSON.stringify("TanStack Start")
             // This is not the same as injecting environment variables.
 
-            ...defineReplaceEnv('TSS_SERVER_FN_BASE', startConfig.serverFns.base),
+            ...defineReplaceEnv('TSS_SERVER_FN_BASE', TSS_SERVER_FN_BASE),
             ...defineReplaceEnv('TSS_CLIENT_OUTPUT_DIR', getClientOutputDirectory(viteConfig)),
-            ...defineReplaceEnv('TSS_APP_BASE', viteAppBase),
+            ...defineReplaceEnv('TSS_ROUTER_BASEPATH', startConfig.router.basepath),
             ...(command === 'serve' ? defineReplaceEnv('TSS_SHELL', startConfig.spa?.enabled ? 'true' : 'false') : {}),
             ...defineReplaceEnv('TSS_DEV_SERVER', command === 'serve' ? 'true' : 'false'),
           },
@@ -306,6 +319,7 @@ export function TanStackStartVitePluginCore(
     loadEnvPlugin(),
     startManifestPlugin({
       getClientBundle: () => getBundle(VITE_ENVIRONMENT_NAMES.client),
+      getConfig,
     }),
     devServerPlugin({ getConfig }),
     {

--- a/packages/start-plugin-core/src/prerender.ts
+++ b/packages/start-plugin-core/src/prerender.ts
@@ -138,6 +138,8 @@ export async function prerender({
         ...page.prerender,
       }
 
+      const routerBasePath = startConfig.router.basepath || '/'
+
       // Add the task
       queue.add(async () => {
         logger.info(`Crawling: ${page.path}`)
@@ -146,7 +148,7 @@ export async function prerender({
           // Fetch the route
           const encodedRoute = encodeURI(page.path)
 
-          const res = await localFetch(withBase(encodedRoute, TSS_APP_BASE), {
+          const res = await localFetch(withBase(encodedRoute, routerBasePath), {
             headers: {
               ...prerenderOptions.headers,
             },
@@ -179,7 +181,7 @@ export async function prerender({
 
           const filename = withoutBase(
             isImplicitHTML ? htmlPath : routeWithIndex,
-            TSS_APP_BASE,
+            routerBasePath,
           )
 
           const html = await res.text()

--- a/packages/start-plugin-core/src/prerender.ts
+++ b/packages/start-plugin-core/src/prerender.ts
@@ -138,7 +138,7 @@ export async function prerender({
         ...page.prerender,
       }
 
-      const routerBasePath = startConfig.router.basepath || '/'
+      const routerBasePath = joinURL('/', startConfig.router.basepath ?? '')
 
       // Add the task
       queue.add(async () => {

--- a/packages/start-plugin-core/src/prerender.ts
+++ b/packages/start-plugin-core/src/prerender.ts
@@ -107,6 +107,7 @@ export async function prerender({
     const concurrency = startConfig.prerender?.concurrency ?? os.cpus().length
     logger.info(`Concurrency: ${concurrency}`)
     const queue = new Queue({ concurrency })
+    const routerBasePath = joinURL('/', startConfig.router.basepath ?? '')
 
     startConfig.pages.forEach((page) => addCrawlPageTask(page))
 
@@ -137,8 +138,6 @@ export async function prerender({
         ...startConfig.prerender,
         ...page.prerender,
       }
-
-      const routerBasePath = joinURL('/', startConfig.router.basepath ?? '')
 
       // Add the task
       queue.add(async () => {

--- a/packages/start-plugin-core/src/schema.ts
+++ b/packages/start-plugin-core/src/schema.ts
@@ -138,6 +138,7 @@ const tanstackStartOptionsSchema = z
     router: z
       .object({
         entry: z.string().optional(),
+        basepath: z.string().optional(),
       })
       .and(tsrConfig.optional().default({}))
       .optional()

--- a/packages/start-server-core/src/createServerRpc.ts
+++ b/packages/start-server-core/src/createServerRpc.ts
@@ -1,26 +1,10 @@
 import { TSS_SERVER_FUNCTION } from '@tanstack/start-client-core'
-import invariant from 'tiny-invariant'
-
-let baseUrl: string
-function sanitizeBase(base: string) {
-  return base.replace(/^\/|\/$/g, '')
-}
 
 export const createServerRpc = (
   functionId: string,
   splitImportFn: (...args: any) => any,
 ) => {
-  if (!baseUrl) {
-    const sanitizedAppBase = sanitizeBase(process.env.TSS_APP_BASE || '/')
-    const sanitizedServerBase = sanitizeBase(process.env.TSS_SERVER_FN_BASE!)
-    baseUrl = `${sanitizedAppBase ? `/${sanitizedAppBase}` : ''}/${sanitizedServerBase}/`
-  }
-  invariant(
-    splitImportFn,
-    '🚨splitImportFn required for the server functions server runtime, but was not provided.',
-  )
-
-  const url = baseUrl + functionId
+  const url = process.env.TSS_SERVER_FN_BASE + functionId
 
   return Object.assign(splitImportFn, {
     url,

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -8,8 +8,6 @@ import {
   executeRewriteInput,
   isRedirect,
   isResolvedRedirect,
-  joinPaths,
-  trimPath,
 } from '@tanstack/router-core'
 import {
   attachRouterServerSsrUtils,
@@ -56,19 +54,7 @@ function getStartResponseHeaders(opts: { router: AnyRouter }) {
 export function createStartHandler<TRegister = Register>(
   cb: HandlerCallback<AnyRouter>,
 ): RequestHandler<TRegister> {
-  if (!process.env.TSS_SERVER_FN_BASE) {
-    throw new Error(
-      'tanstack/start-server-core: TSS_SERVER_FN_BASE must be defined in your environment for createStartHandler()',
-    )
-  }
-  // TODO do we remove this?
-  const APP_BASE = process.env.TSS_APP_BASE || '/'
-  // Add trailing slash to sanitise user defined TSS_SERVER_FN_BASE
-  const serverFnBase = joinPaths([
-    APP_BASE,
-    trimPath(process.env.TSS_SERVER_FN_BASE),
-    '/',
-  ])
+  const ROUTER_BASEPATH = process.env.TSS_ROUTER_BASEPATH || '/'
   let startRoutesManifest: Manifest | null = null
   let startEntry: StartEntry | null = null
   let routerEntry: RouterEntry | null = null
@@ -134,7 +120,6 @@ export function createStartHandler<TRegister = Register>(
     let router: AnyRouter | null = null
     const getRouter = async () => {
       if (router) return router
-      // TODO how does this work with base path? does the router need to be configured the same as APP_BASE?
       router = await (await getEntries()).routerEntry.getRouter()
 
       // Update the client-side router with the history
@@ -162,6 +147,7 @@ export function createStartHandler<TRegister = Register>(
           defaultSsr: startOptions.defaultSsr,
           serializationAdapters: startOptions.serializationAdapters,
         },
+        basepath: ROUTER_BASEPATH,
       })
       return router
     }
@@ -185,7 +171,7 @@ export function createStartHandler<TRegister = Register>(
           async () => {
             try {
               // First, let's attempt to handle server functions
-              if (href.startsWith(serverFnBase)) {
+              if (href.startsWith(process.env.TSS_SERVER_FN_BASE)) {
                 return await handleServerAction({
                   request,
                   context: requestOpts?.context,
@@ -222,9 +208,7 @@ export function createStartHandler<TRegister = Register>(
 
                 // if the startRoutesManifest is not loaded yet, load it once
                 if (startRoutesManifest === null) {
-                  startRoutesManifest = await getStartManifest({
-                    basePath: APP_BASE,
-                  })
+                  startRoutesManifest = await getStartManifest()
                 }
                 const router = await getRouter()
                 attachRouterServerSsrUtils({

--- a/packages/start-server-core/src/global.d.ts
+++ b/packages/start-server-core/src/global.d.ts
@@ -1,8 +1,8 @@
 declare global {
   namespace NodeJS {
     interface ProcessEnv {
-      TSS_APP_BASE?: string
-      TSS_SERVER_FN_BASE?: string
+      TSS_ROUTER_BASEPATH: string
+      TSS_SERVER_FN_BASE: string
       TSS_CLIENT_OUTPUT_DIR?: string
       TSS_SHELL?: 'true' | 'false'
       TSS_PRERENDERING?: 'true' | 'false'

--- a/packages/start-server-core/src/request-response.ts
+++ b/packages/start-server-core/src/request-response.ts
@@ -15,7 +15,6 @@ import {
   sanitizeStatusMessage as h3_sanitizeStatusMessage,
   sealSession as h3_sealSession,
   setCookie as h3_setCookie,
-  toResponse as h3_toResponse,
   unsealSession as h3_unsealSession,
   updateSession as h3_updateSession,
   useSession as h3_useSession,
@@ -55,7 +54,7 @@ export function requestHandler<TRegister = unknown>(
     const response = eventStorage.run({ h3Event }, () =>
       handler(request, requestOpts),
     )
-    return h3_toResponse(response, h3Event)
+    return response // h3_toResponse(response, h3Event)
   }
 }
 

--- a/packages/start-server-core/src/request-response.ts
+++ b/packages/start-server-core/src/request-response.ts
@@ -15,6 +15,7 @@ import {
   sanitizeStatusMessage as h3_sanitizeStatusMessage,
   sealSession as h3_sealSession,
   setCookie as h3_setCookie,
+  toResponse as h3_toResponse,
   unsealSession as h3_unsealSession,
   updateSession as h3_updateSession,
   useSession as h3_useSession,
@@ -54,7 +55,7 @@ export function requestHandler<TRegister = unknown>(
     const response = eventStorage.run({ h3Event }, () =>
       handler(request, requestOpts),
     )
-    return response // h3_toResponse(response, h3Event)
+    return h3_toResponse(response, h3Event)
   }
 }
 

--- a/packages/start-server-core/src/router-manifest.ts
+++ b/packages/start-server-core/src/router-manifest.ts
@@ -8,7 +8,7 @@ import { loadVirtualModule } from './loadVirtualModule'
  * special assets that are needed for the client. It does not include relationships
  * between routes or any other data that is not needed for the client.
  */
-export async function getStartManifest(opts: { basePath: string }) {
+export async function getStartManifest() {
   const { tsrStartManifest } = await loadVirtualModule(
     VIRTUAL_MODULES.startManifest,
   )

--- a/packages/start-server-core/src/server-functions-handler.ts
+++ b/packages/start-server-core/src/server-functions-handler.ts
@@ -10,15 +10,7 @@ import { fromJSON, toCrossJSONAsync, toCrossJSONStream } from 'seroval'
 import { getResponse } from './request-response'
 import { getServerFnById } from './getServerFnById'
 
-function sanitizeBase(base: string | undefined) {
-  if (!base) {
-    throw new Error(
-      '🚨 process.env.TSS_SERVER_FN_BASE is required in start/server-handler/index',
-    )
-  }
-
-  return base.replace(/^\/|\/$/g, '')
-}
+let regex: RegExp | undefined = undefined
 
 export const handleServerAction = async ({
   request,
@@ -32,13 +24,14 @@ export const handleServerAction = async ({
   const abort = () => controller.abort()
   request.signal.addEventListener('abort', abort)
 
+  if (regex === undefined) {
+    regex = new RegExp(`${process.env.TSS_SERVER_FN_BASE}([^/?#]+)`)
+  }
+
   const method = request.method
   const url = new URL(request.url, 'http://localhost:3000')
   // extract the serverFnId from the url as host/_serverFn/:serverFnId
   // Define a regex to match the path and extract the :thing part
-  const regex = new RegExp(
-    `${sanitizeBase(process.env.TSS_SERVER_FN_BASE)}/([^/?#]+)`,
-  )
 
   // Execute the regex
   const match = url.pathname.match(regex)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Router supports a runtime basepath option applied during hydration; manifests and prerendering use configured basepaths. Vite base is respected for public paths.

- Refactor
  - Public API surface simplified (rewriteBasepath removed); manifest retrieval call simplified to no-arg form. Client/server RPC and URL handling unified to rely on environment-driven bases.

- Bug Fixes
  - More consistent asset and navigation URL resolution under custom base paths.

- Chores
  - Environment vars updated: TSS_APP_BASE removed; TSS_ROUTER_BASEPATH and TSS_SERVER_FN_BASE required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->