### PR TITLE
Add title to setup testing documentation

### DIFF
--- a/docs/router/how-to/setup-testing.md
+++ b/docs/router/how-to/setup-testing.md
@@ -1,4 +1,6 @@
-# How to Set Up Testing with Code-Based Routing
+---
+title: How to Set Up Testing with Code-Based Routing
+---
 
 This guide covers setting up comprehensive testing for TanStack Router applications that use code-based routing, including unit tests, integration tests, and end-to-end testing strategies.
 


### PR DESCRIPTION
Add front matter to the setup testing guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reformatted the testing setup guide to use YAML front matter for document metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->