### PR TITLE
fix: revert alias handling for nitro-v2-vite-plugin

### DIFF
--- a/packages/nitro-v2-vite-plugin/package.json
+++ b/packages/nitro-v2-vite-plugin/package.json
@@ -40,6 +40,7 @@
   },
   "type": "module",
   "types": "dist/esm/index.d.ts",
+  "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.js",
   "exports": {
     ".": {
@@ -60,8 +61,7 @@
   },
   "dependencies": {
     "nitropack": "^2.12.6",
-    "pathe": "^2.0.3",
-    "h3-v1": "npm:h3@^1.15.4"
+    "pathe": "^2.0.3"
   },
   "peerDependencies": {
     "vite": ">=7.0.0"

--- a/packages/nitro-v2-vite-plugin/src/index.ts
+++ b/packages/nitro-v2-vite-plugin/src/index.ts
@@ -1,4 +1,3 @@
-import { createRequire } from 'node:module'
 import { build, copyPublicAssets, createNitro, prepare } from 'nitropack'
 import { dirname, resolve } from 'pathe'
 
@@ -16,7 +15,6 @@ function isFullUrl(str: string): boolean {
     return false
   }
 }
-const require = createRequire(import.meta.url)
 
 export function nitroV2Plugin(nitroConfig?: NitroConfig): Array<PluginOption> {
   let resolvedConfig: ResolvedConfig
@@ -94,7 +92,6 @@ export function nitroV2Plugin(nitroConfig?: NitroConfig): Array<PluginOption> {
 
               await builder.build(client)
               await builder.build(server)
-              const h3 = require.resolve('h3-v1')
 
               const virtualEntry = '#tanstack/start/entry'
               const baseURL = !isFullUrl(resolvedConfig.base)
@@ -113,22 +110,7 @@ export function nitroV2Plugin(nitroConfig?: NitroConfig): Array<PluginOption> {
                 renderer: virtualEntry,
                 rollupConfig: {
                   ...nitroConfig?.rollupConfig,
-                  plugins: [
-                    virtualBundlePlugin(ssrBundle) as any,
-                    {
-                      name: 'resolve',
-                      resolveId(source, importer) {
-                        if (
-                          (importer?.includes('nitropack') ||
-                            importer === virtualEntry) &&
-                          source === 'h3'
-                        ) {
-                          return h3
-                        }
-                        return null
-                      },
-                    },
-                  ],
+                  plugins: [virtualBundlePlugin(ssrBundle) as any],
                 },
                 virtual: {
                   ...nitroConfig?.virtual,

--- a/packages/nitro-v2-vite-plugin/src/index.ts
+++ b/packages/nitro-v2-vite-plugin/src/index.ts
@@ -94,7 +94,7 @@ export function nitroV2Plugin(nitroConfig?: NitroConfig): Array<PluginOption> {
 
               await builder.build(client)
               await builder.build(server)
-              const h3v1 = require.resolve('h3-v1')
+              const h3 = require.resolve('h3-v1')
 
               const virtualEntry = '#tanstack/start/entry'
               const baseURL = !isFullUrl(resolvedConfig.base)
@@ -119,11 +119,11 @@ export function nitroV2Plugin(nitroConfig?: NitroConfig): Array<PluginOption> {
                       name: 'resolve',
                       resolveId(source, importer) {
                         if (
-                          source === 'h3' &&
                           (importer?.includes('nitropack') ||
-                            importer?.includes(virtualEntry))
+                            importer === virtualEntry) &&
+                          source === 'h3'
                         ) {
-                          return h3v1
+                          return h3
                         }
                         return null
                       },

--- a/packages/nitro-v2-vite-plugin/vite.config.ts
+++ b/packages/nitro-v2-vite-plugin/vite.config.ts
@@ -9,6 +9,5 @@ export default mergeConfig(
     entry: './src/index.ts',
     srcDir: './src',
     exclude: ['./src/tests/'],
-    cjs: false,
   }),
 )

--- a/packages/start-server-core/package.json
+++ b/packages/start-server-core/package.json
@@ -68,7 +68,7 @@
     "@tanstack/router-core": "workspace:*",
     "@tanstack/start-client-core": "workspace:*",
     "@tanstack/start-storage-context": "workspace:*",
-    "h3": "2.0.0-beta.5",
+    "h3-v2": "npm:h3@2.0.0-beta.4",
     "seroval": "^1.3.2",
     "tiny-invariant": "^1.3.3"
   },

--- a/packages/start-server-core/src/request-response.ts
+++ b/packages/start-server-core/src/request-response.ts
@@ -19,7 +19,7 @@ import {
   unsealSession as h3_unsealSession,
   updateSession as h3_updateSession,
   useSession as h3_useSession,
-} from 'h3'
+} from 'h3-v2'
 import type {
   RequestHeaderMap,
   RequestHeaderName,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6683,9 +6683,6 @@ importers:
 
   packages/nitro-v2-vite-plugin:
     dependencies:
-      h3-v1:
-        specifier: npm:h3@^1.15.4
-        version: h3@1.15.4
       nitropack:
         specifier: ^2.12.6
         version: 2.12.6(@netlify/blobs@9.1.2)
@@ -7464,9 +7461,9 @@ importers:
       '@tanstack/start-storage-context':
         specifier: workspace:*
         version: link:../start-storage-context
-      h3:
-        specifier: 2.0.0-beta.5
-        version: 2.0.0-beta.5
+      h3-v2:
+        specifier: npm:h3@2.0.0-beta.4
+        version: h3@2.0.0-beta.4
       seroval:
         specifier: ^1.3.2
         version: 1.3.2
@@ -13803,8 +13800,8 @@ packages:
   h3@1.15.4:
     resolution: {integrity: sha512-z5cFQWDffyOe4vQ9xIqNfCZdV4p//vy6fBnr8Q1AWnVZ0teurKMG66rLj++TKwKPUP3u7iMUvrvKaEUiQw2QWQ==}
 
-  h3@2.0.0-beta.5:
-    resolution: {integrity: sha512-ApIkLH+nTxzCC0Nq/GN1v6jkvu2eOLfdTnTs6ghiuG1EYHWJBDLzhk5tn7SZMEUNsLUjG4qfmqzBx2LG9I7Q/w==}
+  h3@2.0.0-beta.4:
+    resolution: {integrity: sha512-/JdwHUGuHjbBXAVxQN7T7QeI9cVlhsqMKVNFHebZVs9RoEYH85Ogh9O1DEy/1ZiJkmMwa1gNg6bBcGhc1Itjdg==}
     engines: {node: '>=20.11.1'}
     peerDependencies:
       crossws: ^0.4.1
@@ -15689,8 +15686,8 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rou3@0.7.7:
-    resolution: {integrity: sha512-z+6o7c3DarUbuBMLIdhzj2CqJLtUWrGk4fZlf07dIMitX3UpBXeInJ3lMD9huxj9yh9eo1RqtXf9aL0YzkDDUA==}
+  rou3@0.7.5:
+    resolution: {integrity: sha512-bwUHDHw1HSARty7TWNV71R0NZs5fOt74OM+hcMdJyPfchfRktEmxLoMSNa7PwEp6WqJ0a3feKztsIfTUEYhskw==}
 
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
@@ -15945,11 +15942,6 @@ packages:
 
   srvx@0.8.7:
     resolution: {integrity: sha512-g3+15LlwVOGL2QpoTPZlvRjg+9a5Tx/69CatXjFP6txvhIaW2FmGyzJfb8yft5wyfGddvJmP/Yx+e/uNDMRSLQ==}
-    engines: {node: '>=20.16.0'}
-    hasBin: true
-
-  srvx@0.8.9:
-    resolution: {integrity: sha512-wYc3VLZHRzwYrWJhkEqkhLb31TI0SOkfYZDkUhXdp3NoCnNS0FqajiQszZZjfow/VYEuc6Q5sZh9nM6kPy2NBQ==}
     engines: {node: '>=20.16.0'}
     hasBin: true
 
@@ -24099,12 +24091,12 @@ snapshots:
       ufo: 1.6.1
       uncrypto: 0.1.3
 
-  h3@2.0.0-beta.5:
+  h3@2.0.0-beta.4:
     dependencies:
       cookie-es: 2.0.0
       fetchdts: 0.1.7
-      rou3: 0.7.7
-      srvx: 0.8.9
+      rou3: 0.7.5
+      srvx: 0.8.7
 
   handle-thing@2.0.1: {}
 
@@ -26113,7 +26105,7 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.52.2
       fsevents: 2.3.3
 
-  rou3@0.7.7: {}
+  rou3@0.7.5: {}
 
   router@2.2.0:
     dependencies:
@@ -26442,10 +26434,6 @@ snapshots:
       kysely: 0.27.6
 
   srvx@0.8.7:
-    dependencies:
-      cookie-es: 2.0.0
-
-  srvx@0.8.9:
     dependencies:
       cookie-es: 2.0.0
 


### PR DESCRIPTION
the approach did not work with bun, bun only installs h3@v1 (it probably disregards v2 as it is still beta)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a CommonJS entry point for improved compatibility with CJS environments.

- Refactor
  - Simplified SSR build configuration by removing custom runtime resolution logic.

- Chores
  - Updated HTTP framework dependency to a v2-compatible alias and cleaned up legacy v1 references.
  - Adjusted build settings to rely on default CommonJS behavior.

- Impact
  - Better interoperability with diverse build systems.
  - More predictable server-side builds with fewer edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->