### PR TITLE
feat(devtools): add draggable option to TanStack Router Devtools for toggle button positioning

### DIFF
--- a/packages/react-router-devtools/src/TanStackRouterDevtools.tsx
+++ b/packages/react-router-devtools/src/TanStackRouterDevtools.tsx
@@ -27,8 +27,14 @@ export interface TanStackRouterDevtoolsOptions {
   /**
    * The position of the TanStack Router logo to open and close the devtools panel.
    * Defaults to 'bottom-left'.
+   * Note: This is ignored when draggable is true and user has moved the button.
    */
   position?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
+  /**
+   * Allow the toggle button to be draggable to any position.
+   * Defaults to false.
+   */
+  draggable?: boolean
   /**
    * Use this to render the devtools inside a different type of container element for a11y purposes.
    * Any string which corresponds to a valid intrinsic JSX element is allowed.
@@ -54,6 +60,7 @@ export function TanStackRouterDevtools(
     closeButtonProps,
     toggleButtonProps,
     position,
+    draggable,
     containerElement,
     shadowDOMTarget,
     router: propsRouter,
@@ -73,6 +80,7 @@ export function TanStackRouterDevtools(
         closeButtonProps,
         toggleButtonProps,
         position,
+        draggable,
         containerElement,
         shadowDOMTarget,
         router: activeRouter,
@@ -96,6 +104,7 @@ export function TanStackRouterDevtools(
       closeButtonProps: closeButtonProps,
       toggleButtonProps: toggleButtonProps,
       position: position,
+      draggable: draggable,
       containerElement: containerElement,
       shadowDOMTarget: shadowDOMTarget,
     })
@@ -106,6 +115,7 @@ export function TanStackRouterDevtools(
     closeButtonProps,
     toggleButtonProps,
     position,
+    draggable,
     containerElement,
     shadowDOMTarget,
   ])

--- a/packages/router-devtools-core/src/TanStackRouterDevtoolsCore.tsx
+++ b/packages/router-devtools-core/src/TanStackRouterDevtoolsCore.tsx
@@ -30,8 +30,14 @@ export interface TanStackRouterDevtoolsCoreOptions {
   /**
    * The position of the TanStack Router logo to open and close the devtools panel.
    * Defaults to 'bottom-left'.
+   * Note: This is ignored when draggable is true and user has moved the button.
    */
   position?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
+  /**
+   * Allow the toggle button to be draggable to any position.
+   * Defaults to false.
+   */
+  draggable?: boolean
   /**
    * Use this to render the devtools inside a different type of container element for a11y purposes.
    * Any string which corresponds to a valid intrinsic JSX element is allowed.
@@ -53,6 +59,7 @@ export class TanStackRouterDevtoolsCore {
   #router: Signal<AnyRouter>
   #routerState: Signal<any>
   #position: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
+  #draggable: boolean
   #initialIsOpen: boolean
   #shadowDOMTarget?: ShadowRoot
 
@@ -69,6 +76,7 @@ export class TanStackRouterDevtoolsCore {
     this.#router = createSignal(config.router)
     this.#routerState = createSignal(config.routerState)
     this.#position = config.position ?? 'bottom-left'
+    this.#draggable = config.draggable ?? false
     this.#initialIsOpen = config.initialIsOpen ?? false
     this.#shadowDOMTarget = config.shadowDOMTarget
 
@@ -87,6 +95,7 @@ export class TanStackRouterDevtoolsCore {
       const [router] = this.#router
       const [routerState] = this.#routerState
       const position = this.#position
+      const draggable = this.#draggable
       const initialIsOpen = this.#initialIsOpen
       const shadowDOMTarget = this.#shadowDOMTarget
 
@@ -108,6 +117,7 @@ export class TanStackRouterDevtoolsCore {
         <ShadowDomTargetContext.Provider value={shadowDOMTarget}>
           <Devtools
             position={position}
+            draggable={draggable}
             initialIsOpen={initialIsOpen}
             router={router}
             routerState={routerState}
@@ -144,6 +154,10 @@ export class TanStackRouterDevtoolsCore {
   setOptions(options: Partial<TanStackRouterDevtoolsCoreOptions>) {
     if (options.position !== undefined) {
       this.#position = options.position
+    }
+
+    if (options.draggable !== undefined) {
+      this.#draggable = options.draggable
     }
 
     if (options.initialIsOpen !== undefined) {

--- a/packages/router-devtools-core/src/useStyles.tsx
+++ b/packages/router-devtools-core/src/useStyles.tsx
@@ -614,6 +614,10 @@ const stylesFactory = (shadowDOMTarget?: ShadowRoot) => {
         color: ${colors.blue[300]};
       }
     `,
+    mainCloseBtnDragging: css`
+      user-select: none;
+      transition: none;
+    `,
   }
 }
 

--- a/packages/solid-router-devtools/src/TanStackRouterDevtools.tsx
+++ b/packages/solid-router-devtools/src/TanStackRouterDevtools.tsx
@@ -24,8 +24,14 @@ export interface TanStackRouterDevtoolsOptions {
   /**
    * The position of the TanStack Router logo to open and close the devtools panel.
    * Defaults to 'bottom-left'.
+   * Note: This is ignored when draggable is true and user has moved the button.
    */
   position?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
+  /**
+   * Allow the toggle button to be draggable to any position.
+   * Defaults to false.
+   */
+  draggable?: boolean
   /**
    * Use this to render the devtools inside a different type of container element for a11y purposes.
    * Any string which corresponds to a valid intrinsic JSX element is allowed.
@@ -73,6 +79,7 @@ export const TanStackRouterDevtools: Component<
       closeButtonProps: usedProps.closeButtonProps,
       toggleButtonProps: usedProps.toggleButtonProps,
       position: usedProps.position,
+      draggable: usedProps.draggable,
       containerElement: usedProps.containerElement,
       shadowDOMTarget: usedProps.shadowDOMTarget,
     })


### PR DESCRIPTION
Add an option to the TanStack Router Devtools button to make it draggable.
reflects #4880 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Toggle button for developer tools is now draggable (disabled by default), with position automatically persisted across sessions.
  * Added visual styling feedback for drag operations to improve user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->