### PR TITLE
fix(start): explicitly re-export public API to survive SSR cold-start cycle

### DIFF
--- a/.changeset/trim-start-meta-reexports.md
+++ b/.changeset/trim-start-meta-reexports.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/react-start': patch
+'@tanstack/solid-start': patch
+'@tanstack/vue-start': patch
+---
+
+Explicitly re-export public API names from `@tanstack/start-client-core` (`createServerFn`, `createMiddleware`, `createStart`, `createCsrfMiddleware`, `createIsomorphicFn`, `createClientOnlyFn`, `createServerOnlyFn`) alongside the existing `export *`. The explicit named re-exports are registered at link time (via Vite SSR's `defineExport` at `fileStartIndex`), so the namespace has these getters before any import body runs — survives the cold-start SSR cycle through user middleware where `export *` would otherwise produce a partial facade (`createMiddleware is not a function`). Workaround for vitejs/vite#22491 / #22493.

--- a/packages/react-start/src/index.ts
+++ b/packages/react-start/src/index.ts
@@ -1,6 +1,20 @@
 export { useServerFn } from './useServerFn'
 export * from '@tanstack/start-client-core'
-export { createServerFn } from '@tanstack/start-client-core'
+// Explicit re-exports shadow `export *` above so these public-API names are
+// registered on the namespace at link time (via Vite SSR's `defineExport`
+// at fileStartIndex), surviving the cold-start SSR cycle through user
+// middleware. See vitejs/vite#22491 / #22493. Trim list to genuine public
+// API only; internals fall through `export *` and are safe because they
+// aren't imported at top level in the cycle path.
+export {
+  createClientOnlyFn,
+  createCsrfMiddleware,
+  createIsomorphicFn,
+  createMiddleware,
+  createServerFn,
+  createServerOnlyFn,
+  createStart,
+} from '@tanstack/start-client-core'
 export { Hydrate } from '@tanstack/react-start-client'
 export type {
   HydrateOptions,

--- a/packages/solid-start/src/index.ts
+++ b/packages/solid-start/src/index.ts
@@ -1,5 +1,20 @@
 export { useServerFn } from './useServerFn'
 export * from '@tanstack/start-client-core'
+// Explicit re-exports shadow `export *` above so these public-API names are
+// registered on the namespace at link time (via Vite SSR's `defineExport`
+// at fileStartIndex), surviving the cold-start SSR cycle through user
+// middleware. See vitejs/vite#22491 / #22493. Trim list to genuine public
+// API only; internals fall through `export *` and are safe because they
+// aren't imported at top level in the cycle path.
+export {
+  createClientOnlyFn,
+  createCsrfMiddleware,
+  createIsomorphicFn,
+  createMiddleware,
+  createServerFn,
+  createServerOnlyFn,
+  createStart,
+} from '@tanstack/start-client-core'
 export { Hydrate } from '@tanstack/solid-start-client'
 export type {
   HydrateOptions,

--- a/packages/vue-start/src/index.ts
+++ b/packages/vue-start/src/index.ts
@@ -1,2 +1,17 @@
 export { useServerFn } from './useServerFn'
 export * from '@tanstack/start-client-core'
+// Explicit re-exports shadow `export *` above so these public-API names are
+// registered on the namespace at link time (via Vite SSR's `defineExport`
+// at fileStartIndex), surviving the cold-start SSR cycle through user
+// middleware. See vitejs/vite#22491 / #22493. Trim list to genuine public
+// API only; internals fall through `export *` and are safe because they
+// aren't imported at top level in the cycle path.
+export {
+  createClientOnlyFn,
+  createCsrfMiddleware,
+  createIsomorphicFn,
+  createMiddleware,
+  createServerFn,
+  createServerOnlyFn,
+  createStart,
+} from '@tanstack/start-client-core'


### PR DESCRIPTION
see #7459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where certain public API functions were unavailable during server-side rendering and link-time execution in React Start, Solid Start, and Vue Start. These packages now properly expose all public functions from the core library throughout the complete application lifecycle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/router/pull/7466?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->