### PR TITLE
fix(react-router): use onShellError to destroy stream on unrecoverable SSR errors

### DIFF
--- a/packages/react-router/src/ssr/renderRouterToStream.tsx
+++ b/packages/react-router/src/ssr/renderRouterToStream.tsx
@@ -59,14 +59,16 @@ export const renderRouterToStream = async ({
                 pipeable.pipe(reactAppPassthrough)
               },
             }),
-        onError: (error, info) => {
-          console.error('Error in renderToPipeableStream:', error, info)
-          // Destroy the passthrough stream on error
+        onShellError(error) {
+          console.error('Error in renderToPipeableStream:', error)
           if (!reactAppPassthrough.destroyed) {
             reactAppPassthrough.destroy(
               error instanceof Error ? error : new Error(String(error)),
             )
           }
+        },
+        onError: (error, info) => {
+          console.error('Error in renderToPipeableStream:', error, info)
         },
       })
     } catch (e) {


### PR DESCRIPTION
Fixes #7078

React's `renderToPipeableStream` calls `onError` for **all** errors — both recoverable (caught by Error Boundaries) and unrecoverable. The previous implementation destroyed the `PassThrough` stream in `onError`, which meant:

1. A route throws an error
2. React Error Boundary catches it → renders `defaultErrorComponent`
3. `onShellReady` fires normally with the error UI in the shell
4. `onError` also fires → `stream.destroy()` kills the already-piping stream
5. Response body is broken → upstream proxy returns 502

**Fix:** Follow [React's recommended pattern](https://react.dev/reference/react-dom/server/renderToPipeableStream#setting-the-status-code):
- `onError`: logging only, no stream destruction
- `onShellError` (new): handle unrecoverable shell render failures with `stream.destroy()`

`onShellError` fires only when React cannot produce any HTML at all — the true unrecoverable case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in server-side rendering to better distinguish between shell-level errors and runtime errors, ensuring more accurate error logging and recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->