### PR TITLE
fixed infered type from useServerFn + added type test

### DIFF
--- a/examples/react/start-basic-react-query/src/routes/index.tsx
+++ b/examples/react/start-basic-react-query/src/routes/index.tsx
@@ -1,12 +1,36 @@
+import * as React from 'react'
+import { useMutation } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
+import { createServerFn, useServerFn } from '@tanstack/react-start'
+
+const greetUser = createServerFn({ method: 'POST' })
+  .inputValidator((input: { name: string }) => input)
+  .handler(async ({ data }) => {
+    return Promise.resolve({ message: `Hello ${data.name}!` })
+  })
+
 export const Route = createFileRoute('/')({
   component: Home,
 })
 
 function Home() {
+  const greetingMutation = useMutation({
+    mutationFn: useServerFn(greetUser),
+    onSuccess: (data) => data,
+  })
+
   return (
-    <div className="p-2">
-      <h3>Welcome Home!!!</h3>
+    <div className="p-2 flex flex-col gap-2">
+      <h3>useServerFn + useMutation demo</h3>
+      <button
+        className="rounded bg-blue-500 px-3 py-1 text-white"
+        onClick={() => greetingMutation.mutate({ data: { name: 'TanStack' } })}
+      >
+        Say hi
+      </button>
+      {greetingMutation.data ? (
+        <p data-testid="greeted">{greetingMutation.data.message}</p>
+      ) : null}
     </div>
   )
 }

--- a/packages/react-start/src/tests/useServerFnMutation.test-d.tsx
+++ b/packages/react-start/src/tests/useServerFnMutation.test-d.tsx
@@ -9,12 +9,11 @@ const serverFn = createServerFn({ method: 'POST' })
     })
   })
 
-const optionalServerFn = createServerFn()
-  .handler(async () => {
-    return await Promise.resolve({
-      ok: true as const,
-    })
+const optionalServerFn = createServerFn().handler(async () => {
+  return await Promise.resolve({
+    ok: true as const,
   })
+})
 
 export function UseServerFnMutationRegressionComponent() {
   const mutation = useMutation({

--- a/packages/react-start/src/tests/useServerFnMutation.test-d.tsx
+++ b/packages/react-start/src/tests/useServerFnMutation.test-d.tsx
@@ -3,23 +3,39 @@ import { createServerFn, useServerFn } from '../index'
 
 const serverFn = createServerFn({ method: 'POST' })
   .inputValidator((input: { name: string }) => input)
-  .handler(async ({ data }) => ({
-    message: `Hello ${data.name}!`,
-  }))
+  .handler(async ({ data }) => {
+    return await Promise.resolve({
+      message: `Hello ${data.name}!`,
+    })
+  })
 
-useMutation({
-  mutationFn: useServerFn(serverFn),
-  onSuccess: (data) => {
-    data.message
-  },
-})
+const optionalServerFn = createServerFn()
+  .handler(async () => {
+    return await Promise.resolve({
+      ok: true as const,
+    })
+  })
 
-const optionalServerFn = createServerFn().handler(async () => ({
-  ok: true as const,
-}))
+export function UseServerFnMutationRegressionComponent() {
+  const mutation = useMutation({
+    mutationFn: useServerFn(serverFn),
+    onSuccess: (data, variables) => {
+      data.message
+      variables?.data?.name
+    },
+  })
 
-useServerFn(optionalServerFn)().then((result) => {
-  result.ok
-})
+  void mutation
+  return null
+}
 
-useServerFn(optionalServerFn)({ headers: { 'x-test': '1' } })
+export function useOptionalServerFnRegressionHook() {
+  const optionalHandler = useServerFn(optionalServerFn)
+
+  optionalHandler().then((result) => {
+    result.ok
+  })
+
+  void optionalHandler()
+  void optionalHandler(undefined)
+}

--- a/packages/react-start/src/tests/useServerFnMutation.test-d.tsx
+++ b/packages/react-start/src/tests/useServerFnMutation.test-d.tsx
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query'
+import { createServerFn, useServerFn } from '@tanstack/react-start'
+
+const serverFn = createServerFn({ method: 'POST' })
+  .inputValidator((input: { name: string }) => input)
+  .handler(async ({ data }) => ({
+    message: `Hello ${data.name}!`,
+  }))
+
+useMutation({
+  mutationFn: useServerFn(serverFn),
+  onSuccess: (data) => {
+    data.message
+  },
+})

--- a/packages/react-start/src/tests/useServerFnMutation.test-d.tsx
+++ b/packages/react-start/src/tests/useServerFnMutation.test-d.tsx
@@ -14,10 +14,9 @@ useMutation({
   },
 })
 
-const optionalServerFn = createServerFn()
-  .handler(async () => ({
-    ok: true as const,
-  }))
+const optionalServerFn = createServerFn().handler(async () => ({
+  ok: true as const,
+}))
 
 useServerFn(optionalServerFn)().then((result) => {
   result.ok

--- a/packages/react-start/src/tests/useServerFnMutation.test-d.tsx
+++ b/packages/react-start/src/tests/useServerFnMutation.test-d.tsx
@@ -20,7 +20,7 @@ export function UseServerFnMutationRegressionComponent() {
     mutationFn: useServerFn(serverFn),
     onSuccess: (data, variables) => {
       data.message
-      variables?.data?.name
+      variables.data.name
     },
   })
 

--- a/packages/react-start/src/tests/useServerFnMutation.test-d.tsx
+++ b/packages/react-start/src/tests/useServerFnMutation.test-d.tsx
@@ -3,17 +3,13 @@ import { createServerFn, useServerFn } from '../index'
 
 const serverFn = createServerFn({ method: 'POST' })
   .inputValidator((input: { name: string }) => input)
-  .handler(async ({ data }) => {
-    return await Promise.resolve({
-      message: `Hello ${data.name}!`,
-    })
-  })
+  .handler(async ({ data }) => ({
+    message: `Hello ${data.name}!`,
+  }))
 
-const optionalServerFn = createServerFn().handler(async () => {
-  return await Promise.resolve({
-    ok: true as const,
-  })
-})
+const optionalServerFn = createServerFn().handler(async () => ({
+  ok: true as const,
+}))
 
 export function UseServerFnMutationRegressionComponent() {
   const mutation = useMutation({

--- a/packages/react-start/src/tests/useServerFnMutation.test-d.tsx
+++ b/packages/react-start/src/tests/useServerFnMutation.test-d.tsx
@@ -13,3 +13,14 @@ useMutation({
     data.message
   },
 })
+
+const optionalServerFn = createServerFn()
+  .handler(async () => ({
+    ok: true as const,
+  }))
+
+useServerFn(optionalServerFn)().then((result) => {
+  result.ok
+})
+
+useServerFn(optionalServerFn)({ headers: { 'x-test': '1' } })

--- a/packages/react-start/src/tests/useServerFnMutation.test-d.tsx
+++ b/packages/react-start/src/tests/useServerFnMutation.test-d.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query'
-import { createServerFn, useServerFn } from '@tanstack/react-start'
+import { createServerFn, useServerFn } from '../index'
 
 const serverFn = createServerFn({ method: 'POST' })
   .inputValidator((input: { name: string }) => input)

--- a/packages/react-start/src/useServerFn.ts
+++ b/packages/react-start/src/useServerFn.ts
@@ -5,11 +5,19 @@ type AwaitedReturn<T extends (...args: Array<any>) => Promise<any>> = Awaited<
   ReturnType<T>
 >
 
+type NonUndefined<T> = Exclude<T, undefined>
+
 type UseServerFnReturn<T extends (...args: Array<any>) => Promise<any>> =
   Parameters<T> extends []
     ? () => Promise<AwaitedReturn<T>>
     : Parameters<T> extends [infer TVariables]
-      ? (variables: TVariables) => Promise<AwaitedReturn<T>>
+      ? undefined extends TVariables
+        ? [NonUndefined<TVariables>] extends [never]
+          ? () => Promise<AwaitedReturn<T>>
+          : (
+              variables?: NonUndefined<TVariables>,
+            ) => Promise<AwaitedReturn<T>>
+        : (variables: TVariables) => Promise<AwaitedReturn<T>>
       : (...args: Parameters<T>) => Promise<AwaitedReturn<T>>
 
 export function useServerFn<T extends (...deps: Array<any>) => Promise<any>>(

--- a/packages/react-start/src/useServerFn.ts
+++ b/packages/react-start/src/useServerFn.ts
@@ -14,9 +14,7 @@ type UseServerFnReturn<T extends (...args: Array<any>) => Promise<any>> =
       ? undefined extends TVariables
         ? [NonUndefined<TVariables>] extends [never]
           ? () => Promise<AwaitedReturn<T>>
-          : (
-              variables?: NonUndefined<TVariables>,
-            ) => Promise<AwaitedReturn<T>>
+          : (variables?: NonUndefined<TVariables>) => Promise<AwaitedReturn<T>>
         : (variables: TVariables) => Promise<AwaitedReturn<T>>
       : (...args: Parameters<T>) => Promise<AwaitedReturn<T>>
 

--- a/packages/react-start/src/useServerFn.ts
+++ b/packages/react-start/src/useServerFn.ts
@@ -1,13 +1,24 @@
 import * as React from 'react'
 import { isRedirect, useRouter } from '@tanstack/react-router'
 
+type AwaitedReturn<T extends (...args: Array<any>) => Promise<any>> = Awaited<
+  ReturnType<T>
+>
+
+type UseServerFnReturn<T extends (...args: Array<any>) => Promise<any>> =
+  Parameters<T> extends []
+    ? () => Promise<AwaitedReturn<T>>
+    : Parameters<T> extends [infer TVariables]
+      ? (variables: TVariables) => Promise<AwaitedReturn<T>>
+      : (...args: Parameters<T>) => Promise<AwaitedReturn<T>>
+
 export function useServerFn<T extends (...deps: Array<any>) => Promise<any>>(
   serverFn: T,
-): (...args: Parameters<T>) => ReturnType<T> {
+): UseServerFnReturn<T> {
   const router = useRouter()
 
-  return React.useCallback(
-    async (...args: Array<any>) => {
+  const handler = React.useCallback(
+    async (...args: Parameters<T>) => {
       try {
         const res = await serverFn(...args)
 
@@ -15,16 +26,20 @@ export function useServerFn<T extends (...deps: Array<any>) => Promise<any>>(
           throw res
         }
 
-        return res
+        return res as AwaitedReturn<T>
       } catch (err) {
         if (isRedirect(err)) {
           err.options._fromLocation = router.state.location
-          return router.navigate(router.resolveRedirect(err).options)
+          return router.navigate(
+            router.resolveRedirect(err).options,
+          ) as AwaitedReturn<T>
         }
 
         throw err
       }
     },
     [router, serverFn],
-  ) as any
+  )
+
+  return handler as UseServerFnReturn<T>
 }

--- a/packages/solid-start/src/tests/useServerFnMutation.test-d.tsx
+++ b/packages/solid-start/src/tests/useServerFnMutation.test-d.tsx
@@ -1,0 +1,38 @@
+import { createServerFn, useServerFn } from '../index'
+
+const serverFn = createServerFn({ method: 'POST' })
+  .inputValidator((input: { name: string }) => input)
+  .handler(async ({ data }) => {
+    return await Promise.resolve({
+      message: `Hello ${data.name}!`,
+    })
+  })
+
+const optionalServerFn = createServerFn()
+  .handler(async () => {
+    return await Promise.resolve({
+      ok: true as const,
+    })
+  })
+
+export function UseServerFnRegressionComponent() {
+  const handler = useServerFn(serverFn)
+
+  handler({ data: { name: 'TanStack' } }).then((result) => {
+    result.message
+  })
+
+  void handler
+  return null
+}
+
+export function useOptionalServerFnRegressionHook() {
+  const handler = useServerFn(optionalServerFn)
+
+  handler().then((result) => {
+    result.ok
+  })
+
+  void handler()
+  void handler(undefined)
+}

--- a/packages/solid-start/src/tests/useServerFnMutation.test-d.tsx
+++ b/packages/solid-start/src/tests/useServerFnMutation.test-d.tsx
@@ -2,17 +2,13 @@ import { createServerFn, useServerFn } from '../index'
 
 const serverFn = createServerFn({ method: 'POST' })
   .inputValidator((input: { name: string }) => input)
-  .handler(async ({ data }) => {
-    return await Promise.resolve({
-      message: `Hello ${data.name}!`,
-    })
-  })
+  .handler(async ({ data }) => ({
+    message: `Hello ${data.name}!`,
+  }))
 
-const optionalServerFn = createServerFn().handler(async () => {
-  return await Promise.resolve({
-    ok: true as const,
-  })
-})
+const optionalServerFn = createServerFn().handler(async () => ({
+  ok: true as const,
+}))
 
 export function UseServerFnRegressionComponent() {
   const handler = useServerFn(serverFn)

--- a/packages/solid-start/src/tests/useServerFnMutation.test-d.tsx
+++ b/packages/solid-start/src/tests/useServerFnMutation.test-d.tsx
@@ -8,12 +8,11 @@ const serverFn = createServerFn({ method: 'POST' })
     })
   })
 
-const optionalServerFn = createServerFn()
-  .handler(async () => {
-    return await Promise.resolve({
-      ok: true as const,
-    })
+const optionalServerFn = createServerFn().handler(async () => {
+  return await Promise.resolve({
+    ok: true as const,
   })
+})
 
 export function UseServerFnRegressionComponent() {
   const handler = useServerFn(serverFn)

--- a/packages/solid-start/src/useServerFn.ts
+++ b/packages/solid-start/src/useServerFn.ts
@@ -4,11 +4,19 @@ type AwaitedReturn<T extends (...args: Array<any>) => Promise<any>> = Awaited<
   ReturnType<T>
 >
 
+type NonUndefined<T> = Exclude<T, undefined>
+
 type UseServerFnReturn<T extends (...args: Array<any>) => Promise<any>> =
   Parameters<T> extends []
     ? () => Promise<AwaitedReturn<T>>
     : Parameters<T> extends [infer TVariables]
-      ? (variables: TVariables) => Promise<AwaitedReturn<T>>
+      ? undefined extends TVariables
+        ? [NonUndefined<TVariables>] extends [never]
+          ? () => Promise<AwaitedReturn<T>>
+          : (
+              variables?: NonUndefined<TVariables>,
+            ) => Promise<AwaitedReturn<T>>
+        : (variables: TVariables) => Promise<AwaitedReturn<T>>
       : (...args: Parameters<T>) => Promise<AwaitedReturn<T>>
 
 export function useServerFn<T extends (...deps: Array<any>) => Promise<any>>(

--- a/packages/solid-start/src/useServerFn.ts
+++ b/packages/solid-start/src/useServerFn.ts
@@ -13,9 +13,7 @@ type UseServerFnReturn<T extends (...args: Array<any>) => Promise<any>> =
       ? undefined extends TVariables
         ? [NonUndefined<TVariables>] extends [never]
           ? () => Promise<AwaitedReturn<T>>
-          : (
-              variables?: NonUndefined<TVariables>,
-            ) => Promise<AwaitedReturn<T>>
+          : (variables?: NonUndefined<TVariables>) => Promise<AwaitedReturn<T>>
         : (variables: TVariables) => Promise<AwaitedReturn<T>>
       : (...args: Parameters<T>) => Promise<AwaitedReturn<T>>
 


### PR DESCRIPTION
## Summary
- tighten `useServerFn` typing in React/Solid so inline `useMutation({ mutationFn: useServerFn(fn) })`
  resolves to the awaited payload instead of `unknown`
- add a focused `.test-d.tsx` regression exercising the React Query reproduction
- restore the basic React Query example with a simple server function + mutation flow
- Fixes #5352 
- Updated 1 example to use useServerFn (I can remove it if I should?)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Example app adds a server-side mutation flow with a “Say hi” button and vertical layout that displays the greeting on success.

* **Refactor**
  * Revised useServerFn return shape and behavior for React and Solid to provide more consistent, ergonomic return types.

* **Tests**
  * Added integration/regression tests for server-function usage with mutations in React and Solid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->