### PR TITLE
fix(scroll-restoration): save scroll position when navigating with resetScroll=false

### DIFF
--- a/e2e/react-router/basic-scroll-restoration/src/main.tsx
+++ b/e2e/react-router/basic-scroll-restoration/src/main.tsx
@@ -20,22 +20,39 @@ const rootRoute = createRootRoute({
 function RootComponent() {
   return (
     <>
-      <div className="p-2 flex gap-2 sticky top-0 border-b bg-gray-100 dark:bg-gray-900">
-        <Link to="/" className="[&.active]:font-bold">
-          Home
-        </Link>{' '}
-        <Link to="/about" className="[&.active]:font-bold">
-          About
-        </Link>
-        <Link to="/about" resetScroll={false}>
-          About (No Reset)
-        </Link>
-        <Link to="/by-element" className="[&.active]:font-bold">
-          By-Element
-        </Link>
+      <div
+        id="sidebar"
+        className="fixed left-0 top-0 w-48 h-screen overflow-auto border-r bg-gray-50 dark:bg-gray-800 z-10"
+      >
+        <div className="p-2 space-y-2">
+          {Array.from({ length: 30 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-[50px] p-2 rounded bg-gray-200 dark:bg-gray-700 text-sm"
+            >
+              Sidebar Item {i + 1}
+            </div>
+          ))}
+        </div>
       </div>
-      <Outlet />
-      <TanStackRouterDevtools />
+      <div className="ml-48">
+        <div className="p-2 flex gap-2 sticky top-0 border-b bg-gray-100 dark:bg-gray-900 z-20">
+          <Link to="/" className="[&.active]:font-bold">
+            Home
+          </Link>{' '}
+          <Link to="/about" className="[&.active]:font-bold">
+            About
+          </Link>
+          <Link to="/about" resetScroll={false}>
+            About (No Reset)
+          </Link>
+          <Link to="/by-element" className="[&.active]:font-bold">
+            By-Element
+          </Link>
+        </div>
+        <Outlet />
+        <TanStackRouterDevtools />
+      </div>
     </>
   )
 }
@@ -268,6 +285,7 @@ const router = createRouter({
   defaultPreload: 'intent',
   scrollRestoration: true,
   getScrollRestorationKey: (location) => location.pathname,
+  scrollToTopSelectors: ['#sidebar'],
 })
 
 declare global {

--- a/e2e/react-router/basic-scroll-restoration/tests/app.spec.ts
+++ b/e2e/react-router/basic-scroll-restoration/tests/app.spec.ts
@@ -180,13 +180,10 @@ test('resetScroll=false preserves scrollToTopSelectors element scroll position, 
   await page.goto('/')
   await expect(page.locator('#greeting')).toContainText('Welcome Home!')
 
-  await page.evaluate(
-    (scrollPos: number) => {
-      const sidebar = document.querySelector('#sidebar')
-      if (sidebar) sidebar.scrollTo(0, scrollPos)
-    },
-    sidebarScrollPosition,
-  )
+  await page.evaluate((scrollPos: number) => {
+    const sidebar = document.querySelector('#sidebar')
+    if (sidebar) sidebar.scrollTo(0, scrollPos)
+  }, sidebarScrollPosition)
 
   const sidebarScrollBeforeNav = await page.evaluate(
     () => document.querySelector('#sidebar')?.scrollTop,

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -32,6 +32,7 @@ import { createLRUCache } from './lru-cache'
 import { isNotFound } from './not-found'
 import {
   defaultGetScrollRestorationKey,
+  getCssSelector,
   scrollRestorationCache,
   setupScrollRestoration,
 } from './scroll-restoration'
@@ -2140,6 +2141,18 @@ export class RouterCore<
           keyEntry['window'] = {
             scrollX: window.scrollX || 0,
             scrollY: window.scrollY || 0,
+          }
+          if (this.options.scrollToTopSelectors) {
+            for (const selector of this.options.scrollToTopSelectors) {
+              const element = typeof selector === 'function' ? selector() : document.querySelector(selector)
+              if (element) {
+                const elementSelector = typeof selector === 'string' ? selector : getCssSelector(element)
+                keyEntry[elementSelector] = {
+                  scrollX: element.scrollLeft || 0,
+                  scrollY: element.scrollTop || 0,
+                }
+              }
+            }
           }
           return state
         })

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -30,7 +30,11 @@ import {
 } from './path'
 import { createLRUCache } from './lru-cache'
 import { isNotFound } from './not-found'
-import { setupScrollRestoration } from './scroll-restoration'
+import {
+  defaultGetScrollRestorationKey,
+  scrollRestorationCache,
+  setupScrollRestoration,
+} from './scroll-restoration'
 import { defaultParseSearch, defaultStringifySearch } from './searchParams'
 import { rootRouteId } from './root'
 import { isRedirect, redirect } from './redirect'
@@ -41,6 +45,7 @@ import {
   executeRewriteOutput,
   rewriteBasepath,
 } from './rewrite'
+import type { ScrollRestorationByElement } from './scroll-restoration'
 import type { LRUCache } from './lru-cache'
 import type {
   ProcessRouteTreeResult,
@@ -2126,6 +2131,19 @@ export class RouterCore<
         hashScrollIntoView ?? this.options.defaultHashScrollIntoView ?? true
 
       this.shouldViewTransition = viewTransition
+
+      if (next.resetScroll === false && this.isScrollRestoring && scrollRestorationCache) {
+        const getKey = this.options.getScrollRestorationKey || defaultGetScrollRestorationKey
+        const toKey = getKey(next as unknown as ParsedLocation)
+        scrollRestorationCache.set((state) => {
+          const keyEntry = (state[toKey] ||= {} as ScrollRestorationByElement)
+          keyEntry['window'] = {
+            scrollX: window.scrollX || 0,
+            scrollY: window.scrollY || 0,
+          }
+          return state
+        })
+      }
 
       this.history[next.replace ? 'replace' : 'push'](
         nextHistory.publicHref,

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -2133,8 +2133,13 @@ export class RouterCore<
 
       this.shouldViewTransition = viewTransition
 
-      if (next.resetScroll === false && this.isScrollRestoring && scrollRestorationCache) {
-        const getKey = this.options.getScrollRestorationKey || defaultGetScrollRestorationKey
+      if (
+        next.resetScroll === false &&
+        this.isScrollRestoring &&
+        scrollRestorationCache
+      ) {
+        const getKey =
+          this.options.getScrollRestorationKey || defaultGetScrollRestorationKey
         const toKey = getKey(next as unknown as ParsedLocation)
         scrollRestorationCache.set((state) => {
           const keyEntry = (state[toKey] ||= {} as ScrollRestorationByElement)
@@ -2144,9 +2149,15 @@ export class RouterCore<
           }
           if (this.options.scrollToTopSelectors) {
             for (const selector of this.options.scrollToTopSelectors) {
-              const element = typeof selector === 'function' ? selector() : document.querySelector(selector)
+              const element =
+                typeof selector === 'function'
+                  ? selector()
+                  : document.querySelector(selector)
               if (element) {
-                const elementSelector = typeof selector === 'string' ? selector : getCssSelector(element)
+                const elementSelector =
+                  typeof selector === 'string'
+                    ? selector
+                    : getCssSelector(element)
                 keyEntry[elementSelector] = {
                   scrollX: element.scrollLeft || 0,
                   scrollY: element.scrollTop || 0,


### PR DESCRIPTION
fixes #6595

### Problem Analysis
  When navigating A → B → C → B:
  1. User scrolls on A (Home) to position 1000
  2. User navigates to B (About) with `resetScroll=false` (scroll position maintained)
  3. User navigates to C (Foo) without scrolling on B
  4. User goes back to B (About)
  5. **Bug**: Scroll position is 0 (B has no cache entry because no scroll event occurred on B)

  The root cause is that scroll positions are only saved through the `onScroll` event handler. If the user never scrolls on page B, there's no cache entry for B.

### Solution
  Save the current scroll position to the **destination route's cache key** when navigating with `resetScroll=false`. This must happen **before** `history.push/replace` because the browser resets scroll position after the history change.

### Why `commitLocation` (before `history.push`)?
  I evaluated several insertion points:

  | Location | Timing | Result |
  |----------|--------|--------|
  | `onRendered` event | After page transition | ❌ `window.scrollY` already 0 |
  | `onBeforeLoad` event | After `history.push` | ❌ `window.scrollY` already 0 |
  | `commitLocation` before `history.push` | Before history change | ✅ Captures current scroll |

  The scroll position must be captured **before** `history.push/replace` is called, making `commitLocation` the only viable location.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Example app now uses a persistent sidebar layout and configures scroll restoration for that sidebar.

* **Bug Fixes**
  * Improved scroll restoration on back navigation when scroll reset is disabled — restores both page and element (e.g., sidebar) scroll positions without extra scroll events.

* **Tests**
  * Added end-to-end regression tests covering page and element scroll restoration across navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->