### PR TITLE
fix: add TsrSerializable

### DIFF
--- a/packages/router-core/src/index.ts
+++ b/packages/router-core/src/index.ts
@@ -423,6 +423,8 @@ export type {
   SerializableExtensions,
   DefaultSerializable,
   Serializable,
+  TSR_SERIALIZABLE,
+  TsrSerializable,
 } from './ssr/serializer/transformer'
 
 export {

--- a/packages/router-core/src/ssr/serializer/transformer.ts
+++ b/packages/router-core/src/ssr/serializer/transformer.ts
@@ -9,6 +9,8 @@ import type {
 import type { LooseReturnType } from '../../utils'
 import type { AnyRoute, ResolveAllSSR } from '../../route'
 
+export const TSR_SERIALIZABLE = Symbol.for('TSR_SERIALIZABLE')
+export type TsrSerializable = { [TSR_SERIALIZABLE]: true }
 export interface DefaultSerializable {
   number: number
   string: string
@@ -17,6 +19,7 @@ export interface DefaultSerializable {
   undefined: undefined
   bigint: bigint
   Date: Date
+  TsrSerializable: TsrSerializable
 }
 
 export interface SerializableExtensions extends DefaultSerializable {}

--- a/packages/router-core/src/ssr/serializer/transformer.ts
+++ b/packages/router-core/src/ssr/serializer/transformer.ts
@@ -9,7 +9,9 @@ import type {
 import type { LooseReturnType } from '../../utils'
 import type { AnyRoute, ResolveAllSSR } from '../../route'
 
-export const TSR_SERIALIZABLE = Symbol.for('TSR_SERIALIZABLE')
+declare const TSR_SERIALIZABLE: unique symbol
+export type TSR_SERIALIZABLE = typeof TSR_SERIALIZABLE
+
 export type TsrSerializable = { [TSR_SERIALIZABLE]: true }
 export interface DefaultSerializable {
   number: number

--- a/packages/router-core/src/ssr/server.ts
+++ b/packages/router-core/src/ssr/server.ts
@@ -8,9 +8,3 @@ export {
   transformReadableStreamWithRouter,
 } from './transformStreamWithRouter'
 export { attachRouterServerSsrUtils, getOrigin } from './ssr-server'
-
-// declare module '../router' {
-//   export interface RegisterSsr {
-//     ssr: true
-//   }
-// }

--- a/packages/router-core/tests/serializer.test-d.ts
+++ b/packages/router-core/tests/serializer.test-d.ts
@@ -2,7 +2,7 @@ import { describe, expectTypeOf, it } from 'vitest'
 
 import {
   Serializable,
-  TSR_SERIALIZABLE,
+  TsrSerializable,
   ValidateSerializable,
   ValidateSerializableResult,
 } from '../src/ssr/serializer/transformer'
@@ -66,7 +66,7 @@ describe('Serializer', () => {
   })
 
   it('works for types extending TsrSerializable', () => {
-    type MyCustomType = { f: () => {} } & { [TSR_SERIALIZABLE]: true }
+    type MyCustomType = { f: () => {} } & TsrSerializable
     expectTypeOf<
       ValidateSerializable<MyCustomType, Serializable>
     >().toEqualTypeOf<MyCustomType>()

--- a/packages/router-core/tests/serializer.test-d.ts
+++ b/packages/router-core/tests/serializer.test-d.ts
@@ -1,0 +1,74 @@
+import { describe, expectTypeOf, it } from 'vitest'
+
+import {
+  Serializable,
+  TSR_SERIALIZABLE,
+  ValidateSerializable,
+  ValidateSerializableResult,
+} from '../src/ssr/serializer/transformer'
+
+describe('Serializer', () => {
+  describe('Default types are serializable: $name', () => {
+    it('string', () => {
+      const value: string = 'hello'
+      expectTypeOf<
+        ValidateSerializableResult<typeof value, Serializable>
+      >().toBeString()
+    })
+    it('number', () => {
+      const value: number = 123
+
+      expectTypeOf<
+        ValidateSerializableResult<typeof value, Serializable>
+      >().toBeNumber()
+    })
+    it('boolean', () => {
+      const value: boolean = true
+
+      expectTypeOf<
+        ValidateSerializableResult<typeof value, Serializable>
+      >().toBeBoolean()
+    })
+    it('null', () => {
+      const value = null
+
+      expectTypeOf<
+        ValidateSerializableResult<typeof value, Serializable>
+      >().toBeNull()
+    })
+    it('undefined', () => {
+      const value = undefined
+
+      expectTypeOf<
+        ValidateSerializableResult<typeof value, Serializable>
+      >().toBeUndefined()
+    })
+    it('bigint', () => {
+      const value = BigInt(123)
+
+      expectTypeOf<
+        ValidateSerializableResult<typeof value, Serializable>
+      >().toBeBigInt()
+    })
+    it('Date', () => {
+      const value = new Date()
+
+      expectTypeOf<
+        ValidateSerializableResult<typeof value, Serializable>
+      >().toEqualTypeOf<Date>()
+    })
+  })
+  it('fails for non-serializable types', () => {
+    const value = () => {}
+    expectTypeOf<
+      ValidateSerializable<typeof value, Serializable>
+    >().toEqualTypeOf<'Function is not serializable'>()
+  })
+
+  it('works for types extending TsrSerializable', () => {
+    type MyCustomType = { f: () => {} } & { [TSR_SERIALIZABLE]: true }
+    expectTypeOf<
+      ValidateSerializable<MyCustomType, Serializable>
+    >().toEqualTypeOf<MyCustomType>()
+  })
+})

--- a/packages/start-client-core/src/tests/createServerFn.test-d.ts
+++ b/packages/start-client-core/src/tests/createServerFn.test-d.ts
@@ -2,7 +2,12 @@ import { describe, expectTypeOf, test } from 'vitest'
 import { createMiddleware } from '../createMiddleware'
 import { createServerFn } from '../createServerFn'
 import { TSS_SERVER_FUNCTION } from '../constants'
-import type { Constrain, Register, Validator } from '@tanstack/router-core'
+import type {
+  Constrain,
+  Register,
+  TsrSerializable,
+  Validator,
+} from '@tanstack/router-core'
 import type { ConstrainValidator } from '../createServerFn'
 
 test('createServerFn method with autocomplete', () => {
@@ -637,4 +642,16 @@ test('createServerFn returns sync array', () => {
   })
 
   expectTypeOf(serverFn()).toEqualTypeOf<Promise<Array<{ a: number }>>>()
+})
+
+test('createServerFn respects TsrSerializable', () => {
+  type MyCustomType = { f: () => void; value: string }
+  type MyCustomTypeSerializable = MyCustomType & TsrSerializable
+  const fn1 = createServerFn().handler(() => {
+    const custom: MyCustomType = { f: () => {}, value: 'test' }
+    return { nested: { custom: custom as MyCustomTypeSerializable } }
+  })
+  expectTypeOf(fn1()).toEqualTypeOf<
+    Promise<{ nested: { custom: MyCustomTypeSerializable } }>
+  >()
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public typings to mark custom objects as serializable (TsrSerializable), expanding type-checked serialization support without changing runtime behavior.
  * Extended default serializable recognition to accept types annotated as serializable.

* **Tests**
  * Added type-level tests validating serialization rules and error cases.
  * Updated tests to ensure server-related utilities accept custom serializable types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->