### PR TITLE
chore: update chokidar to v5

### DIFF
--- a/.changeset/chokidar-v5.md
+++ b/.changeset/chokidar-v5.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/router-cli': patch
+'@tanstack/router-plugin': patch
+---
+
+Update chokidar to v5.

--- a/packages/router-cli/package.json
+++ b/packages/router-cli/package.json
@@ -67,10 +67,11 @@
   },
   "dependencies": {
     "@tanstack/router-generator": "workspace:*",
-    "chokidar": "^3.6.0",
+    "chokidar": "^5.0.0",
     "yargs": "^17.7.2"
   },
   "devDependencies": {
+    "@types/node": ">=20",
     "@types/yargs": "^17.0.33",
     "vite": "*"
   }

--- a/packages/router-cli/tsconfig.json
+++ b/packages/router-cli/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src", "vite.config.ts"]
+  "include": ["src", "vite.config.ts"],
+  "compilerOptions": {
+    "types": ["node"]
+  }
 }

--- a/packages/router-plugin/package.json
+++ b/packages/router-plugin/package.json
@@ -127,7 +127,7 @@
     "@tanstack/router-generator": "workspace:*",
     "@tanstack/router-utils": "workspace:*",
     "@tanstack/virtual-file-routes": "workspace:*",
-    "chokidar": "^3.6.0",
+    "chokidar": "^5.0.0",
     "unplugin": "^3.0.0",
     "zod": "^3.24.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12725,12 +12725,15 @@ importers:
         specifier: workspace:*
         version: link:../router-generator
       chokidar:
-        specifier: ^3.6.0
-        version: 3.6.0
+        specifier: ^5.0.0
+        version: 5.0.0
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
     devDependencies:
+      '@types/node':
+        specifier: 25.0.9
+        version: 25.0.9
       '@types/yargs':
         specifier: ^17.0.33
         version: 17.0.33
@@ -12898,8 +12901,8 @@ importers:
         specifier: workspace:*
         version: link:../virtual-file-routes
       chokidar:
-        specifier: ^3.6.0
-        version: 3.6.0
+        specifier: ^5.0.0
+        version: 5.0.0
       unplugin:
         specifier: ^3.0.0
         version: 3.0.0


### PR DESCRIPTION
## Summary
- update direct chokidar dependencies in router CLI and router plugin to v5
- add explicit Node typings for router CLI after chokidar v5 dependency/type changes
- add a patch changeset for the affected packages

## Test plan
- `CI=1 NX_DAEMON=false pnpm nx run-many --targets=test:types,test:build --projects=@tanstack/router-cli,@tanstack/router-plugin --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/router-plugin:test:unit --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run-many --targets=test:eslint --projects=@tanstack/router-cli,@tanstack/router-plugin --outputStyle=stream --skipRemoteCache`
- `node -e "require('./packages/router-cli/dist/cjs/watch.cjs'); require('./packages/router-plugin/dist/cjs/core/router-generator-plugin.cjs'); console.log('ok')"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated chokidar dependency to version 5 across router packages
  * Updated TypeScript configuration and node type definitions for enhanced compatibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/router/pull/7439?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->