### PR TITLE
ci: use trend images in bundle-size PR comments

### DIFF
--- a/scripts/benchmarks/bundle-size/pr-report.mjs
+++ b/scripts/benchmarks/bundle-size/pr-report.mjs
@@ -6,6 +6,7 @@ import path from 'node:path'
 import { parseArgs as parseNodeArgs } from 'node:util'
 
 const DEFAULT_MARKER = '<!-- bundle-size-benchmark -->'
+const TREND_GRAPH_URL = 'https://tiny-graph.florianpellet.com/'
 const INT_FORMAT = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 0,
 })
@@ -132,29 +133,57 @@ function formatDelta(current, baseline) {
   return `${formatBytes(delta, { signed: true })} (${sign}${PERCENT_FORMAT.format(ratio)})`
 }
 
-function sparkline(values) {
-  if (!values.length) {
+function toUnixTimestamp(value) {
+  if (Number.isFinite(value)) {
+    return Math.floor(Number(value) / 1000)
+  }
+
+  if (typeof value !== 'string' || !value) {
+    return undefined
+  }
+
+  const parsed = Date.parse(value)
+  if (Number.isNaN(parsed)) {
+    return undefined
+  }
+
+  return Math.floor(parsed / 1000)
+}
+
+function resolveHistoryEntryTimestamp(entry) {
+  return (
+    toUnixTimestamp(entry?.date) ?? toUnixTimestamp(entry?.commit?.timestamp)
+  )
+}
+
+function resolveCurrentTimestamp(current) {
+  return (
+    toUnixTimestamp(current?.measuredAt) ??
+    toUnixTimestamp(current?.generatedAt)
+  )
+}
+
+function buildTrendGraph(points) {
+  if (!points.length) {
     return 'n/a'
   }
 
-  const blocks = '▁▂▃▄▅▆▇█'
-  const min = Math.min(...values)
-  const max = Math.max(...values)
+  const coords = []
 
-  if (max === min) {
-    return '▅'.repeat(values.length)
+  for (const point of points) {
+    if (!Number.isFinite(point?.x) || !Number.isFinite(point?.y)) {
+      continue
+    }
+
+    coords.push(point.x, point.y)
   }
 
-  return values
-    .map((value) => {
-      const normalized = (value - min) / (max - min)
-      const idx = Math.min(
-        blocks.length - 1,
-        Math.max(0, Math.round(normalized * (blocks.length - 1))),
-      )
-      return blocks[idx]
-    })
-    .join('')
+  if (!coords.length) {
+    return 'n/a'
+  }
+
+  const src = `${TREND_GRAPH_URL}?coords=${encodeURIComponent(coords.join(','))}`
+  return `![Historical gzip bytes trend](${src})`
 }
 
 function normalizeHistoryEntries(history, benchmarkName) {
@@ -177,6 +206,12 @@ function buildSeriesByScenario(historyEntries) {
   const map = new Map()
 
   for (const entry of historyEntries) {
+    const timestamp = resolveHistoryEntryTimestamp(entry)
+
+    if (!Number.isFinite(timestamp)) {
+      continue
+    }
+
     for (const bench of entry?.benches || []) {
       if (typeof bench?.name !== 'string' || !Number.isFinite(bench?.value)) {
         continue
@@ -186,7 +221,10 @@ function buildSeriesByScenario(historyEntries) {
         map.set(bench.name, [])
       }
 
-      map.get(bench.name).push(Number(bench.value))
+      map.get(bench.name).push({
+        x: timestamp,
+        y: Number(bench.value),
+      })
     }
   }
 
@@ -263,6 +301,7 @@ async function main() {
 
   const historyEntries = normalizeHistoryEntries(history, current.benchmarkName)
   const seriesByScenario = buildSeriesByScenario(historyEntries)
+  const currentTimestamp = resolveCurrentTimestamp(current)
 
   const baseline =
     baselineCurrent != null
@@ -274,15 +313,22 @@ async function main() {
   for (const metric of current.metrics || []) {
     const baselineValue = baseline.benchesByName.get(metric.id)
     const historySeries = (seriesByScenario.get(metric.id) || []).slice(
-      // Reserve one slot for the current metric so the sparkline stays at trendPoints.
+      // Reserve one slot for the current metric so the trend stays at trendPoints.
       -args.trendPoints + 1,
     )
+    const currentPoint = {
+      x: currentTimestamp,
+      y: metric.gzipBytes,
+    }
+    const lastPoint = historySeries[historySeries.length - 1]
 
     if (
-      !historySeries.length ||
-      historySeries[historySeries.length - 1] !== metric.gzipBytes
+      Number.isFinite(currentPoint.x) &&
+      (!lastPoint ||
+        lastPoint.x !== currentPoint.x ||
+        lastPoint.y !== currentPoint.y)
     ) {
-      historySeries.push(metric.gzipBytes)
+      historySeries.push(currentPoint)
     }
 
     rows.push({
@@ -291,7 +337,7 @@ async function main() {
       raw: metric.rawBytes,
       brotli: metric.brotliBytes,
       deltaCell: formatDelta(metric.gzipBytes, baselineValue),
-      trendCell: sparkline(historySeries.slice(-args.trendPoints)),
+      trendCell: buildTrendGraph(historySeries.slice(-args.trendPoints)),
     })
   }
 
@@ -321,7 +367,7 @@ async function main() {
 
   lines.push('')
   lines.push(
-    '_Trend sparkline is historical gzip bytes ending with this PR measurement; lower is better._',
+    '_Trend chart uses historical gzip bytes plotted by measurement date, ending with this PR measurement; lower is better._',
   )
 
   const markdown = lines.join('\n') + '\n'

--- a/scripts/benchmarks/bundle-size/pr-report.mjs
+++ b/scripts/benchmarks/bundle-size/pr-report.mjs
@@ -182,7 +182,12 @@ function buildTrendGraph(points) {
     return 'n/a'
   }
 
-  const src = `${TREND_GRAPH_URL}?coords=${encodeURIComponent(coords.join(','))}`
+  const params = new URLSearchParams({
+    coords: coords.join(','),
+    width: '165',
+    height: '45',
+  })
+  const src = `${TREND_GRAPH_URL}?${params.toString()}`
   return `![Historical gzip bytes trend](${src})`
 }
 


### PR DESCRIPTION
## Summary
- replace the bundle-size PR comment sparkline with an inline tiny-graph image built from historical measurement timestamps and gzip byte values
- keep the existing baseline and size reporting intact while appending the current PR measurement as the final trend point
- update the trend note text to describe the chart-based output

## Example output

<!-- bundle-size-benchmark -->
## Bundle Size Benchmarks

- Commit: `616481641456`
- Measured at: `2026-03-22T20:25:12+01:00`
- Baseline source: `history:b9f9ea15b696`
- Dashboard: [bundle-size history](https://tanstack.github.io/router/benchmarks/bundle-size/)

| Scenario | Current (gzip) | Delta vs baseline | Raw | Brotli | Trend |
| --- | ---: | ---: | ---: | ---: | --- |
| `react-router.minimal` | 88.15 KiB | 0 B (0.00%) | 278.36 KiB | 76.56 KiB | ![Historical gzip bytes trend](https://tiny-graph.florianpellet.com/?coords=1773943796%2C89714%2C1773947148%2C89714%2C1773999341%2C90670%2C1774001196%2C90670%2C1774002953%2C90682%2C1774053003%2C90682%2C1774072995%2C90682%2C1774112923%2C90670%2C1774171768%2C90269%2C1774181552%2C90269%2C1774207648%2C90269%2C1774207512%2C90269&width=165&height=45) |
| `react-router.full` | 91.38 KiB | +77 B (+0.08%) | 289.35 KiB | 79.21 KiB | ![Historical gzip bytes trend](https://tiny-graph.florianpellet.com/?coords=1773943796%2C92821%2C1773947148%2C92821%2C1773999341%2C93912%2C1774001196%2C93912%2C1774002953%2C93928%2C1774053003%2C93928%2C1774072995%2C93928%2C1774112923%2C93914%2C1774171768%2C93499%2C1774181552%2C93499%2C1774207648%2C93576%2C1774207512%2C93576&width=165&height=45) |
| `solid-router.minimal` | 35.80 KiB | 0 B (0.00%) | 108.26 KiB | 32.08 KiB | ![Historical gzip bytes trend](https://tiny-graph.florianpellet.com/?coords=1773943796%2C38027%2C1773947148%2C38027%2C1773999341%2C36995%2C1774001196%2C36995%2C1774002953%2C36995%2C1774053003%2C36995%2C1774072995%2C36995%2C1774112923%2C36995%2C1774171768%2C36656%2C1774181552%2C36656%2C1774207648%2C36656%2C1774207512%2C36656&width=165&height=45) |
| `solid-router.full` | 40.22 KiB | +70 B (+0.17%) | 121.66 KiB | 36.01 KiB | ![Historical gzip bytes trend](https://tiny-graph.florianpellet.com/?coords=1773943796%2C42352%2C1773947148%2C42352%2C1773999341%2C41446%2C1774001196%2C41446%2C1774002953%2C41446%2C1774053003%2C41446%2C1774072995%2C41461%2C1774112923%2C41461%2C1774171768%2C41111%2C1774181552%2C41111%2C1774207648%2C41181%2C1774207512%2C41181&width=165&height=45) |
| `vue-router.minimal` | 53.78 KiB | 0 B (0.00%) | 154.49 KiB | 48.23 KiB | ![Historical gzip bytes trend](https://tiny-graph.florianpellet.com/?coords=1773943796%2C54258%2C1773947148%2C54258%2C1773999341%2C55399%2C1774001196%2C55399%2C1774002953%2C55410%2C1774053003%2C55410%2C1774072995%2C55410%2C1774112923%2C55410%2C1774171768%2C55067%2C1774181552%2C55067%2C1774207648%2C55067%2C1774207512%2C55067&width=165&height=45) |
| `vue-router.full` | 58.64 KiB | +96 B (+0.16%) | 169.97 KiB | 52.52 KiB | ![Historical gzip bytes trend](https://tiny-graph.florianpellet.com/?coords=1773943796%2C59071%2C1773947148%2C59071%2C1773999341%2C60289%2C1774001196%2C60289%2C1774002953%2C60301%2C1774053003%2C60301%2C1774072995%2C60301%2C1774112923%2C60301%2C1774171768%2C59955%2C1774181552%2C59955%2C1774207648%2C60051%2C1774207512%2C60051&width=165&height=45) |
| `react-start.minimal` | 102.56 KiB | +121 B (+0.12%) | 326.38 KiB | 88.64 KiB | ![Historical gzip bytes trend](https://tiny-graph.florianpellet.com/?coords=1773943796%2C104436%2C1773947148%2C104436%2C1773999341%2C105454%2C1774001196%2C105454%2C1774002953%2C105471%2C1774053003%2C105471%2C1774072995%2C105471%2C1774112923%2C105451%2C1774171768%2C104896%2C1774181552%2C104896%2C1774207648%2C105017%2C1774207512%2C105017&width=165&height=45) |
| `react-start.full` | 105.95 KiB | +97 B (+0.09%) | 336.69 KiB | 91.49 KiB | ![Historical gzip bytes trend](https://tiny-graph.florianpellet.com/?coords=1773943796%2C107863%2C1773947148%2C107863%2C1773999341%2C108909%2C1774001196%2C108909%2C1774002953%2C108922%2C1774053003%2C108922%2C1774072995%2C108922%2C1774112923%2C108903%2C1774171768%2C108397%2C1774181552%2C108397%2C1774207648%2C108494%2C1774207512%2C108494&width=165&height=45) |
| `solid-start.minimal` | 49.87 KiB | 0 B (0.00%) | 154.45 KiB | 43.93 KiB | ![Historical gzip bytes trend](https://tiny-graph.florianpellet.com/?coords=1773943796%2C52468%2C1773947148%2C52468%2C1773999341%2C51528%2C1774001196%2C51528%2C1774002953%2C51528%2C1774053003%2C51528%2C1774072995%2C51528%2C1774112923%2C51528%2C1774171768%2C51064%2C1774181552%2C51064%2C1774207648%2C51064%2C1774207512%2C51064&width=165&height=45) |
| `solid-start.full` | 55.35 KiB | +99 B (+0.17%) | 170.54 KiB | 48.62 KiB | ![Historical gzip bytes trend](https://tiny-graph.florianpellet.com/?coords=1773943796%2C57888%2C1773947148%2C57888%2C1773999341%2C57060%2C1774001196%2C57060%2C1774002953%2C57060%2C1774053003%2C57060%2C1774072995%2C57072%2C1774112923%2C57072%2C1774171768%2C56583%2C1774181552%2C56583%2C1774207648%2C56682%2C1774207512%2C56682&width=165&height=45) |

_Trend chart uses historical gzip bytes plotted by measurement date, ending with this PR measurement; lower is better._



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored PR bundle size trend visualization from inline sparklines to remote chart-based graphs, improving trend clarity.
  * Modified trend data structure to track measurements as timestamped coordinate pairs (measurement date and gzip byte size).
  * Added timestamp validation to ensure only measurements with valid timestamps and sizes are included in trend reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->