### PR TITLE
docs(history): clarify blockerFn boolean contract

### DIFF
--- a/docs/router/framework/react/api/router/useBlockerHook.md
+++ b/docs/router/framework/react/api/router/useBlockerHook.md
@@ -57,7 +57,7 @@ type ShouldBlockFnArgs = {
 
 - Optional
 - Type: `BlockerFn`
-- The function that returns a `boolean` or `Promise<boolean>` indicating whether to allow navigation.
+- The function that returns a `boolean` or `Promise<boolean>` indicating whether the navigation should be blocked (`true` blocks, `false` allows).
 
 ### `options.condition` option (⚠️ deprecated)
 

--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -58,7 +58,12 @@ export type ParsedHistoryState = HistoryState & {
   __TSR_index: number
 }
 
-type ShouldAllowNavigation = any
+export type ShouldBlockNavigation = boolean
+
+/**
+ * @deprecated Use `ShouldBlockNavigation`. Returning `true` blocks navigation.
+ */
+export type ShouldAllowNavigation = ShouldBlockNavigation
 
 export type HistoryAction = 'PUSH' | 'REPLACE' | 'FORWARD' | 'BACK' | 'GO'
 
@@ -70,7 +75,7 @@ export type BlockerFnArgs = {
 
 export type BlockerFn = (
   args: BlockerFnArgs,
-) => Promise<ShouldAllowNavigation> | ShouldAllowNavigation
+) => Promise<ShouldBlockNavigation> | ShouldBlockNavigation
 
 export type NavigationBlocker = {
   blockerFn: BlockerFn
@@ -149,6 +154,7 @@ export function createHistory(opts: {
           action: actionInfo.type,
         })
         if (isBlocked) {
+          // Truthy means the blocker wants to keep the navigation from proceeding.
           opts.onBlocked?.()
           return
         }
@@ -437,6 +443,7 @@ export function createBrowserHistory(opts?: {
             action,
           })
           if (isBlocked) {
+            // Truthy means the blocker wants to keep the navigation from proceeding.
             ignoreNextPop = true
             win.history.go(1)
             history.notify(notify)


### PR DESCRIPTION
Fixes #3876 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Clarified blocker semantics: returning true blocks navigation; false allows it, improving understanding for React usage.
- Refactor
  - Introduced a clearer public type for navigation blocking and deprecated the previous allow-based alias. This is non-breaking and preserves existing behavior.
- Chores
  - Added inline comments to clarify that a truthy blocker response prevents navigation in both history creation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->