### PR TITLE
perf(router-core): skip JSON parsing for plain search strings

### DIFF
--- a/packages/router-core/src/searchParams.ts
+++ b/packages/router-core/src/searchParams.ts
@@ -16,11 +16,8 @@ function canStringBeJsonParsed(value: string) {
 
   const firstCharCode = value.charCodeAt(0)
 
-  if (firstCharCode <= 32) {
-    return true
-  }
-
   return (
+    firstCharCode <= 32 ||
     firstCharCode === 34 ||
     firstCharCode === 45 ||
     firstCharCode === 91 ||

--- a/packages/router-core/src/searchParams.ts
+++ b/packages/router-core/src/searchParams.ts
@@ -17,12 +17,12 @@ function canStringBeJsonParsed(value: string) {
   const firstCharCode = value.charCodeAt(0)
 
   return (
-    firstCharCode <= 32 ||
-    firstCharCode === 34 ||
-    firstCharCode === 45 ||
-    firstCharCode === 91 ||
-    firstCharCode === 123 ||
-    (firstCharCode >= 48 && firstCharCode <= 57) ||
+    firstCharCode <= 32 || // ASCII control chars through space (' ')
+    firstCharCode === 34 || // double quote ('"')
+    firstCharCode === 45 || // minus sign ('-')
+    firstCharCode === 91 || // opening bracket ('[')
+    firstCharCode === 123 || // opening brace ('{')
+    (firstCharCode >= 48 && firstCharCode <= 57) || // digits ('0' - '9')
     value === 'true' ||
     value === 'false' ||
     value === 'null'

--- a/packages/router-core/src/searchParams.ts
+++ b/packages/router-core/src/searchParams.ts
@@ -9,6 +9,29 @@ export const defaultStringifySearch = stringifySearchWith(
   JSON.parse,
 )
 
+function canStringBeJsonParsed(value: string) {
+  if (!value) {
+    return false
+  }
+
+  const firstCharCode = value.charCodeAt(0)
+
+  if (firstCharCode <= 32) {
+    return true
+  }
+
+  return (
+    firstCharCode === 34 ||
+    firstCharCode === 45 ||
+    firstCharCode === 91 ||
+    firstCharCode === 123 ||
+    (firstCharCode >= 48 && firstCharCode <= 57) ||
+    value === 'true' ||
+    value === 'false' ||
+    value === 'null'
+  )
+}
+
 /**
  * Build a `parseSearch` function using a provided JSON-like parser.
  *
@@ -30,7 +53,7 @@ export function parseSearchWith(parser: (str: string) => any) {
     // Try to parse any query params that might be json
     for (const key in query) {
       const value = query[key]
-      if (typeof value === 'string') {
+      if (typeof value === 'string' && canStringBeJsonParsed(value)) {
         try {
           query[key] = parser(value)
         } catch (_err) {
@@ -67,7 +90,11 @@ export function stringifySearchWith(
       } catch (_err) {
         // silent
       }
-    } else if (hasParser && typeof val === 'string') {
+    } else if (
+      hasParser &&
+      typeof val === 'string' &&
+      canStringBeJsonParsed(val)
+    ) {
       try {
         // Check if it's a valid parseable string.
         // If it is, then stringify it again.

--- a/packages/router-core/src/searchParams.ts
+++ b/packages/router-core/src/searchParams.ts
@@ -43,6 +43,8 @@ function canStringBeJsonParsed(value: string) {
  * @link https://tanstack.com/router/latest/docs/framework/react/guide/custom-search-param-serialization
  */
 export function parseSearchWith(parser: (str: string) => any) {
+  const shouldGuardJsonParse = parser === JSON.parse
+
   return (searchStr: string): AnySchema => {
     if (searchStr[0] === '?') {
       searchStr = searchStr.substring(1)
@@ -53,7 +55,10 @@ export function parseSearchWith(parser: (str: string) => any) {
     // Try to parse any query params that might be json
     for (const key in query) {
       const value = query[key]
-      if (typeof value === 'string' && canStringBeJsonParsed(value)) {
+      if (
+        typeof value === 'string' &&
+        (!shouldGuardJsonParse || canStringBeJsonParsed(value))
+      ) {
         try {
           query[key] = parser(value)
         } catch (_err) {
@@ -83,6 +88,8 @@ export function stringifySearchWith(
   parser?: (str: string) => any,
 ) {
   const hasParser = typeof parser === 'function'
+  const shouldGuardJsonParse = parser === JSON.parse
+
   function stringifyValue(val: any) {
     if (typeof val === 'object' && val !== null) {
       try {
@@ -93,7 +100,7 @@ export function stringifySearchWith(
     } else if (
       hasParser &&
       typeof val === 'string' &&
-      canStringBeJsonParsed(val)
+      (!shouldGuardJsonParse || canStringBeJsonParsed(val))
     ) {
       try {
         // Check if it's a valid parseable string.

--- a/packages/router-core/tests/searchParams.test.ts
+++ b/packages/router-core/tests/searchParams.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, test } from 'vitest'
-import { defaultParseSearch, defaultStringifySearch } from '../src'
+import { describe, expect, test, vi } from 'vitest'
+import {
+  defaultParseSearch,
+  defaultStringifySearch,
+  parseSearchWith,
+  stringifySearchWith,
+} from '../src'
 
 describe('Search Params serialization and deserialization', () => {
   /*
@@ -97,5 +102,40 @@ describe('Search Params serialization and deserialization', () => {
     expect(defaultStringifySearch({ foo: date })).toEqual(
       '?foo=%222024-11-18T00%3A00%3A00.000Z%22',
     )
+  })
+
+  test('skips parser work for obviously non-json strings', () => {
+    const parser = vi.fn(JSON.parse)
+    const parseSearch = parseSearchWith(parser)
+    const stringifySearch = stringifySearchWith(JSON.stringify, parser)
+
+    expect(parseSearch('?plain=value&other=abc123')).toEqual({
+      plain: 'value',
+      other: 'abc123',
+    })
+    expect(stringifySearch({ plain: 'value', other: 'abc123' })).toEqual(
+      '?plain=value&other=abc123',
+    )
+
+    expect(parser).not.toHaveBeenCalled()
+  })
+
+  test('still parses json-like strings', () => {
+    const parser = vi.fn(JSON.parse)
+    const parseSearch = parseSearchWith(parser)
+    const stringifySearch = stringifySearchWith(JSON.stringify, parser)
+
+    expect(
+      parseSearch('?quoted=%22value%22&object=%7B%22ok%22%3Atrue%7D&num=123'),
+    ).toEqual({
+      quoted: 'value',
+      object: { ok: true },
+      num: 123,
+    })
+    expect(
+      stringifySearch({ quoted: '123', object: { ok: true }, num: '42' }),
+    ).toEqual('?quoted=%22123%22&object=%7B%22ok%22%3Atrue%7D&num=%2242%22')
+
+    expect(parser).toHaveBeenCalled()
   })
 })

--- a/packages/router-core/tests/searchParams.test.ts
+++ b/packages/router-core/tests/searchParams.test.ts
@@ -104,38 +104,69 @@ describe('Search Params serialization and deserialization', () => {
     )
   })
 
-  test('skips parser work for obviously non-json strings', () => {
-    const parser = vi.fn(JSON.parse)
-    const parseSearch = parseSearchWith(parser)
-    const stringifySearch = stringifySearchWith(JSON.stringify, parser)
+  test('custom parsers still run for non-json-looking strings', () => {
+    const parser = vi.fn((value: string) => {
+      if (!value.startsWith('~')) {
+        throw new Error('not custom-encoded')
+      }
 
-    expect(parseSearch('?plain=value&other=abc123')).toEqual({
-      plain: 'value',
-      other: 'abc123',
+      return value.slice(1)
     })
-    expect(stringifySearch({ plain: 'value', other: 'abc123' })).toEqual(
-      '?plain=value&other=abc123',
-    )
 
-    expect(parser).not.toHaveBeenCalled()
+    const parseSearch = parseSearchWith(parser)
+    const stringifySearch = stringifySearchWith((value) => `~${value}`, parser)
+
+    expect(parseSearch('?filter=%7Eauthor')).toEqual({ filter: 'author' })
+    expect(stringifySearch({ filter: '~author' })).toEqual(
+      '?filter=%7E%7Eauthor',
+    )
+    expect(parseSearch(stringifySearch({ filter: '~author' }))).toEqual({
+      filter: '~author',
+    })
   })
 
-  test('still parses json-like strings', () => {
-    const parser = vi.fn(JSON.parse)
-    const parseSearch = parseSearchWith(parser)
-    const stringifySearch = stringifySearchWith(JSON.stringify, parser)
+  test('skips JSON.parse work for obviously non-json strings', () => {
+    const parseSpy = vi.spyOn(JSON, 'parse')
 
-    expect(
-      parseSearch('?quoted=%22value%22&object=%7B%22ok%22%3Atrue%7D&num=123'),
-    ).toEqual({
-      quoted: 'value',
-      object: { ok: true },
-      num: 123,
-    })
-    expect(
-      stringifySearch({ quoted: '123', object: { ok: true }, num: '42' }),
-    ).toEqual('?quoted=%22123%22&object=%7B%22ok%22%3Atrue%7D&num=%2242%22')
+    try {
+      const parseSearch = parseSearchWith(JSON.parse)
+      const stringifySearch = stringifySearchWith(JSON.stringify, JSON.parse)
 
-    expect(parser).toHaveBeenCalled()
+      expect(parseSearch('?plain=value&other=abc123')).toEqual({
+        plain: 'value',
+        other: 'abc123',
+      })
+      expect(stringifySearch({ plain: 'value', other: 'abc123' })).toEqual(
+        '?plain=value&other=abc123',
+      )
+
+      expect(parseSpy).not.toHaveBeenCalled()
+    } finally {
+      parseSpy.mockRestore()
+    }
+  })
+
+  test('still parses json-like strings with JSON.parse', () => {
+    const parseSpy = vi.spyOn(JSON, 'parse')
+
+    try {
+      const parseSearch = parseSearchWith(JSON.parse)
+      const stringifySearch = stringifySearchWith(JSON.stringify, JSON.parse)
+
+      expect(
+        parseSearch('?quoted=%22value%22&object=%7B%22ok%22%3Atrue%7D&num=123'),
+      ).toEqual({
+        quoted: 'value',
+        object: { ok: true },
+        num: 123,
+      })
+      expect(
+        stringifySearch({ quoted: '123', object: { ok: true }, num: '42' }),
+      ).toEqual('?quoted=%22123%22&object=%7B%22ok%22%3Atrue%7D&num=%2242%22')
+
+      expect(parseSpy).toHaveBeenCalled()
+    } finally {
+      parseSpy.mockRestore()
+    }
   })
 })


### PR DESCRIPTION
## Summary
- add a cheap lexical guard before calling the JSON-like search parser so plain strings avoid exception-driven parse work
- apply the same fast path in both `parseSearchWith` and `stringifySearchWith` while preserving existing behavior for JSON-like values
- cover the new guard with tests that assert plain strings skip parser calls and JSON-like strings still parse normally

## Benchmark Notes
- Local `@benchmarks/client-nav`: React `29.6119ms -> 28.6312ms` (~3.3% faster)
- Local `@benchmarks/client-nav`: Solid `24.7548ms -> 24.2348ms` (~2.1% faster)
- Local `@benchmarks/client-nav`: Vue `22.5473ms -> 21.7420ms` (~3.6% faster)
- Local `@benchmarks/bundle-size`: router scenario gzip deltas ranged from `+71B` to `+82B`

## Testing
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/router-core:test:unit --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/router-core:test:types --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @benchmarks/client-nav:test:perf --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @benchmarks/bundle-size:build --outputStyle=stream --skipRemoteCache`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved search-parameter handling to avoid parsing attempts on clearly non-JSON strings when using the native JSON parser, preserving behavior for other parsers and maintaining stringify/parse symmetry.

* **Tests**
  * Added tests covering round-trip encoding/decoding for JSON-like and non-JSON values and confirming custom parsers are applied as supplied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->