### PR TITLE
fix(router-devtools-core): bundle solid for smaller package

### DIFF
--- a/packages/router-devtools-core/package.json
+++ b/packages/router-devtools-core/package.json
@@ -38,17 +38,17 @@
   },
   "type": "module",
   "types": "./dist/esm/index.d.ts",
-  "main": "./dist/cjs/index.cjs",
-  "module": "./dist/esm/index.js",
+  "main": "./dist/cjs/packages/router-devtools-core/src/index.cjs",
+  "module": "./dist/esm/packages/router-devtools-core/src/index.js",
   "exports": {
     ".": {
       "import": {
         "types": "./dist/esm/index.d.ts",
-        "default": "./dist/esm/index.js"
+        "default": "./dist/esm/packages/router-devtools-core/src/index.js"
       },
       "require": {
         "types": "./dist/cjs/index.d.cts",
-        "default": "./dist/cjs/index.cjs"
+        "default": "./dist/cjs/packages/router-devtools-core/src/index.cjs"
       }
     },
     "./package.json": "./package.json"
@@ -64,16 +64,15 @@
   "dependencies": {
     "clsx": "^2.1.1",
     "goober": "^2.1.16",
-    "solid-js": "^1.9.5",
     "vite": "^7.1.7"
   },
   "devDependencies": {
+    "solid-js": "^1.9.5",
     "vite-plugin-solid": "^2.11.8"
   },
   "peerDependencies": {
     "@tanstack/router-core": "workspace:^",
     "csstype": "^3.0.10",
-    "solid-js": ">=1.9.5",
     "tiny-invariant": "^1.3.3"
   },
   "peerDependenciesMeta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6976,9 +6976,6 @@ importers:
       goober:
         specifier: ^2.1.16
         version: 2.1.16(csstype@3.1.3)
-      solid-js:
-        specifier: ^1.9.5
-        version: 1.9.5
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3
@@ -6986,6 +6983,9 @@ importers:
         specifier: ^7.1.7
         version: 7.1.7(@types/node@22.10.2)(jiti@2.6.0)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.0)
     devDependencies:
+      solid-js:
+        specifier: ^1.9.5
+        version: 1.9.5
       vite-plugin-solid:
         specifier: ^2.11.8
         version: 2.11.8(@testing-library/jest-dom@6.6.3)(solid-js@1.9.5)(vite@7.1.7(@types/node@22.10.2)(jiti@2.6.0)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.0))


### PR DESCRIPTION
It's pretty weird to be downloading solid into a react app and it adds an extra 3.5MB: https://pkg-size.dev/solid-js

By bundling solid we end up with a much smaller package since we keep only the parts of it that are used (~40kb) and tree-shake away the rest. This prevents deduping for solid users, so it's larger for those users. However, there are 3,700 weekly downloads from solid and 1 million from react, so this is a huge savings overall.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated package metadata and public entry points for the router devtools core package.
  - Moved a framework dependency to development-only and removed its peer-dependency declaration to reduce install warnings.
  - Clarified module entry exports to improve packaging; no functional changes for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->