### PR TITLE
docs: add note to set CLOUDFLARE_ENV for wrangler to load correct env…

### DIFF
--- a/docs/start/framework/react/guide/environment-variables.md
+++ b/docs/start/framework/react/guide/environment-variables.md
@@ -102,8 +102,8 @@ TanStack Start automatically loads environment files in this order:
 > When using the Cloudflare Vite plugin, set `CLOUDFLARE_ENV` to ensure Wrangler loads the correct environment
 >
 > ```bash
->  # .env.development
->  CLOUDFLARE_ENV=development
+> # .env.development
+> CLOUDFLARE_ENV=development
 > ```
 >
 > Otherwise, the variables defined in your `.env.<environment>` files may not be read or injected into `process.env`

--- a/docs/start/framework/react/guide/environment-variables.md
+++ b/docs/start/framework/react/guide/environment-variables.md
@@ -98,6 +98,16 @@ TanStack Start automatically loads environment files in this order:
 .env                # Default variables (commit to git)
 ```
 
+> [!TIP]
+> When using the Cloudflare Vite plugin, set `CLOUDFLARE_ENV` to ensure Wrangler loads the correct environment
+>
+> ```bash
+>  # .env.development
+>  CLOUDFLARE_ENV=development
+> ```
+>
+> Otherwise, the variables defined in your `.env.<environment>` files may not be read or injected into `process.env`
+
 ### Example Setup
 
 **.env** (committed to repository):

--- a/docs/start/framework/solid/guide/environment-variables.md
+++ b/docs/start/framework/solid/guide/environment-variables.md
@@ -102,8 +102,8 @@ TanStack Start automatically loads environment files in this order:
 > When using the Cloudflare Vite plugin, set `CLOUDFLARE_ENV` to ensure Wrangler loads the correct environment
 >
 > ```bash
->  # .env.development
->  CLOUDFLARE_ENV=development
+> # .env.development
+> CLOUDFLARE_ENV=development
 > ```
 >
 > Otherwise, the variables defined in your `.env.<environment>` files may not be read or injected into `process.env`

--- a/docs/start/framework/solid/guide/environment-variables.md
+++ b/docs/start/framework/solid/guide/environment-variables.md
@@ -98,6 +98,16 @@ TanStack Start automatically loads environment files in this order:
 .env                # Default variables (commit to git)
 ```
 
+> [!TIP]
+> When using the Cloudflare Vite plugin, set `CLOUDFLARE_ENV` to ensure Wrangler loads the correct environment
+>
+> ```bash
+>  # .env.development
+>  CLOUDFLARE_ENV=development
+> ```
+>
+> Otherwise, the variables defined in your `.env.<environment>` files may not be read or injected into `process.env`
+
 ### Example Setup
 
 **.env** (committed to repository):


### PR DESCRIPTION
This PR adds a note to the environment variable docs to add `CLOUDFLARE_ENV` to `.env.<environment>` files.

Without specifying a Cloudflare environment, it will default to the top-level (production), so vars specified in .env.development would never be loaded

[Cloudflare Docs about .env on local](https://developers.cloudflare.com/workers/configuration/environment-variables/#local-development-with-secrets)

The solution comes from [Combining Cloudflare environments and Vite modes](https://developers.cloudflare.com/workers/vite-plugin/reference/cloudflare-environments/#combining-cloudflare-environments-and-vite-modes).

Vite loads the correct `.env.<environment>` file and that file specifies `CLOUDFLARE_ENV`. Then the Cloudflare Vite plugin will select the given Cloudflare environment, which means Wrangler will load the corresponding `.env.<environment>` (even if it's the same file where `CLOUDFLARE_ENV` was specified)

Setting `CLOUDFLARE_ENV=development` in `.env.development` should be enough to get most people started

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance to set CLOUDFLARE_ENV when using the Cloudflare Vite plugin so Wrangler loads the correct environment and environment-specific variables are injected into process.env. Tip added within the Environment Variables guides for both React and Solid, including an example for .env.development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->