### PR TITLE
docs: use new query methods

### DIFF
--- a/_artifacts/domain_map.yaml
+++ b/_artifacts/domain_map.yaml
@@ -147,13 +147,15 @@ skills:
           context types to not flow into loader.
         wrong_pattern: |
           createFileRoute('/posts')({
-            loader: ({ context }) => context.queryClient.ensureQueryData(postsQuery),
+            loader: ({ context }) =>
+              context.queryClient.query({ ...postsQuery, staleTime: 'static' }),
             beforeLoad: ({ context }) => ({ queryClient: context.queryClient }),
           })
         correct_pattern: |
           createFileRoute('/posts')({
             beforeLoad: ({ context }) => ({ queryClient: context.queryClient }),
-            loader: ({ context }) => context.queryClient.ensureQueryData(postsQuery),
+            loader: ({ context }) =>
+              context.queryClient.query({ ...postsQuery, staleTime: 'static' }),
           })
         source: 'docs/router/eslint/create-route-property-order.md'
         priority: HIGH
@@ -536,7 +538,7 @@ skills:
       - '@tanstack/react-router-ssr-query'
     covers:
       - External cache coordination pattern
-      - queryClient.ensureQueryData in loader
+      - "queryClient.query with staleTime: 'static' in loader"
       - useSuspenseQuery in components
       - setupRouterSsrQueryIntegration
       - defaultPreloadStaleTime
@@ -579,11 +581,11 @@ skills:
         priority: HIGH
         status: active
 
-      - mistake: 'Awaiting prefetchQuery in loader blocks rendering'
+      - mistake: 'Awaiting a fire-and-forget query in loader blocks rendering'
         mechanism: >-
-          For streaming/deferred patterns, prefetchQuery should NOT
-          be awaited in the loader — it starts fetching on server
-          and streams without blocking. Awaiting defeats the purpose.
+          For streaming/deferred patterns, start a query without awaiting
+          it and handle failures with catch(noop) — it starts fetching on
+          the server and streams without blocking. Awaiting defeats the purpose.
         source: 'docs/router/integrations/query.md'
         priority: MEDIUM
         status: active

--- a/_artifacts/skill_spec.md
+++ b/_artifacts/skill_spec.md
@@ -83,11 +83,11 @@ TanStack Router is a type-safe router for React and Solid applications with buil
 
 ### external-data-loading (3 failure modes)
 
-| #   | Mistake                                           | Priority | Source                           | Cross-skill? |
-| --- | ------------------------------------------------- | -------- | -------------------------------- | ------------ |
-| 1   | Not setting defaultPreloadStaleTime to 0          | HIGH     | docs/guide/external-data-loading | —            |
-| 2   | Creating QueryClient outside createRouter for SSR | HIGH     | docs/guide/external-data-loading | —            |
-| 3   | Awaiting prefetchQuery in loader blocks rendering | MEDIUM   | docs/integrations/query          | —            |
+| #   | Mistake                                                     | Priority | Source                           | Cross-skill? |
+| --- | ----------------------------------------------------------- | -------- | -------------------------------- | ------------ |
+| 1   | Not setting defaultPreloadStaleTime to 0                    | HIGH     | docs/guide/external-data-loading | —            |
+| 2   | Creating QueryClient outside createRouter for SSR           | HIGH     | docs/guide/external-data-loading | —            |
+| 3   | Awaiting a fire-and-forget query in loader blocks rendering | MEDIUM   | docs/integrations/query          | —            |
 
 ### auth-and-guards (3 failure modes)
 

--- a/_artifacts/skill_tree.yaml
+++ b/_artifacts/skill_tree.yaml
@@ -246,7 +246,7 @@ skills:
     package: 'packages/react-router'
     description: >-
       Integrating TanStack Router with TanStack Query: queryClient
-      in router context, ensureQueryData/prefetchQuery in loaders,
+      in router context, static queries and fire-and-forget queries in loaders,
       useSuspenseQuery in components, defaultPreloadStaleTime: 0,
       setupRouterSsrQueryIntegration for SSR dehydration/hydration
       and streaming, per-request QueryClient isolation.

--- a/docs/router/eslint/create-route-property-order.md
+++ b/docs/router/eslint/create-route-property-order.md
@@ -37,7 +37,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/path')({
   loader: async ({ context }) => {
-    await context.queryClient.ensureQueryData(getQueryOptions(context.hello))
+    await context.queryClient.query({ ...getQueryOptions(context.hello), staleTime: 'static' })
   },
   beforeLoad: () => ({ hello: 'world' }),
 })
@@ -55,7 +55,7 @@ import { createFileRoute } from '@tanstack/solid-router'
 
 export const Route = createFileRoute('/path')({
   loader: async ({ context }) => {
-    await context.queryClient.ensureQueryData(getQueryOptions(context.hello))
+    await context.queryClient.query({ ...getQueryOptions(context.hello), staleTime: 'static' })
   },
   beforeLoad: () => ({ hello: 'world' }),
 })
@@ -80,7 +80,7 @@ import { createFileRoute } from '@tanstack/react-router'
 export const Route = createFileRoute('/path')({
   beforeLoad: () => ({ hello: 'world' }),
   loader: async ({ context }) => {
-    await context.queryClient.ensureQueryData(getQueryOptions(context.hello))
+    await context.queryClient.query({ ...getQueryOptions(context.hello), staleTime: 'static' })
   },
 })
 ```
@@ -98,7 +98,7 @@ import { createFileRoute } from '@tanstack/solid-router'
 export const Route = createFileRoute('/path')({
   beforeLoad: () => ({ hello: 'world' }),
   loader: async ({ context }) => {
-    await context.queryClient.ensureQueryData(getQueryOptions(context.hello))
+    await context.queryClient.query({ ...getQueryOptions(context.hello), staleTime: 'static' })
   },
 })
 ```

--- a/docs/router/eslint/create-route-property-order.md
+++ b/docs/router/eslint/create-route-property-order.md
@@ -37,7 +37,10 @@ import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/path')({
   loader: async ({ context }) => {
-    await context.queryClient.query({ ...getQueryOptions(context.hello), staleTime: 'static' })
+    await context.queryClient.query({
+      ...getQueryOptions(context.hello),
+      staleTime: 'static',
+    })
   },
   beforeLoad: () => ({ hello: 'world' }),
 })
@@ -55,7 +58,10 @@ import { createFileRoute } from '@tanstack/solid-router'
 
 export const Route = createFileRoute('/path')({
   loader: async ({ context }) => {
-    await context.queryClient.query({ ...getQueryOptions(context.hello), staleTime: 'static' })
+    await context.queryClient.query({
+      ...getQueryOptions(context.hello),
+      staleTime: 'static',
+    })
   },
   beforeLoad: () => ({ hello: 'world' }),
 })
@@ -80,7 +86,10 @@ import { createFileRoute } from '@tanstack/react-router'
 export const Route = createFileRoute('/path')({
   beforeLoad: () => ({ hello: 'world' }),
   loader: async ({ context }) => {
-    await context.queryClient.query({ ...getQueryOptions(context.hello), staleTime: 'static' })
+    await context.queryClient.query({
+      ...getQueryOptions(context.hello),
+      staleTime: 'static',
+    })
   },
 })
 ```
@@ -98,7 +107,10 @@ import { createFileRoute } from '@tanstack/solid-router'
 export const Route = createFileRoute('/path')({
   beforeLoad: () => ({ hello: 'world' }),
   loader: async ({ context }) => {
-    await context.queryClient.query({ ...getQueryOptions(context.hello), staleTime: 'static' })
+    await context.queryClient.query({
+      ...getQueryOptions(context.hello),
+      staleTime: 'static',
+    })
   },
 })
 ```

--- a/docs/router/guide/deferred-data-loading.md
+++ b/docs/router/guide/deferred-data-loading.md
@@ -95,10 +95,10 @@ import { slowDataOptions, fastDataOptions } from '~/api/query-options'
 export const Route = createFileRoute('/posts/$postId')({
   loader: async ({ context: { queryClient } }) => {
     // Kick off the fetching of some slower data, but do not await it
-    queryClient.prefetchQuery(slowDataOptions())
+    void queryClient.query(slowDataOptions()).catch(noop)
 
     // Fetch and await some data that resolves quickly
-    await queryClient.ensureQueryData(fastDataOptions())
+    await queryClient.query({...fastDataOptions(), staleTime: 'static')
   },
 })
 ```
@@ -113,10 +113,10 @@ import { slowDataOptions, fastDataOptions } from '~/api/query-options'
 export const Route = createFileRoute('/posts/$postId')({
   loader: async ({ context: { queryClient } }) => {
     // Kick off the fetching of some slower data, but do not await it
-    queryClient.prefetchQuery(slowDataOptions())
+    void queryClient.query(slowDataOptions()).catch(noop)
 
     // Fetch and await some data that resolves quickly
-    await queryClient.ensureQueryData(fastDataOptions())
+    await queryClient.query({...fastDataOptions(), staleTime: 'static')
   },
 })
 ```

--- a/docs/router/guide/deferred-data-loading.md
+++ b/docs/router/guide/deferred-data-loading.md
@@ -90,6 +90,7 @@ So, instead of using `defer` and `Await`, you'll instead want to use the Route's
 ```tsx
 // src/routes/posts.$postId.tsx
 import { createFileRoute } from '@tanstack/react-router'
+import { noop } from '@tanstack/react-query'
 import { slowDataOptions, fastDataOptions } from '~/api/query-options'
 
 export const Route = createFileRoute('/posts/$postId')({
@@ -98,7 +99,7 @@ export const Route = createFileRoute('/posts/$postId')({
     void queryClient.query(slowDataOptions()).catch(noop)
 
     // Fetch and await some data that resolves quickly
-    await queryClient.query({...fastDataOptions(), staleTime: 'static')
+    await queryClient.query({ ...fastDataOptions(), staleTime: 'static' })
   },
 })
 ```
@@ -108,6 +109,7 @@ export const Route = createFileRoute('/posts/$postId')({
 ```tsx
 // src/routes/posts.$postId.tsx
 import { createFileRoute } from '@tanstack/solid-router'
+import { noop } from '@tanstack/solid-query'
 import { slowDataOptions, fastDataOptions } from '~/api/query-options'
 
 export const Route = createFileRoute('/posts/$postId')({
@@ -116,7 +118,7 @@ export const Route = createFileRoute('/posts/$postId')({
     void queryClient.query(slowDataOptions()).catch(noop)
 
     // Fetch and await some data that resolves quickly
-    await queryClient.query({...fastDataOptions(), staleTime: 'static')
+    await queryClient.query({ ...fastDataOptions(), staleTime: 'static' })
   },
 })
 ```

--- a/docs/router/guide/external-data-loading.md
+++ b/docs/router/guide/external-data-loading.md
@@ -82,7 +82,7 @@ const postsQueryOptions = queryOptions({
 
 export const Route = createFileRoute('/posts')({
   // Use the `loader` option to ensure that the data is loaded
-  loader: () => queryClient.ensureQueryData(postsQueryOptions),
+  loader: () => queryClient.query({...postsQueryOptions, staleTime: 'static'),
   component: () => {
     // Read the data from the cache and subscribe to updates
     const {
@@ -106,7 +106,7 @@ When an error occurs while using `suspense` with `TanStack Query`, you need to l
 
 ```tsx
 export const Route = createFileRoute('/')({
-  loader: () => queryClient.ensureQueryData(postsQueryOptions),
+  loader: () => queryClient.query({...postsQueryOptions, staleTime: 'static' }),
   errorComponent: ({ error, reset }) => {
     const router = useRouter()
     const queryErrorResetBoundary = useQueryErrorResetBoundary()

--- a/docs/router/guide/external-data-loading.md
+++ b/docs/router/guide/external-data-loading.md
@@ -82,7 +82,8 @@ const postsQueryOptions = queryOptions({
 
 export const Route = createFileRoute('/posts')({
   // Use the `loader` option to ensure that the data is loaded
-  loader: () => queryClient.query({...postsQueryOptions, staleTime: 'static'),
+  loader: () =>
+    queryClient.query({ ...postsQueryOptions, staleTime: 'static' }),
   component: () => {
     // Read the data from the cache and subscribe to updates
     const {
@@ -106,7 +107,8 @@ When an error occurs while using `suspense` with `TanStack Query`, you need to l
 
 ```tsx
 export const Route = createFileRoute('/')({
-  loader: () => queryClient.query({...postsQueryOptions, staleTime: 'static' }),
+  loader: () =>
+    queryClient.query({ ...postsQueryOptions, staleTime: 'static' }),
   errorComponent: ({ error, reset }) => {
     const router = useRouter()
     const queryErrorResetBoundary = useQueryErrorResetBoundary()

--- a/docs/router/guide/router-context.md
+++ b/docs/router/guide/router-context.md
@@ -278,9 +278,10 @@ Then, in your route:
 export const Route = createFileRoute('/todos')({
   component: Todos,
   loader: async ({ context }) => {
-    await context.queryClient.ensureQueryData({
+    await context.queryClient.query({
       queryKey: ['todos', { userId: user.id }],
       queryFn: fetchTodos,
+      staleTime: 'static'
     })
   },
 })

--- a/docs/router/guide/router-context.md
+++ b/docs/router/guide/router-context.md
@@ -281,7 +281,7 @@ export const Route = createFileRoute('/todos')({
     await context.queryClient.query({
       queryKey: ['todos', { userId: user.id }],
       queryFn: fetchTodos,
-      staleTime: 'static'
+      staleTime: 'static',
     })
   },
 })

--- a/docs/router/guide/type-safety.md
+++ b/docs/router/guide/type-safety.md
@@ -137,12 +137,12 @@ As your application scales, TypeScript check times will naturally increase. Ther
 
 ### Only infer types you need
 
-A great pattern with client side data caches (TanStack Query, etc.) is to prefetch data. For example with TanStack Query you might have a route which calls `queryClient.ensureQueryData` in a `loader`.
+A great pattern with client side data caches (TanStack Query, etc.) is to prefetch data. For example with TanStack Query you might have a route which calls `queryClient.query` in a `loader`.
 
 ```tsx
 export const Route = createFileRoute('/posts/$postId/deep')({
   loader: ({ context: { queryClient }, params: { postId } }) =>
-    queryClient.ensureQueryData(postQueryOptions(postId)),
+    queryClient.query({ ...postQueryOptions(postId), staleTime: 'static' }),
   component: PostDeepComponent,
 })
 
@@ -159,7 +159,7 @@ This may look fine and for small route trees and you may not notice any TS perfo
 ```tsx
 export const Route = createFileRoute('/posts/$postId/deep')({
   loader: async ({ context: { queryClient }, params: { postId } }) => {
-    await queryClient.ensureQueryData(postQueryOptions(postId))
+    await queryClient.query({ ...postQueryOptions(postId), staleTime: 'static' })
   },
   component: PostDeepComponent,
 })

--- a/docs/router/guide/type-safety.md
+++ b/docs/router/guide/type-safety.md
@@ -159,7 +159,10 @@ This may look fine and for small route trees and you may not notice any TS perfo
 ```tsx
 export const Route = createFileRoute('/posts/$postId/deep')({
   loader: async ({ context: { queryClient }, params: { postId } }) => {
-    await queryClient.query({ ...postQueryOptions(postId), staleTime: 'static' })
+    await queryClient.query({
+      ...postQueryOptions(postId),
+      staleTime: 'static',
+    })
   },
   component: PostDeepComponent,
 })

--- a/docs/router/guide/type-safety.md
+++ b/docs/router/guide/type-safety.md
@@ -141,6 +141,7 @@ A great pattern with client side data caches (TanStack Query, etc.) is to prefet
 
 ```tsx
 export const Route = createFileRoute('/posts/$postId/deep')({
+  // (ctx: LoaderFnContext) => Promise<PostQueryData>
   loader: ({ context: { queryClient }, params: { postId } }) =>
     queryClient.query({ ...postQueryOptions(postId), staleTime: 'static' }),
   component: PostDeepComponent,
@@ -154,10 +155,11 @@ function PostDeepComponent() {
 }
 ```
 
-This may look fine and for small route trees and you may not notice any TS performance issues. However in this case TS has to infer the loader's return type, despite it never being used in your route. If the loader data is a complex type with many routes that prefetch in this manner, it can slow down editor performance. In this case, the change is quite simple and let typescript infer Promise<void>.
+This may look fine and for small route trees and you may not notice any TS performance issues. However in this case TS has to infer the loader's return type, despite it never being used in your route. If the loader data is a complex type with many routes that prefetch in this manner, it can slow down editor performance. In this case, the change is quite simple and let typescript infer `Promise<void>`.
 
 ```tsx
 export const Route = createFileRoute('/posts/$postId/deep')({
+  // (ctx: LoaderFnContext) => Promise<void>
   loader: async ({ context: { queryClient }, params: { postId } }) => {
     await queryClient.query({
       ...postQueryOptions(postId),

--- a/docs/router/how-to/setup-testing.md
+++ b/docs/router/how-to/setup-testing.md
@@ -651,9 +651,10 @@ describe('React Query Integration', () => {
       path: '/posts',
       component: PostsList,
       loader: ({ context: { queryClient } }) =>
-        queryClient.ensureQueryData({
+        queryClient.query({
           queryKey: ['posts'],
           queryFn: mockFetchPosts,
+          staleTime: 'static'
         }),
     })
 

--- a/docs/router/how-to/setup-testing.md
+++ b/docs/router/how-to/setup-testing.md
@@ -654,7 +654,7 @@ describe('React Query Integration', () => {
         queryClient.query({
           queryKey: ['posts'],
           queryFn: mockFetchPosts,
-          staleTime: 'static'
+          staleTime: 'static',
         }),
     })
 

--- a/docs/router/integrations/query.md
+++ b/docs/router/integrations/query.md
@@ -165,7 +165,7 @@ const postsQuery = queryOptions({
 
 export const Route = createFileRoute('/posts')({
   // Ensure the data is in the cache before render
-  loader: ({ context }) => context.queryClient.ensureQueryData(postsQuery),
+  loader: ({ context }) => context.queryClient.query({...postsQuery, staleTime: 'static' }),
   component: PostsPage,
 })
 
@@ -180,7 +180,7 @@ function PostsPage() {
 
 ### Prefetching and streaming
 
-You can also prefetch with `fetchQuery` or `ensureQueryData` in a loader without consuming the data in a component. If you return the promise directly from the loader, it will be awaited and thus block the SSR request until the query finishes. If you don't await the promise nor return it, the query will be started on the server and will be streamed to the client without blocking the SSR request.
+You can also prefetch with `query` in a loader without consuming the data in a component. If you return the promise directly from the loader, it will be awaited and thus block the SSR request until the query finishes. If you don't await the promise nor return it, the query will be started on the server and will be streamed to the client without blocking the SSR request.
 
 <!-- ::start:framework -->
 

--- a/docs/router/integrations/query.md
+++ b/docs/router/integrations/query.md
@@ -166,7 +166,11 @@ const postsQuery = queryOptions({
 export const Route = createFileRoute('/posts')({
   // Ensure the data is in the cache before render
   loader: ({ context }) =>
-    context.queryClient.query({ ...postsQuery, staleTime: 'static' }),
+    context.queryClient.query({ 
+      ...postsQuery, 
+      // returns data from cache immediately, otherwise executes a fetch
+      staleTime: 'static' 
+    }),
   component: PostsPage,
 })
 
@@ -204,6 +208,9 @@ export const Route = createFileRoute('/user/$id')({
   },
 })
 ```
+
+> [!NOTE]
+> Previous versions of this guide used `queryClient.ensureQueryData` and `queryClient.prefetchQuery`. These methods are now deprecated in TanStack Query in favor of `queryClient.query`. See the TanStack Query [v5 migration guide](https://tanstack.com/query/latest/docs/framework/react/guides/migrating-to-v5#imperative-queryclient-methods) for more details.
 
 <!-- ::end:framework -->
 

--- a/docs/router/integrations/query.md
+++ b/docs/router/integrations/query.md
@@ -209,10 +209,10 @@ export const Route = createFileRoute('/user/$id')({
 })
 ```
 
+<!-- ::end:framework -->
+
 > [!NOTE]
 > Previous versions of this guide used `queryClient.ensureQueryData` and `queryClient.prefetchQuery`. These methods are now deprecated in TanStack Query in favor of `queryClient.query`. See the TanStack Query [v5 migration guide](https://tanstack.com/query/latest/docs/framework/react/guides/migrating-to-v5#imperative-queryclient-methods) for more details.
-
-<!-- ::end:framework -->
 
 ## Redirect handling
 

--- a/docs/router/integrations/query.md
+++ b/docs/router/integrations/query.md
@@ -152,7 +152,7 @@ Preload critical data in the route `loader` to avoid waterfalls and loading flas
 
 <!-- ::start:framework -->
 
-# React
+# Blocking `query` in loader
 
 ```tsx title="src/routes/posts.tsx"
 import { queryOptions, useSuspenseQuery, useQuery } from '@tanstack/react-query'
@@ -189,7 +189,7 @@ You can also prefetch with `query` in a loader without consuming the data in a c
 
 <!-- ::start:framework -->
 
-# React
+# Non-blocking `query` in loader
 
 ```tsx title="src/routes/users.$id.tsx"
 import { createFileRoute } from '@tanstack/react-router'

--- a/docs/router/integrations/query.md
+++ b/docs/router/integrations/query.md
@@ -165,7 +165,8 @@ const postsQuery = queryOptions({
 
 export const Route = createFileRoute('/posts')({
   // Ensure the data is in the cache before render
-  loader: ({ context }) => context.queryClient.query({...postsQuery, staleTime: 'static' }),
+  loader: ({ context }) =>
+    context.queryClient.query({ ...postsQuery, staleTime: 'static' }),
   component: PostsPage,
 })
 
@@ -188,7 +189,7 @@ You can also prefetch with `query` in a loader without consuming the data in a c
 
 ```tsx title="src/routes/users.$id.tsx"
 import { createFileRoute } from '@tanstack/react-router'
-import { queryOptions, useQuery } from '@tanstack/react-query'
+import { noop, queryOptions, useQuery } from '@tanstack/react-query'
 
 const userQuery = (id: string) =>
   queryOptions({
@@ -197,9 +198,9 @@ const userQuery = (id: string) =>
   })
 
 export const Route = createFileRoute('/user/$id')({
-  loader: ({ params }) => {
-    // do not await this nor return the promise, just kick off the query to stream it to the client
-    context.queryClient.fetchQuery(userQuery(params.id))
+  loader: ({ context, params }) => {
+    // Do not await this nor return the promise, just kick off the query to stream it to the client
+    void context.queryClient.query(userQuery(params.id)).catch(noop)
   },
 })
 ```

--- a/docs/start/framework/react/comparison.md
+++ b/docs/start/framework/react/comparison.md
@@ -168,7 +168,7 @@ const postQueryOptions = (postId: string) =>
 
 export const Route = createFileRoute('/posts/$postId')({
   loader: ({ context, params }) =>
-    context.queryClient.ensureQueryData(postQueryOptions(params.postId)),
+    context.queryClient.query({ ...postQueryOptions(params.postId), staleTime: `static` }),
 })
 
 function Post() {

--- a/docs/start/framework/react/comparison.md
+++ b/docs/start/framework/react/comparison.md
@@ -168,7 +168,10 @@ const postQueryOptions = (postId: string) =>
 
 export const Route = createFileRoute('/posts/$postId')({
   loader: ({ context, params }) =>
-    context.queryClient.query({ ...postQueryOptions(params.postId), staleTime: `static` }),
+    context.queryClient.query({
+      ...postQueryOptions(params.postId),
+      staleTime: 'static',
+    }),
 })
 
 function Post() {

--- a/docs/start/framework/react/guide/deferred-hydration.md
+++ b/docs/start/framework/react/guide/deferred-hydration.md
@@ -244,7 +244,7 @@ chunks only exist when `split` is enabled, so TypeScript rejects strategy-form
 Use procedural prefetch when you need custom work:
 
 ```tsx
-import { useQueryClient } from '@tanstack/react-query'
+import { noop, useQueryClient } from '@tanstack/react-query'
 import { Hydrate } from '@tanstack/react-start'
 import { visible } from '@tanstack/react-start/hydration'
 
@@ -255,8 +255,10 @@ function DeferredReviews() {
     <Hydrate
       when={visible()}
       prefetch={async ({ preload }) => {
-        await preload()
-        await queryClient.prefetchQuery(reviewsQueryOptions)
+        await Promise.all([
+          preload(),
+          queryClient.query(reviewsQueryOptions).catch(noop),
+        ])
       }}
     >
       <Reviews />

--- a/docs/start/framework/react/guide/server-components.md
+++ b/docs/start/framework/react/guide/server-components.md
@@ -401,7 +401,10 @@ const postQueryOptions = (postId: string) => ({
 export const Route = createFileRoute('/posts/$postId')({
   loader: async ({ context, params }) => {
     // Prefetch during SSR - data reused on client without refetch
-    await context.queryClient.ensureQueryData(postQueryOptions(params.postId))
+    await context.queryClient.query({
+      ...postQueryOptions(params.postId),
+      staleTime: 'static',
+    })
   },
   component: PostPage,
 })

--- a/examples/react/basic-default-search-params/package.json
+++ b/examples/react/basic-default-search-params/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/react-query": "^5.90.0",
+    "@tanstack/react-query": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",
     "react": "^19.0.0",

--- a/examples/react/basic-default-search-params/package.json
+++ b/examples/react/basic-default-search-params/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query": "catalog:",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",
     "react": "^19.0.0",

--- a/examples/react/basic-devtools-panel/package.json
+++ b/examples/react/basic-devtools-panel/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/react-query": "catalog:",
-    "@tanstack/react-query-devtools": "^5.67.2",
+    "@tanstack/react-query-devtools": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",
     "react": "^19.0.0",

--- a/examples/react/basic-react-query-file-based/package.json
+++ b/examples/react/basic-react-query-file-based/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query": "catalog:",
     "@tanstack/react-query-devtools": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",

--- a/examples/react/basic-react-query-file-based/package.json
+++ b/examples/react/basic-react-query-file-based/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/react-query": "^5.90.0",
-    "@tanstack/react-query-devtools": "^5.90.0",
+    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query-devtools": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",
     "@tanstack/router-plugin": "^1.168.35",

--- a/examples/react/basic-react-query-file-based/src/routes/posts.$postId.tsx
+++ b/examples/react/basic-react-query-file-based/src/routes/posts.$postId.tsx
@@ -11,7 +11,10 @@ import type { ErrorComponentProps } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/posts/$postId')({
   loader: ({ context: { queryClient }, params: { postId } }) => {
-    return queryClient.ensureQueryData(postQueryOptions(postId))
+    return queryClient.query({
+      ...postQueryOptions(postId),
+      staleTime: 'static',
+    })
   },
   errorComponent: PostErrorComponent,
   component: PostComponent,

--- a/examples/react/basic-react-query-file-based/src/routes/posts.route.tsx
+++ b/examples/react/basic-react-query-file-based/src/routes/posts.route.tsx
@@ -6,7 +6,7 @@ import { postsQueryOptions } from '../postsQueryOptions'
 
 export const Route = createFileRoute('/posts')({
   loader: ({ context: { queryClient } }) =>
-    queryClient.ensureQueryData(postsQueryOptions),
+    queryClient.query({ ...postsQueryOptions, staleTime: 'static' }),
   component: PostsLayoutComponent,
 })
 

--- a/examples/react/basic-react-query/package.json
+++ b/examples/react/basic-react-query/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query": "catalog:",
     "@tanstack/react-query-devtools": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",

--- a/examples/react/basic-react-query/package.json
+++ b/examples/react/basic-react-query/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/react-query": "^5.90.0",
-    "@tanstack/react-query-devtools": "^5.90.0",
+    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query-devtools": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",
     "react": "^19.0.0",

--- a/examples/react/basic-react-query/src/main.tsx
+++ b/examples/react/basic-react-query/src/main.tsx
@@ -101,7 +101,7 @@ const postsLayoutRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: 'posts',
   loader: ({ context: { queryClient } }) =>
-    queryClient.ensureQueryData(postsQueryOptions),
+    queryClient.query({ ...postsQueryOptions, staleTime: 'static' }),
 }).lazy(() => import('./posts.lazy').then((d) => d.Route))
 
 const postsIndexRoute = createRoute({
@@ -119,7 +119,7 @@ const postRoute = createRoute({
   path: '$postId',
   errorComponent: PostErrorComponent,
   loader: ({ context: { queryClient }, params: { postId } }) =>
-    queryClient.ensureQueryData(postQueryOptions(postId)),
+    queryClient.query({ ...postQueryOptions(postId), staleTime: 'static' }),
   component: PostRouteComponent,
 })
 

--- a/examples/react/kitchen-sink-react-query-file-based/package.json
+++ b/examples/react/kitchen-sink-react-query-file-based/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query": "catalog:",
     "@tanstack/react-query-devtools": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",

--- a/examples/react/kitchen-sink-react-query-file-based/package.json
+++ b/examples/react/kitchen-sink-react-query-file-based/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/react-query": "^5.90.0",
-    "@tanstack/react-query-devtools": "^5.90.0",
+    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query-devtools": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",
     "@tanstack/router-plugin": "^1.168.35",

--- a/examples/react/kitchen-sink-react-query-file-based/src/routes/dashboard.index.tsx
+++ b/examples/react/kitchen-sink-react-query-file-based/src/routes/dashboard.index.tsx
@@ -6,7 +6,10 @@ import { invoicesQueryOptions } from '../utils/queryOptions'
 
 export const Route = createFileRoute('/dashboard/')({
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(invoicesQueryOptions()),
+    opts.context.queryClient.query({
+      ...invoicesQueryOptions(),
+      staleTime: 'static',
+    }),
   component: DashboardIndexComponent,
 })
 

--- a/examples/react/kitchen-sink-react-query-file-based/src/routes/dashboard.invoices.$invoiceId.tsx
+++ b/examples/react/kitchen-sink-react-query-file-based/src/routes/dashboard.invoices.$invoiceId.tsx
@@ -24,9 +24,10 @@ export const Route = createFileRoute('/dashboard/invoices/$invoiceId')({
       })
       .parse(search),
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(
-      invoiceQueryOptions(opts.params.invoiceId),
-    ),
+    opts.context.queryClient.query({
+      ...invoiceQueryOptions(opts.params.invoiceId),
+      staleTime: 'static',
+    }),
   component: InvoiceComponent,
 })
 

--- a/examples/react/kitchen-sink-react-query-file-based/src/routes/dashboard.invoices.route.tsx
+++ b/examples/react/kitchen-sink-react-query-file-based/src/routes/dashboard.invoices.route.tsx
@@ -7,7 +7,10 @@ import { invoicesQueryOptions } from '../utils/queryOptions'
 
 export const Route = createFileRoute('/dashboard/invoices')({
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(invoicesQueryOptions()),
+    opts.context.queryClient.query({
+      ...invoicesQueryOptions(),
+      staleTime: 'static',
+    }),
   component: InvoicesComponent,
 })
 

--- a/examples/react/kitchen-sink-react-query-file-based/src/routes/dashboard.users.route.tsx
+++ b/examples/react/kitchen-sink-react-query-file-based/src/routes/dashboard.users.route.tsx
@@ -30,7 +30,10 @@ export const Route = createFileRoute('/dashboard/users')({
     middlewares: [retainSearchParams(['usersView'])],
   },
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(usersQueryOptions({})),
+    opts.context.queryClient.query({
+      ...usersQueryOptions({}),
+      staleTime: 'static',
+    }),
   component: UsersComponent,
 })
 

--- a/examples/react/kitchen-sink-react-query-file-based/src/routes/dashboard.users.user.tsx
+++ b/examples/react/kitchen-sink-react-query-file-based/src/routes/dashboard.users.user.tsx
@@ -11,9 +11,10 @@ export const Route = createFileRoute('/dashboard/users/user')({
   }),
   loaderDeps: ({ search: { userId } }) => ({ userId }),
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(
-      userQueryOptions(opts.deps.userId),
-    ),
+    opts.context.queryClient.query({
+      ...userQueryOptions(opts.deps.userId),
+      staleTime: 'static',
+    }),
   component: UserComponent,
 })
 

--- a/examples/react/kitchen-sink-react-query/package.json
+++ b/examples/react/kitchen-sink-react-query/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query": "catalog:",
     "@tanstack/react-query-devtools": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",

--- a/examples/react/kitchen-sink-react-query/package.json
+++ b/examples/react/kitchen-sink-react-query/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/react-query": "^5.90.0",
-    "@tanstack/react-query-devtools": "^5.90.0",
+    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query-devtools": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",
     "immer": "^10.1.1",

--- a/examples/react/kitchen-sink-react-query/src/main.tsx
+++ b/examples/react/kitchen-sink-react-query/src/main.tsx
@@ -253,7 +253,10 @@ const dashboardIndexRoute = createRoute({
   getParentRoute: () => dashboardLayoutRoute,
   path: '/',
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(invoicesQueryOptions()),
+    opts.context.queryClient.query({
+      ...invoicesQueryOptions(),
+      staleTime: 'static',
+    }),
   component: DashboardIndexComponent,
 })
 
@@ -275,7 +278,10 @@ const invoicesLayoutRoute = createRoute({
   getParentRoute: () => dashboardLayoutRoute,
   path: 'invoices',
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(invoicesQueryOptions()),
+    opts.context.queryClient.query({
+      ...invoicesQueryOptions(),
+      staleTime: 'static',
+    }),
   component: InvoicesLayoutComponent,
 })
 
@@ -421,9 +427,10 @@ const invoiceRoute = createRoute({
       })
       .parse(search),
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(
-      invoiceQueryOptions(opts.params.invoiceId),
-    ),
+    opts.context.queryClient.query({
+      ...invoiceQueryOptions(opts.params.invoiceId),
+      staleTime: 'static',
+    }),
   component: InvoiceComponent,
 })
 
@@ -544,7 +551,10 @@ const usersLayoutRoute = createRoute({
     sortBy: search.usersView?.sortBy,
   }),
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(usersQueryOptions(opts.deps)),
+    opts.context.queryClient.query({
+      ...usersQueryOptions(opts.deps),
+      staleTime: 'static',
+    }),
   component: UsersComponent,
 })
 
@@ -710,9 +720,10 @@ const userRoute = createRoute({
     userId: search.userId,
   }),
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(
-      userQueryOptions(opts.deps.userId),
-    ),
+    opts.context.queryClient.query({
+      ...userQueryOptions(opts.deps.userId),
+      staleTime: 'static',
+    }),
   component: UserComponent,
 })
 

--- a/examples/react/large-file-based/package.json
+++ b/examples/react/large-file-based/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query": "catalog:",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",
     "@tanstack/router-plugin": "^1.168.35",

--- a/examples/react/large-file-based/package.json
+++ b/examples/react/large-file-based/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/react-query": "^5.90.0",
+    "@tanstack/react-query": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",
     "@tanstack/router-plugin": "^1.168.35",

--- a/examples/react/large-file-based/src/routes/params/$paramsPlaceholder.tsx
+++ b/examples/react/large-file-based/src/routes/params/$paramsPlaceholder.tsx
@@ -24,7 +24,10 @@ const paramsQueryOptions = queryOptions({
 export const Route = createFileRoute('/params/$paramsPlaceholder')({
   component: ParamsComponent,
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(paramsQueryOptions),
+    opts.context.queryClient.query({
+      ...paramsQueryOptions,
+      staleTime: 'static',
+    }),
 })
 
 function ParamsComponent() {

--- a/examples/react/large-file-based/src/routes/search/searchPlaceholder.tsx
+++ b/examples/react/large-file-based/src/routes/search/searchPlaceholder.tsx
@@ -31,7 +31,10 @@ export const Route = createFileRoute('/search/searchPlaceholder')({
   component: SearchComponent,
   validateSearch: search,
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(searchQueryOptions),
+    opts.context.queryClient.query({
+      ...searchQueryOptions,
+      staleTime: 'static',
+    }),
 })
 
 function SearchComponent() {

--- a/examples/react/location-masking/package.json
+++ b/examples/react/location-masking/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.6",
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query": "catalog:",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",
     "react": "^19.0.0",

--- a/examples/react/location-masking/package.json
+++ b/examples/react/location-masking/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.6",
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/react-query": "^5.90.0",
+    "@tanstack/react-query": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",
     "react": "^19.0.0",

--- a/examples/react/navigation-blocking/package.json
+++ b/examples/react/navigation-blocking/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/react-query": "^5.90.0",
+    "@tanstack/react-query": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",
     "react": "^19.0.0",

--- a/examples/react/navigation-blocking/package.json
+++ b/examples/react/navigation-blocking/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query": "catalog:",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",
     "react": "^19.0.0",

--- a/examples/react/router-monorepo-react-query/package.json
+++ b/examples/react/router-monorepo-react-query/package.json
@@ -10,8 +10,8 @@
     "dev": "pnpm post-query build && pnpm router build && pnpm post-feature build && pnpm app dev"
   },
   "dependencies": {
-    "@tanstack/react-query": "^5.90.0",
-    "@tanstack/react-query-devtools": "^5.90.0",
+    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query-devtools": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",
     "@tanstack/router-plugin": "^1.168.35",

--- a/examples/react/router-monorepo-react-query/package.json
+++ b/examples/react/router-monorepo-react-query/package.json
@@ -10,7 +10,7 @@
     "dev": "pnpm post-query build && pnpm router build && pnpm post-feature build && pnpm app dev"
   },
   "dependencies": {
-    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query": "catalog:",
     "@tanstack/react-query-devtools": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",

--- a/examples/react/router-monorepo-react-query/packages/app/package.json
+++ b/examples/react/router-monorepo-react-query/packages/app/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@router-mono-react-query/post-feature": "workspace:*",
     "@router-mono-react-query/router": "workspace:*",
-    "@tanstack/react-query": "^5.90.0",
+    "@tanstack/react-query": "^5.102.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/examples/react/router-monorepo-react-query/packages/app/package.json
+++ b/examples/react/router-monorepo-react-query/packages/app/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@router-mono-react-query/post-feature": "workspace:*",
     "@router-mono-react-query/router": "workspace:*",
-    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query": "catalog:",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/examples/react/router-monorepo-react-query/packages/post-feature/package.json
+++ b/examples/react/router-monorepo-react-query/packages/post-feature/package.json
@@ -8,7 +8,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query": "catalog:",
     "@router-mono-react-query/post-query": "workspace:*",
     "@router-mono-react-query/router": "workspace:*",
     "react": "^19.0.0",

--- a/examples/react/router-monorepo-react-query/packages/post-feature/package.json
+++ b/examples/react/router-monorepo-react-query/packages/post-feature/package.json
@@ -8,7 +8,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@tanstack/react-query": "^5.90.0",
+    "@tanstack/react-query": "^5.102.3",
     "@router-mono-react-query/post-query": "workspace:*",
     "@router-mono-react-query/router": "workspace:*",
     "react": "^19.0.0",

--- a/examples/react/router-monorepo-react-query/packages/post-query/package.json
+++ b/examples/react/router-monorepo-react-query/packages/post-query/package.json
@@ -8,7 +8,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@tanstack/react-query": "^5.90.0",
+    "@tanstack/react-query": "^5.102.3",
     "redaxios": "catalog:",
     "zod": "^4.4.3"
   },

--- a/examples/react/router-monorepo-react-query/packages/post-query/package.json
+++ b/examples/react/router-monorepo-react-query/packages/post-query/package.json
@@ -8,7 +8,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query": "catalog:",
     "redaxios": "catalog:",
     "zod": "^4.4.3"
   },

--- a/examples/react/router-monorepo-react-query/packages/router/package.json
+++ b/examples/react/router-monorepo-react-query/packages/router/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@router-mono-react-query/post-query": "workspace:*",
     "@tanstack/history": "^1.162.1",
-    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query": "catalog:",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/router-plugin": "^1.168.35",
     "react": "^19.0.0",

--- a/examples/react/router-monorepo-react-query/packages/router/package.json
+++ b/examples/react/router-monorepo-react-query/packages/router/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@router-mono-react-query/post-query": "workspace:*",
     "@tanstack/history": "^1.162.1",
-    "@tanstack/react-query": "^5.90.0",
+    "@tanstack/react-query": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/router-plugin": "^1.168.35",
     "react": "^19.0.0",

--- a/examples/react/router-monorepo-react-query/packages/router/src/routes/$postId.ts
+++ b/examples/react/router-monorepo-react-query/packages/router/src/routes/$postId.ts
@@ -3,6 +3,9 @@ import { postQueryOptions } from '@router-mono-react-query/post-query'
 
 export const Route = createFileRoute('/$postId')({
   loader: ({ context: { queryClient }, params: { postId } }) => {
-    return queryClient.ensureQueryData(postQueryOptions(postId))
+    return queryClient.query({
+      ...postQueryOptions(postId),
+      staleTime: 'static',
+    })
   },
 })

--- a/examples/react/router-monorepo-react-query/packages/router/src/routes/index.ts
+++ b/examples/react/router-monorepo-react-query/packages/router/src/routes/index.ts
@@ -3,6 +3,6 @@ import { postsQueryOptions } from '@router-mono-react-query/post-query'
 
 export const Route = createFileRoute('/')({
   loader: ({ context: { queryClient } }) => {
-    return queryClient.ensureQueryData(postsQueryOptions)
+    return queryClient.query({ ...postsQueryOptions, staleTime: 'static' })
   },
 })

--- a/examples/react/router-monorepo-simple-lazy/packages/post-feature/package.json
+++ b/examples/react/router-monorepo-simple-lazy/packages/post-feature/package.json
@@ -16,7 +16,7 @@
     }
   },
   "dependencies": {
-    "@tanstack/react-query": "^5.90.0",
+    "@tanstack/react-query": "^5.102.3",
     "@router-mono-simple-lazy/router": "workspace:*",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/examples/react/router-monorepo-simple-lazy/packages/post-feature/package.json
+++ b/examples/react/router-monorepo-simple-lazy/packages/post-feature/package.json
@@ -16,7 +16,7 @@
     }
   },
   "dependencies": {
-    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query": "catalog:",
     "@router-mono-simple-lazy/router": "workspace:*",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/examples/react/search-validator-adapters/package.json
+++ b/examples/react/search-validator-adapters/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/arktype-adapter": "^1.167.0",
-    "@tanstack/react-query": "^5.90.0",
+    "@tanstack/react-query": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",
     "@tanstack/router-plugin": "^1.168.35",

--- a/examples/react/search-validator-adapters/package.json
+++ b/examples/react/search-validator-adapters/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/arktype-adapter": "^1.167.0",
-    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query": "catalog:",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",
     "@tanstack/router-plugin": "^1.168.35",

--- a/examples/react/search-validator-adapters/src/routes/users/arktype.index.tsx
+++ b/examples/react/search-validator-adapters/src/routes/users/arktype.index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { useNavigate, createFileRoute } from '@tanstack/react-router'
 import { type } from 'arktype'
+import { noop } from '@tanstack/react-query'
 import { Header } from '../../components/Header'
 import { Users, usersQueryOptions } from '../../components/Users'
 import { Content } from '../../components/Content'
@@ -36,10 +37,9 @@ export const Route = createFileRoute('/users/arktype/')({
   validateSearch: search,
   loaderDeps: (opt) => ({ search: opt.search }),
   loader: (opt) => {
-    opt.context.queryClient.query({
-      ...usersQueryOptions(opt.deps.search.search),
-      staleTime: 'static',
-    })
+    void opt.context.queryClient
+      .query(usersQueryOptions(opt.deps.search.search))
+      .catch(noop)
   },
   component: ArkType,
 })

--- a/examples/react/search-validator-adapters/src/routes/users/arktype.index.tsx
+++ b/examples/react/search-validator-adapters/src/routes/users/arktype.index.tsx
@@ -36,9 +36,10 @@ export const Route = createFileRoute('/users/arktype/')({
   validateSearch: search,
   loaderDeps: (opt) => ({ search: opt.search }),
   loader: (opt) => {
-    opt.context.queryClient.ensureQueryData(
-      usersQueryOptions(opt.deps.search.search),
-    )
+    opt.context.queryClient.query({
+      ...usersQueryOptions(opt.deps.search.search),
+      staleTime: 'static',
+    })
   },
   component: ArkType,
 })

--- a/examples/react/search-validator-adapters/src/routes/users/valibot.index.tsx
+++ b/examples/react/search-validator-adapters/src/routes/users/valibot.index.tsx
@@ -32,9 +32,10 @@ export const Route = createFileRoute('/users/valibot/')({
   }),
   loaderDeps: (opt) => ({ search: opt.search }),
   loader: (opt) => {
-    opt.context.queryClient.ensureQueryData(
-      usersQueryOptions(opt.deps.search.search),
-    )
+    opt.context.queryClient.query({
+      ...usersQueryOptions(opt.deps.search.search),
+      staleTime: 'static',
+    })
   },
   component: Valibot,
 })

--- a/examples/react/search-validator-adapters/src/routes/users/valibot.index.tsx
+++ b/examples/react/search-validator-adapters/src/routes/users/valibot.index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { useNavigate, createFileRoute } from '@tanstack/react-router'
 import * as v from 'valibot'
+import { noop } from '@tanstack/react-query'
 import { Header } from '../../components/Header'
 import { Users, usersQueryOptions } from '../../components/Users'
 import { Content } from '../../components/Content'
@@ -32,10 +33,9 @@ export const Route = createFileRoute('/users/valibot/')({
   }),
   loaderDeps: (opt) => ({ search: opt.search }),
   loader: (opt) => {
-    opt.context.queryClient.query({
-      ...usersQueryOptions(opt.deps.search.search),
-      staleTime: 'static',
-    })
+    void opt.context.queryClient
+      .query(usersQueryOptions(opt.deps.search.search))
+      .catch(noop)
   },
   component: Valibot,
 })

--- a/examples/react/search-validator-adapters/src/routes/users/zod.index.tsx
+++ b/examples/react/search-validator-adapters/src/routes/users/zod.index.tsx
@@ -42,9 +42,10 @@ export const Route = createFileRoute('/users/zod/')({
   ),
   loaderDeps: (opt) => ({ search: opt.search }),
   loader: (opt) => {
-    opt.context.queryClient.ensureQueryData(
-      usersQueryOptions(opt.deps.search.search ?? ''),
-    )
+    opt.context.queryClient.query({
+      ...usersQueryOptions(opt.deps.search.search ?? ''),
+      staleTime: 'static',
+    })
   },
   component: Zod,
 })

--- a/examples/react/start-basic-react-query/package.json
+++ b/examples/react/start-basic-react-query/package.json
@@ -10,7 +10,7 @@
     "start": "pnpx srvx --prod -s ../client dist/server/server.js"
   },
   "dependencies": {
-    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query": "catalog:",
     "@tanstack/react-query-devtools": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",

--- a/examples/react/start-basic-react-query/package.json
+++ b/examples/react/start-basic-react-query/package.json
@@ -10,8 +10,8 @@
     "start": "pnpx srvx --prod -s ../client dist/server/server.js"
   },
   "dependencies": {
-    "@tanstack/react-query": "^5.90.0",
-    "@tanstack/react-query-devtools": "^5.90.0",
+    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query-devtools": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",
     "@tanstack/react-router-ssr-query": "^1.167.1",

--- a/examples/react/start-basic-react-query/src/routes/deferred.tsx
+++ b/examples/react/start-basic-react-query/src/routes/deferred.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { queryOptions, useSuspenseQuery } from '@tanstack/react-query'
+import { noop, queryOptions, useSuspenseQuery } from '@tanstack/react-query'
 import { Suspense, useState } from 'react'
 
 const deferredQueryOptions = () =>
@@ -18,7 +18,7 @@ const deferredQueryOptions = () =>
 export const Route = createFileRoute('/deferred')({
   loader: ({ context }) => {
     // Kick off loading as early as possible!
-    context.queryClient.prefetchQuery(deferredQueryOptions())
+    void context.queryClient.query(deferredQueryOptions()).catch(noop)
   },
   component: Deferred,
 })

--- a/examples/react/start-basic-react-query/src/routes/posts.$postId.tsx
+++ b/examples/react/start-basic-react-query/src/routes/posts.$postId.tsx
@@ -6,9 +6,10 @@ import { NotFound } from '~/components/NotFound'
 
 export const Route = createFileRoute('/posts/$postId')({
   loader: async ({ params: { postId }, context }) => {
-    const data = await context.queryClient.ensureQueryData(
-      postQueryOptions(postId),
-    )
+    const data = await context.queryClient.query({
+      ...postQueryOptions(postId),
+      staleTime: 'static',
+    })
 
     return {
       title: data.title,

--- a/examples/react/start-basic-react-query/src/routes/posts.route.tsx
+++ b/examples/react/start-basic-react-query/src/routes/posts.route.tsx
@@ -4,7 +4,10 @@ import { postsQueryOptions } from '../utils/posts'
 
 export const Route = createFileRoute('/posts')({
   loader: async ({ context }) => {
-    await context.queryClient.ensureQueryData(postsQueryOptions())
+    await context.queryClient.query({
+      ...postsQueryOptions(),
+      staleTime: 'static',
+    })
   },
   head: () => ({
     meta: [{ title: 'Posts' }],

--- a/examples/react/start-basic-react-query/src/routes/posts_.$postId.deep.tsx
+++ b/examples/react/start-basic-react-query/src/routes/posts_.$postId.deep.tsx
@@ -5,9 +5,10 @@ import { PostErrorComponent } from './posts.$postId'
 
 export const Route = createFileRoute('/posts_/$postId/deep')({
   loader: async ({ params: { postId }, context }) => {
-    const data = await context.queryClient.ensureQueryData(
-      postQueryOptions(postId),
-    )
+    const data = await context.queryClient.query({
+      ...postQueryOptions(postId),
+      staleTime: 'static',
+    })
 
     return {
       title: data.title,

--- a/examples/react/start-basic-react-query/src/routes/users.$userId.tsx
+++ b/examples/react/start-basic-react-query/src/routes/users.$userId.tsx
@@ -6,7 +6,10 @@ import { userQueryOptions } from '~/utils/users'
 
 export const Route = createFileRoute('/users/$userId')({
   loader: async ({ context, params: { userId } }) => {
-    await context.queryClient.ensureQueryData(userQueryOptions(userId))
+    await context.queryClient.query({
+      ...userQueryOptions(userId),
+      staleTime: 'static',
+    })
   },
   errorComponent: UserErrorComponent,
   component: UserComponent,

--- a/examples/react/start-basic-react-query/src/routes/users.route.tsx
+++ b/examples/react/start-basic-react-query/src/routes/users.route.tsx
@@ -4,7 +4,10 @@ import { usersQueryOptions } from '../utils/users'
 
 export const Route = createFileRoute('/users')({
   loader: async ({ context }) => {
-    await context.queryClient.ensureQueryData(usersQueryOptions())
+    await context.queryClient.query({
+      ...usersQueryOptions(),
+      staleTime: 'static',
+    })
   },
   component: UsersComponent,
 })

--- a/examples/react/start-convex-trellaux/package.json
+++ b/examples/react/start-convex-trellaux/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@convex-dev/react-query": "0.0.0-alpha.8",
-    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query": "catalog:",
     "@tanstack/react-query-devtools": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",

--- a/examples/react/start-convex-trellaux/package.json
+++ b/examples/react/start-convex-trellaux/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@convex-dev/react-query": "0.0.0-alpha.8",
-    "@tanstack/react-query": "^5.90.0",
-    "@tanstack/react-query-devtools": "^5.90.0",
+    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query-devtools": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",
     "@tanstack/react-router-ssr-query": "^1.167.1",

--- a/examples/react/start-convex-trellaux/src/routes/boards.$boardId.tsx
+++ b/examples/react/start-convex-trellaux/src/routes/boards.$boardId.tsx
@@ -7,7 +7,10 @@ export const Route = createFileRoute('/boards/$boardId')({
   component: Home,
   pendingComponent: () => <Loader />,
   loader: async ({ params, context: { queryClient } }) => {
-    await queryClient.ensureQueryData(boardQueries.detail(params.boardId))
+    await queryClient.query({
+      ...boardQueries.detail(params.boardId),
+      staleTime: 'static',
+    })
   },
 })
 

--- a/examples/react/start-large/package.json
+++ b/examples/react/start-large/package.json
@@ -12,7 +12,7 @@
     "test:types": "tsc --extendedDiagnostics"
   },
   "dependencies": {
-    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query": "catalog:",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",
     "@tanstack/react-start": "^1.168.49",

--- a/examples/react/start-large/package.json
+++ b/examples/react/start-large/package.json
@@ -12,7 +12,7 @@
     "test:types": "tsc --extendedDiagnostics"
   },
   "dependencies": {
-    "@tanstack/react-query": "^5.90.0",
+    "@tanstack/react-query": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",
     "@tanstack/react-start": "^1.168.49",

--- a/examples/react/start-large/src/routes/params/$paramsPlaceholder.tsx
+++ b/examples/react/start-large/src/routes/params/$paramsPlaceholder.tsx
@@ -60,7 +60,10 @@ export const Route = createFileRoute('/params/$paramsPlaceholder')({
     }),
   }),
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(paramsQueryOptions),
+    opts.context.queryClient.query({
+      ...paramsQueryOptions,
+      staleTime: 'static',
+    }),
 })
 
 function ParamsComponent() {

--- a/examples/react/start-large/src/routes/search/searchPlaceholder.tsx
+++ b/examples/react/start-large/src/routes/search/searchPlaceholder.tsx
@@ -58,9 +58,10 @@ export const Route = createFileRoute('/search/searchPlaceholder')({
     }),
   }),
   loader: async (opts) => {
-    const search = await opts.context.queryClient.ensureQueryData(
-      opts.context.searchQueryOptions,
-    )
+    const search = await opts.context.queryClient.query({
+      ...opts.context.searchQueryOptions,
+      staleTime: 'static',
+    })
 
     return {
       search,

--- a/examples/react/start-trellaux/package.json
+++ b/examples/react/start-trellaux/package.json
@@ -10,7 +10,7 @@
     "start": "pnpx srvx --prod -s ../client dist/server/server.js"
   },
   "dependencies": {
-    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query": "catalog:",
     "@tanstack/react-query-devtools": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",

--- a/examples/react/start-trellaux/package.json
+++ b/examples/react/start-trellaux/package.json
@@ -10,8 +10,8 @@
     "start": "pnpx srvx --prod -s ../client dist/server/server.js"
   },
   "dependencies": {
-    "@tanstack/react-query": "^5.90.0",
-    "@tanstack/react-query-devtools": "^5.90.0",
+    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query-devtools": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",
     "@tanstack/react-router-ssr-query": "^1.167.1",

--- a/examples/react/start-trellaux/src/routes/boards.$boardId.tsx
+++ b/examples/react/start-trellaux/src/routes/boards.$boardId.tsx
@@ -7,7 +7,10 @@ export const Route = createFileRoute('/boards/$boardId')({
   component: Home,
   pendingComponent: () => <Loader />,
   loader: async ({ params, context: { queryClient } }) => {
-    await queryClient.ensureQueryData(boardQueries.detail(params.boardId))
+    await queryClient.query({
+      ...boardQueries.detail(params.boardId),
+      staleTime: 'static',
+    })
   },
 })
 

--- a/examples/react/with-trpc-react-query/package.json
+++ b/examples/react/with-trpc-react-query/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/react-query": "^5.90.0",
-    "@tanstack/react-query-devtools": "^5.90.0",
+    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query-devtools": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",
     "@tanstack/router-plugin": "^1.168.35",

--- a/examples/react/with-trpc-react-query/package.json
+++ b/examples/react/with-trpc-react-query/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/react-query": "^5.102.3",
+    "@tanstack/react-query": "catalog:",
     "@tanstack/react-query-devtools": "^5.102.3",
     "@tanstack/react-router": "^1.170.32",
     "@tanstack/react-router-devtools": "^1.167.1",

--- a/examples/react/with-trpc-react-query/src/routes/dashboard.index.tsx
+++ b/examples/react/with-trpc-react-query/src/routes/dashboard.index.tsx
@@ -4,7 +4,10 @@ import { trpc } from '../router'
 
 export const Route = createFileRoute('/dashboard/')({
   loader: async ({ context: { trpc, queryClient } }) => {
-    await queryClient.ensureQueryData(trpc.posts.queryOptions())
+    await queryClient.query({
+      ...trpc.posts.queryOptions(),
+      staleTime: 'static',
+    })
     return
   },
   component: DashboardIndexComponent,

--- a/examples/react/with-trpc-react-query/src/routes/dashboard.posts.$postId.tsx
+++ b/examples/react/with-trpc-react-query/src/routes/dashboard.posts.$postId.tsx
@@ -11,7 +11,10 @@ export const Route = createFileRoute('/dashboard/posts/$postId')({
     notes: z.string().optional(),
   }),
   loader: async ({ context: { trpc, queryClient }, params: { postId } }) => {
-    await queryClient.ensureQueryData(trpc.post.queryOptions(postId))
+    await queryClient.query({
+      ...trpc.post.queryOptions(postId),
+      staleTime: 'static',
+    })
   },
   pendingComponent: Spinner,
   component: DashboardPostsPostIdComponent,

--- a/examples/react/with-trpc-react-query/src/routes/dashboard.posts.tsx
+++ b/examples/react/with-trpc-react-query/src/routes/dashboard.posts.tsx
@@ -12,7 +12,10 @@ import { Spinner } from './-components/spinner'
 export const Route = createFileRoute('/dashboard/posts')({
   errorComponent: () => 'Oh crap!',
   loader: async ({ context: { trpc, queryClient } }) => {
-    await queryClient.ensureQueryData(trpc.posts.queryOptions())
+    await queryClient.query({
+      ...trpc.posts.queryOptions(),
+      staleTime: 'static',
+    })
     return
   },
   pendingComponent: Spinner,

--- a/examples/solid/basic-default-search-params/package.json
+++ b/examples/solid/basic-default-search-params/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/solid-query": "^5.102.3",
+    "@tanstack/solid-query": "catalog:",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/solid-router-devtools": "^1.167.1",
     "redaxios": "catalog:",

--- a/examples/solid/basic-default-search-params/package.json
+++ b/examples/solid/basic-default-search-params/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/solid-query": "^5.90.9",
+    "@tanstack/solid-query": "^5.102.3",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/solid-router-devtools": "^1.167.1",
     "redaxios": "catalog:",

--- a/examples/solid/basic-solid-query-file-based/package.json
+++ b/examples/solid/basic-solid-query-file-based/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/solid-query": "^5.102.3",
+    "@tanstack/solid-query": "catalog:",
     "@tanstack/solid-query-devtools": "^5.102.3",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/solid-router-devtools": "^1.167.1",

--- a/examples/solid/basic-solid-query-file-based/package.json
+++ b/examples/solid/basic-solid-query-file-based/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/solid-query": "^5.90.9",
-    "@tanstack/solid-query-devtools": "^5.90.0",
+    "@tanstack/solid-query": "^5.102.3",
+    "@tanstack/solid-query-devtools": "^5.102.3",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/solid-router-devtools": "^1.167.1",
     "redaxios": "catalog:",

--- a/examples/solid/basic-solid-query-file-based/src/routes/posts.$postId.tsx
+++ b/examples/solid/basic-solid-query-file-based/src/routes/posts.$postId.tsx
@@ -34,7 +34,10 @@ export function PostErrorComponent({ error, reset }: ErrorComponentProps) {
 
 export const Route = createFileRoute('/posts/$postId')({
   loader: ({ context: { queryClient }, params: { postId } }) => {
-    return queryClient.ensureQueryData(postQueryOptions(postId))
+    return queryClient.query({
+      ...postQueryOptions(postId),
+      staleTime: 'static',
+    })
   },
   errorComponent: PostErrorComponent,
   component: PostComponent,

--- a/examples/solid/basic-solid-query-file-based/src/routes/posts.tsx
+++ b/examples/solid/basic-solid-query-file-based/src/routes/posts.tsx
@@ -6,7 +6,7 @@ import { createMemo } from 'solid-js'
 
 export const Route = createFileRoute('/posts')({
   loader: ({ context: { queryClient } }) =>
-    queryClient.ensureQueryData(postsQueryOptions),
+    queryClient.query({ ...postsQueryOptions, staleTime: 'static' }),
   component: PostsComponent,
 })
 

--- a/examples/solid/basic-solid-query/package.json
+++ b/examples/solid/basic-solid-query/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/solid-query": "^5.102.3",
+    "@tanstack/solid-query": "catalog:",
     "@tanstack/solid-query-devtools": "^5.102.3",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/solid-router-devtools": "^1.167.1",

--- a/examples/solid/basic-solid-query/package.json
+++ b/examples/solid/basic-solid-query/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/solid-query": "^5.90.9",
-    "@tanstack/solid-query-devtools": "^5.90.0",
+    "@tanstack/solid-query": "^5.102.3",
+    "@tanstack/solid-query-devtools": "^5.102.3",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/solid-router-devtools": "^1.167.1",
     "redaxios": "catalog:",

--- a/examples/solid/basic-solid-query/src/main.tsx
+++ b/examples/solid/basic-solid-query/src/main.tsx
@@ -102,7 +102,7 @@ const postsLayoutRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: 'posts',
   loader: ({ context: { queryClient } }) =>
-    queryClient.ensureQueryData(postsQueryOptions),
+    queryClient.query({ ...postsQueryOptions, staleTime: 'static' }),
 }).lazy(() => import('./posts.lazy').then((d) => d.Route))
 
 const postsIndexRoute = createRoute({
@@ -120,7 +120,7 @@ const postRoute = createRoute({
   path: '$postId',
   errorComponent: PostErrorComponent,
   loader: ({ context: { queryClient }, params: { postId } }) =>
-    queryClient.ensureQueryData(postQueryOptions(postId)),
+    queryClient.query({ ...postQueryOptions(postId), staleTime: 'static' }),
   component: PostRouteComponent,
 })
 

--- a/examples/solid/kitchen-sink-solid-query-file-based/package.json
+++ b/examples/solid/kitchen-sink-solid-query-file-based/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.168.35",
-    "@tanstack/solid-query": "^5.90.9",
-    "@tanstack/solid-query-devtools": "^5.90.0",
+    "@tanstack/solid-query": "^5.102.3",
+    "@tanstack/solid-query-devtools": "^5.102.3",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/solid-router-devtools": "^1.167.1",
     "immer": "^10.1.1",

--- a/examples/solid/kitchen-sink-solid-query-file-based/package.json
+++ b/examples/solid/kitchen-sink-solid-query-file-based/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.168.35",
-    "@tanstack/solid-query": "^5.102.3",
+    "@tanstack/solid-query": "catalog:",
     "@tanstack/solid-query-devtools": "^5.102.3",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/solid-router-devtools": "^1.167.1",

--- a/examples/solid/kitchen-sink-solid-query-file-based/src/routes/dashboard.index.tsx
+++ b/examples/solid/kitchen-sink-solid-query-file-based/src/routes/dashboard.index.tsx
@@ -4,7 +4,10 @@ import { invoicesQueryOptions } from '../utils/queryOptions'
 
 export const Route = createFileRoute('/dashboard/')({
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(invoicesQueryOptions()),
+    opts.context.queryClient.query({
+      ...invoicesQueryOptions(),
+      staleTime: 'static',
+    }),
   component: DashboardIndexComponent,
 })
 

--- a/examples/solid/kitchen-sink-solid-query-file-based/src/routes/dashboard.invoices.$invoiceId.tsx
+++ b/examples/solid/kitchen-sink-solid-query-file-based/src/routes/dashboard.invoices.$invoiceId.tsx
@@ -23,9 +23,10 @@ export const Route = createFileRoute('/dashboard/invoices/$invoiceId')({
       })
       .parse(search),
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(
-      invoiceQueryOptions(opts.params.invoiceId),
-    ),
+    opts.context.queryClient.query({
+      ...invoiceQueryOptions(opts.params.invoiceId),
+      staleTime: 'static',
+    }),
   component: InvoiceComponent,
 })
 

--- a/examples/solid/kitchen-sink-solid-query-file-based/src/routes/dashboard.invoices.route.tsx
+++ b/examples/solid/kitchen-sink-solid-query-file-based/src/routes/dashboard.invoices.route.tsx
@@ -10,7 +10,10 @@ import { invoicesQueryOptions } from '../utils/queryOptions'
 
 export const Route = createFileRoute('/dashboard/invoices')({
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(invoicesQueryOptions()),
+    opts.context.queryClient.query({
+      ...invoicesQueryOptions(),
+      staleTime: 'static',
+    }),
   component: InvoicesComponent,
 })
 

--- a/examples/solid/kitchen-sink-solid-query-file-based/src/routes/dashboard.users.route.tsx
+++ b/examples/solid/kitchen-sink-solid-query-file-based/src/routes/dashboard.users.route.tsx
@@ -30,7 +30,10 @@ export const Route = createFileRoute('/dashboard/users')({
     middlewares: [retainSearchParams(['usersView'])],
   },
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(usersQueryOptions(opts.deps)),
+    opts.context.queryClient.query({
+      ...usersQueryOptions(opts.deps),
+      staleTime: 'static',
+    }),
   component: UsersComponent,
 })
 

--- a/examples/solid/kitchen-sink-solid-query-file-based/src/routes/dashboard.users.user.tsx
+++ b/examples/solid/kitchen-sink-solid-query-file-based/src/routes/dashboard.users.user.tsx
@@ -9,9 +9,10 @@ export const Route = createFileRoute('/dashboard/users/user')({
   }),
   loaderDeps: ({ search: { userId } }) => ({ userId }),
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(
-      userQueryOptions(opts.deps.userId),
-    ),
+    opts.context.queryClient.query({
+      ...userQueryOptions(opts.deps.userId),
+      staleTime: 'static',
+    }),
   component: UserComponent,
 })
 

--- a/examples/solid/kitchen-sink-solid-query/package.json
+++ b/examples/solid/kitchen-sink-solid-query/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/solid-query": "^5.102.3",
+    "@tanstack/solid-query": "catalog:",
     "@tanstack/solid-query-devtools": "^5.102.3",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/solid-router-devtools": "^1.167.1",

--- a/examples/solid/kitchen-sink-solid-query/package.json
+++ b/examples/solid/kitchen-sink-solid-query/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/solid-query": "^5.90.9",
-    "@tanstack/solid-query-devtools": "^5.90.0",
+    "@tanstack/solid-query": "^5.102.3",
+    "@tanstack/solid-query-devtools": "^5.102.3",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/solid-router-devtools": "^1.167.1",
     "immer": "^10.1.1",

--- a/examples/solid/kitchen-sink-solid-query/src/main.tsx
+++ b/examples/solid/kitchen-sink-solid-query/src/main.tsx
@@ -252,7 +252,10 @@ const dashboardIndexRoute = createRoute({
   getParentRoute: () => dashboardLayoutRoute,
   path: '/',
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(invoicesQueryOptions()),
+    opts.context.queryClient.query({
+      ...invoicesQueryOptions(),
+      staleTime: 'static',
+    }),
   component: DashboardIndexComponent,
 })
 
@@ -274,7 +277,10 @@ const invoicesLayoutRoute = createRoute({
   getParentRoute: () => dashboardLayoutRoute,
   path: 'invoices',
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(invoicesQueryOptions()),
+    opts.context.queryClient.query({
+      ...invoicesQueryOptions(),
+      staleTime: 'static',
+    }),
   component: InvoicesLayoutComponent,
 })
 
@@ -420,9 +426,10 @@ const invoiceRoute = createRoute({
       })
       .parse(search),
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(
-      invoiceQueryOptions(opts.params.invoiceId),
-    ),
+    opts.context.queryClient.query({
+      ...invoiceQueryOptions(opts.params.invoiceId),
+      staleTime: 'static',
+    }),
   component: InvoiceComponent,
 })
 
@@ -542,7 +549,10 @@ const usersLayoutRoute = createRoute({
     sortBy: search.usersView?.sortBy,
   }),
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(usersQueryOptions(opts.deps)),
+    opts.context.queryClient.query({
+      ...usersQueryOptions(opts.deps),
+      staleTime: 'static',
+    }),
   component: UsersComponent,
 })
 
@@ -708,9 +718,10 @@ const userRoute = createRoute({
     userId: search.userId,
   }),
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(
-      userQueryOptions(opts.deps.userId),
-    ),
+    opts.context.queryClient.query({
+      ...userQueryOptions(opts.deps.userId),
+      staleTime: 'static',
+    }),
   component: UserComponent,
 })
 

--- a/examples/solid/large-file-based/package.json
+++ b/examples/solid/large-file-based/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.168.35",
-    "@tanstack/solid-query": "^5.102.3",
+    "@tanstack/solid-query": "catalog:",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/solid-router-devtools": "^1.167.1",
     "redaxios": "catalog:",

--- a/examples/solid/large-file-based/package.json
+++ b/examples/solid/large-file-based/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.168.35",
-    "@tanstack/solid-query": "^5.90.9",
+    "@tanstack/solid-query": "^5.102.3",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/solid-router-devtools": "^1.167.1",
     "redaxios": "catalog:",

--- a/examples/solid/large-file-based/src/routes/params/$paramsPlaceholder.tsx
+++ b/examples/solid/large-file-based/src/routes/params/$paramsPlaceholder.tsx
@@ -22,7 +22,10 @@ const paramsQueryOptions = queryOptions({
 export const Route = createFileRoute('/params/$paramsPlaceholder')({
   component: ParamsComponent,
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(paramsQueryOptions),
+    opts.context.queryClient.query({
+      ...paramsQueryOptions,
+      staleTime: 'static',
+    }),
 })
 
 function ParamsComponent() {

--- a/examples/solid/large-file-based/src/routes/search/searchPlaceholder.tsx
+++ b/examples/solid/large-file-based/src/routes/search/searchPlaceholder.tsx
@@ -29,7 +29,10 @@ export const Route = createFileRoute('/search/searchPlaceholder')({
   component: SearchComponent,
   validateSearch: search,
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(searchQueryOptions),
+    opts.context.queryClient.query({
+      ...searchQueryOptions,
+      staleTime: 'static',
+    }),
 })
 
 function SearchComponent() {

--- a/examples/solid/location-masking/package.json
+++ b/examples/solid/location-masking/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/solid-query": "^5.90.9",
+    "@tanstack/solid-query": "^5.102.3",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/solid-router-devtools": "^1.167.1",
     "solid-js": "^1.9.10",

--- a/examples/solid/location-masking/package.json
+++ b/examples/solid/location-masking/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/solid-query": "^5.102.3",
+    "@tanstack/solid-query": "catalog:",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/solid-router-devtools": "^1.167.1",
     "solid-js": "^1.9.10",

--- a/examples/solid/navigation-blocking/package.json
+++ b/examples/solid/navigation-blocking/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/solid-query": "^5.90.9",
+    "@tanstack/solid-query": "^5.102.3",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/solid-router-devtools": "^1.167.1",
     "solid-js": "^1.9.10",

--- a/examples/solid/navigation-blocking/package.json
+++ b/examples/solid/navigation-blocking/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "@tanstack/solid-query": "^5.102.3",
+    "@tanstack/solid-query": "catalog:",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/solid-router-devtools": "^1.167.1",
     "solid-js": "^1.9.10",

--- a/examples/solid/router-monorepo-simple-lazy/packages/post-feature/package.json
+++ b/examples/solid/router-monorepo-simple-lazy/packages/post-feature/package.json
@@ -16,7 +16,7 @@
     }
   },
   "dependencies": {
-    "@tanstack/solid-query": "^5.102.3",
+    "@tanstack/solid-query": "catalog:",
     "@router-solid-mono-simple-lazy/router": "workspace:*",
     "solid-js": "^1.9.10"
   },

--- a/examples/solid/router-monorepo-simple-lazy/packages/post-feature/package.json
+++ b/examples/solid/router-monorepo-simple-lazy/packages/post-feature/package.json
@@ -16,7 +16,7 @@
     }
   },
   "dependencies": {
-    "@tanstack/solid-query": "^5.90.9",
+    "@tanstack/solid-query": "^5.102.3",
     "@router-solid-mono-simple-lazy/router": "workspace:*",
     "solid-js": "^1.9.10"
   },

--- a/examples/solid/router-monorepo-solid-query/package.json
+++ b/examples/solid/router-monorepo-solid-query/package.json
@@ -10,8 +10,8 @@
     "dev": "pnpm post-query build && pnpm router build && pnpm post-feature build && pnpm app dev"
   },
   "dependencies": {
-    "@tanstack/solid-query": "^5.90.9",
-    "@tanstack/solid-query-devtools": "^5.90.0",
+    "@tanstack/solid-query": "^5.102.3",
+    "@tanstack/solid-query-devtools": "^5.102.3",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/solid-router-devtools": "^1.167.1",
     "@tanstack/router-plugin": "^1.168.35",

--- a/examples/solid/router-monorepo-solid-query/package.json
+++ b/examples/solid/router-monorepo-solid-query/package.json
@@ -10,7 +10,7 @@
     "dev": "pnpm post-query build && pnpm router build && pnpm post-feature build && pnpm app dev"
   },
   "dependencies": {
-    "@tanstack/solid-query": "^5.102.3",
+    "@tanstack/solid-query": "catalog:",
     "@tanstack/solid-query-devtools": "^5.102.3",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/solid-router-devtools": "^1.167.1",

--- a/examples/solid/router-monorepo-solid-query/packages/app/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/app/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@tanstack/solid-query": "^5.102.3",
+    "@tanstack/solid-query": "catalog:",
     "@router-solid-mono-solid-query/post-feature": "workspace:*",
     "@router-solid-mono-solid-query/router": "workspace:*",
     "solid-js": "^1.9.10"

--- a/examples/solid/router-monorepo-solid-query/packages/app/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/app/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@tanstack/solid-query": "^5.90.9",
+    "@tanstack/solid-query": "^5.102.3",
     "@router-solid-mono-solid-query/post-feature": "workspace:*",
     "@router-solid-mono-solid-query/router": "workspace:*",
     "solid-js": "^1.9.10"

--- a/examples/solid/router-monorepo-solid-query/packages/post-feature/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/post-feature/package.json
@@ -8,7 +8,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@tanstack/solid-query": "^5.102.3",
+    "@tanstack/solid-query": "catalog:",
     "@router-solid-mono-solid-query/post-query": "workspace:*",
     "@router-solid-mono-solid-query/router": "workspace:*",
     "solid-js": "^1.9.10"

--- a/examples/solid/router-monorepo-solid-query/packages/post-feature/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/post-feature/package.json
@@ -8,7 +8,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@tanstack/solid-query": "^5.90.9",
+    "@tanstack/solid-query": "^5.102.3",
     "@router-solid-mono-solid-query/post-query": "workspace:*",
     "@router-solid-mono-solid-query/router": "workspace:*",
     "solid-js": "^1.9.10"

--- a/examples/solid/router-monorepo-solid-query/packages/post-query/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/post-query/package.json
@@ -8,7 +8,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@tanstack/solid-query": "^5.90.9",
+    "@tanstack/solid-query": "^5.102.3",
     "redaxios": "^0.5.1",
     "zod": "^4.4.3"
   },

--- a/examples/solid/router-monorepo-solid-query/packages/post-query/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/post-query/package.json
@@ -8,7 +8,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@tanstack/solid-query": "^5.102.3",
+    "@tanstack/solid-query": "catalog:",
     "redaxios": "^0.5.1",
     "zod": "^4.4.3"
   },

--- a/examples/solid/router-monorepo-solid-query/packages/router/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/router/package.json
@@ -9,7 +9,7 @@
   "types": "./dist/index.d.ts",
   "dependencies": {
     "@tanstack/history": "^1.162.1",
-    "@tanstack/solid-query": "^5.102.3",
+    "@tanstack/solid-query": "catalog:",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/router-plugin": "^1.168.35",
     "@router-solid-mono-solid-query/post-query": "workspace:*",

--- a/examples/solid/router-monorepo-solid-query/packages/router/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/router/package.json
@@ -9,7 +9,7 @@
   "types": "./dist/index.d.ts",
   "dependencies": {
     "@tanstack/history": "^1.162.1",
-    "@tanstack/solid-query": "^5.90.9",
+    "@tanstack/solid-query": "^5.102.3",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/router-plugin": "^1.168.35",
     "@router-solid-mono-solid-query/post-query": "workspace:*",

--- a/examples/solid/router-monorepo-solid-query/packages/router/src/routes/$postId.ts
+++ b/examples/solid/router-monorepo-solid-query/packages/router/src/routes/$postId.ts
@@ -3,6 +3,9 @@ import { postQueryOptions } from '@router-solid-mono-solid-query/post-query'
 
 export const Route = createFileRoute('/$postId')({
   loader: ({ context: { queryClient }, params: { postId } }) => {
-    return queryClient.ensureQueryData(postQueryOptions(postId))
+    return queryClient.query({
+      ...postQueryOptions(postId),
+      staleTime: 'static',
+    })
   },
 })

--- a/examples/solid/router-monorepo-solid-query/packages/router/src/routes/index.ts
+++ b/examples/solid/router-monorepo-solid-query/packages/router/src/routes/index.ts
@@ -3,6 +3,6 @@ import { postsQueryOptions } from '@router-solid-mono-solid-query/post-query'
 
 export const Route = createFileRoute('/')({
   loader: ({ context: { queryClient } }) => {
-    return queryClient.ensureQueryData(postsQueryOptions)
+    return queryClient.query({ ...postsQueryOptions, staleTime: 'static' })
   },
 })

--- a/examples/solid/search-validator-adapters/package.json
+++ b/examples/solid/search-validator-adapters/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/arktype-adapter": "^1.167.0",
-    "@tanstack/solid-query": "^5.102.3",
+    "@tanstack/solid-query": "catalog:",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/solid-router-devtools": "^1.167.1",
     "@tanstack/router-plugin": "^1.168.35",

--- a/examples/solid/search-validator-adapters/package.json
+++ b/examples/solid/search-validator-adapters/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/arktype-adapter": "^1.167.0",
-    "@tanstack/solid-query": "^5.90.9",
+    "@tanstack/solid-query": "^5.102.3",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/solid-router-devtools": "^1.167.1",
     "@tanstack/router-plugin": "^1.168.35",

--- a/examples/solid/search-validator-adapters/src/routes/users/arktype.index.tsx
+++ b/examples/solid/search-validator-adapters/src/routes/users/arktype.index.tsx
@@ -1,6 +1,7 @@
 import { useNavigate, createFileRoute } from '@tanstack/solid-router'
 import { type } from 'arktype'
 import { Suspense } from 'solid-js'
+import { noop } from '@tanstack/solid-query'
 import { Header } from '../../components/Header'
 import { Users, usersQueryOptions } from '../../components/Users'
 import { Content } from '../../components/Content'
@@ -34,10 +35,9 @@ export const Route = createFileRoute('/users/arktype/')({
   validateSearch: search,
   loaderDeps: (opt) => ({ search: opt.search }),
   loader: (opt) => {
-    opt.context.queryClient.query({
-      ...usersQueryOptions(opt.deps.search.search),
-      staleTime: 'static',
-    })
+    void opt.context.queryClient
+      .query(usersQueryOptions(opt.deps.search.search))
+      .catch(noop)
   },
   component: ArkType,
 })

--- a/examples/solid/search-validator-adapters/src/routes/users/arktype.index.tsx
+++ b/examples/solid/search-validator-adapters/src/routes/users/arktype.index.tsx
@@ -34,9 +34,10 @@ export const Route = createFileRoute('/users/arktype/')({
   validateSearch: search,
   loaderDeps: (opt) => ({ search: opt.search }),
   loader: (opt) => {
-    opt.context.queryClient.ensureQueryData(
-      usersQueryOptions(opt.deps.search.search),
-    )
+    opt.context.queryClient.query({
+      ...usersQueryOptions(opt.deps.search.search),
+      staleTime: 'static',
+    })
   },
   component: ArkType,
 })

--- a/examples/solid/search-validator-adapters/src/routes/users/valibot.index.tsx
+++ b/examples/solid/search-validator-adapters/src/routes/users/valibot.index.tsx
@@ -1,6 +1,7 @@
 import { useNavigate, createFileRoute } from '@tanstack/solid-router'
 import * as v from 'valibot'
 import { Suspense } from 'solid-js'
+import { noop } from '@tanstack/solid-query'
 import { Header } from '../../components/Header'
 import { Users, usersQueryOptions } from '../../components/Users'
 import { Content } from '../../components/Content'
@@ -32,10 +33,9 @@ export const Route = createFileRoute('/users/valibot/')({
   }),
   loaderDeps: (opt) => ({ search: opt.search }),
   loader: (opt) => {
-    opt.context.queryClient.query({
-      ...usersQueryOptions(opt.deps.search.search),
-      staleTime: 'static',
-    })
+    void opt.context.queryClient
+      .query(usersQueryOptions(opt.deps.search.search))
+      .catch(noop)
   },
   component: Valibot,
 })

--- a/examples/solid/search-validator-adapters/src/routes/users/valibot.index.tsx
+++ b/examples/solid/search-validator-adapters/src/routes/users/valibot.index.tsx
@@ -32,9 +32,10 @@ export const Route = createFileRoute('/users/valibot/')({
   }),
   loaderDeps: (opt) => ({ search: opt.search }),
   loader: (opt) => {
-    opt.context.queryClient.ensureQueryData(
-      usersQueryOptions(opt.deps.search.search),
-    )
+    opt.context.queryClient.query({
+      ...usersQueryOptions(opt.deps.search.search),
+      staleTime: 'static',
+    })
   },
   component: Valibot,
 })

--- a/examples/solid/search-validator-adapters/src/routes/users/zod.index.tsx
+++ b/examples/solid/search-validator-adapters/src/routes/users/zod.index.tsx
@@ -42,9 +42,10 @@ export const Route = createFileRoute('/users/zod/')({
   ),
   loaderDeps: (opt) => ({ search: opt.search }),
   loader: (opt) => {
-    opt.context.queryClient.ensureQueryData(
-      usersQueryOptions(opt.deps.search.search ?? ''),
-    )
+    opt.context.queryClient.query({
+      ...usersQueryOptions(opt.deps.search.search ?? ''),
+      staleTime: 'static',
+    })
   },
   component: Zod,
 })

--- a/examples/solid/search-validator-adapters/src/routes/users/zod.index.tsx
+++ b/examples/solid/search-validator-adapters/src/routes/users/zod.index.tsx
@@ -2,6 +2,7 @@ import { useNavigate, createFileRoute } from '@tanstack/solid-router'
 import { fallback, zodValidator } from '@tanstack/zod-adapter'
 import { z } from 'zod'
 import { Suspense } from 'solid-js'
+import { noop } from '@tanstack/solid-query'
 import { Header } from '../../components/Header'
 import { Users, usersQueryOptions } from '../../components/Users'
 import { Content } from '../../components/Content'
@@ -42,10 +43,9 @@ export const Route = createFileRoute('/users/zod/')({
   ),
   loaderDeps: (opt) => ({ search: opt.search }),
   loader: (opt) => {
-    opt.context.queryClient.query({
-      ...usersQueryOptions(opt.deps.search.search ?? ''),
-      staleTime: 'static',
-    })
+    void opt.context.queryClient
+      .query(usersQueryOptions(opt.deps.search.search ?? ''))
+      .catch(noop)
   },
   component: Zod,
 })

--- a/examples/solid/start-basic-solid-query/package.json
+++ b/examples/solid/start-basic-solid-query/package.json
@@ -10,7 +10,7 @@
     "start": "pnpx srvx --prod -s ../client dist/server/server.js"
   },
   "dependencies": {
-    "@tanstack/solid-query": "^5.102.3",
+    "@tanstack/solid-query": "catalog:",
     "@tanstack/solid-query-devtools": "^5.102.3",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/solid-router-devtools": "^1.167.1",

--- a/examples/solid/start-basic-solid-query/package.json
+++ b/examples/solid/start-basic-solid-query/package.json
@@ -10,8 +10,8 @@
     "start": "pnpx srvx --prod -s ../client dist/server/server.js"
   },
   "dependencies": {
-    "@tanstack/solid-query": "^5.90.9",
-    "@tanstack/solid-query-devtools": "^5.90.0",
+    "@tanstack/solid-query": "^5.102.3",
+    "@tanstack/solid-query-devtools": "^5.102.3",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/solid-router-devtools": "^1.167.1",
     "@tanstack/solid-router-ssr-query": "^1.167.1",

--- a/examples/solid/start-basic-solid-query/src/routes/deferred.tsx
+++ b/examples/solid/start-basic-solid-query/src/routes/deferred.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/solid-router'
-import { queryOptions, useQuery } from '@tanstack/solid-query'
+import { noop, queryOptions, useQuery } from '@tanstack/solid-query'
 import { Suspense, createSignal } from 'solid-js'
 
 const deferredQueryOptions = () =>
@@ -18,7 +18,7 @@ const deferredQueryOptions = () =>
 export const Route = createFileRoute('/deferred')({
   loader: ({ context }) => {
     // Kick off loading as early as possible!
-    context.queryClient.prefetchQuery(deferredQueryOptions())
+    void context.queryClient.query(deferredQueryOptions()).catch(noop)
   },
   component: Deferred,
 })

--- a/examples/solid/start-basic-solid-query/src/routes/posts.$postId.tsx
+++ b/examples/solid/start-basic-solid-query/src/routes/posts.$postId.tsx
@@ -10,9 +10,10 @@ export function PostErrorComponent({ error }: ErrorComponentProps) {
 
 export const Route = createFileRoute('/posts/$postId')({
   loader: async ({ params: { postId }, context }) => {
-    const data = await context.queryClient.ensureQueryData(
-      postQueryOptions(postId),
-    )
+    const data = await context.queryClient.query({
+      ...postQueryOptions(postId),
+      staleTime: 'static',
+    })
 
     return {
       title: data.title,

--- a/examples/solid/start-basic-solid-query/src/routes/posts.route.tsx
+++ b/examples/solid/start-basic-solid-query/src/routes/posts.route.tsx
@@ -4,7 +4,10 @@ import { postsQueryOptions } from '../utils/posts'
 
 export const Route = createFileRoute('/posts')({
   loader: async ({ context }) => {
-    await context.queryClient.ensureQueryData(postsQueryOptions())
+    await context.queryClient.query({
+      ...postsQueryOptions(),
+      staleTime: 'static',
+    })
   },
   head: () => ({
     meta: [{ title: 'Posts' }],

--- a/examples/solid/start-basic-solid-query/src/routes/posts_.$postId.deep.tsx
+++ b/examples/solid/start-basic-solid-query/src/routes/posts_.$postId.deep.tsx
@@ -5,9 +5,10 @@ import { PostErrorComponent } from './posts.$postId'
 
 export const Route = createFileRoute('/posts_/$postId/deep')({
   loader: async ({ params: { postId }, context }) => {
-    const data = await context.queryClient.ensureQueryData(
-      postQueryOptions(postId),
-    )
+    const data = await context.queryClient.query({
+      ...postQueryOptions(postId),
+      staleTime: 'static',
+    })
 
     return {
       title: data.title,

--- a/examples/solid/start-basic-solid-query/src/routes/users.$userId.tsx
+++ b/examples/solid/start-basic-solid-query/src/routes/users.$userId.tsx
@@ -10,7 +10,10 @@ export function UserErrorComponent({ error }: ErrorComponentProps) {
 
 export const Route = createFileRoute('/users/$userId')({
   loader: async ({ context, params: { userId } }) => {
-    await context.queryClient.ensureQueryData(userQueryOptions(userId))
+    await context.queryClient.query({
+      ...userQueryOptions(userId),
+      staleTime: 'static',
+    })
   },
   errorComponent: UserErrorComponent,
   component: UserComponent,

--- a/examples/solid/start-basic-solid-query/src/routes/users.route.tsx
+++ b/examples/solid/start-basic-solid-query/src/routes/users.route.tsx
@@ -4,7 +4,10 @@ import { usersQueryOptions } from '../utils/users'
 
 export const Route = createFileRoute('/users')({
   loader: async ({ context }) => {
-    await context.queryClient.ensureQueryData(usersQueryOptions())
+    await context.queryClient.query({
+      ...usersQueryOptions(),
+      staleTime: 'static',
+    })
   },
   component: UsersComponent,
 })

--- a/examples/solid/start-large/package.json
+++ b/examples/solid/start-large/package.json
@@ -12,7 +12,7 @@
     "test:types": "tsc --extendedDiagnostics"
   },
   "dependencies": {
-    "@tanstack/solid-query": "^5.102.3",
+    "@tanstack/solid-query": "catalog:",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/solid-router-devtools": "^1.167.1",
     "@tanstack/solid-start": "^1.168.47",

--- a/examples/solid/start-large/package.json
+++ b/examples/solid/start-large/package.json
@@ -12,7 +12,7 @@
     "test:types": "tsc --extendedDiagnostics"
   },
   "dependencies": {
-    "@tanstack/solid-query": "^5.90.9",
+    "@tanstack/solid-query": "^5.102.3",
     "@tanstack/solid-router": "^1.170.30",
     "@tanstack/solid-router-devtools": "^1.167.1",
     "@tanstack/solid-start": "^1.168.47",

--- a/examples/solid/start-large/src/routes/params/$paramsPlaceholder.tsx
+++ b/examples/solid/start-large/src/routes/params/$paramsPlaceholder.tsx
@@ -59,7 +59,10 @@ export const Route = createFileRoute('/params/$paramsPlaceholder')({
     }),
   }),
   loader: (opts) =>
-    opts.context.queryClient.ensureQueryData(paramsQueryOptions),
+    opts.context.queryClient.query({
+      ...paramsQueryOptions,
+      staleTime: 'static',
+    }),
 })
 
 function ParamsComponent() {

--- a/examples/solid/start-large/src/routes/search/searchPlaceholder.tsx
+++ b/examples/solid/start-large/src/routes/search/searchPlaceholder.tsx
@@ -58,9 +58,10 @@ export const Route = createFileRoute('/search/searchPlaceholder')({
     }),
   }),
   loader: async (opts) => {
-    const search = await opts.context.queryClient.ensureQueryData(
-      opts.context.searchQueryOptions,
-    )
+    const search = await opts.context.queryClient.query({
+      ...opts.context.searchQueryOptions,
+      staleTime: 'static',
+    })
 
     return {
       search,

--- a/packages/react-router/skills/compositions/router-query/SKILL.md
+++ b/packages/react-router/skills/compositions/router-query/SKILL.md
@@ -2,7 +2,7 @@
 name: router-query
 description: >-
   Integrating TanStack Router with TanStack Query: queryClient
-  in router context, ensureQueryData/prefetchQuery in loaders,
+  in router context, static queries and fire-and-forget queries in loaders,
   useSuspenseQuery in components, defaultPreloadStaleTime: 0,
   setupRouterSsrQueryIntegration for SSR dehydration/hydration
   and streaming, per-request QueryClient isolation.
@@ -182,9 +182,9 @@ export function createAppRouter() {
 }
 ```
 
-## Core Pattern: `ensureQueryData` in Loader + `useSuspenseQuery` in Component
+## Core Pattern: Static `query` in Loader + `useSuspenseQuery` in Component
 
-This is the recommended pattern. The loader ensures data is in the cache before render (no loading flash). The component subscribes to the cache for updates.
+This is the recommended pattern. The loader queries data before render (no loading flash), using `staleTime: 'static'` to reuse cached data without a stale refetch. The component subscribes to the cache for updates.
 
 ```tsx
 // src/routes/posts.tsx
@@ -204,9 +204,12 @@ const postsQueryOptions = queryOptions({
 
 export const Route = createFileRoute('/posts')({
   loader: ({ context }) => {
-    // ensureQueryData returns cached data if available, fetches if not in cache
-    // To also refetch stale data, pass revalidateIfStale: true
-    return context.queryClient.ensureQueryData(postsQueryOptions)
+    // query returns cached data when available and fetches when it is missing
+    // Keep this query static so a stale refetch does not block navigation
+    return context.queryClient.query({
+      ...postsQueryOptions,
+      staleTime: 'static',
+    })
   },
   component: PostsPage,
 })
@@ -246,7 +249,10 @@ const postQueryOptions = (postId: string) =>
 
 export const Route = createFileRoute('/posts/$postId')({
   loader: ({ context, params }) => {
-    return context.queryClient.ensureQueryData(postQueryOptions(params.postId))
+    return context.queryClient.query({
+      ...postQueryOptions(params.postId),
+      staleTime: 'static',
+    })
   },
   component: PostPage,
 })
@@ -259,20 +265,23 @@ function PostPage() {
 }
 ```
 
-## Streaming Pattern: `prefetchQuery` (Not Awaited)
+## Streaming Pattern: Fire-and-Forget `query` (Not Awaited)
 
-For non-critical data, start the fetch without blocking navigation:
+For non-critical data, start a query without blocking navigation. Handle its rejection with `noop` so a background failure does not become an unhandled rejection:
 
 ```tsx
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
+import { noop, useQuery, useSuspenseQuery } from '@tanstack/react-query'
 
 export const Route = createFileRoute('/dashboard')({
   loader: ({ context }) => {
     // Await critical data
-    const user = context.queryClient.ensureQueryData(userQueryOptions)
+    const user = context.queryClient.query({
+      ...userQueryOptions,
+      staleTime: 'static',
+    })
 
-    // Start non-critical fetch without awaiting — streams during SSR
-    context.queryClient.prefetchQuery(analyticsQueryOptions)
+    // Start non-critical query without awaiting — streams during SSR
+    void context.queryClient.query({ ...analyticsQueryOptions }).catch(noop)
 
     return user
   },
@@ -304,7 +313,10 @@ import { useRouter } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/posts')({
   loader: ({ context }) =>
-    context.queryClient.ensureQueryData(postsQueryOptions),
+    context.queryClient.query({
+      ...postsQueryOptions,
+      staleTime: 'static',
+    }),
   errorComponent: PostsErrorComponent,
   component: PostsPage,
 })
@@ -373,24 +385,29 @@ export function createAppRouter() {
 }
 ```
 
-### 3. MEDIUM: Awaiting `prefetchQuery` in loader blocks rendering
+### 3. MEDIUM: Awaiting a fire-and-forget query in a loader blocks rendering
 
-`prefetchQuery` is designed to fire-and-forget. Awaiting it blocks the navigation transition until the data resolves, defeating the purpose of streaming.
+A query used for streaming should start in the background and handle errors with `catch(noop)`. Awaiting it blocks the navigation transition until the data resolves, defeating the purpose of streaming.
 
 ```tsx
+import { noop } from '@tanstack/react-query'
+
 // WRONG — blocks navigation, no streaming benefit
 loader: async ({ context }) => {
-  await context.queryClient.prefetchQuery(analyticsQueryOptions)
+  await context.queryClient.query({ ...analyticsQueryOptions }).catch(noop)
 }
 
-// CORRECT — fire and forget for streaming
+// CORRECT — fire and forget for streaming, with handled rejection
 loader: ({ context }) => {
-  context.queryClient.prefetchQuery(analyticsQueryOptions)
+  void context.queryClient.query({ ...analyticsQueryOptions }).catch(noop)
 }
 
-// If you need to block (critical data), use ensureQueryData instead:
+// If you need to block (critical data), use a static query instead:
 loader: ({ context }) => {
-  return context.queryClient.ensureQueryData(criticalQueryOptions)
+  return context.queryClient.query({
+    ...criticalQueryOptions,
+    staleTime: 'static',
+  })
 }
 ```
 
@@ -415,8 +432,8 @@ const rootRoute = createRootRouteWithContext<{ queryClient: QueryClient }>()({
 TanStack Router has its own SWR cache (`staleTime`, `gcTime`, `defaultPreloadStaleTime`). When using Query as an external cache:
 
 - Set `defaultPreloadStaleTime: 0` to prevent Router's cache from short-circuiting Query's freshness logic
-- Router's `staleTime`/`gcTime` still apply to the loader return value. For pure Query patterns, return nothing from the loader (just `ensureQueryData` for the side effect) and read data exclusively from `useSuspenseQuery`
-- `router.invalidate()` re-runs loaders (which call `ensureQueryData`), but Query decides whether to actually refetch based on its own `staleTime`
+- Router's `staleTime`/`gcTime` still apply to the loader return value. For pure Query patterns, return nothing from the loader (just a static `query` for the side effect) and read data exclusively from `useSuspenseQuery`
+- `router.invalidate()` re-runs loaders (which call `query` with `staleTime: 'static'`), so the cached Query data remains the freshness authority
 
 ## Cross-References
 

--- a/packages/react-start/skills/react-start/server-components/SKILL.md
+++ b/packages/react-start/skills/react-start/server-components/SKILL.md
@@ -74,10 +74,10 @@ Treat TanStack Start RSCs as fetchable React Flight payloads, not as a framework
 
 - Simple server fragment in a route loader -> `renderServerComponent`
 - Interactive slot inside server markup -> `createCompositeComponent`
-- Route component needs browser APIs but loader can still prefetch on the server -> `ssr: 'data-only'`
+- Route component needs browser APIs but loader can still query on the server -> `ssr: 'data-only'`
 - Loader itself needs browser APIs -> `ssr: false`
 - Route cache key must include search params -> `loaderDeps`
-- Query-managed RSC -> `useSuspenseQuery` + SSR `ensureQueryData`
+- Query-managed RSC -> `useSuspenseQuery` + SSR `query` with `staleTime: 'static'`
 - Multiple independent RSCs -> separate server functions + `Promise.all`
 - Multiple RSCs sharing data or invalidating together -> one server function returning many renderables or sources
 - Need isolated widget failures or staggered reveal -> return promises from the loader and resolve with `use()` inside Suspense

--- a/packages/react-start/skills/react-start/server-components/docs/caching-refresh-ssr.md
+++ b/packages/react-start/skills/react-start/server-components/docs/caching-refresh-ssr.md
@@ -73,10 +73,13 @@ const postQueryOptions = (postId: string) => ({
 })
 ```
 
-For SSR reuse, prefetch in the route loader:
+For SSR reuse, run a static query in the route loader so cached data is reused without a stale refetch:
 
 ```tsx
-await context.queryClient.ensureQueryData(postQueryOptions(params.postId))
+await context.queryClient.query({
+  ...postQueryOptions(params.postId),
+  staleTime: 'static',
+})
 ```
 
 Then read it with `useSuspenseQuery` in the component.

--- a/packages/react-start/skills/react-start/server-components/examples/03-query-owned-rsc.tsx
+++ b/packages/react-start/skills/react-start/server-components/examples/03-query-owned-rsc.tsx
@@ -1,5 +1,5 @@
 // Query-owned RSC pattern.
-// Assumes your router context provides a queryClient for SSR prefetch.
+// Assumes your router context provides a queryClient for SSR queries.
 
 import type { ReactNode } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
@@ -68,7 +68,10 @@ const postQueryOptions = (postId: string) => ({
 
 export const Route = createFileRoute('/posts/$postId')({
   loader: async ({ context, params }) => {
-    await context.queryClient.ensureQueryData(postQueryOptions(params.postId))
+    await context.queryClient.query({
+      ...postQueryOptions(params.postId),
+      staleTime: 'static',
+    })
   },
   component: PostPage,
 })

--- a/packages/router-core/skills/router-core/type-safety/SKILL.md
+++ b/packages/router-core/skills/router-core/type-safety/SKILL.md
@@ -230,17 +230,17 @@ With file-based routing the route tree is generated, so this is handled for you.
 When using external caches like TanStack Query, don't let the router infer complex return types you never consume:
 
 ```tsx
-// SLOWER — TS infers the full ensureQueryData return type into the route tree
+// SLOWER — TS infers the full query return type into the route tree
 export const Route = createFileRoute('/posts/$postId')({
   loader: ({ context: { queryClient }, params: { postId } }) =>
-    queryClient.ensureQueryData(postQueryOptions(postId)),
+    queryClient.query({ ...postQueryOptions(postId), staleTime: 'static' }),
   component: PostComponent,
 })
 
-// FASTER — void return, inference stays out of the route tree
+// FASTER — async loader returns no query data, inference stays out of the route tree
 export const Route = createFileRoute('/posts/$postId')({
-  loader: async ({ context: { queryClient }, params: { postId } }) => {
-    await queryClient.ensureQueryData(postQueryOptions(postId))
+  loader: async ({ context: { queryClient }, params: { postId: id } }) => {
+    await queryClient.query({ ...postQueryOptions(id), staleTime: 'static' })
   },
   component: PostComponent,
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,10 +49,10 @@ overrides:
   vite: ^8.0.14
   '@types/node': 25.0.9
   '@playwright/test': ^1.61.0
-  '@tanstack/query-core': ^5.99.0
-  '@tanstack/react-query': ^5.99.0
-  '@tanstack/solid-query': ^5.99.0
-  '@tanstack/vue-query': ^5.99.0
+  '@tanstack/query-core': ^5.102.3
+  '@tanstack/react-query': ^5.102.3
+  '@tanstack/solid-query': ^5.102.3
+  '@tanstack/vue-query': ^5.102.3
   '@tanstack/history': workspace:*
   '@tanstack/router-core': workspace:*
   '@tanstack/react-router': workspace:*
@@ -795,11 +795,11 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-query-devtools':
         specifier: ^5.90.0
-        version: 5.90.2(@tanstack/react-query@5.99.0(react@19.2.3))(react@19.2.3)
+        version: 5.90.2(@tanstack/react-query@5.102.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -844,11 +844,11 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-query-devtools':
         specifier: ^5.90.0
-        version: 5.90.2(@tanstack/react-query@5.99.0(react@19.2.3))(react@19.2.3)
+        version: 5.90.2(@tanstack/react-query@5.102.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -1246,8 +1246,8 @@ importers:
   e2e/react-router/issue-7457:
     dependencies:
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -1885,11 +1885,11 @@ importers:
   e2e/react-start/basic-react-query:
     dependencies:
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-query-devtools':
         specifier: ^5.90.0
-        version: 5.90.2(@tanstack/react-query@5.99.0(react@19.2.3))(react@19.2.3)
+        version: 5.90.2(@tanstack/react-query@5.102.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -2802,11 +2802,11 @@ importers:
   e2e/react-start/query-integration:
     dependencies:
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-query-devtools':
         specifier: ^5.90.0
-        version: 5.90.2(@tanstack/react-query@5.99.0(react@19.2.3))(react@19.2.3)
+        version: 5.90.2(@tanstack/react-query@5.102.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -3071,11 +3071,11 @@ importers:
   e2e/react-start/rsc-query:
     dependencies:
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-query-devtools':
         specifier: ^5.90.0
-        version: 5.90.2(@tanstack/react-query@5.99.0(react@19.2.3))(react@19.2.3)
+        version: 5.90.2(@tanstack/react-query@5.102.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -3349,8 +3349,8 @@ importers:
   e2e/react-start/server-functions:
     dependencies:
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -3489,8 +3489,8 @@ importers:
   e2e/react-start/server-routes:
     dependencies:
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -3810,8 +3810,8 @@ importers:
   e2e/react-start/streaming-ssr:
     dependencies:
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -4264,11 +4264,11 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/solid-query':
-        specifier: ^5.99.0
-        version: 5.99.0(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(solid-js@1.9.12)
       '@tanstack/solid-query-devtools':
         specifier: ^5.90.0
-        version: 5.90.4(@tanstack/solid-query@5.99.0(solid-js@1.9.12))(solid-js@1.9.12)
+        version: 5.90.4(@tanstack/solid-query@5.102.3(solid-js@1.9.12))(solid-js@1.9.12)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4307,11 +4307,11 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/router-plugin
       '@tanstack/solid-query':
-        specifier: ^5.99.0
-        version: 5.99.0(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(solid-js@1.9.12)
       '@tanstack/solid-query-devtools':
         specifier: ^5.90.0
-        version: 5.90.4(@tanstack/solid-query@5.99.0(solid-js@1.9.12))(solid-js@1.9.12)
+        version: 5.90.4(@tanstack/solid-query@5.102.3(solid-js@1.9.12))(solid-js@1.9.12)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4935,11 +4935,11 @@ importers:
   e2e/solid-start/basic-solid-query:
     dependencies:
       '@tanstack/solid-query':
-        specifier: ^5.99.0
-        version: 5.99.0(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(solid-js@1.9.12)
       '@tanstack/solid-query-devtools':
         specifier: ^5.90.0
-        version: 5.90.4(@tanstack/solid-query@5.99.0(solid-js@1.9.12))(solid-js@1.9.12)
+        version: 5.90.4(@tanstack/solid-query@5.102.3(solid-js@1.9.12))(solid-js@1.9.12)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5220,11 +5220,11 @@ importers:
   e2e/solid-start/query-integration:
     dependencies:
       '@tanstack/solid-query':
-        specifier: ^5.99.0
-        version: 5.99.0(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(solid-js@1.9.12)
       '@tanstack/solid-query-devtools':
         specifier: ^5.90.0
-        version: 5.90.4(@tanstack/solid-query@5.99.0(solid-js@1.9.12))(solid-js@1.9.12)
+        version: 5.90.4(@tanstack/solid-query@5.102.3(solid-js@1.9.12))(solid-js@1.9.12)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5422,8 +5422,8 @@ importers:
   e2e/solid-start/server-functions:
     dependencies:
       '@tanstack/solid-query':
-        specifier: ^5.99.0
-        version: 5.99.0(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(solid-js@1.9.12)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5492,8 +5492,8 @@ importers:
   e2e/solid-start/server-routes:
     dependencies:
       '@tanstack/solid-query':
-        specifier: ^5.99.0
-        version: 5.99.0(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(solid-js@1.9.12)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5562,8 +5562,8 @@ importers:
   e2e/solid-start/solid-query-layout-suspense:
     dependencies:
       '@tanstack/solid-query':
-        specifier: ^5.99.0
-        version: 5.99.0(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(solid-js@1.9.12)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5798,11 +5798,11 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/router-plugin
       '@tanstack/vue-query':
-        specifier: ^5.99.0
-        version: 5.99.0(vue@3.5.25(typescript@5.8.3))
+        specifier: ^5.102.3
+        version: 5.102.3(vue@3.5.25(typescript@5.8.3))
       '@tanstack/vue-query-devtools':
         specifier: ^6.1.2
-        version: 6.1.2(@tanstack/vue-query@5.99.0(vue@3.5.25(typescript@5.8.3)))(vue@3.5.25(typescript@5.8.3))
+        version: 6.1.2(@tanstack/vue-query@5.102.3(vue@3.5.25(typescript@5.8.3)))(vue@3.5.25(typescript@5.8.3))
       '@tanstack/vue-router':
         specifier: workspace:*
         version: link:../../../packages/vue-router
@@ -6113,11 +6113,11 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/virtual-file-routes
       '@tanstack/vue-query':
-        specifier: ^5.99.0
-        version: 5.99.0(vue@3.5.25(typescript@5.8.3))
+        specifier: ^5.102.3
+        version: 5.102.3(vue@3.5.25(typescript@5.8.3))
       '@tanstack/vue-query-devtools':
         specifier: ^6.1.2
-        version: 6.1.2(@tanstack/vue-query@5.99.0(vue@3.5.25(typescript@5.8.3)))(vue@3.5.25(typescript@5.8.3))
+        version: 6.1.2(@tanstack/vue-query@5.102.3(vue@3.5.25(typescript@5.8.3)))(vue@3.5.25(typescript@5.8.3))
       '@tanstack/vue-router':
         specifier: workspace:*
         version: link:../../../packages/vue-router
@@ -6168,11 +6168,11 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/virtual-file-routes
       '@tanstack/vue-query':
-        specifier: ^5.99.0
-        version: 5.99.0(vue@3.5.25(typescript@5.8.3))
+        specifier: ^5.102.3
+        version: 5.102.3(vue@3.5.25(typescript@5.8.3))
       '@tanstack/vue-query-devtools':
         specifier: ^6.1.2
-        version: 6.1.2(@tanstack/vue-query@5.99.0(vue@3.5.25(typescript@5.8.3)))(vue@3.5.25(typescript@5.8.3))
+        version: 6.1.2(@tanstack/vue-query@5.102.3(vue@3.5.25(typescript@5.8.3)))(vue@3.5.25(typescript@5.8.3))
       '@tanstack/vue-router':
         specifier: workspace:*
         version: link:../../../packages/vue-router
@@ -6217,11 +6217,11 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/vue-query':
-        specifier: ^5.99.0
-        version: 5.99.0(vue@3.5.25(typescript@5.8.3))
+        specifier: ^5.102.3
+        version: 5.102.3(vue@3.5.25(typescript@5.8.3))
       '@tanstack/vue-query-devtools':
         specifier: ^6.1.2
-        version: 6.1.2(@tanstack/vue-query@5.99.0(vue@3.5.25(typescript@5.8.3)))(vue@3.5.25(typescript@5.8.3))
+        version: 6.1.2(@tanstack/vue-query@5.102.3(vue@3.5.25(typescript@5.8.3)))(vue@3.5.25(typescript@5.8.3))
       '@tanstack/vue-router':
         specifier: workspace:*
         version: link:../../../packages/vue-router
@@ -6269,11 +6269,11 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/router-plugin
       '@tanstack/vue-query':
-        specifier: ^5.99.0
-        version: 5.99.0(vue@3.5.25(typescript@5.8.3))
+        specifier: ^5.102.3
+        version: 5.102.3(vue@3.5.25(typescript@5.8.3))
       '@tanstack/vue-query-devtools':
         specifier: ^6.1.2
-        version: 6.1.2(@tanstack/vue-query@5.99.0(vue@3.5.25(typescript@5.8.3)))(vue@3.5.25(typescript@5.8.3))
+        version: 6.1.2(@tanstack/vue-query@5.102.3(vue@3.5.25(typescript@5.8.3)))(vue@3.5.25(typescript@5.8.3))
       '@tanstack/vue-router':
         specifier: workspace:*
         version: link:../../../packages/vue-router
@@ -6370,11 +6370,11 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/router-plugin
       '@tanstack/vue-query':
-        specifier: ^5.99.0
-        version: 5.99.0(vue@3.5.25(typescript@7.0.2))
+        specifier: ^5.102.3
+        version: 5.102.3(vue@3.5.25(typescript@7.0.2))
       '@tanstack/vue-query-devtools':
         specifier: ^6.1.2
-        version: 6.1.2(@tanstack/vue-query@5.99.0(vue@3.5.25(typescript@7.0.2)))(vue@3.5.25(typescript@7.0.2))
+        version: 6.1.2(@tanstack/vue-query@5.102.3(vue@3.5.25(typescript@7.0.2)))(vue@3.5.25(typescript@7.0.2))
       '@tanstack/vue-router':
         specifier: workspace:*
         version: link:../../../packages/vue-router
@@ -6630,11 +6630,11 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/router-plugin
       '@tanstack/vue-query':
-        specifier: ^5.99.0
-        version: 5.99.0(vue@3.5.25(typescript@5.8.3))
+        specifier: ^5.102.3
+        version: 5.102.3(vue@3.5.25(typescript@5.8.3))
       '@tanstack/vue-query-devtools':
         specifier: ^6.1.2
-        version: 6.1.2(@tanstack/vue-query@5.99.0(vue@3.5.25(typescript@5.8.3)))(vue@3.5.25(typescript@5.8.3))
+        version: 6.1.2(@tanstack/vue-query@5.102.3(vue@3.5.25(typescript@5.8.3)))(vue@3.5.25(typescript@5.8.3))
       '@tanstack/vue-router':
         specifier: workspace:*
         version: link:../../../packages/vue-router
@@ -6929,11 +6929,11 @@ importers:
   e2e/vue-start/basic-vue-query:
     dependencies:
       '@tanstack/vue-query':
-        specifier: ^5.99.0
-        version: 5.99.0(vue@3.5.25(@typescript/typescript6@6.0.2))
+        specifier: ^5.102.3
+        version: 5.102.3(vue@3.5.25(@typescript/typescript6@6.0.2))
       '@tanstack/vue-query-devtools':
         specifier: ^6.1.2
-        version: 6.1.2(@tanstack/vue-query@5.99.0(vue@3.5.25(@typescript/typescript6@6.0.2)))(vue@3.5.25(@typescript/typescript6@6.0.2))
+        version: 6.1.2(@tanstack/vue-query@5.102.3(vue@3.5.25(@typescript/typescript6@6.0.2)))(vue@3.5.25(@typescript/typescript6@6.0.2))
       '@tanstack/vue-router':
         specifier: workspace:*
         version: link:../../../packages/vue-router
@@ -7100,11 +7100,11 @@ importers:
   e2e/vue-start/query-integration:
     dependencies:
       '@tanstack/vue-query':
-        specifier: ^5.99.0
-        version: 5.99.0(vue@3.5.25(@typescript/typescript6@6.0.2))
+        specifier: ^5.102.3
+        version: 5.102.3(vue@3.5.25(@typescript/typescript6@6.0.2))
       '@tanstack/vue-query-devtools':
         specifier: ^5.90.0
-        version: 5.91.0(@tanstack/vue-query@5.99.0(vue@3.5.25(@typescript/typescript6@6.0.2)))(vue@3.5.25(@typescript/typescript6@6.0.2))
+        version: 5.91.0(@tanstack/vue-query@5.102.3(vue@3.5.25(@typescript/typescript6@6.0.2)))(vue@3.5.25(@typescript/typescript6@6.0.2))
       '@tanstack/vue-router':
         specifier: workspace:*
         version: link:../../../packages/vue-router
@@ -7317,8 +7317,8 @@ importers:
   e2e/vue-start/server-functions:
     dependencies:
       '@tanstack/vue-query':
-        specifier: ^5.99.0
-        version: 5.99.0(vue@3.5.25(@typescript/typescript6@6.0.2))
+        specifier: ^5.102.3
+        version: 5.102.3(vue@3.5.25(@typescript/typescript6@6.0.2))
       '@tanstack/vue-router':
         specifier: workspace:*
         version: link:../../../packages/vue-router
@@ -7390,8 +7390,8 @@ importers:
   e2e/vue-start/server-routes:
     dependencies:
       '@tanstack/vue-query':
-        specifier: ^5.99.0
-        version: 5.99.0(vue@3.5.25(@typescript/typescript6@6.0.2))
+        specifier: ^5.102.3
+        version: 5.102.3(vue@3.5.25(@typescript/typescript6@6.0.2))
       '@tanstack/vue-router':
         specifier: workspace:*
         version: link:../../../packages/vue-router
@@ -7815,8 +7815,8 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -7864,11 +7864,11 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-query-devtools':
-        specifier: ^5.67.2
-        version: 5.67.2(@tanstack/react-query@5.99.0(react@19.2.3))(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(@tanstack/react-query@5.102.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -8005,11 +8005,11 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-query-devtools':
-        specifier: ^5.90.0
-        version: 5.90.2(@tanstack/react-query@5.99.0(react@19.2.3))(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(@tanstack/react-query@5.102.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -8054,11 +8054,11 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-query-devtools':
-        specifier: ^5.90.0
-        version: 5.90.2(@tanstack/react-query@5.99.0(react@19.2.3))(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(@tanstack/react-query@5.102.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -8510,11 +8510,11 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-query-devtools':
-        specifier: ^5.90.0
-        version: 5.90.2(@tanstack/react-query@5.99.0(react@19.2.3))(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(@tanstack/react-query@5.102.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -8565,11 +8565,11 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-query-devtools':
-        specifier: ^5.90.0
-        version: 5.90.2(@tanstack/react-query@5.99.0(react@19.2.3))(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(@tanstack/react-query@5.102.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -8623,8 +8623,8 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -8678,8 +8678,8 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -8724,8 +8724,8 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -8988,11 +8988,11 @@ importers:
   examples/react/router-monorepo-react-query:
     dependencies:
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-query-devtools':
-        specifier: ^5.90.0
-        version: 5.90.2(@tanstack/react-query@5.99.0(react@19.2.3))(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(@tanstack/react-query@5.102.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -9046,8 +9046,8 @@ importers:
         specifier: workspace:*
         version: link:../router
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -9095,8 +9095,8 @@ importers:
         specifier: workspace:*
         version: link:../router
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -9129,8 +9129,8 @@ importers:
   examples/react/router-monorepo-react-query/packages/post-query:
     dependencies:
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       redaxios:
         specifier: 'catalog:'
         version: 0.5.1
@@ -9160,8 +9160,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../../packages/history
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../../../packages/react-router
@@ -9347,8 +9347,8 @@ importers:
         specifier: workspace:*
         version: link:../router
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -9602,8 +9602,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/arktype-adapter
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -9944,11 +9944,11 @@ importers:
   examples/react/start-basic-react-query:
     dependencies:
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-query-devtools':
-        specifier: ^5.90.0
-        version: 5.90.2(@tanstack/react-query@5.99.0(react@19.2.3))(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(@tanstack/react-query@5.102.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -10253,13 +10253,13 @@ importers:
     dependencies:
       '@convex-dev/react-query':
         specifier: 0.0.0-alpha.8
-        version: 0.0.0-alpha.8(@tanstack/react-query@5.99.0(react@19.2.3))(convex@1.19.0(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: 0.0.0-alpha.8(@tanstack/react-query@5.102.3(react@19.2.3))(convex@1.19.0(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-query-devtools':
-        specifier: ^5.90.0
-        version: 5.90.2(@tanstack/react-query@5.99.0(react@19.2.3))(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(@tanstack/react-query@5.102.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -10426,8 +10426,8 @@ importers:
   examples/react/start-large:
     dependencies:
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -10750,11 +10750,11 @@ importers:
   examples/react/start-trellaux:
     dependencies:
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-query-devtools':
-        specifier: ^5.90.0
-        version: 5.90.2(@tanstack/react-query@5.99.0(react@19.2.3))(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(@tanstack/react-query@5.102.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -11025,11 +11025,11 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-query-devtools':
-        specifier: ^5.90.0
-        version: 5.90.2(@tanstack/react-query@5.99.0(react@19.2.3))(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(@tanstack/react-query@5.102.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -11047,7 +11047,7 @@ importers:
         version: 11.4.3(@typescript/typescript6@6.0.2)
       '@trpc/tanstack-react-query':
         specifier: ^11.4.3
-        version: 11.4.3(@tanstack/react-query@5.99.0(react@19.2.3))(@trpc/client@11.4.3(@trpc/server@11.4.3(@typescript/typescript6@6.0.2))(@typescript/typescript6@6.0.2))(@trpc/server@11.4.3(@typescript/typescript6@6.0.2))(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 11.4.3(@tanstack/react-query@5.102.3(react@19.2.3))(@trpc/client@11.4.3(@trpc/server@11.4.3(@typescript/typescript6@6.0.2))(@typescript/typescript6@6.0.2))(@trpc/server@11.4.3(@typescript/typescript6@6.0.2))(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       express:
         specifier: ^5.2.1
         version: 5.2.1(supports-color@10.2.2)
@@ -11218,8 +11218,8 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/solid-query':
-        specifier: ^5.99.0
-        version: 5.99.0(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(solid-js@1.9.12)
       '@tanstack/solid-router':
         specifier: ^1.170.30
         version: link:../../../packages/solid-router
@@ -11372,11 +11372,11 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/solid-query':
-        specifier: ^5.99.0
-        version: 5.99.0(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(solid-js@1.9.12)
       '@tanstack/solid-query-devtools':
-        specifier: ^5.90.0
-        version: 5.90.4(@tanstack/solid-query@5.99.0(solid-js@1.9.12))(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(@tanstack/solid-query@5.102.3(solid-js@1.9.12))(solid-js@1.9.12)
       '@tanstack/solid-router':
         specifier: ^1.170.30
         version: link:../../../packages/solid-router
@@ -11415,11 +11415,11 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/solid-query':
-        specifier: ^5.99.0
-        version: 5.99.0(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(solid-js@1.9.12)
       '@tanstack/solid-query-devtools':
-        specifier: ^5.90.0
-        version: 5.90.4(@tanstack/solid-query@5.99.0(solid-js@1.9.12))(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(@tanstack/solid-query@5.102.3(solid-js@1.9.12))(solid-js@1.9.12)
       '@tanstack/solid-router':
         specifier: ^1.170.30
         version: link:../../../packages/solid-router
@@ -11802,11 +11802,11 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/solid-query':
-        specifier: ^5.99.0
-        version: 5.99.0(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(solid-js@1.9.12)
       '@tanstack/solid-query-devtools':
-        specifier: ^5.90.0
-        version: 5.90.4(@tanstack/solid-query@5.99.0(solid-js@1.9.12))(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(@tanstack/solid-query@5.102.3(solid-js@1.9.12))(solid-js@1.9.12)
       '@tanstack/solid-router':
         specifier: ^1.170.30
         version: link:../../../packages/solid-router
@@ -11851,11 +11851,11 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/router-plugin
       '@tanstack/solid-query':
-        specifier: ^5.99.0
-        version: 5.99.0(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(solid-js@1.9.12)
       '@tanstack/solid-query-devtools':
-        specifier: ^5.90.0
-        version: 5.90.4(@tanstack/solid-query@5.99.0(solid-js@1.9.12))(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(@tanstack/solid-query@5.102.3(solid-js@1.9.12))(solid-js@1.9.12)
       '@tanstack/solid-router':
         specifier: ^1.170.30
         version: link:../../../packages/solid-router
@@ -11900,8 +11900,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/router-plugin
       '@tanstack/solid-query':
-        specifier: ^5.99.0
-        version: 5.99.0(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(solid-js@1.9.12)
       '@tanstack/solid-router':
         specifier: ^1.170.30
         version: link:../../../packages/solid-router
@@ -11940,8 +11940,8 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/solid-query':
-        specifier: ^5.99.0
-        version: 5.99.0(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(solid-js@1.9.12)
       '@tanstack/solid-router':
         specifier: ^1.170.30
         version: link:../../../packages/solid-router
@@ -11977,8 +11977,8 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/solid-query':
-        specifier: ^5.99.0
-        version: 5.99.0(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(solid-js@1.9.12)
       '@tanstack/solid-router':
         specifier: ^1.170.30
         version: link:../../../packages/solid-router
@@ -12291,11 +12291,11 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/router-plugin
       '@tanstack/solid-query':
-        specifier: ^5.99.0
-        version: 5.99.0(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(solid-js@1.9.12)
       '@tanstack/solid-query-devtools':
-        specifier: ^5.90.0
-        version: 5.90.4(@tanstack/solid-query@5.99.0(solid-js@1.9.12))(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(@tanstack/solid-query@5.102.3(solid-js@1.9.12))(solid-js@1.9.12)
       '@tanstack/solid-router':
         specifier: ^1.170.30
         version: link:../../../packages/solid-router
@@ -12374,8 +12374,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/router-plugin
       '@tanstack/solid-query':
-        specifier: ^5.99.0
-        version: 5.99.0(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(solid-js@1.9.12)
       '@tanstack/solid-router':
         specifier: ^1.170.30
         version: link:../../../packages/solid-router
@@ -12705,11 +12705,11 @@ importers:
   examples/solid/start-basic-solid-query:
     dependencies:
       '@tanstack/solid-query':
-        specifier: ^5.99.0
-        version: 5.99.0(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(solid-js@1.9.12)
       '@tanstack/solid-query-devtools':
-        specifier: ^5.90.0
-        version: 5.90.4(@tanstack/solid-query@5.99.0(solid-js@1.9.12))(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(@tanstack/solid-query@5.102.3(solid-js@1.9.12))(solid-js@1.9.12)
       '@tanstack/solid-router':
         specifier: ^1.170.30
         version: link:../../../packages/solid-router
@@ -13023,8 +13023,8 @@ importers:
   examples/solid/start-large:
     dependencies:
       '@tanstack/solid-query':
-        specifier: ^5.99.0
-        version: 5.99.0(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(solid-js@1.9.12)
       '@tanstack/solid-router':
         specifier: ^1.170.30
         version: link:../../../packages/solid-router
@@ -13652,8 +13652,8 @@ importers:
         specifier: 'catalog:'
         version: 1.26.2(@typescript/typescript6@6.0.2)(eslint@9.22.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(ts-api-utils@2.4.0(@typescript/typescript6@6.0.2))
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/vite-config':
         specifier: 'catalog:'
         version: 0.5.2(@types/node@25.0.9)(@typescript/typescript6@6.0.2)(supports-color@10.2.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -13767,8 +13767,8 @@ importers:
   packages/react-router-ssr-query:
     dependencies:
       '@tanstack/query-core':
-        specifier: ^5.99.0
-        version: 5.99.0
+        specifier: ^5.102.3
+        version: 5.102.3
       '@tanstack/router-ssr-query-core':
         specifier: workspace:*
         version: link:../router-ssr-query-core
@@ -13780,8 +13780,8 @@ importers:
         specifier: 'catalog:'
         version: 1.26.2(@typescript/typescript6@6.0.2)(eslint@9.22.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(ts-api-utils@2.4.0(@typescript/typescript6@6.0.2))
       '@tanstack/react-query':
-        specifier: ^5.99.0
-        version: 5.99.0(react@19.2.3)
+        specifier: ^5.102.3
+        version: 5.102.3(react@19.2.3)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../react-router
@@ -14429,8 +14429,8 @@ importers:
         specifier: 'catalog:'
         version: 0.18.4
       '@tanstack/query-core':
-        specifier: ^5.99.0
-        version: 5.99.0
+        specifier: ^5.102.3
+        version: 5.102.3
       '@tanstack/router-core':
         specifier: workspace:*
         version: link:../router-core
@@ -14634,8 +14634,8 @@ importers:
   packages/solid-router-ssr-query:
     dependencies:
       '@tanstack/query-core':
-        specifier: ^5.99.0
-        version: 5.99.0
+        specifier: ^5.102.3
+        version: 5.102.3
       '@tanstack/router-ssr-query-core':
         specifier: workspace:*
         version: link:../router-ssr-query-core
@@ -14644,8 +14644,8 @@ importers:
         specifier: 'catalog:'
         version: 0.18.4
       '@tanstack/solid-query':
-        specifier: ^5.99.0
-        version: 5.99.0(solid-js@1.9.12)
+        specifier: ^5.102.3
+        version: 5.102.3(solid-js@1.9.12)
       '@tanstack/solid-router':
         specifier: workspace:*
         version: link:../solid-router
@@ -15293,14 +15293,14 @@ importers:
   packages/vue-router-ssr-query:
     dependencies:
       '@tanstack/query-core':
-        specifier: ^5.99.0
-        version: 5.99.0
+        specifier: ^5.102.3
+        version: 5.102.3
       '@tanstack/router-ssr-query-core':
         specifier: workspace:*
         version: link:../router-ssr-query-core
       '@tanstack/vue-query':
-        specifier: ^5.99.0
-        version: 5.99.0(vue@3.5.25(typescript@7.0.2))
+        specifier: ^5.102.3
+        version: 5.102.3(vue@3.5.25(typescript@7.0.2))
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
@@ -16199,7 +16199,7 @@ packages:
   '@convex-dev/react-query@0.0.0-alpha.8':
     resolution: {integrity: sha512-Rv/q7/CplU75f7ckBd2vh+HoeeQ0tOrjwMl14Hk7D/03e55oUIU0TV5JYYzC79ZQyyAtoj7CmCo5ZxcmtKNv1Q==}
     peerDependencies:
-      '@tanstack/react-query': ^5.99.0
+      '@tanstack/react-query': ^5.102.3
       convex: ^1.17.0
 
   '@cspotcode/source-map-support@0.8.1':
@@ -21170,11 +21170,11 @@ packages:
     resolution: {integrity: sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg==}
     engines: {node: '>=12'}
 
-  '@tanstack/query-core@5.99.0':
-    resolution: {integrity: sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==}
+  '@tanstack/query-core@5.102.3':
+    resolution: {integrity: sha512-5O2VEceonqC4uaTLUGglb0hgPouWCJ4K1ykVWyeV8aThhdNCzwpwu01bYoaRNJ9mgFUXS7Kf9utJ46ysT8m+bw==}
 
-  '@tanstack/query-devtools@5.67.2':
-    resolution: {integrity: sha512-O4QXFFd7xqp6EX7sdvc9tsVO8nm4lpWBqwpgjpVLW5g7IeOY6VnS/xvs/YzbRhBVkKTMaJMOUGU7NhSX+YGoNg==}
+  '@tanstack/query-devtools@5.102.3':
+    resolution: {integrity: sha512-J/QKK3J+YuqOY/CQBypJSUGANGcdurFyHP4GZDP90QiB3G/wQVeGamo3zFJ/sTcM2uvF3+V7K3rS521xS8B3lQ==}
 
   '@tanstack/query-devtools@5.90.1':
     resolution: {integrity: sha512-GtINOPjPUH0OegJExZ70UahT9ykmAhmtNVcmtdnOZbxLwT7R5OmRztR5Ahe3/Cu7LArEmR6/588tAycuaWb1xQ==}
@@ -21191,20 +21191,20 @@ packages:
       react: ^19.2.3
       react-dom: ^19.2.3
 
-  '@tanstack/react-query-devtools@5.67.2':
-    resolution: {integrity: sha512-cmj2DxBc+/9btQ66n5xI8wTtAma2BLVa403K7zIYiguzJ/kV201jnGensYqJeu1Rd8uRMLLRM74jLVMLDWNRJA==}
+  '@tanstack/react-query-devtools@5.102.3':
+    resolution: {integrity: sha512-OFxO8PAccjxdf2l1kt0MpcUdrVdSside4lPyucsrSZHssvHc4Vaz1RdtRIuEU0C0Z0P2vMWVIqfF2WlmFtdsng==}
     peerDependencies:
-      '@tanstack/react-query': ^5.99.0
+      '@tanstack/react-query': ^5.102.3
       react: ^19.2.3
 
   '@tanstack/react-query-devtools@5.90.2':
     resolution: {integrity: sha512-vAXJzZuBXtCQtrY3F/yUNJCV4obT/A/n81kb3+YqLbro5Z2+phdAbceO+deU3ywPw8B42oyJlp4FhO0SoivDFQ==}
     peerDependencies:
-      '@tanstack/react-query': ^5.99.0
+      '@tanstack/react-query': ^5.102.3
       react: ^19.2.3
 
-  '@tanstack/react-query@5.99.0':
-    resolution: {integrity: sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==}
+  '@tanstack/react-query@5.102.3':
+    resolution: {integrity: sha512-nHazxUEUQSGJOswGgSL2DI77f2K75WRCowDgaiyEi0ACocZTFKewTv+A/rJfq6QkuE35rVPff1QUT3ClbaePGQ==}
     peerDependencies:
       react: ^19.2.3
 
@@ -21226,14 +21226,20 @@ packages:
     peerDependencies:
       solid-js: 1.9.12
 
+  '@tanstack/solid-query-devtools@5.102.3':
+    resolution: {integrity: sha512-KSmBy6YbK1MUyqgXkpSWAgXEYUosrvnDEZG76E4CeT18ZxR2HmJztHf94dCWYhe0looB4KXyAbDAmJAR24HeNQ==}
+    peerDependencies:
+      '@tanstack/solid-query': ^5.102.3
+      solid-js: 1.9.12
+
   '@tanstack/solid-query-devtools@5.90.4':
     resolution: {integrity: sha512-ygyAiXZ+NR1tw33jVibpjiWB1IoAQWCeqSLmO/6PoSWrI9yDTwaPNAXheniEMrO6/a/vTQq2tB4N+FPNjhGaNw==}
     peerDependencies:
-      '@tanstack/solid-query': ^5.99.0
+      '@tanstack/solid-query': ^5.102.3
       solid-js: 1.9.12
 
-  '@tanstack/solid-query@5.99.0':
-    resolution: {integrity: sha512-XZxt95MYWivATb6ykmUobhtzR0l8uW3CNQt7FKkV1AgMR8YDirDoHoXBbNGRQidN30g3lqDxgFWdbi6HrZqDdg==}
+  '@tanstack/solid-query@5.102.3':
+    resolution: {integrity: sha512-DTKgjeZGp7tQGR6XBT7SrdjwZz1sYKJq8PazY/wdor6ljmInFbnLkz0qiqJ28wTkCP+T3kLZJ7Du1nGk2T48/Q==}
     peerDependencies:
       solid-js: 1.9.12
 
@@ -21263,17 +21269,17 @@ packages:
   '@tanstack/vue-query-devtools@5.91.0':
     resolution: {integrity: sha512-Kn6p5ffEKUj+YGEP+BapoPI8kUiPtNnFDyzjTvUx6GHbyfzfefQPhYoRtFiWeyrGHjUB/Mvtnr7Rosbzs/ngVg==}
     peerDependencies:
-      '@tanstack/vue-query': ^5.99.0
+      '@tanstack/vue-query': ^5.102.3
       vue: ^3.3.0
 
   '@tanstack/vue-query-devtools@6.1.2':
     resolution: {integrity: sha512-1E886RHorY432aOJU3dyzLbI67PhqQzvAPQyp8hU6UR4EVXKZSVzVT0O0utmTT2jnBpbbUiCFt2uNSs8W3grHw==}
     peerDependencies:
-      '@tanstack/vue-query': ^5.99.0
+      '@tanstack/vue-query': ^5.102.3
       vue: ^3.3.0
 
-  '@tanstack/vue-query@5.99.0':
-    resolution: {integrity: sha512-okrHNkouasL5cjo7O8hUxul22DiIL335KUQus/cfoAdCOUytF/OIv3BpNDevfqE6zHqqJ651Fb9OkUJPUCL0ZQ==}
+  '@tanstack/vue-query@5.102.3':
+    resolution: {integrity: sha512-CNR35/HPFlfajOg2dYS2WLJIMFV/G1cE7n9PA/SOaJCwqgSR5cPUwN+huoQW8gQBHFIbz1kFw08Ymdx9ii7WVQ==}
     peerDependencies:
       '@vue/composition-api': ^1.1.2
       vue: ^2.6.0 || ^3.3.0
@@ -21361,7 +21367,7 @@ packages:
   '@trpc/tanstack-react-query@11.4.3':
     resolution: {integrity: sha512-aYPp12wE9IrakccGWoQU/waZuWr3FLw9RtagsqJmX9NKHpQOVzoDvHA1W0amwyTQSAfL98Bn5rWmD7KTdr5AWg==}
     peerDependencies:
-      '@tanstack/react-query': ^5.99.0
+      '@tanstack/react-query': ^5.102.3
       '@trpc/client': 11.4.3
       '@trpc/server': 11.4.3
       react: ^19.2.3
@@ -29870,9 +29876,9 @@ snapshots:
       - hono
       - typescript
 
-  '@convex-dev/react-query@0.0.0-alpha.8(@tanstack/react-query@5.99.0(react@19.2.3))(convex@1.19.0(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+  '@convex-dev/react-query@0.0.0-alpha.8(@tanstack/react-query@5.102.3(react@19.2.3))(convex@1.19.0(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
     dependencies:
-      '@tanstack/react-query': 5.99.0(react@19.2.3)
+      '@tanstack/react-query': 5.102.3(react@19.2.3)
       convex: 1.19.0(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   '@cspotcode/source-map-support@0.8.1':
@@ -34577,9 +34583,9 @@ snapshots:
     dependencies:
       remove-accents: 0.5.0
 
-  '@tanstack/query-core@5.99.0': {}
+  '@tanstack/query-core@5.102.3': {}
 
-  '@tanstack/query-devtools@5.67.2': {}
+  '@tanstack/query-devtools@5.102.3': {}
 
   '@tanstack/query-devtools@5.90.1': {}
 
@@ -34598,21 +34604,21 @@ snapshots:
       - solid-js
       - utf-8-validate
 
-  '@tanstack/react-query-devtools@5.67.2(@tanstack/react-query@5.99.0(react@19.2.3))(react@19.2.3)':
+  '@tanstack/react-query-devtools@5.102.3(@tanstack/react-query@5.102.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@tanstack/query-devtools': 5.67.2
-      '@tanstack/react-query': 5.99.0(react@19.2.3)
+      '@tanstack/query-devtools': 5.102.3
+      '@tanstack/react-query': 5.102.3(react@19.2.3)
       react: 19.2.3
 
-  '@tanstack/react-query-devtools@5.90.2(@tanstack/react-query@5.99.0(react@19.2.3))(react@19.2.3)':
+  '@tanstack/react-query-devtools@5.90.2(@tanstack/react-query@5.102.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@tanstack/query-devtools': 5.90.1
-      '@tanstack/react-query': 5.99.0(react@19.2.3)
+      '@tanstack/react-query': 5.102.3(react@19.2.3)
       react: 19.2.3
 
-  '@tanstack/react-query@5.99.0(react@19.2.3)':
+  '@tanstack/react-query@5.102.3(react@19.2.3)':
     dependencies:
-      '@tanstack/query-core': 5.99.0
+      '@tanstack/query-core': 5.102.3
       react: 19.2.3
 
   '@tanstack/react-store@0.9.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
@@ -34637,15 +34643,21 @@ snapshots:
       - csstype
       - utf-8-validate
 
-  '@tanstack/solid-query-devtools@5.90.4(@tanstack/solid-query@5.99.0(solid-js@1.9.12))(solid-js@1.9.12)':
+  '@tanstack/solid-query-devtools@5.102.3(@tanstack/solid-query@5.102.3(solid-js@1.9.12))(solid-js@1.9.12)':
     dependencies:
-      '@tanstack/query-devtools': 5.90.1
-      '@tanstack/solid-query': 5.99.0(solid-js@1.9.12)
+      '@tanstack/query-devtools': 5.102.3
+      '@tanstack/solid-query': 5.102.3(solid-js@1.9.12)
       solid-js: 1.9.12
 
-  '@tanstack/solid-query@5.99.0(solid-js@1.9.12)':
+  '@tanstack/solid-query-devtools@5.90.4(@tanstack/solid-query@5.102.3(solid-js@1.9.12))(solid-js@1.9.12)':
     dependencies:
-      '@tanstack/query-core': 5.99.0
+      '@tanstack/query-devtools': 5.90.1
+      '@tanstack/solid-query': 5.102.3(solid-js@1.9.12)
+      solid-js: 1.9.12
+
+  '@tanstack/solid-query@5.102.3(solid-js@1.9.12)':
+    dependencies:
+      '@tanstack/query-core': 5.102.3
       solid-js: 1.9.12
 
   '@tanstack/solid-virtual@3.13.12(solid-js@1.9.12)':
@@ -34697,50 +34709,50 @@ snapshots:
       - supports-color
       - typescript
 
-  '@tanstack/vue-query-devtools@5.91.0(@tanstack/vue-query@5.99.0(vue@3.5.25(@typescript/typescript6@6.0.2)))(vue@3.5.25(@typescript/typescript6@6.0.2))':
+  '@tanstack/vue-query-devtools@5.91.0(@tanstack/vue-query@5.102.3(vue@3.5.25(@typescript/typescript6@6.0.2)))(vue@3.5.25(@typescript/typescript6@6.0.2))':
     dependencies:
       '@tanstack/query-devtools': 5.90.1
-      '@tanstack/vue-query': 5.99.0(vue@3.5.25(@typescript/typescript6@6.0.2))
+      '@tanstack/vue-query': 5.102.3(vue@3.5.25(@typescript/typescript6@6.0.2))
       vue: 3.5.25(@typescript/typescript6@6.0.2)
 
-  '@tanstack/vue-query-devtools@6.1.2(@tanstack/vue-query@5.99.0(vue@3.5.25(@typescript/typescript6@6.0.2)))(vue@3.5.25(@typescript/typescript6@6.0.2))':
+  '@tanstack/vue-query-devtools@6.1.2(@tanstack/vue-query@5.102.3(vue@3.5.25(@typescript/typescript6@6.0.2)))(vue@3.5.25(@typescript/typescript6@6.0.2))':
     dependencies:
       '@tanstack/query-devtools': 5.91.1
-      '@tanstack/vue-query': 5.99.0(vue@3.5.25(@typescript/typescript6@6.0.2))
+      '@tanstack/vue-query': 5.102.3(vue@3.5.25(@typescript/typescript6@6.0.2))
       vue: 3.5.25(@typescript/typescript6@6.0.2)
 
-  '@tanstack/vue-query-devtools@6.1.2(@tanstack/vue-query@5.99.0(vue@3.5.25(typescript@5.8.3)))(vue@3.5.25(typescript@5.8.3))':
+  '@tanstack/vue-query-devtools@6.1.2(@tanstack/vue-query@5.102.3(vue@3.5.25(typescript@5.8.3)))(vue@3.5.25(typescript@5.8.3))':
     dependencies:
       '@tanstack/query-devtools': 5.91.1
-      '@tanstack/vue-query': 5.99.0(vue@3.5.25(typescript@5.8.3))
+      '@tanstack/vue-query': 5.102.3(vue@3.5.25(typescript@5.8.3))
       vue: 3.5.25(typescript@5.8.3)
 
-  '@tanstack/vue-query-devtools@6.1.2(@tanstack/vue-query@5.99.0(vue@3.5.25(typescript@7.0.2)))(vue@3.5.25(typescript@7.0.2))':
+  '@tanstack/vue-query-devtools@6.1.2(@tanstack/vue-query@5.102.3(vue@3.5.25(typescript@7.0.2)))(vue@3.5.25(typescript@7.0.2))':
     dependencies:
       '@tanstack/query-devtools': 5.91.1
-      '@tanstack/vue-query': 5.99.0(vue@3.5.25(typescript@7.0.2))
+      '@tanstack/vue-query': 5.102.3(vue@3.5.25(typescript@7.0.2))
       vue: 3.5.25(typescript@7.0.2)
 
-  '@tanstack/vue-query@5.99.0(vue@3.5.25(@typescript/typescript6@6.0.2))':
+  '@tanstack/vue-query@5.102.3(vue@3.5.25(@typescript/typescript6@6.0.2))':
     dependencies:
       '@tanstack/match-sorter-utils': 8.19.4
-      '@tanstack/query-core': 5.99.0
+      '@tanstack/query-core': 5.102.3
       '@vue/devtools-api': 6.6.4
       vue: 3.5.25(@typescript/typescript6@6.0.2)
       vue-demi: 0.14.10(vue@3.5.25(@typescript/typescript6@6.0.2))
 
-  '@tanstack/vue-query@5.99.0(vue@3.5.25(typescript@5.8.3))':
+  '@tanstack/vue-query@5.102.3(vue@3.5.25(typescript@5.8.3))':
     dependencies:
       '@tanstack/match-sorter-utils': 8.19.4
-      '@tanstack/query-core': 5.99.0
+      '@tanstack/query-core': 5.102.3
       '@vue/devtools-api': 6.6.4
       vue: 3.5.25(typescript@5.8.3)
       vue-demi: 0.14.10(vue@3.5.25(typescript@5.8.3))
 
-  '@tanstack/vue-query@5.99.0(vue@3.5.25(typescript@7.0.2))':
+  '@tanstack/vue-query@5.102.3(vue@3.5.25(typescript@7.0.2))':
     dependencies:
       '@tanstack/match-sorter-utils': 8.19.4
-      '@tanstack/query-core': 5.99.0
+      '@tanstack/query-core': 5.102.3
       '@vue/devtools-api': 6.6.4
       vue: 3.5.25(typescript@7.0.2)
       vue-demi: 0.14.10(vue@3.5.25(typescript@7.0.2))
@@ -34826,9 +34838,9 @@ snapshots:
     dependencies:
       typescript: '@typescript/typescript6@6.0.2'
 
-  '@trpc/tanstack-react-query@11.4.3(@tanstack/react-query@5.99.0(react@19.2.3))(@trpc/client@11.4.3(@trpc/server@11.4.3(@typescript/typescript6@6.0.2))(@typescript/typescript6@6.0.2))(@trpc/server@11.4.3(@typescript/typescript6@6.0.2))(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@trpc/tanstack-react-query@11.4.3(@tanstack/react-query@5.102.3(react@19.2.3))(@trpc/client@11.4.3(@trpc/server@11.4.3(@typescript/typescript6@6.0.2))(@typescript/typescript6@6.0.2))(@trpc/server@11.4.3(@typescript/typescript6@6.0.2))(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@tanstack/react-query': 5.99.0(react@19.2.3)
+      '@tanstack/react-query': 5.102.3(react@19.2.3)
       '@trpc/client': 11.4.3(@trpc/server@11.4.3(@typescript/typescript6@6.0.2))(@typescript/typescript6@6.0.2)
       '@trpc/server': 11.4.3(@typescript/typescript6@6.0.2)
       react: 19.2.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,10 +52,10 @@ catalog:
   vitest: ^4.1.4
   '@types/node': 25.0.9
   '@playwright/test': ^1.61.0
-  '@tanstack/query-core': ^5.99.0
-  '@tanstack/react-query': ^5.99.0
-  '@tanstack/solid-query': ^5.99.0
-  '@tanstack/vue-query': ^5.99.0
+  '@tanstack/query-core': ^5.102.3
+  '@tanstack/react-query': ^5.102.3
+  '@tanstack/solid-query': ^5.102.3
+  '@tanstack/vue-query': ^5.102.3
 
 overrides:
   '@types/babel__traverse': '^7.28.0'


### PR DESCRIPTION
Companion PR to
- https://github.com/TanStack/query/discussions/9135
- https://github.com/TanStack/query/pull/9835
- https://github.com/TanStack/query/releases/tag/release-2026-08-22-1856

Updates the docs, example and intent for query intergrations with router and start. The RFC and https://tanstack.com/query/latest/docs/framework/react/guides/migrating-to-v5#imperative-queryclient-methods has detailed migration guide on Queries side and this aims to bring Routers docs up to day as it relateds to Router-Query intergration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated data-loading, deferred-loading, SSR, routing, and type-safety guidance for consistent static caching.
  - Clarified when loaders await data versus running background queries without blocking rendering.
  - Added guidance for safely handling background query failures.

- **Examples**
  - Refreshed React and Solid examples across posts, users, invoices, search, dashboards, and SSR scenarios.
  - Standardized example package versions through the workspace catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->