### PR TITLE
feat: add `$withType<TFn>()` to restrict isomorphicFn

### DIFF
--- a/docs/start/framework/react/guide/environment-functions.md
+++ b/docs/start/framework/react/guide/environment-functions.md
@@ -83,6 +83,28 @@ A no-op (short for "no operation") is a function that does nothing when executed
 function noop() {}
 ```
 
+### Restricting the type of the implementations
+
+You can use `.$withType<TFn>()` to enforce the type of both the server and client implementations matches the same function signature.
+
+```tsx
+import { createIsomorphicFn } from '@tanstack/react-start'
+import type { Environment } from '@/types/environment'
+
+const getEnv = createIsomorphicFn()
+  .$withType<() => Environment>()
+  .server(() => 'server')
+  .client(() => 'client')
+
+const env = getEnv()
+//    ^? Environment
+```
+
+You will get a type error if either implementation mismatches from the function signature passed to `$withType`.
+
+> [!NOTE]
+> When using `$withType()`, TypeScript will enforce that you define both the server and client implementations.
+
 ---
 
 ## `env`Only Functions

--- a/packages/start-client-core/src/createIsomorphicFn.ts
+++ b/packages/start-client-core/src/createIsomorphicFn.ts
@@ -21,7 +21,36 @@ export interface ClientOnlyFn<TArgs extends Array<any>, TClient>
   ) => IsomorphicFn<TArgs, TServer, TClient>
 }
 
+type AnyFn = (...args: Array<any>) => any
+export interface ServerOnlyFnWithType<TArgs extends Array<any>, TReturnType>
+  extends IsomorphicFn<TArgs, TReturnType> {
+  client: (
+    clientImpl: (...args: TArgs) => TReturnType,
+  ) => IsomorphicFn<TArgs, TReturnType, TReturnType>
+}
+
+export interface ClientOnlyFnWithType<TArgs extends Array<any>, TReturnType>
+  extends IsomorphicFn<TArgs, TReturnType, TReturnType> {
+  server: (
+    serverImpl: (...args: TArgs) => TReturnType,
+  ) => IsomorphicFn<TArgs, TReturnType, TReturnType>
+}
+
+export interface IsomorphicFnWithType<TArgs extends Array<any>, TReturnType>
+  extends IsomorphicFn<TArgs, TReturnType> {
+  server: (
+    serverImpl: (...args: TArgs) => TReturnType,
+  ) => ServerOnlyFnWithType<TArgs, TReturnType>
+  client: (
+    clientImpl: (...args: TArgs) => TReturnType,
+  ) => ClientOnlyFnWithType<TArgs, TReturnType>
+}
+
 export interface IsomorphicFnBase extends IsomorphicFn {
+  $withType: <TFn extends AnyFn>() => IsomorphicFnWithType<
+    Parameters<TFn>,
+    ReturnType<TFn>
+  >
   server: <TArgs extends Array<any>, TServer>(
     serverImpl: (...args: TArgs) => TServer,
   ) => ServerOnlyFn<TArgs, TServer>
@@ -35,7 +64,9 @@ export interface IsomorphicFnBase extends IsomorphicFn {
 // therefore we must return a dummy function that allows calling `server` and `client` method chains.
 export function createIsomorphicFn(): IsomorphicFnBase {
   return {
+    $withType: () => {},
     server: () => ({ client: () => () => {} }),
     client: () => ({ server: () => () => {} }),
   } as any
 }
+

--- a/packages/start-client-core/src/createIsomorphicFn.ts
+++ b/packages/start-client-core/src/createIsomorphicFn.ts
@@ -21,7 +21,6 @@ export interface ClientOnlyFn<TArgs extends Array<any>, TClient>
   ) => IsomorphicFn<TArgs, TServer, TClient>
 }
 
-type AnyFn = (...args: Array<any>) => any
 export interface ClientImplRequired<TArgs extends Array<any>, TReturnType> {
   client: (
     clientImpl: (...args: TArgs) => TReturnType,
@@ -44,10 +43,9 @@ export interface IsomorphicFnWithType<TArgs extends Array<any>, TReturnType> {
 }
 
 export interface IsomorphicFnBase extends IsomorphicFn {
-  $withType: <TFn extends AnyFn>() => IsomorphicFnWithType<
-    Parameters<TFn>,
-    ReturnType<TFn>
-  >
+  $withType: <
+    TFn extends (...args: Array<any>) => any,
+  >() => IsomorphicFnWithType<Parameters<TFn>, ReturnType<TFn>>
   server: <TArgs extends Array<any>, TServer>(
     serverImpl: (...args: TArgs) => TServer,
   ) => ServerOnlyFn<TArgs, TServer>

--- a/packages/start-client-core/src/createIsomorphicFn.ts
+++ b/packages/start-client-core/src/createIsomorphicFn.ts
@@ -22,31 +22,25 @@ export interface ClientOnlyFn<TArgs extends Array<any>, TClient>
 }
 
 type AnyFn = (...args: Array<any>) => any
-export interface ServerOnlyFnWithType<TArgs extends Array<any>, TReturnType>
-  extends IsomorphicFn<TArgs, TReturnType> {
+export interface ClientImplRequired<TArgs extends Array<any>, TReturnType> {
   client: (
     clientImpl: (...args: TArgs) => TReturnType,
   ) => IsomorphicFn<TArgs, TReturnType, TReturnType>
 }
 
-export interface ClientOnlyFnWithType<TArgs extends Array<any>, TReturnType>
-  extends IsomorphicFn<TArgs, TReturnType, TReturnType> {
+export interface ServerImplRequired<TArgs extends Array<any>, TReturnType> {
   server: (
     serverImpl: (...args: TArgs) => TReturnType,
   ) => IsomorphicFn<TArgs, TReturnType, TReturnType>
 }
 
 export interface IsomorphicFnWithType<TArgs extends Array<any>, TReturnType> {
-  server: (serverImpl: (...args: TArgs) => TReturnType) => {
-    client: (
-      clientImpl: (...args: TArgs) => TReturnType,
-    ) => IsomorphicFn<TArgs, TReturnType, TReturnType>
-  }
-  client: (clientImpl: (...args: TArgs) => TReturnType) => {
-    server: (
-      serverImpl: (...args: TArgs) => TReturnType,
-    ) => IsomorphicFn<TArgs, TReturnType, TReturnType>
-  }
+  server: (
+    serverImpl: (...args: TArgs) => TReturnType,
+  ) => ClientImplRequired<TArgs, TReturnType>
+  client: (
+    clientImpl: (...args: TArgs) => TReturnType,
+  ) => ServerImplRequired<TArgs, TReturnType>
 }
 
 export interface IsomorphicFnBase extends IsomorphicFn {

--- a/packages/start-client-core/src/tests/createIsomorphicFn.test-d.ts
+++ b/packages/start-client-core/src/tests/createIsomorphicFn.test-d.ts
@@ -100,6 +100,17 @@ test('createIsomorphicFn with type', () => {
   expectTypeOf(fn2).toBeCallableWith('foo', 1)
   expectTypeOf(fn2).returns.toEqualTypeOf<boolean>()
 
+  const noServerImpl = createIsomorphicFn()
+    .$withType<(a: string) => string>()
+    .client((a) => 'data')
+    expectTypeOf(noServerImpl).not.toBeFunction()
+
+    // Missing server implementation
+  const noClientImpl = createIsomorphicFn()
+  .$withType<(a: string) => string>()
+  .server((a) => 'data')
+  expectTypeOf(noClientImpl).not.toBeFunction()
+
   const _invalidFnReturn = createIsomorphicFn()
     .$withType<(a: string) => string>()
     .server(() => '1')

--- a/packages/start-client-core/src/tests/createIsomorphicFn.test-d.ts
+++ b/packages/start-client-core/src/tests/createIsomorphicFn.test-d.ts
@@ -70,3 +70,45 @@ test('createIsomorphicFn with arguments', () => {
   expectTypeOf(fn2).toBeCallableWith(1, 'a')
   expectTypeOf(fn2).returns.toEqualTypeOf<string | number>()
 })
+
+test('createIsomorphicFn with type', () => {
+  const fn1 = createIsomorphicFn()
+    .$withType<(a: string) => string>()
+    .server((a) => {
+      expectTypeOf(a).toEqualTypeOf<string>()
+      return 'data'
+    })
+    .client((a) => {
+      expectTypeOf(a).toEqualTypeOf<string>()
+      return 'data'
+    })
+  expectTypeOf(fn1).toBeCallableWith('foo')
+  expectTypeOf(fn1).returns.toEqualTypeOf<string>()
+
+  const fn2 = createIsomorphicFn()
+    .$withType<(a: string, b: number) => boolean>()
+    .client((a, b) => {
+      expectTypeOf(a).toEqualTypeOf<string>()
+      expectTypeOf(b).toEqualTypeOf<number>()
+      return true as const
+    })
+    .server((a, b) => {
+      expectTypeOf(a).toEqualTypeOf<string>()
+      expectTypeOf(b).toEqualTypeOf<number>()
+      return false as const
+    })
+  expectTypeOf(fn2).toBeCallableWith('foo', 1)
+  expectTypeOf(fn2).returns.toEqualTypeOf<boolean>()
+
+  const _invalidFnReturn = createIsomorphicFn()
+    .$withType<(a: string) => string>()
+    .server(() => '1')
+    // @ts-expect-error - invalid return type
+    .client(() => 2)
+
+  const _invalidFnArgs = createIsomorphicFn()
+    .$withType<(a: string) => string>()
+    .server((a: string) => 'data')
+    // @ts-expect-error - invalid argument type
+    .client((a: number) => 'data')
+})

--- a/packages/start-client-core/src/tests/createIsomorphicFn.test-d.ts
+++ b/packages/start-client-core/src/tests/createIsomorphicFn.test-d.ts
@@ -103,12 +103,12 @@ test('createIsomorphicFn with type', () => {
   const noServerImpl = createIsomorphicFn()
     .$withType<(a: string) => string>()
     .client((a) => 'data')
-    expectTypeOf(noServerImpl).not.toBeFunction()
+  expectTypeOf(noServerImpl).not.toBeFunction()
 
-    // Missing server implementation
+  // Missing server implementation
   const noClientImpl = createIsomorphicFn()
-  .$withType<(a: string) => string>()
-  .server((a) => 'data')
+    .$withType<(a: string) => string>()
+    .server((a) => 'data')
   expectTypeOf(noClientImpl).not.toBeFunction()
 
   const _invalidFnReturn = createIsomorphicFn()

--- a/packages/start-plugin-core/tests/createIsomorphicFn/snapshots/client/createIsomorphicFnDestructured.tsx
+++ b/packages/start-plugin-core/tests/createIsomorphicFn/snapshots/client/createIsomorphicFnDestructured.tsx
@@ -14,3 +14,4 @@ function abstractedClientFn() {
 const clientOnlyFnAbstracted = abstractedClientFn;
 const serverThenClientFnAbstracted = abstractedClientFn;
 const clientThenServerFnAbstracted = abstractedClientFn;
+const withTypeRestriction = () => 'client';

--- a/packages/start-plugin-core/tests/createIsomorphicFn/snapshots/server/createIsomorphicFnDestructured.tsx
+++ b/packages/start-plugin-core/tests/createIsomorphicFn/snapshots/server/createIsomorphicFnDestructured.tsx
@@ -14,3 +14,4 @@ function abstractedClientFn() {
 const clientOnlyFnAbstracted = () => {};
 const serverThenClientFnAbstracted = abstractedServerFn;
 const clientThenServerFnAbstracted = abstractedServerFn;
+const withTypeRestriction = () => 'server';

--- a/packages/start-plugin-core/tests/createIsomorphicFn/test-files/createIsomorphicFnDestructured.tsx
+++ b/packages/start-plugin-core/tests/createIsomorphicFn/test-files/createIsomorphicFnDestructured.tsx
@@ -33,3 +33,8 @@ const serverThenClientFnAbstracted = createIsomorphicFn()
 const clientThenServerFnAbstracted = createIsomorphicFn()
   .client(abstractedClientFn)
   .server(abstractedServerFn)
+
+const withTypeRestriction = createIsomorphicFn()
+  .$withType<() => string>()
+  .server(() => 'server')
+  .client(() => 'client')


### PR DESCRIPTION
allows restricting the type on both "branches" in an isomorphic fn.

## Notes

- Use special naming convention `$withType` to signal that it's a special thing, does not have any affect at runtime
- When called with `$withType()`, both `.server()` and `.client()` must be chained
  - This is not (currently) enforced by the compiler, just typescript.
  - An argument could be made that when the return type of the type parameter passed to `$withType` extends `undefined`, then it should be fine that one of server/client can be omitted? idk...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added $withType() to isomorphic functions to declare explicit server/client signatures and expose typed server-only, client-only, and both-side variants.

* **Tests**
  * Added type-checking tests validating typed isomorphic-function chains and expected type errors.

* **Documentation**
  * Added docs demonstrating how to restrict and enforce server/client implementation signatures with examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->