### PR TITLE
docs: Add route-level head explanation and example

### DIFF
--- a/docs/router/framework/react/guide/document-head-management.md
+++ b/docs/router/framework/react/guide/document-head-management.md
@@ -62,6 +62,31 @@ Out of the box, TanStack Router will dedupe `title` and `meta` tags, preferring 
 - `title` tags defined in nested routes will override a `title` tag defined in a parent route (but you can compose them together, which is covered in a future section of this guide)
 - `meta` tags with the same `name` or `property` will be overridden by the last occurrence of that tag found in nested routes
 
+### Route-level Document Head
+
+You can use the `context` object inside the `head` function to customize the document head for a route — for example, updating the title or meta tags based on route data.
+You can find the full list of available properties on the `context` object [here](https://tanstack.com/router/latest/docs/framework/react/api/router/RouteOptionsType#head-method).
+
+```tsx
+export const Route = createRootRoute({
+  loader: async ({ params }) {
+    const id = params.id;
+    return await fetchPost({ id });
+  },
+  head: (context) => ({
+    meta: [
+      {
+        name: 'description',
+        content: context.loaderData.content.slice(0, 100),
+      },
+      {
+        title: context.loaderData.title,
+      },
+    ],
+  }),
+})
+```
+
 ### `<HeadContent />`
 
 The `<HeadContent />` component is **required** to render the head, title, meta, link, and head-related script tags of a document.

--- a/docs/router/framework/react/guide/document-head-management.md
+++ b/docs/router/framework/react/guide/document-head-management.md
@@ -20,7 +20,7 @@ To manage the document head, it's required that you render both the `<HeadConten
 ## Managing the Document Head
 
 ```tsx
-export const Route = createRootRoute({
+export const Route = createFileRoute({
   head: () => ({
     meta: [
       {

--- a/docs/router/framework/react/guide/document-head-management.md
+++ b/docs/router/framework/react/guide/document-head-management.md
@@ -20,7 +20,7 @@ To manage the document head, it's required that you render both the `<HeadConten
 ## Managing the Document Head
 
 ```tsx
-export const Route = createFileRoute({
+export const Route = createRootRoute({
   head: () => ({
     meta: [
       {
@@ -68,7 +68,7 @@ You can use the `context` object inside the `head` function to customize the doc
 You can find the full list of available properties on the `context` object [here](https://tanstack.com/router/latest/docs/framework/react/api/router/RouteOptionsType#head-method).
 
 ```tsx
-export const Route = createRootRoute({
+export const Route = createFileRoute({
   loader: async ({ params }) {
     const id = params.id;
     return await fetchPost({ id });


### PR DESCRIPTION
I needed to set different titles for same page with different data and found that this can be done using the `head(ctx)` function.
It wasn’t clearly mentioned in the current docs, but my editor suggested the `head(ctx)` syntax, which worked as expected.
Since most other frameworks include a short explanation or example for this pattern, I thought it would be helpful to add a brief note here as well.

English is not my first language, so the added sentence and this description was refined with AI assistance — please feel free to adjust the wording if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Route-level Document Head section to the React guide.
  * Shows how to use the route context inside the head function to customize titles and meta per route.
  * Includes an example of dynamic title/meta based on route data and illustrates RouteOptionsType head usage.
  * Clarifies required placement of the HeadContent component and links to head-method docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->