### PR TITLE
chore: enforce pnpm 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "url": "git+https://github.com/TanStack/router.git"
   },
   "packageManager": "pnpm@11.1.0",
+  "engines": {
+    "pnpm": ">=11.0.0"
+  },
   "type": "module",
   "scripts": {
     "cleanNodeModules": "pnpm -r exec rm -rf node_modules",


### PR DESCRIPTION
## Summary

Adds a root `engines.pnpm` requirement of `>=11.0.0` alongside the existing exact `packageManager` declaration.

## What This Blocks

- Blocks pnpm versions below 11 from running the repo's install workflow when that older pnpm binary is the one actually executing the command.
- Blocks pnpm versions below 11 from running `pnpm run` project-script workflows when that older pnpm binary is the one actually executing the command.
- Produces pnpm's `ERR_PNPM_UNSUPPORTED_ENGINE` error with the expected range and actual pnpm version for those guarded paths.
- Covers cases where `packageManager` is not honored as an automatic handoff to pnpm 11+, or that handoff is explicitly disabled.

## What This Does Not Block

- Does not force the exact `pnpm@11.1.0` version. The engine range allows any pnpm `>=11.0.0`; the existing `packageManager` field remains the exact version hint for tools and pnpm versions that honor it.
- Does not necessarily error for every pnpm 10 invocation. A direct pnpm 10 binary can honor `packageManager` and hand off to pnpm 11.1.0 before running the command; in that case the command succeeds under pnpm 11 rather than failing under pnpm 10.
- Does not fully intercept every possible pnpm subcommand once an older pnpm binary is already executing. In local checks, `pnpm list` and `pnpm exec` still ran under pnpm 9/10.
- Does not auto-upgrade a globally installed pnpm. Users with pnpm 9/10 installed directly still need their tooling to honor `packageManager`, or they need to install/invoke pnpm 11+.
- Does not add `engineStrict`; the blocking behavior here comes from pnpm honoring the project `engines.pnpm` field for install and run workflows.

## Verification

- `pnpm install --lockfile-only --frozen-lockfile --ignore-scripts` succeeds with pnpm 11.1.0.
- A direct pnpm 9.15.9 binary fails `pnpm install --lockfile-only --frozen-lockfile --ignore-scripts` with `ERR_PNPM_UNSUPPORTED_ENGINE`.
- A direct pnpm 9.15.9 binary fails `pnpm run` with `ERR_PNPM_UNSUPPORTED_ENGINE`.
- A direct pnpm 10.0.0 binary reports pnpm 11.1.0 inside this repo by default because it honors `packageManager` and hands off to the declared package-manager version.
- With that pnpm 10 handoff disabled via `npm_config_manage_package_manager_versions=false`, pnpm 10.0.0 fails `pnpm install --lockfile-only --frozen-lockfile --ignore-scripts` with `ERR_PNPM_UNSUPPORTED_ENGINE`.
- With that pnpm 10 handoff disabled via `npm_config_manage_package_manager_versions=false`, pnpm 10.0.0 fails `pnpm run` with `ERR_PNPM_UNSUPPORTED_ENGINE`.
- Direct pnpm 9/10 checks also confirmed `pnpm list --depth 0` and `pnpm exec node -e "console.log('ok')"` are not blocked by this field.
