### PR TITLE
fix(router-core): retain search over validation defaults

### DIFF
--- a/.changeset/retain-search-validation-defaults.md
+++ b/.changeset/retain-search-validation-defaults.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+Fix `retainSearchParams` preserving current search params when validation adds default search values during navigation.

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -3120,16 +3120,17 @@ function applySearchMiddleware({
 }
 
 function buildMiddlewareChain(destRoutes: ReadonlyArray<AnyRoute>) {
-  const context = {
-    dest: null as unknown as BuildNextOptions,
-    _includeValidateSearch: false,
-    middlewares: [] as Array<SearchMiddleware<any>>,
-  }
+  let dest: BuildNextOptions
+  let includeValidateSearch: boolean | undefined
+  const middlewares = [] as Array<SearchMiddleware<any>>
+  // Flat pairs: [searchBeforeValidation, validatedSearch, ...]
+  type ValidatedSearches = Array<Record<PropertyKey, unknown>>
 
   for (const route of destRoutes) {
     if ('search' in route.options) {
-      if (route.options.search?.middlewares) {
-        context.middlewares.push(...route.options.search.middlewares)
+      const routeMiddlewares = route.options.search?.middlewares
+      if (routeMiddlewares) {
+        middlewares.push(...routeMiddlewares)
       }
     }
     // TODO remove preSearchFilters and postSearchFilters in v2
@@ -3164,71 +3165,78 @@ function buildMiddlewareChain(destRoutes: ReadonlyArray<AnyRoute>) {
 
         return result
       }
-      context.middlewares.push(legacyMiddleware)
+      middlewares.push(legacyMiddleware)
     }
 
     if (route.options.validateSearch) {
-      const validate: SearchMiddleware<any> = ({ search, next }) => {
+      const validate: SearchMiddleware<any> = (
+        { search, next },
+        validations?: ValidatedSearches,
+      ) => {
         const result = next(search)
-        if (!context._includeValidateSearch) return result
+        if (!includeValidateSearch) return result
         try {
-          const validatedSearch = {
-            ...result,
-            ...(validateSearch(route.options.validateSearch, result) ??
-              undefined),
+          const validated = validateSearch(
+            route.options.validateSearch,
+            result,
+          ) as any
+
+          if (validations && validated) {
+            validations.push(result, validated)
           }
-          return validatedSearch
+          return { ...result, ...validated }
         } catch {
           // ignore errors here because they are already handled in matchRoutes
           return result
         }
       }
 
-      context.middlewares.push(validate)
+      middlewares.push(validate)
     }
   }
-
-  // the chain ends here since `next` is not called
-  const final: SearchMiddleware<any> = ({ search }) => {
-    const dest = context.dest
-    if (!dest.search) {
-      return {}
-    }
-    if (dest.search === true) {
-      return search
-    }
-    return functionalUpdate(dest.search, search)
-  }
-
-  context.middlewares.push(final)
 
   const applyNext = (
     index: number,
     currentSearch: any,
-    middlewares: Array<SearchMiddleware<any>>,
+    validations?: ValidatedSearches,
   ): any => {
     // no more middlewares left, return the current search
     if (index >= middlewares.length) {
-      return currentSearch
+      if (!dest.search) {
+        return {}
+      }
+      if (dest.search === true) {
+        return currentSearch
+      }
+      return functionalUpdate(dest.search, currentSearch)
     }
 
     const middleware = middlewares[index]!
 
-    const next = (newSearch: any): any => {
-      return applyNext(index + 1, newSearch, middlewares)
+    const next = (newSearch: any, collectValidations?: true): any => {
+      if (collectValidations) {
+        const nextValidations: ValidatedSearches = []
+        const nextSearch = applyNext(index + 1, newSearch, nextValidations)
+        return [nextSearch, nextValidations]
+      }
+      return applyNext(index + 1, newSearch, validations)
     }
 
-    return middleware({ search: currentSearch, next })
+    const result = (middleware as any)(
+      { search: currentSearch, next },
+      validations,
+    )
+    return result
   }
 
   return function middleware(
     search: any,
-    dest: BuildNextOptions,
+    nextDest: BuildNextOptions,
     _includeValidateSearch: boolean,
   ) {
-    context.dest = dest
-    context._includeValidateSearch = _includeValidateSearch
-    return applyNext(0, search, context.middlewares)
+    dest = nextDest
+    includeValidateSearch = _includeValidateSearch
+    return applyNext(0, search)
   }
 }
 

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -3127,68 +3127,54 @@ function buildMiddlewareChain(destRoutes: ReadonlyArray<AnyRoute>) {
   type ValidatedSearches = Array<Record<PropertyKey, unknown>>
 
   for (const route of destRoutes) {
-    if ('search' in route.options) {
-      const routeMiddlewares = route.options.search?.middlewares
-      if (routeMiddlewares) {
-        middlewares.push(...routeMiddlewares)
+    const routeOptions = route.options
+    if ('search' in routeOptions) {
+      if (routeOptions.search?.middlewares) {
+        middlewares.push(...routeOptions.search.middlewares)
       }
     }
     // TODO remove preSearchFilters and postSearchFilters in v2
-    else if (
-      route.options.preSearchFilters ||
-      route.options.postSearchFilters
-    ) {
+    else if (routeOptions.preSearchFilters || routeOptions.postSearchFilters) {
       const legacyMiddleware: SearchMiddleware<any> = ({ search, next }) => {
-        let nextSearch = search
-
-        if (
-          'preSearchFilters' in route.options &&
-          route.options.preSearchFilters
-        ) {
-          nextSearch = route.options.preSearchFilters.reduce(
-            (prev, next) => next(prev),
-            search,
-          )
-        }
+        const nextSearch = routeOptions.preSearchFilters
+          ? routeOptions.preSearchFilters.reduce(
+              (prev, next) => next(prev),
+              search,
+            )
+          : search
 
         const result = next(nextSearch)
 
-        if (
-          'postSearchFilters' in route.options &&
-          route.options.postSearchFilters
-        ) {
-          return route.options.postSearchFilters.reduce(
-            (prev, next) => next(prev),
-            result,
-          )
-        }
-
-        return result
+        return routeOptions.postSearchFilters
+          ? routeOptions.postSearchFilters.reduce(
+              (prev, next) => next(prev),
+              result,
+            )
+          : result
       }
       middlewares.push(legacyMiddleware)
     }
 
-    if (route.options.validateSearch) {
+    const routeValidateSearch = routeOptions.validateSearch
+    if (routeValidateSearch) {
       const validate: SearchMiddleware<any> = (
         { search, next },
         validations?: ValidatedSearches,
       ) => {
         const result = next(search)
-        if (!includeValidateSearch) return result
-        try {
-          const validated = validateSearch(
-            route.options.validateSearch,
-            result,
-          ) as any
+        if (includeValidateSearch) {
+          try {
+            const validated = validateSearch(routeValidateSearch, result) as any
 
-          if (validations && validated) {
-            validations.push(result, validated)
+            if (validations && validated) {
+              validations.push(result, validated)
+            }
+            return { ...result, ...validated }
+          } catch {
+            // ignore errors here because they are already handled in matchRoutes
           }
-          return { ...result, ...validated }
-        } catch {
-          // ignore errors here because they are already handled in matchRoutes
-          return result
         }
+        return result
       }
 
       middlewares.push(validate)
@@ -3211,22 +3197,21 @@ function buildMiddlewareChain(destRoutes: ReadonlyArray<AnyRoute>) {
       return functionalUpdate(dest.search, currentSearch)
     }
 
-    const middleware = middlewares[index]!
-
     const next = (newSearch: any, collectValidations?: true): any => {
       if (collectValidations) {
         const nextValidations: ValidatedSearches = []
-        const nextSearch = applyNext(index + 1, newSearch, nextValidations)
-        return [nextSearch, nextValidations]
+        return [
+          applyNext(index + 1, newSearch, nextValidations),
+          nextValidations,
+        ]
       }
       return applyNext(index + 1, newSearch, validations)
     }
 
-    const result = (middleware as any)(
+    return (middlewares[index]! as any)(
       { search: currentSearch, next },
       validations,
     )
-    return result
   }
 
   return function middleware(

--- a/packages/router-core/src/searchMiddleware.ts
+++ b/packages/router-core/src/searchMiddleware.ts
@@ -1,4 +1,4 @@
-import { deepEqual } from './utils'
+import { createNull, deepEqual } from './utils'
 import type { NoInfer, PickOptional } from './utils'
 import type { SearchMiddleware } from './route'
 import type { IsRequiredParams } from './link'
@@ -17,19 +17,56 @@ export function retainSearchParams<TSearchSchema extends object>(
   keys: Array<keyof TSearchSchema> | true,
 ): SearchMiddleware<TSearchSchema> {
   return ({ search, next }) => {
-    const result = next(search)
+    const [resultSearch, validations] = (next as any)(search, true) as [
+      TSearchSchema,
+      Array<Record<PropertyKey, unknown>>,
+    ]
+    const defaultKeys = validations.length
+      ? getValidationDefaultKeys(search, resultSearch, validations)
+      : undefined
+
     if (keys === true) {
-      return { ...search, ...result }
+      const copy = { ...search, ...resultSearch }
+      if (defaultKeys) {
+        for (const key in defaultKeys) {
+          copy[key as keyof TSearchSchema] = search[key as keyof TSearchSchema]
+        }
+      }
+      return copy
     }
-    const copy = { ...result }
+
+    const copy = { ...resultSearch }
     // add missing keys from search to copy
-    keys.forEach((key) => {
-      if (!(key in copy)) {
+    for (const key of keys) {
+      if (!(key in copy) || (defaultKeys ? key in defaultKeys : false)) {
         copy[key] = search[key]
       }
-    })
+    }
     return copy
   }
+}
+
+function getValidationDefaultKeys(
+  search: any,
+  resultSearch: any,
+  validations: Array<Record<PropertyKey, unknown>>,
+) {
+  let defaultKeys: Record<PropertyKey, true> | undefined
+  for (let i = 0; i < validations.length; i += 2) {
+    const baseSearch = validations[i]!
+    const validatedSearch = validations[i + 1]!
+    for (const key in validatedSearch) {
+      if (
+        key in search &&
+        !(key in baseSearch) &&
+        resultSearch[key] === validatedSearch[key]
+      ) {
+        const target = defaultKeys || (defaultKeys = createNull())
+        target[key] = true
+      }
+    }
+  }
+  return defaultKeys
 }
 
 /**

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -222,7 +222,7 @@ export function hasKeys(obj: Record<string, unknown>) {
   return false
 }
 
-const createNull = () => Object.create(null)
+export const createNull = () => Object.create(null)
 export const nullReplaceEqualDeep: typeof replaceEqualDeep = (prev, next) =>
   replaceEqualDeep(prev, next, createNull)
 

--- a/packages/router-core/tests/build-location.test.ts
+++ b/packages/router-core/tests/build-location.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from 'vitest'
 import { createMemoryHistory } from '@tanstack/history'
-import { BaseRootRoute, BaseRoute } from '../src'
+import { BaseRootRoute, BaseRoute, retainSearchParams } from '../src'
 import { createTestRouter } from './routerTestUtils'
 
 describe('buildLocation - params function receives parsed params', () => {
@@ -213,6 +213,173 @@ describe('buildLocation - params function receives parsed params', () => {
 })
 
 describe('buildLocation - search params', () => {
+  test('retainSearchParams should preserve current search over defaults during navigation', async () => {
+    const rootRoute = new BaseRootRoute({
+      validateSearch: (search: Record<string, unknown>) => ({
+        Auth: search.Auth === undefined ? 'true' : `${search.Auth}`,
+      }),
+      search: {
+        middlewares: [retainSearchParams(['Auth'])],
+      },
+    })
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const aboutRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/about',
+    })
+
+    const routeTree = rootRoute.addChildren([indexRoute, aboutRoute])
+
+    const router = createTestRouter({
+      routeTree,
+      history: createMemoryHistory({ initialEntries: ['/about?Auth=false'] }),
+    })
+
+    await router.load()
+
+    const location = router.buildLocation({
+      to: '/',
+      _includeValidateSearch: true,
+    } as any)
+
+    expect(location.search).toEqual({ Auth: 'false' })
+  })
+
+  test('retainSearchParams should keep downstream values added after validation', async () => {
+    const rootRoute = new BaseRootRoute({
+      validateSearch: (search: Record<string, unknown>) => ({
+        Auth: search.Auth === undefined ? 'default' : `${search.Auth}`,
+      }),
+      search: {
+        middlewares: [
+          retainSearchParams(['Auth']),
+          ({ search, next }) => ({ ...next(search), Auth: 'explicit' }),
+        ],
+      },
+    })
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+
+    const routeTree = rootRoute.addChildren([indexRoute])
+
+    const router = createTestRouter({
+      routeTree,
+      history: createMemoryHistory({ initialEntries: ['/?Auth=current'] }),
+    })
+
+    await router.load()
+
+    const location = router.buildLocation({
+      to: '/',
+      _includeValidateSearch: true,
+    } as any)
+
+    expect(location.search).toEqual({ Auth: 'explicit' })
+  })
+
+  test('retainSearchParams(true) should preserve nested current search over defaults during navigation', async () => {
+    const rootRoute = new BaseRootRoute({
+      validateSearch: (search: Record<string, unknown>) => ({
+        filter: Array.isArray(search.filter) ? search.filter : ['default'],
+        filterOrder:
+          typeof search.filterOrder === 'object' && search.filterOrder
+            ? search.filterOrder
+            : {},
+        anotherFilterOrder: Array.isArray(search.anotherFilterOrder)
+          ? search.anotherFilterOrder
+          : [],
+      }),
+      search: {
+        middlewares: [retainSearchParams(true)],
+      },
+    })
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+
+    const routeTree = rootRoute.addChildren([indexRoute])
+
+    const router = createTestRouter({
+      routeTree,
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+
+    const currentLocation = router.buildLocation({
+      to: '/',
+      search: { filterOrder: { filter1: [1], filter2: [0] } },
+      _includeValidateSearch: true,
+    } as any)
+
+    const location = router.buildLocation({
+      to: '/',
+      _fromLocation: currentLocation,
+      _includeValidateSearch: true,
+    } as any)
+
+    expect(location.search).toEqual({
+      filter: ['default'],
+      filterOrder: { filter1: [1], filter2: [0] },
+      anotherFilterOrder: [],
+    })
+  })
+
+  test('retainSearchParams should preserve root search during navigation', async () => {
+    const rootRoute = new BaseRootRoute({
+      validateSearch: (search: Record<string, unknown>) => ({
+        rootValue: search.rootValue as string | undefined,
+      }),
+      search: {
+        middlewares: [retainSearchParams(['rootValue'])],
+      },
+    })
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const settingsRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/settings',
+    })
+    const aboutRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/about',
+      validateSearch: (search: Record<string, unknown>) => ({
+        param1: search.param1 as string | undefined,
+      }),
+    })
+
+    const routeTree = rootRoute.addChildren([
+      indexRoute,
+      settingsRoute,
+      aboutRoute,
+    ])
+
+    const router = createTestRouter({
+      routeTree,
+      history: createMemoryHistory({
+        initialEntries: ['/settings?rootValue=value'],
+      }),
+    })
+
+    await router.load()
+
+    const linkLocation = router.buildLocation({ to: '/about' })
+    expect(linkLocation.search).toEqual({ rootValue: 'value' })
+
+    await router.navigate({ to: '/about' })
+
+    expect(router.latestLocation.pathname).toBe('/about')
+    expect(router.latestLocation.search).toEqual({ rootValue: 'value' })
+  })
+
   test('search as object should set search params', async () => {
     const rootRoute = new BaseRootRoute({})
     const postsRoute = new BaseRoute({

--- a/packages/router-core/tests/searchMiddleware.test.ts
+++ b/packages/router-core/tests/searchMiddleware.test.ts
@@ -13,7 +13,7 @@ describe('searchMiddleware - mutation prevention', () => {
       // so retainSearchParams should add them from search
       const result = middleware({
         search: originalSearch,
-        next: () => ({ page: 'new' }) as any,
+        next: () => [{ page: 'new' }, []] as any,
       })
 
       expect(originalSearch).toEqual(originalCopy)
@@ -29,7 +29,7 @@ describe('searchMiddleware - mutation prevention', () => {
       // next() returns object without 'id' and 'filter' keys
       const result1 = middleware({
         search: sharedSearch,
-        next: () => ({ page: '2' }) as any,
+        next: () => [{ page: '2' }, []] as any,
       })
 
       expect(sharedSearch).toEqual({ id: '1', filter: 'active', page: '1' })
@@ -37,7 +37,7 @@ describe('searchMiddleware - mutation prevention', () => {
 
       const result2 = middleware({
         search: sharedSearch,
-        next: () => ({ page: '3' }) as any,
+        next: () => [{ page: '3' }, []] as any,
       })
 
       expect(sharedSearch).toEqual({ id: '1', filter: 'active', page: '1' })
@@ -52,7 +52,7 @@ describe('searchMiddleware - mutation prevention', () => {
 
       const result = middleware({
         search: originalSearch,
-        next: () => ({ id: '2' }) as any,
+        next: () => [{ id: '2' }, []] as any,
       })
 
       expect(originalSearch).toEqual(originalCopy)


### PR DESCRIPTION
fixes #2830
fixes #2845

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed retainSearchParams so current search values are preserved when route validation injects default search values during navigation.
* **Tests**
  * Updated and expanded tests to cover retainSearchParams behavior across navigation and validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->