### PR TITLE
fix(router-core): respect stripped params in retainSearchParams

### DIFF
--- a/.changeset/fuzzy-pandas-sip.md
+++ b/.changeset/fuzzy-pandas-sip.md
@@ -1,0 +1,8 @@
+---
+'@tanstack/router-core': patch
+'@tanstack/react-router': patch
+'@tanstack/solid-router': patch
+'@tanstack/vue-router': patch
+---
+
+Fix search middleware composition so `retainSearchParams` does not restore search params that a downstream `stripSearchParams` removed.

--- a/benchmarks/bundle-size/scenarios/react-router-full/src/routes/index.tsx
+++ b/benchmarks/bundle-size/scenarios/react-router-full/src/routes/index.tsx
@@ -1,6 +1,18 @@
-import { createFileRoute } from '@tanstack/react-router'
+import {
+  createFileRoute,
+  retainSearchParams,
+  stripSearchParams,
+} from '@tanstack/react-router'
+
+const defaultSearch = { page: 1 }
 
 export const Route = createFileRoute('/')({
+  search: {
+    middlewares: [
+      retainSearchParams<Record<string, unknown>>(['persist']),
+      stripSearchParams(defaultSearch),
+    ],
+  },
   component: IndexComponent,
 })
 

--- a/benchmarks/bundle-size/scenarios/solid-router-full/src/routes/index.tsx
+++ b/benchmarks/bundle-size/scenarios/solid-router-full/src/routes/index.tsx
@@ -1,6 +1,18 @@
-import { createFileRoute } from '@tanstack/solid-router'
+import {
+  createFileRoute,
+  retainSearchParams,
+  stripSearchParams,
+} from '@tanstack/solid-router'
+
+const defaultSearch = { page: 1 }
 
 export const Route = createFileRoute('/')({
+  search: {
+    middlewares: [
+      retainSearchParams<Record<string, unknown>>(['persist']),
+      stripSearchParams(defaultSearch),
+    ],
+  },
   component: IndexComponent,
 })
 

--- a/benchmarks/bundle-size/scenarios/vue-router-full/src/routes/index.tsx
+++ b/benchmarks/bundle-size/scenarios/vue-router-full/src/routes/index.tsx
@@ -1,6 +1,18 @@
-import { createFileRoute } from '@tanstack/vue-router'
+import {
+  createFileRoute,
+  retainSearchParams,
+  stripSearchParams,
+} from '@tanstack/vue-router'
+
+const defaultSearch = { page: 1 }
 
 export const Route = createFileRoute('/')({
+  search: {
+    middlewares: [
+      retainSearchParams<Record<string, unknown>>(['persist']),
+      stripSearchParams(defaultSearch),
+    ],
+  },
   component: IndexComponent,
 })
 

--- a/packages/router-core/src/route.ts
+++ b/packages/router-core/src/route.ts
@@ -74,9 +74,16 @@ export type RoutePathOptionsIntersection<TCustomId, TPath> = {
 
 export type SearchFilter<TInput, TResult = TInput> = (prev: TInput) => TResult
 
+export type SearchMiddlewareMeta = {
+  removed?: Map<string, unknown>
+  removedAny?: Set<string>
+  defaulted?: Map<string, unknown>
+}
+
 export type SearchMiddlewareContext<TSearchSchema> = {
   search: TSearchSchema
   next: (newSearch: TSearchSchema) => TSearchSchema
+  meta?: SearchMiddlewareMeta
 }
 
 export type SearchMiddleware<TSearchSchema> = (

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -79,6 +79,7 @@ import type {
   RouteLike,
   RouteMask,
   SearchMiddleware,
+  SearchMiddlewareMeta,
 } from './route'
 import type {
   FullSearchSchema,
@@ -3123,8 +3124,6 @@ function buildMiddlewareChain(destRoutes: ReadonlyArray<AnyRoute>) {
   let dest: BuildNextOptions
   let includeValidateSearch: boolean | undefined
   const middlewares = [] as Array<SearchMiddleware<any>>
-  // Flat pairs: [searchBeforeValidation, validatedSearch, ...]
-  type ValidatedSearches = Array<Record<PropertyKey, unknown>>
 
   for (const route of destRoutes) {
     const routeOptions = route.options
@@ -3157,17 +3156,18 @@ function buildMiddlewareChain(destRoutes: ReadonlyArray<AnyRoute>) {
 
     const routeValidateSearch = routeOptions.validateSearch
     if (routeValidateSearch) {
-      const validate: SearchMiddleware<any> = (
-        { search, next },
-        validations?: ValidatedSearches,
-      ) => {
+      const validate: SearchMiddleware<any> = ({ search, next, meta }) => {
         const result = next(search)
         if (includeValidateSearch) {
           try {
             const validated = validateSearch(routeValidateSearch, result) as any
 
-            if (validations && validated) {
-              validations.push(result, validated)
+            if (meta && validated) {
+              for (const key in validated) {
+                if (!(key in result)) {
+                  ;(meta.defaulted ||= new Map()).set(key, validated[key])
+                }
+              }
             }
             return { ...result, ...validated }
           } catch {
@@ -3184,7 +3184,7 @@ function buildMiddlewareChain(destRoutes: ReadonlyArray<AnyRoute>) {
   const applyNext = (
     index: number,
     currentSearch: any,
-    validations?: ValidatedSearches,
+    meta?: SearchMiddlewareMeta,
   ): any => {
     // no more middlewares left, return the current search
     if (index >= middlewares.length) {
@@ -3197,21 +3197,18 @@ function buildMiddlewareChain(destRoutes: ReadonlyArray<AnyRoute>) {
       return functionalUpdate(dest.search, currentSearch)
     }
 
-    const next = (newSearch: any, collectValidations?: true): any => {
-      if (collectValidations) {
-        const nextValidations: ValidatedSearches = []
-        return [
-          applyNext(index + 1, newSearch, nextValidations),
-          nextValidations,
-        ]
+    const next = (newSearch: any, collectMeta?: true): any => {
+      if (collectMeta) {
+        const nextMeta = {} as SearchMiddlewareMeta
+        return {
+          search: applyNext(index + 1, newSearch, nextMeta),
+          meta: nextMeta,
+        }
       }
-      return applyNext(index + 1, newSearch, validations)
+      return applyNext(index + 1, newSearch, meta)
     }
 
-    return (middlewares[index]! as any)(
-      { search: currentSearch, next },
-      validations,
-    )
+    return (middlewares[index]! as any)({ search: currentSearch, next, meta })
   }
 
   return function middleware(

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -3199,7 +3199,7 @@ function buildMiddlewareChain(destRoutes: ReadonlyArray<AnyRoute>) {
 
     const next = (newSearch: any, collectMeta?: true): any => {
       if (collectMeta) {
-        const nextMeta = {} as SearchMiddlewareMeta
+        const nextMeta = meta || ({} as SearchMiddlewareMeta)
         return {
           search: applyNext(index + 1, newSearch, nextMeta),
           meta: nextMeta,

--- a/packages/router-core/src/searchMiddleware.ts
+++ b/packages/router-core/src/searchMiddleware.ts
@@ -1,7 +1,16 @@
-import { createNull, deepEqual } from './utils'
+import { deepEqual } from './utils'
 import type { NoInfer, PickOptional } from './utils'
-import type { SearchMiddleware } from './route'
+import type {
+  SearchMiddleware,
+  SearchMiddlewareContext,
+  SearchMiddlewareMeta,
+} from './route'
 import type { IsRequiredParams } from './link'
+
+type SearchMiddlewareNextWithMeta<TSearchSchema> = (
+  newSearch: TSearchSchema,
+  collectMeta: true,
+) => { search: TSearchSchema; meta: SearchMiddlewareMeta }
 
 /**
  * Retain specified search params across navigations.
@@ -17,18 +26,30 @@ export function retainSearchParams<TSearchSchema extends object>(
   keys: Array<keyof TSearchSchema> | true,
 ): SearchMiddleware<TSearchSchema> {
   return ({ search, next }) => {
-    const [resultSearch, validations] = (next as any)(search, true) as [
-      TSearchSchema,
-      Array<Record<PropertyKey, unknown>>,
-    ]
-    const defaultKeys = validations.length
-      ? getValidationDefaultKeys(search, resultSearch, validations)
-      : undefined
+    const { search: resultSearch, meta } = (
+      next as unknown as SearchMiddlewareNextWithMeta<TSearchSchema>
+    )(search, true)
 
     if (keys === true) {
       const copy = { ...search, ...resultSearch }
-      if (defaultKeys) {
-        for (const key in defaultKeys) {
+      const removed = meta.removed
+      for (const key of removed?.keys() || []) {
+        if (deepEqual(search[key as keyof TSearchSchema], removed!.get(key))) {
+          delete copy[key as keyof TSearchSchema]
+        }
+      }
+      for (const key of meta.removedAny || []) {
+        delete copy[key as keyof TSearchSchema]
+      }
+      for (const key of meta.defaulted?.keys() || []) {
+        if (
+          key in search &&
+          !meta.removedAny?.has(key) &&
+          !(
+            meta.removed?.has(key) &&
+            deepEqual(search[key as keyof TSearchSchema], meta.removed.get(key))
+          )
+        ) {
           copy[key as keyof TSearchSchema] = search[key as keyof TSearchSchema]
         }
       }
@@ -38,35 +59,23 @@ export function retainSearchParams<TSearchSchema extends object>(
     const copy = { ...resultSearch }
     // add missing keys from search to copy
     for (const key of keys) {
-      if (!(key in copy) || (defaultKeys ? key in defaultKeys : false)) {
+      const stringKey = key as string
+      const removed =
+        meta.removedAny?.has(stringKey) ||
+        (meta.removed?.has(stringKey) &&
+          deepEqual(search[key], meta.removed.get(stringKey)))
+      if (
+        !removed &&
+        (!(key in copy) ||
+          (key in search &&
+            meta.defaulted?.has(stringKey) &&
+            deepEqual(copy[key], meta.defaulted.get(stringKey))))
+      ) {
         copy[key] = search[key]
       }
     }
     return copy
   }
-}
-
-function getValidationDefaultKeys(
-  search: any,
-  resultSearch: any,
-  validations: Array<Record<PropertyKey, unknown>>,
-) {
-  let defaultKeys: Record<PropertyKey, true> | undefined
-  for (let i = 0; i < validations.length; i += 2) {
-    const baseSearch = validations[i]!
-    const validatedSearch = validations[i + 1]!
-    for (const key in validatedSearch) {
-      if (
-        key in search &&
-        !(key in baseSearch) &&
-        resultSearch[key] === validatedSearch[key]
-      ) {
-        const target = defaultKeys || (defaultKeys = createNull())
-        target[key] = true
-      }
-    }
-  }
-  return defaultKeys
 }
 
 /**
@@ -87,24 +96,38 @@ export function stripSearchParams<
     ? TValues | true
     : TValues,
 >(input: NoInfer<TInput>): SearchMiddleware<TSearchSchema> {
-  return ({ search, next }) => {
+  return ((
+    { search, next, meta }: SearchMiddlewareContext<TSearchSchema>,
+  ) => {
     if (input === true) {
+      Object.keys(search as object).forEach((key) => {
+        if (meta) {
+          ;(meta.removedAny ||= new Set()).add(key)
+        }
+      })
       return {}
     }
-    const result = { ...next(search) } as Record<string, unknown>
+    const nextResult = next(search)
+    const result = { ...nextResult } as Record<string, unknown>
     if (Array.isArray(input)) {
       input.forEach((key) => {
-        delete result[key]
+        delete result[key as string]
+        if (meta) {
+          ;(meta.removedAny ||= new Set()).add(key as string)
+        }
       })
     } else {
       Object.entries(input as Record<string, unknown>).forEach(
         ([key, value]) => {
           if (deepEqual(result[key], value)) {
             delete result[key]
+            if (meta) {
+              ;(meta.removed ||= new Map()).set(key, value)
+            }
           }
         },
       )
     }
     return result as any
-  }
+  }) as SearchMiddleware<TSearchSchema>
 }

--- a/packages/router-core/src/searchMiddleware.ts
+++ b/packages/router-core/src/searchMiddleware.ts
@@ -96,9 +96,7 @@ export function stripSearchParams<
     ? TValues | true
     : TValues,
 >(input: NoInfer<TInput>): SearchMiddleware<TSearchSchema> {
-  return ((
-    { search, next, meta }: SearchMiddlewareContext<TSearchSchema>,
-  ) => {
+  return (({ search, next, meta }: SearchMiddlewareContext<TSearchSchema>) => {
     if (input === true) {
       Object.keys(search as object).forEach((key) => {
         if (meta) {

--- a/packages/router-core/tests/build-location.test.ts
+++ b/packages/router-core/tests/build-location.test.ts
@@ -353,6 +353,39 @@ describe('buildLocation - search params', () => {
     expect(location.search).toEqual({ param1: 10 })
   })
 
+  test('nested retainSearchParams should preserve stripped param metadata', async () => {
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      search: {
+        middlewares: [
+          retainSearchParams(['param1']),
+          retainSearchParams(['param2']),
+          stripSearchParams<Record<string, unknown>>(['param1']),
+        ],
+      },
+    })
+
+    const routeTree = rootRoute.addChildren([indexRoute])
+
+    const router = createTestRouter({
+      routeTree,
+      history: createMemoryHistory({
+        initialEntries: ['/?param1=stripped&param2=retained'],
+      }),
+    })
+
+    await router.load()
+
+    const location = router.buildLocation({
+      to: '/',
+      search: { param3: 'next' },
+    } as any)
+
+    expect(location.search).toEqual({ param2: 'retained', param3: 'next' })
+  })
+
   test('retainSearchParams should preserve non-default params when defaults are stripped', async () => {
     const rootRoute = new BaseRootRoute({
       validateSearch: (search: Record<string, unknown>) => ({

--- a/packages/router-core/tests/build-location.test.ts
+++ b/packages/router-core/tests/build-location.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test, vi } from 'vitest'
 import { createMemoryHistory } from '@tanstack/history'
-import { BaseRootRoute, BaseRoute, retainSearchParams } from '../src'
+import {
+  BaseRootRoute,
+  BaseRoute,
+  retainSearchParams,
+  stripSearchParams,
+} from '../src'
 import { createTestRouter } from './routerTestUtils'
 
 describe('buildLocation - params function receives parsed params', () => {
@@ -220,6 +225,144 @@ describe('buildLocation - search params', () => {
       }),
       search: {
         middlewares: [retainSearchParams(['Auth'])],
+      },
+    })
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const aboutRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/about',
+    })
+
+    const routeTree = rootRoute.addChildren([indexRoute, aboutRoute])
+
+    const router = createTestRouter({
+      routeTree,
+      history: createMemoryHistory({ initialEntries: ['/about?Auth=false'] }),
+    })
+
+    await router.load()
+
+    const location = router.buildLocation({
+      to: '/',
+      _includeValidateSearch: true,
+    } as any)
+
+    expect(location.search).toEqual({ Auth: 'false' })
+  })
+
+  test('retainSearchParams should not replace defaults with missing current search', async () => {
+    const rootRoute = new BaseRootRoute({
+      validateSearch: (search: Record<string, unknown>) => ({
+        Auth: search.Auth === undefined ? 'true' : `${search.Auth}`,
+      }),
+      search: {
+        middlewares: [retainSearchParams(['Auth'])],
+      },
+    })
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+
+    const routeTree = rootRoute.addChildren([indexRoute])
+
+    const router = createTestRouter({
+      routeTree,
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+
+    const location = router.buildLocation({
+      to: '/',
+      _includeValidateSearch: true,
+    } as any)
+
+    expect(location.search).toEqual({ Auth: 'true' })
+  })
+
+  test('retainSearchParams should not restore default-valued params removed by stripSearchParams', async () => {
+    const defaults = {
+      param1: 1,
+      param2: 2,
+    }
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      validateSearch: (search: Record<string, unknown>) => ({
+        param1: search.param1 === undefined ? defaults.param1 : search.param1,
+        param2: search.param2 === undefined ? defaults.param2 : search.param2,
+      }),
+      search: {
+        middlewares: [
+          retainSearchParams(['param2']),
+          stripSearchParams(defaults),
+        ],
+      },
+    })
+
+    const routeTree = rootRoute.addChildren([indexRoute])
+
+    const router = createTestRouter({
+      routeTree,
+      history: createMemoryHistory({ initialEntries: ['/?param2=2'] }),
+    })
+
+    await router.load()
+
+    const location = router.buildLocation({
+      to: '/',
+      search: { param1: 10 },
+      _includeValidateSearch: true,
+    } as any)
+
+    expect(location.search).toEqual({ param1: 10 })
+  })
+
+  test('retainSearchParams should not restore params explicitly removed by stripSearchParams', async () => {
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      search: {
+        middlewares: [
+          retainSearchParams(['param2']),
+          stripSearchParams<Record<string, unknown>>(['param2']),
+        ],
+      },
+    })
+
+    const routeTree = rootRoute.addChildren([indexRoute])
+
+    const router = createTestRouter({
+      routeTree,
+      history: createMemoryHistory({ initialEntries: ['/?param2=not-default'] }),
+    })
+
+    await router.load()
+
+    const location = router.buildLocation({
+      to: '/',
+      search: { param1: 10 },
+    } as any)
+
+    expect(location.search).toEqual({ param1: 10 })
+  })
+
+  test('retainSearchParams should preserve non-default params when defaults are stripped', async () => {
+    const rootRoute = new BaseRootRoute({
+      validateSearch: (search: Record<string, unknown>) => ({
+        Auth: search.Auth === undefined ? 'true' : `${search.Auth}`,
+      }),
+      search: {
+        middlewares: [
+          retainSearchParams(['Auth']),
+          stripSearchParams({ Auth: 'true' }),
+        ],
       },
     })
     const indexRoute = new BaseRoute({

--- a/packages/router-core/tests/build-location.test.ts
+++ b/packages/router-core/tests/build-location.test.ts
@@ -340,7 +340,9 @@ describe('buildLocation - search params', () => {
 
     const router = createTestRouter({
       routeTree,
-      history: createMemoryHistory({ initialEntries: ['/?param2=not-default'] }),
+      history: createMemoryHistory({
+        initialEntries: ['/?param2=not-default'],
+      }),
     })
 
     await router.load()

--- a/packages/router-core/tests/searchMiddleware.test.ts
+++ b/packages/router-core/tests/searchMiddleware.test.ts
@@ -13,7 +13,11 @@ describe('searchMiddleware - mutation prevention', () => {
       // so retainSearchParams should add them from search
       const result = middleware({
         search: originalSearch,
-        next: () => [{ page: 'new' }, []] as any,
+        next: () =>
+          ({
+            search: { page: 'new' },
+            meta: {},
+          }) as any,
       })
 
       expect(originalSearch).toEqual(originalCopy)
@@ -29,7 +33,11 @@ describe('searchMiddleware - mutation prevention', () => {
       // next() returns object without 'id' and 'filter' keys
       const result1 = middleware({
         search: sharedSearch,
-        next: () => [{ page: '2' }, []] as any,
+        next: () =>
+          ({
+            search: { page: '2' },
+            meta: {},
+          }) as any,
       })
 
       expect(sharedSearch).toEqual({ id: '1', filter: 'active', page: '1' })
@@ -37,7 +45,11 @@ describe('searchMiddleware - mutation prevention', () => {
 
       const result2 = middleware({
         search: sharedSearch,
-        next: () => [{ page: '3' }, []] as any,
+        next: () =>
+          ({
+            search: { page: '3' },
+            meta: {},
+          }) as any,
       })
 
       expect(sharedSearch).toEqual({ id: '1', filter: 'active', page: '1' })
@@ -52,7 +64,11 @@ describe('searchMiddleware - mutation prevention', () => {
 
       const result = middleware({
         search: originalSearch,
-        next: () => [{ id: '2' }, []] as any,
+        next: () =>
+          ({
+            search: { id: '2' },
+            meta: {},
+          }) as any,
       })
 
       expect(originalSearch).toEqual(originalCopy)


### PR DESCRIPTION
fixes #7551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Example route configs now preserve a "persist" query parameter and apply a default page=1 when normalizing search params.
* **Bug Fixes**
  * Fixed search-parameter middleware composition so removed query params are not reinstated later in the chain.
* **Tests**
  * Expanded tests to cover retain/strip middleware interactions, defaults, and nested composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->