### PR TITLE
refactor(router-core): add error when building route tree if trying to add children routes to an index route

### DIFF
--- a/packages/router-core/src/route.ts
+++ b/packages/router-core/src/route.ts
@@ -1744,12 +1744,10 @@ export class BaseRoute<
     THandlers
   > = (children) => {
     if (process.env.NODE_ENV !== 'production') {
-      if (!this.isRoot && this.fullPath.endsWith('/')) {
-        invariant(
-          false,
-          `Cannot add children to index route '${this.id}'. Index routes cannot have child routes.`,
-        )
-      }
+      invariant(
+        this.isRoot || !this.fullPath.endsWith('/'),
+        `Cannot add children to index route '${this.id}'. Index routes cannot have child routes.`,
+      )
     }
     return this._addFileChildren(children) as any
   }

--- a/packages/router-core/src/route.ts
+++ b/packages/router-core/src/route.ts
@@ -1675,21 +1675,6 @@ export class BaseRoute<
       )
     }
 
-    if (process.env.NODE_ENV !== 'production') {
-      if (this.parentRoute) {
-        invariant(
-          this.parentRoute.isRoot || !this.parentRoute.fullPath.endsWith('/'),
-          `Parent route with id '${this.parentRoute.id}' returned by getParentRoute on '${this.id}' is an index route and cannot have child routes.`,
-        )
-      }
-      if (this.parentRoute) {
-        invariant(
-          this.parentRoute.children && this.parentRoute.children.includes(this),
-          `Parent route with id '${this.parentRoute.id}' returned by getParentRoute has no child route with id '${this.id}'. Did you forget to call .addChildren()?`,
-        )
-      }
-    }
-
     let path: undefined | string = isRoot ? rootRouteId : options?.path
 
     // If the path is anything other than an index path, trim it up
@@ -1722,6 +1707,23 @@ export class BaseRoute<
     this._id = id as TId
     this._fullPath = fullPath as TFullPath
     this._to = fullPath as TrimPathRight<TFullPath>
+
+    if (process.env.NODE_ENV !== 'production') {
+      if (this.parentRoute) {
+        invariant(
+          this.parentRoute.isRoot || !this.parentRoute.fullPath.endsWith('/'),
+          `Parent route with id '${this.parentRoute.id}' returned by getParentRoute on '${this.id}' is an index route and cannot have child routes.`,
+        )
+        invariant(
+          this.parentRoute.children && this.parentRoute.children.includes(this),
+          `Parent route with id '${this.parentRoute.id}' returned by getParentRoute has no child route with id '${this.id}'. Did you forget to call .addChildren()?`,
+        )
+      }
+      invariant(
+        this.children && (this.isRoot || !this.fullPath.endsWith('/')),
+        `Cannot add children to index route '${this.id}'. Index routes cannot have child routes.`,
+      )
+    }
   }
 
   addChildren: RouteAddChildrenFn<
@@ -1743,12 +1745,6 @@ export class BaseRoute<
     TServerMiddlewares,
     THandlers
   > = (children) => {
-    if (process.env.NODE_ENV !== 'production') {
-      invariant(
-        this.isRoot || !this.fullPath.endsWith('/'),
-        `Cannot add children to index route '${this.id}'. Index routes cannot have child routes.`,
-      )
-    }
     return this._addFileChildren(children) as any
   }
 

--- a/packages/router-core/src/route.ts
+++ b/packages/router-core/src/route.ts
@@ -1675,6 +1675,15 @@ export class BaseRoute<
       )
     }
 
+    if (process.env.NODE_ENV !== 'production') {
+      if (this.parentRoute && !this.parentRoute.isRoot && this.parentRoute.fullPath.endsWith('/')) {
+        invariant(
+          false,
+          `Parent route with id '${this.parentRoute.id}' returned by getParentRoute on '${this.id}' is an index route and cannot have child routes.`,
+        )
+      }
+    }
+
     let path: undefined | string = isRoot ? rootRouteId : options?.path
 
     // If the path is anything other than an index path, trim it up
@@ -1728,6 +1737,14 @@ export class BaseRoute<
     TServerMiddlewares,
     THandlers
   > = (children) => {
+     if (process.env.NODE_ENV !== 'production') {
+      if (!this.isRoot && this.fullPath.endsWith('/')) {
+        invariant(
+          false,
+          `Cannot add children to index route '${this.id}'. Index routes cannot have child routes.`,
+        )
+      }
+     }
     return this._addFileChildren(children) as any
   }
 

--- a/packages/router-core/src/route.ts
+++ b/packages/router-core/src/route.ts
@@ -1676,14 +1676,16 @@ export class BaseRoute<
     }
 
     if (process.env.NODE_ENV !== 'production') {
-      if (
-        this.parentRoute &&
-        !this.parentRoute.isRoot &&
-        this.parentRoute.fullPath.endsWith('/')
-      ) {
+      if (this.parentRoute) {
         invariant(
-          false,
+          this.parentRoute.isRoot || !this.parentRoute.fullPath.endsWith('/'),
           `Parent route with id '${this.parentRoute.id}' returned by getParentRoute on '${this.id}' is an index route and cannot have child routes.`,
+        )
+      }
+      if (this.parentRoute) {
+        invariant(
+          this.parentRoute.children && this.parentRoute.children.includes(this),
+          `Parent route with id '${this.parentRoute.id}' returned by getParentRoute has no child route with id '${this.id}'. Did you forget to call .addChildren()?`,
         )
       }
     }

--- a/packages/router-core/src/route.ts
+++ b/packages/router-core/src/route.ts
@@ -1676,7 +1676,11 @@ export class BaseRoute<
     }
 
     if (process.env.NODE_ENV !== 'production') {
-      if (this.parentRoute && !this.parentRoute.isRoot && this.parentRoute.fullPath.endsWith('/')) {
+      if (
+        this.parentRoute &&
+        !this.parentRoute.isRoot &&
+        this.parentRoute.fullPath.endsWith('/')
+      ) {
         invariant(
           false,
           `Parent route with id '${this.parentRoute.id}' returned by getParentRoute on '${this.id}' is an index route and cannot have child routes.`,
@@ -1737,14 +1741,14 @@ export class BaseRoute<
     TServerMiddlewares,
     THandlers
   > = (children) => {
-     if (process.env.NODE_ENV !== 'production') {
+    if (process.env.NODE_ENV !== 'production') {
       if (!this.isRoot && this.fullPath.endsWith('/')) {
         invariant(
           false,
           `Cannot add children to index route '${this.id}'. Index routes cannot have child routes.`,
         )
       }
-     }
+    }
     return this._addFileChildren(children) as any
   }
 

--- a/packages/router-core/src/route.ts
+++ b/packages/router-core/src/route.ts
@@ -1719,10 +1719,12 @@ export class BaseRoute<
           `Parent route with id '${this.parentRoute.id}' returned by getParentRoute has no child route with id '${this.id}'. Did you forget to call .addChildren()?`,
         )
       }
-      invariant(
-        this.children && (this.isRoot || !this.fullPath.endsWith('/')),
-        `Cannot add children to index route '${this.id}'. Index routes cannot have child routes.`,
-      )
+      if (this.children) {
+        invariant(
+          this.isRoot || !this.fullPath.endsWith('/'),
+          `Cannot add children to index route '${this.id}'. Index routes cannot have child routes.`,
+        )
+      }
     }
   }
 


### PR DESCRIPTION
It seems some theoretically invalid route tree configurations used to work before https://github.com/TanStack/router/pull/5867 but don't work anymore.

This PR proposes that we add some runtime checks (when `NODE_ENV !== 'production'`) to warn users of such patterns.


Those env checks persist in the `dist` build of tanstack/router-core distributed through npm

<img width="1030" height="402" alt="Screenshot 2025-11-19 at 09 49 11" src="https://github.com/user-attachments/assets/120fb33a-73c5-4eca-ae08-482bb7dcfd15" />

But get erased at build-time (tested w/ Vite rollup 7.1.12) when the production environment is set (`vite build --mode production` or simply `vite build`)

<img width="822" height="483" alt="Screenshot 2025-11-19 at 09 51 15" src="https://github.com/user-attachments/assets/6208a985-9893-4f51-9bd8-71aac63d677d" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added development-time validation that surfaces clear errors for invalid route configurations—prevents index routes from having children and ensures parent/child route relationships are consistent, helping catch routing setup mistakes earlier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->