### PR TITLE
fix(start): use setHeader in preview server for HTTP/2 compatibility …

### DIFF
--- a/packages/start-plugin-core/src/preview-server-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/preview-server-plugin/plugin.ts
@@ -54,7 +54,7 @@ export function previewServerPlugin(): Plugin {
               // Temporary workaround
               // Vite preview's compression middleware doesn't support flattened array headers that srvx sets
               // Call writeHead() before srvx to avoid corruption
-              res.setHeaders(webRes.headers)
+              webRes.headers.forEach((value, key) => res.setHeader(key, value));
               res.writeHead(webRes.status, webRes.statusText)
 
               return sendNodeResponse(res, webRes)


### PR DESCRIPTION
Fixes #6294 

Http2ServerResponse (used by Vite when HTTPS is enabled) doesn't have setHeaders, which is only available on http.ServerResponse. This causes the preview server to crash when using HTTPS (e.g. via vite-plugin-mkcert).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal header processing in the preview server for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->