### PR TITLE
fix(router-core): fix search middleware type to use schema output

### DIFF
--- a/.changeset/quiet-plums-help.md
+++ b/.changeset/quiet-plums-help.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+fix(router-core): use search validator output type for search middleware context

--- a/packages/router-core/src/route.ts
+++ b/packages/router-core/src/route.ts
@@ -1274,9 +1274,7 @@ export interface UpdatableRouteOptions<
   preloadGcTime?: number
   search?: {
     middlewares?: Array<
-      SearchMiddleware<
-        ResolveFullSearchSchemaInput<TParentRoute, TSearchValidator>
-      >
+      SearchMiddleware<ResolveFullSearchSchema<TParentRoute, TSearchValidator>>
     >
   }
   /** 

--- a/packages/router-core/src/searchMiddleware.ts
+++ b/packages/router-core/src/searchMiddleware.ts
@@ -45,9 +45,7 @@ export function retainSearchParams<TSearchSchema extends object>(
 export function stripSearchParams<
   TSearchSchema,
   TOptionalProps = PickOptional<NoInfer<TSearchSchema>>,
-  const TValues =
-    | Partial<NoInfer<TOptionalProps>>
-    | Array<keyof TOptionalProps>,
+  const TValues = Partial<NoInfer<TSearchSchema>> | Array<keyof TOptionalProps>,
   const TInput = IsRequiredParams<TSearchSchema> extends never
     ? TValues | true
     : TValues,

--- a/packages/router-core/tests/searchMiddleware.test-d.ts
+++ b/packages/router-core/tests/searchMiddleware.test-d.ts
@@ -1,0 +1,39 @@
+import { describe, expectTypeOf, test } from 'vitest'
+import { BaseRootRoute, BaseRoute, type ValidatorAdapter } from '../src'
+
+describe('search middlewares', () => {
+  test('should use search validator output for middleware context', () => {
+    type SearchInput = {
+      page?: string
+    }
+
+    type SearchOutput = {
+      page: number
+    }
+
+    const searchValidator: ValidatorAdapter<SearchInput, SearchOutput> = {
+      types: undefined as never,
+      parse: () => ({ page: 1 }),
+    }
+
+    const rootRoute = new BaseRootRoute({})
+
+    new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/posts',
+      validateSearch: searchValidator,
+      search: {
+        middlewares: [
+          ({ search, next }) => {
+            expectTypeOf(search).toEqualTypeOf<SearchOutput>()
+            expectTypeOf(next).toBeCallableWith({ page: 2 })
+            expectTypeOf(next).parameter(0).toEqualTypeOf<SearchOutput>()
+            expectTypeOf(next({ page: 2 })).toEqualTypeOf<SearchOutput>()
+
+            return search
+          },
+        ],
+      },
+    })
+  })
+})

--- a/packages/router-core/tests/searchMiddleware.test-d.ts
+++ b/packages/router-core/tests/searchMiddleware.test-d.ts
@@ -1,5 +1,10 @@
 import { describe, expectTypeOf, test } from 'vitest'
-import { BaseRootRoute, BaseRoute, type ValidatorAdapter } from '../src'
+import {
+  BaseRootRoute,
+  BaseRoute,
+  stripSearchParams,
+  type ValidatorAdapter,
+} from '../src'
 
 describe('search middlewares', () => {
   test('should use search validator output for middleware context', () => {
@@ -33,6 +38,38 @@ describe('search middlewares', () => {
             return search
           },
         ],
+      },
+    })
+  })
+
+  test('should allow stripping default-valued validator output keys', () => {
+    type RootSearch = {
+      root?: string
+    }
+
+    type SearchInput = {
+      foo?: string
+    }
+
+    type SearchOutput = {
+      foo: string
+    }
+
+    const searchValidator: ValidatorAdapter<SearchInput, SearchOutput> = {
+      types: undefined as never,
+      parse: () => ({ foo: 'default' }),
+    }
+
+    const rootRoute = new BaseRootRoute({
+      validateSearch: (search: RootSearch): RootSearch => search,
+    })
+
+    new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/posts',
+      validateSearch: searchValidator,
+      search: {
+        middlewares: [stripSearchParams({ foo: 'default' })],
       },
     })
   })


### PR DESCRIPTION
## Summary

The type for `search` passed to a route's search middleware is currently set to the input of whatever is passed to `validateSearch`. In reality this value is the output of the search validator.

In the majority of cases these types are the same, but it becomes a pronounced issue with asymmetric schemas, for example with Zod codecs:

```ts
// input is number, output is BigInt
const numberToBigInt = z.codec(z.int(), z.bigint(), {
  decode: (num) => BigInt(num),
  encode: (bigint) => Number(bigint),
});

const searchSchema = z.object({
  codec: numberToBigInt.optional(),
})
```

The value that we get in the search middleware is a `BigInt` but it's typed as a `number`.

## Changes

Simple switch from `ResolveFullSearchSchemaInput` to `ResolveFullSearchSchema`.

## Reproduction

You can find here a small TanStack Start project with a demo of the mismatch: https://github.com/sprusr/tanstack-router-search-middleware-types


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Search middleware now consistently receives the validated search shape (middleware input types aligned with validator output).
  * Helper that strips defaulted search parameters accepts validator-shaped defaults for consistent typing.
* **Tests**
  * Added type-level tests to verify middleware and validators produce matching search shapes and stripping behavior.
* **Chores**
  * Recorded a patch changeset for the router-core package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->