### PR TITLE
Implement meta tag deduplication logic

### DIFF
--- a/packages/react-router/src/HeadContent.tsx
+++ b/packages/react-router/src/HeadContent.tsx
@@ -4,6 +4,12 @@ import { useRouter } from './useRouter'
 import { useRouterState } from './useRouterState'
 import type { RouterManagedTag } from '@tanstack/router-core'
 
+const METAS_TO_ALLOW_MULTIPLE = new Set(['theme-color'])
+
+function shouldDeduplicateMetaTag(attribute: string) {
+  return METAS_TO_ALLOW_MULTIPLE.has(attribute) === false
+}
+
 /**
  * Build the list of head/link/meta/script tags to render for active matches.
  * Used internally by `HeadContent`.
@@ -37,7 +43,7 @@ export const useTags = () => {
         } else {
           const attribute = m.name ?? m.property
           if (attribute) {
-            if (metaByAttribute[attribute]) {
+            if (metaByAttribute[attribute] && shouldDeduplicateMetaTag(attribute)) {
               continue
             } else {
               metaByAttribute[attribute] = true

--- a/packages/react-router/src/HeadContent.tsx
+++ b/packages/react-router/src/HeadContent.tsx
@@ -43,7 +43,10 @@ export const useTags = () => {
         } else {
           const attribute = m.name ?? m.property
           if (attribute) {
-            if (metaByAttribute[attribute] && shouldDeduplicateMetaTag(attribute)) {
+            if (
+              metaByAttribute[attribute] &&
+              shouldDeduplicateMetaTag(attribute)
+            ) {
               continue
             } else {
               metaByAttribute[attribute] = true


### PR DESCRIPTION
Add logic to determine if meta tags should be deduplicated.

Closes #5146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved meta tag handling to allow multiple theme-color entries while preserving automatic deduplication for other meta attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->