### PR TITLE
docs: correct ActiveOptions default in LinkOptionsProps JSDoc

### DIFF
--- a/packages/router-core/src/link.ts
+++ b/packages/router-core/src/link.ts
@@ -665,7 +665,7 @@ export interface LinkOptionsProps {
   target?: HTMLAnchorElement['target']
   /**
    * Configurable options to determine if the link should be considered active or not
-   * @default {exact:true,includeHash:true}
+   * @default {includeSearch:true}
    */
   activeOptions?: ActiveOptions
   /**


### PR DESCRIPTION
## Summary

- Fixes incorrect `@default` JSDoc comment on `LinkOptionsProps.activeOptions` that stated `{exact:true, includeHash:true}` instead of the actual runtime defaults `{includeSearch: true}`

## Details

The `@default` comment on `activeOptions` was inconsistent with both:
1. The individual property `@default` comments in the `ActiveOptions` interface (`exact: false`, `includeHash: false`, `includeSearch: true`)
2. The actual runtime defaults in `packages/react-router/src/link.tsx`

Closes #5775

## Test Plan

- [x] Verified the fix matches individual property defaults in `ActiveOptions` interface
- [x] Verified the fix matches runtime defaults in `packages/react-router/src/link.tsx`
- [x] Documentation-only change, no runtime behavior affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated documentation for link configuration options to reflect current default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->