### PR TITLE
fix(start-client-core): allow middleware to return custom error structures

### DIFF
--- a/e2e/react-start/server-functions/src/routeTree.gen.ts
+++ b/e2e/react-start/server-functions/src/routeTree.gen.ts
@@ -47,6 +47,7 @@ import { Route as MiddlewareMiddlewareFactoryRouteImport } from './routes/middle
 import { Route as MiddlewareFunctionMetadataRouteImport } from './routes/middleware/function-metadata'
 import { Route as MiddlewareClientMiddlewareRouterRouteImport } from './routes/middleware/client-middleware-router'
 import { Route as MiddlewareCatchHandlerErrorRouteImport } from './routes/middleware/catch-handler-error'
+import { Route as MiddlewareNonErrorPayloadRouteImport } from './routes/middleware/non-error-payload'
 import { Route as MethodNotAllowedMethodRouteImport } from './routes/method-not-allowed/$method'
 import { Route as CookiesSetRouteImport } from './routes/cookies/set'
 import { Route as AbortSignalMethodRouteImport } from './routes/abort-signal/$method'
@@ -251,6 +252,12 @@ const MiddlewareCatchHandlerErrorRoute =
     path: '/middleware/catch-handler-error',
     getParentRoute: () => rootRouteImport,
   } as any)
+const MiddlewareNonErrorPayloadRoute =
+  MiddlewareNonErrorPayloadRouteImport.update({
+    id: '/middleware/non-error-payload',
+    path: '/middleware/non-error-payload',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const MethodNotAllowedMethodRoute = MethodNotAllowedMethodRouteImport.update({
   id: '/method-not-allowed/$method',
   path: '/method-not-allowed/$method',
@@ -307,6 +314,7 @@ export interface FileRoutesByFullPath {
   '/cookies/set': typeof CookiesSetRoute
   '/method-not-allowed/$method': typeof MethodNotAllowedMethodRoute
   '/middleware/catch-handler-error': typeof MiddlewareCatchHandlerErrorRoute
+  '/middleware/non-error-payload': typeof MiddlewareNonErrorPayloadRoute
   '/middleware/client-middleware-router': typeof MiddlewareClientMiddlewareRouterRoute
   '/middleware/function-metadata': typeof MiddlewareFunctionMetadataRoute
   '/middleware/middleware-factory': typeof MiddlewareMiddlewareFactoryRoute
@@ -353,6 +361,7 @@ export interface FileRoutesByTo {
   '/cookies/set': typeof CookiesSetRoute
   '/method-not-allowed/$method': typeof MethodNotAllowedMethodRoute
   '/middleware/catch-handler-error': typeof MiddlewareCatchHandlerErrorRoute
+  '/middleware/non-error-payload': typeof MiddlewareNonErrorPayloadRoute
   '/middleware/client-middleware-router': typeof MiddlewareClientMiddlewareRouterRoute
   '/middleware/function-metadata': typeof MiddlewareFunctionMetadataRoute
   '/middleware/middleware-factory': typeof MiddlewareMiddlewareFactoryRoute
@@ -400,6 +409,7 @@ export interface FileRoutesById {
   '/cookies/set': typeof CookiesSetRoute
   '/method-not-allowed/$method': typeof MethodNotAllowedMethodRoute
   '/middleware/catch-handler-error': typeof MiddlewareCatchHandlerErrorRoute
+  '/middleware/non-error-payload': typeof MiddlewareNonErrorPayloadRoute
   '/middleware/client-middleware-router': typeof MiddlewareClientMiddlewareRouterRoute
   '/middleware/function-metadata': typeof MiddlewareFunctionMetadataRoute
   '/middleware/middleware-factory': typeof MiddlewareMiddlewareFactoryRoute
@@ -448,6 +458,7 @@ export interface FileRouteTypes {
     | '/cookies/set'
     | '/method-not-allowed/$method'
     | '/middleware/catch-handler-error'
+    | '/middleware/non-error-payload'
     | '/middleware/client-middleware-router'
     | '/middleware/function-metadata'
     | '/middleware/middleware-factory'
@@ -494,6 +505,7 @@ export interface FileRouteTypes {
     | '/cookies/set'
     | '/method-not-allowed/$method'
     | '/middleware/catch-handler-error'
+    | '/middleware/non-error-payload'
     | '/middleware/client-middleware-router'
     | '/middleware/function-metadata'
     | '/middleware/middleware-factory'
@@ -540,6 +552,7 @@ export interface FileRouteTypes {
     | '/cookies/set'
     | '/method-not-allowed/$method'
     | '/middleware/catch-handler-error'
+    | '/middleware/non-error-payload'
     | '/middleware/client-middleware-router'
     | '/middleware/function-metadata'
     | '/middleware/middleware-factory'
@@ -587,6 +600,7 @@ export interface RootRouteChildren {
   CookiesSetRoute: typeof CookiesSetRoute
   MethodNotAllowedMethodRoute: typeof MethodNotAllowedMethodRoute
   MiddlewareCatchHandlerErrorRoute: typeof MiddlewareCatchHandlerErrorRoute
+  MiddlewareNonErrorPayloadRoute: typeof MiddlewareNonErrorPayloadRoute
   MiddlewareClientMiddlewareRouterRoute: typeof MiddlewareClientMiddlewareRouterRoute
   MiddlewareFunctionMetadataRoute: typeof MiddlewareFunctionMetadataRoute
   MiddlewareMiddlewareFactoryRoute: typeof MiddlewareMiddlewareFactoryRoute
@@ -880,6 +894,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MiddlewareCatchHandlerErrorRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/middleware/non-error-payload': {
+      id: '/middleware/non-error-payload'
+      path: '/middleware/non-error-payload'
+      fullPath: '/middleware/non-error-payload'
+      preLoaderRoute: typeof MiddlewareNonErrorPayloadRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/method-not-allowed/$method': {
       id: '/method-not-allowed/$method'
       path: '/method-not-allowed/$method'
@@ -947,6 +968,7 @@ const rootRouteChildren: RootRouteChildren = {
   CookiesSetRoute: CookiesSetRoute,
   MethodNotAllowedMethodRoute: MethodNotAllowedMethodRoute,
   MiddlewareCatchHandlerErrorRoute: MiddlewareCatchHandlerErrorRoute,
+  MiddlewareNonErrorPayloadRoute: MiddlewareNonErrorPayloadRoute,
   MiddlewareClientMiddlewareRouterRoute: MiddlewareClientMiddlewareRouterRoute,
   MiddlewareFunctionMetadataRoute: MiddlewareFunctionMetadataRoute,
   MiddlewareMiddlewareFactoryRoute: MiddlewareMiddlewareFactoryRoute,

--- a/e2e/react-start/server-functions/src/routes/middleware/non-error-payload.tsx
+++ b/e2e/react-start/server-functions/src/routes/middleware/non-error-payload.tsx
@@ -1,0 +1,55 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { createMiddleware, createServerFn } from '@tanstack/react-start'
+import { useState } from 'react'
+
+const structuredErrorMiddleware = createMiddleware({ type: 'function' }).server(
+  async ({ next }) => {
+    try {
+      return await next()
+    } catch {
+      // Throw a plain object — not an Error instance — as a structured payload.
+      // The client should receive this object as the resolved value, not undefined.
+      throw { code: 'HANDLED', message: 'Middleware returned structured payload' }
+    }
+  },
+)
+
+const $serverFnThatThrows = createServerFn({ method: 'GET' })
+  .middleware([structuredErrorMiddleware])
+  .handler(() => {
+    throw new Error('Trigger middleware catch')
+  })
+
+export const Route = createFileRoute('/middleware/non-error-payload')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const [result, setResult] = useState<unknown>(undefined)
+  const [loading, setLoading] = useState(false)
+
+  const handleClick = async () => {
+    setLoading(true)
+    const value = await $serverFnThatThrows()
+    setResult(value)
+    setLoading(false)
+  }
+
+  return (
+    <div className="p-4">
+      <h1 data-testid="non-error-payload-title">
+        Non-Error Middleware Payload Test
+      </h1>
+      <button
+        data-testid="trigger-non-error-btn"
+        onClick={handleClick}
+        disabled={loading}
+      >
+        {loading ? 'Loading' : 'Call Server Function'}
+      </button>
+      {result !== undefined && (
+        <div data-testid="payload-result">{JSON.stringify(result)}</div>
+      )}
+    </div>
+  )
+}

--- a/e2e/react-start/server-functions/tests/server-functions.spec.ts
+++ b/e2e/react-start/server-functions/tests/server-functions.spec.ts
@@ -1050,6 +1050,27 @@ test('middleware can catch errors thrown by server function handlers', async ({
   )
 })
 
+test('middleware can surface non-Error structured payloads to the caller', async ({
+  page,
+}) => {
+  await page.goto('/middleware/non-error-payload')
+
+  await page.waitForLoadState('networkidle')
+
+  await expect(page.getByTestId('non-error-payload-title')).toBeVisible()
+
+  await page.getByTestId('trigger-non-error-btn').click()
+
+  await expect(page.getByTestId('payload-result')).toBeVisible()
+
+  const text = await page.getByTestId('payload-result').textContent()
+  const payload = JSON.parse(text!)
+  expect(payload).toEqual({
+    code: 'HANDLED',
+    message: 'Middleware returned structured payload',
+  })
+})
+
 test('server function with custom fetch implementation passed directly', async ({
   page,
 }) => {

--- a/packages/start-client-core/src/client/hydrateStart.ts
+++ b/packages/start-client-core/src/client/hydrateStart.ts
@@ -1,14 +1,14 @@
 import { hydrate } from '@tanstack/router-core/ssr/client'
 
-import { ServerFunctionSerializationAdapter } from './ServerFunctionSerializationAdapter'
-import type { AnyRouter, AnySerializationAdapter } from '@tanstack/router-core'
-import type { AnyStartInstanceOptions } from '../createStart'
 import { startInstance } from '#tanstack-start-entry'
 import {
   hasPluginAdapters,
   pluginSerializationAdapters,
 } from '#tanstack-start-plugin-adapters'
 import { getRouter } from '#tanstack-router-entry'
+import { ServerFunctionSerializationAdapter } from './ServerFunctionSerializationAdapter'
+import type { AnyRouter, AnySerializationAdapter } from '@tanstack/router-core'
+import type { AnyStartInstanceOptions } from '../createStart'
 
 export async function hydrateStart(): Promise<AnyRouter> {
   const router = await getRouter()

--- a/packages/start-client-core/src/client/hydrateStart.ts
+++ b/packages/start-client-core/src/client/hydrateStart.ts
@@ -1,14 +1,14 @@
 import { hydrate } from '@tanstack/router-core/ssr/client'
 
+import { ServerFunctionSerializationAdapter } from './ServerFunctionSerializationAdapter'
+import type { AnyRouter, AnySerializationAdapter } from '@tanstack/router-core'
+import type { AnyStartInstanceOptions } from '../createStart'
 import { startInstance } from '#tanstack-start-entry'
 import {
   hasPluginAdapters,
   pluginSerializationAdapters,
 } from '#tanstack-start-plugin-adapters'
 import { getRouter } from '#tanstack-router-entry'
-import { ServerFunctionSerializationAdapter } from './ServerFunctionSerializationAdapter'
-import type { AnyRouter, AnySerializationAdapter } from '@tanstack/router-core'
-import type { AnyStartInstanceOptions } from '../createStart'
 
 export async function hydrateStart(): Promise<AnyRouter> {
   const router = await getRouter()

--- a/packages/start-client-core/src/createServerFn.ts
+++ b/packages/start-client-core/src/createServerFn.ts
@@ -31,7 +31,6 @@ import type {
   IntersectAllValidatorOutputs,
 } from './createMiddleware'
 
-
 type TODO = any
 
 export type ServerFnStrict = boolean | { input?: boolean; output?: boolean }

--- a/packages/start-client-core/src/createServerFn.ts
+++ b/packages/start-client-core/src/createServerFn.ts
@@ -1,18 +1,6 @@
 import { mergeHeaders } from '@tanstack/router-core/ssr/client'
 
 import { isNotFound, isRedirect, parseRedirect } from '@tanstack/router-core'
-import type {
-  AnyValidator,
-  Constrain,
-  Expand,
-  Register,
-  RegisteredSerializableInput,
-  ResolveValidatorInput,
-  ValidateSerializable,
-  ValidateSerializableInput,
-  Validator,
-} from '@tanstack/router-core'
-
 import { TSS_SERVER_FUNCTION_FACTORY } from './constants'
 import { getStartOptions } from './getStartOptions'
 import { getStartContextServerOnly } from './getStartContextServerOnly'
@@ -30,6 +18,17 @@ import type {
   IntersectAllValidatorInputs,
   IntersectAllValidatorOutputs,
 } from './createMiddleware'
+import type {
+  AnyValidator,
+  Constrain,
+  Expand,
+  Register,
+  RegisteredSerializableInput,
+  ResolveValidatorInput,
+  ValidateSerializable,
+  ValidateSerializableInput,
+  Validator,
+} from '@tanstack/router-core'
 
 type TODO = any
 

--- a/packages/start-client-core/src/createServerFn.ts
+++ b/packages/start-client-core/src/createServerFn.ts
@@ -162,8 +162,10 @@ export const createServerFn: CreateServerFn<Register> = (options, __opts) => {
             throw redirect
           }
 
-          if (result.error) throw result.error
-          return result.result
+          if (result.error instanceof Error) throw result.error
+          // Non-Error values in result.error are application-level error payloads;
+          // return them as the resolved value when no explicit result is present.
+          return result.result ?? result.error
         },
         {
           // This copies over the URL, function ID
@@ -302,10 +304,12 @@ export async function executeMiddleware(
 
           const result = await callNextMiddleware(nextCtx)
 
-          if (result.error) {
+          if (result.error instanceof Error) {
             throw result.error
           }
 
+          // Non-Error values in result.error are application-level error payloads;
+          // preserve them for downstream handlers.
           return result
         }
 

--- a/packages/start-client-core/src/createServerFn.ts
+++ b/packages/start-client-core/src/createServerFn.ts
@@ -165,7 +165,7 @@ export const createServerFn: CreateServerFn<Register> = (options, __opts) => {
           if (result.error instanceof Error) throw result.error
           // Non-Error values in result.error are application-level error payloads;
           // return them as the resolved value when no explicit result is present.
-          return result.result ?? result.error
+          return result.result !== undefined ? result.result : result.error
         },
         {
           // This copies over the URL, function ID

--- a/packages/start-client-core/src/createServerFn.ts
+++ b/packages/start-client-core/src/createServerFn.ts
@@ -1,15 +1,6 @@
 import { mergeHeaders } from '@tanstack/router-core/ssr/client'
 
 import { isNotFound, isRedirect, parseRedirect } from '@tanstack/router-core'
-import { TSS_SERVER_FUNCTION_FACTORY } from './constants'
-import { getStartOptions } from './getStartOptions'
-import { getStartContextServerOnly } from './getStartContextServerOnly'
-import { createNullProtoObject, safeObjectMerge } from './safeObjectMerge'
-import type {
-  ClientFnMeta,
-  ServerFnMeta,
-  TSS_SERVER_FUNCTION,
-} from './constants'
 import type {
   AnyValidator,
   Constrain,
@@ -21,6 +12,16 @@ import type {
   ValidateSerializableInput,
   Validator,
 } from '@tanstack/router-core'
+
+import { TSS_SERVER_FUNCTION_FACTORY } from './constants'
+import { getStartOptions } from './getStartOptions'
+import { getStartContextServerOnly } from './getStartContextServerOnly'
+import { createNullProtoObject, safeObjectMerge } from './safeObjectMerge'
+import type {
+  ClientFnMeta,
+  ServerFnMeta,
+  TSS_SERVER_FUNCTION,
+} from './constants'
 import type {
   AnyFunctionMiddleware,
   AnyRequestMiddleware,
@@ -29,6 +30,7 @@ import type {
   IntersectAllValidatorInputs,
   IntersectAllValidatorOutputs,
 } from './createMiddleware'
+
 
 type TODO = any
 

--- a/packages/start-client-core/src/createServerFn.ts
+++ b/packages/start-client-core/src/createServerFn.ts
@@ -1,6 +1,6 @@
 import { mergeHeaders } from '@tanstack/router-core/ssr/client'
 
-import { isRedirect, parseRedirect } from '@tanstack/router-core'
+import { isNotFound, isRedirect, parseRedirect } from '@tanstack/router-core'
 import { TSS_SERVER_FUNCTION_FACTORY } from './constants'
 import { getStartOptions } from './getStartOptions'
 import { getStartContextServerOnly } from './getStartContextServerOnly'
@@ -162,7 +162,12 @@ export const createServerFn: CreateServerFn<Register> = (options, __opts) => {
             throw redirect
           }
 
-          if (result.error instanceof Error) throw result.error
+          if (
+            result.error instanceof Error ||
+            isRedirect(result.error) ||
+            isNotFound(result.error)
+          )
+            throw result.error
           // Non-Error values in result.error are application-level error payloads;
           // return them as the resolved value when no explicit result is present.
           return result.result !== undefined ? result.result : result.error
@@ -304,7 +309,11 @@ export async function executeMiddleware(
 
           const result = await callNextMiddleware(nextCtx)
 
-          if (result.error instanceof Error) {
+          if (
+            result.error instanceof Error ||
+            isRedirect(result.error) ||
+            isNotFound(result.error)
+          ) {
             throw result.error
           }
 


### PR DESCRIPTION
Fixes #7238

## Problem

Middleware that wanted to return structured error responses from catch blocks would have those errors thrown immediately to the client, preventing global error classification middleware from working:

```typescript
// Before: result.error gets thrown, { success: false } is lost
try {
  await next()
} catch (e) {
  return { success: false, error: { code: 'BILLING_ERROR', message: e.message } }
}
```

The middleware protocol was using `.error` property for two incompatible purposes:
1. **Framework errors**: Thrown exceptions from middleware, validation failures (instances of Error)
2. **Application errors**: Custom error structures returned by middleware (plain objects)

This collision meant middleware couldn't distinguish between "I'm returning an error as application data" and "this is a framework-level failure that should be thrown."

## Solution

Use JavaScript's type system to distinguish errors:
- Only throw \`Error\` instances (actual exceptions)
- Pass through non-Error values in \`result.error\` as application data

This allows middleware to return custom error structures while preserving proper error propagation for real framework errors.

```typescript
// After: Custom error structure is returned intact
try {
  await next()
} catch (e) {
  return { success: false, error: { code: 'BILLING_ERROR', message: e.message } }
}
// Client receives: { success: false, error: { code: 'BILLING_ERROR', ... } }
```

## Changes

- Line 165: \`if (result.error)\` → \`if (result.error instanceof Error)\`
- Line 305: \`if (result.error)\` → \`if (result.error instanceof Error)\`

## Breaking Change (Minor)

Middleware that throw non-Error values will now have those values captured in \`result.error\` instead of being thrown to the client.

**Impact**: Only affects middleware using non-standard error throwing patterns. Best practice is to throw \`Error\` instances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new page with a button to invoke a server call and display a structured non-error payload when returned.
* **Bug Fixes**
  * Client fetcher and middleware now preserve non-exception structured payloads (returned to callers) while still throwing real exceptions and redirect/not-found signals.
* **Tests**
  * Added an end-to-end test validating the UI shows the expected structured payload.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/router/pull/7364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->