### PR TITLE
Update RouteMatchType.md

### DIFF
--- a/docs/router/framework/react/api/router/RouteMatchType.md
+++ b/docs/router/framework/react/api/router/RouteMatchType.md
@@ -25,5 +25,6 @@ interface RouteMatch {
   abortController: AbortController
   cause: 'enter' | 'stay'
   ssr?: boolean | 'data-only'
+  staticData: StaticDataRouteOption
 }
 ```


### PR DESCRIPTION
add `staticData` property to the RouteMatchType

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Route matching now provides access to static route data through a new property on the RouteMatch interface, giving developers additional route configuration information during route matching operations.

* **Documentation**
  * Updated API reference documentation for the RouteMatch interface to reflect the new capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->