### PR TITLE
docs: fixed example of env variable validation with zod

### DIFF
--- a/docs/start/framework/react/guide/environment-variables.md
+++ b/docs/start/framework/react/guide/environment-variables.md
@@ -278,13 +278,8 @@ Use Zod for runtime validation of environment variables:
 
 ```typescript
 // src/config/env.ts
+import { createIsomorphicFn } from "@tanstack/react-start";
 import { z } from 'zod'
-
-const envSchema = z.object({
-  DATABASE_URL: z.string().url(),
-  JWT_SECRET: z.string().min(32),
-  NODE_ENV: z.enum(['development', 'production', 'test']),
-})
 
 const clientEnvSchema = z.object({
   VITE_APP_NAME: z.string(),
@@ -293,11 +288,21 @@ const clientEnvSchema = z.object({
   VITE_AUTH0_CLIENT_ID: z.string(),
 })
 
-// Validate server environment
-export const serverEnv = envSchema.parse(process.env)
+const serverEnvSchema = z
+  .object({
+    DATABASE_URL: z.string().url(),
+    JWT_SECRET: z.string().min(32),
+    NODE_ENV: z.enum(["development", "production", "test"]),
+  })
+  .and(clientEnvSchema);
 
-// Validate client environment
-export const clientEnv = clientEnvSchema.parse(import.meta.env)
+const getEnv = createIsomorphicFn()
+  .server(() => serverEnvSchema.parse(process.env))
+  .client(() => clientEnvSchema.parse(import.meta.env));
+
+type Env = z.infer<typeof serverEnvSchema>;
+
+export const env = getEnv() as Env;
 ```
 
 ## Security Best Practices

--- a/docs/start/framework/react/guide/environment-variables.md
+++ b/docs/start/framework/react/guide/environment-variables.md
@@ -278,7 +278,7 @@ Use Zod for runtime validation of environment variables:
 
 ```typescript
 // src/config/env.ts
-import { createIsomorphicFn } from "@tanstack/react-start";
+import { createIsomorphicFn } from '@tanstack/react-start'
 import { z } from 'zod'
 
 const clientEnvSchema = z.object({
@@ -292,17 +292,17 @@ const serverEnvSchema = z
   .object({
     DATABASE_URL: z.string().url(),
     JWT_SECRET: z.string().min(32),
-    NODE_ENV: z.enum(["development", "production", "test"]),
+    NODE_ENV: z.enum(['development', 'production', 'test']),
   })
-  .and(clientEnvSchema);
+  .and(clientEnvSchema)
 
 const getEnv = createIsomorphicFn()
   .server(() => serverEnvSchema.parse(process.env))
-  .client(() => clientEnvSchema.parse(import.meta.env));
+  .client(() => clientEnvSchema.parse(import.meta.env))
 
-type Env = z.infer<typeof serverEnvSchema>;
+type Env = z.infer<typeof serverEnvSchema>
 
-export const env = getEnv() as Env;
+export const env = getEnv() as Env
 ```
 
 ## Security Best Practices

--- a/docs/start/framework/react/guide/environment-variables.md
+++ b/docs/start/framework/react/guide/environment-variables.md
@@ -283,14 +283,14 @@ import { z } from 'zod'
 
 const clientEnvSchema = z.object({
   VITE_APP_NAME: z.string(),
-  VITE_API_URL: z.string().url(),
+  VITE_API_URL: z.url(),
   VITE_AUTH0_DOMAIN: z.string(),
   VITE_AUTH0_CLIENT_ID: z.string(),
 })
 
 const serverEnvSchema = z
   .object({
-    DATABASE_URL: z.string().url(),
+    DATABASE_URL: z.url(),
     JWT_SECRET: z.string().min(32),
     NODE_ENV: z.enum(['development', 'production', 'test']),
   })

--- a/docs/start/framework/solid/guide/environment-variables.md
+++ b/docs/start/framework/solid/guide/environment-variables.md
@@ -278,13 +278,8 @@ Use Zod for runtime validation of environment variables:
 
 ```typescript
 // src/config/env.ts
+import { createIsomorphicFn } from "@tanstack/react-start";
 import { z } from 'zod'
-
-const envSchema = z.object({
-  DATABASE_URL: z.string().url(),
-  JWT_SECRET: z.string().min(32),
-  NODE_ENV: z.enum(['development', 'production', 'test']),
-})
 
 const clientEnvSchema = z.object({
   VITE_APP_NAME: z.string(),
@@ -293,11 +288,21 @@ const clientEnvSchema = z.object({
   VITE_AUTH0_CLIENT_ID: z.string(),
 })
 
-// Validate server environment
-export const serverEnv = envSchema.parse(process.env)
+const serverEnvSchema = z
+  .object({
+    DATABASE_URL: z.string().url(),
+    JWT_SECRET: z.string().min(32),
+    NODE_ENV: z.enum(["development", "production", "test"]),
+  })
+  .and(clientEnvSchema);
 
-// Validate client environment
-export const clientEnv = clientEnvSchema.parse(import.meta.env)
+const getEnv = createIsomorphicFn()
+  .server(() => serverEnvSchema.parse(process.env))
+  .client(() => clientEnvSchema.parse(import.meta.env));
+
+type Env = z.infer<typeof serverEnvSchema>;
+
+export const env = getEnv() as Env;
 ```
 
 ## Security Best Practices

--- a/docs/start/framework/solid/guide/environment-variables.md
+++ b/docs/start/framework/solid/guide/environment-variables.md
@@ -278,7 +278,7 @@ Use Zod for runtime validation of environment variables:
 
 ```typescript
 // src/config/env.ts
-import { createIsomorphicFn } from "@tanstack/react-start";
+import { createIsomorphicFn } from '@tanstack/react-start'
 import { z } from 'zod'
 
 const clientEnvSchema = z.object({
@@ -292,17 +292,17 @@ const serverEnvSchema = z
   .object({
     DATABASE_URL: z.string().url(),
     JWT_SECRET: z.string().min(32),
-    NODE_ENV: z.enum(["development", "production", "test"]),
+    NODE_ENV: z.enum(['development', 'production', 'test']),
   })
-  .and(clientEnvSchema);
+  .and(clientEnvSchema)
 
 const getEnv = createIsomorphicFn()
   .server(() => serverEnvSchema.parse(process.env))
-  .client(() => clientEnvSchema.parse(import.meta.env));
+  .client(() => clientEnvSchema.parse(import.meta.env))
 
-type Env = z.infer<typeof serverEnvSchema>;
+type Env = z.infer<typeof serverEnvSchema>
 
-export const env = getEnv() as Env;
+export const env = getEnv() as Env
 ```
 
 ## Security Best Practices

--- a/docs/start/framework/solid/guide/environment-variables.md
+++ b/docs/start/framework/solid/guide/environment-variables.md
@@ -278,7 +278,7 @@ Use Zod for runtime validation of environment variables:
 
 ```typescript
 // src/config/env.ts
-import { createIsomorphicFn } from '@tanstack/react-start'
+import { createIsomorphicFn } from '@tanstack/solid-start'
 import { z } from 'zod'
 
 const clientEnvSchema = z.object({

--- a/docs/start/framework/solid/guide/environment-variables.md
+++ b/docs/start/framework/solid/guide/environment-variables.md
@@ -283,14 +283,14 @@ import { z } from 'zod'
 
 const clientEnvSchema = z.object({
   VITE_APP_NAME: z.string(),
-  VITE_API_URL: z.string().url(),
+  VITE_API_URL: z.url(),
   VITE_AUTH0_DOMAIN: z.string(),
   VITE_AUTH0_CLIENT_ID: z.string(),
 })
 
 const serverEnvSchema = z
   .object({
-    DATABASE_URL: z.string().url(),
+    DATABASE_URL: z.url(),
     JWT_SECRET: z.string().min(32),
     NODE_ENV: z.enum(['development', 'production', 'test']),
   })


### PR DESCRIPTION
This PR changes the example provided in the docs for **environment variables validation with `zod`**

The current example in the docs is error-prone because it validates both client and server variables in the same file and when imported in any client-side code, the server side validation fails because `process.env` does not exist on client-side

So I make the following changes

1. Make use of the `createIsomorphicFn` to validate the variables in their respective environments
2. Intersect client side variables with server schema using zod's `.and` method because client-side variables are available in the server environment
3. Export a singular `env` object and typecast it to the server env schema type so that all variables are detected by TypeScript, just that in runtime if a server variable is used on client side, it'll fail. TypeScript cannot know which file is client-side code hence the typecast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified isomorphic environment handling: single, consistent env access across server and client via a new isomorphic getter.

* **Documentation**
  * Updated environment variable guides for React and Solid to reflect the unified approach and new usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->