### PR TITLE
Update the authentication guide to use useQuery within the AuthProvider context.

### DIFF
--- a/docs/start/framework/react/guide/authentication.md
+++ b/docs/start/framework/react/guide/authentication.md
@@ -143,8 +143,10 @@ type AuthContextType = {
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
 export function AuthProvider({ children }: { children: ReactNode }) {
-  const { data: user, isLoading, refetch } = useServerFn(getCurrentUserFn)
-
+  const { data: user, isLoading, refetch } = useQuery({
+    queryKey: ["auth"],
+    queryFn: useServerFn(getCurrentUserFn),
+  })
   return (
     <AuthContext.Provider value={{ user, isLoading, refetch }}>
       {children}


### PR DESCRIPTION
The guide on authentication implies that `useServerFn` has a similar api to `useQuery`:

```tsx
export function AuthProvider({ children }: { children: ReactNode }) {
  const { data: user, isLoading, refetch } = useServerFn(getCurrentUserFn)

  return (
    <AuthContext.Provider value={{ user, isLoading, refetch }}>
      {children}
    </AuthContext.Provider>
  )
}
```

But this is not the correct return shape if the guide is followed; instead useServerFn will be returning a promise here. As such I have updated this component by wrapping the `userServerFn` with `useQuery`, to avoid any confusion. 

I am not sure if this is deliberate sudo-code here - but I think this suggestion is correct for the example provided, and also aligns with the useage guide on using server functions in components: https://tanstack.com/start/latest/docs/framework/react/guide/server-functions#where-to-call-server-functions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication guide to reflect improved data loading with enhanced support for caching, refetching, and loading state management in authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->