### PR TITLE
fix(start): emit boot-sibling chunks as scripts for IIFE entries

### DIFF
--- a/.changeset/seven-times-pump.md
+++ b/.changeset/seven-times-pump.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/start-plugin-core': patch
+'@tanstack/start-server-core': patch
+---
+
+fix(start): emit `<script>` tags for client entry boot siblings under IIFE. When `scriptFormat: 'iife'` and the entry chunk has static-import siblings (e.g. an extracted runtime via `optimization.runtimeChunk: 'single'`), the manifest now carries vlientEntryImports`and`<Scripts />`emits a`<script>` for each before the entry, fixing hydration for IIFE bundles with extracted runtimes.

--- a/.changeset/seven-times-pump.md
+++ b/.changeset/seven-times-pump.md
@@ -3,4 +3,4 @@
 '@tanstack/start-server-core': patch
 ---
 
-fix(start): emit `<script>` tags for client entry boot siblings under IIFE. When `scriptFormat: 'iife'` and the entry chunk has static-import siblings (e.g. an extracted runtime via `optimization.runtimeChunk: 'single'`), the manifest now carries vlientEntryImports`and`<Scripts />`emits a`<script>` for each before the entry, fixing hydration for IIFE bundles with extracted runtimes.
+fix(start): emit client entry scripts from the root route manifest. When `scriptFormat: 'iife'` and the entry chunk has static-import siblings (e.g. an extracted runtime via `optimization.runtimeChunk: 'single'`), the manifest now includes those async siblings before the async client entry in root route scripts, fixing hydration for IIFE bundles with extracted runtimes.

--- a/e2e/react-start/custom-server-rsbuild/rsbuild.config.ts
+++ b/e2e/react-start/custom-server-rsbuild/rsbuild.config.ts
@@ -8,15 +8,14 @@ import { tanstackStart } from '@tanstack/react-start/plugin/rsbuild'
 // repro is:
 //
 //   - `client.output: 'iife'` — emit the client entry as a self-executing
-//     script. `<Scripts />` reads `scriptFormat` from the manifest and
-//     switches between `<script type="module">` and plain `<script>`;
-//     setting IIFE here exercises the plain-script path.
+//     script. The manifest uses plain script tags and classic script preloads;
+//     setting IIFE here exercises that non-module asset path.
 //
 //   - Client `runtimeChunk: 'single'` — extracts the webpack runtime into
 //     its own chunk. With IIFE plain scripts, the entry can't bootstrap
 //     until the runtime has executed, so `<Scripts />` has to emit a
 //     `<script>` for the runtime chunk (not just a preload). This was
-//     the regression the upstream `clientEntryImports` fix addresses.
+//     the regression this fixture covers.
 //
 //   - `client.distPath.root` + `distPath.js: ''` — flat layout, JS at the
 //     dist root. Matches the path `express-server.ts` serves via

--- a/e2e/react-start/custom-server-rsbuild/rsbuild.config.ts
+++ b/e2e/react-start/custom-server-rsbuild/rsbuild.config.ts
@@ -1,10 +1,66 @@
+import path from 'node:path'
 import { defineConfig } from '@rsbuild/core'
 import { pluginReact } from '@rsbuild/plugin-react'
 import { tanstackStart } from '@tanstack/react-start/plugin/rsbuild'
 
+// Stress-test fixture for `<Scripts />` and the start manifest under a
+// non-default client chunk layout. The combination that matters for the
+// repro is:
+//
+//   - `client.output: 'iife'` — emit the client entry as a self-executing
+//     script. `<Scripts />` reads `scriptFormat` from the manifest and
+//     switches between `<script type="module">` and plain `<script>`;
+//     setting IIFE here exercises the plain-script path.
+//
+//   - Client `runtimeChunk: 'single'` — extracts the webpack runtime into
+//     its own chunk. With IIFE plain scripts, the entry can't bootstrap
+//     until the runtime has executed, so `<Scripts />` has to emit a
+//     `<script>` for the runtime chunk (not just a preload). This was
+//     the regression the upstream `clientEntryImports` fix addresses.
+//
+//   - `client.distPath.root` + `distPath.js: ''` — flat layout, JS at the
+//     dist root. Matches the path `express-server.ts` serves via
+//     `express.static('dist/client')`.
+//
+//   - `performance.buildCache: true` — exercise the rspack persistent
+//     cache, including warm-restart paths.
+//
+//   - `output.assetPrefix: '/static/'` — force manifest URLs through an
+//     explicit prefix.
 export default defineConfig({
   plugins: [
-    pluginReact({ splitChunks: false }),
-    tanstackStart({ rsbuild: { installDevServerMiddleware: false } }),
+    pluginReact(),
+    tanstackStart({
+      rsbuild: {
+        installDevServerMiddleware: false,
+        client: {
+          output: 'iife',
+        },
+      },
+    }),
   ],
+  performance: {
+    buildCache: true,
+  },
+  output: {
+    assetPrefix: '/static/',
+  },
+  environments: {
+    client: {
+      output: {
+        distPath: {
+          root: path.resolve(__dirname, 'dist/client'),
+          js: '',
+        },
+      },
+      tools: {
+        rspack: (config) => {
+          config.optimization = {
+            ...(config.optimization ?? {}),
+            runtimeChunk: 'single',
+          }
+        },
+      },
+    },
+  },
 })

--- a/packages/start-plugin-core/src/rsbuild/virtual-modules.ts
+++ b/packages/start-plugin-core/src/rsbuild/virtual-modules.ts
@@ -72,14 +72,27 @@ function getScriptFormatProperty(scriptFormat: ScriptFormat): string {
   return scriptFormat === 'iife' ? `  scriptFormat: 'iife',\n` : ''
 }
 
+function getEntryScriptAttrs(
+  entryUrl: string,
+  scriptFormat: ScriptFormat,
+): string {
+  return scriptFormat === 'module'
+    ? `{ type: 'module', async: true, src: '${entryUrl}' }`
+    : `{ async: true, src: '${entryUrl}' }`
+}
+
 function generateManifestModuleDev(
   devClientEntryUrl: string,
   scriptFormat: ScriptFormat,
 ): string {
   const scriptFormatProperty = getScriptFormatProperty(scriptFormat)
   return `const fallbackManifest = {
-${scriptFormatProperty}  routes: {},
-  clientEntry: '${devClientEntryUrl}',
+${scriptFormatProperty}  routes: {
+    __root__: {
+      preloads: ['${devClientEntryUrl}'],
+      scripts: [{ attrs: ${getEntryScriptAttrs(devClientEntryUrl, scriptFormat)} }],
+    },
+  },
 }
 export const tsrStartManifest = () => globalThis[${JSON.stringify(DEV_START_MANIFEST_GLOBAL)}] ?? fallbackManifest`
 }

--- a/packages/start-plugin-core/src/start-manifest-plugin/manifestBuilder.ts
+++ b/packages/start-plugin-core/src/start-manifest-plugin/manifestBuilder.ts
@@ -7,11 +7,6 @@ import {
   resolveManifestCssLink,
   rootRouteId,
 } from '@tanstack/router-core'
-import {
-  getRouteFilePathsFromModuleIds,
-  normalizeViteClientBuild,
-  normalizeViteClientChunk,
-} from '../vite/start-manifest-plugin/normalized-client-build'
 import { processInlineCssUrls } from './inlineCss'
 import type {
   ManifestAssetLink,
@@ -58,8 +53,6 @@ type DedupeRoute = {
 export interface StartManifest {
   scriptFormat?: ScriptFormat
   routes: Record<string, RouteTreeRoute>
-  clientEntry: string
-  clientEntryImports?: Array<string>
   inlineCss?: {
     styles: Record<string, string>
     templates?: Record<string, InlineCssTemplate>
@@ -188,6 +181,56 @@ function appendRouteStylesheets(
   route.css = appendUniqueStylesheets(route.css, stylesheets)
 }
 
+function appendRouteScripts(
+  route: RouteTreeRoute,
+  scripts: Array<ManifestScript>,
+) {
+  if (scripts.length === 0) {
+    return
+  }
+
+  route.scripts = [...(route.scripts ?? []), ...scripts]
+}
+
+function buildScript(src: string, scriptFormat: ScriptFormat): ManifestScript {
+  return {
+    attrs: {
+      ...(scriptFormat === 'module' ? { type: 'module' } : {}),
+      async: true,
+      src,
+    },
+  }
+}
+
+function appendEntryChunkScripts(options: {
+  route: RouteTreeRoute
+  chunk: NormalizedClientChunk
+  scriptFormat: ScriptFormat
+  getAssetPath: (fileName: string) => string
+}) {
+  const scripts: Array<ManifestScript> = []
+
+  if (options.scriptFormat === 'iife') {
+    for (let i = 0; i < options.chunk.imports.length; i++) {
+      scripts.push(
+        buildScript(
+          options.getAssetPath(options.chunk.imports[i]!),
+          options.scriptFormat,
+        ),
+      )
+    }
+  }
+
+  scripts.push(
+    buildScript(
+      options.getAssetPath(options.chunk.fileName),
+      options.scriptFormat,
+    ),
+  )
+
+  appendRouteScripts(options.route, scripts)
+}
+
 function appendAdditionalRouteEntries(
   route: RouteTreeRoute,
   entries: ReadonlyArray<AdditionalRouteManifestEntry>,
@@ -208,9 +251,7 @@ function appendAdditionalRouteEntries(
   }
 
   appendRouteStylesheets(route, stylesheets)
-  if (scripts.length > 0) {
-    route.scripts = [...(route.scripts ?? []), ...scripts]
-  }
+  appendRouteScripts(route, scripts)
 }
 
 export function buildStartManifest(options: {
@@ -235,6 +276,13 @@ export function buildStartManifest(options: {
     additionalRouteAssets: options.additionalRouteAssets,
   })
 
+  appendEntryChunkScripts({
+    route: routes[rootRouteId]!,
+    chunk: scannedChunks.entryChunk,
+    scriptFormat: options.scriptFormat ?? 'module',
+    getAssetPath: assetResolvers.getAssetPath,
+  })
+
   dedupeNestedRouteManifestEntries(rootRouteId, routes[rootRouteId]!, routes)
 
   // Prune routes with no manifest data
@@ -250,17 +298,10 @@ export function buildStartManifest(options: {
 
   const result: StartManifest = {
     routes,
-    clientEntry: assetResolvers.getAssetPath(scannedChunks.entryChunk.fileName),
   }
 
   if (options.scriptFormat === 'iife') {
     result.scriptFormat = 'iife'
-
-    if (scannedChunks.entryChunk.imports.length > 0) {
-      result.clientEntryImports = scannedChunks.entryChunk.imports.map(
-        (importedFileName) => assetResolvers.getAssetPath(importedFileName),
-      )
-    }
   }
 
   if (options.inlineCss?.enabled) {
@@ -511,7 +552,7 @@ export function buildRouteManifestRoutes(options: {
   for (const [routeId, route] of Object.entries(options.routeTreeRoutes)) {
     if (!route.filePath) {
       if (routeId === rootRouteId) {
-        routes[routeId] = route
+        routes[routeId] = { ...route }
         continue
       }
 
@@ -520,7 +561,7 @@ export function buildRouteManifestRoutes(options: {
 
     const chunks = options.routeChunksByFilePath.get(route.filePath)
     if (!chunks) {
-      routes[routeId] = route
+      routes[routeId] = { ...route }
       continue
     }
 
@@ -639,12 +680,6 @@ function mergeReachableHydrationChunkData(options: {
   }
 
   visitStaticChunk(options.chunk)
-}
-
-export {
-  getRouteFilePathsFromModuleIds,
-  normalizeViteClientBuild,
-  normalizeViteClientChunk,
 }
 
 function dedupeNestedRouteManifestEntries(

--- a/packages/start-plugin-core/src/start-manifest-plugin/manifestBuilder.ts
+++ b/packages/start-plugin-core/src/start-manifest-plugin/manifestBuilder.ts
@@ -59,6 +59,7 @@ export interface StartManifest {
   scriptFormat?: ScriptFormat
   routes: Record<string, RouteTreeRoute>
   clientEntry: string
+  clientEntryImports?: Array<string>
   inlineCss?: {
     styles: Record<string, string>
     templates?: Record<string, InlineCssTemplate>
@@ -254,6 +255,12 @@ export function buildStartManifest(options: {
 
   if (options.scriptFormat === 'iife') {
     result.scriptFormat = 'iife'
+
+    if (scannedChunks.entryChunk.imports.length > 0) {
+      result.clientEntryImports = scannedChunks.entryChunk.imports.map(
+        (importedFileName) => assetResolvers.getAssetPath(importedFileName),
+      )
+    }
   }
 
   if (options.inlineCss?.enabled) {

--- a/packages/start-plugin-core/src/vite/start-manifest-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/vite/start-manifest-plugin/plugin.ts
@@ -8,9 +8,9 @@ import {
   serializeStartManifest,
 } from '../../start-manifest-plugin/manifestBuilder'
 import { createVirtualModule } from '../createVirtualModule'
+import { normalizeViteClientBuild } from './normalized-client-build'
 import type { GetConfigFn, NormalizedClientBuild } from '../../types'
 import type { PluginOption, Rollup } from 'vite'
-import { normalizeViteClientBuild } from './normalized-client-build'
 
 type StartManifestEnvironment = {
   config: {

--- a/packages/start-plugin-core/src/vite/start-manifest-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/vite/start-manifest-plugin/plugin.ts
@@ -5,12 +5,12 @@ import { DEV_CLIENT_ENTRY, START_ENVIRONMENT_NAMES } from '../../constants'
 import {
   buildStartManifest,
   createManifestAssetResolvers,
-  normalizeViteClientBuild,
   serializeStartManifest,
 } from '../../start-manifest-plugin/manifestBuilder'
 import { createVirtualModule } from '../createVirtualModule'
 import type { GetConfigFn, NormalizedClientBuild } from '../../types'
 import type { PluginOption, Rollup } from 'vite'
+import { normalizeViteClientBuild } from './normalized-client-build'
 
 type StartManifestEnvironment = {
   config: {
@@ -137,8 +137,12 @@ function getAssetFileNameByName(
 
 function getEmptyStartManifestModule(clientEntry: string) {
   return `export const tsrStartManifest = () => ({
-      routes: {},
-      clientEntry: '${clientEntry}',
+      routes: {
+        __root__: {
+          preloads: ['${clientEntry}'],
+          scripts: [{ attrs: { type: 'module', async: true, src: '${clientEntry}' } }],
+        },
+      },
     })`
 }
 

--- a/packages/start-plugin-core/tests/start-manifest-plugin.test.ts
+++ b/packages/start-plugin-core/tests/start-manifest-plugin.test.ts
@@ -12,13 +12,13 @@ vi.mock('@tanstack/start-server-core', () => ({
 describe('startManifestPlugin', () => {
   test('uses the virtual client entry during unbundled dev', () => {
     expect(loadDevManifest({ bundledDev: false })).toContain(
-      `clientEntry: '/@id/${DEV_CLIENT_ENTRY}'`,
+      `src: '/@id/${DEV_CLIENT_ENTRY}'`,
     )
   })
 
   test('uses the bundled client entry during bundled dev', () => {
     expect(loadDevManifest({ bundledDev: true })).toContain(
-      `clientEntry: '/assets/index.js'`,
+      `src: '/assets/index.js'`,
     )
   })
 })

--- a/packages/start-plugin-core/tests/start-manifest-plugin/manifestBuilder.test.ts
+++ b/packages/start-plugin-core/tests/start-manifest-plugin/manifestBuilder.test.ts
@@ -6,15 +6,17 @@ import {
   buildStartManifest,
   createChunkCssAssetCollector,
   createManifestAssetResolvers,
-  getRouteFilePathsFromModuleIds,
-  normalizeViteClientBuild,
-  normalizeViteClientChunk,
   serializeStartManifest,
   scanClientChunks,
   type StartManifest,
 } from '../../src/start-manifest-plugin/manifestBuilder'
 import type { ManifestCssLink } from '@tanstack/router-core'
 import type { Rollup } from 'vite'
+import {
+  getRouteFilePathsFromModuleIds,
+  normalizeViteClientBuild,
+  normalizeViteClientChunk,
+} from '../../src/vite/start-manifest-plugin/normalized-client-build'
 
 function normalizeTestBuild(bundle: Rollup.OutputBundle) {
   return normalizeViteClientBuild(bundle)
@@ -461,7 +463,16 @@ describe('buildStartManifest', () => {
       },
     })
 
-    expect(manifest.routes.__root__!.scripts).toEqual([script])
+    expect(manifest.routes.__root__!.scripts).toEqual([
+      script,
+      {
+        attrs: {
+          type: 'module',
+          async: true,
+          src: '/assets/entry.js',
+        },
+      },
+    ])
   })
 
   test('dedupes additional route scripts already owned by ancestor routes', () => {
@@ -492,7 +503,16 @@ describe('buildStartManifest', () => {
       },
     })
 
-    expect(manifest.routes.__root__!.scripts).toEqual([script])
+    expect(manifest.routes.__root__!.scripts).toEqual([
+      script,
+      {
+        attrs: {
+          type: 'module',
+          async: true,
+          src: '/assets/entry.js',
+        },
+      },
+    ])
     expect(manifest.routes['/about']?.scripts).toBeUndefined()
   })
 
@@ -892,7 +912,6 @@ describe('buildStartManifest', () => {
           preloads: ['/assets/c.js'],
         },
       },
-      clientEntry: '/assets/entry.js',
     }
 
     const evaluated = deserializeSerializedManifest(
@@ -930,7 +949,6 @@ describe('buildStartManifest', () => {
           ],
         },
       },
-      clientEntry: '/assets/entry.js',
     }
 
     expect(
@@ -950,7 +968,6 @@ describe('buildStartManifest', () => {
           preloads: ['/assets/posts.js'],
         },
       },
-      clientEntry: '/assets/entry.js',
     }
 
     expect(
@@ -986,6 +1003,64 @@ describe('buildStartManifest', () => {
         scriptFormat: 'iife',
       }).scriptFormat,
     ).toBe('iife')
+  })
+
+  test('buildStartManifest emits client entry assets as root route scripts', () => {
+    const entryChunk = makeChunk({
+      fileName: 'entry.js',
+      isEntry: true,
+      imports: ['runtime.js', 'vendor.js'],
+    })
+    const runtimeChunk = makeChunk({ fileName: 'runtime.js' })
+    const vendorChunk = makeChunk({ fileName: 'vendor.js' })
+    const routeTreeRoutes = {
+      __root__: {
+        filePath: '/routes/__root.tsx',
+      },
+    }
+
+    const moduleManifest = buildStartManifest({
+      clientBuild: normalizeTestBuild({
+        'entry.js': entryChunk,
+        'runtime.js': runtimeChunk,
+        'vendor.js': vendorChunk,
+      }),
+      routeTreeRoutes,
+      basePath: '/assets',
+      scriptFormat: 'module',
+    })
+
+    expect(moduleManifest.routes.__root__?.scripts).toEqual([
+      {
+        attrs: {
+          type: 'module',
+          async: true,
+          src: '/assets/entry.js',
+        },
+      },
+    ])
+
+    const iifeManifest = buildStartManifest({
+      clientBuild: normalizeTestBuild({
+        'entry.js': entryChunk,
+        'runtime.js': runtimeChunk,
+        'vendor.js': vendorChunk,
+      }),
+      routeTreeRoutes,
+      basePath: '/assets',
+      scriptFormat: 'iife',
+    })
+
+    expect(iifeManifest.routes.__root__?.preloads).toEqual([
+      '/assets/entry.js',
+      '/assets/runtime.js',
+      '/assets/vendor.js',
+    ])
+    expect(iifeManifest.routes.__root__?.scripts).toEqual([
+      { attrs: { async: true, src: '/assets/runtime.js' } },
+      { attrs: { async: true, src: '/assets/vendor.js' } },
+      { attrs: { async: true, src: '/assets/entry.js' } },
+    ])
   })
 })
 

--- a/packages/start-server-core/src/finalManifest.ts
+++ b/packages/start-server-core/src/finalManifest.ts
@@ -1,5 +1,5 @@
 import {
-  buildManifestWithClientEntry,
+  buildManifest,
   resolveTransformAssetsConfig,
   transformManifestAssets,
 } from './transformAssetUrls'
@@ -11,16 +11,11 @@ import type { ServerManifest } from '@tanstack/router-core'
 import type { HandlerInlineCssOption } from './inlineCss'
 import type {
   CreateTransformAssetsContext,
-  StartManifestWithClientEntry,
   TransformAssets,
   TransformAssetsFn,
 } from './transformAssetUrls'
 
-export type {
-  HandlerInlineCssOption,
-  StartManifestWithClientEntry,
-  TransformAssets,
-}
+export type { HandlerInlineCssOption, TransformAssets }
 
 export interface FinalManifestOptions {
   /**
@@ -37,8 +32,8 @@ export interface FinalManifestOptions {
    * Transform manifest-managed asset URLs and attributes at runtime, e.g. to
    * prepend a CDN prefix.
    *
-   * This covers JS preloads, CSS links, the client entry script, and URLs
-   * inside build-collected inline CSS. Asset imports used directly in
+   * This covers JS preloads, manifest script tags, CSS links, and URLs inside
+   * build-collected inline CSS. Asset imports used directly in
    * components should be handled by the bundler instead.
    */
   transformAssets?: TransformAssets
@@ -46,7 +41,7 @@ export interface FinalManifestOptions {
 
 type FinalManifestCacheKey = 'inline-css' | 'linked-css'
 type FinalManifestCache = Map<FinalManifestCacheKey, Promise<ServerManifest>>
-export type GetBaseManifest = () => Promise<StartManifestWithClientEntry>
+export type GetBaseManifest = () => Promise<ServerManifest>
 
 export interface FinalManifestRequestOptions {
   request: Request
@@ -76,7 +71,7 @@ export interface FinalManifestResolver {
 export function createCachedBaseManifestLoader(
   loadBaseManifest: GetBaseManifest,
 ): GetBaseManifest {
-  let baseManifestPromise: Promise<StartManifestWithClientEntry> | undefined
+  let baseManifestPromise: Promise<ServerManifest> | undefined
 
   return () => {
     if (!baseManifestPromise) {
@@ -241,7 +236,7 @@ function getOrCreateCachedFinalManifestPromise(
 }
 
 async function buildFinalManifest(opts: {
-  base: StartManifestWithClientEntry
+  base: ServerManifest
   transformFn: TransformAssetsFn | undefined
   inlineCss: boolean
 }): Promise<ServerManifest> {
@@ -249,11 +244,11 @@ async function buildFinalManifest(opts: {
     ? await transformManifestAssets(opts.base, opts.transformFn, {
         inlineCss: opts.inlineCss,
       })
-    : buildManifestWithClientEntry(opts.base, { inlineCss: opts.inlineCss })
+    : buildManifest(opts.base, { inlineCss: opts.inlineCss })
 }
 
 async function resolveFinalManifest(opts: {
-  getBaseManifest: () => Promise<StartManifestWithClientEntry>
+  getBaseManifest: () => Promise<ServerManifest>
   transformFn: TransformAssetsFn | undefined
   cache: boolean
   inlineCss: boolean
@@ -283,7 +278,7 @@ function warmupFinalManifest(opts: {
   handlerDefaultInlineCss: boolean | undefined
   cache: boolean
   finalManifestCache: FinalManifestCache
-  getBaseManifest: () => Promise<StartManifestWithClientEntry>
+  getBaseManifest: () => Promise<ServerManifest>
   getTransformFn: () => Promise<TransformAssetsFn | undefined>
   onError?: () => void
 }): Promise<ServerManifest> | undefined {

--- a/packages/start-server-core/src/router-manifest.ts
+++ b/packages/start-server-core/src/router-manifest.ts
@@ -3,8 +3,11 @@ import {
   buildDevStylesUrl,
   rootRouteId,
 } from '@tanstack/router-core'
-import type { AnyRoute, ServerManifestRoute } from '@tanstack/router-core'
-import type { StartManifestWithClientEntry } from './transformAssetUrls'
+import type {
+  AnyRoute,
+  ServerManifest,
+  ServerManifestRoute,
+} from '@tanstack/router-core'
 
 // Pre-computed constant for dev styles URL basepath.
 // Defaults to vite `base` (set via TSS_DEV_SSR_STYLES_BASEPATH in the plugin),
@@ -16,15 +19,12 @@ const DEV_SSR_STYLES_BASEPATH = process.env.TSS_DEV_SSR_STYLES_BASEPATH || '/'
  * special assets that are needed for the client. It does not include relationships
  * between routes or any other data that is not needed for the client.
  *
- * The client entry URL is returned separately so that it can be transformed
- * (e.g. for CDN rewriting) before being embedded into the `<script>` tag.
- *
  * @param matchedRoutes - In dev mode, the matched routes are used to build
  * the dev styles URL for route-scoped CSS collection.
  */
 export async function getStartManifest(
   matchedRoutes?: ReadonlyArray<AnyRoute>,
-): Promise<StartManifestWithClientEntry> {
+): Promise<ServerManifest> {
   const { tsrStartManifest } = await import('tanstack-start-manifest:v')
   const startManifest = tsrStartManifest()
   let routes = startManifest.routes
@@ -85,11 +85,5 @@ export async function getStartManifest(
     routes: manifestRoutes,
   }
 
-  return {
-    manifest: manifest as StartManifestWithClientEntry['manifest'],
-    clientEntry: startManifest.clientEntry,
-    ...(startManifest.clientEntryImports
-      ? { clientEntryImports: startManifest.clientEntryImports }
-      : {}),
-  }
+  return manifest
 }

--- a/packages/start-server-core/src/router-manifest.ts
+++ b/packages/start-server-core/src/router-manifest.ts
@@ -88,5 +88,8 @@ export async function getStartManifest(
   return {
     manifest: manifest as StartManifestWithClientEntry['manifest'],
     clientEntry: startManifest.clientEntry,
+    ...(startManifest.clientEntryImports
+      ? { clientEntryImports: startManifest.clientEntryImports }
+      : {}),
   }
 }

--- a/packages/start-server-core/src/tanstack-start.d.ts
+++ b/packages/start-server-core/src/tanstack-start.d.ts
@@ -1,7 +1,10 @@
 declare module 'tanstack-start-manifest:v' {
   import type { ServerManifest } from '@tanstack/router-core'
 
-  export const tsrStartManifest: () => ServerManifest & { clientEntry: string }
+  export const tsrStartManifest: () => ServerManifest & {
+    clientEntry: string
+    clientEntryImports?: Array<string>
+  }
 }
 
 declare module 'tanstack-start-route-tree:v' {

--- a/packages/start-server-core/src/tanstack-start.d.ts
+++ b/packages/start-server-core/src/tanstack-start.d.ts
@@ -1,10 +1,7 @@
 declare module 'tanstack-start-manifest:v' {
   import type { ServerManifest } from '@tanstack/router-core'
 
-  export const tsrStartManifest: () => ServerManifest & {
-    clientEntry: string
-    clientEntryImports?: Array<string>
-  }
+  export const tsrStartManifest: () => ServerManifest
 }
 
 declare module 'tanstack-start-route-tree:v' {

--- a/packages/start-server-core/src/transformAssetUrls.ts
+++ b/packages/start-server-core/src/transformAssetUrls.ts
@@ -1,5 +1,4 @@
 import {
-  getManifestScriptFormat,
   resolveManifestAssetLink,
   resolveManifestCssLink,
 } from '@tanstack/router-core'
@@ -9,8 +8,6 @@ import type {
   Awaitable,
   ManifestAssetLink,
   ManifestCssLink,
-  ManifestScript,
-  ScriptFormat,
   ServerManifest,
 } from '@tanstack/router-core'
 
@@ -322,31 +319,6 @@ export function resolveTransformAssetsConfig(
   }
 }
 
-export interface StartManifestWithClientEntry {
-  manifest: ServerManifest
-  clientEntry: string
-  clientEntryImports?: Array<string>
-}
-
-/**
- * Builds the client entry `<script>` tag from a (possibly transformed) client
- * entry URL.
- */
-export function buildClientEntryScriptTag(
-  clientEntry: string,
-  scriptFormat: ScriptFormat = 'module',
-  crossOrigin?: AssetCrossOrigin,
-): ManifestScript {
-  return {
-    attrs: {
-      ...(scriptFormat === 'module' ? { type: 'module' } : {}),
-      async: true,
-      src: clientEntry,
-      ...(crossOrigin ? { crossOrigin } : {}),
-    },
-  }
-}
-
 type AssignableManifestLink = ManifestAssetLink | ManifestCssLink
 
 function assignManifestLink(
@@ -379,60 +351,15 @@ function assignManifestLink(
   return nextLink
 }
 
-function appendUniqueManifestAssetLink(
-  target: Array<ManifestAssetLink> | undefined,
-  link: ManifestAssetLink,
-) {
-  const href = typeof link === 'string' ? link : link.href
-
-  if (target) {
-    for (const item of target) {
-      if ((typeof item === 'string' ? item : item.href) === href) {
-        return target
-      }
-    }
-  }
-
-  return [...(target ?? []), link]
-}
-
-function addClientEntryToManifest(
-  manifest: ServerManifest,
-  clientEntry: string,
-) {
-  const rootRoute = manifest.routes.__root__ ?? {}
-  const rootScripts = rootRoute.scripts ?? []
-  const scripts = rootScripts.some(
-    (script) => script.attrs?.src === clientEntry,
-  )
-    ? rootScripts
-    : [
-        ...rootScripts,
-        buildClientEntryScriptTag(
-          clientEntry,
-          getManifestScriptFormat(manifest),
-        ),
-      ]
-
-  manifest.routes = {
-    ...manifest.routes,
-    __root__: {
-      ...rootRoute,
-      preloads: appendUniqueManifestAssetLink(rootRoute.preloads, clientEntry),
-      scripts,
-    },
-  }
-}
-
 export async function transformManifestAssets(
-  source: StartManifestWithClientEntry,
+  source: ServerManifest,
   transformFn: TransformAssetsFn,
   _opts?: {
     clone?: boolean
     inlineCss?: boolean
   },
 ): Promise<ServerManifest> {
-  const manifest = structuredClone(source.manifest)
+  const manifest = structuredClone(source)
   const inlineCssEnabled = _opts?.inlineCss !== false
   const scriptTransforms = new Map<
     string,
@@ -462,16 +389,6 @@ export async function transformManifestAssets(
       transformFn,
     )
   }
-
-  // Sibling chunks the entry boots from (e.g. an extracted runtime under
-  // IIFE) get the same treatment as the entry, and land before it in
-  // `__root__.scripts`.
-  if (source.clientEntryImports) {
-    for (const importUrl of source.clientEntryImports) {
-      addClientEntryToManifest(manifest, importUrl)
-    }
-  }
-  addClientEntryToManifest(manifest, source.clientEntry)
 
   for (const route of Object.values(manifest.routes)) {
     if (route.preloads?.length) {
@@ -533,33 +450,24 @@ export async function transformManifestAssets(
 }
 
 /**
- * Builds a final ServerManifest from a StartManifestWithClientEntry without any
- * URL transforms. Used when no transformAssets option is provided.
+ * Builds a final ServerManifest without URL transforms. Used when no
+ * transformAssets option is provided.
  *
  * Returns a new manifest object so the cached base manifest is never mutated.
  */
-export function buildManifestWithClientEntry(
-  source: StartManifestWithClientEntry,
+export function buildManifest(
+  source: ServerManifest,
   opts?: { inlineCss?: boolean },
 ): ServerManifest {
   const manifest: ServerManifest = {
-    ...(source.manifest.scriptFormat
-      ? { scriptFormat: source.manifest.scriptFormat }
-      : {}),
-    ...(opts?.inlineCss !== false && source.manifest.inlineCss
-      ? { inlineCss: structuredClone(source.manifest.inlineCss) }
+    ...(source.scriptFormat ? { scriptFormat: source.scriptFormat } : {}),
+    ...(opts?.inlineCss !== false && source.inlineCss
+      ? { inlineCss: structuredClone(source.inlineCss) }
       : {}),
     routes: {
-      ...source.manifest.routes,
+      ...source.routes,
     },
   }
-
-  if (source.clientEntryImports) {
-    for (const importUrl of source.clientEntryImports) {
-      addClientEntryToManifest(manifest, importUrl)
-    }
-  }
-  addClientEntryToManifest(manifest, source.clientEntry)
 
   return manifest
 }

--- a/packages/start-server-core/src/transformAssetUrls.ts
+++ b/packages/start-server-core/src/transformAssetUrls.ts
@@ -325,6 +325,7 @@ export function resolveTransformAssetsConfig(
 export interface StartManifestWithClientEntry {
   manifest: ServerManifest
   clientEntry: string
+  clientEntryImports?: Array<string>
 }
 
 /**
@@ -462,6 +463,14 @@ export async function transformManifestAssets(
     )
   }
 
+  // Sibling chunks the entry boots from (e.g. an extracted runtime under
+  // IIFE) get the same treatment as the entry, and land before it in
+  // `__root__.scripts`.
+  if (source.clientEntryImports) {
+    for (const importUrl of source.clientEntryImports) {
+      addClientEntryToManifest(manifest, importUrl)
+    }
+  }
   addClientEntryToManifest(manifest, source.clientEntry)
 
   for (const route of Object.values(manifest.routes)) {
@@ -545,6 +554,11 @@ export function buildManifestWithClientEntry(
     },
   }
 
+  if (source.clientEntryImports) {
+    for (const importUrl of source.clientEntryImports) {
+      addClientEntryToManifest(manifest, importUrl)
+    }
+  }
   addClientEntryToManifest(manifest, source.clientEntry)
 
   return manifest

--- a/packages/start-server-core/tests/finalManifest.test.ts
+++ b/packages/start-server-core/tests/finalManifest.test.ts
@@ -3,21 +3,29 @@ import {
   createCachedBaseManifestLoader,
   createFinalManifestResolver,
 } from '../src/finalManifest'
-import type { StartManifestWithClientEntry } from '../src/finalManifest'
+import type { ServerManifest } from '@tanstack/router-core'
 import type { TransformAssetsFn } from '../src/transformAssetUrls'
 
-const baseManifest: StartManifestWithClientEntry = {
-  manifest: {
-    inlineCss: {
-      styles: {
-        '/assets/app.css': '.app{color:red}',
-      },
-    },
-    routes: {
-      __root__: {},
+const baseManifest: ServerManifest = {
+  inlineCss: {
+    styles: {
+      '/assets/app.css': '.app{color:red}',
     },
   },
-  clientEntry: '/assets/entry.js',
+  routes: {
+    __root__: {
+      preloads: ['/assets/entry.js'],
+      scripts: [
+        {
+          attrs: {
+            type: 'module',
+            async: true,
+            src: '/assets/entry.js',
+          },
+        },
+      ],
+    },
+  },
 }
 
 describe('final manifest resolver', () => {
@@ -35,7 +43,7 @@ describe('final manifest resolver', () => {
 
   it('evicts rejected cached base manifest promises so requests can retry', async () => {
     const loadBaseManifest = vi
-      .fn<() => Promise<StartManifestWithClientEntry>>()
+      .fn<() => Promise<ServerManifest>>()
       .mockRejectedValueOnce(new Error('transient'))
       .mockResolvedValueOnce(baseManifest)
     const getBaseManifest = createCachedBaseManifestLoader(loadBaseManifest)
@@ -79,7 +87,7 @@ describe('final manifest resolver', () => {
 
   it('evicts rejected cached final manifest promises so requests can retry', async () => {
     const getBaseManifest = vi
-      .fn<() => Promise<StartManifestWithClientEntry>>()
+      .fn<() => Promise<ServerManifest>>()
       .mockRejectedValueOnce(new Error('transient'))
       .mockResolvedValueOnce(baseManifest)
     const resolver = createFinalManifestResolver({ cacheCreateTransform: true })
@@ -99,7 +107,7 @@ describe('final manifest resolver', () => {
         requestInlineCss: true,
         getBaseManifest,
       }),
-    ).resolves.toMatchObject({ inlineCss: baseManifest.manifest.inlineCss })
+    ).resolves.toMatchObject({ inlineCss: baseManifest.inlineCss })
     expect(getBaseManifest).toHaveBeenCalledTimes(2)
   })
 

--- a/packages/start-server-core/tests/transformAssets.test.ts
+++ b/packages/start-server-core/tests/transformAssets.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
-  buildManifestWithClientEntry,
+  buildManifest,
   resolveTransformAssetsConfig,
   transformManifestAssets,
 } from '../src/transformAssetUrls'
-import type { StartManifestWithClientEntry } from '../src/transformAssetUrls'
+import type { ServerManifest } from '@tanstack/router-core'
 
 describe('transformAssets', () => {
   it('supports string shorthand', async () => {
@@ -26,15 +26,21 @@ describe('transformAssets', () => {
   it('supports object return values with crossOrigin', async () => {
     const manifest = await transformManifestAssets(
       {
-        manifest: {
-          routes: {
-            __root__: {
-              preloads: ['/assets/app.js'],
-              css: ['/assets/app.css'],
-            },
+        routes: {
+          __root__: {
+            preloads: ['/assets/app.js'],
+            css: ['/assets/app.css'],
+            scripts: [
+              {
+                attrs: {
+                  type: 'module',
+                  async: true,
+                  src: '/assets/entry.js',
+                },
+              },
+            ],
           },
         },
-        clientEntry: '/assets/entry.js',
       },
       (context) => {
         if (context.kind === 'script') {
@@ -54,139 +60,63 @@ describe('transformAssets', () => {
         href: 'https://cdn.example.com/assets/app.js',
         crossOrigin: 'anonymous',
       },
-      {
-        href: 'https://cdn.example.com/assets/entry.js',
-        crossOrigin: 'anonymous',
-      },
     ])
     expect(manifest.routes.__root__?.css?.[0]).toBe(
       'https://cdn.example.com/assets/app.css',
     )
+    expect(manifest.routes.__root__?.scripts?.[0]).toEqual({
+      attrs: {
+        type: 'module',
+        async: true,
+        src: 'https://cdn.example.com/assets/entry.js',
+        crossOrigin: 'anonymous',
+      },
+    })
   })
 
   it('preserves string preload format when transform returns no crossOrigin', async () => {
     const manifest = await transformManifestAssets(
       {
-        manifest: {
-          routes: {
-            __root__: {
-              preloads: ['/assets/app.js'],
-            },
+        routes: {
+          __root__: {
+            preloads: ['/assets/app.js'],
           },
         },
-        clientEntry: '/assets/entry.js',
       },
       ({ url }) => ({ href: `https://cdn.example.com${url}` }),
       { clone: true },
     )
 
-    // When original was a string and no crossOrigin is added, should remain a string
     expect(manifest.routes.__root__?.preloads?.[0]).toBe(
       'https://cdn.example.com/assets/app.js',
     )
-    expect(manifest.routes.__root__?.preloads?.[1]).toBe(
-      'https://cdn.example.com/assets/entry.js',
-    )
   })
 
-  it('passes script context for route preloads and client entry assets', async () => {
+  it('passes script context for manifest preloads and scripts', async () => {
     const transformFn = vi.fn(({ url }) => ({
       href: `https://cdn.example.com${url}`,
     }))
 
     await transformManifestAssets(
       {
-        manifest: {
-          scriptFormat: 'iife',
-          routes: {
-            __root__: {
-              preloads: ['/assets/app.js'],
-            },
+        scriptFormat: 'iife',
+        routes: {
+          __root__: {
+            preloads: ['/assets/app.js'],
+            scripts: [{ attrs: { src: '/assets/entry.js' } }],
           },
         },
-        clientEntry: '/assets/entry.js',
       },
       transformFn,
     )
 
-    expect(transformFn).toHaveBeenCalledWith({
-      kind: 'script',
-      url: '/assets/app.js',
-    })
-    expect(transformFn).toHaveBeenCalledWith({
-      kind: 'script',
-      url: '/assets/entry.js',
-    })
-    expect(transformFn).toHaveBeenCalledTimes(2)
     expect(transformFn.mock.calls).toEqual([
       [{ kind: 'script', url: '/assets/app.js' }],
       [{ kind: 'script', url: '/assets/entry.js' }],
     ])
   })
 
-  it('does not duplicate the client entry preload when it already exists', async () => {
-    const transformFn = vi.fn(({ url }) => ({
-      href: `https://cdn.example.com${url}`,
-    }))
-
-    const manifest = await transformManifestAssets(
-      {
-        manifest: {
-          routes: {
-            __root__: {
-              preloads: ['/assets/entry.js'],
-            },
-          },
-        },
-        clientEntry: '/assets/entry.js',
-      },
-      transformFn,
-    )
-
-    expect(manifest.routes.__root__?.preloads).toEqual([
-      'https://cdn.example.com/assets/entry.js',
-    ])
-    expect(transformFn).toHaveBeenCalledTimes(1)
-    expect(transformFn.mock.calls).toEqual([
-      [{ kind: 'script', url: '/assets/entry.js' }],
-    ])
-  })
-
-  it('does not duplicate an object-form client entry preload', async () => {
-    const transformFn = vi.fn(({ url }) => ({
-      href: `https://cdn.example.com${url}`,
-      crossOrigin: 'anonymous' as const,
-    }))
-
-    const manifest = await transformManifestAssets(
-      {
-        manifest: {
-          routes: {
-            __root__: {
-              preloads: [
-                { href: '/assets/entry.js', crossOrigin: 'use-credentials' },
-              ],
-            },
-          },
-        },
-        clientEntry: '/assets/entry.js',
-      },
-      transformFn,
-    )
-
-    expect(manifest.routes.__root__?.preloads).toEqual([
-      {
-        href: 'https://cdn.example.com/assets/entry.js',
-        crossOrigin: 'anonymous',
-      },
-    ])
-    expect(transformFn).toHaveBeenCalledTimes(1)
-    expect(transformFn.mock.calls).toEqual([
-      [{ kind: 'script', url: '/assets/entry.js' }],
-    ])
-  })
-
-  it('reuses the transformed client entry URL for matching preload and script tags', async () => {
+  it('reuses transformed URLs for matching preload and script tags', async () => {
     let signature = 0
     const transformFn = vi.fn(({ url }) => ({
       href: `https://cdn.example.com${url}?sig=${++signature}`,
@@ -194,12 +124,20 @@ describe('transformAssets', () => {
 
     const manifest = await transformManifestAssets(
       {
-        manifest: {
-          routes: {
-            __root__: {},
+        routes: {
+          __root__: {
+            preloads: ['/assets/entry.js'],
+            scripts: [
+              {
+                attrs: {
+                  type: 'module',
+                  async: true,
+                  src: '/assets/entry.js',
+                },
+              },
+            ],
           },
         },
-        clientEntry: '/assets/entry.js',
       },
       transformFn,
     )
@@ -212,108 +150,60 @@ describe('transformAssets', () => {
     ])
   })
 
-  it('does not duplicate the client entry script when it already exists', async () => {
-    let signature = 0
+  it('keeps root route boot scripts before an iife client entry', async () => {
     const transformFn = vi.fn(({ url }) => ({
-      href: `https://cdn.example.com${url}?sig=${++signature}`,
+      href: `https://cdn.example.com${url}`,
     }))
 
     const manifest = await transformManifestAssets(
       {
-        manifest: {
-          routes: {
-            __root__: {
-              scripts: [
-                {
-                  attrs: {
-                    type: 'module',
-                    async: true,
-                    src: '/assets/entry.js',
-                  },
-                },
-              ],
-            },
+        scriptFormat: 'iife',
+        routes: {
+          __root__: {
+            preloads: ['/assets/runtime.js', '/assets/entry.js'],
+            scripts: [
+              { attrs: { src: '/assets/runtime.js' } },
+              { attrs: { src: '/assets/entry.js' } },
+            ],
           },
         },
-        clientEntry: '/assets/entry.js',
       },
       transformFn,
     )
 
     expect(manifest.routes.__root__?.preloads).toEqual([
-      'https://cdn.example.com/assets/entry.js?sig=1',
+      'https://cdn.example.com/assets/runtime.js',
+      'https://cdn.example.com/assets/entry.js',
     ])
     expect(manifest.routes.__root__?.scripts).toEqual([
-      {
-        attrs: {
-          type: 'module',
-          async: true,
-          src: 'https://cdn.example.com/assets/entry.js?sig=1',
-        },
-      },
+      { attrs: { src: 'https://cdn.example.com/assets/runtime.js' } },
+      { attrs: { src: 'https://cdn.example.com/assets/entry.js' } },
     ])
     expect(transformFn.mock.calls).toEqual([
+      [{ kind: 'script', url: '/assets/runtime.js' }],
       [{ kind: 'script', url: '/assets/entry.js' }],
     ])
   })
 
-  it('adds external client entry script tags to root scripts for module and iife formats', () => {
-    const moduleManifest = buildManifestWithClientEntry({
-      manifest: { routes: { __root__: {} } },
-      clientEntry: '/assets/entry.js',
-    })
-
-    expect(moduleManifest.routes.__root__?.scripts?.at(-1)).toEqual({
-      attrs: {
-        type: 'module',
-        async: true,
-        src: '/assets/entry.js',
-      },
-    })
-    expect(moduleManifest.routes.__root__?.preloads).toEqual([
-      '/assets/entry.js',
-    ])
-
-    const iifeManifest = buildManifestWithClientEntry({
-      manifest: { scriptFormat: 'iife', routes: { __root__: {} } },
-      clientEntry: '/assets/entry.js',
-    })
-
-    expect(iifeManifest.routes.__root__?.scripts?.at(-1)).toEqual({
-      attrs: {
-        async: true,
-        src: '/assets/entry.js',
-      },
-    })
-    expect(iifeManifest.routes.__root__?.preloads).toEqual(['/assets/entry.js'])
-  })
-
-  it('does not mutate the source manifest when clone is false', async () => {
-    const source: StartManifestWithClientEntry = {
-      manifest: {
-        routes: {
-          __root__: {
-            preloads: ['/assets/app.js'],
-            css: ['/assets/app.css'],
-          },
+  it('does not mutate the source manifest', async () => {
+    const source: ServerManifest = {
+      routes: {
+        __root__: {
+          preloads: ['/assets/app.js'],
+          css: ['/assets/app.css'],
         },
       },
-      clientEntry: '/assets/entry.js',
     }
 
-    const manifest = await transformManifestAssets(
-      source,
-      ({ url }) => ({ href: `https://cdn.example.com${url}` }),
-      { clone: false },
-    )
+    const manifest = await transformManifestAssets(source, ({ url }) => ({
+      href: `https://cdn.example.com${url}`,
+    }))
 
     expect(manifest.routes.__root__?.preloads?.[0]).toBe(
       'https://cdn.example.com/assets/app.js',
     )
-    expect(source.manifest.routes.__root__?.preloads?.[0]).toBe(
-      '/assets/app.js',
-    )
-    expect(source.manifest.routes.__root__?.css?.[0]).toBe('/assets/app.css')
+    expect(source.routes.__root__?.preloads?.[0]).toBe('/assets/app.js')
+    expect(source.routes.__root__?.css?.[0]).toBe('/assets/app.css')
   })
 
   it('transforms manifest stylesheet links', async () => {
@@ -323,15 +213,12 @@ describe('transformAssets', () => {
 
     const manifest = await transformManifestAssets(
       {
-        manifest: {
-          routes: {
-            __root__: {
-              preloads: [],
-              css: ['/assets/app.css'],
-            },
+        routes: {
+          __root__: {
+            preloads: [],
+            css: ['/assets/app.css'],
           },
         },
-        clientEntry: '/assets/entry.js',
       },
       transformFn,
       { clone: true },
@@ -344,42 +231,24 @@ describe('transformAssets', () => {
     expect(manifest.routes.__root__?.css).toEqual([
       'https://cdn.example.com/assets/app.css',
     ])
-    expect(manifest.routes.__root__?.scripts).toEqual([
-      {
-        attrs: {
-          type: 'module',
-          async: true,
-          src: 'https://cdn.example.com/assets/entry.js',
-        },
-      },
-    ])
-    expect(manifest.routes.__root__?.scripts?.at(-1)).toEqual({
-      attrs: {
-        type: 'module',
-        async: true,
-        src: 'https://cdn.example.com/assets/entry.js',
-      },
-    })
+    expect(manifest.routes.__root__?.scripts).toBeUndefined()
   })
 
   it('transforms existing manifest route script src values', async () => {
     const manifest = await transformManifestAssets(
       {
-        manifest: {
-          routes: {
-            __root__: {
-              scripts: [
-                {
-                  attrs: {
-                    src: '/assets/route-script.js',
-                    type: 'module',
-                  },
+        routes: {
+          __root__: {
+            scripts: [
+              {
+                attrs: {
+                  src: '/assets/route-script.js',
+                  type: 'module',
                 },
-              ],
-            },
+              },
+            ],
           },
         },
-        clientEntry: '/assets/entry.js',
       },
       ({ url }) => ({ href: `https://cdn.example.com${url}` }),
       { clone: true },
@@ -404,30 +273,27 @@ describe('transformAssets', () => {
 
     const manifest = await transformManifestAssets(
       {
-        manifest: {
-          inlineCss: {
-            styles: {
-              '/assets/app.css':
-                '@font-face{src:url(/assets/font.woff2)}.card{background:url(/images/bg.png)}.icon{background:url(data:image/svg+xml,foo)}',
-            },
-            templates: {
-              '/assets/app.css': {
-                strings: [
-                  '@font-face{src:url("',
-                  '")}.card{background:url("',
-                  '")}.icon{background:url(data:image/svg+xml,foo)}',
-                ],
-                urls: ['/assets/font.woff2', '/images/bg.png'],
-              },
-            },
+        inlineCss: {
+          styles: {
+            '/assets/app.css':
+              '@font-face{src:url(/assets/font.woff2)}.card{background:url(/images/bg.png)}.icon{background:url(data:image/svg+xml,foo)}',
           },
-          routes: {
-            __root__: {
-              css: ['/assets/app.css'],
+          templates: {
+            '/assets/app.css': {
+              strings: [
+                '@font-face{src:url("',
+                '")}.card{background:url("',
+                '")}.icon{background:url(data:image/svg+xml,foo)}',
+              ],
+              urls: ['/assets/font.woff2', '/images/bg.png'],
             },
           },
         },
-        clientEntry: '/assets/entry.js',
+        routes: {
+          __root__: {
+            css: ['/assets/app.css'],
+          },
+        },
       },
       transformFn,
     )
@@ -463,15 +329,12 @@ describe('transformAssets', () => {
 
     const manifest = await transformManifestAssets(
       {
-        manifest: {
-          inlineCss: {
-            styles: {
-              '/assets/app.css': '.card{background:url(/images/bg.png)}',
-            },
+        inlineCss: {
+          styles: {
+            '/assets/app.css': '.card{background:url(/images/bg.png)}',
           },
-          routes: {},
         },
-        clientEntry: '/assets/entry.js',
+        routes: {},
       },
       transformFn,
     )
@@ -495,19 +358,16 @@ describe('transformAssets', () => {
 
     const manifest = await transformManifestAssets(
       {
-        manifest: {
-          inlineCss: {
-            styles: {
-              '/assets/app.css': '.root{color:red}',
-            },
-          },
-          routes: {
-            __root__: {
-              css: ['/assets/app.css'],
-            },
+        inlineCss: {
+          styles: {
+            '/assets/app.css': '.root{color:red}',
           },
         },
-        clientEntry: '/assets/entry.js',
+        routes: {
+          __root__: {
+            css: ['/assets/app.css'],
+          },
+        },
       },
       transformFn,
     )
@@ -533,26 +393,23 @@ describe('transformAssets', () => {
 
     const manifestPromise = transformManifestAssets(
       {
-        manifest: {
-          inlineCss: {
-            styles: {
-              '/assets/a.css': '.a{background:url(/assets/a.png)}',
-              '/assets/b.css': '.b{background:url(/assets/b.png)}',
+        inlineCss: {
+          styles: {
+            '/assets/a.css': '.a{background:url(/assets/a.png)}',
+            '/assets/b.css': '.b{background:url(/assets/b.png)}',
+          },
+          templates: {
+            '/assets/a.css': {
+              strings: ['.a{background:url("', '")}'],
+              urls: ['/assets/a.png'],
             },
-            templates: {
-              '/assets/a.css': {
-                strings: ['.a{background:url("', '")}'],
-                urls: ['/assets/a.png'],
-              },
-              '/assets/b.css': {
-                strings: ['.b{background:url("', '")}'],
-                urls: ['/assets/b.png'],
-              },
+            '/assets/b.css': {
+              strings: ['.b{background:url("', '")}'],
+              urls: ['/assets/b.png'],
             },
           },
-          routes: {},
         },
-        clientEntry: '/assets/entry.js',
+        routes: {},
       },
       transformFn,
     )
@@ -579,41 +436,36 @@ describe('transformAssets', () => {
   })
 
   it('clones inline CSS when building a manifest without transforms', () => {
-    const source = {
-      manifest: {
-        inlineCss: {
-          styles: {
-            '/assets/app.css': '.app{color:red}',
-          },
-          templates: {
-            '/assets/app.css': {
-              strings: ['.app{background:url("', '")}'],
-              urls: ['/assets/bg.png'],
-            },
-          },
+    const source: ServerManifest = {
+      inlineCss: {
+        styles: {
+          '/assets/app.css': '.app{color:red}',
         },
-        routes: {
-          __root__: {},
+        templates: {
+          '/assets/app.css': {
+            strings: ['.app{background:url("', '")}'],
+            urls: ['/assets/bg.png'],
+          },
         },
       },
-      clientEntry: '/assets/entry.js',
+      routes: {
+        __root__: {},
+      },
     }
 
-    const manifest = buildManifestWithClientEntry(source)
+    const manifest = buildManifest(source)
     manifest.inlineCss!.styles['/assets/app.css'] = '.mutated{}'
     manifest.inlineCss!.templates!['/assets/app.css']!.urls[0] =
       '/assets/mutated.png'
 
-    expect(source.manifest.inlineCss.styles['/assets/app.css']).toBe(
-      '.app{color:red}',
+    expect(source.inlineCss!.styles['/assets/app.css']).toBe('.app{color:red}')
+    expect(source.inlineCss!.templates!['/assets/app.css']!.urls[0]).toBe(
+      '/assets/bg.png',
     )
-    expect(
-      source.manifest.inlineCss.templates['/assets/app.css']!.urls[0],
-    ).toBe('/assets/bg.png')
   })
 
   describe('object shorthand', () => {
-    it('supports { prefix } — same as string shorthand', () => {
+    it('supports { prefix } - same as string shorthand', () => {
       const config = resolveTransformAssetsConfig({
         prefix: 'https://cdn.example.com',
       })
@@ -630,7 +482,7 @@ describe('transformAssets', () => {
       ).toEqual({ href: 'https://cdn.example.com/assets/app.js' })
     })
 
-    it('supports { prefix, crossOrigin: string } — uniform crossOrigin', () => {
+    it('supports { prefix, crossOrigin: string } - uniform crossOrigin', () => {
       const config = resolveTransformAssetsConfig({
         prefix: 'https://cdn.example.com',
         crossOrigin: 'anonymous',
@@ -657,16 +509,6 @@ describe('transformAssets', () => {
 
       expect(
         config.transformFn({
-          kind: 'script',
-          url: '/assets/entry.js',
-        }),
-      ).toEqual({
-        href: 'https://cdn.example.com/assets/entry.js',
-        crossOrigin: 'anonymous',
-      })
-
-      expect(
-        config.transformFn({
           kind: 'css-url',
           url: '/assets/font.woff2',
           stylesheetHref: '/assets/app.css',
@@ -676,7 +518,7 @@ describe('transformAssets', () => {
       })
     })
 
-    it('supports { prefix, crossOrigin: per-kind } — different crossOrigin per kind', () => {
+    it('supports { prefix, crossOrigin: per-kind } - different crossOrigin per kind', () => {
       const config = resolveTransformAssetsConfig({
         prefix: 'https://cdn.example.com',
         crossOrigin: {
@@ -702,17 +544,6 @@ describe('transformAssets', () => {
       ).toEqual({
         href: 'https://cdn.example.com/assets/app.css',
         crossOrigin: 'use-credentials',
-      })
-
-      // client entry is a script, so script crossOrigin applies
-      expect(
-        config.transformFn({
-          kind: 'script',
-          url: '/assets/entry.js',
-        }),
-      ).toEqual({
-        href: 'https://cdn.example.com/assets/entry.js',
-        crossOrigin: 'anonymous',
       })
     })
 
@@ -729,7 +560,7 @@ describe('transformAssets', () => {
       ).toEqual({ href: '/assets/app.js' })
     })
 
-    it('applies object shorthand crossOrigin to manifest stylesheets and preloads', async () => {
+    it('applies object shorthand crossOrigin to manifest stylesheets, preloads, and scripts', async () => {
       const config = resolveTransformAssetsConfig({
         prefix: 'https://cdn.example.com',
         crossOrigin: {
@@ -742,15 +573,13 @@ describe('transformAssets', () => {
 
       const manifest = await transformManifestAssets(
         {
-          manifest: {
-            routes: {
-              __root__: {
-                preloads: ['/assets/app.js'],
-                css: ['/assets/app.css'],
-              },
+          routes: {
+            __root__: {
+              preloads: ['/assets/app.js'],
+              css: ['/assets/app.css'],
+              scripts: [{ attrs: { src: '/assets/entry.js' } }],
             },
           },
-          clientEntry: '/assets/entry.js',
         },
         config.transformFn,
         { clone: true },
@@ -761,15 +590,17 @@ describe('transformAssets', () => {
           href: 'https://cdn.example.com/assets/app.js',
           crossOrigin: 'anonymous',
         },
-        {
-          href: 'https://cdn.example.com/assets/entry.js',
-          crossOrigin: 'anonymous',
-        },
       ])
 
       expect(manifest.routes.__root__?.css?.[0]).toEqual({
         href: 'https://cdn.example.com/assets/app.css',
         crossOrigin: 'use-credentials',
+      })
+      expect(manifest.routes.__root__?.scripts?.[0]).toEqual({
+        attrs: {
+          src: 'https://cdn.example.com/assets/entry.js',
+          crossOrigin: 'anonymous',
+        },
       })
     })
   })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure client entry scripts are emitted for IIFE bundles with static-import siblings so hydration works correctly.

* **Chores**
  * Update build/test fixture for more extensive development stress-testing.
  * Manifest/public API changes: manifests and TypeScript types no longer expose a top-level clientEntry; manifest shape/asset handling standardized and simplified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/router/pull/7501?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->