### PR TITLE
fix(router-core): defer $_TSR teardown until DOMContentLoaded

### DIFF
--- a/.changeset/witty-tires-flow.md
+++ b/.changeset/witty-tires-flow.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+defer $\_TSR teardown until DOMContentLoaded

--- a/.changeset/witty-tires-flow.md
+++ b/.changeset/witty-tires-flow.md
@@ -2,4 +2,4 @@
 '@tanstack/router-core': patch
 ---
 
-defer $\_TSR teardown until DOMContentLoaded
+defer `$_TSR` teardown until DOMContentLoaded

--- a/packages/router-core/src/ssr/tsrScript.ts
+++ b/packages/router-core/src/ssr/tsrScript.ts
@@ -9,8 +9,17 @@ self.$_TSR = {
   },
   c() {
     if (this.hydrated && this.streamEnded) {
-      delete self.$_TSR
-      delete self.$R['tsr']
+      const cleanup = () => {
+        if (self.$_TSR?.hydrated && self.$_TSR?.streamEnded) {
+          delete self.$_TSR
+          delete self.$R['tsr']
+        }
+      }
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', cleanup, { once: true })
+      } else {
+        cleanup()
+      }
     }
   },
   p(script) {


### PR DESCRIPTION
I'm experience an issue where the `$_TSR` is deleted too early, and ends up undefined. This is a small defensive change to hold it until the streaming has ended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side rendering stability by deferring cleanup until the DOM is fully loaded, ensuring hydration and streaming complete before teardown.
* **Chores**
  * Bumped router-core with a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->