### PR TITLE
docs(react-start): serialization adapters

### DIFF
--- a/docs/start/framework/react/guide/server-functions.md
+++ b/docs/start/framework/react/guide/server-functions.md
@@ -270,6 +270,31 @@ export default defineConfig({
 })
 ```
 
+### Custom serialization adapters
+
+You can create custom serialization adapters to handle complex types that can't be serialized by default.
+
+Example:
+
+```ts
+// src/start.ts
+import { createStart } from "@tanstack/react-start";
+import { createSerializationAdapter } from "@tanstack/react-router";
+
+const bigIntAdapter = createSerializationAdapter({
+  key: "bigint",
+  test: (value: unknown): value is bigint => typeof value === "bigint",
+  toSerializable: (bigInt) => bigInt.toString(),
+  fromSerializable: (value) => BigInt(value),
+});
+
+export const startInstance = createStart(() => {
+  return {
+    serializationAdapters: [bigIntAdapter],
+  };
+});
+```
+
 ---
 
 > **Note**: Server functions use a compilation process that extracts server code from client bundles while maintaining seamless calling patterns. On the client, calls become `fetch` requests to the server.

--- a/docs/start/framework/solid/guide/server-functions.md
+++ b/docs/start/framework/solid/guide/server-functions.md
@@ -7,3 +7,28 @@ replace:
     '@tanstack/react-router': '@tanstack/solid-router',
   }
 ---
+
+### Custom serialization adapters
+
+You can create custom serialization adapters to handle complex types that can't be serialized by default.
+
+Example:
+
+```ts
+// src/start.ts
+import { createStart } from '@tanstack/solid-start'
+import { createSerializationAdapter } from '@tanstack/solid-router'
+
+const bigIntAdapter = createSerializationAdapter({
+  key: 'bigint',
+  test: (value: unknown): value is bigint => typeof value === 'bigint',
+  toSerializable: (bigInt) => bigInt.toString(),
+  fromSerializable: (value) => BigInt(value),
+})
+
+export const startInstance = createStart(() => {
+  return {
+    serializationAdapters: [bigIntAdapter],
+  }
+})
+```


### PR DESCRIPTION
Added an example on how to add serialization adapters for React Start. Not 100% sure if the right place is in the server function docs. LMK otherwise!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive "Custom serialization adapters" guide with a complete example (includes a bigint adapter) for handling complex types.
  * Guide published in both React and Solid server-functions guides; the React guide includes the new section in two locations for easier discovery.
  * No changes to public APIs or declarations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->