### PR TITLE
Restore scroll when navigating back from a resetScroll=false navigation without having scrolled

### DIFF
--- a/e2e/react-router/basic-scroll-restoration/src/main.tsx
+++ b/e2e/react-router/basic-scroll-restoration/src/main.tsx
@@ -288,7 +288,6 @@ const router = createRouter({
   routeTree,
   defaultPreload: 'intent',
   scrollRestoration: true,
-  getScrollRestorationKey: (location) => location.pathname,
   scrollToTopSelectors: ['#sidebar'],
 })
 

--- a/e2e/react-router/basic-scroll-restoration/src/main.tsx
+++ b/e2e/react-router/basic-scroll-restoration/src/main.tsx
@@ -20,21 +20,42 @@ const rootRoute = createRootRoute({
 function RootComponent() {
   return (
     <>
-      <div className="p-2 flex gap-2 sticky top-0 border-b bg-gray-100 dark:bg-gray-900">
-        <Link to="/" className="[&.active]:font-bold">
-          Home
-        </Link>{' '}
-        <Link to="/about" className="[&.active]:font-bold">
-          About
-        </Link>
-        <Link to="/about" resetScroll={false}>
-          About (No Reset)
-        </Link>
-        <Link to="/by-element" className="[&.active]:font-bold">
-          By-Element
-        </Link>
+      <div
+        id="sidebar"
+        className="fixed left-0 top-0 w-48 h-screen overflow-auto border-r bg-gray-50 dark:bg-gray-800 z-10"
+      >
+        <div className="p-2 space-y-2">
+          {Array.from({ length: 30 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-[50px] p-2 rounded bg-gray-200 dark:bg-gray-700 text-sm"
+            >
+              Sidebar Item {i + 1}
+            </div>
+          ))}
+        </div>
       </div>
-      <Outlet />
+      <div className="ml-48">
+        <div className="p-2 flex gap-2 sticky top-0 border-b bg-gray-100 dark:bg-gray-900">
+          <Link to="/" className="[&.active]:font-bold">
+            Home
+          </Link>{' '}
+          <Link to="/about" className="[&.active]:font-bold">
+            About
+          </Link>
+          <Link to="/about" resetScroll={false}>
+            About (No Reset)
+          </Link>
+          <Link to="/bar" resetScroll={false}>
+            Bar (No Reset)
+          </Link>
+          <Link to="/by-element" className="[&.active]:font-bold">
+            By-Element
+          </Link>
+        </div>
+        <Outlet />
+
+      </div>
       <TanStackRouterDevtools />
     </>
   )
@@ -268,6 +289,7 @@ const router = createRouter({
   defaultPreload: 'intent',
   scrollRestoration: true,
   getScrollRestorationKey: (location) => location.pathname,
+  scrollToTopSelectors: ['#sidebar'],
 })
 
 declare global {

--- a/packages/router-core/src/scroll-restoration.ts
+++ b/packages/router-core/src/scroll-restoration.ts
@@ -110,6 +110,10 @@ export function getCssSelector(el: any): string {
   return `${path.reverse().join(' > ')}`.toLowerCase()
 }
 
+/** 
+ * Finds the first matching string selector for a given element from a list of selectors.
+ * Ignores function selectors, see https://github.com/TanStack/router/pull/6632
+ */
 function findMatchingSelector(el: Element, selectors: Array<string | (() => Element | null | undefined)>): string | undefined {
   for (const selector of selectors) {
     if (typeof selector === 'string' && el.matches(selector)) {
@@ -311,7 +315,7 @@ export function setupScrollRestoration(router: AnyRouter, force?: boolean) {
       if (attrId) {
         elementSelector = `[data-scroll-restoration-id="${attrId}"]`
       } else {
-        elementSelector = findMatchingSelector(event.target as Element, router.options.scrollToTopSelectors ?? []) 
+        elementSelector = findMatchingSelector(event.target as Element, router.options.scrollToTopSelectors ?? [])
           ?? getCssSelector(event.target)
       }
     }
@@ -384,7 +388,8 @@ export function setupScrollRestoration(router: AnyRouter, force?: boolean) {
             }
           }
 
-          state[cacheKey] = newState;
+          state[cacheKey] ||= {} as ScrollRestorationByElement
+          state[cacheKey] = { ...state[cacheKey], ...newState };
         }
   
         return state

--- a/packages/router-core/src/scroll-restoration.ts
+++ b/packages/router-core/src/scroll-restoration.ts
@@ -110,7 +110,7 @@ export function getCssSelector(el: any): string {
   return `${path.reverse().join(' > ')}`.toLowerCase()
 }
 
-/** 
+/**
  * Finds the first matching string selector for a given element from a list of selectors.
  * Ignores function selectors, see https://github.com/TanStack/router/pull/6632
  */


### PR DESCRIPTION
Fixes https://github.com/TanStack/router/issues/6595

In the case of scroll to top selectors, this PR updates the scroll restoration code to use the string selector itself as the selector stored in onScroll, rather than generating a CSS selector on the fly. This then is copied across when navigating with resetScroll=false in order to remember the scroll positions without having a scroll event firing. If the CSS selector were created dynamically it'd risk becoming stale and referring to the wrong element between navigations.

This does mean the problem will still happen for scroll to top selectors initialized using a function call, which this PR doesn't change - I think this is a reasonable trade-off.

This PR also updates the tests. I've updated the basic scroll restoration test to use the default scroll restoration tests - its compatible with all of the old tests, and seems more reasonable to check against the default behaviour for the basic tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced the top navigation with a persistent fixed sidebar and adjusted main content layout.
  * Improved scroll restoration so scroll positions for the page and key page elements are preserved across navigation.

* **Tests**
  * Added an end-to-end regression test verifying scroll positions are maintained during navigation and back navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->