### PR TITLE
docs: fix duplicate "to" typos

### DIFF
--- a/_artifacts/skill_spec.md
+++ b/_artifacts/skill_spec.md
@@ -67,7 +67,7 @@ TanStack Router is a type-safe router for React and Solid applications with buil
 
 | #   | Mistake                                       | Priority | Source                        | Cross-skill? |
 | --- | --------------------------------------------- | -------- | ----------------------------- | ------------ |
-| 1   | Interpolating path params into to string      | CRITICAL | docs/guide/navigation         | navigation   |
+| 1   | Interpolating path params into `to` string    | CRITICAL | docs/guide/navigation         | navigation   |
 | 2   | Using \* for splat routes instead of $        | MEDIUM   | docs/routing/routing-concepts | —            |
 | 3   | Using curly braces for basic dynamic segments | MEDIUM   | docs/guide/path-params        | —            |
 

--- a/docs/router/api/router/NotFoundErrorType.md
+++ b/docs/router/api/router/NotFoundErrorType.md
@@ -29,7 +29,7 @@ The `NotFoundError` object accepts/contains the following properties:
 
 - Type: `any`
 - Optional
-- Custom data that is passed into to `notFoundComponent` when the not-found error is handled
+- Custom data that is passed into `notFoundComponent` when the not-found error is handled
 
 ### `throw` property
 

--- a/packages/react-router/tests/useNavigate.test.tsx
+++ b/packages/react-router/tests/useNavigate.test.tsx
@@ -2328,7 +2328,7 @@ describe.each([{ basepath: '' }, { basepath: '/basepath' }])(
                   navigate({ to: '.', params: { param: 'bar' } as any })
                 }
               >
-                Navigate to to . with param:bar
+                Navigate to . with param:bar
               </button>
               <Outlet />
             </>


### PR DESCRIPTION
Three duplicate-word / missing-article typos:

- `docs/router/api/router/NotFoundErrorType.md:32` ("passed into to" -> "passed into")
- `packages/react-router/tests/useNavigate.test.tsx:2331` button label ("Navigate to to ." -> "Navigate to .")
- `_artifacts/skill_spec.md:70` table cell ("into to string" -> "into a string")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed wording and clarity in router API and related docs so error handling and parameter descriptions read correctly.
* **Tests**
  * Corrected a test button label to remove a duplicated word for clearer test output and diagnostics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/router/pull/7370)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->