### PR TITLE
docs: clarify auth data boundaries

### DIFF
--- a/docs/router/guide/authenticated-routes.md
+++ b/docs/router/guide/authenticated-routes.md
@@ -5,7 +5,7 @@ title: Authenticated Routes
 
 Authentication is an extremely common requirement for web applications. In this guide, we'll walk through how to use TanStack Router to build protected routes, and how to redirect users to login if they try to access them.
 
-> **A route guard does not protect a server function.** This guide shows how to gate a route's UI behind `beforeLoad`. If you also have a `createServerFn` that fetches sensitive data, the route guard does NOT stop a direct request to that RPC — server functions are reachable by POST regardless of which route renders them. Pair routing-side guards with **handler-level enforcement** (auth middleware or in-handler check). See [Authentication Server Primitives](../../start/framework/react/guide/authentication-server-primitives.md) in the Start docs.
+> **A route guard is not a data authorization boundary.** This guide shows how to gate a route's UI behind `beforeLoad`. Any server function, server route, or API endpoint that returns private data must authorize the request itself, because it can be requested independently of the route that calls it. See [Authentication Server Primitives](../../start/framework/react/guide/authentication-server-primitives.md) in the Start docs.
 
 ## The `route.beforeLoad` Option
 

--- a/docs/start/config.json
+++ b/docs/start/config.json
@@ -166,6 +166,10 @@
               "to": "framework/react/guide/authentication-overview"
             },
             {
+              "label": "Authentication Server Primitives",
+              "to": "framework/react/guide/authentication-server-primitives"
+            },
+            {
               "label": "Authentication",
               "to": "framework/react/guide/authentication"
             },
@@ -289,6 +293,10 @@
             {
               "label": "Authentication Overview",
               "to": "framework/solid/guide/authentication-overview"
+            },
+            {
+              "label": "Authentication Server Primitives",
+              "to": "framework/solid/guide/authentication-server-primitives"
             },
             {
               "label": "Authentication",

--- a/docs/start/framework/react/guide/authentication-overview.md
+++ b/docs/start/framework/react/guide/authentication-overview.md
@@ -72,11 +72,11 @@ title: Authentication
 - Good for mixed public/private content on same route
 - Requires careful handling to prevent layout shifts
 
-**Server Function Guards**
+**Data/API Protection (Security Boundary)**
 
-- Server-side validation before executing sensitive operations
-- Works alongside route-level protection
-- Essential for API security regardless of client-side protection
+- Authorize every server function, server route, or API endpoint that reads or writes private data
+- Reject unauthorized requests even if no protected route was loaded first
+- Treat route guards as UX and navigation control, not as the data boundary
 
 ### State Management Patterns
 
@@ -207,14 +207,17 @@ Build your own authentication system using TanStack Start's server functions and
 - Specific business logic needs
 - Full ownership of authentication data
 
-### Security Considerations
+### Production Auth Checklist
 
-- Use HTTPS in production
-- Use HTTP-only cookies when possible
-- Validate all inputs on the server
-- Keep secrets in server-only functions
-- Implement rate limiting for auth endpoints
-- Use CSRF protection for form submissions
+- Use HTTPS in production and set a strong session secret.
+- Store sessions in `HttpOnly`, `Secure`, `SameSite` cookies. Do not store session tokens in `localStorage` or `sessionStorage`.
+- Enforce auth in every server function, server route, or API endpoint that reads or writes private user, tenant, or account data. Use `beforeLoad` for page UX, not as the data boundary.
+- Use `.inputValidator()` on every server function that accepts input.
+- Hash passwords with bcrypt, scrypt, or Argon2. For missing users, verify against a dummy hash and return the same login/reset message.
+- Rate limit login, registration, and password-reset endpoints.
+- Use CSRF or same-origin protections for non-GET server functions and server routes.
+- Log authentication events and monitor failures.
+- Test direct unauthenticated calls to protected server functions; they should reject before returning data.
 
 ## Next Steps
 

--- a/docs/start/framework/react/guide/authentication-server-primitives.md
+++ b/docs/start/framework/react/guide/authentication-server-primitives.md
@@ -7,14 +7,14 @@ This guide covers the **server-side primitives** for building authentication in 
 
 If you can use a managed solution like [Clerk](https://go.clerk.com/wOwHtuJ) or [WorkOS](https://workos.com/), prefer that — they handle most of what this guide describes. Read on if you're rolling your own.
 
-## The Two Halves of Auth
+## Protect Data First
 
-Authentication has a routing half and a server half. They both need to be implemented; either one alone is incomplete.
+Authentication has a data/API boundary and a route/UI layer. The data boundary is the security boundary: every server function, server route, or API endpoint that reads or writes private data must authorize the request before returning data or mutating state.
 
-- **Routing half** (`router-core/auth-and-guards`): redirect unauthenticated users away from protected pages, gate UI on roles/permissions, surface a login form.
-- **Server half** (this guide): issue and verify session cookies, exchange OAuth codes, hash and verify passwords, rate-limit credential endpoints, defeat user enumeration.
+- **Data/API boundary** (this guide): issue and verify session cookies, exchange OAuth codes, hash and verify passwords, rate-limit credential endpoints, defeat user enumeration, and authorize private data access.
+- **Route/UI layer** (`router-core/auth-and-guards`): redirect unauthenticated users away from screens they cannot use, gate UI on roles/permissions, surface a login form, and avoid triggering requests that would fail anyway.
 
-> **A route guard does NOT protect a `createServerFn` on that route.** Server functions are RPC endpoints — they're reachable via direct POST regardless of which route renders them. Auth must be enforced on the handler (or via middleware), not on the calling route.
+> **A route guard is not a data authorization boundary.** Server functions and server routes are API endpoints; they are reachable independently of the route that calls them. Auth must be enforced in the handler or middleware for the endpoint that touches private data. `beforeLoad` is for route UX.
 
 ## Session Cookies
 

--- a/docs/start/framework/react/guide/authentication.md
+++ b/docs/start/framework/react/guide/authentication.md
@@ -36,6 +36,8 @@ Authentication involves many considerations including password security, session
 
 TanStack Start provides the tools for both through server functions, sessions, and route protection.
 
+> Protect the data/API boundary first. Any server function, server route, or other API endpoint that returns or mutates private data must authorize the request itself. `beforeLoad` is useful for route UX: it keeps users out of screens they cannot use and avoids triggering work that would fail anyway. It is not the security boundary for the data. See [Authentication Server Primitives](./authentication-server-primitives.md) for the server-side pattern.
+
 ## Essential Building Blocks
 
 ### 1. Server Functions for Authentication

--- a/docs/start/framework/react/guide/middleware.md
+++ b/docs/start/framework/react/guide/middleware.md
@@ -822,7 +822,7 @@ Static middlewares are created once and reused across routes. A middleware facto
 
 This middleware validates the session and injects it into `context` for downstream middlewares.
 
-> **Attach `authMiddleware` to every `createServerFn` that needs auth.** A route `beforeLoad` redirect protects the page experience but does NOT protect the RPC — server functions are reachable via direct POST regardless of which route renders them. Pair routing-side guards with handler-level enforcement here. See [Authentication Server Primitives](./authentication-server-primitives.md).
+> **Attach `authMiddleware` to every `createServerFn` that needs auth.** Server functions are API endpoints, so protect the endpoint that reads or mutates private data. A route `beforeLoad` guard improves route UX, but it is not the data boundary. See [Authentication Server Primitives](./authentication-server-primitives.md).
 
 ```tsx
 // middleware.ts

--- a/docs/start/framework/react/guide/server-functions.md
+++ b/docs/start/framework/react/guide/server-functions.md
@@ -397,7 +397,7 @@ Use server functions without JavaScript by leveraging the `.url` property with H
 
 Compose server functions with middleware for authentication, logging, and shared logic. See the [Middleware guide](./middleware.md).
 
-> **Auth must be enforced on the server function, not the route.** A `createServerFn` is an RPC endpoint reachable by direct POST regardless of which route renders the calling UI — a route `beforeLoad` redirect protects the page experience, but it does not stop a request from hitting the RPC directly. Apply `authMiddleware` (or an equivalent in-handler check) to every server function that needs auth. See [Authentication Server Primitives](./authentication-server-primitives.md).
+> **Protect data in the endpoint that serves it.** Server functions are API endpoints reachable independently of whichever route renders the calling UI. Apply `authMiddleware` or an equivalent in-handler check to every server function that reads or writes private data. `beforeLoad` is useful route UX, but it is not the data boundary. See [Authentication Server Primitives](./authentication-server-primitives.md).
 
 ### Static Server Functions
 

--- a/docs/start/framework/solid/guide/authentication-server-primitives.md
+++ b/docs/start/framework/solid/guide/authentication-server-primitives.md
@@ -1,0 +1,9 @@
+---
+ref: docs/start/framework/react/guide/authentication-server-primitives.md
+replace:
+  {
+    '@tanstack/react-start': '@tanstack/solid-start',
+    '@tanstack/react-router': '@tanstack/solid-router',
+    'React': 'SolidJS',
+  }
+---

--- a/docs/start/framework/solid/guide/authentication.md
+++ b/docs/start/framework/solid/guide/authentication.md
@@ -36,6 +36,8 @@ Authentication involves many considerations including password security, session
 
 TanStack Start provides the tools for both through server functions, sessions, and route protection.
 
+> Protect the data/API boundary first. Any server function, server route, or other API endpoint that returns or mutates private data must authorize the request itself. `beforeLoad` is useful for route UX: it keeps users out of screens they cannot use and avoids triggering work that would fail anyway. It is not the security boundary for the data. See [Authentication Server Primitives](./authentication-server-primitives.md) for the server-side pattern.
+
 ## Essential Building Blocks
 
 ### 1. Server Functions for Authentication

--- a/packages/router-core/skills/router-core/auth-and-guards/SKILL.md
+++ b/packages/router-core/skills/router-core/auth-and-guards/SKILL.md
@@ -21,9 +21,9 @@ sources:
 
 # Auth and Guards
 
-> **This skill covers the routing side of auth.** For the **server-side primitives** — session cookies (`HttpOnly`/`Secure`/`SameSite`), `useSession`-style helpers, OAuth `state` + PKCE, password-reset enumeration defense, CSRF, rate limiting — see [start-core/auth-server-primitives](../../../../start-client-core/skills/start-core/auth-server-primitives/SKILL.md). The two skills are designed to be used together.
+> **This skill covers the routing side of auth.** Route guards are UX and navigation control; the data/API boundary still belongs in the server function, server route, or API endpoint that reads or mutates private data. For the **server-side primitives** — session cookies (`HttpOnly`/`Secure`/`SameSite`), `useSession`-style helpers, OAuth `state` + PKCE, password-reset enumeration defense, CSRF, rate limiting — see [start-core/auth-server-primitives](../../../../start-client-core/skills/start-core/auth-server-primitives/SKILL.md).
 >
-> **CRITICAL**: A route guard (`beforeLoad`) does NOT protect a `createServerFn` declared on that route. Server functions are RPC endpoints reachable by direct POST regardless of which route renders them. See "Route guards do not protect server functions" below.
+> **CRITICAL**: A route guard (`beforeLoad`) does NOT protect a `createServerFn` declared on that route. Server functions are API endpoints reachable independently of the route that calls them. See "Route guards do not protect server functions" below.
 
 ## Setup
 
@@ -408,7 +408,7 @@ const getMyOrders = createServerFn({ method: 'GET' })
   })
 ```
 
-Rule of thumb: every `createServerFn` that touches user data needs `authMiddleware` (or an equivalent in-handler check). The route guard is for the page experience; the RPC guard is for the data. See [start-core/auth-server-primitives](../../../../start-client-core/skills/start-core/auth-server-primitives/SKILL.md) for the full session/middleware pattern.
+Rule of thumb: every `createServerFn`, server route, or API endpoint that touches user data needs `authMiddleware` (or an equivalent in-handler check). The route guard is for the page experience; the endpoint guard is for the data. See [start-core/auth-server-primitives](../../../../start-client-core/skills/start-core/auth-server-primitives/SKILL.md) for the full session/middleware pattern.
 
 ### HIGH: Auth check in component instead of beforeLoad
 

--- a/packages/start-client-core/skills/start-core/auth-server-primitives/SKILL.md
+++ b/packages/start-client-core/skills/start-core/auth-server-primitives/SKILL.md
@@ -24,9 +24,20 @@ sources:
 
 This skill covers the **server half** of authentication: session storage, cookie issuance, OAuth flow, password-reset hardening, CSRF, rate limiting. For the **routing half** (`_authenticated` layout, `beforeLoad` redirects, RBAC checks), see [router-core/auth-and-guards](../../../../router-core/skills/router-core/auth-and-guards/SKILL.md).
 
-> **CRITICAL**: A route guard does NOT protect a `createServerFn` on that route. Server functions are RPC endpoints reachable by direct POST regardless of which route renders them. Auth must be enforced **inside the handler** (or via middleware), not on the calling route.
+> **CRITICAL**: Protect the data/API boundary first. Server functions, server routes, and other API endpoints that touch private data must enforce auth **inside the handler** or middleware. Route guards are route UX, not the data security boundary.
 > **CRITICAL**: Validating the _shape_ of a client-supplied identifier (`z.string().uuid().parse(...)`) is not authorization. A parsed UUID is still _some_ tenant — re-check membership against the session principal before using it.
 > **CRITICAL**: Read session/cookies inside `.handler()` or middleware `.server()`, not at module scope. Module-level reads run before requests exist (and are also undefined on Cloudflare Workers).
+
+## Production Checklist
+
+- Enforce auth in every server function, server route, or API endpoint that reads or writes private user, tenant, or account data. Use route `beforeLoad` for page UX, not as the data boundary.
+- Use `.inputValidator()` on every server function that accepts input.
+- Store sessions in `HttpOnly`, `Secure`, `SameSite` cookies. Do not store session tokens in `localStorage` or `sessionStorage`.
+- Hash passwords with bcrypt, scrypt, or Argon2. For missing users, verify against a dummy hash and return the same login/reset message.
+- Rate limit login, registration, and password-reset endpoints.
+- Use CSRF or same-origin protections for non-GET server functions and server routes.
+- Log authentication events and monitor failures.
+- Test direct unauthenticated calls to protected server functions; they should reject before returning data.
 
 ## Session Cookies
 
@@ -117,7 +128,7 @@ export const getMyOrders = createServerFn({ method: 'GET' })
   })
 ```
 
-> **Route guards do not cover this.** A `createFileRoute('/_authenticated/orders')` with a `beforeLoad` redirect does NOT protect `getMyOrders` — the RPC is reachable via direct POST whether or not the user ever hits the route. Apply `authMiddleware` (or re-check inside `.handler()`) on every server function that needs auth.
+> **Route guards do not cover this.** A `createFileRoute('/_authenticated/orders')` with a `beforeLoad` redirect does NOT protect `getMyOrders` — the RPC is reachable directly whether or not the user ever hits the route. Apply `authMiddleware` (or re-check inside `.handler()`) on every server function that needs auth.
 
 ## Issuing a Session on Login
 

--- a/packages/start-client-core/skills/start-core/middleware/SKILL.md
+++ b/packages/start-client-core/skills/start-core/middleware/SKILL.md
@@ -243,7 +243,7 @@ const authMiddleware = createMiddleware().server(async ({ next, request }) => {
 })
 ```
 
-> **Attach `authMiddleware` to every `createServerFn` that needs auth.** Server functions are RPC endpoints — a route `beforeLoad` does NOT protect the RPC, only the route's UI. Pair every protected route with handler-level enforcement here. See [router-core/auth-and-guards](../../../../router-core/skills/router-core/auth-and-guards/SKILL.md) and [start-core/auth-server-primitives](../auth-server-primitives/SKILL.md).
+> **Attach `authMiddleware` to every `createServerFn` that needs auth.** Server functions are API endpoints; a route `beforeLoad` does not protect their data, only the route's UI. Protect the endpoint that reads or mutates private data. See [router-core/auth-and-guards](../../../../router-core/skills/router-core/auth-and-guards/SKILL.md) and [start-core/auth-server-primitives](../auth-server-primitives/SKILL.md).
 
 ```tsx
 type Permissions = Record<string, string[]>
@@ -395,4 +395,4 @@ createMiddleware({ type: 'function' })
 - [start-core/server-functions](../server-functions/SKILL.md) — what middleware wraps
 - [start-core/server-routes](../server-routes/SKILL.md) — middleware on API endpoints
 - [start-core/auth-server-primitives](../auth-server-primitives/SKILL.md) — building the `authMiddleware` factory itself: session cookie reads, OAuth state, CSRF
-- [router-core/auth-and-guards](../../../../router-core/skills/router-core/auth-and-guards/SKILL.md) — routing-side guards (route `beforeLoad` does NOT protect server functions; pair guards with `authMiddleware` on every protected RPC)
+- [router-core/auth-and-guards](../../../../router-core/skills/router-core/auth-and-guards/SKILL.md) — routing-side UX guards; data auth belongs in the server function, server route, or API endpoint handler/middleware

--- a/packages/start-client-core/skills/start-core/server-functions/SKILL.md
+++ b/packages/start-client-core/skills/start-core/server-functions/SKILL.md
@@ -19,7 +19,7 @@ sources:
 
 Server functions are type-safe RPCs created with `createServerFn`. They run exclusively on the server but can be called from anywhere — loaders, components, hooks, event handlers, or other server functions.
 
-> **CRITICAL**: Server functions are RPC endpoints. They are reachable by direct POST regardless of which route renders the calling UI. **Auth must be enforced inside the handler (or via middleware) — a route `beforeLoad` does NOT protect the RPC.** See [start-core/auth-server-primitives](../auth-server-primitives/SKILL.md) for the session/middleware pattern.
+> **CRITICAL**: Server functions are API endpoints. They are reachable independently of whichever route renders the calling UI. **Auth must be enforced inside the handler (or via middleware) for any server function that touches private data.** Route `beforeLoad` is UX, not the data boundary. See [start-core/auth-server-primitives](../auth-server-primitives/SKILL.md) for the session/middleware pattern.
 > **CRITICAL**: Loaders are ISOMORPHIC — they run on BOTH client and server. Database queries, file system access, and secret API keys MUST go inside `createServerFn`, NOT in loaders directly.
 > **CRITICAL**: Do not use `"use server"` directives, `getServerSideProps`, or any Next.js/Remix server patterns. TanStack Start uses `createServerFn` exclusively.
 
@@ -270,7 +270,7 @@ Static imports of server functions are safe — the build replaces implementatio
 
 ### 1. CRITICAL: Relying on a route guard to protect a server function
 
-A `beforeLoad` redirect protects the **route's UI**, not the **RPC**. `createServerFn` exposes a callable endpoint that an attacker can hit directly — no need to load the route at all. Auth on the route is necessary but not sufficient.
+A `beforeLoad` redirect protects the **route's UI**, not the **data endpoint**. `createServerFn` exposes a callable endpoint that an attacker can hit directly — no need to load the route at all. Auth on the endpoint is the security boundary; auth on the route is UX.
 
 ```tsx
 // WRONG — the route guard doesn't reach the handler
@@ -430,4 +430,4 @@ If in doubt: wrap with `useServerFn`. It's a no-op for plain-data functions and 
 - [start-core/execution-model](../execution-model/SKILL.md) — understanding where code runs
 - [start-core/middleware](../middleware/SKILL.md) — composing server functions with middleware
 - [start-core/auth-server-primitives](../auth-server-primitives/SKILL.md) — sessions, cookies, OAuth, CSRF, rate limiting (the server-side half of auth; `getCurrentUser`/`useSession`-style helpers belong here, not at module scope)
-- [router-core/auth-and-guards](../../../../router-core/skills/router-core/auth-and-guards/SKILL.md) — the routing side: route guards do NOT protect server functions, so always re-check auth in the handler or via middleware
+- [router-core/auth-and-guards](../../../../router-core/skills/router-core/auth-and-guards/SKILL.md) — routing-side UX guards; data auth belongs in the server function, server route, or API endpoint handler/middleware


### PR DESCRIPTION
## Summary
- Clarify that private data must be protected at server functions, server routes, or API endpoints
- Reframe route guards as UX/navigation control rather than the data security boundary
- Add Start auth server primitives to the Solid docs nav via a ref page

## Validation
- Parsed docs/start/config.json
- Ran git diff --check

Note: Prettier could not run locally because pnpm attempted to install missing workspace dependencies and registry DNS was unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that route guards serve user experience purposes, not security boundaries.
  * Emphasized that server functions and API endpoints must enforce authorization independently.
  * Added production authentication checklist covering HTTPS, secure cookies, input validation, password hashing, rate limiting, and CSRF protection.
  * Created new authentication server primitives guide.
  * Updated authentication guidance across React and Solid frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->