### PR TITLE
fix: queue pushpop actions

### DIFF
--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -413,10 +413,17 @@ export function createBrowserHistory(opts?: {
 
       action()
     } else {
-      scheduledPushPopAction.then(() => {
-        nextOnPushPop = { nextPopIsGo: isGo, skipBlockerNextPop: ignoreBlocker }
-        action()
-      })
+      scheduledPushPopAction = scheduledPushPopAction.then(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveScheduledPushPopAction = resolve
+            nextOnPushPop = {
+              nextPopIsGo: isGo,
+              skipBlockerNextPop: ignoreBlocker,
+            }
+            action()
+          }),
+      )
     }
   }
 

--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -471,7 +471,7 @@ export function createBrowserHistory(opts?: {
             })
             if (isBlocked) {
               ignoreNextPop = true
-              win.history.go(1)
+              win.history.go(-delta)
               history.notify(notify)
               return
             }


### PR DESCRIPTION
When running push/pop actions like back, forward or go in quick succession the `ignoreBlocker` functionality does not work since the event which flips back the ignore flag does not run right away and the second call to `back` for example runs before the event meaning the flag is not reset correctly when the second pushpop event is called. This PR fixes this by implementing a promise based queue system

It also ensure that ignoreBlocker also works with go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced scheduling of back/forward/go navigation to make transitions more reliable and to avoid races.
  * Improved coordination with navigation blockers and state synchronization for consistent history behavior.
  * Added an option to bypass blockers for certain navigations when needed.

* **Breaking Changes**
  * Public navigation API signature updated; create-memory-history options signature adjusted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->