### PR TITLE
fix: preserve suspense promises for pending route matches

### DIFF
--- a/.changeset/fancy-camels-rhyme.md
+++ b/.changeset/fancy-camels-rhyme.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/react-router': patch
+'@tanstack/router-core': patch
+---
+
+fix throw undefined on immediate redirect during route load

--- a/packages/react-router/src/Match.tsx
+++ b/packages/react-router/src/Match.tsx
@@ -19,6 +19,7 @@ import { ScrollRestoration } from './scroll-restoration'
 import { ClientOnly } from './ClientOnly'
 import type {
   AnyRoute,
+  ControlledPromise,
   ParsedLocation,
   RootRouteOptions,
 } from '@tanstack/router-core'
@@ -339,6 +340,16 @@ export const MatchInner = React.memo(function MatchInnerImpl({
     return out
   }
 
+  return <MatchInnerClient matchId={matchId} router={router} />
+})
+
+function MatchInnerClient({
+  matchId,
+  router,
+}: {
+  matchId: string
+  router: ReturnType<typeof useRouter>
+}) {
   const matchStore = router.stores.activeMatchStoresById.get(matchId)
   if (!matchStore) {
     if (process.env.NODE_ENV !== 'production') {
@@ -349,11 +360,9 @@ export const MatchInner = React.memo(function MatchInnerImpl({
 
     invariant()
   }
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const match = useStore(matchStore, (value) => value)
   const routeId = match.routeId as string
   const route = router.routesById[routeId] as AnyRoute
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const key = React.useMemo(() => {
     const remountFn =
       (router.routesById[routeId] as AnyRoute).options.remountDeps ??
@@ -374,7 +383,6 @@ export const MatchInner = React.memo(function MatchInnerImpl({
     router.routesById,
   ])
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const out = React.useMemo(() => {
     const Comp = route.options.component ?? router.options.defaultComponent
     if (Comp) {
@@ -382,6 +390,38 @@ export const MatchInner = React.memo(function MatchInnerImpl({
     }
     return <Outlet />
   }, [key, route.options.component, router.options.defaultComponent])
+
+  const suspensePromiseRef = React.useRef<ControlledPromise<void> | undefined>(
+    undefined,
+  )
+
+  React.useEffect(() => {
+    if (match.status !== 'pending' && match.status !== 'redirected') {
+      suspensePromiseRef.current?.resolve()
+      suspensePromiseRef.current = undefined
+    }
+  }, [match.status])
+
+  React.useEffect(() => {
+    return () => {
+      suspensePromiseRef.current?.resolve()
+      suspensePromiseRef.current = undefined
+    }
+  }, [match.id])
+
+  const getSuspensePromise = React.useCallback(() => {
+    const loadPromise = router.getMatch(match.id)?._nonReactive.loadPromise
+
+    if (loadPromise?.status === 'pending') {
+      return loadPromise
+    }
+
+    if (!suspensePromiseRef.current) {
+      suspensePromiseRef.current = createControlledPromise<void>()
+    }
+
+    return suspensePromiseRef.current
+  }, [router, match.id])
 
   if (match._displayPending) {
     throw router.getMatch(match.id)?._nonReactive.displayPendingPromise
@@ -413,7 +453,7 @@ export const MatchInner = React.memo(function MatchInnerImpl({
         }
       }
     }
-    throw router.getMatch(match.id)?._nonReactive.loadPromise
+    throw getSuspensePromise()
   }
 
   if (match.status === 'notFound') {
@@ -442,7 +482,7 @@ export const MatchInner = React.memo(function MatchInnerImpl({
     //   false,
     //   'Tried to render a redirected route match! This is a weird circumstance, please file an issue!',
     // )
-    throw router.getMatch(match.id)?._nonReactive.loadPromise
+    throw getSuspensePromise()
   }
 
   if (match.status === 'error') {
@@ -471,7 +511,7 @@ export const MatchInner = React.memo(function MatchInnerImpl({
   }
 
   return out
-})
+}
 
 /**
  * Render the next child match in the route tree. Typically used inside

--- a/packages/react-router/src/Match.tsx
+++ b/packages/react-router/src/Match.tsx
@@ -19,7 +19,6 @@ import { ScrollRestoration } from './scroll-restoration'
 import { ClientOnly } from './ClientOnly'
 import type {
   AnyRoute,
-  ControlledPromise,
   ParsedLocation,
   RootRouteOptions,
 } from '@tanstack/router-core'
@@ -340,16 +339,6 @@ export const MatchInner = React.memo(function MatchInnerImpl({
     return out
   }
 
-  return <MatchInnerClient matchId={matchId} router={router} />
-})
-
-function MatchInnerClient({
-  matchId,
-  router,
-}: {
-  matchId: string
-  router: ReturnType<typeof useRouter>
-}) {
   const matchStore = router.stores.activeMatchStoresById.get(matchId)
   if (!matchStore) {
     if (process.env.NODE_ENV !== 'production') {
@@ -360,9 +349,11 @@ function MatchInnerClient({
 
     invariant()
   }
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const match = useStore(matchStore, (value) => value)
   const routeId = match.routeId as string
   const route = router.routesById[routeId] as AnyRoute
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const key = React.useMemo(() => {
     const remountFn =
       (router.routesById[routeId] as AnyRoute).options.remountDeps ??
@@ -383,6 +374,7 @@ function MatchInnerClient({
     router.routesById,
   ])
 
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const out = React.useMemo(() => {
     const Comp = route.options.component ?? router.options.defaultComponent
     if (Comp) {
@@ -390,38 +382,6 @@ function MatchInnerClient({
     }
     return <Outlet />
   }, [key, route.options.component, router.options.defaultComponent])
-
-  const suspensePromiseRef = React.useRef<ControlledPromise<void> | undefined>(
-    undefined,
-  )
-
-  React.useEffect(() => {
-    if (match.status !== 'pending' && match.status !== 'redirected') {
-      suspensePromiseRef.current?.resolve()
-      suspensePromiseRef.current = undefined
-    }
-  }, [match.status])
-
-  React.useEffect(() => {
-    return () => {
-      suspensePromiseRef.current?.resolve()
-      suspensePromiseRef.current = undefined
-    }
-  }, [match.id])
-
-  const getSuspensePromise = React.useCallback(() => {
-    const loadPromise = router.getMatch(match.id)?._nonReactive.loadPromise
-
-    if (loadPromise?.status === 'pending') {
-      return loadPromise
-    }
-
-    if (!suspensePromiseRef.current) {
-      suspensePromiseRef.current = createControlledPromise<void>()
-    }
-
-    return suspensePromiseRef.current
-  }, [router, match.id])
 
   if (match._displayPending) {
     throw router.getMatch(match.id)?._nonReactive.displayPendingPromise
@@ -453,7 +413,7 @@ function MatchInnerClient({
         }
       }
     }
-    throw getSuspensePromise()
+    throw router.getMatch(match.id)?._nonReactive.loadPromise
   }
 
   if (match.status === 'notFound') {
@@ -482,7 +442,7 @@ function MatchInnerClient({
     //   false,
     //   'Tried to render a redirected route match! This is a weird circumstance, please file an issue!',
     // )
-    throw getSuspensePromise()
+    throw router.getMatch(match.id)?._nonReactive.loadPromise
   }
 
   if (match.status === 'error') {
@@ -511,7 +471,7 @@ function MatchInnerClient({
   }
 
   return out
-}
+})
 
 /**
  * Render the next child match in the route tree. Typically used inside

--- a/packages/react-router/src/Match.tsx
+++ b/packages/react-router/src/Match.tsx
@@ -413,7 +413,10 @@ export const MatchInner = React.memo(function MatchInnerImpl({
         }
       }
     }
-    throw router.getMatch(match.id)?._nonReactive.loadPromise
+    if (match._nonReactive.pendingRenderPromise?.status !== 'pending') {
+      match._nonReactive.pendingRenderPromise = createControlledPromise<void>()
+    }
+    throw match._nonReactive.pendingRenderPromise
   }
 
   if (match.status === 'notFound') {

--- a/packages/react-router/tests/loaders.test.tsx
+++ b/packages/react-router/tests/loaders.test.tsx
@@ -5,6 +5,7 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
 } from '@testing-library/react'
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
@@ -939,4 +940,99 @@ test('reproducer for #6388 - rapid navigation between parameterized routes shoul
   expect(paramPage).toBeInTheDocument()
   expect(paramPage).toHaveTextContent('Param Component 1 Done')
   expect(loaderCompleteMock).toHaveBeenCalled()
+})
+
+test('keeps rendering the current pending route when a regular navigation aborts it', async () => {
+  const firstLoaderAborted = vi.fn()
+  const firstErrorComponentRenderCount = vi.fn()
+  let resolveSecondLoader: (() => void) | undefined
+
+  const rootRoute = createRootRoute({
+    component: () => <Outlet />,
+  })
+
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <div data-testid="home-page">Home page</div>,
+  })
+
+  const firstRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/first',
+    pendingMs: 0,
+    loader: async ({ abortController }) => {
+      await new Promise<void>((_resolve, reject) => {
+        abortController.signal.addEventListener('abort', () => {
+          firstLoaderAborted()
+          reject(new DOMException('Aborted', 'AbortError'))
+        })
+      })
+
+      return 'first'
+    },
+    component: () => (
+      <div data-testid="first-page">{firstRoute.useLoaderData()}</div>
+    ),
+    pendingComponent: () => (
+      <div data-testid="first-pending">Pending first route</div>
+    ),
+    errorComponent: ({ error }) => {
+      firstErrorComponentRenderCount(error)
+      return <div data-testid="first-error">{String(error)}</div>
+    },
+  })
+
+  const secondRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/second',
+    loader: async () => {
+      await new Promise<void>((resolve) => {
+        resolveSecondLoader = resolve
+      })
+
+      return 'second'
+    },
+    component: () => (
+      <div data-testid="second-page">{secondRoute.useLoaderData()}</div>
+    ),
+  })
+
+  const routeTree = rootRoute.addChildren([indexRoute, firstRoute, secondRoute])
+  const router = createRouter({
+    routeTree,
+    history,
+    defaultPreload: false,
+  })
+
+  render(<RouterProvider router={router} />)
+  await act(() => router.latestLoadPromise)
+
+  expect(await screen.findByTestId('home-page')).toBeInTheDocument()
+
+  act(() => {
+    void router.navigate({ to: '/first' })
+  })
+  expect(await screen.findByTestId('first-pending')).toBeInTheDocument()
+
+  act(() => {
+    void router.navigate({ to: '/second' })
+  })
+  await act(() => sleep(0))
+
+  await waitFor(() => {
+    expect(resolveSecondLoader).toBeDefined()
+  })
+
+  expect(firstLoaderAborted).toHaveBeenCalled()
+  expect(screen.getByTestId('first-pending')).toBeInTheDocument()
+  expect(firstErrorComponentRenderCount).not.toHaveBeenCalled()
+  expect(screen.queryByTestId('first-error')).not.toBeInTheDocument()
+
+  act(() => {
+    resolveSecondLoader?.()
+  })
+
+  await act(() => router.latestLoadPromise)
+  expect(await screen.findByTestId('second-page')).toHaveTextContent('second')
 })

--- a/packages/react-router/tests/router.test.tsx
+++ b/packages/react-router/tests/router.test.tsx
@@ -1423,6 +1423,79 @@ describe('invalidate', () => {
     })
   })
 
+  it('keeps rendering a suspense fallback when invalidate({ forcePending: true }) reloads a route', async () => {
+    const history = createMemoryHistory({
+      initialEntries: ['/force-pending'],
+    })
+    const errorComponentRenderCount = vi.fn()
+    let shouldSuspendReload = false
+    let resolveReload: (() => void) | undefined
+
+    const rootRoute = createRootRoute({
+      component: () => <Outlet />,
+    })
+
+    const forcePendingRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/force-pending',
+      pendingMs: 0,
+      pendingMinMs: 10,
+      loader: async () => {
+        if (shouldSuspendReload) {
+          await new Promise<void>((resolve) => {
+            resolveReload = resolve
+          })
+        }
+
+        return 'done'
+      },
+      component: () => (
+        <div data-testid="force-pending-route">
+          {forcePendingRoute.useLoaderData()}
+        </div>
+      ),
+      pendingComponent: () => (
+        <div data-testid="force-pending-fallback">Pending...</div>
+      ),
+      errorComponent: ({ error }) => {
+        errorComponentRenderCount(error)
+        return <div data-testid="force-pending-error">{String(error)}</div>
+      },
+    })
+
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([forcePendingRoute]),
+      history,
+    })
+
+    render(<RouterProvider router={router} />)
+
+    await act(() => router.load())
+    expect(await screen.findByTestId('force-pending-route')).toHaveTextContent(
+      'done',
+    )
+
+    shouldSuspendReload = true
+    act(() => {
+      void router.invalidate({ forcePending: true })
+    })
+
+    expect(
+      await screen.findByTestId('force-pending-fallback'),
+    ).toBeInTheDocument()
+    expect(errorComponentRenderCount).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('force-pending-error')).not.toBeInTheDocument()
+
+    act(() => {
+      resolveReload?.()
+    })
+
+    await act(() => router.latestLoadPromise)
+    expect(await screen.findByTestId('force-pending-route')).toHaveTextContent(
+      'done',
+    )
+  })
+
   /**
    * Regression test:
    * - When a route loader throws `notFound()`, the match enters a `'notFound'` status.

--- a/packages/router-core/src/Matches.ts
+++ b/packages/router-core/src/Matches.ts
@@ -145,6 +145,7 @@ export interface RouteMatch<
     /** @internal */
     pendingTimeout?: ReturnType<typeof setTimeout>
     loadPromise?: ControlledPromise<void>
+    pendingRenderPromise?: ControlledPromise<void>
     displayPendingPromise?: Promise<void>
     minPendingPromise?: ControlledPromise<void>
     dehydrated?: boolean

--- a/packages/router-core/src/load-matches.ts
+++ b/packages/router-core/src/load-matches.ts
@@ -839,7 +839,9 @@ const loadRouteMatch = async (
           await runLoader(inner, matchPromises, matchId, index, route)
           const match = inner.router.getMatch(matchId)!
           match._nonReactive.loaderPromise?.resolve()
-          match._nonReactive.loadPromise?.resolve()
+          if (match.status !== 'pending') {
+            match._nonReactive.loadPromise?.resolve()
+          }
           match._nonReactive.loaderPromise = undefined
         } catch (err) {
           if (isRedirect(err)) {
@@ -938,7 +940,9 @@ const loadRouteMatch = async (
   const match = inner.router.getMatch(matchId)!
   if (!loaderIsRunningAsync) {
     match._nonReactive.loaderPromise?.resolve()
-    match._nonReactive.loadPromise?.resolve()
+    if (match.status !== 'pending') {
+      match._nonReactive.loadPromise?.resolve()
+    }
   }
 
   clearTimeout(match._nonReactive.pendingTimeout)

--- a/packages/router-core/src/load-matches.ts
+++ b/packages/router-core/src/load-matches.ts
@@ -839,9 +839,10 @@ const loadRouteMatch = async (
           await runLoader(inner, matchPromises, matchId, index, route)
           const match = inner.router.getMatch(matchId)!
           match._nonReactive.loaderPromise?.resolve()
-          match._nonReactive.loadPromise?.resolve()
+          if (match.status !== 'pending') {
+            match._nonReactive.loadPromise?.resolve()
+          }
           match._nonReactive.loaderPromise = undefined
-          match._nonReactive.loadPromise = undefined
         } catch (err) {
           if (isRedirect(err)) {
             await inner.router.navigate(err.options)
@@ -939,8 +940,9 @@ const loadRouteMatch = async (
   const match = inner.router.getMatch(matchId)!
   if (!loaderIsRunningAsync) {
     match._nonReactive.loaderPromise?.resolve()
-    match._nonReactive.loadPromise?.resolve()
-    match._nonReactive.loadPromise = undefined
+    if (match.status !== 'pending') {
+      match._nonReactive.loadPromise?.resolve()
+    }
   }
 
   clearTimeout(match._nonReactive.pendingTimeout)

--- a/packages/router-core/src/load-matches.ts
+++ b/packages/router-core/src/load-matches.ts
@@ -839,9 +839,7 @@ const loadRouteMatch = async (
           await runLoader(inner, matchPromises, matchId, index, route)
           const match = inner.router.getMatch(matchId)!
           match._nonReactive.loaderPromise?.resolve()
-          if (match.status !== 'pending') {
-            match._nonReactive.loadPromise?.resolve()
-          }
+          match._nonReactive.loadPromise?.resolve()
           match._nonReactive.loaderPromise = undefined
         } catch (err) {
           if (isRedirect(err)) {
@@ -940,9 +938,7 @@ const loadRouteMatch = async (
   const match = inner.router.getMatch(matchId)!
   if (!loaderIsRunningAsync) {
     match._nonReactive.loaderPromise?.resolve()
-    if (match.status !== 'pending') {
-      match._nonReactive.loadPromise?.resolve()
-    }
+    match._nonReactive.loadPromise?.resolve()
   }
 
   clearTimeout(match._nonReactive.pendingTimeout)

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -112,6 +112,13 @@ export type ControllablePromise<T = any> = Promise<T> & {
 
 export type InjectedHtmlEntry = Promise<string>
 
+const clearPendingRenderPromise = (match: AnyRouteMatch | undefined) => {
+  if (match) {
+    match._nonReactive.pendingRenderPromise?.resolve()
+    match._nonReactive.pendingRenderPromise = undefined
+  }
+}
+
 export interface Register {
   // Lots of things on here like...
   // router
@@ -2475,6 +2482,19 @@ export class RouterCore<
                      * or reloads re-run their loaders instead of reusing the failed/not-found data.
                      */
                     if (mountPending) {
+                      const pendingMatchesById = new Map(
+                        pendingMatches.map((match) => [match.id, match]),
+                      )
+
+                      currentMatches.forEach((currentMatch) => {
+                        if (
+                          pendingMatchesById.get(currentMatch.id)?.status !==
+                          'pending'
+                        ) {
+                          clearPendingRenderPromise(currentMatch)
+                        }
+                      })
+
                       this.stores.setActiveMatches(pendingMatches)
                       this.stores.setPendingMatches([])
                       this.stores.setCachedMatches([
@@ -2634,7 +2654,11 @@ export class RouterCore<
 
       const activeMatch = this.stores.activeMatchStoresById.get(id)
       if (activeMatch) {
-        activeMatch.setState(updater)
+        const next = updater(activeMatch.state)
+        if (next.status !== 'pending') {
+          clearPendingRenderPromise(activeMatch.state)
+        }
+        activeMatch.setState(() => next)
         return
       }
 
@@ -2696,9 +2720,16 @@ export class RouterCore<
     }
 
     this.batch(() => {
-      this.stores.setActiveMatches(
-        this.stores.activeMatchesSnapshot.state.map(invalidate),
-      )
+      const activeMatches = this.stores.activeMatchesSnapshot.state
+      const nextActiveMatches = activeMatches.map(invalidate)
+
+      activeMatches.forEach((activeMatch, index) => {
+        if (nextActiveMatches[index]?.status !== 'pending') {
+          clearPendingRenderPromise(activeMatch)
+        }
+      })
+
+      this.stores.setActiveMatches(nextActiveMatches)
       this.stores.setCachedMatches(
         this.stores.cachedMatchesSnapshot.state.map(invalidate),
       )


### PR DESCRIPTION
## Summary
- keep a route's suspense promise alive while the match still renders as `pending`
- add a regular navigation regression test where aborting a pending route must keep rendering the pending UI
- add an `invalidate({ forcePending: true })` regression test that keeps rendering the suspense fallback instead of throwing `undefined`

## Testing
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/react-router:test:unit --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/react-router:test:types --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/react-router:test:eslint --outputStyle=stream --skipRemoteCache`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented spurious error rendering during route loads and navigations; pending UI is now preserved when in-flight loaders are aborted or when reloads are forced into a pending state.

* **Tests**
  * Added regression tests covering aborted-loader navigation and forced-pending reloads to ensure pending UI remains visible and error components do not render incorrectly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->