### PR TITLE
feat: add static function middleware support of basepath

### DIFF
--- a/packages/start-static-server-functions/src/staticFunctionMiddleware.ts
+++ b/packages/start-static-server-functions/src/staticFunctionMiddleware.ts
@@ -116,7 +116,9 @@ const fetchItem = async ({
 
   let result: any = staticClientCache?.get(url)
 
-  result = await fetch(url, {
+  const basePath = process.env.TSS_ROUTER_BASEPATH!
+  const prefixedUrl = path.join(basePath, url)
+  result = await fetch(prefixedUrl, {
     method: 'GET',
   })
     .then((r) => r.json())


### PR DESCRIPTION
Hello 👋 

I tried the new `staticFunctionMiddleware`, but I've found an issue as my application is hosted on a subpath (`/docs`). I propose to fix this, but I'm not sure the router basepath is the right variable to use. Ideally, I would prefer to use the `import.meta.env. BASE_URL` of Vite, as I think TSR files are quite similar to bundling assets, but I'm not sure it will work.

Let me know what you think and I'll change this straightaway. Thanks for this package!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated request routing to support environment-configured base paths, enabling the application to function correctly when deployed to non-root server paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->