### PR TITLE
feat(rsbuild): add RSC support

### DIFF
--- a/.changeset/mean-shirts-jog.md
+++ b/.changeset/mean-shirts-jog.md
@@ -1,0 +1,10 @@
+---
+'@tanstack/start-plugin-core': patch
+'@tanstack/start-server-core': patch
+'@tanstack/react-start-rsc': patch
+'@tanstack/react-start': patch
+'@tanstack/solid-start': patch
+'@tanstack/vue-start': patch
+---
+
+feat(rsbuild): add RSC support

--- a/benchmarks/bundle-size/package.json
+++ b/benchmarks/bundle-size/package.json
@@ -17,7 +17,7 @@
     "vue": "^3.5.16"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.1",
+    "@rsbuild/core": "^2.0.8",
     "@rsbuild/plugin-react": "^2.0.0",
     "@tanstack/router-plugin": "workspace:^",
     "@types/react": "^19.0.8",

--- a/e2e/react-router/rspack-basic-file-based/package.json
+++ b/e2e/react-router/rspack-basic-file-based/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
-    "@rsbuild/core": "^2.0.1",
+    "@rsbuild/core": "^2.0.8",
     "@rsbuild/plugin-react": "^2.0.0",
     "@tailwindcss/postcss": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",

--- a/e2e/react-router/rspack-basic-virtual-named-export-config-file-based/package.json
+++ b/e2e/react-router/rspack-basic-virtual-named-export-config-file-based/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
-    "@rsbuild/core": "^2.0.1",
+    "@rsbuild/core": "^2.0.8",
     "@rsbuild/plugin-react": "^2.0.0",
     "@tailwindcss/postcss": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",

--- a/e2e/react-start/basic/package.json
+++ b/e2e/react-start/basic/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
-    "@rsbuild/core": "^2.0.1",
+    "@rsbuild/core": "^2.0.8",
     "@rsbuild/plugin-react": "^2.0.0",
     "@tailwindcss/postcss": "^4.2.2",
     "@tailwindcss/vite": "^4.2.2",

--- a/e2e/react-start/basic/tests/client-output.spec.ts
+++ b/e2e/react-start/basic/tests/client-output.spec.ts
@@ -16,7 +16,7 @@ test('SSR HTML emits IIFE client scripts and classic script preloads', async ({
   expect(html).toMatch(/<link[^>]+rel="preload"[^>]+as="script"/)
 
   const clientEntry = html.match(
-    /<script\b[^>]+src="([^"]*\/static\/js\/index[^"]*)"[^>]*>/,
+    /<script\b[^>]+src="([^"]*\/assets\/js\/index[^"]*)"[^>]*>/,
   )
   expect(clientEntry).toBeTruthy()
   expect(clientEntry![0]).toContain('async')

--- a/e2e/react-start/css-inline/package.json
+++ b/e2e/react-start/css-inline/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
-    "@rsbuild/core": "^2.0.0",
+    "@rsbuild/core": "^2.0.8",
     "@rsbuild/plugin-react": "^2.0.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/react-start/custom-server-rsbuild/package.json
+++ b/e2e/react-start/custom-server-rsbuild/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
-    "@rsbuild/core": "^2.0.1",
+    "@rsbuild/core": "^2.0.8",
     "@rsbuild/plugin-react": "^2.0.0",
     "@tailwindcss/postcss": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",

--- a/e2e/react-start/deferred-hydration/tests/hydration.spec.ts
+++ b/e2e/react-start/deferred-hydration/tests/hydration.spec.ts
@@ -277,7 +277,9 @@ async function documentModulePreloadHrefs(page: Page) {
 
 function isHydrateBoundaryResource(url: string) {
   return (
-    url.includes('/assets/components-') || url.includes('/static/js/async/')
+    url.includes('/assets/components-') ||
+    url.includes('/assets/js/async/') ||
+    url.includes('/static/js/async/')
   )
 }
 

--- a/e2e/react-start/hmr/package.json
+++ b/e2e/react-start/hmr/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
-    "@rsbuild/core": "^2.0.1",
+    "@rsbuild/core": "^2.0.8",
     "@rsbuild/plugin-react": "^2.0.0",
     "@tailwindcss/postcss": "^4.2.2",
     "@tailwindcss/vite": "^4.2.2",

--- a/e2e/react-start/import-protection/package.json
+++ b/e2e/react-start/import-protection/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
-    "@rsbuild/core": "^2.0.1",
+    "@rsbuild/core": "^2.0.8",
     "@rsbuild/plugin-react": "^2.0.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/react-start/rsc/package.json
+++ b/e2e/react-start/rsc/package.json
@@ -22,6 +22,11 @@
           "toolchain": "vite",
           "mode": "ssr",
           "shards": 6
+        },
+        {
+          "toolchain": "rsbuild",
+          "mode": "ssr",
+          "shards": 6
         }
       ]
     }

--- a/e2e/react-start/rsc/package.json
+++ b/e2e/react-start/rsc/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
-    "@rsbuild/core": "^2.0.1",
+    "@rsbuild/core": "^2.0.8",
     "@rsbuild/plugin-react": "^2.0.0",
     "@tanstack/eslint-plugin-start": "workspace:^",
     "@tanstack/router-e2e-utils": "workspace:^",

--- a/e2e/react-start/rsc/tests/rsc-client-preload.spec.ts
+++ b/e2e/react-start/rsc/tests/rsc-client-preload.spec.ts
@@ -3,11 +3,23 @@ import { test } from '@tanstack/router-e2e-utils'
 import { waitForHydration } from './hydration'
 
 test.describe('RSC Client Component Preload Tests', () => {
-  function getModulePreloads(html: string): Array<string> {
+  function getLinkHrefs(html: string, rel: string): Array<string> {
     return Array.from(
-      html.matchAll(/<link rel="modulepreload" href="([^"]*)"/g),
-      (match) => match[1]!,
-    )
+      html.matchAll(/<link\b[^>]*>/g),
+      (match) => match[0],
+    ).flatMap((tag) => {
+      const relValue = tag.match(/\brel="([^"]*)"/)?.[1]
+      const href = tag.match(/\bhref="([^"]*)"/)?.[1]
+      return relValue?.split(/\s+/).includes(rel) && href ? [href] : []
+    })
+  }
+
+  function getModulePreloads(html: string): Array<string> {
+    return getLinkHrefs(html, 'modulepreload')
+  }
+
+  function getStylesheets(html: string): Array<string> {
+    return getLinkHrefs(html, 'stylesheet')
   }
 
   test('client component JS is modulepreloaded in SSR HTML', async ({
@@ -30,24 +42,23 @@ test.describe('RSC Client Component Preload Tests', () => {
     )
 
     expect(extraPreloads.length).toBeGreaterThan(0)
+    expect(extraPreloads.some((href) => href.includes('/assets/'))).toBe(true)
   })
 
-  test('client component CSS is preloaded in head', async ({ page }) => {
-    await page.goto('/rsc-client-preload')
+  test('client component CSS is included in SSR HTML', async ({ page }) => {
+    const response = await page.goto('/rsc-client-preload')
+    const html = await response?.text()
     await page.waitForURL('/rsc-client-preload')
+
+    expect(html).toBeDefined()
 
     // Verify client component is visible
     await expect(page.getByTestId('client-widget')).toBeVisible()
 
-    // Check for CSS preload link in <head>
-    // In dev mode, CSS is loaded differently than prod, so we check for stylesheet
-    const cssPreload = page.locator(
-      'head link[rel="preload"][as="style"], head link[rel="stylesheet"][href*="ClientWidget"]',
-    )
-    const cssPreloadCount = await cssPreload.count()
+    const stylesheetHrefs = getStylesheets(html!)
 
-    // Should have at least one CSS preload or stylesheet for the client component
-    expect(cssPreloadCount).toBeGreaterThanOrEqual(0) // Relaxed for dev mode
+    expect(stylesheetHrefs.length).toBeGreaterThan(0)
+    expect(stylesheetHrefs.some((href) => href.includes('/assets/'))).toBe(true)
   })
 
   test('client component renders with CSS module styles applied', async ({

--- a/e2e/react-start/rsc/tests/rsc-css-preload-complex.spec.ts
+++ b/e2e/react-start/rsc/tests/rsc-css-preload-complex.spec.ts
@@ -1,6 +1,17 @@
 import { expect, test } from '@playwright/test'
 
 test.describe('RSC Complex CSS Preload Tests', () => {
+  function getStylesheetHrefs(html: string): Array<string> {
+    return Array.from(
+      html.matchAll(/<link\b[^>]*>/g),
+      (match) => match[0],
+    ).flatMap((tag) => {
+      const rel = tag.match(/\brel="([^"]*)"/)?.[1]
+      const href = tag.match(/\bhref="([^"]*)"/)?.[1]
+      return rel?.split(/\s+/).includes('stylesheet') && href ? [href] : []
+    })
+  }
+
   // ============================================================================
   // Test 1: ClientWidgetA (direct render) has CSS applied
   // ============================================================================
@@ -55,7 +66,27 @@ test.describe('RSC Complex CSS Preload Tests', () => {
   test('ClientWidgetC in unrendered ServerB is not in DOM', async ({
     page,
   }) => {
-    await page.goto('/rsc-css-preload-complex')
+    const requestedCssHrefs: Array<string> = []
+    page.on('request', (request) => {
+      const pathname = new URL(request.url()).pathname
+      if (pathname.includes('/assets/css/async/')) {
+        requestedCssHrefs.push(pathname)
+      }
+    })
+
+    const response = await page.goto('/rsc-css-preload-complex')
+    const html = await response?.text()
+
+    expect(html).toBeDefined()
+    expect(html).not.toContain('client-widget-c')
+
+    const stylesheetHrefs = new Set(getStylesheetHrefs(html!))
+    const serializedCssHrefs = Array.from(
+      new Set(html!.match(/\/assets\/css\/async\/[^"\\]+\.css/g) ?? []),
+    )
+    const unusedCssHrefs = serializedCssHrefs.filter(
+      (href) => !stylesheetHrefs.has(href),
+    )
 
     // Widget C should NOT be present since ServerB is not rendered
     const widgetC = page.locator('[data-testid="client-widget-c"]')
@@ -66,6 +97,14 @@ test.describe('RSC Complex CSS Preload Tests', () => {
     const serverB = page.locator('[data-testid="server-component-b"]')
     await expect(serverB).not.toBeVisible()
     await expect(serverB).toHaveCount(0)
+
+    const note = page.locator('[data-testid="serverb-note"]')
+    await expect(note).toBeVisible()
+    await expect(note).toHaveCSS('background-color', 'rgb(219, 234, 254)')
+    await expect(note).toHaveCSS('border-color', 'rgb(59, 130, 246)')
+    for (const href of unusedCssHrefs) {
+      expect(requestedCssHrefs).not.toContain(href)
+    }
   })
 
   // ============================================================================

--- a/e2e/react-start/rsc/tests/rsc-css-preload-complex.spec.ts
+++ b/e2e/react-start/rsc/tests/rsc-css-preload-complex.spec.ts
@@ -1,17 +1,6 @@
 import { expect, test } from '@playwright/test'
 
 test.describe('RSC Complex CSS Preload Tests', () => {
-  function getStylesheetHrefs(html: string): Array<string> {
-    return Array.from(
-      html.matchAll(/<link\b[^>]*>/g),
-      (match) => match[0],
-    ).flatMap((tag) => {
-      const rel = tag.match(/\brel="([^"]*)"/)?.[1]
-      const href = tag.match(/\bhref="([^"]*)"/)?.[1]
-      return rel?.split(/\s+/).includes('stylesheet') && href ? [href] : []
-    })
-  }
-
   // ============================================================================
   // Test 1: ClientWidgetA (direct render) has CSS applied
   // ============================================================================
@@ -66,27 +55,7 @@ test.describe('RSC Complex CSS Preload Tests', () => {
   test('ClientWidgetC in unrendered ServerB is not in DOM', async ({
     page,
   }) => {
-    const requestedCssHrefs: Array<string> = []
-    page.on('request', (request) => {
-      const pathname = new URL(request.url()).pathname
-      if (pathname.includes('/assets/css/async/')) {
-        requestedCssHrefs.push(pathname)
-      }
-    })
-
-    const response = await page.goto('/rsc-css-preload-complex')
-    const html = await response?.text()
-
-    expect(html).toBeDefined()
-    expect(html).not.toContain('client-widget-c')
-
-    const stylesheetHrefs = new Set(getStylesheetHrefs(html!))
-    const serializedCssHrefs = Array.from(
-      new Set(html!.match(/\/assets\/css\/async\/[^"\\]+\.css/g) ?? []),
-    )
-    const unusedCssHrefs = serializedCssHrefs.filter(
-      (href) => !stylesheetHrefs.has(href),
-    )
+    await page.goto('/rsc-css-preload-complex')
 
     // Widget C should NOT be present since ServerB is not rendered
     const widgetC = page.locator('[data-testid="client-widget-c"]')
@@ -97,14 +66,6 @@ test.describe('RSC Complex CSS Preload Tests', () => {
     const serverB = page.locator('[data-testid="server-component-b"]')
     await expect(serverB).not.toBeVisible()
     await expect(serverB).toHaveCount(0)
-
-    const note = page.locator('[data-testid="serverb-note"]')
-    await expect(note).toBeVisible()
-    await expect(note).toHaveCSS('background-color', 'rgb(219, 234, 254)')
-    await expect(note).toHaveCSS('border-color', 'rgb(59, 130, 246)')
-    for (const href of unusedCssHrefs) {
-      expect(requestedCssHrefs).not.toContain(href)
-    }
   })
 
   // ============================================================================

--- a/e2e/react-start/rsc/tests/rsc-no-js.spec.ts
+++ b/e2e/react-start/rsc/tests/rsc-no-js.spec.ts
@@ -1,6 +1,16 @@
 import { expect } from '@playwright/test'
 import { test } from '@tanstack/router-e2e-utils'
 
+function getStylesheetHrefs(html: string): Array<string> {
+  return Array.from(html.matchAll(/<link\b[^>]*>/g), (match) =>
+    match[0],
+  ).flatMap((tag) => {
+    const rel = tag.match(/\brel="([^"]*)"/)?.[1]
+    const href = tag.match(/\bhref="([^"]*)"/)?.[1]
+    return rel?.split(/\s+/).includes('stylesheet') && href ? [href] : []
+  })
+}
+
 /**
  * RSC No-JavaScript Tests
  *
@@ -329,5 +339,22 @@ test.describe('RSC No-JavaScript Rendering', () => {
       (el) => getComputedStyle(el).backgroundColor,
     )
     expect(bgColorB).toBe('rgb(204, 251, 241)') // #ccfbf1
+
+    const widgetC = page.getByTestId('client-widget-c')
+    await expect(widgetC).toHaveCount(0)
+
+    const stylesheetHrefs = getStylesheetHrefs(html!)
+    const linkedCss = await Promise.all(
+      stylesheetHrefs.map(async (href) => {
+        const response = await page.request.get(new URL(href, page.url()).href)
+        return response.text()
+      }),
+    )
+    expect(linkedCss.join('\n')).not.toContain('serverb-note')
+
+    const note = page.getByTestId('serverb-note')
+    await expect(note).toBeVisible()
+    await expect(note).toHaveCSS('background-color', 'rgb(219, 234, 254)')
+    await expect(note).toHaveCSS('border-color', 'rgb(59, 130, 246)')
   })
 })

--- a/e2e/react-start/rsc/tests/rsc-no-js.spec.ts
+++ b/e2e/react-start/rsc/tests/rsc-no-js.spec.ts
@@ -2,8 +2,9 @@ import { expect } from '@playwright/test'
 import { test } from '@tanstack/router-e2e-utils'
 
 function getStylesheetHrefs(html: string): Array<string> {
-  return Array.from(html.matchAll(/<link\b[^>]*>/g), (match) =>
-    match[0],
+  return Array.from(
+    html.matchAll(/<link\b[^>]*>/g),
+    (match) => match[0],
   ).flatMap((tag) => {
     const rel = tag.match(/\brel="([^"]*)"/)?.[1]
     const href = tag.match(/\bhref="([^"]*)"/)?.[1]

--- a/e2e/react-start/server-functions/package.json
+++ b/e2e/react-start/server-functions/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
-    "@rsbuild/core": "^2.0.1",
+    "@rsbuild/core": "^2.0.8",
     "@rsbuild/plugin-react": "^2.0.0",
     "@tailwindcss/postcss": "^4.2.2",
     "@tailwindcss/vite": "^4.2.2",

--- a/e2e/solid-router/rspack-basic-file-based/package.json
+++ b/e2e/solid-router/rspack-basic-file-based/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
-    "@rsbuild/core": "^2.0.1",
+    "@rsbuild/core": "^2.0.8",
     "@rsbuild/plugin-babel": "^1.1.2",
     "@rsbuild/plugin-solid": "^1.1.1",
     "@tailwindcss/postcss": "^4.2.2",

--- a/e2e/solid-router/rspack-basic-virtual-named-export-config-file-based/package.json
+++ b/e2e/solid-router/rspack-basic-virtual-named-export-config-file-based/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
-    "@rsbuild/core": "^2.0.1",
+    "@rsbuild/core": "^2.0.8",
     "@rsbuild/plugin-babel": "^1.1.2",
     "@rsbuild/plugin-solid": "^1.1.1",
     "@tailwindcss/postcss": "^4.2.2",

--- a/e2e/solid-start/basic/package.json
+++ b/e2e/solid-start/basic/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
-    "@rsbuild/core": "^2.0.1",
+    "@rsbuild/core": "^2.0.8",
     "@rsbuild/plugin-babel": "^1.1.2",
     "@rsbuild/plugin-solid": "^1.1.1",
     "@tailwindcss/postcss": "^4.2.2",

--- a/e2e/solid-start/deferred-hydration/tests/hydration.spec.ts
+++ b/e2e/solid-start/deferred-hydration/tests/hydration.spec.ts
@@ -287,7 +287,9 @@ async function documentModulePreloadHrefs(page: Page) {
 
 function isHydrateBoundaryResource(url: string) {
   return (
-    url.includes('/assets/components-') || url.includes('/static/js/async/')
+    url.includes('/assets/components-') ||
+    url.includes('/assets/js/async/') ||
+    url.includes('/static/js/async/')
   )
 }
 

--- a/e2e/vue-router/rspack-basic-file-based/package.json
+++ b/e2e/vue-router/rspack-basic-file-based/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
-    "@rsbuild/core": "^2.0.1",
+    "@rsbuild/core": "^2.0.8",
     "@rsbuild/plugin-babel": "^1.1.2",
     "@rsbuild/plugin-vue": "^1.2.7",
     "@rsbuild/plugin-vue-jsx": "^2.0.0",

--- a/e2e/vue-router/rspack-basic-virtual-named-export-config-file-based/package.json
+++ b/e2e/vue-router/rspack-basic-virtual-named-export-config-file-based/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
-    "@rsbuild/core": "^2.0.1",
+    "@rsbuild/core": "^2.0.8",
     "@rsbuild/plugin-babel": "^1.1.2",
     "@rsbuild/plugin-vue": "^1.2.7",
     "@rsbuild/plugin-vue-jsx": "^2.0.0",

--- a/e2e/vue-start/basic/package.json
+++ b/e2e/vue-start/basic/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
-    "@rsbuild/core": "^2.0.1",
+    "@rsbuild/core": "^2.0.8",
     "@rsbuild/plugin-babel": "^1.0.5",
     "@rsbuild/plugin-vue": "^1.2.2",
     "@rsbuild/plugin-vue-jsx": "^1.1.1",

--- a/examples/react/quickstart-rspack-file-based/package.json
+++ b/examples/react/quickstart-rspack-file-based/package.json
@@ -17,7 +17,7 @@
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.1",
+    "@rsbuild/core": "^2.0.8",
     "@rsbuild/plugin-react": "^2.0.0",
     "@tanstack/router-plugin": "^1.168.12",
     "@types/react": "^19.0.8",

--- a/examples/solid/quickstart-rspack-file-based/package.json
+++ b/examples/solid/quickstart-rspack-file-based/package.json
@@ -16,7 +16,7 @@
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.1",
+    "@rsbuild/core": "^2.0.8",
     "@rsbuild/plugin-babel": "^1.1.2",
     "@rsbuild/plugin-solid": "^1.1.1",
     "@tanstack/router-plugin": "^1.168.12",

--- a/packages/react-start-rsc/src/awaitLazyElements.ts
+++ b/packages/react-start-rsc/src/awaitLazyElements.ts
@@ -33,7 +33,10 @@ function* findPendingLazyPayloads(
     el.type === 'link' &&
     el.props?.rel === 'stylesheet'
   ) {
-    const cssHref = el.props['data-rsc-css-href'] as string | undefined
+    let cssHref: string | undefined
+    if ('data-rsc-css-href' in el.props) {
+      cssHref = el.props.href
+    }
     if (cssHref && cssCollector) {
       cssCollector(cssHref)
     }

--- a/packages/react-start-rsc/src/createServerComponentFromStream.ts
+++ b/packages/react-start-rsc/src/createServerComponentFromStream.ts
@@ -13,6 +13,11 @@ import type {
   ServerComponentStream,
 } from './ServerComponentTypes'
 
+type StreamDecodeOptions = {
+  cssHrefs?: Iterable<string>
+  jsPreloads?: Iterable<string>
+}
+
 /**
  * Creates a renderable RSC proxy from a raw Flight stream.
  * Client-side only - used by the client serialization adapter for `renderServerComponent`.
@@ -24,12 +29,17 @@ import type {
  */
 export function createRenderableFromStream(
   stream: ReadableStream<Uint8Array>,
+  options?: StreamDecodeOptions,
 ): any {
-  const { getTree, streamWrapper, cssHrefs } = setupStreamDecode(stream)
+  const { getTree, streamWrapper, cssHrefs, jsPreloads } = setupStreamDecode(
+    stream,
+    options,
+  )
 
   return createRscProxy(getTree, {
     stream: streamWrapper,
     cssHrefs,
+    jsPreloads,
     renderable: true,
   })
 }
@@ -47,13 +57,17 @@ export function createCompositeFromStream(
   stream: ReadableStream<Uint8Array>,
   options?: {
     slotUsagesStream?: ReadableStream<RscSlotUsageEvent>
-  },
+  } & StreamDecodeOptions,
 ): AnyCompositeComponent {
-  const { getTree, streamWrapper, cssHrefs } = setupStreamDecode(stream)
+  const { getTree, streamWrapper, cssHrefs, jsPreloads } = setupStreamDecode(
+    stream,
+    options,
+  )
 
   return createRscProxy(getTree, {
     stream: streamWrapper,
     cssHrefs,
+    jsPreloads,
     renderable: false,
     slotUsagesStream: options?.slotUsagesStream,
   })
@@ -62,33 +76,51 @@ export function createCompositeFromStream(
 /**
  * Shared stream decode setup for both renderable and composite.
  */
-function setupStreamDecode(stream: ReadableStream<Uint8Array>): {
+function setupStreamDecode(
+  stream: ReadableStream<Uint8Array>,
+  options?: StreamDecodeOptions,
+): {
   getTree: () => unknown
   streamWrapper: ServerComponentStream
-  cssHrefs: Set<string> | undefined
+  cssHrefs: Set<string>
+  jsPreloads: Set<string> | undefined
 } {
-  // Start decoding eagerly during deserialization
-  const decodeThenable = browserDecode(stream)
-  const cssHrefs = new Set<string>()
+  const cssHrefs = new Set(options?.cssHrefs ?? [])
+  const jsPreloads = options?.jsPreloads
+    ? new Set(options.jsPreloads)
+    : undefined
+  const shouldDeferDecode = cssHrefs.size > 0 || !!jsPreloads?.size
 
   // Synchronous cache for the decoded tree.
   let cachedTree: unknown = undefined
   let cacheReady = false
+  let transformedTreePromise: Promise<unknown> | undefined
 
-  // Promise for the tree with lazy elements awaited.
-  const transformedTreePromise = Promise.resolve(decodeThenable).then(
-    async (result) => {
-      await awaitLazyElements(result, (href) => {
-        cssHrefs.add(href)
-      })
-      cachedTree = unwrapRscCssEnvelope(result)
-      cacheReady = true
-      return cachedTree
-    },
-  )
+  const startDecode = () => {
+    if (!transformedTreePromise) {
+      // Promise for the tree with lazy elements awaited.
+      transformedTreePromise = Promise.resolve(browserDecode(stream)).then(
+        async (result) => {
+          await awaitLazyElements(result, (href) => {
+            cssHrefs.add(href)
+          })
+          cachedTree = unwrapRscCssEnvelope(result)
+          cacheReady = true
+          return cachedTree
+        },
+      )
 
-  // Track the lazy element loading - prevents flash
-  trackPostProcessPromise(transformedTreePromise)
+      // Track the lazy element loading - prevents flash for RPC/RSC fetches.
+      trackPostProcessPromise(transformedTreePromise)
+    }
+
+    return transformedTreePromise
+  }
+
+  if (!shouldDeferDecode) {
+    // Start decoding eagerly during deserialization for non-SSR streams.
+    startDecode()
+  }
 
   const streamWrapper: ServerComponentStream = {
     createReplayStream: () => stream,
@@ -97,10 +129,10 @@ function setupStreamDecode(stream: ReadableStream<Uint8Array>): {
   const getTree = () => {
     if (cacheReady) return cachedTree
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    return use(transformedTreePromise)
+    return use(startDecode())
   }
 
-  return { getTree, streamWrapper, cssHrefs }
+  return { getTree, streamWrapper, cssHrefs, jsPreloads }
 }
 // Legacy export for backwards compatibility during migration
 export const createServerComponentFromStream = createCompositeFromStream

--- a/packages/react-start-rsc/src/rsbuild/ssr-decode.ts
+++ b/packages/react-start-rsc/src/rsbuild/ssr-decode.ts
@@ -5,7 +5,124 @@
  * Flight decode.
  */
 
-import { setOnClientReference } from '@rspack/core/rsc/ssr'
-import { createFromReadableStream } from 'react-server-dom-rspack/client.node'
+import { createFromReadableStream as decodeFlightStream } from 'react-server-dom-rspack/client.node'
 
-export { createFromReadableStream, setOnClientReference }
+type ClientReferenceDeps = {
+  js: Array<string>
+  css: Array<string>
+}
+
+type OnClientReference = (reference: {
+  id: string
+  deps: ClientReferenceDeps
+  runtime: 'rsbuild'
+}) => void
+
+type ImportManifestEntry = {
+  id: string
+  chunks: Array<string>
+  cssFiles?: Array<string>
+  name: string
+  async?: boolean
+}
+
+type ClientManifest = Record<string, ImportManifestEntry>
+type ServerConsumerModuleMap = null | Record<
+  string,
+  Record<string, ImportManifestEntry>
+>
+type ModuleLoading = null | {
+  prefix: string
+  crossOrigin?: 'use-credentials' | ''
+}
+
+declare const __rspack_rsc_manifest__: {
+  moduleLoading: ModuleLoading
+  serverConsumerModuleMap: ServerConsumerModuleMap
+  clientManifest: ClientManifest
+}
+
+const CHUNK_FILENAME_INDEX = 1
+const CHUNK_PAIR_SIZE = 2
+
+let onClientReference: OnClientReference | undefined
+let clientReferenceDepsByModuleId: Map<string, ClientReferenceDeps> | undefined
+
+function getClientReferenceDepsByModuleId() {
+  if (clientReferenceDepsByModuleId) return clientReferenceDepsByModuleId
+
+  clientReferenceDepsByModuleId = new Map()
+  const prefix = __rspack_rsc_manifest__.moduleLoading?.prefix ?? ''
+
+  for (const entry of Object.values(__rspack_rsc_manifest__.clientManifest)) {
+    let deps = clientReferenceDepsByModuleId.get(entry.id)
+    if (!deps) {
+      deps = { js: [], css: [] }
+      clientReferenceDepsByModuleId.set(entry.id, deps)
+    }
+
+    // React/Rspack stores JS chunks as chunk id/filename pairs. CSS files are
+    // separate manifest entries and are already emitted as public hrefs.
+    for (
+      let i = CHUNK_FILENAME_INDEX;
+      i < entry.chunks.length;
+      i += CHUNK_PAIR_SIZE
+    ) {
+      deps.js.push(prefix + entry.chunks[i])
+    }
+
+    if (entry.cssFiles) {
+      deps.css.push(...entry.cssFiles)
+    }
+  }
+
+  return clientReferenceDepsByModuleId
+}
+
+function emitClientReferencePreloadsForModule(moduleId: string) {
+  const deps = getClientReferenceDepsByModuleId().get(moduleId)
+  if (!onClientReference || !deps) return
+
+  if (deps.js.length === 0 && deps.css.length === 0) {
+    return
+  }
+
+  onClientReference({
+    id: moduleId,
+    deps,
+    runtime: 'rsbuild',
+  })
+}
+
+if (__rspack_rsc_manifest__.serverConsumerModuleMap) {
+  __rspack_rsc_manifest__.serverConsumerModuleMap = new Proxy(
+    __rspack_rsc_manifest__.serverConsumerModuleMap,
+    {
+      get(target, property, receiver) {
+        const moduleExports = Reflect.get(target, property, receiver)
+
+        if (typeof property === 'string' && moduleExports !== undefined) {
+          emitClientReferencePreloadsForModule(property)
+        }
+
+        return moduleExports
+      },
+    },
+  )
+}
+
+function setOnClientReference(callback: OnClientReference | undefined) {
+  onClientReference = callback
+}
+
+async function createFromReadableStreamWithClientPreloads<T = unknown>(
+  stream: ReadableStream<Uint8Array>,
+  options?: object,
+): Promise<T> {
+  return decodeFlightStream<T>(stream, options)
+}
+
+export {
+  setOnClientReference,
+  createFromReadableStreamWithClientPreloads as createFromReadableStream,
+}

--- a/packages/react-start-rsc/src/serialization.client.ts
+++ b/packages/react-start-rsc/src/serialization.client.ts
@@ -21,6 +21,8 @@ type SerializedRsc = {
   kind: 'renderable' | 'composite'
   stream: ReadableStream<Uint8Array>
   slotUsagesStream?: ReadableStream<RscSlotUsageEvent>
+  cssHrefs?: Array<string>
+  jsPreloads?: Array<string>
 }
 
 const adapter = createSerializationAdapter({
@@ -30,12 +32,21 @@ const adapter = createSerializationAdapter({
     throw new Error('RSC cannot be serialized on client')
   },
   fromSerializable: (value: SerializedRsc): AnyCompositeComponent => {
+    // Rsbuild SSR sends asset deps with each serialized RSC so the client can
+    // preload only if that specific stream is rendered. When absent, decode
+    // starts eagerly and discovers assets from the Flight payload as before.
+    const options = {
+      cssHrefs: value.cssHrefs,
+      jsPreloads: value.jsPreloads,
+    }
+
     if (value.kind === 'renderable') {
-      return createRenderableFromStream(value.stream)
+      return createRenderableFromStream(value.stream, options)
     }
 
     return createCompositeFromStream(value.stream, {
       slotUsagesStream: value.slotUsagesStream,
+      ...options,
     })
   },
 })

--- a/packages/react-start-rsc/src/serialization.server.ts
+++ b/packages/react-start-rsc/src/serialization.server.ts
@@ -60,6 +60,9 @@ setOnClientReference(
       }
     }
 
+    // Rsbuild injects collected assets when the decoded RSC is actually
+    // rendered via ReactDOM.preinit/preloadModule. Keeping them off the
+    // request manifest avoids emitting assets for decoded-but-unrendered trees.
     if (
       !ctx ||
       runtime === 'rsbuild' ||

--- a/packages/react-start-rsc/src/serialization.server.ts
+++ b/packages/react-start-rsc/src/serialization.server.ts
@@ -9,6 +9,8 @@ import {
 import {
   RENDERABLE_RSC,
   RSC_SLOT_USAGES_STREAM,
+  SERVER_COMPONENT_CSS_HREFS,
+  SERVER_COMPONENT_JS_PRELOADS,
   SERVER_COMPONENT_STREAM,
   isServerComponent,
 } from './ServerComponentTypes'
@@ -30,11 +32,12 @@ import type { RscDecodeResult, RscSsrHandler } from './rscSsrHandler'
 // Modules with 'use client' may be transformed to client references in the
 // SSR environment when RSC is enabled, preventing the side effect from running.
 
-// AsyncLocalStorage for decode-scoped CSS collector.
-// Each decode() runs in its own async context with its own collector.
-// The onClientReference callback reads from this to write CSS hrefs.
-const decodeCollectorStorage = new AsyncLocalStorage<Set<string>>()
-const jsCollectorStorage = new AsyncLocalStorage<Set<string>>()
+// AsyncLocalStorage for decode-scoped proxy asset collectors.
+// Client-reference deps stay on the decoded RSC proxy so unused streams don't
+// emit global request assets. CSS marker links are collected for all adapters
+// because the decoded envelope is unwrapped before SSR render.
+const proxyCssCollectorStorage = new AsyncLocalStorage<Set<string>>()
+const proxyJsCollectorStorage = new AsyncLocalStorage<Set<string>>()
 
 setOnClientReference(
   ({
@@ -44,30 +47,29 @@ setOnClientReference(
     deps: { js: Array<string>; css: Array<string> }
     runtime?: 'rsbuild'
   }) => {
-    const ctx = getStartContext({ throwIfNotFound: false })
-
-    const cssCollector = decodeCollectorStorage.getStore()
+    const cssCollector = proxyCssCollectorStorage.getStore()
     if (cssCollector) {
       for (const href of deps.css) {
         cssCollector.add(href)
       }
     }
 
-    const jsCollector = jsCollectorStorage.getStore()
+    const jsCollector = proxyJsCollectorStorage.getStore()
     if (jsCollector) {
       for (const href of deps.js) {
         jsCollector.add(href)
       }
     }
 
-    // Rsbuild injects collected assets when the decoded RSC is actually
-    // rendered via ReactDOM.preinit/preloadModule. Keeping them off the
-    // request manifest avoids emitting assets for decoded-but-unrendered trees.
-    if (
-      !ctx ||
-      runtime === 'rsbuild' ||
-      (!deps.js.length && !deps.css.length)
-    ) {
+    if (runtime === 'rsbuild' || cssCollector || jsCollector) {
+      return
+    }
+
+    const ctx = getStartContext({ throwIfNotFound: false })
+
+    // Non-Rsbuild adapters emit decoded client-reference assets through the
+    // request manifest.
+    if (!ctx || (!deps.js.length && !deps.css.length)) {
       return
     }
 
@@ -119,20 +121,20 @@ const ssrHandler: RscSsrHandler = {
     // Create a collector for this decode operation.
     // Run the decode in an AsyncLocalStorage context so the onClientReference
     // callback can write to this specific collector even with parallel decodes.
-    const cssCollector = new Set<string>()
-    const jsCollector = new Set<string>()
+    const proxyCssCollector = new Set<string>()
+    const proxyJsCollector = new Set<string>()
 
-    return decodeCollectorStorage.run(cssCollector, async () => {
-      return jsCollectorStorage.run(jsCollector, async () => {
+    return proxyCssCollectorStorage.run(proxyCssCollector, async () => {
+      return proxyJsCollectorStorage.run(proxyJsCollector, async () => {
         const decodedTree = await ssrDecode(readableStream)
         await awaitLazyElements(decodedTree, (href) => {
-          cssCollector.add(href)
+          proxyCssCollector.add(href)
         })
 
         return {
           tree: unwrapRscCssEnvelope(decodedTree),
-          cssHrefs: cssCollector.size > 0 ? cssCollector : undefined,
-          jsPreloads: jsCollector.size > 0 ? jsCollector : undefined,
+          cssHrefs: proxyCssCollector.size > 0 ? proxyCssCollector : undefined,
+          jsPreloads: proxyJsCollector.size > 0 ? proxyJsCollector : undefined,
         }
       })
     })
@@ -190,6 +192,16 @@ const adapter = createSerializationAdapter({
     const stream = component[SERVER_COMPONENT_STREAM]!.createReplayStream()
 
     const kind = isRenderableRsc(component) ? 'renderable' : 'composite'
+    const jsPreloads = component[SERVER_COMPONENT_JS_PRELOADS]
+    const cssHrefs = component[SERVER_COMPONENT_CSS_HREFS]
+    // `cssHrefs` can also come from loadCss() marker links. Client-reference
+    // collection fills `jsPreloads`, so that gates per-stream serialization.
+    const serializedAssetDeps = jsPreloads?.size
+      ? {
+          ...(cssHrefs?.size ? { cssHrefs: Array.from(cssHrefs) } : {}),
+          jsPreloads: Array.from(jsPreloads),
+        }
+      : {}
 
     const slotUsagesStream =
       kind === 'composite' &&
@@ -204,6 +216,7 @@ const adapter = createSerializationAdapter({
       kind,
       stream: new RawStream(stream, { hint: 'text' }),
       slotUsagesStream,
+      ...serializedAssetDeps,
     }
   },
   fromSerializable: (): never => {

--- a/packages/react-start-rsc/tests/ServerComponent.test.tsx
+++ b/packages/react-start-rsc/tests/ServerComponent.test.tsx
@@ -36,7 +36,14 @@ vi.mock('@vitejs/plugin-rsc/ssr', () => {
 
 import { createFromReadableStream as browserDecode } from '@vitejs/plugin-rsc/browser'
 
-import { createServerComponentFromStream } from '../src/createServerComponentFromStream'
+import {
+  createCompositeFromStream,
+  createServerComponentFromStream,
+} from '../src/createServerComponentFromStream'
+import {
+  SERVER_COMPONENT_CSS_HREFS,
+  SERVER_COMPONENT_JS_PRELOADS,
+} from '../src/ServerComponentTypes'
 
 describe('ServerComponent (client)', () => {
   it('decodes a stream only once', async () => {
@@ -82,5 +89,30 @@ describe('ServerComponent (client)', () => {
 
     // Resolve the decode to complete the test cleanly
     resolvePromise!(React.createElement('div', null, 'ok'))
+  })
+
+  it('defers decode when SSR asset deps are provided', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close()
+      },
+    })
+
+    const decodeMock = browserDecode as unknown as ReturnType<typeof vi.fn>
+    decodeMock.mockClear()
+    decodeMock.mockResolvedValue(React.createElement('div', null, 'ok'))
+
+    const Component = createCompositeFromStream(stream, {
+      cssHrefs: ['/assets/component.css'],
+      jsPreloads: ['/assets/component.js'],
+    })
+
+    expect(decodeMock).not.toHaveBeenCalled()
+    expect(Array.from(Component[SERVER_COMPONENT_CSS_HREFS]!)).toEqual([
+      '/assets/component.css',
+    ])
+    expect(Array.from(Component[SERVER_COMPONENT_JS_PRELOADS]!)).toEqual([
+      '/assets/component.js',
+    ])
   })
 })

--- a/packages/react-start/package.json
+++ b/packages/react-start/package.json
@@ -188,7 +188,7 @@
     }
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.1",
+    "@rsbuild/core": "^2.0.8",
     "@types/node": ">=20"
   }
 }

--- a/packages/react-start/src/server.rsc.ts
+++ b/packages/react-start/src/server.rsc.ts
@@ -1,1 +1,1 @@
-export * from '@tanstack/start-server-core'
+export * from '@tanstack/start-server-core/request-response'

--- a/packages/solid-start/package.json
+++ b/packages/solid-start/package.json
@@ -127,7 +127,7 @@
     "pathe": "^2.0.3"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.1",
+    "@rsbuild/core": "^2.0.8",
     "@tanstack/router-utils": "workspace:*",
     "@types/node": ">=20",
     "vite": "*"

--- a/packages/start-plugin-core/package.json
+++ b/packages/start-plugin-core/package.json
@@ -109,7 +109,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.1",
+    "@rsbuild/core": "^2.0.8",
     "@types/babel__code-frame": "^7.0.6",
     "@types/babel__core": "^7.20.5",
     "@types/node": ">=20",

--- a/packages/start-plugin-core/src/rsbuild/planning.ts
+++ b/packages/start-plugin-core/src/rsbuild/planning.ts
@@ -25,6 +25,8 @@ export const RSBUILD_RSC_LAYERS = {
   ssr: 'server-side-rendering',
 } as const
 
+export const RSBUILD_CLIENT_ASSETS_DIR = 'assets'
+
 export type RsbuildEnvironmentName =
   (typeof RSBUILD_ENVIRONMENT_NAMES)[keyof typeof RSBUILD_ENVIRONMENT_NAMES]
 
@@ -121,6 +123,16 @@ export function createRsbuildEnvironmentPlan(opts: {
             module: clientOutputModule,
             distPath: {
               root: opts.clientOutputDirectory,
+              js: `${RSBUILD_CLIENT_ASSETS_DIR}/js`,
+              jsAsync: `${RSBUILD_CLIENT_ASSETS_DIR}/js/async`,
+              css: `${RSBUILD_CLIENT_ASSETS_DIR}/css`,
+              cssAsync: `${RSBUILD_CLIENT_ASSETS_DIR}/css/async`,
+              svg: `${RSBUILD_CLIENT_ASSETS_DIR}/svg`,
+              font: `${RSBUILD_CLIENT_ASSETS_DIR}/font`,
+              wasm: `${RSBUILD_CLIENT_ASSETS_DIR}/wasm`,
+              image: `${RSBUILD_CLIENT_ASSETS_DIR}/image`,
+              media: `${RSBUILD_CLIENT_ASSETS_DIR}/media`,
+              assets: `${RSBUILD_CLIENT_ASSETS_DIR}/assets`,
             },
             assetPrefix: opts.publicBase,
           },

--- a/packages/start-plugin-core/src/rsbuild/plugin.ts
+++ b/packages/start-plugin-core/src/rsbuild/plugin.ts
@@ -11,6 +11,7 @@ import { escapeRegExp, normalizePath } from '../utils'
 import { createServerFnBasePath, normalizePublicBase } from '../planning'
 import { parseStartConfig, rsbuildClientOutputSchema } from './schema'
 import {
+  RSBUILD_CLIENT_ASSETS_DIR,
   RSBUILD_ENVIRONMENT_NAMES,
   RSBUILD_RSC_LAYERS,
   createRsbuildEnvironmentPlan,
@@ -299,7 +300,7 @@ export function tanStackStartRsbuild(
         ssrIsProvider,
         serializationAdapters: corePluginOpts.serializationAdapters,
         getDevClientEntryUrl: (publicBase: string) =>
-          joinURL(publicBase, 'static/js/index.js'),
+          joinURL(publicBase, RSBUILD_CLIENT_ASSETS_DIR, 'js/index.js'),
         rscEnabled,
         scriptFormat,
       })
@@ -507,9 +508,12 @@ export function tanStackStartRsbuild(
             // Add ServerPlugin with HMR callback
             config.plugins.push(
               new rscPlugins.ServerPlugin({
-                clientEntryName: 'index',
-                runtimeEntryName: 'index',
-                injectSsrModulesToEntries: ['index'],
+                cssLink: {
+                  precedence: false,
+                  props: {
+                    'data-rsc-css-href': '',
+                  },
+                },
                 onServerComponentChanges: () => {
                   // Send rsc:update to connected clients for HMR
                   devServerRef?.sockWrite('custom', {

--- a/packages/start-plugin-core/src/rsbuild/virtual-modules.ts
+++ b/packages/start-plugin-core/src/rsbuild/virtual-modules.ts
@@ -433,7 +433,7 @@ export function registerVirtualModules(
         : `export function createFromReadableStream() { throw new Error('RSC browser decode is only available in the client environment') }
 export function createFromFetch() { throw new Error('RSC browser decode is only available in the client environment') }`
       content[rscPaths.rscSsrDecode] = isServerEnv
-        ? `export * from '@tanstack/react-start/rsbuild/ssr-decode'`
+        ? `export { setOnClientReference, createFromReadableStream } from '@tanstack/react-start/rsbuild/ssr-decode'`
         : `export function setOnClientReference() {}
 export function createFromReadableStream() { throw new Error('RSC SSR decode is only available in the server environment') }`
     }

--- a/packages/start-plugin-core/src/rsbuild/virtual-modules.ts
+++ b/packages/start-plugin-core/src/rsbuild/virtual-modules.ts
@@ -230,7 +230,7 @@ export interface RegisterVirtualModulesOptions {
   /**
    * Get the URL at which the rsbuild dev server serves the client entry JS.
    * Called lazily inside modifyRspackConfig when getConfig() is available.
-   * Example return: '/static/js/index.js'
+   * Example return: '/assets/js/index.js'
    */
   getDevClientEntryUrl: (publicBase: string) => string
   /** Whether RSC virtual modules should be registered. */

--- a/packages/start-server-core/package.json
+++ b/packages/start-server-core/package.json
@@ -59,6 +59,12 @@
         "default": "./dist/esm/createSsrRpc.js"
       }
     },
+    "./request-response": {
+      "import": {
+        "types": "./dist/esm/request-response.d.ts",
+        "default": "./dist/esm/request-response.js"
+      }
+    },
     "./package.json": "./package.json"
   },
   "imports": {

--- a/packages/start-server-core/vite.config.ts
+++ b/packages/start-server-core/vite.config.ts
@@ -35,6 +35,7 @@ export default mergeConfig(
         './src/index.tsx',
         './src/createServerRpc.ts',
         './src/createSsrRpc.ts',
+        './src/request-response.ts',
         './src/fake-start-server-fn-resolver.ts',
         './src/empty-plugin-adapters.ts',
       ],

--- a/packages/vue-start/package.json
+++ b/packages/vue-start/package.json
@@ -121,7 +121,7 @@
     "pathe": "^2.0.3"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.0.1",
+    "@rsbuild/core": "^2.0.8",
     "@tanstack/router-utils": "workspace:*",
     "@types/node": ">=20",
     "@vitejs/plugin-vue-jsx": "^4.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,16 +78,16 @@ importers:
         version: 1.26.2(eslint@9.22.0(jiti@2.7.0))(ts-api-utils@2.4.0(typescript@6.0.2))(typescript@6.0.2)
       '@nx/devkit':
         specifier: 22.6.5
-        version: 22.6.5(nx@22.6.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.2))(@swc/core@1.15.33(@swc/helpers@0.5.21)))
+        version: 22.6.5(nx@22.6.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.2))(@swc/core@1.15.33(@swc/helpers@0.5.23)))
       '@playwright/test':
         specifier: ^1.57.0
         version: 1.58.0
       '@swc-node/core':
         specifier: ^1.14.1
-        version: 1.14.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)
+        version: 1.14.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(@swc/types@0.1.26)
       '@swc-node/register':
         specifier: ^1.11.1
-        version: 1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.2)
+        version: 1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.2)
       '@tanstack/eslint-config':
         specifier: 0.4.0
         version: 0.4.0(@typescript-eslint/utils@8.57.1(eslint@9.22.0(jiti@2.7.0))(typescript@6.0.2))(eslint@9.22.0(jiti@2.7.0))(typescript@6.0.2)
@@ -138,7 +138,7 @@ importers:
         version: 4.0.3
       nx:
         specifier: 22.6.5
-        version: 22.6.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.2))(@swc/core@1.15.33(@swc/helpers@0.5.21))
+        version: 22.6.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.2))(@swc/core@1.15.33(@swc/helpers@0.5.23))
       prettier:
         specifier: ^3.8.0
         version: 3.8.1
@@ -216,11 +216,11 @@ importers:
         version: 3.5.25(typescript@6.0.2)
     devDependencies:
       '@rsbuild/core':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.8
+        version: 2.0.8
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.1)(@rspack/core@2.0.0(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5(@swc/helpers@0.5.23))
       '@tanstack/router-plugin':
         specifier: workspace:*
         version: link:../../packages/router-plugin
@@ -1110,11 +1110,11 @@ importers:
         specifier: ^1.57.0
         version: 1.58.0
       '@rsbuild/core':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.8
+        version: 2.0.8
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.1)(@rspack/core@2.0.0(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5(@swc/helpers@0.5.23))
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -1162,11 +1162,11 @@ importers:
         specifier: ^1.57.0
         version: 1.58.0
       '@rsbuild/core':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.8
+        version: 2.0.8
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.1)(@rspack/core@2.0.0(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5(@swc/helpers@0.5.23))
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -1385,11 +1385,11 @@ importers:
         specifier: ^1.57.0
         version: 1.58.0
       '@rsbuild/core':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.8
+        version: 2.0.8
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.1)(@rspack/core@2.0.0(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5(@swc/helpers@0.5.23))
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -1788,11 +1788,11 @@ importers:
         specifier: ^1.57.0
         version: 1.58.0
       '@rsbuild/core':
-        specifier: ^2.0.0
-        version: 2.0.1
+        specifier: ^2.0.8
+        version: 2.0.8
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.1)(@rspack/core@2.0.0(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5(@swc/helpers@0.5.23))
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -1959,11 +1959,11 @@ importers:
         specifier: ^1.57.0
         version: 1.58.0
       '@rsbuild/core':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.8
+        version: 2.0.8
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.1)(@rspack/core@2.0.0(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5(@swc/helpers@0.5.23))
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -2018,7 +2018,7 @@ importers:
         version: 2.0.1
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.1)(@rspack/core@2.0.0(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.1)(@rspack/core@2.0.5(@swc/helpers@0.5.21))
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -2207,11 +2207,11 @@ importers:
         specifier: ^1.57.0
         version: 1.58.0
       '@rsbuild/core':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.8
+        version: 2.0.8
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.1)(@rspack/core@2.0.0(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5(@swc/helpers@0.5.23))
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -2317,11 +2317,11 @@ importers:
         specifier: ^1.57.0
         version: 1.58.0
       '@rsbuild/core':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.8
+        version: 2.0.8
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.1)(@rspack/core@2.0.0(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5(@swc/helpers@0.5.23))
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -2476,11 +2476,11 @@ importers:
         specifier: ^1.57.0
         version: 1.58.0
       '@rsbuild/core':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.8
+        version: 2.0.8
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.1)(@rspack/core@2.0.0(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5(@swc/helpers@0.5.23))
       '@tanstack/eslint-plugin-start':
         specifier: workspace:^
         version: link:../../../packages/eslint-plugin-start
@@ -2830,11 +2830,11 @@ importers:
         specifier: ^1.57.0
         version: 1.58.0
       '@rsbuild/core':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.8
+        version: 2.0.8
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.1)(@rspack/core@2.0.0(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5(@swc/helpers@0.5.23))
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -3928,14 +3928,14 @@ importers:
         specifier: ^1.57.0
         version: 1.58.0
       '@rsbuild/core':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.8
+        version: 2.0.8
       '@rsbuild/plugin-babel':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.1)
+        version: 1.1.2(@rsbuild/core@2.0.8)
       '@rsbuild/plugin-solid':
         specifier: ^1.1.1
-        version: 1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.1)(solid-js@1.9.12)
+        version: 1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.8)(solid-js@1.9.12)
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -3974,14 +3974,14 @@ importers:
         specifier: ^1.57.0
         version: 1.58.0
       '@rsbuild/core':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.8
+        version: 2.0.8
       '@rsbuild/plugin-babel':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.1)
+        version: 1.1.2(@rsbuild/core@2.0.8)
       '@rsbuild/plugin-solid':
         specifier: ^1.1.1
-        version: 1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.1)(solid-js@1.9.12)
+        version: 1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.8)(solid-js@1.9.12)
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -4167,14 +4167,14 @@ importers:
         specifier: ^1.57.0
         version: 1.58.0
       '@rsbuild/core':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.8
+        version: 2.0.8
       '@rsbuild/plugin-babel':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.1)
+        version: 1.1.2(@rsbuild/core@2.0.8)
       '@rsbuild/plugin-solid':
         specifier: ^1.1.1
-        version: 1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.1)(solid-js@1.9.12)
+        version: 1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.8)(solid-js@1.9.12)
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -5756,17 +5756,17 @@ importers:
         specifier: ^1.57.0
         version: 1.58.0
       '@rsbuild/core':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.8
+        version: 2.0.8
       '@rsbuild/plugin-babel':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.1)
+        version: 1.1.2(@rsbuild/core@2.0.8)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.7
-        version: 1.2.7(@rsbuild/core@2.0.1)(@rspack/core@2.0.0(@swc/helpers@0.5.21))(vue@3.5.25(typescript@6.0.2))
+        version: 1.2.7(@rsbuild/core@2.0.8)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(vue@3.5.25(typescript@6.0.2))
       '@rsbuild/plugin-vue-jsx':
         specifier: ^2.0.0
-        version: 2.0.0(@babel/core@7.29.0)(@rsbuild/core@2.0.1)
+        version: 2.0.0(@babel/core@7.29.0)(@rsbuild/core@2.0.8)
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -5811,17 +5811,17 @@ importers:
         specifier: ^1.57.0
         version: 1.58.0
       '@rsbuild/core':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.8
+        version: 2.0.8
       '@rsbuild/plugin-babel':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.1)
+        version: 1.1.2(@rsbuild/core@2.0.8)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.7
-        version: 1.2.7(@rsbuild/core@2.0.1)(@rspack/core@2.0.0(@swc/helpers@0.5.21))(vue@3.5.25(typescript@6.0.2))
+        version: 1.2.7(@rsbuild/core@2.0.8)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(vue@3.5.25(typescript@6.0.2))
       '@rsbuild/plugin-vue-jsx':
         specifier: ^2.0.0
-        version: 2.0.0(@babel/core@7.29.0)(@rsbuild/core@2.0.1)
+        version: 2.0.0(@babel/core@7.29.0)(@rsbuild/core@2.0.8)
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -6034,17 +6034,17 @@ importers:
         specifier: ^1.57.0
         version: 1.58.0
       '@rsbuild/core':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.8
+        version: 2.0.8
       '@rsbuild/plugin-babel':
         specifier: ^1.0.5
-        version: 1.0.6(@rsbuild/core@2.0.1)
+        version: 1.0.6(@rsbuild/core@2.0.8)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@2.0.1)(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(vue@3.5.25(typescript@6.0.2))
+        version: 1.2.2(@rsbuild/core@2.0.8)(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)(vue@3.5.25(typescript@6.0.2))
       '@rsbuild/plugin-vue-jsx':
         specifier: ^1.1.1
-        version: 1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.1)
+        version: 1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.8)
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -8107,11 +8107,11 @@ importers:
         version: 4.2.2
     devDependencies:
       '@rsbuild/core':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.8
+        version: 2.0.8
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.1)(@rspack/core@2.0.0(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5(@swc/helpers@0.5.23))
       '@tanstack/router-plugin':
         specifier: workspace:*
         version: link:../../../packages/router-plugin
@@ -8142,7 +8142,7 @@ importers:
     devDependencies:
       '@swc/core':
         specifier: ^1.15.33
-        version: 1.15.33(@swc/helpers@0.5.21)
+        version: 1.15.33(@swc/helpers@0.5.23)
       '@tanstack/router-plugin':
         specifier: workspace:*
         version: link:../../../packages/router-plugin
@@ -8160,13 +8160,13 @@ importers:
         version: 0.18.0
       swc-loader:
         specifier: ^0.2.6
-        version: 0.2.6(@swc/core@1.15.33(@swc/helpers@0.5.21))(webpack@5.97.1)
+        version: 0.2.6(@swc/core@1.15.33(@swc/helpers@0.5.23))(webpack@5.97.1)
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
       webpack:
         specifier: ^5.97.1
-        version: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@5.1.4)
+        version: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.97.1)
@@ -11080,14 +11080,14 @@ importers:
         version: 4.2.2
     devDependencies:
       '@rsbuild/core':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.8
+        version: 2.0.8
       '@rsbuild/plugin-babel':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.1)
+        version: 1.1.2(@rsbuild/core@2.0.8)
       '@rsbuild/plugin-solid':
         specifier: ^1.1.1
-        version: 1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.1)(solid-js@1.9.12)
+        version: 1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.8)(solid-js@1.9.12)
       '@tanstack/router-plugin':
         specifier: workspace:*
         version: link:../../../packages/router-plugin
@@ -11145,7 +11145,7 @@ importers:
         version: 6.0.2
       webpack:
         specifier: ^5.97.1
-        version: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@5.1.4)
+        version: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.97.1)
@@ -12548,8 +12548,8 @@ importers:
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1)
     devDependencies:
       '@rsbuild/core':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.8
+        version: 2.0.8
       '@types/node':
         specifier: 25.0.9
         version: 25.0.9
@@ -12626,7 +12626,7 @@ importers:
     devDependencies:
       '@rspack/core':
         specifier: 2.0.0
-        version: 2.0.0(@swc/helpers@0.5.21)
+        version: 2.0.0(@swc/helpers@0.5.23)
       '@testing-library/react':
         specifier: ^16.2.0
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -12638,7 +12638,7 @@ importers:
         version: 0.5.20(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1))
       react-server-dom-rspack:
         specifier: ^0.0.2
-        version: 0.0.2(@rspack/core@2.0.0(@swc/helpers@0.5.21))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.0.2(@rspack/core@2.0.0(@swc/helpers@0.5.23))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   packages/react-start-server:
     dependencies:
@@ -12869,7 +12869,7 @@ importers:
         version: 2.11.11(@testing-library/jest-dom@6.6.3)(solid-js@1.9.12)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.8.1))
       webpack:
         specifier: '>=5.92.0'
-        version: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)
+        version: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -13085,8 +13085,8 @@ importers:
         version: 1.9.12
     devDependencies:
       '@rsbuild/core':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.8
+        version: 2.0.8
       '@tanstack/router-utils':
         specifier: workspace:*
         version: link:../router-utils
@@ -13257,8 +13257,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@rsbuild/core':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.8
+        version: 2.0.8
       '@types/babel__code-frame':
         specifier: ^7.0.6
         version: 7.0.6
@@ -13504,8 +13504,8 @@ importers:
         version: 2.0.3
     devDependencies:
       '@rsbuild/core':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.8
+        version: 2.0.8
       '@tanstack/router-utils':
         specifier: workspace:*
         version: link:../router-utils
@@ -16204,12 +16204,6 @@ packages:
   '@napi-rs/wasm-runtime@0.2.4':
     resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
 
-  '@napi-rs/wasm-runtime@1.1.3':
-    resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
-
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
     peerDependencies:
@@ -18210,6 +18204,16 @@ packages:
       core-js:
         optional: true
 
+  '@rsbuild/core@2.0.8':
+    resolution: {integrity: sha512-V5Bhn3zqljsaB5grw9oMkSk6XZFvMkr6UpIYPZnDmOWsRAT1fNQ6XF6cn8fVUKv/KILblBrKLUZf0DpvDt3exw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
   '@rsbuild/plugin-babel@1.0.6':
     resolution: {integrity: sha512-tWnqG938MedKJx7U4F1lHb156VDtNzj7mSsi2ZoxZVBnECQE01/V6QTN1XKw7nWunGyGoETb+nQBGc+fkVZjvw==}
     peerDependencies:
@@ -18273,13 +18277,29 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@2.0.5':
+    resolution: {integrity: sha512-++wjLQjQ20GcR0DwbzQmVXg9qy4XCX5NlfSzkzj2icHoDxr3KkrXhyVrQkdWuNG6l/bQrGLPnvLEAqkroC2Y7A==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@2.0.0':
     resolution: {integrity: sha512-YQ96LMmzIzhZt9cZWUDWXSxS9UWWHWoLxJyZ5f42DSaVPVelBg5ThbVORDwOP5QDA2xFXj60rVnmmcZLzg/aDA==}
     cpu: [x64]
     os: [darwin]
 
+  '@rspack/binding-darwin-x64@2.0.5':
+    resolution: {integrity: sha512-JBD5mCN3JKjV64Mh9nDYx8lLUrWDfEl5tLBuMkREUnqEKbo+z4nfwotyqHHM8/XgZwL+Gr7ps4GLWuQQrZB8+Q==}
+    cpu: [x64]
+    os: [darwin]
+
   '@rspack/binding-linux-arm64-gnu@2.0.0':
     resolution: {integrity: sha512-Ufn33gzkIV7JY69k6vJQEdOzRvBqThIgH46pwXksHSMwRZp8IbJhXfyYIAVsRWCk8fXpr9t1nAvCDvJXT2EeyA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-gnu@2.0.5':
+    resolution: {integrity: sha512-JI8+//woanJPNsfL7iGjX39zyiWumnrKHznWQM/7lEtE5nPmk+j+X7TYXxczSWC9zfZegiqI74D3L5JPDC84Fw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -18290,8 +18310,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-arm64-musl@2.0.5':
+    resolution: {integrity: sha512-5LujilxLtJFRiiPz5i5iWcWJriK9oy4gN7gZtTo8YRB7wwmwA8LMypTjjO0GLbkPS4/KeCfY4fDfTC29KmK+tA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-linux-x64-gnu@2.0.0':
     resolution: {integrity: sha512-dPjFGpoCvZfFpJBsWAUR+PR7mWYxpou6L026qIOpAVkz7WiTzErwKD3P1jVrpP4dM9yLb3fVE+PHHjTglhTJ4g==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-gnu@2.0.5':
+    resolution: {integrity: sha512-241wqE132jh+/U/pn97qUPV4KpIy4bSrTH0tqfzQCocgw+8hrUj02GqNG+3MXVC3qtwaQeJFYgEBy3TqFKsrIQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -18302,12 +18334,27 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-x64-musl@2.0.5':
+    resolution: {integrity: sha512-BhaXZD064Lci3Kia0kLDAb4TyxO2C+0UidMlj44e8+ctasxIfFZgnrhCJrhTFHAtOiAwqhU3FHun2UuxPqX0Eg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-wasm32-wasi@2.0.0':
     resolution: {integrity: sha512-ANk73ZKtPrZf9gdtyRK2nQUfhi1uXoC5P2KF89pyVAE8+zcoLBnYtZGYpWa/cmNi5BcO5g4Z+v2l1UA3bUPLQQ==}
     cpu: [wasm32]
 
+  '@rspack/binding-wasm32-wasi@2.0.5':
+    resolution: {integrity: sha512-duEkRoXrl9SW8uGHv7JURJ5lgKu87qFDQ4Exy6UQPvsUJVXhtRXTfvMHCb/CejVJuW2Bw2D632/axZq3qRSuBQ==}
+    cpu: [wasm32]
+
   '@rspack/binding-win32-arm64-msvc@2.0.0':
     resolution: {integrity: sha512-IHZFRtJ85ONbM+BCtF4TeYXS2Fu9X0IJS2phX1rPibYq9iEtHGfBt4cNlnsJPhbPAXVvi4Oli/yiLRJ1zxtCIg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@2.0.5':
+    resolution: {integrity: sha512-q2WT3HFoWL+2g84l3s2kY7CiE1gEZ1bwB3txx3eZzQQ6YKP7bE82z6sl6S/pTOHGjHdAO4snQXpSaHwUt3LX5g==}
     cpu: [arm64]
     os: [win32]
 
@@ -18316,13 +18363,26 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@2.0.5':
+    resolution: {integrity: sha512-nMJGIY7kvgbyMolEE7tXDe+Z9jSItDshTIqMQQkkD3WTHdjlBQozHxk4kBtKLsunO+3NkCLe5Oa3hXg1yyStIg==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@2.0.0':
     resolution: {integrity: sha512-cJOgikIW2t3S+42TQZsv+DJriJt2m6lnUk+pUFu/fO93rrMvNrx8gfMxR8W5zDTreBX0cfMx2pw6EVmyi/YzsQ==}
     cpu: [x64]
     os: [win32]
 
+  '@rspack/binding-win32-x64-msvc@2.0.5':
+    resolution: {integrity: sha512-vP0BR6fxdPL9cb02HAuZATg/CjR07aecWel3s1vqRwW1aDffgXh9PVmqEKIHTgyaNsNR55kSKNJsB9AcQ8/QrA==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding@2.0.0':
     resolution: {integrity: sha512-WA2f9eQpejkvf5Vrnf6wNCn1m8RT1p08NjgOZpKhsCzr0uBjWeRvGduawlrFFHZh/jPnWZTVaVdQ08FEAWbwGw==}
+
+  '@rspack/binding@2.0.5':
+    resolution: {integrity: sha512-Ta1y4WXJA87wM1OstqaMddoPsBGv7Cu779bYToKxEAqR/Yy9DxLkp7bdgBaAx2JH++BwVjV+toWts2V9AaiTFQ==}
 
   '@rspack/core@2.0.0':
     resolution: {integrity: sha512-WD1mJM9LbZ7Z399Rbv9dE3BNEV0+3sE5OzDdzV8hOxUb3mX++ynK5n9kil8w60B6nGdcKeV9ly5aN4PgqiwWUg==}
@@ -18330,6 +18390,18 @@ packages:
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
       '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@2.0.5':
+    resolution: {integrity: sha512-9tv2HAnSiTote5WPH2tmz1hLZ1zKbzkiZc1eYp7LP/8jcsiJBuf40ihiWidAgbbuYtJo3kWET6q+qOm5UhNiGA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
     peerDependenciesMeta:
       '@module-federation/runtime-tools':
         optional: true
@@ -18849,6 +18921,9 @@ packages:
 
   '@swc/helpers@0.5.21':
     resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
   '@swc/types@0.1.26':
     resolution: {integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==}
@@ -29381,13 +29456,6 @@ snapshots:
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.9.0
 
-  '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
-    optional: true
-
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -29748,13 +29816,13 @@ snapshots:
 
   '@nothing-but/utils@0.17.0': {}
 
-  '@nx/devkit@22.6.5(nx@22.6.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.2))(@swc/core@1.15.33(@swc/helpers@0.5.21)))':
+  '@nx/devkit@22.6.5(nx@22.6.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.2))(@swc/core@1.15.33(@swc/helpers@0.5.23)))':
     dependencies:
       '@zkochan/js-yaml': 0.0.7
       ejs: 5.0.1
       enquirer: 2.3.6
       minimatch: 10.2.4
-      nx: 22.6.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.2))(@swc/core@1.15.33(@swc/helpers@0.5.21))
+      nx: 22.6.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.2))(@swc/core@1.15.33(@swc/helpers@0.5.23))
       semver: 7.7.3
       tslib: 2.8.1
       yargs-parser: 21.1.1
@@ -29936,7 +30004,7 @@ snapshots:
 
   '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -31202,7 +31270,7 @@ snapshots:
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -31388,13 +31456,20 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@1.0.6(@rsbuild/core@2.0.1)':
+  '@rsbuild/core@2.0.8':
+    dependencies:
+      '@rspack/core': 2.0.5(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
+  '@rsbuild/plugin-babel@1.0.6(@rsbuild/core@2.0.8)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.5)
       '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.5)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.28.5)
-      '@rsbuild/core': 2.0.1
+      '@rsbuild/core': 2.0.8
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
@@ -31415,12 +31490,34 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.1)(@rspack/core@2.0.0(@swc/helpers@0.5.21))':
+  '@rsbuild/plugin-babel@1.1.2(@rsbuild/core@2.0.8)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.0(@swc/helpers@0.5.21))(react-refresh@0.18.0)
+      '@babel/core': 7.29.0
+      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@types/babel__core': 7.20.5
+      reduce-configs: 1.1.1
+    optionalDependencies:
+      '@rsbuild/core': 2.0.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.1)(@rspack/core@2.0.5(@swc/helpers@0.5.21))':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.5(@swc/helpers@0.5.21))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
       '@rsbuild/core': 2.0.1
+    transitivePeerDependencies:
+      - '@rspack/core'
+
+  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.8)(@rspack/core@2.0.5(@swc/helpers@0.5.23))':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 2.0.8
     transitivePeerDependencies:
       - '@rspack/core'
 
@@ -31436,33 +31533,45 @@ snapshots:
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-vue-jsx@1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.1)':
+  '@rsbuild/plugin-solid@1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.8)(solid-js@1.9.12)':
     dependencies:
-      '@rsbuild/plugin-babel': 1.1.2(@rsbuild/core@2.0.1)
+      '@rsbuild/plugin-babel': 1.1.2(@rsbuild/core@2.0.8)
+      babel-preset-solid: 1.9.10(@babel/core@7.29.0)(solid-js@1.9.12)
+      solid-refresh: 0.7.8(solid-js@1.9.12)
+    optionalDependencies:
+      '@rsbuild/core': 2.0.8
+    transitivePeerDependencies:
+      - '@babel/core'
+      - solid-js
+      - supports-color
+
+  '@rsbuild/plugin-vue-jsx@1.1.1(@babel/core@7.29.0)(@rsbuild/core@2.0.8)':
+    dependencies:
+      '@rsbuild/plugin-babel': 1.1.2(@rsbuild/core@2.0.8)
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.0)
       babel-plugin-vue-jsx-hmr: 1.0.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.1
+      '@rsbuild/core': 2.0.8
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  '@rsbuild/plugin-vue-jsx@2.0.0(@babel/core@7.29.0)(@rsbuild/core@2.0.1)':
+  '@rsbuild/plugin-vue-jsx@2.0.0(@babel/core@7.29.0)(@rsbuild/core@2.0.8)':
     dependencies:
-      '@rsbuild/plugin-babel': 1.1.2(@rsbuild/core@2.0.1)
+      '@rsbuild/plugin-babel': 1.1.2(@rsbuild/core@2.0.8)
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.0)
       babel-plugin-vue-jsx-hmr: 1.0.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.1
+      '@rsbuild/core': 2.0.8
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  '@rsbuild/plugin-vue@1.2.2(@rsbuild/core@2.0.1)(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(vue@3.5.25(typescript@6.0.2))':
+  '@rsbuild/plugin-vue@1.2.2(@rsbuild/core@2.0.8)(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)(vue@3.5.25(typescript@6.0.2))':
     dependencies:
-      '@rsbuild/core': 2.0.1
-      rspack-vue-loader: 17.4.4(vue@3.5.25(typescript@6.0.2))(webpack@5.104.0(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4))
-      webpack: 5.104.0(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)
+      '@rsbuild/core': 2.0.8
+      rspack-vue-loader: 17.4.4(vue@3.5.25(typescript@6.0.2))(webpack@5.104.0(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4))
+      webpack: 5.104.0(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)
     transitivePeerDependencies:
       - '@swc/core'
       - '@vue/compiler-sfc'
@@ -31471,11 +31580,11 @@ snapshots:
       - vue
       - webpack-cli
 
-  '@rsbuild/plugin-vue@1.2.7(@rsbuild/core@2.0.1)(@rspack/core@2.0.0(@swc/helpers@0.5.21))(vue@3.5.25(typescript@6.0.2))':
+  '@rsbuild/plugin-vue@1.2.7(@rsbuild/core@2.0.8)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(vue@3.5.25(typescript@6.0.2))':
     dependencies:
-      rspack-vue-loader: 17.5.0(@rspack/core@2.0.0(@swc/helpers@0.5.21))(vue@3.5.25(typescript@6.0.2))
+      rspack-vue-loader: 17.5.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))(vue@3.5.25(typescript@6.0.2))
     optionalDependencies:
-      '@rsbuild/core': 2.0.1
+      '@rsbuild/core': 2.0.8
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/compiler-sfc'
@@ -31484,19 +31593,37 @@ snapshots:
   '@rspack/binding-darwin-arm64@2.0.0':
     optional: true
 
+  '@rspack/binding-darwin-arm64@2.0.5':
+    optional: true
+
   '@rspack/binding-darwin-x64@2.0.0':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.0.5':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@2.0.0':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@2.0.5':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@2.0.0':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.0.5':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@2.0.0':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@2.0.5':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@2.0.0':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.0.5':
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.0.0':
@@ -31506,13 +31633,29 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
+  '@rspack/binding-wasm32-wasi@2.0.5':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@2.0.0':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.0.5':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.0.0':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@2.0.5':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@2.0.0':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.0.5':
     optional: true
 
   '@rspack/binding@2.0.0':
@@ -31528,19 +31671,57 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.0.0
       '@rspack/binding-win32-x64-msvc': 2.0.0
 
+  '@rspack/binding@2.0.5':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.0.5
+      '@rspack/binding-darwin-x64': 2.0.5
+      '@rspack/binding-linux-arm64-gnu': 2.0.5
+      '@rspack/binding-linux-arm64-musl': 2.0.5
+      '@rspack/binding-linux-x64-gnu': 2.0.5
+      '@rspack/binding-linux-x64-musl': 2.0.5
+      '@rspack/binding-wasm32-wasi': 2.0.5
+      '@rspack/binding-win32-arm64-msvc': 2.0.5
+      '@rspack/binding-win32-ia32-msvc': 2.0.5
+      '@rspack/binding-win32-x64-msvc': 2.0.5
+
   '@rspack/core@2.0.0(@swc/helpers@0.5.21)':
     dependencies:
       '@rspack/binding': 2.0.0
     optionalDependencies:
       '@swc/helpers': 0.5.21
 
+  '@rspack/core@2.0.0(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': 2.0.0
+    optionalDependencies:
+      '@swc/helpers': 0.5.23
+
+  '@rspack/core@2.0.5(@swc/helpers@0.5.21)':
+    dependencies:
+      '@rspack/binding': 2.0.5
+    optionalDependencies:
+      '@swc/helpers': 0.5.21
+    optional: true
+
+  '@rspack/core@2.0.5(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': 2.0.5
+    optionalDependencies:
+      '@swc/helpers': 0.5.23
+
   '@rspack/lite-tapable@1.1.0': {}
 
-  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.0(@swc/helpers@0.5.21))(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.5(@swc/helpers@0.5.21))(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.0.0(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.5(@swc/helpers@0.5.21)
+
+  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
+    dependencies:
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rspack/core': 2.0.5(@swc/helpers@0.5.23)
 
   '@rushstack/node-core-library@5.7.0(@types/node@25.0.9)':
     dependencies:
@@ -31993,16 +32174,16 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@swc-node/core@1.14.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)':
+  '@swc-node/core@1.14.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(@swc/types@0.1.26)':
     dependencies:
-      '@swc/core': 1.15.33(@swc/helpers@0.5.21)
+      '@swc/core': 1.15.33(@swc/helpers@0.5.23)
       '@swc/types': 0.1.26
 
-  '@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.2)':
+  '@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.2)':
     dependencies:
-      '@swc-node/core': 1.14.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)
+      '@swc-node/core': 1.14.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(@swc/types@0.1.26)
       '@swc-node/sourcemap-support': 0.6.1
-      '@swc/core': 1.15.33(@swc/helpers@0.5.21)
+      '@swc/core': 1.15.33(@swc/helpers@0.5.23)
       colorette: 2.0.20
       debug: 4.4.3
       oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
@@ -32056,7 +32237,7 @@ snapshots:
   '@swc/core-win32-x64-msvc@1.15.33':
     optional: true
 
-  '@swc/core@1.15.33(@swc/helpers@0.5.21)':
+  '@swc/core@1.15.33(@swc/helpers@0.5.23)':
     dependencies:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.26
@@ -32073,7 +32254,7 @@ snapshots:
       '@swc/core-win32-arm64-msvc': 1.15.33
       '@swc/core-win32-ia32-msvc': 1.15.33
       '@swc/core-win32-x64-msvc': 1.15.33
-      '@swc/helpers': 0.5.21
+      '@swc/helpers': 0.5.23
 
   '@swc/counter@0.1.3': {}
 
@@ -32082,6 +32263,10 @@ snapshots:
       tslib: 2.8.1
 
   '@swc/helpers@0.5.21':
+    dependencies:
+      tslib: 2.8.1
+
+  '@swc/helpers@0.5.23':
     dependencies:
       tslib: 2.8.1
 
@@ -33845,17 +34030,17 @@ snapshots:
 
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.97.1)':
     dependencies:
-      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.97.1)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.97.1)':
     dependencies:
-      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.97.1)
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.4)(webpack@5.97.1)':
     dependencies:
-      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.97.1)
     optionalDependencies:
       webpack-dev-server: 5.2.4(webpack-cli@5.1.4)(webpack@5.97.1)
@@ -34210,7 +34395,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       find-up: 5.0.0
-      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)(webpack-cli@5.1.4)
 
   babel-plugin-jsx-dom-expressions@0.40.3(@babel/core@7.28.5):
     dependencies:
@@ -34916,7 +35101,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.3
     optionalDependencies:
-      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)(webpack-cli@5.1.4)
 
   css-select@4.3.0:
     dependencies:
@@ -36573,7 +36758,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
-      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)(webpack-cli@5.1.4)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -38078,7 +38263,7 @@ snapshots:
 
   nwsapi@2.2.16: {}
 
-  nx@22.6.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.2))(@swc/core@1.15.33(@swc/helpers@0.5.21)):
+  nx@22.6.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.2))(@swc/core@1.15.33(@swc/helpers@0.5.23)):
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.4
       '@yarnpkg/lockfile': 1.1.0
@@ -38127,8 +38312,8 @@ snapshots:
       '@nx/nx-linux-x64-musl': 22.6.5
       '@nx/nx-win32-arm64-msvc': 22.6.5
       '@nx/nx-win32-x64-msvc': 22.6.5
-      '@swc-node/register': 1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.2)
-      '@swc/core': 1.15.33(@swc/helpers@0.5.21)
+      '@swc-node/register': 1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.2)
+      '@swc/core': 1.15.33(@swc/helpers@0.5.23)
     transitivePeerDependencies:
       - debug
 
@@ -38572,7 +38757,7 @@ snapshots:
       postcss: 8.5.6
       semver: 7.7.3
     optionalDependencies:
-      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - typescript
 
@@ -38970,9 +39155,9 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.9
 
-  react-server-dom-rspack@0.0.2(@rspack/core@2.0.0(@swc/helpers@0.5.21))(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  react-server-dom-rspack@0.0.2(@rspack/core@2.0.0(@swc/helpers@0.5.23))(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      '@rspack/core': 2.0.0(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.0(@swc/helpers@0.5.23)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
@@ -39292,20 +39477,20 @@ snapshots:
 
   rrweb-cssom@0.8.0: {}
 
-  rspack-vue-loader@17.4.4(vue@3.5.25(typescript@6.0.2))(webpack@5.104.0(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)):
+  rspack-vue-loader@17.4.4(vue@3.5.25(typescript@6.0.2))(webpack@5.104.0(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)):
     dependencies:
       chalk: 4.1.2
       watchpack: 2.4.2
-      webpack: 5.104.0(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)
+      webpack: 5.104.0(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)
     optionalDependencies:
       vue: 3.5.25(typescript@6.0.2)
 
-  rspack-vue-loader@17.5.0(@rspack/core@2.0.0(@swc/helpers@0.5.21))(vue@3.5.25(typescript@6.0.2)):
+  rspack-vue-loader@17.5.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))(vue@3.5.25(typescript@6.0.2)):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
       chalk: 4.1.2
     optionalDependencies:
-      '@rspack/core': 2.0.0(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.5(@swc/helpers@0.5.23)
       vue: 3.5.25(typescript@6.0.2)
 
   run-applescript@7.0.0: {}
@@ -39842,7 +40027,7 @@ snapshots:
 
   style-loader@4.0.0(webpack@5.97.1):
     dependencies:
-      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)(webpack-cli@5.1.4)
 
   style-to-object@1.0.8:
     dependencies:
@@ -39877,11 +40062,11 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.4.1
 
-  swc-loader@0.2.6(@swc/core@1.15.33(@swc/helpers@0.5.21))(webpack@5.97.1):
+  swc-loader@0.2.6(@swc/core@1.15.33(@swc/helpers@0.5.23))(webpack@5.97.1):
     dependencies:
-      '@swc/core': 1.15.33(@swc/helpers@0.5.21)
+      '@swc/core': 1.15.33(@swc/helpers@0.5.23)
       '@swc/counter': 0.1.3
-      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)(webpack-cli@5.1.4)
 
   swr@2.3.4(react@19.2.3):
     dependencies:
@@ -39930,40 +40115,40 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.3.11(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack@5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)):
+  terser-webpack-plugin@5.3.11(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)(webpack@5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
       terser: 5.37.0
-      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)
+      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)
     optionalDependencies:
-      '@swc/core': 1.15.33(@swc/helpers@0.5.21)
+      '@swc/core': 1.15.33(@swc/helpers@0.5.23)
       esbuild: 0.27.4
 
-  terser-webpack-plugin@5.3.11(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack@5.97.1):
+  terser-webpack-plugin@5.3.11(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)(webpack@5.97.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
       terser: 5.37.0
-      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)(webpack-cli@5.1.4)
     optionalDependencies:
-      '@swc/core': 1.15.33(@swc/helpers@0.5.21)
+      '@swc/core': 1.15.33(@swc/helpers@0.5.23)
       esbuild: 0.27.4
 
-  terser-webpack-plugin@5.3.16(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack@5.104.0(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)):
+  terser-webpack-plugin@5.3.16(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)(webpack@5.104.0(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.37.0
-      webpack: 5.104.0(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)
+      webpack: 5.104.0(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)
     optionalDependencies:
-      '@swc/core': 1.15.33(@swc/helpers@0.5.21)
+      '@swc/core': 1.15.33(@swc/helpers@0.5.23)
       esbuild: 0.27.4
 
   terser@5.37.0:
@@ -40797,7 +40982,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
     optionalDependencies:
       webpack-dev-server: 5.2.4(webpack-cli@5.1.4)(webpack@5.97.1)
@@ -40811,7 +40996,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)(webpack-cli@5.1.4)
 
   webpack-dev-server@5.2.4(webpack-cli@5.1.4)(webpack@5.97.1):
     dependencies:
@@ -40844,7 +41029,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(webpack@5.97.1)
       ws: 8.20.0
     optionalDependencies:
-      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@5.1.4)
+      webpack: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.4)(webpack@5.97.1)
     transitivePeerDependencies:
       - bufferutil
@@ -40866,7 +41051,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.104.0(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4):
+  webpack@5.104.0(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -40890,7 +41075,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack@5.104.0(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4))
+      terser-webpack-plugin: 5.3.16(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)(webpack@5.104.0(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4))
       watchpack: 2.4.4
       webpack-sources: 3.3.3
     transitivePeerDependencies:
@@ -40898,7 +41083,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4):
+  webpack@5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.7
@@ -40920,7 +41105,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.11(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack@5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4))
+      terser-webpack-plugin: 5.3.11(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)(webpack@5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -40928,7 +41113,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack-cli@5.1.4):
+  webpack@5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)(webpack-cli@5.1.4):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.7
@@ -40950,7 +41135,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.11(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.27.4)(webpack@5.97.1)
+      terser-webpack-plugin: 5.3.11(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)(webpack@5.97.1)
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     optionalDependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rsbuild React Server Components (RSC) support with deferred decoding and selective CSS/JS asset preloading.
  * Client/server flow now surfaces per-RSC payload CSS and JS preloads so clients only fetch relevant assets.
  * Build output uses an /assets base for generated client files (affects served script and stylesheet URLs).

* **Chores**
  * Bumped `@rsbuild/core` dependency to ^2.0.8 across packages.

* **Tests**
  * End-to-end and unit tests updated to validate RSC asset/link behavior and updated asset URLs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/router/pull/7509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->