### PR TITLE
fix: scope router to basepath for MFE support

### DIFF
--- a/packages/router-core/src/path.ts
+++ b/packages/router-core/src/path.ts
@@ -351,3 +351,29 @@ function encodePathParam(value: string, decodeCharMap?: Map<string, string>) {
   }
   return encoded
 }
+
+/**
+ * Checks if a pathname is within a basepath scope.
+ * Used to determine if a router should process a location change.
+ * This enables MFE architectures where multiple routers coexist.
+ *
+ * Mirrors React Router's stripBasename behavior where paths outside
+ * the basename are silently ignored.
+ *
+ * @param pathname - The current pathname to check
+ * @param basepath - The router's configured basepath
+ * @returns true if pathname is within basepath scope, false otherwise
+ */
+export function isPathInScope(pathname: string, basepath: string): boolean {
+  if (basepath === '/') return true
+
+  // Case-insensitive comparison (same as React Router)
+  if (!pathname.toLowerCase().startsWith(basepath.toLowerCase())) {
+    return false
+  }
+
+  // Ensure basepath is followed by / or end of string
+  // This prevents /app from matching /application
+  const nextChar = pathname.charAt(basepath.length)
+  return !nextChar || nextChar === '/'
+}

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -19,6 +19,7 @@ import {
 import {
   cleanPath,
   interpolatePath,
+  isPathInScope,
   resolvePath,
   trimPath,
   trimPathRight,
@@ -2098,6 +2099,28 @@ export class RouterCore<
   }
 
   load: LoadFn = async (opts?: { sync?: boolean }): Promise<void> => {
+    // If this router has a basepath, only respond to paths within scope.
+    // This enables MFE architectures where multiple routers coexist.
+    if (this.basepath && this.basepath !== '/') {
+      // Get the current path from history
+      let pathToCheck = this.history.location.pathname
+
+      // For hash history, extract path from the hash portion
+      const href = this.history.location.href
+      if (href.includes('#')) {
+        const hashPart = href.split('#')[1]
+        if (hashPart) {
+          // Remove query string and nested hash from path
+          pathToCheck = hashPart.split('?')[0]?.split('#')[0] || '/'
+        }
+      }
+
+      // If path is outside this router's scope, silently ignore
+      if (!isPathInScope(pathToCheck, this.basepath)) {
+        return
+      }
+    }
+
     let redirect: AnyRedirect | undefined
     let notFound: NotFoundError | undefined
     let loadPromise: Promise<void>

--- a/packages/router-core/tests/path.test.ts
+++ b/packages/router-core/tests/path.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   exactPathTest,
   interpolatePath,
+  isPathInScope,
   removeTrailingSlash,
   resolvePath,
   trimPathLeft,
@@ -84,6 +85,60 @@ describe.each([{ basepath: '/' }, { basepath: '/app' }, { basepath: '/app/' }])(
     })
   },
 )
+
+describe('isPathInScope', () => {
+  it('returns true for root basepath with any path', () => {
+    expect(isPathInScope('/anything', '/')).toBe(true)
+    expect(isPathInScope('/', '/')).toBe(true)
+    expect(isPathInScope('/deep/nested/path', '/')).toBe(true)
+  })
+
+  it('returns true when pathname matches basepath exactly', () => {
+    expect(isPathInScope('/app', '/app')).toBe(true)
+    expect(isPathInScope('/user-management', '/user-management')).toBe(true)
+  })
+
+  it('returns true when pathname starts with basepath followed by /', () => {
+    expect(isPathInScope('/app/page', '/app')).toBe(true)
+    expect(isPathInScope('/app/nested/deep', '/app')).toBe(true)
+    expect(isPathInScope('/user-management/users', '/user-management')).toBe(
+      true,
+    )
+  })
+
+  it('returns false when pathname does not start with basepath', () => {
+    expect(isPathInScope('/other', '/app')).toBe(false)
+    expect(isPathInScope('/', '/app')).toBe(false)
+    expect(isPathInScope('/settings', '/app')).toBe(false)
+    expect(isPathInScope('/home', '/user-management')).toBe(false)
+  })
+
+  it('returns false when basepath is prefix but not at path boundary', () => {
+    // /app should not match /application
+    expect(isPathInScope('/application', '/app')).toBe(false)
+    expect(isPathInScope('/apps', '/app')).toBe(false)
+    expect(isPathInScope('/appstore/page', '/app')).toBe(false)
+  })
+
+  it('handles case-insensitive comparison', () => {
+    expect(isPathInScope('/APP/page', '/app')).toBe(true)
+    expect(isPathInScope('/App/Page', '/app')).toBe(true)
+    expect(isPathInScope('/app/page', '/APP')).toBe(true)
+    expect(isPathInScope('/USER-MANAGEMENT/users', '/user-management')).toBe(
+      true,
+    )
+  })
+
+  it('handles trailing slashes correctly', () => {
+    expect(isPathInScope('/app/', '/app')).toBe(true)
+    expect(isPathInScope('/app/page/', '/app')).toBe(true)
+  })
+
+  it('handles edge cases', () => {
+    expect(isPathInScope('', '/')).toBe(true)
+    expect(isPathInScope('/', '/')).toBe(true)
+  })
+})
 
 describe('resolvePath', () => {
   describe.each([


### PR DESCRIPTION
## Problem

When multiple TanStack routers coexist in a micro-frontend (MFE) architecture, **all routers respond to all history changes**, even when the path is outside their configured `basepath`. This causes unexpected behavior:

- **404 errors**: MFE router tries to match paths it shouldn't handle
- **Navigation conflicts**: `defaultNotFoundComponent` triggers incorrectly
- **Broken user experience**: Users can't navigate between shell and MFE modules

### Root Cause

In `Transitioner.tsx` (line 44), every router subscribes to history changes via:
```typescript
router.history.subscribe(router.load)
```

This means when the shell navigates to `/settings`, an MFE router with `basepath: '/user-management'` still receives the event and attempts to match `/settings` against its routes - which fails, triggering a 404.

### Why This Happens

TanStack Router's `basepath` option is currently only used for:
1. Prefixing generated links
2. Stripping the prefix when matching routes

But it does **not** filter which history events the router processes. A router with `basepath: '/app'` will still try to process navigation to `/`, `/settings`, `/other-module`, etc.

## Solution

Add a basepath scope check at the beginning of the router's `load` method. When a router has a `basepath` configured, it now **only processes location changes within its basepath scope**.

### Implementation

1. **New utility function** `isPathInScope(pathname, basepath)` in `path.ts`:
   - Returns `true` if the pathname is within the basepath scope
   - Case-insensitive comparison (matches React Router behavior)
   - Ensures basepath boundary check (e.g., `/app` doesn't match `/application`)

2. **Basepath check in `router.load()`**:
   - If `basepath` is set and not `/`, check if current path is in scope
   - If out of scope, return early (silent ignore - no 404, no redirect)
   - Supports both browser history and hash history

### How React Router Handles This

This implementation mirrors React Router's `stripBasename` behavior:

```typescript
// React Router's approach (from @remix-run/router)
export function stripBasename(pathname: string, basename: string): string | null {
  if (basename === "/") return pathname;
  if (!pathname.toLowerCase().startsWith(basename.toLowerCase())) {
    return null;  // Path outside basename scope - IGNORE
  }
  let nextChar = pathname.charAt(basename.length);
  if (nextChar && nextChar !== "/") {
    return null;  // Must have / after basename
  }
  return pathname.slice(basename.length) || "/";
}
```

When `stripBasename()` returns `null`, `matchRoutes()` returns `null`, and **nothing renders** - the router completely ignores out-of-scope paths.

## Use Case: Micro-Frontends

```
Shell Application (TanStack Router)
├── / (home)
├── /settings
└── /user-management/* (splat route loads MFE)

MFE Application (TanStack Router, basepath: '/user-management')
├── /user-management/users
├── /user-management/roles
└── /user-management/permissions
```

### Before This Fix
1. User is on `/user-management/users` (MFE is loaded)
2. User clicks link to `/settings` (shell route)
3. ❌ MFE router receives history event
4. ❌ MFE router tries to match `/settings`
5. ❌ No match → 404 or `defaultNotFoundComponent` renders

### After This Fix
1. User is on `/user-management/users` (MFE is loaded)
2. User clicks link to `/settings` (shell route)
3. ✅ MFE router receives history event
4. ✅ MFE router checks: is `/settings` within `/user-management`? **No**
5. ✅ MFE router returns early (silent ignore)
6. ✅ Shell router handles `/settings` correctly

## Breaking Changes

**None for most users.**

- Routers without `basepath` (or `basepath: '/'`) behave exactly the same
- Routers with `basepath` will now correctly ignore out-of-scope paths

This is actually **fixing** the expected behavior. If you set `basepath: '/app'`, you intuitively expect the router to only care about paths like `/app/*`.

## Testing

- Added 8 comprehensive unit tests for `isPathInScope()`:
  - Root basepath always returns true
  - Exact basepath match
  - Pathname starting with basepath followed by `/`
  - Pathname not starting with basepath
  - Basepath as prefix but not at path boundary (`/app` vs `/application`)
  - Case-insensitive comparison
  - Trailing slashes
  - Edge cases

All existing tests pass (213 path tests total).

## Files Changed

- `packages/router-core/src/path.ts` - Added `isPathInScope()` utility
- `packages/router-core/src/router.ts` - Added basepath scope check in `load()`
- `packages/router-core/tests/path.test.ts` - Added unit tests

---

Fixes #2103
Fixes #2108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented basepath scope validation. The router now prevents navigation to paths outside the configured basepath scope, silently ignoring out-of-scope navigation requests. This enhancement applies to both standard URL routing and hash-based routing configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->