### PR TITLE
fix: prevent duplicate title tags in document head

### DIFF
--- a/packages/react-router/src/Asset.tsx
+++ b/packages/react-router/src/Asset.tsx
@@ -16,11 +16,7 @@ export function Asset({
 }: RouterManagedTag & { nonce?: string }): React.ReactElement | null {
   switch (tag) {
     case 'title':
-      return (
-        <title {...attrs} suppressHydrationWarning>
-          {children}
-        </title>
-      )
+      return <Title attrs={attrs}>{children}</Title>
     case 'meta':
       return <meta {...attrs} suppressHydrationWarning />
     case 'link':
@@ -38,6 +34,48 @@ export function Asset({
     default:
       return null
   }
+}
+
+// Track if we've taken control of the title
+let titleControlled = false
+
+function Title({
+  attrs,
+  children,
+}: {
+  attrs?: Record<string, any>
+  children?: string
+}) {
+  const router = useRouter()
+
+  React.useEffect(() => {
+    if (typeof children === 'string') {
+      // On the first title update, clean up any existing titles
+      if (!titleControlled) {
+        // Remove all existing title tags - router will now manage the title
+        const existingTitles = Array.from(document.querySelectorAll('title'))
+        existingTitles.forEach(titleEl => {
+          titleEl.remove()
+        })
+        titleControlled = true
+      }
+      
+      // Set document.title directly - no DOM title tags needed on client
+      document.title = children
+    }
+  }, [children])
+
+  if (!router.isServer) {
+    // On client, don't render title tag - we manage document.title directly
+    return null
+  }
+
+  // On server, render title tag normally for SSR
+  return (
+    <title {...attrs} suppressHydrationWarning>
+      {children}
+    </title>
+  )
 }
 
 function Script({


### PR DESCRIPTION
# PR Description:

## 🐛 Problem & User Need

### The Original Need
I want to display meaningful page titles **immediately during route loading**, before `head()` executes. Currently, there's a title gap because:

1. **Route matches** → empty/stale title period begins
2. **beforeLoad executes** → still no title update  
3. **loader executes** → still no title update
4. **head() executes** → title finally updates

This creates poor UX with blank or stale titles during navigation.

### Current Workaround & Issue
Based on existing APIs, the only way to set immediate titles is in `beforeLoad`:

```typescript
export const Route = createFileRoute('/posts/$postId')({
  beforeLoad: ({ params }) => {
    // Only way to set immediate title with current API
    document.title = `Loading Post ${params.postId}...`
  },
  head: ({ loaderData }) => ({
    meta: [{ title: loaderData.title }], // Final title after loading
  }),
})
```

**This causes duplicate title tags:**
```html
<!-- After beforeLoad sets document.title -->
<head>
  <title>Loading Post 123...</title>  <!-- Set by beforeLoad -->
</head>

<!-- After head() executes and Asset renders -->
<head>
  <title>Loading Post 123...</title>  <!-- Original from document.title -->
  <title>My Amazing Post</title>      <!-- New one from head() -->
</head>
```

The result is invalid HTML with multiple `<title>` elements, causing SEO and browser issues.

## ✅ Solution

This PR **enables the workaround** mentioned above by fixing the duplicate title issue. Now developers can safely use `beforeLoad` to set immediate titles without worrying about invalid HTML.

The fix modifies title handling in `Asset.tsx` to:

1. **Clean up conflicts**: On first router-managed title update, automatically remove any existing `<title>` tags
2. **Use document.title API on client**: Directly set `document.title` instead of rendering additional `<title>` elements  
3. **Maintain SSR compatibility**: Continue rendering `<title>` tags normally on the server for SEO

### Result: Clean HTML
```html
<!-- After this fix, only one title exists -->
<head>
  <title>My Amazing Post</title>  <!-- Only the final title -->
</head>
```

### Technical Implementation

**Client-side behavior:**
- First title update removes all existing `<title>` DOM elements
- Subsequent updates only use `document.title` API
- No additional `<title>` tags are rendered

**Server-side behavior:**
- Normal `<title>` tag rendering for SSR/SEO
- No changes to existing SSR behavior

## 🔧 Implementation Details

### File Changed: `packages/react-router/src/Asset.tsx`

**Before:**
```typescript
case 'title':
  return (
    <title {...attrs} suppressHydrationWarning>
      {children}
    </title>
  )
```

**After:**
```typescript
case 'title':
  return <Title attrs={attrs}>{children}</Title>

// New Title component that handles deduplication
function Title({ attrs, children }) {
  const router = useRouter()

  React.useEffect(() => {
    if (typeof children === 'string') {
      // Clean up existing titles on first update
      if (!titleControlled) {
        document.querySelectorAll('title').forEach(el => el.remove())
        titleControlled = true
      }
      // Use document.title API directly
      document.title = children
    }
  }, [children])

  // Client: no DOM rendering, Server: normal SSR
  return !router.isServer ? null : <title {...attrs}>{children}</title>
}
```

## 📝 Usage & Developer Experience

### Before This Fix
Developers faced a dilemma:
- Use only `head()` → good HTML, but title gaps during loading
- Use `beforeLoad` + `head()` → immediate titles, but invalid HTML with duplicates

### After This Fix  
Developers can now safely use the `beforeLoad` pattern without HTML validity concerns:

```typescript
export const Route = createFileRoute('/posts/$postId')({
  beforeLoad: ({ params }) => {
    // ✅ Now safe to use - no more duplicate title tags!
    if (typeof window !== 'undefined') {
      document.title = `Loading Post ${params.postId}...`
    }
  },
  head: ({ loaderData }) => ({
    meta: [{ title: loaderData.title }], // Will cleanly replace the loading title
  }),
})
```


---

**Summary**: This PR fixes duplicate title tags by implementing clean title management that automatically handles conflicts while maintaining full backward compatibility and SSR support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized how page titles are managed, improving client-side performance by updating the document title more efficiently while maintaining proper server-side behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->