### PR TITLE
docs: Update environment variable validation to use z.url()

### DIFF
--- a/docs/start/framework/react/guide/environment-variables.md
+++ b/docs/start/framework/react/guide/environment-variables.md
@@ -281,14 +281,14 @@ Use Zod for runtime validation of environment variables:
 import { z } from 'zod'
 
 const envSchema = z.object({
-  DATABASE_URL: z.string().url(),
+  DATABASE_URL: z.url(),
   JWT_SECRET: z.string().min(32),
   NODE_ENV: z.enum(['development', 'production', 'test']),
 })
 
 const clientEnvSchema = z.object({
   VITE_APP_NAME: z.string(),
-  VITE_API_URL: z.string().url(),
+  VITE_API_URL: z.url(),
   VITE_AUTH0_DOMAIN: z.string(),
   VITE_AUTH0_CLIENT_ID: z.string(),
 })


### PR DESCRIPTION
`z.string().url()` is now deprecated, this PR update this doc to use `z.url()` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated environment variable validation documentation to provide clearer guidance on configuring database and API endpoint settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->