### PR TITLE
fix(examples): make isRoot check work

### DIFF
--- a/e2e/react-start/basic-auth/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/react-start/basic-auth/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/react-router'
 import type { ErrorComponentProps } from '@tanstack/react-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/e2e/react-start/basic-cloudflare/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/react-start/basic-cloudflare/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/react-router'
 import type { ErrorComponentProps } from '@tanstack/react-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/e2e/react-start/basic-react-query/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/react-start/basic-react-query/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/react-router'
 import type { ErrorComponentProps } from '@tanstack/react-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/e2e/react-start/basic/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/react-start/basic/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/react-router'
 import type { ErrorComponentProps } from '@tanstack/react-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/e2e/react-start/clerk-basic/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/react-start/clerk-basic/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/react-router'
 import type { ErrorComponentProps } from '@tanstack/react-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/e2e/react-start/custom-basepath/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/react-start/custom-basepath/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/react-router'
 import type { ErrorComponentProps } from '@tanstack/react-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/e2e/react-start/scroll-restoration/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/react-start/scroll-restoration/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/react-router'
 import type { ErrorComponentProps } from '@tanstack/react-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/e2e/react-start/server-functions/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/react-start/server-functions/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/react-router'
 import type { ErrorComponentProps } from '@tanstack/react-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/e2e/react-start/server-routes/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/react-start/server-routes/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/react-router'
 import type { ErrorComponentProps } from '@tanstack/react-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/e2e/react-start/website/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/react-start/website/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/react-router'
 import type { ErrorComponentProps } from '@tanstack/react-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/e2e/solid-start/basic-auth/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/solid-start/basic-auth/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/solid-router'
 import type { ErrorComponentProps } from '@tanstack/solid-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/e2e/solid-start/basic-cloudflare/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/solid-start/basic-cloudflare/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/solid-router'
 import type { ErrorComponentProps } from '@tanstack/solid-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/e2e/solid-start/basic/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/solid-start/basic/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/solid-router'
 import type { ErrorComponentProps } from '@tanstack/solid-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/e2e/solid-start/custom-basepath/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/solid-start/custom-basepath/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/solid-router'
 import type { ErrorComponentProps } from '@tanstack/solid-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/e2e/solid-start/scroll-restoration/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/solid-start/scroll-restoration/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/solid-router'
 import type { ErrorComponentProps } from '@tanstack/solid-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/e2e/solid-start/server-functions/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/solid-start/server-functions/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/solid-router'
 import type { ErrorComponentProps } from '@tanstack/solid-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/e2e/solid-start/server-routes/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/solid-start/server-routes/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/solid-router'
 import type { ErrorComponentProps } from '@tanstack/solid-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/e2e/solid-start/website/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/solid-start/website/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/solid-router'
 import type { ErrorComponentProps } from '@tanstack/solid-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/e2e/vue-start/basic-auth/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/vue-start/basic-auth/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/vue-router'
 import type { ErrorComponentProps } from '@tanstack/vue-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/e2e/vue-start/basic-cloudflare/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/vue-start/basic-cloudflare/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/vue-router'
 import type { ErrorComponentProps } from '@tanstack/vue-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/e2e/vue-start/basic/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/vue-start/basic/src/components/DefaultCatchBoundary.tsx
@@ -1,11 +1,9 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/vue-router'
-import type { ErrorComponentProps } from '@tanstack/vue-router'
 import { defineComponent } from 'vue'
 
 export const DefaultCatchBoundary = defineComponent({
@@ -17,9 +15,8 @@ export const DefaultCatchBoundary = defineComponent({
   },
   setup(props) {
     const router = useRouter()
-    const isRoot = useMatch({
-      strict: false,
-      select: (state) => state.id === rootRouteId,
+    const isRoot = useLocation({
+      select: (location) => location.pathname === '/',
     })
 
     console.error(props.error)

--- a/e2e/vue-start/custom-basepath/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/vue-start/custom-basepath/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/vue-router'
 import type { ErrorComponentProps } from '@tanstack/vue-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/e2e/vue-start/scroll-restoration/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/vue-start/scroll-restoration/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/vue-router'
 import type { ErrorComponentProps } from '@tanstack/vue-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/e2e/vue-start/server-functions/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/vue-start/server-functions/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/vue-router'
 import type { ErrorComponentProps } from '@tanstack/vue-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/e2e/vue-start/server-routes/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/vue-start/server-routes/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/vue-router'
 import type { ErrorComponentProps } from '@tanstack/vue-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/e2e/vue-start/website/src/components/DefaultCatchBoundary.tsx
+++ b/e2e/vue-start/website/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/vue-router'
 import type { ErrorComponentProps } from '@tanstack/vue-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/examples/react/start-basic-auth/src/components/DefaultCatchBoundary.tsx
+++ b/examples/react/start-basic-auth/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/react-router'
 import type { ErrorComponentProps } from '@tanstack/react-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/examples/react/start-basic-authjs/src/components/DefaultCatchBoundary.tsx
+++ b/examples/react/start-basic-authjs/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/react-router'
 import type { ErrorComponentProps } from '@tanstack/react-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error('DefaultCatchBoundary Error:', error)

--- a/examples/react/start-basic-cloudflare/src/components/DefaultCatchBoundary.tsx
+++ b/examples/react/start-basic-cloudflare/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/react-router'
 import type { ErrorComponentProps } from '@tanstack/react-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error('DefaultCatchBoundary Error:', error)

--- a/examples/react/start-basic-react-query/src/components/DefaultCatchBoundary.tsx
+++ b/examples/react/start-basic-react-query/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/react-router'
 import type { ErrorComponentProps } from '@tanstack/react-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/examples/react/start-basic-static/src/components/DefaultCatchBoundary.tsx
+++ b/examples/react/start-basic-static/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/react-router'
 import type { ErrorComponentProps } from '@tanstack/react-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error('DefaultCatchBoundary Error:', error)

--- a/examples/react/start-basic/src/components/DefaultCatchBoundary.tsx
+++ b/examples/react/start-basic/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/react-router'
 import type { ErrorComponentProps } from '@tanstack/react-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error('DefaultCatchBoundary Error:', error)

--- a/examples/react/start-clerk-basic/src/components/DefaultCatchBoundary.tsx
+++ b/examples/react/start-clerk-basic/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/react-router'
 import type { ErrorComponentProps } from '@tanstack/react-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/examples/react/start-convex-trellaux/src/components/DefaultCatchBoundary.tsx
+++ b/examples/react/start-convex-trellaux/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/react-router'
 import type { ErrorComponentProps } from '@tanstack/react-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/examples/react/start-supabase-basic/src/components/DefaultCatchBoundary.tsx
+++ b/examples/react/start-supabase-basic/src/components/DefaultCatchBoundary.tsx
@@ -1,18 +1,15 @@
-import * as React from 'react'
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/react-router'
 import type { ErrorComponentProps } from '@tanstack/react-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/examples/react/start-trellaux/src/components/DefaultCatchBoundary.tsx
+++ b/examples/react/start-trellaux/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/react-router'
 import type { ErrorComponentProps } from '@tanstack/react-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error('DefaultCatchBoundary Error:', error)

--- a/examples/solid/start-basic-auth/src/components/DefaultCatchBoundary.tsx
+++ b/examples/solid/start-basic-auth/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/solid-router'
 import type { ErrorComponentProps } from '@tanstack/solid-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/examples/solid/start-basic-authjs/src/components/DefaultCatchBoundary.tsx
+++ b/examples/solid/start-basic-authjs/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/solid-router'
 import type { ErrorComponentProps } from '@tanstack/solid-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error('DefaultCatchBoundary Error:', error)

--- a/examples/solid/start-basic-cloudflare/src/components/DefaultCatchBoundary.tsx
+++ b/examples/solid/start-basic-cloudflare/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/solid-router'
 import type { ErrorComponentProps } from '@tanstack/solid-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error('DefaultCatchBoundary Error:', error)

--- a/examples/solid/start-basic-netlify/src/components/DefaultCatchBoundary.tsx
+++ b/examples/solid/start-basic-netlify/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/solid-router'
 import type { ErrorComponentProps } from '@tanstack/solid-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error('DefaultCatchBoundary Error:', error)

--- a/examples/solid/start-basic-nitro/src/components/DefaultCatchBoundary.tsx
+++ b/examples/solid/start-basic-nitro/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/solid-router'
 import type { ErrorComponentProps } from '@tanstack/solid-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error('DefaultCatchBoundary Error:', error)

--- a/examples/solid/start-basic-solid-query/src/components/DefaultCatchBoundary.tsx
+++ b/examples/solid/start-basic-solid-query/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/solid-router'
 import type { ErrorComponentProps } from '@tanstack/solid-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)

--- a/examples/solid/start-basic-static/src/components/DefaultCatchBoundary.tsx
+++ b/examples/solid/start-basic-static/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/solid-router'
 import type { ErrorComponentProps } from '@tanstack/solid-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error('DefaultCatchBoundary Error:', error)

--- a/examples/solid/start-basic/src/components/DefaultCatchBoundary.tsx
+++ b/examples/solid/start-basic/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/solid-router'
 import type { ErrorComponentProps } from '@tanstack/solid-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error('DefaultCatchBoundary Error:', error)

--- a/examples/solid/start-supabase-basic/src/components/DefaultCatchBoundary.tsx
+++ b/examples/solid/start-supabase-basic/src/components/DefaultCatchBoundary.tsx
@@ -1,17 +1,15 @@
 import {
   ErrorComponent,
   Link,
-  rootRouteId,
-  useMatch,
+  useLocation,
   useRouter,
 } from '@tanstack/solid-router'
 import type { ErrorComponentProps } from '@tanstack/solid-router'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
-  const isRoot = useMatch({
-    strict: false,
-    select: (state) => state.id === rootRouteId,
+  const isRoot = useLocation({
+    select: (location) => location.pathname === '/',
   })
 
   console.error(error)


### PR DESCRIPTION
Closes #7536

Before:
```tsx
const isRoot = useMatch({
  strict: false,
  select: (state) => state.id === rootRouteId,
})
```

After:
```tsx
const isRoot = useLocation({
  select: (location) => location.pathname === '/',
})
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated error boundary components to use a simplified approach for detecting the root route. No user-facing functionality changes; error handling and navigation behavior remain consistent across all implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->