### PR TITLE
chore: ignore nx generated folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ ts-perf
 nx-cloud.env
 .nx/cache
 .nx/workspace-data
+.nx/polygraph
+.nx/self-healing
 
 gpt/db.json
 


### PR DESCRIPTION
## Summary
- Ignore Nx-generated `.nx/polygraph` and `.nx/self-healing` folders.
- Keeps local/generated Nx state out of git status.

## Tests
- Not run; `.gitignore`-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to exclude additional build directories from version control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/router/pull/7451?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->