### PR TITLE
fix: stream solid suspense chunks independently

### DIFF
--- a/e2e/solid-start/basic-test-suite/src/streaming.spec.ts
+++ b/e2e/solid-start/basic-test-suite/src/streaming.spec.ts
@@ -27,6 +27,22 @@ test('Directly visiting the deferred route', async ({ page }) => {
   )
 })
 
+test('deferred route streams boundaries independently', async ({ page }) => {
+  await page.goto('/deferred', { waitUntil: 'commit' })
+
+  await expect(page.getByTestId('regular-person')).toContainText('John Doe')
+  await expect(page.getByText('Loading person...')).toBeVisible()
+  await expect(page.getByText('Loading stuff...')).toBeVisible()
+
+  await expect(page.getByTestId('deferred-person')).toContainText(
+    'Tanner Linsley',
+  )
+  await expect(page.getByText('Loading stuff...')).toBeVisible()
+  await expect(page.getByTestId('deferred-stuff')).toContainText(
+    'Hello deferred!',
+  )
+})
+
 test('streaming loader data', async ({ page }) => {
   await page.goto('/stream')
 

--- a/packages/router-core/src/ssr/transformStreamWithRouter.ts
+++ b/packages/router-core/src/ssr/transformStreamWithRouter.ts
@@ -227,7 +227,9 @@ export function transformStreamWithRouter(
   // between-chunk text buffer; keep bounded to avoid unbounded memory
   let leftover = ''
 
-  // captured closing tags from </body> onward
+  // Captured closing tags that must stay after router-injected scripts.
+  // Some renderers, like Solid, continue streaming boundary chunks after
+  // </html>; those chunks should still pass through before these tags.
   let pendingClosingTags = ''
 
   // conservative cap: enough to hold any partial closing tag + a bit
@@ -404,9 +406,11 @@ export function transformStreamWithRouter(
           }
         }
 
-        // If we already saw </body>, everything else is part of tail; buffer it.
+        // If we already saw </body>, keep streaming app chunks before the
+        // captured closing tags instead of buffering them until render end.
         if (pendingClosingTags) {
-          pendingClosingTags += chunkString
+          flushPendingRouterHtml()
+          safeEnqueue(chunkString)
           leftover = ''
           continue
         }
@@ -419,9 +423,11 @@ export function transformStreamWithRouter(
           htmlEndIndex !== -1 &&
           bodyEndIndex < htmlEndIndex
         ) {
-          pendingClosingTags = chunkString.slice(bodyEndIndex)
+          const htmlEndTagEnd = htmlEndIndex + HTML_END_TAG.length
+          pendingClosingTags = chunkString.slice(bodyEndIndex, htmlEndTagEnd)
           safeEnqueue(chunkString.slice(0, bodyEndIndex))
           flushPendingRouterHtml()
+          safeEnqueue(chunkString.slice(htmlEndTagEnd))
           leftover = ''
           continue
         }


### PR DESCRIPTION
Not sure if this should go on main or just the `solid-router-v2-pre` branch.

# Solid Streaming Fix

## Why This Is Needed

Solid SSR can stream resolved `Loading`/Suspense boundaries after the main HTML document has already emitted `</body></html>`.

TanStack Router's SSR stream transform needs to inject router serialization scripts before the closing document tags. Before the fix, the transform treated everything from `</body>` onward as the closing HTML tail and buffered it until the whole app render and router serialization finished.

That accidentally buffered Solid's later boundary chunks too. In practice, a fast boundary like `deferredPerson` resolving at 1s was held until a slower boundary like `deferredStuff` resolved at 2s, so both appeared together instead of streaming independently.

## What The Fix Does

The transform now captures only the actual closing tags (`</body></html>`) so router scripts can still be injected before them.

Any renderer chunks that arrive after those closing tags, including Solid boundary templates and scripts, are streamed immediately instead of being appended to the closing-tag buffer.

This preserves the required router script ordering while allowing Solid boundaries to reveal as each promise resolves.

