### PR TITLE
docs: Rename validator to inputValidator

### DIFF
--- a/docs/start/framework/react/start-vs-nextjs.md
+++ b/docs/start/framework/react/start-vs-nextjs.md
@@ -211,7 +211,7 @@ Server Actions integrate with forms and transitions. They're convenient for simp
 
 ```tsx
 export const createPost = createServerFn({ method: 'POST' })
-  .validator(z.object({ title: z.string().min(1) }))
+  .inputValidator(z.object({ title: z.string().min(1) }))
   .middleware([authMiddleware])
   .handler(async ({ data, context }) => {
     // data is typed and validated


### PR DESCRIPTION
Rename `.validator()` to `.inputValidator()` as per the new API for `createServerFn()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated React framework documentation examples to reflect the current API method naming convention for input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->