### PR TITLE
Fix rest Parameters of `react-router-ssr-query`

### DIFF
--- a/packages/router-ssr-query-core/src/index.ts
+++ b/packages/router-ssr-query-core/src/index.ts
@@ -133,31 +133,26 @@ export function setupCoreRouterSsrQueryIntegration<TRouter extends AnyRouter>({
       const ogMutationCacheConfig = queryClient.getMutationCache().config
       queryClient.getMutationCache().config = {
         ...ogMutationCacheConfig,
-        onError: (error, _variables, _context, _mutation) => {
+        onError: (error, ...rest) => {
           if (isRedirect(error)) {
             error.options._fromLocation = router.state.location
             return router.navigate(router.resolveRedirect(error).options)
           }
 
-          return ogMutationCacheConfig.onError?.(
-            error,
-            _variables,
-            _context,
-            _mutation,
-          )
+          return ogMutationCacheConfig.onError?.(error, ...rest)
         },
       }
 
       const ogQueryCacheConfig = queryClient.getQueryCache().config
       queryClient.getQueryCache().config = {
         ...ogQueryCacheConfig,
-        onError: (error, _query) => {
+        onError: (error, ...rest) => {
           if (isRedirect(error)) {
             error.options._fromLocation = router.state.location
             return router.navigate(router.resolveRedirect(error).options)
           }
 
-          return ogQueryCacheConfig.onError?.(error, _query)
+          return ogQueryCacheConfig.onError?.(error, ...rest)
         },
       }
     }


### PR DESCRIPTION
Tanstack Query recently updated (5.89.0) to pass another parameter to its `onError` callbacks, which wasn't being forwarded on correctly when using this package. It was capturing and forwarding them on one-by-one (omitting the new one). Now, it just captures the error parameter and spreads the rest. This will future-proof it if any more parameters are added or the order changes (assuming error is always the first one).