### PR TITLE
fix(start): import Register from framework package so module augmentation works

### DIFF
--- a/packages/react-start/src/default-entry/server.ts
+++ b/packages/react-start/src/default-entry/server.ts
@@ -2,7 +2,7 @@ import {
   createStartHandler,
   defaultStreamHandler,
 } from '@tanstack/react-start/server'
-import type { Register } from '@tanstack/react-router'
+import type { Register } from '@tanstack/react-start'
 import type { RequestHandler } from '@tanstack/react-start/server'
 
 const fetch = createStartHandler(defaultStreamHandler)

--- a/packages/solid-start/src/default-entry/server.ts
+++ b/packages/solid-start/src/default-entry/server.ts
@@ -2,7 +2,7 @@ import {
   createStartHandler,
   defaultStreamHandler,
 } from '@tanstack/solid-start/server'
-import type { Register } from '@tanstack/solid-router'
+import type { Register } from '@tanstack/solid-start'
 import type { RequestHandler } from '@tanstack/solid-start/server'
 
 const fetch = createStartHandler(defaultStreamHandler)

--- a/packages/vue-start/src/default-entry/server.ts
+++ b/packages/vue-start/src/default-entry/server.ts
@@ -2,7 +2,7 @@ import {
   createStartHandler,
   defaultStreamHandler,
 } from '@tanstack/vue-start/server'
-import type { Register } from '@tanstack/vue-router'
+import type { Register } from '@tanstack/vue-start'
 import type { RequestHandler } from '@tanstack/vue-start/server'
 
 const fetch = createStartHandler(defaultStreamHandler)


### PR DESCRIPTION
Fixes #7353.

`createServerEntry` in all three framework adapters imported `Register` from the router package (`@tanstack/react-router`, `@tanstack/solid-router`, `@tanstack/vue-router`), while the docs tell users to augment their start package:

```ts
declare module '@tanstack/react-start' {
  interface Register {
    server: { requestContext: { userId: string } }
  }
}
```

TypeScript module augmentation is module-scoped, so augmenting `@tanstack/react-start` had no effect on a `Register` imported from `@tanstack/react-router`. The typed `context` parameter just silently didn't show up — no error, just no types, which makes it genuinely hard to debug.

The fix follows the same pattern as the existing `router` registration (you augment `@tanstack/react-router` and import from it). All three packages already re-export `Register` through `@tanstack/start-client-core`, and the server-entry files already self-import from their own packages (e.g. `from '@tanstack/react-start/server'`). Changing the `Register` import to match the module users are told to augment is all it takes.

### Changes

- `packages/react-start/src/default-entry/server.ts`: `from '@tanstack/react-router'` → `from '@tanstack/react-start'`
- `packages/solid-start/src/default-entry/server.ts`: `from '@tanstack/solid-router'` → `from '@tanstack/solid-start'`
- `packages/vue-start/src/default-entry/server.ts`: `from '@tanstack/vue-router'` → `from '@tanstack/vue-start'`

No runtime behavior changes.

### How to verify

Add this augmentation in your project:

```ts
declare module '@tanstack/react-start' {
  interface Register {
    server: { requestContext: { userId: string } }
  }
}
```

Before: `context` on `createServerEntry({ fetch })` is optional and typed as `BaseContext` regardless of the augmentation. After: `context` is required and typed as `{ userId: string } & { nonce?: string }`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated type imports in React Start, Solid Start, and Vue Start framework integration packages to improve internal consistency and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->