### PR TITLE
fix(react-router): preserve inline head scripts in React tree after hydration

### DIFF
--- a/packages/react-router/src/Asset.tsx
+++ b/packages/react-router/src/Asset.tsx
@@ -51,6 +51,11 @@ function Script({
 }) {
   const router = useRouter()
   const hydrated = useHydrated()
+  // Track whether this component instance went through the !hydrated (pre-hydration) phase.
+  // true  → component was SSR-rendered; the inline script was already executed by the browser.
+  // false → component was mounted fresh on the client (client-side navigation); useEffect must
+  //         inject an executable script because dangerouslySetInnerHTML never executes scripts.
+  const wentThroughNonHydratedPhase = React.useRef(!hydrated)
   const dataScript =
     typeof attrs?.type === 'string' &&
     attrs.type !== '' &&
@@ -215,11 +220,20 @@ function Script({
     }
   }
 
-  // For inline scripts (children, no src), keep the element in the React tree after
-  // hydration so React doesn't unmount the SSR-rendered script from the DOM.
+  // For inline scripts (children, no src) that went through SSR hydration, keep the element
+  // in the React tree so React doesn't unmount the SSR-rendered script from the DOM.
   // The useEffect above detects the existing element via textContent match and skips
   // re-injection, so the script won't execute a second time.
-  if (!attrs?.src && typeof children === 'string') {
+  //
+  // For client-side navigation (wentThroughNonHydratedPhase === false), skip this path and
+  // fall through to return null — the useEffect handles imperative injection in that case.
+  // (dangerouslySetInnerHTML does not execute scripts, so we must not render an inert element
+  // that would fool the existingScript dedup check into returning early without executing.)
+  if (
+    !attrs?.src &&
+    typeof children === 'string' &&
+    wentThroughNonHydratedPhase.current
+  ) {
     return (
       <script
         {...attrs}

--- a/packages/react-router/src/Asset.tsx
+++ b/packages/react-router/src/Asset.tsx
@@ -215,5 +215,19 @@ function Script({
     }
   }
 
+  // For inline scripts (children, no src), keep the element in the React tree after
+  // hydration so React doesn't unmount the SSR-rendered script from the DOM.
+  // The useEffect above detects the existing element via textContent match and skips
+  // re-injection, so the script won't execute a second time.
+  if (!attrs?.src && typeof children === 'string') {
+    return (
+      <script
+        {...attrs}
+        dangerouslySetInnerHTML={{ __html: children }}
+        suppressHydrationWarning
+      />
+    )
+  }
+
   return null
 }


### PR DESCRIPTION
Fixes #7104

## Problem

When a route's `head()` function returns `scripts[]` entries with `children` (inline script content) but no `src`, those script tags are rendered correctly on the server and during initial hydration, but **disappear from the DOM after hydration completes**.

Root cause in `Asset.tsx` — the `Script` component:

1. During SSR: renders `<script dangerouslySetInnerHTML={{ __html: children }} />` ✓
2. Pre-hydration (`!hydrated`): renders the same element to match server HTML ✓
3. After hydration: falls through to `return null` — **React unmounts the script from the DOM** ✗
4. `useEffect` fires after React commits the removal → `querySelectorAll('script:not([src])')` no longer finds the script → creates a new one and appends it → **script re-executes** (e.g. `gtag` config double-fires)

Both `solid-router` and `vue-router` already keep inline scripts rendered after hydration — only `react-router` had this gap.

## Fix

After the `!hydrated` block, add an early-return that keeps inline `children` scripts in the React tree:

```tsx
if (!attrs?.src && typeof children === 'string') {
  return <script {...attrs} dangerouslySetInnerHTML={{ __html: children }} suppressHydrationWarning />
}
```

With this change:
- React never unmounts the SSR-rendered script element
- The `useEffect` still runs, but the `existingScript` check finds the element and returns early — so the script is **not re-executed**
- Behavior is now consistent with `solid-router` and `vue-router`

Scripts with `src` are unaffected (still managed imperatively via `useEffect`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where inline scripts were being removed after page hydration, ensuring they remain active and functional throughout the page lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->