### PR TITLE
feat(server-functions): add rawHandler for streaming file uploads

### DIFF
--- a/packages/start-client-core/src/createServerFn.ts
+++ b/packages/start-client-core/src/createServerFn.ts
@@ -88,6 +88,80 @@ export const createServerFn: CreateServerFn<Register> = (options, __opts) => {
       const newOptions = { ...resolvedOptions, inputValidator }
       return createServerFn(undefined, newOptions) as any
     },
+    rawHandler: (...args) => {
+      // This function signature changes due to AST transformations
+      // in the babel plugin. We need to cast it to the correct
+      // function signature post-transformation
+      const [extractedFn, serverFn] = args as unknown as [
+        CompiledFetcherFn<Register, any>,
+        RawServerFn<Register, any, any>,
+      ]
+
+      // Keep the original function around so we can use it
+      // in the server environment
+      const newOptions = {
+        ...resolvedOptions,
+        extractedFn,
+        serverFn: serverFn as any,
+        rawHandler: true,
+      }
+
+      const resolvedMiddleware = [
+        ...(newOptions.middleware || []),
+        serverFnBaseToMiddleware(newOptions),
+      ]
+
+      // We want to make sure the new function has the same
+      // properties as the original function
+
+      return Object.assign(
+        async (opts?: CompiledFetcherFnOptions) => {
+          // Start by executing the client-side middleware chain
+          return executeMiddleware(resolvedMiddleware, 'client', {
+            ...extractedFn,
+            ...newOptions,
+            data: opts?.data as any,
+            headers: opts?.headers,
+            signal: opts?.signal,
+            context: {},
+          }).then((d) => {
+            if (d.error) throw d.error
+            return d.result
+          })
+        },
+        {
+          // This copies over the URL, function ID
+          ...extractedFn,
+          __rawHandler: true,
+          // The extracted function on the server-side calls
+          // this function
+          __executeServer: async (opts: any, signal: AbortSignal) => {
+            const startContext = getStartContextServerOnly()
+            const serverContextAfterGlobalMiddlewares =
+              startContext.contextAfterGlobalMiddlewares
+            const ctx = {
+              ...extractedFn,
+              ...opts,
+              context: {
+                ...serverContextAfterGlobalMiddlewares,
+                ...opts.context,
+              },
+              signal,
+              request: startContext.request,
+            }
+
+            return executeMiddleware(resolvedMiddleware, 'server', ctx).then(
+              (d) => ({
+                // Only send the result and sendContext back to the client
+                result: d.result,
+                error: d.error,
+                context: d.sendContext,
+              }),
+            )
+          },
+        },
+      ) as any
+    },
     handler: (...args) => {
       // This function signature changes due to AST transformations
       // in the babel plugin. We need to cast it to the correct
@@ -315,6 +389,12 @@ export type ServerFn<
   ctx: ServerFnCtx<TRegister, TMethod, TMiddlewares, TInputValidator>,
 ) => ServerFnReturnType<TRegister, TResponse>
 
+export type RawServerFn<TRegister, TMiddlewares, TResponse> = (ctx: {
+  request: Request
+  signal: AbortSignal
+  context: Expand<AssignAllServerFnContext<TRegister, TMiddlewares, {}>>
+}) => ServerFnReturnType<TRegister, TResponse>
+
 export interface ServerFnCtx<
   TRegister,
   TMethod,
@@ -356,6 +436,7 @@ export type ServerFnBaseOptions<
     TResponse
   >
   functionId: string
+  rawHandler?: boolean
 }
 
 export type ValidateValidatorInput<
@@ -513,6 +594,9 @@ export interface ServerFnHandler<
       TNewResponse
     >,
   ) => Fetcher<TMiddlewares, TInputValidator, TNewResponse>
+  rawHandler: <TNewResponse>(
+    fn?: RawServerFn<TRegister, TMiddlewares, TNewResponse>,
+  ) => Fetcher<TMiddlewares, TInputValidator, TNewResponse>
 }
 
 export interface ServerFnBuilder<TRegister, TMethod extends Method = 'GET'>
@@ -611,6 +695,7 @@ export type ServerFnMiddlewareOptions = {
   sendContext?: any
   context?: any
   functionId: string
+  request?: Request
 }
 
 export type ServerFnMiddlewareResult = ServerFnMiddlewareOptions & {
@@ -718,7 +803,19 @@ function serverFnBaseToMiddleware(
       },
       server: async ({ next, ...ctx }) => {
         // Execute the server function
-        const result = await options.serverFn?.(ctx as TODO)
+        let result: any
+        if (options.rawHandler) {
+          // For raw handlers, pass request, signal, and context
+          const ctxWithRequest = ctx as typeof ctx & { request: Request }
+          result = await (options.serverFn as any)?.({
+            request: ctxWithRequest.request,
+            signal: ctx.signal,
+            context: ctx.context,
+          })
+        } else {
+          // For normal handlers, pass the full context
+          result = await options.serverFn?.(ctx as TODO)
+        }
 
         return next({
           ...ctx,

--- a/packages/start-plugin-core/src/create-server-fn-plugin/compiler.ts
+++ b/packages/start-plugin-core/src/create-server-fn-plugin/compiler.ts
@@ -35,7 +35,7 @@ const LookupSetup: Record<
   LookupKind,
   { candidateCallIdentifier: Set<string> }
 > = {
-  ServerFn: { candidateCallIdentifier: new Set(['handler']) },
+  ServerFn: { candidateCallIdentifier: new Set(['handler', 'rawHandler']) },
   Middleware: {
     candidateCallIdentifier: new Set(['server', 'client', 'createMiddlewares']),
   },

--- a/packages/start-plugin-core/src/create-server-fn-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/create-server-fn-plugin/plugin.ts
@@ -85,8 +85,8 @@ export function createServerFnPlugin(
           },
           code: {
             // TODO apply this plugin with a different filter per environment so that .createMiddleware() calls are not scanned in server env
-            // only scan files that mention `.handler(` | `.createMiddleware()`
-            include: [/\.\s*handler\(/, /\.\s*createMiddleware\(\)/],
+            // only scan files that mention `.handler(` | `.rawHandler(` | `.createMiddleware()`
+            include: [/\.\s*handler\(/, /\.\s*rawHandler\(/, /\.\s*createMiddleware\(\)/],
           },
         },
         async handler(code, id) {

--- a/packages/start-plugin-core/tests/createServerFn/createServerFn.test.ts
+++ b/packages/start-plugin-core/tests/createServerFn/createServerFn.test.ts
@@ -95,6 +95,106 @@ describe('createServerFn compiles correctly', async () => {
     `)
   })
 
+  test('should work with rawHandler', async () => {
+    const code = `
+        import { createServerFn } from '@tanstack/react-start'
+        const myRawFunc = ({ request, signal }) => {
+          return new Response('hello from raw handler')
+        }
+        const myServerFn = createServerFn({ method: 'POST' }).rawHandler(myRawFunc)`
+
+    const compiledResultClient = await compile({
+      id: 'test.ts',
+      code,
+      env: 'client',
+    })
+
+    const compiledResultServer = await compile({
+      id: 'test.ts',
+      code,
+      env: 'server',
+    })
+
+    expect(compiledResultClient!.code).toMatchInlineSnapshot(`
+      "import { createServerFn } from '@tanstack/react-start';
+      const myServerFn = createServerFn({
+        method: 'POST'
+      }).rawHandler((opts, signal) => {
+        "use server";
+
+        return myServerFn.__executeServer(opts, signal);
+      });"
+    `)
+
+    expect(compiledResultServer!.code).toMatchInlineSnapshot(`
+      "import { createServerFn } from '@tanstack/react-start';
+      const myRawFunc = ({
+        request,
+        signal
+      }) => {
+        return new Response('hello from raw handler');
+      };
+      const myServerFn = createServerFn({
+        method: 'POST'
+      }).rawHandler((opts, signal) => {
+        "use server";
+
+        return myServerFn.__executeServer(opts, signal);
+      }, myRawFunc);"
+    `)
+  })
+
+  test('should work with inline rawHandler', async () => {
+    const code = `
+        import { createServerFn } from '@tanstack/react-start'
+        export const uploadFile = createServerFn({ method: 'POST' }).rawHandler(async ({ request, signal }) => {
+          const contentType = request.headers.get('content-type')
+          return new Response(JSON.stringify({ contentType }))
+        })`
+
+    const compiledResultClient = await compile({
+      id: 'test.ts',
+      code,
+      env: 'client',
+    })
+
+    const compiledResultServer = await compile({
+      id: 'test.ts',
+      code,
+      env: 'server',
+    })
+
+    expect(compiledResultClient!.code).toMatchInlineSnapshot(`
+      "import { createServerFn } from '@tanstack/react-start';
+      export const uploadFile = createServerFn({
+        method: 'POST'
+      }).rawHandler((opts, signal) => {
+        "use server";
+
+        return uploadFile.__executeServer(opts, signal);
+      });"
+    `)
+
+    expect(compiledResultServer!.code).toMatchInlineSnapshot(`
+      "import { createServerFn } from '@tanstack/react-start';
+      export const uploadFile = createServerFn({
+        method: 'POST'
+      }).rawHandler((opts, signal) => {
+        "use server";
+
+        return uploadFile.__executeServer(opts, signal);
+      }, async ({
+        request,
+        signal
+      }) => {
+        const contentType = request.headers.get('content-type');
+        return new Response(JSON.stringify({
+          contentType
+        }));
+      });"
+    `)
+  })
+
   test('should use dce by default', async () => {
     const code = `
       import { createServerFn } from '@tanstack/react-start'

--- a/packages/start-server-core/src/server-functions-handler.ts
+++ b/packages/start-server-core/src/server-functions-handler.ts
@@ -66,6 +66,11 @@ export const handleServerAction = async ({
   const response = await (async () => {
     try {
       let result = await (async () => {
+        // For raw handlers, skip FormData parsing and pass the request directly
+        if ((action as any).__rawHandler) {
+          return await action({ context }, signal)
+        }
+
         // FormData
         if (
           formDataContentTypes.some(


### PR DESCRIPTION
Adds .rawHandler() method to createServerFn() that provides direct access to the raw Request object without automatic body parsing. This enables:

- Streaming large file uploads directly to cloud storage without buffering in memory
- Enforcing file size limits during upload rather than after
- Implementing custom body parsing with libraries like busboy
- Minimizing memory footprint for file operations

The raw handler receives { request, signal, context } where:
- request: Raw Request object with unread body stream
- signal: AbortSignal for cancellation support
- context: Full middleware context (auth, user info, etc.)

Closes #5704

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `rawHandler()` method for server functions, enabling streaming file uploads and direct access to the raw Request object.
  * Provides granular control over request handling with built-in backpressure and memory efficiency.

* **Documentation**
  * Added comprehensive guide covering `rawHandler()` usage, streaming patterns, and comparison with standard `handler()` approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->