### PR TITLE
ci: fix release notes diff range after Release PR flow

### DIFF
--- a/scripts/create-github-release.mjs
+++ b/scripts/create-github-release.mjs
@@ -54,10 +54,10 @@ async function resolveAuthorForPR(prNumber) {
 }
 
 // Get the previous release commit to diff against.
-// This script runs right after the "ci: changeset release" commit is pushed,
+// This script runs right after the "ci: Version Packages" PR is merged,
 // so HEAD is the release commit.
 const releaseLogs = execSync(
-  'git log --oneline --grep="ci: changeset release" --format=%H',
+  'git log --oneline --grep="^ci: Version Packages" --grep="^ci: changeset release" --format=%H',
 )
   .toString()
   .trim()
@@ -159,7 +159,11 @@ for (const line of commits) {
   const [, hash, email, subject] = match
 
   // Skip release commits
-  if (subject.startsWith('ci: changeset release')) continue
+  if (
+    subject.startsWith('ci: Version Packages') ||
+    subject.startsWith('ci: changeset release')
+  )
+    continue
 
   // Parse conventional commit: type(scope)!: message
   const conventionalMatch = subject.match(/^(\w+)(?:\(([^)]*)\))?(!)?:\s*(.*)$/)


### PR DESCRIPTION
Fix `scripts/create-github-release.mjs` previous-release detection so GitHub release notes only contain changes since the prior release.

After moving to a separate changeset PR the commit title for releases is now `ci: Version Packages` where previously it was `ci: changeset release`. We have to adjust the create release script, so it also looks for `ci: Version Packages` so that it gets the right diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation tooling to refine how release commits are identified and filtered during changelog generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/router/pull/7456?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->