### PR TITLE
fix(router-core): fix typing of search in remountDeps

### DIFF
--- a/packages/router-core/src/route.ts
+++ b/packages/router-core/src/route.ts
@@ -987,7 +987,7 @@ export interface FilebaseRouteOptionsInterface<
     (
       opt: RemountDepsOptions<
         TId,
-        FullSearchSchemaOption<TParentRoute, TSearchValidator>,
+        ResolveFullSearchSchema<TParentRoute, TSearchValidator>,
         Expand<ResolveAllParamsFromParent<TParentRoute, TParams>>,
         TLoaderDeps
       >,

--- a/packages/router-core/tests/remountDeps.test-d.ts
+++ b/packages/router-core/tests/remountDeps.test-d.ts
@@ -1,0 +1,16 @@
+import { describe, expectTypeOf, test } from 'vitest'
+import type { RemountDepsOptions } from '../src'
+
+type SearchSchema = {
+  testParam: string
+}
+
+type TestRemountDepsOptions = RemountDepsOptions<'/test', SearchSchema, {}, {}>
+
+describe('RemountDepsOptions type test', () => {
+  test('search field should be directly accessible', () => {
+    expectTypeOf<
+      TestRemountDepsOptions['search']
+    >().toEqualTypeOf<SearchSchema>()
+  })
+})

--- a/packages/router-core/tests/remountDeps.test.ts
+++ b/packages/router-core/tests/remountDeps.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest'
+import type { RemountDepsOptions } from '../src'
+
+describe('RemountDepsOptions unit tests', () => {
+  test('search field should be directly accessible', () => {
+    type SearchSchema = {
+      testParam: string
+    }
+
+    const mockOptions: RemountDepsOptions<'/test', SearchSchema, {}, {}> = {
+      routeId: '/test',
+      search: {
+        testParam: 'test-value',
+      },
+      params: {},
+      loaderDeps: {},
+    }
+
+    expect(mockOptions.search.testParam).toBe('test-value')
+  })
+})


### PR DESCRIPTION
close #5361 

use `ResolveFullSearchSchema` instead of `FullSearchSchemaOption`

<img width="406" height="122" alt="스크린샷 2025-10-04 오후 6 34 23" src="https://github.com/user-attachments/assets/6a800149-64b2-4f87-a526-9b4ac4991bdc" />

<img width="407" height="113" alt="스크린샷 2025-10-04 오후 6 34 33" src="https://github.com/user-attachments/assets/ab00e940-7bd3-4bb5-b21c-b3af0594c786" />


`search` is iffered as correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined TypeScript typings for route remount dependencies to improve type safety and editor IntelliSense. No runtime behavior changes.

* **Tests**
  * Added unit tests to validate direct access to remount dependency search fields.
  * Added type-level tests to ensure the search schema is correctly inferred.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->