### PR TITLE
chore: update express and webpack-dev-server

### DIFF
--- a/e2e/react-start/basic/package.json
+++ b/e2e/react-start/basic/package.json
@@ -21,7 +21,7 @@
     "@tanstack/react-router": "workspace:^",
     "@tanstack/react-router-devtools": "workspace:^",
     "@tanstack/react-start": "workspace:^",
-    "express": "^5.1.0",
+    "express": "^5.2.1",
     "http-proxy-middleware": "^3.0.5",
     "js-cookie": "^3.0.5",
     "react": "^19.0.0",

--- a/e2e/react-start/basic/server.js
+++ b/e2e/react-start/basic/server.js
@@ -79,19 +79,22 @@ export async function createSpaServer() {
 
 if (isSpaMode) {
   createSpaServer().then(async ({ app }) =>
-    app.listen(port, () => {
+    app.listen(port, (error) => {
+      if (error) throw error
       console.info(`Client Server: http://localhost:${port}`)
     }),
   )
 
   createStartServer().then(async ({ app }) =>
-    app.listen(startPort, () => {
+    app.listen(startPort, (error) => {
+      if (error) throw error
       console.info(`Start Server: http://localhost:${startPort}`)
     }),
   )
 } else {
   createStartServer().then(async ({ app }) =>
-    app.listen(port, () => {
+    app.listen(port, (error) => {
+      if (error) throw error
       console.info(`Start Server: http://localhost:${port}`)
     }),
   )

--- a/e2e/react-start/css-inline/package.json
+++ b/e2e/react-start/css-inline/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@tanstack/react-router": "workspace:^",
     "@tanstack/react-start": "workspace:^",
-    "express": "^5.1.0",
+    "express": "^5.2.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "srvx": "^0.11.9"

--- a/e2e/react-start/css-inline/server.js
+++ b/e2e/react-start/css-inline/server.js
@@ -37,7 +37,8 @@ async function createStartServer() {
 }
 
 createStartServer().then((app) => {
-  app.listen(port, () => {
+  app.listen(port, (error) => {
+    if (error) throw error
     console.info(`Start Server: http://localhost:${port}`)
   })
 })

--- a/e2e/react-start/custom-basepath/express-server.ts
+++ b/e2e/react-start/custom-basepath/express-server.ts
@@ -40,6 +40,7 @@ if (DEVELOPMENT) {
   })
 }
 
-app.listen(PORT, () => {
+app.listen(PORT, (error) => {
+  if (error) throw error
   console.log(`Server is running on http://localhost:${PORT}`)
 })

--- a/e2e/react-start/custom-basepath/package.json
+++ b/e2e/react-start/custom-basepath/package.json
@@ -14,7 +14,7 @@
     "@tanstack/react-router": "workspace:^",
     "@tanstack/react-router-devtools": "workspace:^",
     "@tanstack/react-start": "workspace:^",
-    "express": "^5.1.0",
+    "express": "^5.2.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "redaxios": "^0.5.1"
@@ -23,7 +23,7 @@
     "@playwright/test": "^1.50.1",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
-    "@types/express": "^5.0.3",
+    "@types/express": "^5.0.6",
     "@types/node": "^22.10.2",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",

--- a/e2e/react-start/custom-server-rsbuild/express-server.ts
+++ b/e2e/react-start/custom-server-rsbuild/express-server.ts
@@ -57,7 +57,8 @@ if (DEVELOPMENT) {
     }
   })
 
-  const httpServer = app.listen(PORT, async () => {
+  const httpServer = app.listen(PORT, async (error) => {
+    if (error) throw error
     await devServer.afterListen()
     console.log(`Server is running on http://localhost:${PORT}`)
   })
@@ -74,7 +75,8 @@ if (DEVELOPMENT) {
       next(error)
     }
   })
-  app.listen(PORT, () => {
+  app.listen(PORT, (error) => {
+    if (error) throw error
     console.log(`Server is running on http://localhost:${PORT}`)
   })
 }

--- a/e2e/react-start/custom-server-rsbuild/package.json
+++ b/e2e/react-start/custom-server-rsbuild/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@tanstack/react-router": "workspace:^",
     "@tanstack/react-start": "workspace:^",
-    "express": "^5.1.0",
+    "express": "^5.2.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -25,7 +25,7 @@
     "@rsbuild/plugin-react": "^2.0.0",
     "@tailwindcss/postcss": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
-    "@types/express": "^5.0.3",
+    "@types/express": "^5.0.6",
     "@types/node": "^22.10.2",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",

--- a/e2e/react-start/split-base-and-basepath/package.json
+++ b/e2e/react-start/split-base-and-basepath/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@tanstack/react-router": "workspace:^",
     "@tanstack/react-start": "workspace:^",
-    "express": "^5.1.0",
+    "express": "^5.2.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/e2e/react-start/split-base-and-basepath/prod-server.js
+++ b/e2e/react-start/split-base-and-basepath/prod-server.js
@@ -20,6 +20,7 @@ app.use(async (req, res, next) => {
   }
 })
 
-app.listen(PORT, () => {
+app.listen(PORT, (error) => {
+  if (error) throw error
   console.log(`Server is running on http://localhost:${PORT}`)
 })

--- a/e2e/react-start/transform-asset-urls/package.json
+++ b/e2e/react-start/transform-asset-urls/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@tanstack/react-router": "workspace:^",
     "@tanstack/react-start": "workspace:^",
-    "express": "^5.1.0",
+    "express": "^5.2.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/e2e/react-start/transform-asset-urls/tests/cdn-server.mjs
+++ b/e2e/react-start/transform-asset-urls/tests/cdn-server.mjs
@@ -36,6 +36,7 @@ app.use((req, res, next) => {
 
 app.use(express.static(path.resolve(__dirname, '..', 'dist', 'client')))
 
-app.listen(port, () => {
+app.listen(port, (error) => {
+  if (error) throw error
   console.info(`CDN Server: http://localhost:${port}`)
 })

--- a/e2e/solid-start/basic/package.json
+++ b/e2e/solid-start/basic/package.json
@@ -17,7 +17,7 @@
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "express": "^5.1.0",
+    "express": "^5.2.1",
     "http-proxy-middleware": "^3.0.5",
     "js-cookie": "^3.0.5",
     "redaxios": "^0.5.1",

--- a/e2e/solid-start/basic/server.js
+++ b/e2e/solid-start/basic/server.js
@@ -79,19 +79,22 @@ export async function createSpaServer() {
 
 if (isSpaMode) {
   createSpaServer().then(async ({ app }) =>
-    app.listen(port, () => {
+    app.listen(port, (error) => {
+      if (error) throw error
       console.info(`Client Server: http://localhost:${port}`)
     }),
   )
 
   createStartServer().then(async ({ app }) =>
-    app.listen(startPort, () => {
+    app.listen(startPort, (error) => {
+      if (error) throw error
       console.info(`Start Server: http://localhost:${startPort}`)
     }),
   )
 } else {
   createStartServer().then(async ({ app }) =>
-    app.listen(port, () => {
+    app.listen(port, (error) => {
+      if (error) throw error
       console.info(`Start Server: http://localhost:${port}`)
     }),
   )

--- a/e2e/solid-start/custom-basepath/express-server.ts
+++ b/e2e/solid-start/custom-basepath/express-server.ts
@@ -40,6 +40,7 @@ if (DEVELOPMENT) {
   })
 }
 
-app.listen(PORT, () => {
+app.listen(PORT, (error) => {
+  if (error) throw error
   console.log(`Server is running on http://localhost:${PORT}`)
 })

--- a/e2e/solid-start/custom-basepath/package.json
+++ b/e2e/solid-start/custom-basepath/package.json
@@ -14,7 +14,7 @@
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "express": "^5.1.0",
+    "express": "^5.2.1",
     "redaxios": "^0.5.1",
     "solid-js": "^1.9.10"
   },
@@ -22,7 +22,7 @@
     "@playwright/test": "^1.50.1",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
-    "@types/express": "^5.0.3",
+    "@types/express": "^5.0.6",
     "@types/node": "^22.10.2",
     "cross-env": "^10.0.0",
     "srvx": "^0.11.9",

--- a/e2e/vue-start/basic/package.json
+++ b/e2e/vue-start/basic/package.json
@@ -17,7 +17,7 @@
     "@tanstack/vue-router": "workspace:^",
     "@tanstack/vue-router-devtools": "workspace:^",
     "@tanstack/vue-start": "workspace:^",
-    "express": "^5.1.0",
+    "express": "^5.2.1",
     "http-proxy-middleware": "^3.0.5",
     "js-cookie": "^3.0.5",
     "redaxios": "^0.5.1",

--- a/e2e/vue-start/basic/server.js
+++ b/e2e/vue-start/basic/server.js
@@ -79,19 +79,22 @@ export async function createSpaServer() {
 
 if (isSpaMode) {
   createSpaServer().then(async ({ app }) =>
-    app.listen(port, () => {
+    app.listen(port, (error) => {
+      if (error) throw error
       console.info(`Client Server: http://localhost:${port}`)
     }),
   )
 
   createStartServer().then(async ({ app }) =>
-    app.listen(startPort, () => {
+    app.listen(startPort, (error) => {
+      if (error) throw error
       console.info(`Start Server: http://localhost:${startPort}`)
     }),
   )
 } else {
   createStartServer().then(async ({ app }) =>
-    app.listen(port, () => {
+    app.listen(port, (error) => {
+      if (error) throw error
       console.info(`Start Server: http://localhost:${port}`)
     }),
   )

--- a/e2e/vue-start/custom-basepath/express-server.ts
+++ b/e2e/vue-start/custom-basepath/express-server.ts
@@ -40,6 +40,7 @@ if (DEVELOPMENT) {
   })
 }
 
-app.listen(PORT, () => {
+app.listen(PORT, (error) => {
+  if (error) throw error
   console.log(`Server is running on http://localhost:${PORT}`)
 })

--- a/e2e/vue-start/custom-basepath/package.json
+++ b/e2e/vue-start/custom-basepath/package.json
@@ -14,7 +14,7 @@
     "@tanstack/vue-router": "workspace:^",
     "@tanstack/vue-router-devtools": "workspace:^",
     "@tanstack/vue-start": "workspace:^",
-    "express": "^5.1.0",
+    "express": "^5.2.1",
     "redaxios": "^0.5.1",
     "vue": "^3.5.25"
   },
@@ -22,7 +22,7 @@
     "@playwright/test": "^1.50.1",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
-    "@types/express": "^5.0.3",
+    "@types/express": "^5.0.6",
     "@types/node": "^22.10.2",
     "cross-env": "^10.0.0",
     "srvx": "^0.11.9",

--- a/examples/react/basic-ssr-file-based/package.json
+++ b/examples/react/basic-ssr-file-based/package.json
@@ -14,7 +14,7 @@
     "@tanstack/react-router": "^1.170.4",
     "@tanstack/router-plugin": "^1.168.6",
     "compression": "^1.8.0",
-    "express": "^4.21.2",
+    "express": "^5.2.1",
     "get-port": "^7.1.0",
     "node-fetch": "^3.3.2",
     "react": "^19.0.0",
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@tanstack/react-router-devtools": "^1.167.0",
-    "@types/express": "^4.17.23",
+    "@types/express": "^5.0.6",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.1",
     "@vitejs/plugin-react": "^6.0.1",

--- a/examples/react/basic-ssr-file-based/server.js
+++ b/examples/react/basic-ssr-file-based/server.js
@@ -51,7 +51,7 @@ export async function createServer(
 
   if (isProd) app.use(express.static('./dist/client'))
 
-  app.use('*', async (req, res) => {
+  app.use('/{*splat}', async (req, res) => {
     try {
       const url = req.originalUrl
 
@@ -97,7 +97,8 @@ export async function createServer(
 
 if (!isTest) {
   createServer().then(async ({ app }) =>
-    app.listen(await getPort({ port: portNumbers(3000, 3100) }), () => {
+    app.listen(await getPort({ port: portNumbers(3000, 3100) }), (error) => {
+      if (error) throw error
       console.info('Client Server: http://localhost:3000')
     }),
   )

--- a/examples/react/basic-ssr-streaming-file-based/package.json
+++ b/examples/react/basic-ssr-streaming-file-based/package.json
@@ -14,7 +14,7 @@
     "@tanstack/react-router": "^1.170.4",
     "@tanstack/router-plugin": "^1.168.6",
     "compression": "^1.8.0",
-    "express": "^4.21.2",
+    "express": "^5.2.1",
     "get-port": "^7.1.0",
     "node-fetch": "^3.3.2",
     "react": "^19.0.0",
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@tanstack/react-router-devtools": "^1.167.0",
-    "@types/express": "^4.17.23",
+    "@types/express": "^5.0.6",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.1",
     "@vitejs/plugin-react": "^6.0.1",

--- a/examples/react/basic-ssr-streaming-file-based/server.js
+++ b/examples/react/basic-ssr-streaming-file-based/server.js
@@ -51,7 +51,7 @@ export async function createServer(
 
   if (isProd) app.use(express.static('./dist/client'))
 
-  app.use('*', async (req, res) => {
+  app.use('/{*splat}', async (req, res) => {
     try {
       const url = req.originalUrl
 
@@ -97,7 +97,8 @@ export async function createServer(
 
 if (!isTest) {
   createServer().then(async ({ app }) =>
-    app.listen(await getPort({ port: portNumbers(3000, 3100) }), () => {
+    app.listen(await getPort({ port: portNumbers(3000, 3100) }), (error) => {
+      if (error) throw error
       console.info('Client Server: http://localhost:3000')
     }),
   )

--- a/examples/react/quickstart-webpack-file-based/package.json
+++ b/examples/react/quickstart-webpack-file-based/package.json
@@ -23,6 +23,6 @@
     "typescript": "^6.0.2",
     "webpack": "^5.97.1",
     "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^5.2.0"
+    "webpack-dev-server": "^5.2.4"
   }
 }

--- a/examples/react/with-trpc-react-query/package.json
+++ b/examples/react/with-trpc-react-query/package.json
@@ -19,7 +19,7 @@
     "@trpc/client": "^11.4.3",
     "@trpc/server": "^11.4.3",
     "@trpc/tanstack-react-query": "^11.4.3",
-    "express": "^4.21.2",
+    "express": "^5.2.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "redaxios": "^0.5.1",
@@ -27,7 +27,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@types/express": "^4.17.23",
+    "@types/express": "^5.0.6",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^6.0.1",

--- a/examples/react/with-trpc-react-query/src/server/server.ts
+++ b/examples/react/with-trpc-react-query/src/server/server.ts
@@ -50,7 +50,7 @@ export const createServer = async (
     app.use(viteServer.middlewares)
 
     // Handle any requests that don't match an API route by serving the React app's index.html
-    app.get('*', async (req, res, next) => {
+    app.get('/{*splat}', async (req, res, next) => {
       try {
         let html = fs.readFileSync(path.resolve(root, 'index.html'), 'utf-8')
 
@@ -68,7 +68,7 @@ export const createServer = async (
     app.use(express.static(path.resolve(__dirname, '../client')))
 
     // Handle any requests that don't match an API route by serving the React app's index.html
-    app.get('*', (req, res) => {
+    app.get('/{*splat}', (req, res) => {
       res.sendFile(path.resolve(__dirname, '../client', 'index.html'))
     })
   }
@@ -78,7 +78,8 @@ export const createServer = async (
 
 if (!isTest) {
   createServer().then(({ app }) =>
-    app.listen(PORT, () => {
+    app.listen(PORT, (error) => {
+      if (error) throw error
       console.info(`Server available at: http://localhost:${PORT}`)
     }),
   )

--- a/examples/react/with-trpc/package.json
+++ b/examples/react/with-trpc/package.json
@@ -16,7 +16,7 @@
     "@tanstack/router-plugin": "^1.168.6",
     "@trpc/client": "^11.4.3",
     "@trpc/server": "^11.4.3",
-    "express": "^4.21.2",
+    "express": "^5.2.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "redaxios": "^0.5.1",
@@ -24,7 +24,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@types/express": "^4.17.23",
+    "@types/express": "^5.0.6",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^6.0.1",

--- a/examples/react/with-trpc/src/server/server.ts
+++ b/examples/react/with-trpc/src/server/server.ts
@@ -50,7 +50,7 @@ export const createServer = async (
     app.use(viteServer.middlewares)
 
     // Handle any requests that don't match an API route by serving the React app's index.html
-    app.get('*', async (req, res, next) => {
+    app.get('/{*splat}', async (req, res, next) => {
       try {
         let html = fs.readFileSync(path.resolve(root, 'index.html'), 'utf-8')
 
@@ -68,7 +68,7 @@ export const createServer = async (
     app.use(express.static(path.resolve(__dirname, '../client')))
 
     // Handle any requests that don't match an API route by serving the React app's index.html
-    app.get('*', (req, res) => {
+    app.get('/{*splat}', (req, res) => {
       res.sendFile(path.resolve(__dirname, '../client', 'index.html'))
     })
   }
@@ -78,7 +78,8 @@ export const createServer = async (
 
 if (!isTest) {
   createServer().then(({ app }) =>
-    app.listen(PORT, () => {
+    app.listen(PORT, (error) => {
+      if (error) throw error
       console.info(`Server available at: http://localhost:${PORT}`)
     }),
   )

--- a/examples/solid/basic-ssr-file-based/package.json
+++ b/examples/solid/basic-ssr-file-based/package.json
@@ -14,14 +14,14 @@
     "@tanstack/solid-router": "^1.170.4",
     "@tanstack/router-plugin": "^1.168.6",
     "compression": "^1.8.0",
-    "express": "^4.21.2",
+    "express": "^5.2.1",
     "get-port": "^7.1.0",
     "node-fetch": "^3.3.2",
     "solid-js": "^1.9.10"
   },
   "devDependencies": {
     "@tanstack/solid-router-devtools": "^1.167.0",
-    "@types/express": "^4.17.23",
+    "@types/express": "^5.0.6",
     "vite-plugin-solid": "^2.11.11",
     "typescript": "^6.0.2",
     "vite": "^8.0.0"

--- a/examples/solid/basic-ssr-file-based/server.js
+++ b/examples/solid/basic-ssr-file-based/server.js
@@ -51,7 +51,7 @@ export async function createServer(
 
   if (isProd) app.use(express.static('./dist/client'))
 
-  app.use('*', async (req, res) => {
+  app.use('/{*splat}', async (req, res) => {
     try {
       const url = req.originalUrl
 
@@ -97,7 +97,8 @@ export async function createServer(
 
 if (!isTest) {
   createServer().then(async ({ app }) =>
-    app.listen(await getPort({ port: portNumbers(3000, 3100) }), () => {
+    app.listen(await getPort({ port: portNumbers(3000, 3100) }), (error) => {
+      if (error) throw error
       console.info('Client Server: http://localhost:3000')
     }),
   )

--- a/examples/solid/basic-ssr-streaming-file-based/package.json
+++ b/examples/solid/basic-ssr-streaming-file-based/package.json
@@ -15,7 +15,7 @@
     "@tanstack/solid-router": "^1.170.4",
     "@tanstack/solid-router-devtools": "^1.167.0",
     "compression": "^1.8.0",
-    "express": "^4.21.2",
+    "express": "^5.2.1",
     "get-port": "^7.1.0",
     "node-fetch": "^3.3.2",
     "redaxios": "^0.5.1",
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@tanstack/router-plugin": "^1.168.6",
-    "@types/express": "^4.17.23",
+    "@types/express": "^5.0.6",
     "typescript": "^6.0.2",
     "vite": "^8.0.0",
     "vite-plugin-solid": "^2.11.11"

--- a/examples/solid/basic-ssr-streaming-file-based/server.js
+++ b/examples/solid/basic-ssr-streaming-file-based/server.js
@@ -51,7 +51,7 @@ export async function createServer(
 
   if (isProd) app.use(express.static('./dist/client'))
 
-  app.use('*', async (req, res) => {
+  app.use('/{*splat}', async (req, res) => {
     try {
       const url = req.originalUrl
 
@@ -97,7 +97,8 @@ export async function createServer(
 
 if (!isTest) {
   createServer().then(async ({ app }) =>
-    app.listen(await getPort({ port: portNumbers(3000, 3100) }), () => {
+    app.listen(await getPort({ port: portNumbers(3000, 3100) }), (error) => {
+      if (error) throw error
       console.info('Client Server: http://localhost:3000')
     }),
   )

--- a/examples/solid/quickstart-webpack-file-based/package.json
+++ b/examples/solid/quickstart-webpack-file-based/package.json
@@ -26,6 +26,6 @@
     "typescript": "^6.0.2",
     "webpack": "^5.97.1",
     "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^5.2.0"
+    "webpack-dev-server": "^5.2.4"
   }
 }

--- a/examples/solid/with-trpc/package.json
+++ b/examples/solid/with-trpc/package.json
@@ -16,14 +16,14 @@
     "@tanstack/solid-router-devtools": "^1.167.0",
     "@trpc/client": "^11.4.3",
     "@trpc/server": "^11.4.3",
-    "express": "^4.21.2",
+    "express": "^5.2.1",
     "redaxios": "^0.5.1",
     "solid-js": "^1.9.10",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@types/express": "^4.17.23",
+    "@types/express": "^5.0.6",
     "tsx": "^4.20.3",
     "vite": "^8.0.0",
     "vite-plugin-solid": "^2.11.11"

--- a/examples/solid/with-trpc/src/server/server.ts
+++ b/examples/solid/with-trpc/src/server/server.ts
@@ -50,7 +50,7 @@ export const createServer = async (
     app.use(viteServer.middlewares)
 
     // Handle any requests that don't match an API route by serving the React app's index.html
-    app.get('*', async (req, res, next) => {
+    app.get('/{*splat}', async (req, res, next) => {
       try {
         let html = fs.readFileSync(path.resolve(root, 'index.html'), 'utf-8')
 
@@ -68,7 +68,7 @@ export const createServer = async (
     app.use(express.static(path.resolve(__dirname, '../client')))
 
     // Handle any requests that don't match an API route by serving the React app's index.html
-    app.get('*', (req, res) => {
+    app.get('/{*splat}', (req, res) => {
       res.sendFile(path.resolve(__dirname, '../client', 'index.html'))
     })
   }
@@ -78,7 +78,8 @@ export const createServer = async (
 
 if (!isTest) {
   createServer().then(({ app }) =>
-    app.listen(PORT, () => {
+    app.listen(PORT, (error) => {
+      if (error) throw error
       console.info(`Server available at: http://localhost:${PORT}`)
     }),
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8169,10 +8169,10 @@ importers:
         version: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
-        version: 5.1.4(webpack-dev-server@5.2.0)(webpack@5.97.1)
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.97.1)
       webpack-dev-server:
-        specifier: ^5.2.0
-        version: 5.2.0(webpack-cli@5.1.4)(webpack@5.97.1)
+        specifier: ^5.2.4
+        version: 5.2.4(webpack-cli@5.1.4)(webpack@5.97.1)
 
   examples/react/router-monorepo-react-query:
     dependencies:
@@ -11148,10 +11148,10 @@ importers:
         version: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
-        version: 5.1.4(webpack-dev-server@5.2.0)(webpack@5.97.1)
+        version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.97.1)
       webpack-dev-server:
-        specifier: ^5.2.0
-        version: 5.2.0(webpack-cli@5.1.4)(webpack@5.97.1)
+        specifier: ^5.2.4
+        version: 5.2.4(webpack-cli@5.1.4)(webpack@5.97.1)
 
   examples/solid/router-monorepo-simple:
     dependencies:
@@ -16342,6 +16342,10 @@ packages:
     resolution: {integrity: sha512-xHK3XHPUW8DTAobU+G0XT+/w+JLM7/8k1UFdB5xg/zTFPnFCobhftzw8wl4Lw2aq/Rvir5pxfZV5fEazmeCJ2g==}
     engines: {node: '>= 20.19.0'}
 
+  '@noble/hashes@1.4.0':
+    resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
+    engines: {node: '>= 16'}
+
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
     engines: {node: '>= 20.19.0'}
@@ -16926,35 +16930,72 @@ packages:
   '@peculiar/asn1-cms@2.5.0':
     resolution: {integrity: sha512-p0SjJ3TuuleIvjPM4aYfvYw8Fk1Hn/zAVyPJZTtZ2eE9/MIer6/18ROxX6N/e6edVSfvuZBqhxAj3YgsmSjQ/A==}
 
+  '@peculiar/asn1-cms@2.7.0':
+    resolution: {integrity: sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==}
+
   '@peculiar/asn1-csr@2.5.0':
     resolution: {integrity: sha512-ioigvA6WSYN9h/YssMmmoIwgl3RvZlAYx4A/9jD2qaqXZwGcNlAxaw54eSx2QG1Yu7YyBC5Rku3nNoHrQ16YsQ==}
+
+  '@peculiar/asn1-csr@2.7.0':
+    resolution: {integrity: sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA==}
 
   '@peculiar/asn1-ecc@2.5.0':
     resolution: {integrity: sha512-t4eYGNhXtLRxaP50h3sfO6aJebUCDGQACoeexcelL4roMFRRVgB20yBIu2LxsPh/tdW9I282gNgMOyg3ywg/mg==}
 
+  '@peculiar/asn1-ecc@2.7.0':
+    resolution: {integrity: sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==}
+
   '@peculiar/asn1-pfx@2.5.0':
     resolution: {integrity: sha512-Vj0d0wxJZA+Ztqfb7W+/iu8Uasw6hhKtCdLKXLG/P3kEPIQpqGI4P4YXlROfl7gOCqFIbgsj1HzFIFwQ5s20ug==}
+
+  '@peculiar/asn1-pfx@2.7.0':
+    resolution: {integrity: sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA==}
 
   '@peculiar/asn1-pkcs8@2.5.0':
     resolution: {integrity: sha512-L7599HTI2SLlitlpEP8oAPaJgYssByI4eCwQq2C9eC90otFpm8MRn66PpbKviweAlhinWQ3ZjDD2KIVtx7PaVw==}
 
+  '@peculiar/asn1-pkcs8@2.7.0':
+    resolution: {integrity: sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw==}
+
   '@peculiar/asn1-pkcs9@2.5.0':
     resolution: {integrity: sha512-UgqSMBLNLR5TzEZ5ZzxR45Nk6VJrammxd60WMSkofyNzd3DQLSNycGWSK5Xg3UTYbXcDFyG8pA/7/y/ztVCa6A==}
+
+  '@peculiar/asn1-pkcs9@2.7.0':
+    resolution: {integrity: sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew==}
 
   '@peculiar/asn1-rsa@2.5.0':
     resolution: {integrity: sha512-qMZ/vweiTHy9syrkkqWFvbT3eLoedvamcUdnnvwyyUNv5FgFXA3KP8td+ATibnlZ0EANW5PYRm8E6MJzEB/72Q==}
 
+  '@peculiar/asn1-rsa@2.7.0':
+    resolution: {integrity: sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==}
+
   '@peculiar/asn1-schema@2.5.0':
     resolution: {integrity: sha512-YM/nFfskFJSlHqv59ed6dZlLZqtZQwjRVJ4bBAiWV08Oc+1rSd5lDZcBEx0lGDHfSoH3UziI2pXt2UM33KerPQ==}
+
+  '@peculiar/asn1-schema@2.7.0':
+    resolution: {integrity: sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==}
 
   '@peculiar/asn1-x509-attr@2.5.0':
     resolution: {integrity: sha512-9f0hPOxiJDoG/bfNLAFven+Bd4gwz/VzrCIIWc1025LEI4BXO0U5fOCTNDPbbp2ll+UzqKsZ3g61mpBp74gk9A==}
 
+  '@peculiar/asn1-x509-attr@2.7.0':
+    resolution: {integrity: sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w==}
+
   '@peculiar/asn1-x509@2.5.0':
     resolution: {integrity: sha512-CpwtMCTJvfvYTFMuiME5IH+8qmDe3yEWzKHe7OOADbGfq7ohxeLaXwQo0q4du3qs0AII3UbLCvb9NF/6q0oTKQ==}
 
+  '@peculiar/asn1-x509@2.7.0':
+    resolution: {integrity: sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==}
+
+  '@peculiar/utils@2.0.3':
+    resolution: {integrity: sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==}
+
   '@peculiar/x509@1.14.0':
     resolution: {integrity: sha512-Yc4PDxN3OrxUPiXgU63c+ZRXKGE8YKF2McTciYhUHFtHVB0KMnjeFSU0qpztGhsp4P0uKix4+J2xEpIEDu8oXg==}
+
+  '@peculiar/x509@1.14.3':
+    resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
+    engines: {node: '>=20.0.0'}
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -19342,11 +19383,8 @@ packages:
   '@types/express-serve-static-core@5.0.6':
     resolution: {integrity: sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==}
 
-  '@types/express@4.17.23':
-    resolution: {integrity: sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==}
-
-  '@types/express@5.0.3':
-    resolution: {integrity: sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==}
+  '@types/express@4.17.25':
+    resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
 
   '@types/express@5.0.6':
     resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
@@ -20488,8 +20526,8 @@ packages:
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
-  body-parser@1.20.3:
-    resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
+  body-parser@1.20.5:
+    resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   body-parser@2.2.2:
@@ -20557,6 +20595,10 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  bytestreamjs@2.0.1:
+    resolution: {integrity: sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==}
+    engines: {node: '>=6.0.0'}
 
   c12@3.1.0:
     resolution: {integrity: sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==}
@@ -20811,6 +20853,10 @@ packages:
     resolution: {integrity: sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==}
     engines: {node: '>= 0.8.0'}
 
+  compression@1.8.1:
+    resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
+    engines: {node: '>= 0.8.0'}
+
   computeds@0.0.1:
     resolution: {integrity: sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==}
 
@@ -20944,10 +20990,6 @@ packages:
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
-
-  cookie@0.7.1:
-    resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
-    engines: {node: '>= 0.6'}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -21872,8 +21914,8 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  express@4.21.2:
-    resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
+  express@4.22.2:
+    resolution: {integrity: sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==}
     engines: {node: '>= 0.10.0'}
 
   express@5.2.1:
@@ -22450,6 +22492,10 @@ packages:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   http-parser-js@0.5.9:
     resolution: {integrity: sha512-n1XsPy3rXVxlqxVioEWdC+0+M+SQw0DpJynwtOPo1X+ZlvdzTLtDBIJJlDQTnwZIFJrZSzSGmIOUdP8tu+SgLw==}
 
@@ -22457,8 +22503,8 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
-  http-proxy-middleware@2.0.7:
-    resolution: {integrity: sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==}
+  http-proxy-middleware@2.0.9:
+    resolution: {integrity: sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/express': ^4.17.13
@@ -23841,6 +23887,10 @@ packages:
     resolution: {integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==}
     engines: {node: '>= 0.8'}
 
+  on-headers@1.1.0:
+    resolution: {integrity: sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==}
+    engines: {node: '>= 0.8'}
+
   on-net-listen@1.1.2:
     resolution: {integrity: sha512-y1HRYy8s/RlcBvDUwKXSmkODMdx4KSuIvloCnQYJ2LdBBC1asY4HtfhXwe3UWknLakATZDnbzht2Ijw3M1EqFg==}
     engines: {node: '>=9.4.0 || ^8.9.4'}
@@ -24115,6 +24165,10 @@ packages:
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
+  pkijs@3.4.0:
+    resolution: {integrity: sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==}
+    engines: {node: '>=16.0.0'}
+
   playwright-core@1.58.0:
     resolution: {integrity: sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==}
     engines: {node: '>=18'}
@@ -24358,10 +24412,6 @@ packages:
     resolution: {integrity: sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==}
     engines: {node: '>=6.0.0'}
 
-  qs@6.13.0:
-    resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
-    engines: {node: '>=0.6'}
-
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
@@ -24408,8 +24458,8 @@ packages:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
 
-  raw-body@2.5.2:
-    resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
+  raw-body@2.5.3:
+    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
     engines: {node: '>= 0.8'}
 
   raw-body@3.0.1:
@@ -24849,9 +24899,9 @@ packages:
   select-hose@2.0.0:
     resolution: {integrity: sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==}
 
-  selfsigned@2.4.1:
-    resolution: {integrity: sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==}
-    engines: {node: '>=10'}
+  selfsigned@5.5.0:
+    resolution: {integrity: sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==}
+    engines: {node: '>=18'}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -25149,6 +25199,10 @@ packages:
 
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
@@ -26377,8 +26431,8 @@ packages:
       webpack:
         optional: true
 
-  webpack-dev-server@5.2.0:
-    resolution: {integrity: sha512-90SqqYXA2SK36KcT6o1bvwvZfJFcmoamqeJY7+boioffX9g9C0wjjJRGUrQIuh43pb0ttX7+ssavmj/WN2RHtA==}
+  webpack-dev-server@5.2.4:
+    resolution: {integrity: sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==}
     engines: {node: '>= 18.12.0'}
     hasBin: true
     peerDependencies:
@@ -29754,6 +29808,8 @@ snapshots:
 
   '@noble/ciphers@2.0.1': {}
 
+  '@noble/hashes@1.4.0': {}
+
   '@noble/hashes@2.0.1': {}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -30123,6 +30179,14 @@ snapshots:
       asn1js: 3.0.6
       tslib: 2.8.1
 
+  '@peculiar/asn1-cms@2.7.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      '@peculiar/asn1-x509-attr': 2.7.0
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
   '@peculiar/asn1-csr@2.5.0':
     dependencies:
       '@peculiar/asn1-schema': 2.5.0
@@ -30130,10 +30194,24 @@ snapshots:
       asn1js: 3.0.6
       tslib: 2.8.1
 
+  '@peculiar/asn1-csr@2.7.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
   '@peculiar/asn1-ecc@2.5.0':
     dependencies:
       '@peculiar/asn1-schema': 2.5.0
       '@peculiar/asn1-x509': 2.5.0
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-ecc@2.7.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
       asn1js: 3.0.6
       tslib: 2.8.1
 
@@ -30146,10 +30224,26 @@ snapshots:
       asn1js: 3.0.6
       tslib: 2.8.1
 
+  '@peculiar/asn1-pfx@2.7.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.7.0
+      '@peculiar/asn1-pkcs8': 2.7.0
+      '@peculiar/asn1-rsa': 2.7.0
+      '@peculiar/asn1-schema': 2.7.0
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
   '@peculiar/asn1-pkcs8@2.5.0':
     dependencies:
       '@peculiar/asn1-schema': 2.5.0
       '@peculiar/asn1-x509': 2.5.0
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs8@2.7.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
       asn1js: 3.0.6
       tslib: 2.8.1
 
@@ -30164,10 +30258,28 @@ snapshots:
       asn1js: 3.0.6
       tslib: 2.8.1
 
+  '@peculiar/asn1-pkcs9@2.7.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.7.0
+      '@peculiar/asn1-pfx': 2.7.0
+      '@peculiar/asn1-pkcs8': 2.7.0
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      '@peculiar/asn1-x509-attr': 2.7.0
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
   '@peculiar/asn1-rsa@2.5.0':
     dependencies:
       '@peculiar/asn1-schema': 2.5.0
       '@peculiar/asn1-x509': 2.5.0
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-rsa@2.7.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
       asn1js: 3.0.6
       tslib: 2.8.1
 
@@ -30177,10 +30289,23 @@ snapshots:
       pvtsutils: 1.3.6
       tslib: 2.8.1
 
+  '@peculiar/asn1-schema@2.7.0':
+    dependencies:
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
   '@peculiar/asn1-x509-attr@2.5.0':
     dependencies:
       '@peculiar/asn1-schema': 2.5.0
       '@peculiar/asn1-x509': 2.5.0
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509-attr@2.7.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
       asn1js: 3.0.6
       tslib: 2.8.1
 
@@ -30189,6 +30314,17 @@ snapshots:
       '@peculiar/asn1-schema': 2.5.0
       asn1js: 3.0.6
       pvtsutils: 1.3.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509@2.7.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.6
+      tslib: 2.8.1
+
+  '@peculiar/utils@2.0.3':
+    dependencies:
       tslib: 2.8.1
 
   '@peculiar/x509@1.14.0':
@@ -30200,6 +30336,20 @@ snapshots:
       '@peculiar/asn1-rsa': 2.5.0
       '@peculiar/asn1-schema': 2.5.0
       '@peculiar/asn1-x509': 2.5.0
+      pvtsutils: 1.3.6
+      reflect-metadata: 0.2.2
+      tslib: 2.8.1
+      tsyringe: 4.10.0
+
+  '@peculiar/x509@1.14.3':
+    dependencies:
+      '@peculiar/asn1-cms': 2.7.0
+      '@peculiar/asn1-csr': 2.7.0
+      '@peculiar/asn1-ecc': 2.7.0
+      '@peculiar/asn1-pkcs9': 2.7.0
+      '@peculiar/asn1-rsa': 2.7.0
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
       pvtsutils: 1.3.6
       reflect-metadata: 0.2.2
       tslib: 2.8.1
@@ -32574,17 +32724,11 @@ snapshots:
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
 
-  '@types/express@4.17.23':
+  '@types/express@4.17.25':
     dependencies:
       '@types/body-parser': 1.19.5
       '@types/express-serve-static-core': 4.19.6
       '@types/qs': 6.9.18
-      '@types/serve-static': 1.15.7
-
-  '@types/express@5.0.3':
-    dependencies:
-      '@types/body-parser': 1.19.5
-      '@types/express-serve-static-core': 5.0.6
       '@types/serve-static': 1.15.7
 
   '@types/express@5.0.6':
@@ -32661,7 +32805,7 @@ snapshots:
 
   '@types/serve-index@1.9.4':
     dependencies:
-      '@types/express': 5.0.3
+      '@types/express': 5.0.6
 
   '@types/serve-static@1.15.7':
     dependencies:
@@ -33842,19 +33986,19 @@ snapshots:
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.97.1)':
     dependencies:
       webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.0)(webpack@5.97.1)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.97.1)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.97.1)':
     dependencies:
       webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.0)(webpack@5.97.1)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.97.1)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.0)(webpack@5.97.1)':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.4)(webpack@5.97.1)':
     dependencies:
       webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.0)(webpack@5.97.1)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.97.1)
     optionalDependencies:
-      webpack-dev-server: 5.2.0(webpack-cli@5.1.4)(webpack@5.97.1)
+      webpack-dev-server: 5.2.4(webpack-cli@5.1.4)(webpack@5.97.1)
 
   '@whatwg-node/disposablestack@0.0.6':
     dependencies:
@@ -34328,18 +34472,18 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
-  body-parser@1.20.3:
+  body-parser@1.20.5:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
       debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
-      http-errors: 2.0.0
+      http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.13.0
-      raw-body: 2.5.2
+      qs: 6.15.2
+      raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
     transitivePeerDependencies:
@@ -34426,6 +34570,8 @@ snapshots:
       run-applescript: 7.0.0
 
   bytes@3.1.2: {}
+
+  bytestreamjs@2.0.1: {}
 
   c12@3.1.0:
     dependencies:
@@ -34715,6 +34861,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  compression@1.8.1:
+    dependencies:
+      bytes: 3.1.2
+      compressible: 2.0.18
+      debug: 2.6.9
+      negotiator: 0.6.4
+      on-headers: 1.1.0
+      safe-buffer: 5.2.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   computeds@0.0.1: {}
 
   concat-map@0.0.1: {}
@@ -34816,8 +34974,6 @@ snapshots:
   cookie-signature@1.0.6: {}
 
   cookie-signature@1.2.2: {}
-
-  cookie@0.7.1: {}
 
   cookie@0.7.2: {}
 
@@ -35901,14 +36057,14 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express@4.21.2:
+  express@4.22.2:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.3
+      body-parser: 1.20.5
       content-disposition: 0.5.4
       content-type: 1.0.5
-      cookie: 0.7.1
+      cookie: 0.7.2
       cookie-signature: 1.0.6
       debug: 2.6.9
       depd: 2.0.0
@@ -35924,7 +36080,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
-      qs: 6.13.0
+      qs: 6.15.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.0
@@ -36586,6 +36742,14 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   http-parser-js@0.5.9: {}
 
   http-proxy-agent@7.0.2:
@@ -36595,7 +36759,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-middleware@2.0.7(@types/express@4.17.23):
+  http-proxy-middleware@2.0.9(@types/express@4.17.25):
     dependencies:
       '@types/http-proxy': 1.17.15
       http-proxy: 1.18.1(debug@4.4.3)
@@ -36603,7 +36767,7 @@ snapshots:
       is-plain-obj: 3.0.0
       micromatch: 4.0.8
     optionalDependencies:
-      '@types/express': 4.17.23
+      '@types/express': 4.17.25
     transitivePeerDependencies:
       - debug
 
@@ -37201,7 +37365,7 @@ snapshots:
   launch-editor@2.9.1:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.2
+      shell-quote: 1.8.3
 
   lazystream@1.0.1:
     dependencies:
@@ -38164,6 +38328,8 @@ snapshots:
 
   on-headers@1.0.2: {}
 
+  on-headers@1.1.0: {}
+
   on-net-listen@1.1.2: {}
 
   once@1.4.0:
@@ -38510,6 +38676,15 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
+  pkijs@3.4.0:
+    dependencies:
+      '@noble/hashes': 1.4.0
+      asn1js: 3.0.6
+      bytestreamjs: 2.0.1
+      pvtsutils: 1.3.6
+      pvutils: 1.1.3
+      tslib: 2.8.1
+
   playwright-core@1.58.0: {}
 
   playwright@1.58.0:
@@ -38765,10 +38940,6 @@ snapshots:
 
   pvutils@1.1.3: {}
 
-  qs@6.13.0:
-    dependencies:
-      side-channel: 1.1.0
-
   qs@6.14.0:
     dependencies:
       side-channel: 1.1.0
@@ -38853,10 +39024,10 @@ snapshots:
 
   range-parser@1.2.1: {}
 
-  raw-body@2.5.2:
+  raw-body@2.5.3:
     dependencies:
       bytes: 3.1.2
-      http-errors: 2.0.0
+      http-errors: 2.0.1
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
@@ -39362,10 +39533,10 @@ snapshots:
 
   select-hose@2.0.0: {}
 
-  selfsigned@2.4.1:
+  selfsigned@5.5.0:
     dependencies:
-      '@types/node-forge': 1.3.14
-      node-forge: 1.3.1
+      '@peculiar/x509': 1.14.3
+      pkijs: 3.4.0
 
   semver@6.3.1: {}
 
@@ -39747,6 +39918,8 @@ snapshots:
   statuses@1.5.0: {}
 
   statuses@2.0.1: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -40756,12 +40929,12 @@ snapshots:
 
   webidl-conversions@8.0.0: {}
 
-  webpack-cli@5.1.4(webpack-dev-server@5.2.0)(webpack@5.97.1):
+  webpack-cli@5.1.4(webpack-dev-server@5.2.4)(webpack@5.97.1):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
       '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.97.1)
       '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.97.1)
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.0)(webpack@5.97.1)
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.4)(webpack@5.97.1)
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.6
@@ -40773,7 +40946,7 @@ snapshots:
       webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
     optionalDependencies:
-      webpack-dev-server: 5.2.0(webpack-cli@5.1.4)(webpack@5.97.1)
+      webpack-dev-server: 5.2.4(webpack-cli@5.1.4)(webpack@5.97.1)
 
   webpack-dev-middleware@7.4.2(webpack@5.97.1):
     dependencies:
@@ -40782,15 +40955,16 @@ snapshots:
       mime-types: 2.1.35
       on-finished: 2.4.1
       range-parser: 1.2.1
-      schema-utils: 4.3.0
+      schema-utils: 4.3.3
     optionalDependencies:
       webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@5.1.4)
 
-  webpack-dev-server@5.2.0(webpack-cli@5.1.4)(webpack@5.97.1):
+  webpack-dev-server@5.2.4(webpack-cli@5.1.4)(webpack@5.97.1):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
-      '@types/express': 4.17.23
+      '@types/express': 4.17.25
+      '@types/express-serve-static-core': 4.19.6
       '@types/serve-index': 1.9.4
       '@types/serve-static': 1.15.7
       '@types/sockjs': 0.3.36
@@ -40799,25 +40973,25 @@ snapshots:
       bonjour-service: 1.3.0
       chokidar: 3.6.0
       colorette: 2.0.20
-      compression: 1.8.0
+      compression: 1.8.1
       connect-history-api-fallback: 2.0.0
-      express: 4.21.2
+      express: 4.22.2
       graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.7(@types/express@4.17.23)
+      http-proxy-middleware: 2.0.9(@types/express@4.17.25)
       ipaddr.js: 2.2.0
       launch-editor: 2.9.1
       open: 10.1.0
       p-retry: 6.2.1
-      schema-utils: 4.3.0
-      selfsigned: 2.4.1
+      schema-utils: 4.3.3
+      selfsigned: 5.5.0
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
       webpack-dev-middleware: 7.4.2(webpack@5.97.1)
-      ws: 8.18.0
+      ws: 8.20.0
     optionalDependencies:
       webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.0)(webpack@5.97.1)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.97.1)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -40926,7 +41100,7 @@ snapshots:
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     optionalDependencies:
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.0)(webpack@5.97.1)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.97.1)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1360,8 +1360,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/react-start
       express:
-        specifier: ^5.1.0
-        version: 5.1.0
+        specifier: ^5.2.1
+        version: 5.2.1
       http-proxy-middleware:
         specifier: ^3.0.5
         version: 3.0.5
@@ -1772,8 +1772,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/react-start
       express:
-        specifier: ^5.1.0
-        version: 5.1.0
+        specifier: ^5.2.1
+        version: 5.2.1
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -1882,8 +1882,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/react-start
       express:
-        specifier: ^5.1.0
-        version: 5.1.0
+        specifier: ^5.2.1
+        version: 5.2.1
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -1904,8 +1904,8 @@ importers:
         specifier: workspace:^
         version: link:../../e2e-utils
       '@types/express':
-        specifier: ^5.0.3
-        version: 5.0.3
+        specifier: ^5.0.6
+        version: 5.0.6
       '@types/node':
         specifier: 25.0.9
         version: 25.0.9
@@ -1946,8 +1946,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/react-start
       express:
-        specifier: ^5.1.0
-        version: 5.1.0
+        specifier: ^5.2.1
+        version: 5.2.1
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -1971,8 +1971,8 @@ importers:
         specifier: workspace:^
         version: link:../../e2e-utils
       '@types/express':
-        specifier: ^5.0.3
-        version: 5.0.3
+        specifier: ^5.0.6
+        version: 5.0.6
       '@types/node':
         specifier: 25.0.9
         version: 25.0.9
@@ -3098,8 +3098,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/react-start
       express:
-        specifier: ^5.1.0
-        version: 5.1.0
+        specifier: ^5.2.1
+        version: 5.2.1
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -3279,8 +3279,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/react-start
       express:
-        specifier: ^5.1.0
-        version: 5.1.0
+        specifier: ^5.2.1
+        version: 5.2.1
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -4139,8 +4139,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       express:
-        specifier: ^5.1.0
-        version: 5.1.0
+        specifier: ^5.2.1
+        version: 5.2.1
       http-proxy-middleware:
         specifier: ^3.0.5
         version: 3.0.5
@@ -4494,8 +4494,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       express:
-        specifier: ^5.1.0
-        version: 5.1.0
+        specifier: ^5.2.1
+        version: 5.2.1
       redaxios:
         specifier: ^0.5.1
         version: 0.5.1
@@ -4513,8 +4513,8 @@ importers:
         specifier: workspace:^
         version: link:../../e2e-utils
       '@types/express':
-        specifier: ^5.0.3
-        version: 5.0.3
+        specifier: ^5.0.6
+        version: 5.0.6
       '@types/node':
         specifier: 25.0.9
         version: 25.0.9
@@ -6009,8 +6009,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/vue-start
       express:
-        specifier: ^5.1.0
-        version: 5.1.0
+        specifier: ^5.2.1
+        version: 5.2.1
       http-proxy-middleware:
         specifier: ^3.0.5
         version: 3.0.5
@@ -6348,8 +6348,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/vue-start
       express:
-        specifier: ^5.1.0
-        version: 5.1.0
+        specifier: ^5.2.1
+        version: 5.2.1
       redaxios:
         specifier: ^0.5.1
         version: 0.5.1
@@ -6367,8 +6367,8 @@ importers:
         specifier: workspace:^
         version: link:../../e2e-utils
       '@types/express':
-        specifier: ^5.0.3
-        version: 5.0.3
+        specifier: ^5.0.6
+        version: 5.0.6
       '@types/node':
         specifier: 25.0.9
         version: 25.0.9
@@ -7355,8 +7355,8 @@ importers:
         specifier: ^1.8.0
         version: 1.8.0
       express:
-        specifier: ^4.21.2
-        version: 4.21.2
+        specifier: ^5.2.1
+        version: 5.2.1
       get-port:
         specifier: ^7.1.0
         version: 7.1.0
@@ -7374,8 +7374,8 @@ importers:
         specifier: workspace:^
         version: link:../../../packages/react-router-devtools
       '@types/express':
-        specifier: ^4.17.23
-        version: 4.17.23
+        specifier: ^5.0.6
+        version: 5.0.6
       '@types/react':
         specifier: ^19.2.8
         version: 19.2.9
@@ -7404,8 +7404,8 @@ importers:
         specifier: ^1.8.0
         version: 1.8.0
       express:
-        specifier: ^4.21.2
-        version: 4.21.2
+        specifier: ^5.2.1
+        version: 5.2.1
       get-port:
         specifier: ^7.1.0
         version: 7.1.0
@@ -7423,8 +7423,8 @@ importers:
         specifier: workspace:^
         version: link:../../../packages/react-router-devtools
       '@types/express':
-        specifier: ^4.17.23
-        version: 4.17.23
+        specifier: ^5.0.6
+        version: 5.0.6
       '@types/react':
         specifier: ^19.2.8
         version: 19.2.9
@@ -10002,8 +10002,8 @@ importers:
         specifier: ^11.4.3
         version: 11.4.3(typescript@6.0.2)
       express:
-        specifier: ^4.21.2
-        version: 4.21.2
+        specifier: ^5.2.1
+        version: 5.2.1
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -10021,8 +10021,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@types/express':
-        specifier: ^4.17.23
-        version: 4.17.23
+        specifier: ^5.0.6
+        version: 5.0.6
       '@types/react':
         specifier: ^19.2.8
         version: 19.2.9
@@ -10069,8 +10069,8 @@ importers:
         specifier: ^11.4.3
         version: 11.4.3(@tanstack/react-query@5.99.0(react@19.2.3))(@trpc/client@11.4.3(@trpc/server@11.4.3(typescript@6.0.2))(typescript@6.0.2))(@trpc/server@11.4.3(typescript@6.0.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2)
       express:
-        specifier: ^4.21.2
-        version: 4.21.2
+        specifier: ^5.2.1
+        version: 5.2.1
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -10088,8 +10088,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@types/express':
-        specifier: ^4.17.23
-        version: 4.17.23
+        specifier: ^5.0.6
+        version: 5.0.6
       '@types/react':
         specifier: ^19.2.8
         version: 19.2.9
@@ -10460,8 +10460,8 @@ importers:
         specifier: ^1.8.0
         version: 1.8.0
       express:
-        specifier: ^4.21.2
-        version: 4.21.2
+        specifier: ^5.2.1
+        version: 5.2.1
       get-port:
         specifier: ^7.1.0
         version: 7.1.0
@@ -10476,8 +10476,8 @@ importers:
         specifier: workspace:^
         version: link:../../../packages/solid-router-devtools
       '@types/express':
-        specifier: ^4.17.23
-        version: 4.17.23
+        specifier: ^5.0.6
+        version: 5.0.6
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -10503,8 +10503,8 @@ importers:
         specifier: ^1.8.0
         version: 1.8.0
       express:
-        specifier: ^4.21.2
-        version: 4.21.2
+        specifier: ^5.2.1
+        version: 5.2.1
       get-port:
         specifier: ^7.1.0
         version: 7.1.0
@@ -10528,8 +10528,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/router-plugin
       '@types/express':
-        specifier: ^4.17.23
-        version: 4.17.23
+        specifier: ^5.0.6
+        version: 5.0.6
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -12160,8 +12160,8 @@ importers:
         specifier: ^11.4.3
         version: 11.4.3(typescript@6.0.2)
       express:
-        specifier: ^4.21.2
-        version: 4.21.2
+        specifier: ^5.2.1
+        version: 5.2.1
       redaxios:
         specifier: ^0.5.1
         version: 0.5.1
@@ -12176,8 +12176,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@types/express':
-        specifier: ^4.17.23
-        version: 4.17.23
+        specifier: ^5.0.6
+        version: 5.0.6
       tsx:
         specifier: ^4.20.3
         version: 4.20.3
@@ -19348,6 +19348,9 @@ packages:
   '@types/express@5.0.3':
     resolution: {integrity: sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==}
 
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
   '@types/html-minifier-terser@6.1.0':
     resolution: {integrity: sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==}
 
@@ -19426,6 +19429,9 @@ packages:
 
   '@types/serve-static@1.15.7':
     resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@types/sockjs@0.3.36':
     resolution: {integrity: sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==}
@@ -20486,8 +20492,8 @@ packages:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
-  body-parser@2.2.0:
-    resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
   bonjour-service@1.3.0:
@@ -21870,8 +21876,8 @@ packages:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
 
-  express@5.1.0:
-    resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
   exsolve@1.0.7:
@@ -24360,6 +24366,10 @@ packages:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
 
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+    engines: {node: '>=0.6'}
+
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
@@ -24901,10 +24911,6 @@ packages:
   serve-static@1.16.2:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
     engines: {node: '>= 0.8.0'}
-
-  serve-static@2.2.0:
-    resolution: {integrity: sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==}
-    engines: {node: '>= 18'}
 
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
@@ -32581,6 +32587,12 @@ snapshots:
       '@types/express-serve-static-core': 5.0.6
       '@types/serve-static': 1.15.7
 
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.5
+      '@types/express-serve-static-core': 5.0.6
+      '@types/serve-static': 2.2.0
+
   '@types/html-minifier-terser@6.1.0': {}
 
   '@types/http-errors@2.0.4': {}
@@ -32656,6 +32668,11 @@ snapshots:
       '@types/http-errors': 2.0.4
       '@types/node': 25.0.9
       '@types/send': 0.17.4
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.4
+      '@types/node': 25.0.9
 
   '@types/sockjs@0.3.36':
     dependencies:
@@ -34328,15 +34345,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  body-parser@2.2.0:
+  body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
       debug: 4.4.3
       http-errors: 2.0.0
-      iconv-lite: 0.6.3
+      iconv-lite: 0.7.0
       on-finished: 2.4.1
-      qs: 6.14.0
+      qs: 6.15.2
       raw-body: 3.0.1
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -35920,15 +35937,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@5.1.0:
+  express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.0
+      body-parser: 2.2.2
       content-disposition: 1.0.0
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
       debug: 4.4.3
+      depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -35945,7 +35963,7 @@ snapshots:
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.0
-      serve-static: 2.2.0
+      serve-static: 2.2.1
       statuses: 2.0.1
       type-is: 2.0.1
       vary: 1.1.2
@@ -38755,6 +38773,10 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  qs@6.15.2:
+    dependencies:
+      side-channel: 1.1.0
+
   quansync@0.2.11: {}
 
   querystringify@2.2.0: {}
@@ -39425,15 +39447,6 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.0
-    transitivePeerDependencies:
-      - supports-color
-
-  serve-static@2.2.0:
-    dependencies:
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      parseurl: 1.3.3
-      send: 1.2.0
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary
- update direct Express dependencies in examples and e2e apps to 5.2.1
- update direct @types/express dependencies to 5.0.6
- migrate Express 5 wildcard routes and app.listen error callback handling
- update Webpack quickstart examples to webpack-dev-server 5.2.4

## Testing
- pnpm install --lockfile-only
- pnpm install
- pnpm install --lockfile-only --fix-lockfile
- git diff --check
- targeted Nx builds for React/Solid/Vue example and e2e apps
- runtime checks for /{*splat} matching / and /posts/1
- reviewed webpack-dev-server changelog from 5.2.0 to 5.2.4; no config/code migration required for affected examples
- CI=1 NX_DAEMON=false pnpm nx run tanstack-router-react-example-quickstart-webpack-file-based:build --outputStyle=stream --skipRemoteCache
- CI=1 NX_DAEMON=false pnpm nx run tanstack-router-solid-example-quickstart-webpack-file-based:build --outputStyle=stream --skipRemoteCache
- timeout 25s pnpm --dir examples/react/quickstart-webpack-file-based exec webpack serve --port 0 --no-open
- timeout 25s pnpm --dir examples/solid/quickstart-webpack-file-based exec webpack serve --port 0 --no-open

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Express framework dependency to v5.2.1 across projects and examples.
  * Updated Express type definitions to v5.0.6 for improved TypeScript support.
  * Bumped webpack-dev-server in a couple of examples to v5.2.4.

* **Bug Fixes**
  * Enhanced server startup error handling to throw immediately on listen failures.
  * Adjusted fallback route patterns to an explicit splat (/{*splat}) for more accurate SSR/static routing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/router/pull/7443?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->