### PR TITLE
rename inputValidator to validator

### DIFF
--- a/.changeset/clean-rules-warn.md
+++ b/.changeset/clean-rules-warn.md
@@ -1,0 +1,9 @@
+---
+'@tanstack/react-start': patch
+'@tanstack/solid-start': patch
+'@tanstack/vue-start': patch
+'@tanstack/start-client-core': patch
+'@tanstack/start-plugin-core': patch
+---
+
+Add `validator()` as the canonical server function and middleware validator method. Deprecate `inputValidator()` and emit compiler warnings for remaining uses.

--- a/_artifacts/start_domain_map.yaml
+++ b/_artifacts/start_domain_map.yaml
@@ -134,7 +134,7 @@ skills:
       - '@tanstack/start-server-core'
     covers:
       - createServerFn (GET/POST)
-      - inputValidator (Zod or function)
+      - validator (Zod or function)
       - useServerFn hook
       - Server context utilities (getRequest, getRequestHeader, setResponseHeader, setResponseStatus)
       - Error handling (throw errors, redirect, notFound)
@@ -229,7 +229,7 @@ skills:
       - Middleware factories
       - Fetch override precedence
       - Header merging
-      - Method order enforcement (middleware → inputValidator → client → server)
+      - Method order enforcement (middleware → validator → client → server)
     tasks:
       - 'Add authentication middleware'
       - 'Pass context through middleware chain'
@@ -247,7 +247,7 @@ skills:
 
       - mistake: 'Wrong middleware method order'
         mechanism: >-
-          TypeScript enforces method order: middleware → inputValidator
+          TypeScript enforces method order: middleware → validator
           → client → server. Wrong order causes type errors and
           runtime failures.
         source: 'docs/start/framework/react/guide/middleware.md'

--- a/_artifacts/start_skill_tree.yaml
+++ b/_artifacts/start_skill_tree.yaml
@@ -37,7 +37,7 @@ skills:
     path: 'skills/start-core/server-functions/SKILL.md'
     package: 'packages/start-client-core'
     description: >-
-      createServerFn (GET/POST), inputValidator (Zod or function),
+      createServerFn (GET/POST), validator (Zod or function),
       useServerFn hook, server context utilities (getRequest,
       getRequestHeader, setResponseHeader, setResponseStatus), error
       handling (throw errors, redirect, notFound), streaming

--- a/docs/start/framework/react/build-from-scratch.md
+++ b/docs/start/framework/react/build-from-scratch.md
@@ -290,7 +290,7 @@ const getCount = createServerFn({
 })
 
 const updateCount = createServerFn({ method: 'POST' })
-  .inputValidator((d: number) => d)
+  .validator((d: number) => d)
   .handler(async ({ data }) => {
     const count = await readCount()
     await fs.promises.writeFile(filePath, `${count + data}`)

--- a/docs/start/framework/react/comparison.md
+++ b/docs/start/framework/react/comparison.md
@@ -188,7 +188,7 @@ function Post() {
 
 ```tsx
 export const getTodos = createServerFn({ method: 'GET' })
-  .inputValidator(zodValidator(z.object({ userId: z.string() })))
+  .validator(zodValidator(z.object({ userId: z.string() })))
   .middleware([authMiddleware])
   .handler(async ({ data, context }) => {
     // Fully typed data and context

--- a/docs/start/framework/react/guide/authentication-overview.md
+++ b/docs/start/framework/react/guide/authentication-overview.md
@@ -212,7 +212,7 @@ Build your own authentication system using TanStack Start's server functions and
 - Use HTTPS in production and set a strong session secret.
 - Store sessions in `HttpOnly`, `Secure`, `SameSite` cookies. Do not store session tokens in `localStorage` or `sessionStorage`.
 - Enforce auth in every server function, server route, or API endpoint that reads or writes private user, tenant, or account data. Use `beforeLoad` for page UX, not as the data boundary.
-- Use `.inputValidator()` on every server function that accepts input.
+- Use `.validator()` on every server function that accepts input.
 - Hash passwords with bcrypt, scrypt, or Argon2. For missing users, verify against a dummy hash and return the same login/reset message.
 - Rate limit login, registration, and password-reset endpoints.
 - Use CSRF or same-origin protections for non-GET server functions and server routes.

--- a/docs/start/framework/react/guide/authentication-server-primitives.md
+++ b/docs/start/framework/react/guide/authentication-server-primitives.md
@@ -119,7 +119,7 @@ import { z } from 'zod'
 import { setSessionCookie } from './session'
 
 export const login = createServerFn({ method: 'POST' })
-  .inputValidator(z.object({ email: z.string().email(), password: z.string() }))
+  .validator(z.object({ email: z.string().email(), password: z.string() }))
   .handler(async ({ data }) => {
     const user = await db.users.findByEmail(data.email)
     // Always run verifyPasswordHash — even when the user doesn't exist —
@@ -228,7 +228,7 @@ import { createServerFn } from '@tanstack/react-start'
 import { z } from 'zod'
 
 export const requestPasswordReset = createServerFn({ method: 'POST' })
-  .inputValidator(z.object({ email: z.string().email() }))
+  .validator(z.object({ email: z.string().email() }))
   .handler(async ({ data }) => {
     const user = await db.users.findByEmail(data.email)
     if (user) {

--- a/docs/start/framework/react/guide/authentication.md
+++ b/docs/start/framework/react/guide/authentication.md
@@ -221,9 +221,7 @@ import { createServerFn } from '@tanstack/react-start'
 
 // User registration
 export const registerFn = createServerFn({ method: 'POST' })
-  .validator(
-    (data: { email: string; password: string; name: string }) => data,
-  )
+  .validator((data: { email: string; password: string; name: string }) => data)
   .handler(async ({ data }) => {
     // Check if user exists
     const existingUser = await getUserByEmail(data.email)

--- a/docs/start/framework/react/guide/authentication.md
+++ b/docs/start/framework/react/guide/authentication.md
@@ -50,7 +50,7 @@ import { redirect } from '@tanstack/react-router'
 
 // Login server function
 export const loginFn = createServerFn({ method: 'POST' })
-  .inputValidator((data: { email: string; password: string }) => data)
+  .validator((data: { email: string; password: string }) => data)
   .handler(async ({ data }) => {
     // Verify credentials (replace with your auth logic)
     const user = await authenticateUser(data.email, data.password)
@@ -221,7 +221,7 @@ import { createServerFn } from '@tanstack/react-start'
 
 // User registration
 export const registerFn = createServerFn({ method: 'POST' })
-  .inputValidator(
+  .validator(
     (data: { email: string; password: string; name: string }) => data,
   )
   .handler(async ({ data }) => {
@@ -305,7 +305,7 @@ export const authProviders = {
 }
 
 export const initiateOAuthFn = createServerFn({ method: 'POST' })
-  .inputValidator((data: { provider: 'google' | 'github' }) => data)
+  .validator((data: { provider: 'google' | 'github' }) => data)
   .handler(async ({ data }) => {
     const provider = authProviders[data.provider]
     const state = generateRandomState()
@@ -326,7 +326,7 @@ export const initiateOAuthFn = createServerFn({ method: 'POST' })
 ```tsx
 // Password reset request
 export const requestPasswordResetFn = createServerFn({ method: 'POST' })
-  .inputValidator((data: { email: string }) => data)
+  .validator((data: { email: string }) => data)
   .handler(async ({ data }) => {
     const user = await getUserByEmail(data.email)
     if (!user) {
@@ -345,7 +345,7 @@ export const requestPasswordResetFn = createServerFn({ method: 'POST' })
 
 // Password reset confirmation
 export const resetPasswordFn = createServerFn({ method: 'POST' })
-  .inputValidator((data: { token: string; newPassword: string }) => data)
+  .validator((data: { token: string; newPassword: string }) => data)
   .handler(async ({ data }) => {
     const resetToken = await getPasswordResetToken(data.token)
 
@@ -426,7 +426,7 @@ const loginSchema = z.object({
 })
 
 export const loginFn = createServerFn({ method: 'POST' })
-  .inputValidator((data) => loginSchema.parse(data))
+  .validator((data) => loginSchema.parse(data))
   .handler(async ({ data }) => {
     // data is now validated
   })
@@ -522,7 +522,7 @@ function LoginForm() {
 
 ```tsx
 export const loginFn = createServerFn({ method: 'POST' })
-  .inputValidator(
+  .validator(
     (data: { email: string; password: string; rememberMe?: boolean }) => data,
   )
   .handler(async ({ data }) => {

--- a/docs/start/framework/react/guide/environment-variables.md
+++ b/docs/start/framework/react/guide/environment-variables.md
@@ -77,7 +77,7 @@ const connectToDatabase = createServerFn().handler(async () => {
 
 // Authentication (server-only)
 const authenticateUser = createServerFn()
-  .inputValidator(z.object({ token: z.string() }))
+  .validator(z.object({ token: z.string() }))
   .handler(async ({ data }) => {
     const jwtSecret = process.env.JWT_SECRET // Server-only
     return jwt.verify(data.token, jwtSecret)
@@ -257,7 +257,7 @@ import { createServerFn } from '@tanstack/react-start'
 
 // Server-side API calls (can use secret keys)
 const fetchUserData = createServerFn()
-  .inputValidator(z.object({ userId: z.string() }))
+  .validator(z.object({ userId: z.string() }))
   .handler(async ({ data }) => {
     const response = await fetch(
       `${process.env.EXTERNAL_API_URL}/users/${data.userId}`,

--- a/docs/start/framework/react/guide/execution-model.md
+++ b/docs/start/framework/react/guide/execution-model.md
@@ -62,7 +62,7 @@ import { createServerFn, createServerOnlyFn } from '@tanstack/react-start'
 
 // RPC: Server execution, callable from client
 const updateUser = createServerFn({ method: 'POST' })
-  .inputValidator((data: UserData) => data)
+  .validator((data: UserData) => data)
   .handler(async ({ data }) => {
     // Only runs on server, but client can call it
     return await db.users.update(data)

--- a/docs/start/framework/react/guide/middleware.md
+++ b/docs/start/framework/react/guide/middleware.md
@@ -34,7 +34,7 @@ There are two types of middleware: **request middleware** and **server function 
 | ----------------- | -------------------------------- | -------------------------- |
 | Scope             | All server requests              | Server functions only      |
 | Methods           | `.server()`                      | `.client()`, `.server()`   |
-| Input Validation  | No                               | Yes (`.inputValidator()`)  |
+| Input Validation  | No                               | Yes (`.validator()`)       |
 | Client-side Logic | No                               | Yes                        |
 | Dependencies      | Can depend on request middleware | Can depend on both types   |
 
@@ -210,7 +210,7 @@ const loggingMiddleware = createMiddleware({ type: 'function' })
 Server function middleware has the following methods:
 
 - `middleware`: Add a middleware to the chain.
-- `inputValidator`: Modify the data object before it is passed to this middleware and any nested middleware and eventually the server function.
+- `validator`: Modify the data object before it is passed to this middleware and any nested middleware and eventually the server function.
 - `client`: Define client-side logic that the middleware will execute on the client before (and after) the server function calls into the server to execute the function.
 - `server`: Define server-side logic that the middleware will execute on the server before (and after) the server function is executed.
 
@@ -232,9 +232,9 @@ const loggingMiddleware = createMiddleware({ type: 'function' }).client(
 )
 ```
 
-### The `.inputValidator` method
+### The `.validator` method
 
-The `inputValidator` method is used to modify the data object before it is passed to this middleware, nested middleware, and ultimately the server function. This method should receive a function that takes the data object and returns a validated (and optionally modified) data object. It's common to use a validation library like `zod` to do this.
+The `validator` method is used to modify the data object before it is passed to this middleware, nested middleware, and ultimately the server function. This method should receive a function that takes the data object and returns a validated (and optionally modified) data object. It's common to use a validation library like `zod` to do this.
 
 ```tsx
 import { createMiddleware } from '@tanstack/react-start'
@@ -246,7 +246,7 @@ const mySchema = z.object({
 })
 
 const workspaceMiddleware = createMiddleware({ type: 'function' })
-  .inputValidator(zodValidator(mySchema))
+  .validator(zodValidator(mySchema))
   .server(({ next, data }) => {
     console.log('Workspace ID:', data.workspaceId)
     return next()

--- a/docs/start/framework/react/guide/observability.md
+++ b/docs/start/framework/react/guide/observability.md
@@ -61,7 +61,7 @@ Add logging to your server functions to track execution, performance, and errors
 import { createServerFn } from '@tanstack/react-start'
 
 const getUser = createServerFn({ method: 'GET' })
-  .inputValidator((id: string) => id)
+  .validator((id: string) => id)
   .handler(async ({ data: id }) => {
     const startTime = Date.now()
 
@@ -634,7 +634,7 @@ import { trace, SpanStatusCode } from '@opentelemetry/api'
 const tracer = trace.getTracer('tanstack-start')
 
 const getUserWithTracing = createServerFn({ method: 'GET' })
-  .inputValidator((id: string) => id)
+  .validator((id: string) => id)
   .handler(async ({ data: id }) => {
     return tracer.startActiveSpan('get-user', async (span) => {
       span.setAttributes({

--- a/docs/start/framework/react/guide/rendering-markdown.md
+++ b/docs/start/framework/react/guide/rendering-markdown.md
@@ -426,9 +426,7 @@ type GitHubContent = {
 }
 
 export const fetchRepoContents = createServerFn({ method: 'GET' })
-  .validator(
-    (params: { repo: string; branch: string; path: string }) => params,
-  )
+  .validator((params: { repo: string; branch: string; path: string }) => params)
   .handler(async ({ data: { repo, branch, path } }) => {
     const url = `https://api.github.com/repos/${repo}/contents/${path}?ref=${branch}`
 

--- a/docs/start/framework/react/guide/rendering-markdown.md
+++ b/docs/start/framework/react/guide/rendering-markdown.md
@@ -332,7 +332,7 @@ type FetchDocsParams = {
 }
 
 export const fetchDocs = createServerFn({ method: 'GET' })
-  .inputValidator((params: FetchDocsParams) => params)
+  .validator((params: FetchDocsParams) => params)
   .handler(async ({ data: { repo, branch, filePath } }) => {
     const url = `https://raw.githubusercontent.com/${repo}/${branch}/${filePath}`
 
@@ -364,7 +364,7 @@ For production, add appropriate cache headers:
 
 ```tsx
 export const fetchDocs = createServerFn({ method: 'GET' })
-  .inputValidator((params: FetchDocsParams) => params)
+  .validator((params: FetchDocsParams) => params)
   .handler(async ({ data: { repo, branch, filePath }, context }) => {
     // Set cache headers for CDN caching
     context.response.headers.set(
@@ -426,7 +426,7 @@ type GitHubContent = {
 }
 
 export const fetchRepoContents = createServerFn({ method: 'GET' })
-  .inputValidator(
+  .validator(
     (params: { repo: string; branch: string; path: string }) => params,
   )
   .handler(async ({ data: { repo, branch, path } }) => {

--- a/docs/start/framework/react/guide/server-functions.md
+++ b/docs/start/framework/react/guide/server-functions.md
@@ -122,7 +122,7 @@ import { createServerFn } from '@tanstack/react-start'
 import { findUserById } from './users.server'
 
 export const getUser = createServerFn({ method: 'GET' })
-  .inputValidator((data: { id: string }) => data)
+  .validator((data: { id: string }) => data)
   .handler(async ({ data }) => {
     return findUserById(data.id)
   })
@@ -164,7 +164,7 @@ Server functions accept a single `data` parameter. Since they cross the network 
 import { createServerFn } from '@tanstack/react-start'
 
 export const greetUser = createServerFn({ method: 'GET' })
-  .inputValidator((data: { name: string }) => data)
+  .validator((data: { name: string }) => data)
   .handler(async ({ data }) => {
     return `Hello, ${data.name}!`
   })
@@ -186,7 +186,7 @@ const UserSchema = z.object({
 })
 
 export const createUser = createServerFn({ method: 'POST' })
-  .inputValidator(UserSchema)
+  .validator(UserSchema)
   .handler(async ({ data }) => {
     // data is fully typed and validated
     return `Created user: ${data.name}, age ${data.age}`
@@ -199,7 +199,7 @@ Handle form submissions with FormData:
 
 ```tsx
 export const submitForm = createServerFn({ method: 'POST' })
-  .inputValidator((data) => {
+  .validator((data) => {
     if (!(data instanceof FormData)) {
       throw new Error('Expected FormData')
     }
@@ -219,7 +219,7 @@ export const submitForm = createServerFn({ method: 'POST' })
 
 Server function inputs and outputs cross the network boundary, so TypeScript checks that they are serializable:
 
-- Input validator input types must be serializable. `FormData` is also allowed for `POST` server functions.
+- Validator input types must be serializable. `FormData` is also allowed for `POST` server functions.
 - Handler return types must be serializable. `Response` objects are allowed.
 
 This default behavior is called `strict` mode. If you intentionally need to opt out of these type-level serialization checks, pass the `strict` option to `createServerFn`:
@@ -227,7 +227,7 @@ This default behavior is called `strict` mode. If you intentionally need to opt 
 ```tsx
 // Disable input and output serialization type checks
 export const looseServerFn = createServerFn({ strict: false })
-  .inputValidator((data: { value: unknown }) => data)
+  .validator((data: { value: unknown }) => data)
   .handler(async ({ data }) => {
     return data.value
   })
@@ -236,7 +236,7 @@ export const looseServerFn = createServerFn({ strict: false })
 export const looseInputServerFn = createServerFn({
   strict: { input: false },
 })
-  .inputValidator((data: { value: unknown }) => data)
+  .validator((data: { value: unknown }) => data)
   .handler(async () => {
     return { ok: true }
   })
@@ -304,7 +304,7 @@ import { createServerFn } from '@tanstack/react-start'
 import { notFound } from '@tanstack/react-router'
 
 export const getPost = createServerFn()
-  .inputValidator((data: { id: string }) => data)
+  .validator((data: { id: string }) => data)
   .handler(async ({ data }) => {
     const post = await db.findPost(data.id)
 

--- a/docs/start/framework/react/tutorial/reading-writing-file.md
+++ b/docs/start/framework/react/tutorial/reading-writing-file.md
@@ -264,7 +264,7 @@ export const getJokes = createServerFn({ method: 'GET' }).handler(async () => {
 
 // Add this new server function
 export const addJoke = createServerFn({ method: 'POST' })
-  .inputValidator((data: { question: string; answer: string }) => {
+  .validator((data: { question: string; answer: string }) => {
     // Validate input data
     if (!data.question || !data.question.trim()) {
       throw new Error('Joke question is required')
@@ -307,7 +307,7 @@ export const addJoke = createServerFn({ method: 'POST' })
 In this code:
 
 - We are using `createServerFn` to create server functions that run on the server but can be called from the client. This server function is used to write data to the file.
-- We are going to first use `inputValidator` to validate the input data. This is a good practice to ensure that the data we are receiving is in the correct format.
+- We are going to first use `validator` to validate the input data. This is a good practice to ensure that the data we are receiving is in the correct format.
 - We are going to perform the actual write operation in the `handler` function.
 - `getJokes` reads the jokes from our JSON file.
 - `addJoke` validates the input data and adds a new joke to our file.

--- a/docs/start/framework/solid/build-from-scratch.md
+++ b/docs/start/framework/solid/build-from-scratch.md
@@ -295,7 +295,7 @@ const getCount = createServerFn({
 })
 
 const updateCount = createServerFn({ method: 'POST' })
-  .inputValidator((d: number) => d)
+  .validator((d: number) => d)
   .handler(async ({ data }) => {
     const count = await readCount()
     await fs.promises.writeFile(filePath, `${count + data}`)

--- a/docs/start/framework/solid/guide/authentication.md
+++ b/docs/start/framework/solid/guide/authentication.md
@@ -221,9 +221,7 @@ import { createServerFn } from '@tanstack/solid-start'
 
 // User registration
 export const registerFn = createServerFn({ method: 'POST' })
-  .validator(
-    (data: { email: string; password: string; name: string }) => data,
-  )
+  .validator((data: { email: string; password: string; name: string }) => data)
   .handler(async ({ data }) => {
     // Check if user exists
     const existingUser = await getUserByEmail(data.email)

--- a/docs/start/framework/solid/guide/authentication.md
+++ b/docs/start/framework/solid/guide/authentication.md
@@ -50,7 +50,7 @@ import { redirect } from '@tanstack/solid-router'
 
 // Login server function
 export const loginFn = createServerFn({ method: 'POST' })
-  .inputValidator((data: { email: string; password: string }) => data)
+  .validator((data: { email: string; password: string }) => data)
   .handler(async ({ data }) => {
     // Verify credentials (replace with your auth logic)
     const user = await authenticateUser(data.email, data.password)
@@ -221,7 +221,7 @@ import { createServerFn } from '@tanstack/solid-start'
 
 // User registration
 export const registerFn = createServerFn({ method: 'POST' })
-  .inputValidator(
+  .validator(
     (data: { email: string; password: string; name: string }) => data,
   )
   .handler(async ({ data }) => {
@@ -305,7 +305,7 @@ export const authProviders = {
 }
 
 export const initiateOAuthFn = createServerFn({ method: 'POST' })
-  .inputValidator((data: { provider: 'google' | 'github' }) => data)
+  .validator((data: { provider: 'google' | 'github' }) => data)
   .handler(async ({ data }) => {
     const provider = authProviders[data.provider]
     const state = generateRandomState()
@@ -326,7 +326,7 @@ export const initiateOAuthFn = createServerFn({ method: 'POST' })
 ```tsx
 // Password reset request
 export const requestPasswordResetFn = createServerFn({ method: 'POST' })
-  .inputValidator((data: { email: string }) => data)
+  .validator((data: { email: string }) => data)
   .handler(async ({ data }) => {
     const user = await getUserByEmail(data.email)
     if (!user) {
@@ -345,7 +345,7 @@ export const requestPasswordResetFn = createServerFn({ method: 'POST' })
 
 // Password reset confirmation
 export const resetPasswordFn = createServerFn({ method: 'POST' })
-  .inputValidator((data: { token: string; newPassword: string }) => data)
+  .validator((data: { token: string; newPassword: string }) => data)
   .handler(async ({ data }) => {
     const resetToken = await getPasswordResetToken(data.token)
 
@@ -426,7 +426,7 @@ const loginSchema = z.object({
 })
 
 export const loginFn = createServerFn({ method: 'POST' })
-  .inputValidator((data) => loginSchema.parse(data))
+  .validator((data) => loginSchema.parse(data))
   .handler(async ({ data }) => {
     // data is now validated
   })
@@ -522,7 +522,7 @@ function LoginForm() {
 
 ```tsx
 export const loginFn = createServerFn({ method: 'POST' })
-  .inputValidator(
+  .validator(
     (data: { email: string; password: string; rememberMe?: boolean }) => data,
   )
   .handler(async ({ data }) => {

--- a/docs/start/framework/solid/guide/execution-model.md
+++ b/docs/start/framework/solid/guide/execution-model.md
@@ -62,7 +62,7 @@ import { createServerFn, createServerOnlyFn } from '@tanstack/solid-start'
 
 // RPC: Server execution, callable from client
 const updateUser = createServerFn({ method: 'POST' })
-  .inputValidator((data: UserData) => data)
+  .validator((data: UserData) => data)
   .handler(async ({ data }) => {
     // Only runs on server, but client can call it
     return await db.users.update(data)

--- a/docs/start/framework/solid/guide/observability.md
+++ b/docs/start/framework/solid/guide/observability.md
@@ -61,7 +61,7 @@ Add logging to your server functions to track execution, performance, and errors
 import { createServerFn } from '@tanstack/solid-start'
 
 const getUser = createServerFn({ method: 'GET' })
-  .inputValidator((id: string) => id)
+  .validator((id: string) => id)
   .handler(async ({ data: id }) => {
     const startTime = Date.now()
 
@@ -517,7 +517,7 @@ import { trace, SpanStatusCode } from '@opentelemetry/api'
 const tracer = trace.getTracer('tanstack-start')
 
 const getUserWithTracing = createServerFn({ method: 'GET' })
-  .inputValidator((id: string) => id)
+  .validator((id: string) => id)
   .handler(async ({ data: id }) => {
     return tracer.startActiveSpan('get-user', async (span) => {
       span.setAttributes({

--- a/docs/start/framework/solid/tutorial/reading-writing-file.md
+++ b/docs/start/framework/solid/tutorial/reading-writing-file.md
@@ -264,7 +264,7 @@ export const getJokes = createServerFn({ method: 'GET' }).handler(async () => {
 
 // Add this new server function
 export const addJoke = createServerFn({ method: 'POST' })
-  .inputValidator((data: { question: string; answer: string }) => {
+  .validator((data: { question: string; answer: string }) => {
     // Validate input data
     if (!data.question || !data.question.trim()) {
       throw new Error('Joke question is required')
@@ -307,7 +307,7 @@ export const addJoke = createServerFn({ method: 'POST' })
 In this code:
 
 - We are using `createServerFn` to create server functions that run on the server but can be called from the client. This server function is used to write data to the file.
-- We are going to first use `inputValidator` to validate the input data. This is a good practice to ensure that the data we are receiving is in the correct format.
+- We are going to first use `validator` to validate the input data. This is a good practice to ensure that the data we are receiving is in the correct format.
 - We are going to perform the actual write operation in the `handler` function.
 - `getJokes` reads the jokes from our JSON file.
 - `addJoke` validates the input data and adds a new joke to our file.

--- a/e2e/react-start/basic-auth/src/routes/_authed.tsx
+++ b/e2e/react-start/basic-auth/src/routes/_authed.tsx
@@ -8,7 +8,7 @@ import { useAppSession } from '~/utils/session'
 export const loginFn = createServerFn({
   method: 'POST',
 })
-  .inputValidator((payload: { email: string; password: string }) => payload)
+  .validator((payload: { email: string; password: string }) => payload)
   .handler(async ({ data }) => {
     // Find the user
     const user = await prismaClient.user.findUnique({

--- a/e2e/react-start/basic-auth/src/routes/signup.tsx
+++ b/e2e/react-start/basic-auth/src/routes/signup.tsx
@@ -9,7 +9,7 @@ import { useAppSession } from '~/utils/session'
 export const signupFn = createServerFn({
   method: 'POST',
 })
-  .inputValidator(
+  .validator(
     (data: { email: string; password: string; redirectUrl?: string }) => data,
   )
   .handler(async ({ data: payload }) => {

--- a/e2e/react-start/basic-auth/src/utils/posts.ts
+++ b/e2e/react-start/basic-auth/src/utils/posts.ts
@@ -9,7 +9,7 @@ export type PostType = {
 }
 
 export const fetchPost = createServerFn({ method: 'GET' })
-  .inputValidator((postId: string) => postId)
+  .validator((postId: string) => postId)
   .handler(async ({ data: postId }) => {
     console.info(`Fetching post with id ${postId}...`)
     const post = await axios

--- a/e2e/react-start/basic-react-query/src/utils/posts.tsx
+++ b/e2e/react-start/basic-react-query/src/utils/posts.tsx
@@ -31,7 +31,7 @@ export const postsQueryOptions = () =>
   })
 
 export const fetchPost = createServerFn({ method: 'GET' })
-  .inputValidator((postId: string) => postId)
+  .validator((postId: string) => postId)
   .handler(async ({ data: postId }) => {
     console.info(`Fetching post with id ${postId}...`)
     const post = await axios

--- a/e2e/react-start/basic-tsr-config/src/routes/index.tsx
+++ b/e2e/react-start/basic-tsr-config/src/routes/index.tsx
@@ -12,7 +12,7 @@ const getCount = createServerFn({
 })
 
 const updateCount = createServerFn({ method: 'POST' })
-  .inputValidator((d: number) => d)
+  .validator((d: number) => d)
   .handler(async ({ data }) => {
     const count = await getCount()
     await fs.promises.writeFile(filePath, `${count + data}`)

--- a/e2e/react-start/basic/src/components/throwRedirect.ts
+++ b/e2e/react-start/basic/src/components/throwRedirect.ts
@@ -2,7 +2,7 @@ import { redirect } from '@tanstack/react-router'
 import { createServerFn } from '@tanstack/react-start'
 
 export const throwRedirect = createServerFn()
-  .inputValidator(
+  .validator(
     (opts: {
       target: 'internal' | 'external'
       reloadDocument?: boolean

--- a/e2e/react-start/basic/src/routes/deferred.tsx
+++ b/e2e/react-start/basic/src/routes/deferred.tsx
@@ -3,13 +3,13 @@ import { createServerFn } from '@tanstack/react-start'
 import { Suspense, useState } from 'react'
 
 const personServerFn = createServerFn({ method: 'GET' })
-  .inputValidator((data: { name: string }) => data)
+  .validator((data: { name: string }) => data)
   .handler(({ data }) => {
     return { name: data.name, randomNumber: Math.floor(Math.random() * 100) }
   })
 
 const slowServerFn = createServerFn({ method: 'GET' })
-  .inputValidator((data: { name: string }) => data)
+  .validator((data: { name: string }) => data)
   .handler(async ({ data }) => {
     await new Promise((r) => setTimeout(r, 1000))
     return { name: data.name, randomNumber: Math.floor(Math.random() * 100) }

--- a/e2e/react-start/basic/src/utils/posts.tsx
+++ b/e2e/react-start/basic/src/utils/posts.tsx
@@ -15,7 +15,7 @@ if (import.meta.env.VITE_NODE_ENV === 'test') {
 }
 
 export const fetchPost = createServerFn({ method: 'GET' })
-  .inputValidator((postId: string) => postId)
+  .validator((postId: string) => postId)
   .handler(async ({ data: postId }) => {
     console.info(`Fetching post with id ${postId}...`)
     const post = await axios

--- a/e2e/react-start/clerk-basic/src/utils/posts.ts
+++ b/e2e/react-start/clerk-basic/src/utils/posts.ts
@@ -9,7 +9,7 @@ export type PostType = {
 }
 
 export const fetchPost = createServerFn({ method: 'GET' })
-  .inputValidator((postId: string) => postId)
+  .validator((postId: string) => postId)
   .handler(async ({ data: postId }) => {
     console.info(`Fetching post with id ${postId}...`)
     const post = await axios

--- a/e2e/react-start/custom-basepath/src/routes/deferred.tsx
+++ b/e2e/react-start/custom-basepath/src/routes/deferred.tsx
@@ -3,13 +3,13 @@ import { createServerFn } from '@tanstack/react-start'
 import { Suspense, useState } from 'react'
 
 const personServerFn = createServerFn({ method: 'GET' })
-  .inputValidator((data: { name: string }) => data)
+  .validator((data: { name: string }) => data)
   .handler(({ data }) => {
     return { name: data.name, randomNumber: Math.floor(Math.random() * 100) }
   })
 
 const slowServerFn = createServerFn({ method: 'GET' })
-  .inputValidator((data: { name: string }) => data)
+  .validator((data: { name: string }) => data)
   .handler(async ({ data }) => {
     await new Promise((r) => setTimeout(r, 1000))
     return { name: data.name, randomNumber: Math.floor(Math.random() * 100) }

--- a/e2e/react-start/custom-basepath/src/utils/posts.tsx
+++ b/e2e/react-start/custom-basepath/src/utils/posts.tsx
@@ -15,7 +15,7 @@ if (import.meta.env.VITE_NODE_ENV === 'test') {
 }
 
 export const fetchPost = createServerFn({ method: 'GET' })
-  .inputValidator((postId: string) => postId)
+  .validator((postId: string) => postId)
   .handler(async ({ data: postId }) => {
     console.info(`Fetching post with id ${postId}...`)
     const post = await axios

--- a/e2e/react-start/custom-server-rsbuild/src/routes/index.tsx
+++ b/e2e/react-start/custom-server-rsbuild/src/routes/index.tsx
@@ -3,11 +3,11 @@ import { createServerFn } from '@tanstack/react-start'
 import { useState } from 'react'
 
 const getGreeting = createServerFn()
-  .inputValidator((d: { name: string }) => d)
+  .validator((d: { name: string }) => d)
   .handler(({ data }) => ({ greeting: `Hello, ${data.name}!` }))
 
 const postMessage = createServerFn({ method: 'POST' })
-  .inputValidator((d: { message: string }) => d)
+  .validator((d: { message: string }) => d)
   .handler(({ data }) => ({ echo: `Echo: ${data.message}` }))
 
 export const Route = createFileRoute('/')({

--- a/e2e/react-start/i18n-paraglide/src/routes/index.tsx
+++ b/e2e/react-start/i18n-paraglide/src/routes/index.tsx
@@ -3,7 +3,7 @@ import { m } from '@/paraglide/messages.js'
 import { createServerFn } from '@tanstack/react-start'
 
 const getServerMessage = createServerFn()
-  .inputValidator((emoji: string) => emoji)
+  .validator((emoji: string) => emoji)
   .handler((ctx) => {
     return m.server_message({ emoji: ctx.data })
   })

--- a/e2e/react-start/rsc-query/src/utils/noLoaderCssServerComponent.tsx
+++ b/e2e/react-start/rsc-query/src/utils/noLoaderCssServerComponent.tsx
@@ -5,7 +5,7 @@ import { CssModulesContent } from './CssModulesContent'
 export const getNoLoaderCssServerComponent = createServerFn({
   method: 'GET',
 })
-  .inputValidator((data: { title?: string; delayMs?: number }) => data)
+  .validator((data: { title?: string; delayMs?: number }) => data)
   .handler(async ({ data }) => {
     await new Promise((resolve) => setTimeout(resolve, data.delayMs ?? 150))
 

--- a/e2e/react-start/rsc-query/src/utils/serverComponents.tsx
+++ b/e2e/react-start/rsc-query/src/utils/serverComponents.tsx
@@ -36,7 +36,7 @@ const serverStyles = {
  * - Explicitly refetching updates the server timestamp (simulating fresh data)
  */
 export const getProductDetailComponent = createServerFn({ method: 'GET' })
-  .inputValidator((data: { productId: string }) => data)
+  .validator((data: { productId: string }) => data)
   .handler(async ({ data }) => {
     const fetchedAt = Date.now()
 

--- a/e2e/react-start/rsc/src/routes/rsc-async-bundle.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-async-bundle.tsx
@@ -30,7 +30,7 @@ async function simulateDelay(ms: number): Promise<void> {
 }
 
 const getAsyncRscBundle = createServerFn({ method: 'GET' })
-  .inputValidator((data: { scenario: string }) => data)
+  .validator((data: { scenario: string }) => data)
   .handler(async ({ data }) => {
     const serverTimestamp = Date.now()
     const bundleId = Math.random().toString(36).slice(2, 8)

--- a/e2e/react-start/rsc/src/routes/rsc-bundle.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-bundle.tsx
@@ -19,7 +19,7 @@ import { pageStyles, clientStyles, formatTime } from '~/utils/styles'
 // ============================================================================
 
 const getPageLayoutBundle = createServerFn({ method: 'GET' })
-  .inputValidator((data: { pageTitle: string }) => data)
+  .validator((data: { pageTitle: string }) => data)
   .handler(async ({ data }) => {
     const serverTimestamp = Date.now()
     const bundleId = Math.random().toString(36).slice(2, 8)

--- a/e2e/react-start/rsc/src/routes/rsc-caching.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-caching.tsx
@@ -15,7 +15,7 @@ import { pageStyles, clientStyles, formatTime } from '~/utils/styles'
 // ============================================================================
 
 const getCachedDataServerComponent = createServerFn({ method: 'GET' })
-  .inputValidator((data: { dataType: string }) => data)
+  .validator((data: { dataType: string }) => data)
   .handler(async ({ data }) => {
     const serverTimestamp = Date.now()
     const fetchId = Math.random().toString(36).slice(2, 8)

--- a/e2e/react-start/rsc/src/routes/rsc-component-slot.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-component-slot.tsx
@@ -18,7 +18,7 @@ import {
 // ============================================================================
 
 const getProductCardServer = createServerFn({ method: 'GET' })
-  .inputValidator((data: { productId: string }) => data)
+  .validator((data: { productId: string }) => data)
   .handler(async ({ data }) => {
     const serverTimestamp = Date.now()
 

--- a/e2e/react-start/rsc/src/routes/rsc-context.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-context.tsx
@@ -17,7 +17,7 @@ import { pageStyles, clientStyles, formatTime } from '~/utils/styles'
 const getContextAwareServerComponent = createServerFn({
   method: 'GET',
 })
-  .inputValidator((data: { userId: string }) => data)
+  .validator((data: { userId: string }) => data)
   .handler(async ({ data }) => {
     const serverTimestamp = Date.now()
 

--- a/e2e/react-start/rsc/src/routes/rsc-deferred.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-deferred.tsx
@@ -44,7 +44,7 @@ async function fetchDeferredAnalytics(): Promise<{
 }
 
 const getDeferredDataBundle = createServerFn({ method: 'GET' })
-  .inputValidator((data: { reportType: string }) => data)
+  .validator((data: { reportType: string }) => data)
   .handler(async ({ data }) => {
     const serverTimestamp = Date.now()
     const instanceId = Math.random().toString(36).slice(2, 8)

--- a/e2e/react-start/rsc/src/routes/rsc-error.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-error.tsx
@@ -15,9 +15,7 @@ import { pageStyles, clientStyles, formatTime } from '~/utils/styles'
 // ============================================================================
 
 const getErrorProneServerComponent = createServerFn({ method: 'GET' })
-  .validator(
-    (data: { shouldError: boolean; errorMessage?: string }) => data,
-  )
+  .validator((data: { shouldError: boolean; errorMessage?: string }) => data)
   .handler(async ({ data }) => {
     const serverTimestamp = Date.now()
 

--- a/e2e/react-start/rsc/src/routes/rsc-error.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-error.tsx
@@ -15,7 +15,7 @@ import { pageStyles, clientStyles, formatTime } from '~/utils/styles'
 // ============================================================================
 
 const getErrorProneServerComponent = createServerFn({ method: 'GET' })
-  .inputValidator(
+  .validator(
     (data: { shouldError: boolean; errorMessage?: string }) => data,
   )
   .handler(async ({ data }) => {

--- a/e2e/react-start/rsc/src/routes/rsc-external.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-external.tsx
@@ -14,7 +14,7 @@ import { pageStyles, formatTime } from '~/utils/styles'
 // ============================================================================
 
 const getExternalDataServerComponent = createServerFn({ method: 'GET' })
-  .inputValidator((data: { endpoint: string }) => data)
+  .validator((data: { endpoint: string }) => data)
   .handler(async ({ data }) => {
     const serverTimestamp = Date.now()
     const fetchStart = Date.now()

--- a/e2e/react-start/rsc/src/routes/rsc-forms.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-forms.tsx
@@ -25,7 +25,7 @@ const todoStore: Array<{ id: string; text: string; completed: boolean }> = [
 ]
 
 const addTodo = createServerFn({ method: 'POST' })
-  .inputValidator((data: { text: string }) => data)
+  .validator((data: { text: string }) => data)
   .handler(async ({ data }) => {
     const newTodo = {
       id: `todo_${Date.now()}`,
@@ -37,7 +37,7 @@ const addTodo = createServerFn({ method: 'POST' })
   })
 
 const toggleTodo = createServerFn({ method: 'POST' })
-  .inputValidator((data: { id: string }) => data)
+  .validator((data: { id: string }) => data)
   .handler(async ({ data }) => {
     const todo = todoStore.find((t) => t.id === data.id)
     if (todo) {
@@ -47,7 +47,7 @@ const toggleTodo = createServerFn({ method: 'POST' })
   })
 
 const deleteTodo = createServerFn({ method: 'POST' })
-  .inputValidator((data: { id: string }) => data)
+  .validator((data: { id: string }) => data)
   .handler(async ({ data }) => {
     const index = todoStore.findIndex((t) => t.id === data.id)
     if (index !== -1) {

--- a/e2e/react-start/rsc/src/routes/rsc-invalidation.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-invalidation.tsx
@@ -17,7 +17,7 @@ import { pageStyles, clientStyles, formatTime } from '~/utils/styles'
 const getSearchResultsServerComponent = createServerFn({
   method: 'GET',
 })
-  .inputValidator((data: { query: string; page: number }) => data)
+  .validator((data: { query: string; page: number }) => data)
   .handler(async ({ data }) => {
     const serverTimestamp = Date.now()
     const instanceId = Math.random().toString(36).slice(2, 8)

--- a/e2e/react-start/rsc/src/routes/rsc-large.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-large.tsx
@@ -15,7 +15,7 @@ import { pageStyles, clientStyles, formatTime } from '~/utils/styles'
 // ============================================================================
 
 const getLargePayloadServerComponent = createServerFn({ method: 'GET' })
-  .inputValidator((data: { itemCount: number }) => data)
+  .validator((data: { itemCount: number }) => data)
   .handler(async ({ data }) => {
     const serverTimestamp = Date.now()
 

--- a/e2e/react-start/rsc/src/routes/rsc-link.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-link.tsx
@@ -14,7 +14,7 @@ import { formatTime, pageStyles } from '~/utils/styles'
 // ============================================================================
 
 const getLinkServerComponent = createServerFn({ method: 'GET' })
-  .inputValidator((data: { targetRoute: string; linkText: string }) => data)
+  .validator((data: { targetRoute: string; linkText: string }) => data)
   .handler(async ({ data }) => {
     const { Link } = await import('@tanstack/react-router')
     const serverTimestamp = Date.now()

--- a/e2e/react-start/rsc/src/routes/rsc-nested-structure.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-nested-structure.tsx
@@ -19,7 +19,7 @@ import {
 // ============================================================================
 
 const getNestedServerComponents = createServerFn({ method: 'GET' })
-  .inputValidator((data: { title: string }) => data)
+  .validator((data: { title: string }) => data)
   .handler(async ({ data }) => {
     const serverTimestamp = Date.now()
 

--- a/e2e/react-start/rsc/src/routes/rsc-nested.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-nested.tsx
@@ -20,7 +20,7 @@ import { pageStyles, clientStyles, formatTime } from '~/utils/styles'
 const getProductCardServerComponent = createServerFn({
   method: 'GET',
 })
-  .inputValidator((data: { productId: string }) => data)
+  .validator((data: { productId: string }) => data)
   .handler(async ({ data }) => {
     const serverTimestamp = Date.now()
 
@@ -200,7 +200,7 @@ const getProductCardServerComponent = createServerFn({
 const getProductReviewsServerComponent = createServerFn({
   method: 'GET',
 })
-  .inputValidator((data: { productId: string }) => data)
+  .validator((data: { productId: string }) => data)
   .handler(async ({ data }) => {
     const serverTimestamp = Date.now()
 

--- a/e2e/react-start/rsc/src/routes/rsc-param/$id.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-param/$id.tsx
@@ -18,7 +18,7 @@ import {
 import { clientStyles, pageStyles } from '~/utils/styles'
 
 const getParamRsc = createServerFn({ method: 'GET' })
-  .inputValidator((data: { id: string }) => data)
+  .validator((data: { id: string }) => data)
   .handler(async ({ data }) => {
     const serverTimestamp = Date.now()
 

--- a/e2e/react-start/rsc/src/routes/rsc-react-cache.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-react-cache.tsx
@@ -511,7 +511,7 @@ async function ReactCacheContent({
 
 // Server component that demonstrates React.cache
 const getReactCacheServerComponent = createServerFn({ method: 'GET' })
-  .inputValidator((data: { testCache: boolean }) => data)
+  .validator((data: { testCache: boolean }) => data)
   .handler(async ({ data }) => {
     const serverTimestamp = Date.now()
 

--- a/e2e/react-start/rsc/src/routes/rsc-slot-jsx-args.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-slot-jsx-args.tsx
@@ -18,7 +18,7 @@ import {
 // ============================================================================
 
 const getPromoServerComponent = createServerFn({ method: 'GET' })
-  .inputValidator((data: { headline: string }) => data)
+  .validator((data: { headline: string }) => data)
   .handler(async ({ data }) => {
     const serverTimestamp = Date.now()
 

--- a/e2e/react-start/rsc/src/routes/rsc-slots.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-slots.tsx
@@ -18,7 +18,7 @@ import {
 // ============================================================================
 
 const getSlottedServerComponent = createServerFn({ method: 'GET' })
-  .inputValidator((data: { title: string }) => data)
+  .validator((data: { title: string }) => data)
   .handler(async ({ data }) => {
     const serverTimestamp = Date.now()
 

--- a/e2e/react-start/rsc/src/routes/rsc-ssr-data-only.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-ssr-data-only.tsx
@@ -20,7 +20,7 @@ import {
 // ============================================================================
 
 const getAnalyticsServerComponent = createServerFn({ method: 'GET' })
-  .inputValidator((data: { reportPeriod: string }) => data)
+  .validator((data: { reportPeriod: string }) => data)
   .handler(async ({ data }) => {
     const serverTimestamp = Date.now()
 

--- a/e2e/react-start/rsc/src/routes/rsc-ssr-false.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-ssr-false.tsx
@@ -20,9 +20,7 @@ import {
 // ============================================================================
 
 const getDrawingToolsServerComponent = createServerFn({ method: 'GET' })
-  .validator(
-    (data: { savedDrawingName?: string; lastColor?: string }) => data,
-  )
+  .validator((data: { savedDrawingName?: string; lastColor?: string }) => data)
   .handler(async ({ data }) => {
     const serverTimestamp = Date.now()
 

--- a/e2e/react-start/rsc/src/routes/rsc-ssr-false.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-ssr-false.tsx
@@ -20,7 +20,7 @@ import {
 // ============================================================================
 
 const getDrawingToolsServerComponent = createServerFn({ method: 'GET' })
-  .inputValidator(
+  .validator(
     (data: { savedDrawingName?: string; lastColor?: string }) => data,
   )
   .handler(async ({ data }) => {

--- a/e2e/react-start/rsc/src/routes/rsc-suspense.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-suspense.tsx
@@ -93,7 +93,7 @@ async function AsyncMetric({ label, delay }: { label: string; delay: number }) {
 }
 
 const getSuspenseServerComponent = createServerFn({ method: 'GET' })
-  .inputValidator((data: { delay?: number }) => data)
+  .validator((data: { delay?: number }) => data)
   .handler(async ({ data }) => {
     const serverTimestamp = Date.now()
     const delay = data.delay ?? 100

--- a/e2e/react-start/rsc/src/utils/basicServerComponent.tsx
+++ b/e2e/react-start/rsc/src/utils/basicServerComponent.tsx
@@ -8,7 +8,7 @@ import { serverBox, serverBadge, serverHeader, timestamp } from './serverStyles'
 // ============================================================================
 
 export const getBasicServerComponent = createServerFn({ method: 'GET' })
-  .inputValidator((data: { label?: string }) => data)
+  .validator((data: { label?: string }) => data)
   .handler(async ({ data }) => {
     const serverTimestamp = Date.now()
 

--- a/e2e/react-start/rsc/src/utils/clientPreloadServerComponent.tsx
+++ b/e2e/react-start/rsc/src/utils/clientPreloadServerComponent.tsx
@@ -9,7 +9,7 @@ import { ClientPreloadContent } from './ClientPreloadContent'
 // ============================================================================
 
 export const getClientPreloadServerComponent = createServerFn({ method: 'GET' })
-  .inputValidator((data: { title: string }) => data)
+  .validator((data: { title: string }) => data)
   .handler(async ({ data }) => {
     return renderServerComponent(<ClientPreloadContent data={data} />)
   })

--- a/e2e/react-start/rsc/src/utils/complexPreloadServerComponentA.tsx
+++ b/e2e/react-start/rsc/src/utils/complexPreloadServerComponentA.tsx
@@ -11,7 +11,7 @@ import { ComplexPreloadContentA } from './ComplexPreloadContentA'
 export const getComplexPreloadServerComponentA = createServerFn({
   method: 'GET',
 })
-  .inputValidator((data: { title: string }) => data)
+  .validator((data: { title: string }) => data)
   .handler(async ({ data }) => {
     return createCompositeComponent((props: { children?: React.ReactNode }) => (
       <ComplexPreloadContentA data={data}>

--- a/e2e/react-start/rsc/src/utils/complexPreloadServerComponentB.tsx
+++ b/e2e/react-start/rsc/src/utils/complexPreloadServerComponentB.tsx
@@ -10,7 +10,7 @@ import { ComplexPreloadContentB } from './ComplexPreloadContentB'
 export const getComplexPreloadServerComponentB = createServerFn({
   method: 'GET',
 })
-  .inputValidator((data: { title: string }) => data)
+  .validator((data: { title: string }) => data)
   .handler(async ({ data }) => {
     return renderServerComponent(<ComplexPreloadContentB data={data} />)
   })

--- a/e2e/react-start/rsc/src/utils/conditionalCssServerComponent.tsx
+++ b/e2e/react-start/rsc/src/utils/conditionalCssServerComponent.tsx
@@ -6,7 +6,7 @@ import { ConditionalVioletPanel } from './ConditionalVioletPanel'
 export const getConditionalCssServerComponent = createServerFn({
   method: 'GET',
 })
-  .inputValidator((data: { branch?: 'orange' | 'violet' }) => data)
+  .validator((data: { branch?: 'orange' | 'violet' }) => data)
   .handler(async ({ data }) => {
     const branch = data.branch === 'violet' ? 'violet' : 'orange'
 

--- a/e2e/react-start/rsc/src/utils/cssModulesServerComponent.tsx
+++ b/e2e/react-start/rsc/src/utils/cssModulesServerComponent.tsx
@@ -9,7 +9,7 @@ import { CssModulesContent } from './CssModulesContent'
 // ============================================================================
 
 export const getCssModulesServerComponent = createServerFn({ method: 'GET' })
-  .inputValidator((data: { title?: string }) => data)
+  .validator((data: { title?: string }) => data)
   .handler(async ({ data }) => {
     return renderServerComponent(
       <>

--- a/e2e/react-start/rsc/src/utils/globalCssServerComponent.tsx
+++ b/e2e/react-start/rsc/src/utils/globalCssServerComponent.tsx
@@ -9,7 +9,7 @@ import { GlobalCssContent } from './GlobalCssContent'
 // ============================================================================
 
 export const getGlobalCssServerComponent = createServerFn({ method: 'GET' })
-  .inputValidator((data: { title?: string }) => data)
+  .validator((data: { title?: string }) => data)
   .handler(async ({ data }) => {
     const serverTimestamp = Date.now()
 

--- a/e2e/react-start/rsc/src/utils/streamingServerComponents.tsx
+++ b/e2e/react-start/rsc/src/utils/streamingServerComponents.tsx
@@ -102,7 +102,7 @@ async function createNotificationRSC(notification: NotificationData) {
  * then `streamCount` more stream in with delays.
  */
 export const streamNotificationsReadable = createServerFn({ method: 'GET' })
-  .inputValidator(
+  .validator(
     (data: { initialCount: number; streamCount: number; delayMs: number }) =>
       data,
   )
@@ -140,7 +140,7 @@ export const streamNotificationsReadable = createServerFn({ method: 'GET' })
  * then `streamCount` more stream in with delays.
  */
 export const streamNotificationsGenerator = createServerFn({ method: 'GET' })
-  .inputValidator(
+  .validator(
     (data: { initialCount: number; streamCount: number; delayMs: number }) =>
       data,
   )

--- a/e2e/react-start/serialization-adapters/src/routes/server-function/custom-error.tsx
+++ b/e2e/react-start/serialization-adapters/src/routes/server-function/custom-error.tsx
@@ -7,7 +7,7 @@ import { CustomError } from '~/CustomError'
 
 const schema = z.object({ hello: z.string() })
 const serverFnThrowing = createServerFn()
-  .inputValidator(schema)
+  .validator(schema)
   .handler(async ({ data }) => {
     if (data.hello === 'world') {
       return 'Hello, world!'

--- a/e2e/react-start/server-functions-global-middleware/src/routes/context-collision.tsx
+++ b/e2e/react-start/server-functions-global-middleware/src/routes/context-collision.tsx
@@ -24,7 +24,7 @@ const getCollisionContext = createServerFn()
 
 const postCollisionContext = createServerFn({ method: 'POST' })
   .middleware([collisionMiddleware])
-  .inputValidator((data: unknown) => {
+  .validator((data: unknown) => {
     if (!(data instanceof FormData)) {
       throw new Error('Expected FormData')
     }

--- a/e2e/react-start/server-functions/src/routes/async-validation.tsx
+++ b/e2e/react-start/server-functions/src/routes/async-validation.tsx
@@ -12,7 +12,7 @@ const asyncValidationSchema = z
   .refine((data) => Promise.resolve(data !== 'invalid'))
 
 const asyncValidationServerFn = createServerFn()
-  .inputValidator(asyncValidationSchema)
+  .validator(asyncValidationSchema)
   .handler(({ data }) => data)
 
 function RouteComponent() {

--- a/e2e/react-start/server-functions/src/routes/consistent.tsx
+++ b/e2e/react-start/server-functions/src/routes/consistent.tsx
@@ -20,25 +20,25 @@ export const Route = createFileRoute('/consistent')({
 })
 
 const cons_getFn1 = createServerFn()
-  .inputValidator((d: { username: string }) => d)
+  .validator((d: { username: string }) => d)
   .handler(({ data }) => {
     return { payload: data }
   })
 
 const cons_serverGetFn1 = createServerFn()
-  .inputValidator((d: { username: string }) => d)
+  .validator((d: { username: string }) => d)
   .handler(async ({ data }) => {
     return cons_getFn1({ data })
   })
 
 const cons_postFn1 = createServerFn({ method: 'POST' })
-  .inputValidator((d: { username: string }) => d)
+  .validator((d: { username: string }) => d)
   .handler(({ data }) => {
     return { payload: data }
   })
 
 const cons_serverPostFn1 = createServerFn({ method: 'POST' })
-  .inputValidator((d: { username: string }) => d)
+  .validator((d: { username: string }) => d)
   .handler(({ data }) => {
     return cons_postFn1({ data })
   })

--- a/e2e/react-start/server-functions/src/routes/cookies/set.tsx
+++ b/e2e/react-start/server-functions/src/routes/cookies/set.tsx
@@ -18,14 +18,14 @@ export const Route = createFileRoute('/cookies/set')({
 })
 
 export const setCookieServerFn1 = createServerFn()
-  .inputValidator(cookieSchema)
+  .validator(cookieSchema)
   .handler(({ data }) => {
     setCookie(`cookie-1-${data.value}`, data.value)
     setCookie(`cookie-2-${data.value}`, data.value)
   })
 
 export const setCookieServerFn2 = createServerFn()
-  .inputValidator(cookieSchema)
+  .validator(cookieSchema)
   .handler(({ data }) => {
     setCookie(`cookie-3-${data.value}`, data.value)
     setCookie(`cookie-4-${data.value}`, data.value)

--- a/e2e/react-start/server-functions/src/routes/formdata-context.tsx
+++ b/e2e/react-start/server-functions/src/routes/formdata-context.tsx
@@ -23,7 +23,7 @@ const testMiddleware = createMiddleware({ type: 'function' })
 // Server function with FormData
 export const formDataWithContextFn = createServerFn({ method: 'POST' })
   .middleware([testMiddleware])
-  .inputValidator((data: unknown) => {
+  .validator((data: unknown) => {
     const formData = z.instanceof(FormData).parse(data)
     return {
       name: z.string().parse(formData.get('name')),

--- a/e2e/react-start/server-functions/src/routes/formdata-redirect/index.tsx
+++ b/e2e/react-start/server-functions/src/routes/formdata-redirect/index.tsx
@@ -14,7 +14,7 @@ const testValues = {
 }
 
 export const greetUser = createServerFn({ method: 'POST' })
-  .inputValidator((data: FormData) => {
+  .validator((data: FormData) => {
     if (!(data instanceof FormData)) {
       throw new Error('Invalid! FormData is required')
     }

--- a/e2e/react-start/server-functions/src/routes/isomorphic-fns.tsx
+++ b/e2e/react-start/server-functions/src/routes/isomorphic-fns.tsx
@@ -13,7 +13,7 @@ const getEcho = createIsomorphicFn()
   .client((input) => 'client received ' + input)
 
 const getServerEcho = createServerFn()
-  .inputValidator((input: string) => input)
+  .validator((input: string) => input)
   .handler(({ data }) => getEcho(data))
 
 export const Route = createFileRoute('/isomorphic-fns')({

--- a/e2e/react-start/server-functions/src/routes/multipart.tsx
+++ b/e2e/react-start/server-functions/src/routes/multipart.tsx
@@ -7,7 +7,7 @@ export const Route = createFileRoute('/multipart')({
 })
 
 const multipartFormDataServerFn = createServerFn({ method: 'POST' })
-  .inputValidator((x: unknown) => {
+  .validator((x: unknown) => {
     if (!(x instanceof FormData)) {
       throw new Error('Invalid form data')
     }

--- a/e2e/react-start/server-functions/src/routes/primitives/index.tsx
+++ b/e2e/react-start/server-functions/src/routes/primitives/index.tsx
@@ -12,27 +12,27 @@ function stringify(data: any) {
 }
 
 const $stringPost = createServerFn({ method: 'POST' })
-  .inputValidator(z.string())
+  .validator(z.string())
   .handler((ctx) => ctx.data)
 
 const $stringGet = createServerFn({ method: 'GET' })
-  .inputValidator(z.string())
+  .validator(z.string())
   .handler((ctx) => ctx.data)
 
 const $undefinedPost = createServerFn({ method: 'POST' })
-  .inputValidator(z.undefined())
+  .validator(z.undefined())
   .handler((ctx) => ctx.data)
 
 const $undefinedGet = createServerFn({ method: 'GET' })
-  .inputValidator(z.undefined())
+  .validator(z.undefined())
   .handler((ctx) => ctx.data)
 
 const $nullPost = createServerFn({ method: 'POST' })
-  .inputValidator(z.null())
+  .validator(z.null())
   .handler((ctx) => ctx.data)
 
 const $nullGet = createServerFn({ method: 'GET' })
-  .inputValidator(z.null())
+  .validator(z.null())
   .handler((ctx) => ctx.data)
 
 interface PrimitiveComponentProps<T> {

--- a/e2e/react-start/server-functions/src/routes/serialize-form-data.tsx
+++ b/e2e/react-start/server-functions/src/routes/serialize-form-data.tsx
@@ -16,7 +16,7 @@ const testValues = {
 }
 
 export const greetUser = createServerFn({ method: 'POST' })
-  .inputValidator((data: FormData) => {
+  .validator((data: FormData) => {
     if (!(data instanceof FormData)) {
       throw new Error('Invalid! FormData is required')
     }

--- a/e2e/react-start/server-functions/src/routes/submit-post-formdata.tsx
+++ b/e2e/react-start/server-functions/src/routes/submit-post-formdata.tsx
@@ -10,7 +10,7 @@ const testValues = {
 }
 
 export const greetUser = createServerFn({ method: 'POST' })
-  .inputValidator((data: FormData) => {
+  .validator((data: FormData) => {
     if (!(data instanceof FormData)) {
       throw new Error('Invalid! FormData is required')
     }

--- a/e2e/react-start/streaming-ssr/src/routes/deferred.tsx
+++ b/e2e/react-start/streaming-ssr/src/routes/deferred.tsx
@@ -4,7 +4,7 @@ import { Suspense } from 'react'
 
 // Server function that returns immediately
 const getImmediateData = createServerFn({ method: 'GET' })
-  .inputValidator((data: { name: string }) => data)
+  .validator((data: { name: string }) => data)
   .handler(({ data }) => {
     return {
       name: data.name,
@@ -16,7 +16,7 @@ const getImmediateData = createServerFn({ method: 'GET' })
 
 // Server function that takes time to complete
 const getSlowData = createServerFn({ method: 'GET' })
-  .inputValidator((data: { name: string; delay: number }) => data)
+  .validator((data: { name: string; delay: number }) => data)
   .handler(async ({ data }) => {
     await new Promise((r) => setTimeout(r, data.delay))
     return {

--- a/e2e/react-start/virtual-routes/src/utils/posts.tsx
+++ b/e2e/react-start/virtual-routes/src/utils/posts.tsx
@@ -15,7 +15,7 @@ if (import.meta.env.VITE_NODE_ENV === 'test') {
 }
 
 export const fetchPost = createServerFn({ method: 'GET' })
-  .inputValidator((postId: string) => postId)
+  .validator((postId: string) => postId)
   .handler(async ({ data: postId }) => {
     console.info(`Fetching post with id ${postId}...`)
     const post = await axios

--- a/e2e/react-start/website/src/server/document.tsx
+++ b/e2e/react-start/website/src/server/document.tsx
@@ -41,7 +41,7 @@ export const getDocumentHeads = createServerFn({ method: 'GET' }).handler(
 )
 
 export const getDocument = createServerFn({ method: 'GET' })
-  .inputValidator((id: string) => id)
+  .validator((id: string) => id)
   .handler(async ({ data: id }) => {
     await new Promise((resolve) => setTimeout(resolve, 200))
 

--- a/e2e/react-start/website/src/server/projects.tsx
+++ b/e2e/react-start/website/src/server/projects.tsx
@@ -13,7 +13,7 @@ export const getProjects = createServerFn({ method: 'GET' }).handler(
 )
 
 export const getProject = createServerFn({ method: 'GET' })
-  .inputValidator((project: string) => project)
+  .validator((project: string) => project)
   .handler(async (ctx) => {
     await new Promise((resolve) => setTimeout(resolve, 200))
 

--- a/e2e/solid-start/basic-auth/src/routes/_authed.tsx
+++ b/e2e/solid-start/basic-auth/src/routes/_authed.tsx
@@ -8,7 +8,7 @@ import { useAppSession } from '~/utils/session'
 export const loginFn = createServerFn({
   method: 'POST',
 })
-  .inputValidator((payload: { email: string; password: string }) => payload)
+  .validator((payload: { email: string; password: string }) => payload)
   .handler(async ({ data }) => {
     // Find the user
     const user = await prismaClient.user.findUnique({

--- a/e2e/solid-start/basic-auth/src/routes/signup.tsx
+++ b/e2e/solid-start/basic-auth/src/routes/signup.tsx
@@ -9,7 +9,7 @@ import { useAppSession } from '~/utils/session'
 export const signupFn = createServerFn({
   method: 'POST',
 })
-  .inputValidator(
+  .validator(
     (data: { email: string; password: string; redirectUrl?: string }) => data,
   )
   .handler(async ({ data: payload }) => {

--- a/e2e/solid-start/basic-auth/src/utils/posts.ts
+++ b/e2e/solid-start/basic-auth/src/utils/posts.ts
@@ -9,7 +9,7 @@ export type PostType = {
 }
 
 export const fetchPost = createServerFn({ method: 'GET' })
-  .inputValidator((postId: string) => postId)
+  .validator((postId: string) => postId)
   .handler(async ({ data: postId }) => {
     console.info(`Fetching post with id ${postId}...`)
     const post = await axios

--- a/e2e/solid-start/basic-tsr-config/src/app/routes/index.tsx
+++ b/e2e/solid-start/basic-tsr-config/src/app/routes/index.tsx
@@ -12,7 +12,7 @@ const getCount = createServerFn({
 })
 
 const updateCount = createServerFn({ method: 'POST' })
-  .inputValidator((d: number) => d)
+  .validator((d: number) => d)
   .handler(async ({ data }) => {
     const count = await getCount()
     await fs.promises.writeFile(filePath, `${count + data}`)

--- a/e2e/solid-start/basic/src/components/throwRedirect.ts
+++ b/e2e/solid-start/basic/src/components/throwRedirect.ts
@@ -2,7 +2,7 @@ import { redirect } from '@tanstack/solid-router'
 import { createServerFn } from '@tanstack/solid-start'
 
 export const throwRedirect = createServerFn()
-  .inputValidator(
+  .validator(
     (opts: {
       target: 'internal' | 'external'
       reloadDocument?: boolean

--- a/e2e/solid-start/basic/src/routes/deferred.tsx
+++ b/e2e/solid-start/basic/src/routes/deferred.tsx
@@ -3,13 +3,13 @@ import { createServerFn } from '@tanstack/solid-start'
 import { Suspense, createSignal } from 'solid-js'
 
 const personServerFn = createServerFn({ method: 'GET' })
-  .inputValidator((data: { name: string }) => data)
+  .validator((data: { name: string }) => data)
   .handler(({ data }) => {
     return { name: data.name, randomNumber: Math.floor(Math.random() * 100) }
   })
 
 const slowServerFn = createServerFn({ method: 'GET' })
-  .inputValidator((data: { name: string }) => data)
+  .validator((data: { name: string }) => data)
   .handler(async ({ data }) => {
     await new Promise((r) => setTimeout(r, 1000))
     return { name: data.name, randomNumber: Math.floor(Math.random() * 100) }

--- a/e2e/solid-start/basic/src/utils/posts.tsx
+++ b/e2e/solid-start/basic/src/utils/posts.tsx
@@ -15,7 +15,7 @@ if (import.meta.env.VITE_NODE_ENV === 'test') {
 }
 
 export const fetchPost = createServerFn({ method: 'GET' })
-  .inputValidator((postId: string) => postId)
+  .validator((postId: string) => postId)
   .handler(async ({ data: postId }) => {
     console.info(`Fetching post with id ${postId}...`)
     const post = await axios

--- a/e2e/solid-start/custom-basepath/src/routes/deferred.tsx
+++ b/e2e/solid-start/custom-basepath/src/routes/deferred.tsx
@@ -3,13 +3,13 @@ import { createServerFn } from '@tanstack/solid-start'
 import { Suspense, createSignal } from 'solid-js'
 
 const personServerFn = createServerFn({ method: 'GET' })
-  .inputValidator((data: { name: string }) => data)
+  .validator((data: { name: string }) => data)
   .handler(({ data }) => {
     return { name: data.name, randomNumber: Math.floor(Math.random() * 100) }
   })
 
 const slowServerFn = createServerFn({ method: 'GET' })
-  .inputValidator((data: { name: string }) => data)
+  .validator((data: { name: string }) => data)
   .handler(async ({ data }) => {
     await new Promise((r) => setTimeout(r, 1000))
     return { name: data.name, randomNumber: Math.floor(Math.random() * 100) }

--- a/e2e/solid-start/custom-basepath/src/utils/posts.tsx
+++ b/e2e/solid-start/custom-basepath/src/utils/posts.tsx
@@ -15,7 +15,7 @@ if (import.meta.env.VITE_NODE_ENV === 'test') {
 }
 
 export const fetchPost = createServerFn({ method: 'GET' })
-  .inputValidator((postId: string) => postId)
+  .validator((postId: string) => postId)
   .handler(async ({ data: postId }) => {
     console.info(`Fetching post with id ${postId}...`)
     const post = await axios

--- a/e2e/solid-start/serialization-adapters/src/routes/server-function/custom-error.tsx
+++ b/e2e/solid-start/serialization-adapters/src/routes/server-function/custom-error.tsx
@@ -7,7 +7,7 @@ import { CustomError } from '~/CustomError'
 
 const schema = z.object({ hello: z.string() })
 const serverFnThrowing = createServerFn()
-  .inputValidator(schema)
+  .validator(schema)
   .handler(async ({ data }) => {
     if (data.hello === 'world') {
       return 'Hello, world!'

--- a/e2e/solid-start/server-functions/src/routes/consistent.tsx
+++ b/e2e/solid-start/server-functions/src/routes/consistent.tsx
@@ -20,25 +20,25 @@ export const Route = createFileRoute('/consistent')({
 })
 
 const cons_getFn1 = createServerFn()
-  .inputValidator((d: { username: string }) => d)
+  .validator((d: { username: string }) => d)
   .handler(({ data }) => {
     return { payload: data }
   })
 
 const cons_serverGetFn1 = createServerFn()
-  .inputValidator((d: { username: string }) => d)
+  .validator((d: { username: string }) => d)
   .handler(async ({ data }) => {
     return cons_getFn1({ data })
   })
 
 const cons_postFn1 = createServerFn({ method: 'POST' })
-  .inputValidator((d: { username: string }) => d)
+  .validator((d: { username: string }) => d)
   .handler(({ data }) => {
     return { payload: data }
   })
 
 const cons_serverPostFn1 = createServerFn({ method: 'POST' })
-  .inputValidator((d: { username: string }) => d)
+  .validator((d: { username: string }) => d)
   .handler(({ data }) => {
     return cons_postFn1({ data })
   })

--- a/e2e/solid-start/server-functions/src/routes/cookies/set.tsx
+++ b/e2e/solid-start/server-functions/src/routes/cookies/set.tsx
@@ -18,14 +18,14 @@ export const Route = createFileRoute('/cookies/set')({
 })
 
 export const setCookieServerFn1 = createServerFn()
-  .inputValidator(cookieSchema)
+  .validator(cookieSchema)
   .handler(({ data }) => {
     setCookie(`cookie-1-${data.value}`, data.value)
     setCookie(`cookie-2-${data.value}`, data.value)
   })
 
 export const setCookieServerFn2 = createServerFn()
-  .inputValidator(cookieSchema)
+  .validator(cookieSchema)
   .handler(({ data }) => {
     setCookie(`cookie-3-${data.value}`, data.value)
     setCookie(`cookie-4-${data.value}`, data.value)

--- a/e2e/solid-start/server-functions/src/routes/formdata-redirect/index.tsx
+++ b/e2e/solid-start/server-functions/src/routes/formdata-redirect/index.tsx
@@ -14,7 +14,7 @@ const testValues = {
 }
 
 export const greetUser = createServerFn({ method: 'POST' })
-  .inputValidator((data: FormData) => {
+  .validator((data: FormData) => {
     if (!(data instanceof FormData)) {
       throw new Error('Invalid! FormData is required')
     }

--- a/e2e/solid-start/server-functions/src/routes/isomorphic-fns.tsx
+++ b/e2e/solid-start/server-functions/src/routes/isomorphic-fns.tsx
@@ -13,7 +13,7 @@ const getEcho = createIsomorphicFn()
   .client((input) => 'client received ' + input)
 
 const getServerEcho = createServerFn()
-  .inputValidator((input: string) => input)
+  .validator((input: string) => input)
   .handler(({ data }) => getEcho(data))
 
 export const Route = createFileRoute('/isomorphic-fns')({

--- a/e2e/solid-start/server-functions/src/routes/multipart.tsx
+++ b/e2e/solid-start/server-functions/src/routes/multipart.tsx
@@ -7,7 +7,7 @@ export const Route = createFileRoute('/multipart')({
 })
 
 const multipartFormDataServerFn = createServerFn({ method: 'POST' })
-  .inputValidator((x: unknown) => {
+  .validator((x: unknown) => {
     if (!(x instanceof FormData)) {
       throw new Error('Invalid form data')
     }

--- a/e2e/solid-start/server-functions/src/routes/primitives/index.tsx
+++ b/e2e/solid-start/server-functions/src/routes/primitives/index.tsx
@@ -13,27 +13,27 @@ function stringify(data: any) {
 }
 
 const $stringPost = createServerFn({ method: 'POST' })
-  .inputValidator(z.string())
+  .validator(z.string())
   .handler((ctx) => ctx.data)
 
 const $stringGet = createServerFn({ method: 'GET' })
-  .inputValidator(z.string())
+  .validator(z.string())
   .handler((ctx) => ctx.data)
 
 const $undefinedPost = createServerFn({ method: 'POST' })
-  .inputValidator(z.undefined())
+  .validator(z.undefined())
   .handler((ctx) => ctx.data)
 
 const $undefinedGet = createServerFn({ method: 'GET' })
-  .inputValidator(z.undefined())
+  .validator(z.undefined())
   .handler((ctx) => ctx.data)
 
 const $nullPost = createServerFn({ method: 'POST' })
-  .inputValidator(z.null())
+  .validator(z.null())
   .handler((ctx) => ctx.data)
 
 const $nullGet = createServerFn({ method: 'GET' })
-  .inputValidator(z.null())
+  .validator(z.null())
   .handler((ctx) => ctx.data)
 
 interface PrimitiveComponentProps<T> {

--- a/e2e/solid-start/server-functions/src/routes/serialize-form-data.tsx
+++ b/e2e/solid-start/server-functions/src/routes/serialize-form-data.tsx
@@ -12,7 +12,7 @@ const testValues = {
 }
 
 export const greetUser = createServerFn({ method: 'POST' })
-  .inputValidator((data: FormData) => {
+  .validator((data: FormData) => {
     if (!(data instanceof FormData)) {
       throw new Error('Invalid! FormData is required')
     }

--- a/e2e/solid-start/server-functions/src/routes/submit-post-formdata.tsx
+++ b/e2e/solid-start/server-functions/src/routes/submit-post-formdata.tsx
@@ -10,7 +10,7 @@ const testValues = {
 }
 
 export const greetUser = createServerFn({ method: 'POST' })
-  .inputValidator((data: FormData) => {
+  .validator((data: FormData) => {
     if (!(data instanceof FormData)) {
       throw new Error('Invalid! FormData is required')
     }

--- a/e2e/solid-start/virtual-routes/src/utils/posts.tsx
+++ b/e2e/solid-start/virtual-routes/src/utils/posts.tsx
@@ -15,7 +15,7 @@ if (import.meta.env.VITE_NODE_ENV === 'test') {
 }
 
 export const fetchPost = createServerFn({ method: 'GET' })
-  .inputValidator((postId: string) => postId)
+  .validator((postId: string) => postId)
   .handler(async ({ data: postId }) => {
     console.info(`Fetching post with id ${postId}...`)
     const post = await axios

--- a/e2e/solid-start/website/src/server/document.tsx
+++ b/e2e/solid-start/website/src/server/document.tsx
@@ -41,7 +41,7 @@ export const getDocumentHeads = createServerFn({ method: 'GET' }).handler(
 )
 
 export const getDocument = createServerFn({ method: 'GET' })
-  .inputValidator((id: string) => id)
+  .validator((id: string) => id)
   .handler(async ({ data: id }) => {
     await new Promise((resolve) => setTimeout(resolve, 200))
 

--- a/e2e/solid-start/website/src/server/projects.tsx
+++ b/e2e/solid-start/website/src/server/projects.tsx
@@ -13,7 +13,7 @@ export const getProjects = createServerFn({ method: 'GET' }).handler(
 )
 
 export const getProject = createServerFn({ method: 'GET' })
-  .inputValidator((project: string) => project)
+  .validator((project: string) => project)
   .handler(async (ctx) => {
     await new Promise((resolve) => setTimeout(resolve, 200))
 

--- a/e2e/vue-start/basic-auth/src/routes/_authed.tsx
+++ b/e2e/vue-start/basic-auth/src/routes/_authed.tsx
@@ -8,7 +8,7 @@ import { useAppSession } from '~/utils/session'
 export const loginFn = createServerFn({
   method: 'POST',
 })
-  .inputValidator((payload: { email: string; password: string }) => payload)
+  .validator((payload: { email: string; password: string }) => payload)
   .handler(async ({ data }) => {
     // Find the user
     const user = await prismaClient.user.findUnique({

--- a/e2e/vue-start/basic-auth/src/routes/signup.tsx
+++ b/e2e/vue-start/basic-auth/src/routes/signup.tsx
@@ -10,7 +10,7 @@ import { useAppSession } from '~/utils/session'
 export const signupFn = createServerFn({
   method: 'POST',
 })
-  .inputValidator(
+  .validator(
     (data: { email: string; password: string; redirectUrl?: string }) => data,
   )
   .handler(async ({ data: payload }) => {

--- a/e2e/vue-start/basic-auth/src/utils/posts.ts
+++ b/e2e/vue-start/basic-auth/src/utils/posts.ts
@@ -9,7 +9,7 @@ export type PostType = {
 }
 
 export const fetchPost = createServerFn({ method: 'GET' })
-  .inputValidator((postId: string) => postId)
+  .validator((postId: string) => postId)
   .handler(async ({ data: postId }) => {
     console.info(`Fetching post with id ${postId}...`)
     const post = await axios

--- a/e2e/vue-start/basic-tsr-config/src/app/routes/index.tsx
+++ b/e2e/vue-start/basic-tsr-config/src/app/routes/index.tsx
@@ -12,7 +12,7 @@ const getCount = createServerFn({
 })
 
 const updateCount = createServerFn({ method: 'POST' })
-  .inputValidator((d: number) => d)
+  .validator((d: number) => d)
   .handler(async ({ data }) => {
     const count = await getCount()
     await fs.promises.writeFile(filePath, `${count + data}`)

--- a/e2e/vue-start/basic/src/components/throwRedirect.ts
+++ b/e2e/vue-start/basic/src/components/throwRedirect.ts
@@ -2,7 +2,7 @@ import { redirect } from '@tanstack/vue-router'
 import { createServerFn } from '@tanstack/vue-start'
 
 export const throwRedirect = createServerFn()
-  .inputValidator(
+  .validator(
     (opts: {
       target: 'internal' | 'external'
       reloadDocument?: boolean

--- a/e2e/vue-start/basic/src/routes/deferred.tsx
+++ b/e2e/vue-start/basic/src/routes/deferred.tsx
@@ -3,13 +3,13 @@ import { createServerFn } from '@tanstack/vue-start'
 import { Suspense, ref, defineComponent } from 'vue'
 
 const personServerFn = createServerFn({ method: 'GET' })
-  .inputValidator((data: { name: string }) => data)
+  .validator((data: { name: string }) => data)
   .handler(({ data }) => {
     return { name: data.name, randomNumber: Math.floor(Math.random() * 100) }
   })
 
 const slowServerFn = createServerFn({ method: 'GET' })
-  .inputValidator((data: { name: string }) => data)
+  .validator((data: { name: string }) => data)
   .handler(async ({ data }) => {
     await new Promise((r) => setTimeout(r, 1000))
     return { name: data.name, randomNumber: Math.floor(Math.random() * 100) }

--- a/e2e/vue-start/basic/src/utils/posts.tsx
+++ b/e2e/vue-start/basic/src/utils/posts.tsx
@@ -15,7 +15,7 @@ if (import.meta.env.VITE_NODE_ENV === 'test') {
 }
 
 export const fetchPost = createServerFn({ method: 'GET' })
-  .inputValidator((postId: string) => postId)
+  .validator((postId: string) => postId)
   .handler(async ({ data: postId }) => {
     console.info(`Fetching post with id ${postId}...`)
     const post = await axios

--- a/e2e/vue-start/custom-basepath/src/routes/deferred.tsx
+++ b/e2e/vue-start/custom-basepath/src/routes/deferred.tsx
@@ -3,13 +3,13 @@ import { createServerFn } from '@tanstack/vue-start'
 import { Suspense, defineComponent, ref } from 'vue'
 
 const personServerFn = createServerFn({ method: 'GET' })
-  .inputValidator((data: { name: string }) => data)
+  .validator((data: { name: string }) => data)
   .handler(({ data }) => {
     return { name: data.name, randomNumber: Math.floor(Math.random() * 100) }
   })
 
 const slowServerFn = createServerFn({ method: 'GET' })
-  .inputValidator((data: { name: string }) => data)
+  .validator((data: { name: string }) => data)
   .handler(async ({ data }) => {
     await new Promise((r) => setTimeout(r, 1000))
     return { name: data.name, randomNumber: Math.floor(Math.random() * 100) }

--- a/e2e/vue-start/custom-basepath/src/utils/posts.tsx
+++ b/e2e/vue-start/custom-basepath/src/utils/posts.tsx
@@ -15,7 +15,7 @@ if (import.meta.env.VITE_NODE_ENV === 'test') {
 }
 
 export const fetchPost = createServerFn({ method: 'GET' })
-  .inputValidator((postId: string) => postId)
+  .validator((postId: string) => postId)
   .handler(async ({ data: postId }) => {
     console.info(`Fetching post with id ${postId}...`)
     const post = await axios

--- a/e2e/vue-start/serialization-adapters/src/routes/server-function/custom-error.tsx
+++ b/e2e/vue-start/serialization-adapters/src/routes/server-function/custom-error.tsx
@@ -7,7 +7,7 @@ import { CustomError } from '~/CustomError'
 
 const schema = z.object({ hello: z.string() })
 const serverFnThrowing = createServerFn()
-  .inputValidator(schema)
+  .validator(schema)
   .handler(async ({ data }) => {
     if (data.hello === 'world') {
       return 'Hello, world!'

--- a/e2e/vue-start/server-functions/src/routes/consistent.tsx
+++ b/e2e/vue-start/server-functions/src/routes/consistent.tsx
@@ -11,25 +11,25 @@ import { defineComponent, ref } from 'vue'
  */
 
 const cons_getFn1 = createServerFn()
-  .inputValidator((d: { username: string }) => d)
+  .validator((d: { username: string }) => d)
   .handler(({ data }) => {
     return { payload: data }
   })
 
 const cons_serverGetFn1 = createServerFn()
-  .inputValidator((d: { username: string }) => d)
+  .validator((d: { username: string }) => d)
   .handler(async ({ data }) => {
     return cons_getFn1({ data })
   })
 
 const cons_postFn1 = createServerFn({ method: 'POST' })
-  .inputValidator((d: { username: string }) => d)
+  .validator((d: { username: string }) => d)
   .handler(({ data }) => {
     return { payload: data }
   })
 
 const cons_serverPostFn1 = createServerFn({ method: 'POST' })
-  .inputValidator((d: { username: string }) => d)
+  .validator((d: { username: string }) => d)
   .handler(({ data }) => {
     return cons_postFn1({ data })
   })

--- a/e2e/vue-start/server-functions/src/routes/cookies/set.tsx
+++ b/e2e/vue-start/server-functions/src/routes/cookies/set.tsx
@@ -8,14 +8,14 @@ import { defineComponent, ref, watch } from 'vue'
 const cookieSchema = z.object({ value: z.string() })
 
 export const setCookieServerFn1 = createServerFn()
-  .inputValidator(cookieSchema)
+  .validator(cookieSchema)
   .handler(({ data }) => {
     setCookie(`cookie-1-${data.value}`, data.value)
     setCookie(`cookie-2-${data.value}`, data.value)
   })
 
 export const setCookieServerFn2 = createServerFn()
-  .inputValidator(cookieSchema)
+  .validator(cookieSchema)
   .handler(({ data }) => {
     setCookie(`cookie-3-${data.value}`, data.value)
     setCookie(`cookie-4-${data.value}`, data.value)

--- a/e2e/vue-start/server-functions/src/routes/formdata-redirect/index.tsx
+++ b/e2e/vue-start/server-functions/src/routes/formdata-redirect/index.tsx
@@ -14,7 +14,7 @@ const testValues = {
 }
 
 export const greetUser = createServerFn({ method: 'POST' })
-  .inputValidator((data: FormData) => {
+  .validator((data: FormData) => {
     if (!(data instanceof FormData)) {
       throw new Error('Invalid! FormData is required')
     }

--- a/e2e/vue-start/server-functions/src/routes/isomorphic-fns.tsx
+++ b/e2e/vue-start/server-functions/src/routes/isomorphic-fns.tsx
@@ -13,7 +13,7 @@ const getEcho = createIsomorphicFn()
   .client((input) => 'client received ' + input)
 
 const getServerEcho = createServerFn()
-  .inputValidator((input: string) => input)
+  .validator((input: string) => input)
   .handler(({ data }) => getEcho(data))
 
 const RouteComponent = defineComponent({

--- a/e2e/vue-start/server-functions/src/routes/multipart.tsx
+++ b/e2e/vue-start/server-functions/src/routes/multipart.tsx
@@ -3,7 +3,7 @@ import { createServerFn } from '@tanstack/vue-start'
 import { defineComponent, ref } from 'vue'
 
 const multipartFormDataServerFn = createServerFn({ method: 'POST' })
-  .inputValidator((x: unknown) => {
+  .validator((x: unknown) => {
     if (!(x instanceof FormData)) {
       throw new Error('Invalid form data')
     }

--- a/e2e/vue-start/server-functions/src/routes/primitives/index.tsx
+++ b/e2e/vue-start/server-functions/src/routes/primitives/index.tsx
@@ -9,27 +9,27 @@ function stringify(data: any) {
 }
 
 const $stringPost = createServerFn({ method: 'POST' })
-  .inputValidator(z.string())
+  .validator(z.string())
   .handler((ctx) => ctx.data)
 
 const $stringGet = createServerFn({ method: 'GET' })
-  .inputValidator(z.string())
+  .validator(z.string())
   .handler((ctx) => ctx.data)
 
 const $undefinedPost = createServerFn({ method: 'POST' })
-  .inputValidator(z.undefined())
+  .validator(z.undefined())
   .handler((ctx) => ctx.data)
 
 const $undefinedGet = createServerFn({ method: 'GET' })
-  .inputValidator(z.undefined())
+  .validator(z.undefined())
   .handler((ctx) => ctx.data)
 
 const $nullPost = createServerFn({ method: 'POST' })
-  .inputValidator(z.null())
+  .validator(z.null())
   .handler((ctx) => ctx.data)
 
 const $nullGet = createServerFn({ method: 'GET' })
-  .inputValidator(z.null())
+  .validator(z.null())
   .handler((ctx) => ctx.data)
 
 interface PrimitiveComponentProps<T> {

--- a/e2e/vue-start/server-functions/src/routes/serialize-form-data.tsx
+++ b/e2e/vue-start/server-functions/src/routes/serialize-form-data.tsx
@@ -11,7 +11,7 @@ const testValues = {
 }
 
 export const greetUser = createServerFn({ method: 'POST' })
-  .inputValidator((data: FormData) => {
+  .validator((data: FormData) => {
     if (!(data instanceof FormData)) {
       throw new Error('Invalid! FormData is required')
     }

--- a/e2e/vue-start/server-functions/src/routes/submit-post-formdata.tsx
+++ b/e2e/vue-start/server-functions/src/routes/submit-post-formdata.tsx
@@ -10,7 +10,7 @@ const testValues = {
 }
 
 export const greetUser = createServerFn({ method: 'POST' })
-  .inputValidator((data: FormData) => {
+  .validator((data: FormData) => {
     if (!(data instanceof FormData)) {
       throw new Error('Invalid! FormData is required')
     }

--- a/e2e/vue-start/virtual-routes/src/utils/posts.tsx
+++ b/e2e/vue-start/virtual-routes/src/utils/posts.tsx
@@ -15,7 +15,7 @@ if (import.meta.env.VITE_NODE_ENV === 'test') {
 }
 
 export const fetchPost = createServerFn({ method: 'GET' })
-  .inputValidator((postId: string) => postId)
+  .validator((postId: string) => postId)
   .handler(async ({ data: postId }) => {
     console.info(`Fetching post with id ${postId}...`)
     const post = await axios

--- a/e2e/vue-start/website/src/server/document.tsx
+++ b/e2e/vue-start/website/src/server/document.tsx
@@ -41,7 +41,7 @@ export const getDocumentHeads = createServerFn({ method: 'GET' }).handler(
 )
 
 export const getDocument = createServerFn({ method: 'GET' })
-  .inputValidator((id: string) => id)
+  .validator((id: string) => id)
   .handler(async ({ data: id }) => {
     await new Promise((resolve) => setTimeout(resolve, 200))
 

--- a/e2e/vue-start/website/src/server/projects.tsx
+++ b/e2e/vue-start/website/src/server/projects.tsx
@@ -13,7 +13,7 @@ export const getProjects = createServerFn({ method: 'GET' }).handler(
 )
 
 export const getProject = createServerFn({ method: 'GET' })
-  .inputValidator((project: string) => project)
+  .validator((project: string) => project)
   .handler(async (ctx) => {
     await new Promise((resolve) => setTimeout(resolve, 200))
 

--- a/examples/react/start-basic-auth/src/routes/_authed.tsx
+++ b/examples/react/start-basic-auth/src/routes/_authed.tsx
@@ -5,7 +5,7 @@ import { Login } from '~/components/Login'
 import { useAppSession } from '~/utils/session'
 
 export const loginFn = createServerFn({ method: 'POST' })
-  .inputValidator((d: { email: string; password: string }) => d)
+  .validator((d: { email: string; password: string }) => d)
   .handler(async ({ data }) => {
     // Find the user
     const user = await prismaClient.user.findUnique({

--- a/examples/react/start-basic-auth/src/routes/signup.tsx
+++ b/examples/react/start-basic-auth/src/routes/signup.tsx
@@ -6,7 +6,7 @@ import { Auth } from '~/components/Auth'
 import { useAppSession } from '~/utils/session'
 
 export const signupFn = createServerFn({ method: 'POST' })
-  .inputValidator(
+  .validator(
     (d: { email: string; password: string; redirectUrl?: string }) => d,
   )
   .handler(async ({ data }) => {

--- a/examples/react/start-basic-auth/src/utils/posts.ts
+++ b/examples/react/start-basic-auth/src/utils/posts.ts
@@ -9,7 +9,7 @@ export type PostType = {
 }
 
 export const fetchPost = createServerFn({ method: 'GET' })
-  .inputValidator((postId: string) => postId)
+  .validator((postId: string) => postId)
   .handler(async ({ data }) => {
     console.info(`Fetching post with id ${data}...`)
     const post = await axios

--- a/examples/react/start-basic-cloudflare/src/routes/deferred.tsx
+++ b/examples/react/start-basic-cloudflare/src/routes/deferred.tsx
@@ -3,13 +3,13 @@ import { createServerFn } from '@tanstack/react-start'
 import { Suspense, useState } from 'react'
 
 const personServerFn = createServerFn({ method: 'GET' })
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(({ data: name }) => {
     return { name, randomNumber: Math.floor(Math.random() * 100) }
   })
 
 const slowServerFn = createServerFn({ method: 'GET' })
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(async ({ data: name }) => {
     await new Promise((r) => setTimeout(r, 1000))
     return { name, randomNumber: Math.floor(Math.random() * 100) }

--- a/examples/react/start-basic-cloudflare/src/utils/posts.tsx
+++ b/examples/react/start-basic-cloudflare/src/utils/posts.tsx
@@ -8,7 +8,7 @@ export type PostType = {
 }
 
 export const fetchPost = createServerFn({ method: 'POST' })
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(async ({ data }) => {
     console.info(`Fetching post with id ${data}...`)
     const res = await fetch(

--- a/examples/react/start-basic-react-query/src/utils/posts.tsx
+++ b/examples/react/start-basic-react-query/src/utils/posts.tsx
@@ -25,7 +25,7 @@ export const postsQueryOptions = () =>
   })
 
 export const fetchPost = createServerFn({ method: 'GET' })
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(async ({ data }) => {
     console.info(`Fetching post with id ${data}...`)
     const post = await axios

--- a/examples/react/start-basic-static/src/routes/deferred.tsx
+++ b/examples/react/start-basic-static/src/routes/deferred.tsx
@@ -5,14 +5,14 @@ import { staticFunctionMiddleware } from '@tanstack/start-static-server-function
 
 const personServerFn = createServerFn({ method: 'GET' })
   .middleware([staticFunctionMiddleware])
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(({ data: name }) => {
     return { name, randomNumber: Math.floor(Math.random() * 100) }
   })
 
 const slowServerFn = createServerFn({ method: 'GET' })
   .middleware([staticFunctionMiddleware])
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(async ({ data: name }) => {
     await new Promise((r) => setTimeout(r, 1000))
     return { name, randomNumber: Math.floor(Math.random() * 100) }

--- a/examples/react/start-basic-static/src/routes/users.$userId.tsx
+++ b/examples/react/start-basic-static/src/routes/users.$userId.tsx
@@ -8,7 +8,7 @@ import { staticFunctionMiddleware } from '@tanstack/start-static-server-function
 
 const fetchUser = createServerFn({ method: 'GET' })
   .middleware([staticFunctionMiddleware])
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(async ({ data: userId }) => {
     return axios
       .get<User>('https://jsonplaceholder.typicode.com/users/' + userId)

--- a/examples/react/start-basic-static/src/utils/posts.tsx
+++ b/examples/react/start-basic-static/src/utils/posts.tsx
@@ -12,7 +12,7 @@ export type PostType = {
 
 export const fetchPost = createServerFn({ method: 'GET' })
   .middleware([logMiddleware, staticFunctionMiddleware])
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(async ({ data }) => {
     console.info(`Fetching post with id ${data}...`)
     const post = await axios

--- a/examples/react/start-basic/src/routes/deferred.tsx
+++ b/examples/react/start-basic/src/routes/deferred.tsx
@@ -3,13 +3,13 @@ import { createServerFn } from '@tanstack/react-start'
 import { Suspense, useState } from 'react'
 
 const personServerFn = createServerFn({ method: 'GET' })
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(({ data: name }) => {
     return { name, randomNumber: Math.floor(Math.random() * 100) }
   })
 
 const slowServerFn = createServerFn({ method: 'GET' })
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(async ({ data: name }) => {
     await new Promise((r) => setTimeout(r, 1000))
     return { name, randomNumber: Math.floor(Math.random() * 100) }

--- a/examples/react/start-basic/src/utils/posts.tsx
+++ b/examples/react/start-basic/src/utils/posts.tsx
@@ -8,7 +8,7 @@ export type PostType = {
 }
 
 export const fetchPost = createServerFn({ method: 'POST' })
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(async ({ data }) => {
     console.info(`Fetching post with id ${data}...`)
     const res = await fetch(

--- a/examples/react/start-bun/src/routes/demo.start.server-funcs.tsx
+++ b/examples/react/start-bun/src/routes/demo.start.server-funcs.tsx
@@ -25,7 +25,7 @@ const getTodos = createServerFn({
 }).handler(async () => await readTodos())
 
 const addTodo = createServerFn({ method: 'POST' })
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(async ({ data }) => {
     const todos = await readTodos()
     todos.push({ id: todos.length + 1, name: data })

--- a/examples/react/start-clerk-basic/src/utils/posts.ts
+++ b/examples/react/start-clerk-basic/src/utils/posts.ts
@@ -9,7 +9,7 @@ export type PostType = {
 }
 
 export const fetchPost = createServerFn({ method: 'GET' })
-  .inputValidator((postId: string) => postId)
+  .validator((postId: string) => postId)
   .handler(async ({ data }) => {
     console.info(`Fetching post with id ${data}...`)
     const post = await axios

--- a/examples/react/start-convex-trellaux/src/utils/posts.tsx
+++ b/examples/react/start-convex-trellaux/src/utils/posts.tsx
@@ -9,7 +9,7 @@ export type PostType = {
 }
 
 export const fetchPost = createServerFn({ method: 'GET' })
-  .inputValidator((postId: string) => postId)
+  .validator((postId: string) => postId)
   .handler(async ({ data }) => {
     console.info(`Fetching post with id ${data}...`)
     const post = await axios

--- a/examples/react/start-counter/src/routes/index.tsx
+++ b/examples/react/start-counter/src/routes/index.tsx
@@ -15,7 +15,7 @@ const getCount = createServerFn({ method: 'GET' }).handler(() => {
 })
 
 const updateCount = createServerFn({ method: 'POST' })
-  .inputValidator((addBy: number) => addBy)
+  .validator((addBy: number) => addBy)
   .handler(async ({ data }) => {
     const count = await readCount()
     await fs.promises.writeFile(filePath, `${count + data}`)

--- a/examples/react/start-i18n-paraglide/src/routes/index.tsx
+++ b/examples/react/start-i18n-paraglide/src/routes/index.tsx
@@ -4,7 +4,7 @@ import { getLocale } from '@/paraglide/runtime.js'
 import { createServerFn } from '@tanstack/react-start'
 
 const getServerMessage = createServerFn()
-  .inputValidator((emoji: string) => emoji)
+  .validator((emoji: string) => emoji)
   .handler((ctx) => {
     return m.server_message({ emoji: ctx.data })
   })

--- a/examples/react/start-large/src/routes/params/$paramsPlaceholder.tsx
+++ b/examples/react/start-large/src/routes/params/$paramsPlaceholder.tsx
@@ -15,7 +15,7 @@ const loaderResult = v.object({
 })
 
 const middleware = createMiddleware({ type: 'function' })
-  .inputValidator(params)
+  .validator(params)
   .client(({ next }) => {
     const context = { client: { paramsPlaceholder: 'paramsPlaceholder' } }
     return next({

--- a/examples/react/start-large/src/routes/search/searchPlaceholder.tsx
+++ b/examples/react/start-large/src/routes/search/searchPlaceholder.tsx
@@ -15,7 +15,7 @@ const loaderResult = v.object({
 })
 
 const middleware = createMiddleware({ type: 'function' })
-  .inputValidator(search)
+  .validator(search)
   .client(({ next }) => {
     const context = { client: { searchPlaceholder: 'searchPlaceholder' } }
     return next({

--- a/examples/react/start-rscs/src/low-level/components/dexie-cache/server-functions.tsx
+++ b/examples/react/start-rscs/src/low-level/components/dexie-cache/server-functions.tsx
@@ -50,7 +50,7 @@ function CounterCard({ count }: { count: number }) {
 
 // Server function that returns Flight payload as a string for caching
 export const getCounterRscPayload = createServerFn()
-  .inputValidator((data: { count: number }) => data)
+  .validator((data: { count: number }) => data)
   .handler(async ({ data }) => {
     console.log(`[Server] Creating Flight payload for count: ${data.count}`)
 

--- a/examples/react/start-supabase-basic/src/routes/_authed.tsx
+++ b/examples/react/start-supabase-basic/src/routes/_authed.tsx
@@ -4,7 +4,7 @@ import { Login } from '../components/Login'
 import { getSupabaseServerClient } from '../utils/supabase'
 
 export const loginFn = createServerFn({ method: 'POST' })
-  .inputValidator((d: { email: string; password: string }) => d)
+  .validator((d: { email: string; password: string }) => d)
   .handler(async ({ data }) => {
     const supabase = getSupabaseServerClient()
     const { error } = await supabase.auth.signInWithPassword({

--- a/examples/react/start-supabase-basic/src/routes/signup.tsx
+++ b/examples/react/start-supabase-basic/src/routes/signup.tsx
@@ -5,7 +5,7 @@ import { Auth } from '../components/Auth'
 import { getSupabaseServerClient } from '../utils/supabase'
 
 export const signupFn = createServerFn({ method: 'POST' })
-  .inputValidator(
+  .validator(
     (d: { email: string; password: string; redirectUrl?: string }) => d,
   )
   .handler(async ({ data }) => {

--- a/examples/react/start-supabase-basic/src/utils/posts.ts
+++ b/examples/react/start-supabase-basic/src/utils/posts.ts
@@ -9,7 +9,7 @@ export type PostType = {
 }
 
 export const fetchPost = createServerFn({ method: 'GET' })
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(async ({ data: postId }) => {
     console.info(`Fetching post with id ${postId}...`)
     const post = await axios

--- a/examples/react/start-trellaux/src/db/board.ts
+++ b/examples/react/start-trellaux/src/db/board.ts
@@ -33,7 +33,7 @@ export const getBoards = createServerFn({ method: 'GET' }).handler(async () => {
 })
 
 export const getBoard = createServerFn({ method: 'GET' })
-  .inputValidator(z.string())
+  .validator(z.string())
   .handler(async ({ data }) => {
     await delay(DELAY)
     const board = boards.find((b) => b.id === data)
@@ -42,7 +42,7 @@ export const getBoard = createServerFn({ method: 'GET' })
   })
 
 export const createColumn = createServerFn()
-  .inputValidator(newColumnSchema)
+  .validator(newColumnSchema)
   .handler(async ({ data }) => {
     await delay(DELAY)
     const newColumn = newColumnSchema.parse(data)
@@ -62,7 +62,7 @@ export const createColumn = createServerFn()
   })
 
 export const createItem = createServerFn()
-  .inputValidator(itemSchema)
+  .validator(itemSchema)
   .handler(async ({ data }) => {
     await delay(DELAY)
     const item = itemSchema.parse(data)
@@ -75,7 +75,7 @@ export const createItem = createServerFn()
   })
 
 export const deleteItem = createServerFn({ method: 'GET' })
-  .inputValidator(deleteItemSchema)
+  .validator(deleteItemSchema)
   .handler(async ({ data }) => {
     await delay(DELAY)
     const { id } = deleteItemSchema.parse(data)
@@ -85,7 +85,7 @@ export const deleteItem = createServerFn({ method: 'GET' })
   })
 
 export const updateItem = createServerFn()
-  .inputValidator(itemSchema)
+  .validator(itemSchema)
   .handler(async ({ data }) => {
     await delay(DELAY)
     const item = itemSchema.parse(data)
@@ -97,7 +97,7 @@ export const updateItem = createServerFn()
   })
 
 export const updateColumn = createServerFn()
-  .inputValidator(updateColumnSchema)
+  .validator(updateColumnSchema)
   .handler(async ({ data }) => {
     await delay(DELAY)
     const column = updateColumnSchema.parse(data)
@@ -109,7 +109,7 @@ export const updateColumn = createServerFn()
   })
 
 export const updateBoard = createServerFn()
-  .inputValidator(updateBoardSchema)
+  .validator(updateBoardSchema)
   .handler(async ({ data }) => {
     await delay(DELAY)
     const update = updateBoardSchema.parse(data)
@@ -119,7 +119,7 @@ export const updateBoard = createServerFn()
   })
 
 export const deleteColumn = createServerFn({ method: 'GET' })
-  .inputValidator(deleteColumnSchema)
+  .validator(deleteColumnSchema)
   .handler(async ({ data }) => {
     await delay(DELAY)
     const { id } = deleteColumnSchema.parse(data)

--- a/examples/react/start-trellaux/src/utils/posts.tsx
+++ b/examples/react/start-trellaux/src/utils/posts.tsx
@@ -9,7 +9,7 @@ export type PostType = {
 }
 
 export const fetchPost = createServerFn({ method: 'GET' })
-  .inputValidator((postId: string) => postId)
+  .validator((postId: string) => postId)
   .handler(async ({ data }) => {
     console.info(`Fetching post with id ${data}...`)
     const post = await axios

--- a/examples/solid/start-basic-auth/src/routes/_authed.tsx
+++ b/examples/solid/start-basic-auth/src/routes/_authed.tsx
@@ -5,7 +5,7 @@ import { Login } from '~/components/Login'
 import { useAppSession } from '~/utils/session'
 
 export const loginFn = createServerFn({ method: 'POST' })
-  .inputValidator((d: { email: string; password: string }) => d)
+  .validator((d: { email: string; password: string }) => d)
   .handler(async ({ data }) => {
     // Find the user
     const user = await prismaClient.user.findUnique({

--- a/examples/solid/start-basic-auth/src/routes/signup.tsx
+++ b/examples/solid/start-basic-auth/src/routes/signup.tsx
@@ -6,7 +6,7 @@ import { Auth } from '~/components/Auth'
 import { useAppSession } from '~/utils/session'
 
 export const signupFn = createServerFn({ method: 'POST' })
-  .inputValidator(
+  .validator(
     (d: { email: string; password: string; redirectUrl?: string }) => d,
   )
   .handler(async ({ data }) => {

--- a/examples/solid/start-basic-auth/src/utils/posts.ts
+++ b/examples/solid/start-basic-auth/src/utils/posts.ts
@@ -9,7 +9,7 @@ export type PostType = {
 }
 
 export const fetchPost = createServerFn({ method: 'GET' })
-  .inputValidator((postId: string) => postId)
+  .validator((postId: string) => postId)
   .handler(async ({ data }) => {
     console.info(`Fetching post with id ${data}...`)
     const post = await axios

--- a/examples/solid/start-basic-cloudflare/src/routes/deferred.tsx
+++ b/examples/solid/start-basic-cloudflare/src/routes/deferred.tsx
@@ -3,13 +3,13 @@ import { createServerFn } from '@tanstack/solid-start'
 import { Suspense, createSignal } from 'solid-js'
 
 const personServerFn = createServerFn({ method: 'GET' })
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(({ data: name }) => {
     return { name, randomNumber: Math.floor(Math.random() * 100) }
   })
 
 const slowServerFn = createServerFn({ method: 'GET' })
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(async ({ data: name }) => {
     await new Promise((r) => setTimeout(r, 1000))
     return { name, randomNumber: Math.floor(Math.random() * 100) }

--- a/examples/solid/start-basic-cloudflare/src/utils/posts.tsx
+++ b/examples/solid/start-basic-cloudflare/src/utils/posts.tsx
@@ -8,7 +8,7 @@ export type PostType = {
 }
 
 export const fetchPost = createServerFn({ method: 'POST' })
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(async ({ data }) => {
     console.info(`Fetching post with id ${data}...`)
     const res = await fetch(

--- a/examples/solid/start-basic-netlify/src/routes/deferred.tsx
+++ b/examples/solid/start-basic-netlify/src/routes/deferred.tsx
@@ -3,13 +3,13 @@ import { createServerFn } from '@tanstack/solid-start'
 import { Suspense, createSignal } from 'solid-js'
 
 const personServerFn = createServerFn({ method: 'GET' })
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(({ data: name }) => {
     return { name, randomNumber: Math.floor(Math.random() * 100) }
   })
 
 const slowServerFn = createServerFn({ method: 'GET' })
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(async ({ data: name }) => {
     await new Promise((r) => setTimeout(r, 1000))
     return { name, randomNumber: Math.floor(Math.random() * 100) }

--- a/examples/solid/start-basic-netlify/src/utils/posts.tsx
+++ b/examples/solid/start-basic-netlify/src/utils/posts.tsx
@@ -8,7 +8,7 @@ export type PostType = {
 }
 
 export const fetchPost = createServerFn({ method: 'POST' })
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(async ({ data }) => {
     console.info(`Fetching post with id ${data}...`)
     const res = await fetch(

--- a/examples/solid/start-basic-nitro/src/routes/deferred.tsx
+++ b/examples/solid/start-basic-nitro/src/routes/deferred.tsx
@@ -3,13 +3,13 @@ import { createServerFn } from '@tanstack/solid-start'
 import { Suspense, createSignal } from 'solid-js'
 
 const personServerFn = createServerFn({ method: 'GET' })
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(({ data: name }) => {
     return { name, randomNumber: Math.floor(Math.random() * 100) }
   })
 
 const slowServerFn = createServerFn({ method: 'GET' })
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(async ({ data: name }) => {
     await new Promise((r) => setTimeout(r, 1000))
     return { name, randomNumber: Math.floor(Math.random() * 100) }

--- a/examples/solid/start-basic-nitro/src/utils/posts.tsx
+++ b/examples/solid/start-basic-nitro/src/utils/posts.tsx
@@ -8,7 +8,7 @@ export type PostType = {
 }
 
 export const fetchPost = createServerFn({ method: 'POST' })
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(async ({ data }) => {
     console.info(`Fetching post with id ${data}...`)
     const res = await fetch(

--- a/examples/solid/start-basic-solid-query/src/utils/posts.tsx
+++ b/examples/solid/start-basic-solid-query/src/utils/posts.tsx
@@ -25,7 +25,7 @@ export const postsQueryOptions = () =>
   })
 
 export const fetchPost = createServerFn({ method: 'GET' })
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(async ({ data }) => {
     console.info(`Fetching post with id ${data}...`)
     const post = await axios

--- a/examples/solid/start-basic-static/src/routes/deferred.tsx
+++ b/examples/solid/start-basic-static/src/routes/deferred.tsx
@@ -5,14 +5,14 @@ import { staticFunctionMiddleware } from '@tanstack/start-static-server-function
 
 const personServerFn = createServerFn({ method: 'GET' })
   .middleware([staticFunctionMiddleware])
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(({ data: name }) => {
     return { name, randomNumber: Math.floor(Math.random() * 100) }
   })
 
 const slowServerFn = createServerFn({ method: 'GET' })
   .middleware([staticFunctionMiddleware])
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(async ({ data: name }) => {
     await new Promise((r) => setTimeout(r, 1000))
     return { name, randomNumber: Math.floor(Math.random() * 100) }

--- a/examples/solid/start-basic-static/src/routes/users.$userId.tsx
+++ b/examples/solid/start-basic-static/src/routes/users.$userId.tsx
@@ -8,7 +8,7 @@ import { staticFunctionMiddleware } from '@tanstack/start-static-server-function
 
 const fetchUser = createServerFn({ method: 'GET' })
   .middleware([staticFunctionMiddleware])
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(async ({ data: userId }) => {
     return axios
       .get<User>('https://jsonplaceholder.typicode.com/users/' + userId)

--- a/examples/solid/start-basic-static/src/utils/posts.tsx
+++ b/examples/solid/start-basic-static/src/utils/posts.tsx
@@ -12,7 +12,7 @@ export type PostType = {
 
 export const fetchPost = createServerFn({ method: 'GET' })
   .middleware([logMiddleware, staticFunctionMiddleware])
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(async ({ data }) => {
     console.info(`Fetching post with id ${data}...`)
     const post = await axios

--- a/examples/solid/start-basic/src/routes/deferred.tsx
+++ b/examples/solid/start-basic/src/routes/deferred.tsx
@@ -3,13 +3,13 @@ import { createServerFn } from '@tanstack/solid-start'
 import { Suspense, createSignal } from 'solid-js'
 
 const personServerFn = createServerFn({ method: 'GET' })
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(({ data: name }) => {
     return { name, randomNumber: Math.floor(Math.random() * 100) }
   })
 
 const slowServerFn = createServerFn({ method: 'GET' })
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(async ({ data: name }) => {
     await new Promise((r) => setTimeout(r, 1000))
     return { name, randomNumber: Math.floor(Math.random() * 100) }

--- a/examples/solid/start-basic/src/utils/posts.tsx
+++ b/examples/solid/start-basic/src/utils/posts.tsx
@@ -9,7 +9,7 @@ export type PostType = {
 }
 
 export const fetchPost = createServerFn({ method: 'GET' })
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(async ({ data }) => {
     console.info(`Fetching post with id ${data}...`)
     const post = await axios

--- a/examples/solid/start-bun/src/routes/demo.start.server-funcs.tsx
+++ b/examples/solid/start-bun/src/routes/demo.start.server-funcs.tsx
@@ -25,7 +25,7 @@ const getTodos = createServerFn({
 }).handler(async () => await readTodos())
 
 const addTodo = createServerFn({ method: 'POST' })
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(async ({ data }) => {
     const todos = await readTodos()
     todos.push({ id: todos.length + 1, name: data })

--- a/examples/solid/start-i18n-paraglide/src/routes/index.tsx
+++ b/examples/solid/start-i18n-paraglide/src/routes/index.tsx
@@ -4,7 +4,7 @@ import { m } from '@/paraglide/messages.js'
 // import { getLocale } from '@/paraglide/runtime.js'
 
 const getServerMessage = createServerFn()
-  .inputValidator((emoji: string) => emoji)
+  .validator((emoji: string) => emoji)
   .handler((ctx) => {
     return m.server_message({ emoji: ctx.data })
   })

--- a/examples/solid/start-large/src/routes/params/$paramsPlaceholder.tsx
+++ b/examples/solid/start-large/src/routes/params/$paramsPlaceholder.tsx
@@ -14,7 +14,7 @@ const loaderResult = v.object({
 })
 
 const middleware = createMiddleware({ type: 'function' })
-  .inputValidator(params)
+  .validator(params)
   .client(({ next }) => {
     const context = { client: { paramsPlaceholder: 'paramsPlaceholder' } }
     return next({

--- a/examples/solid/start-large/src/routes/search/searchPlaceholder.tsx
+++ b/examples/solid/start-large/src/routes/search/searchPlaceholder.tsx
@@ -15,7 +15,7 @@ const loaderResult = v.object({
 })
 
 const middleware = createMiddleware({ type: 'function' })
-  .inputValidator(search)
+  .validator(search)
   .client(({ next }) => {
     const context = { client: { searchPlaceholder: 'searchPlaceholder' } }
     return next({

--- a/examples/solid/start-supabase-basic/src/routes/_authed.tsx
+++ b/examples/solid/start-supabase-basic/src/routes/_authed.tsx
@@ -4,7 +4,7 @@ import { Login } from '../components/Login'
 import { getSupabaseServerClient } from '../utils/supabase'
 
 export const loginFn = createServerFn({ method: 'POST' })
-  .inputValidator((d: { email: string; password: string }) => d)
+  .validator((d: { email: string; password: string }) => d)
   .handler(async ({ data }) => {
     const supabase = getSupabaseServerClient()
     const { error } = await supabase.auth.signInWithPassword({

--- a/examples/solid/start-supabase-basic/src/routes/signup.tsx
+++ b/examples/solid/start-supabase-basic/src/routes/signup.tsx
@@ -5,7 +5,7 @@ import { Auth } from '../components/Auth'
 import { getSupabaseServerClient } from '../utils/supabase'
 
 export const signupFn = createServerFn({ method: 'POST' })
-  .inputValidator(
+  .validator(
     (d: { email: string; password: string; redirectUrl?: string }) => d,
   )
   .handler(async ({ data }) => {

--- a/examples/solid/start-supabase-basic/src/utils/posts.ts
+++ b/examples/solid/start-supabase-basic/src/utils/posts.ts
@@ -9,7 +9,7 @@ export type PostType = {
 }
 
 export const fetchPost = createServerFn({ method: 'GET' })
-  .inputValidator((d: string) => d)
+  .validator((d: string) => d)
   .handler(async ({ data: postId }) => {
     console.info(`Fetching post with id ${postId}...`)
     const post = await axios

--- a/packages/react-start/skills/_artifacts/domain_map.yaml
+++ b/packages/react-start/skills/_artifacts/domain_map.yaml
@@ -134,7 +134,7 @@ skills:
       - '@tanstack/start-server-core'
     covers:
       - createServerFn (GET/POST)
-      - inputValidator (Zod or function)
+      - validator (Zod or function)
       - useServerFn hook
       - Server context utilities (getRequest, getRequestHeader, setResponseHeader, setResponseStatus)
       - Error handling (throw errors, redirect, notFound)
@@ -229,7 +229,7 @@ skills:
       - Middleware factories
       - Fetch override precedence
       - Header merging
-      - Method order enforcement (middleware → inputValidator → client → server)
+      - Method order enforcement (middleware → validator → client → server)
     tasks:
       - 'Add authentication middleware'
       - 'Pass context through middleware chain'
@@ -247,7 +247,7 @@ skills:
 
       - mistake: 'Wrong middleware method order'
         mechanism: >-
-          TypeScript enforces method order: middleware → inputValidator
+          TypeScript enforces method order: middleware → validator
           → client → server. Wrong order causes type errors and
           runtime failures.
         source: 'docs/start/framework/react/guide/middleware.md'
@@ -498,7 +498,7 @@ skills:
         mechanism: >-
           Older snippets may use renderRsc or .validator(...).
           Normalize them to renderServerComponent and
-          .inputValidator(...) before using them in current code.
+          .validator(...) before using them in current code.
         source: 'docs/start/framework/react/guide/server-functions.md'
         priority: MEDIUM
         status: active

--- a/packages/react-start/skills/_artifacts/skill_tree.yaml
+++ b/packages/react-start/skills/_artifacts/skill_tree.yaml
@@ -37,7 +37,7 @@ skills:
     path: 'skills/start-core/server-functions/SKILL.md'
     package: 'packages/start-client-core'
     description: >-
-      createServerFn (GET/POST), inputValidator (Zod or function),
+      createServerFn (GET/POST), validator (Zod or function),
       useServerFn hook, server context utilities (getRequest,
       getRequestHeader, setResponseHeader, setResponseStatus), error
       handling (throw errors, redirect, notFound), streaming

--- a/packages/react-start/skills/lifecycle/migrate-from-nextjs/SKILL.md
+++ b/packages/react-start/skills/lifecycle/migrate-from-nextjs/SKILL.md
@@ -220,7 +220,7 @@ TanStack Start:
 import { createServerFn } from '@tanstack/react-start'
 
 export const createPost = createServerFn({ method: 'POST' })
-  .inputValidator((data) => {
+  .validator((data) => {
     if (!(data instanceof FormData)) throw new Error('Expected FormData')
     return { title: data.get('title')?.toString() || '' }
   })

--- a/packages/react-start/skills/react-start/SKILL.md
+++ b/packages/react-start/skills/react-start/SKILL.md
@@ -181,7 +181,7 @@ Use `useServerFn` to call server functions from React components with proper int
 import { createServerFn, useServerFn } from '@tanstack/react-start'
 
 const updatePost = createServerFn({ method: 'POST' })
-  .inputValidator((data: { id: string; title: string }) => data)
+  .validator((data: { id: string; title: string }) => data)
   .handler(async ({ data }) => {
     await db.posts.update(data.id, { title: data.title })
     return { success: true }

--- a/packages/react-start/skills/react-start/server-components/SKILL.md
+++ b/packages/react-start/skills/react-start/server-components/SKILL.md
@@ -46,7 +46,7 @@ Treat TanStack Start RSCs as fetchable React Flight payloads, not as a framework
 - Query-cached RSC values require `structuralSharing: false`.
 - Slot payloads are opaque on the server. Do not inspect, map, or clone `props.children`.
 - Render-prop and component-slot arguments must stay Flight-serializable.
-- Current server function validation API is `.inputValidator(...)`. Older snippets may still show `.validator(...)`; normalize them.
+- Current server function validation API is `.validator(...)`. Older snippets may still show `.validator(...)`; normalize them.
 - TanStack custom serialization does not apply inside RSCs yet. Stay inside native Flight-supported values.
 
 ## Decide three things immediately
@@ -97,7 +97,7 @@ Treat TanStack Start RSCs as fetchable React Flight payloads, not as a framework
 - Are query options using `structuralSharing: false` for any RSC value?
 - Are mutations explicit `createServerFn({ method: 'POST' })` calls instead of hidden server actions?
 - Are server-only imports kept inside server functions or server-only boundaries?
-- Are examples using current names (`renderServerComponent`, `.inputValidator`) instead of stale ones?
+- Are examples using current names (`renderServerComponent`, `.validator`) instead of stale ones?
 
 ## Debug fast
 

--- a/packages/react-start/skills/react-start/server-components/docs/current-api-notes.md
+++ b/packages/react-start/skills/react-start/server-components/docs/current-api-notes.md
@@ -29,7 +29,7 @@ Use low-level APIs only for custom transport:
 
 ## Current validation API
 
-Use `.inputValidator(...)` on `createServerFn`.
+Use `.validator(...)` on `createServerFn`.
 
 Important because some current RSC docs snippets still show the older `.validator(...)` spelling. Normalize those examples before copying them into real code.
 
@@ -48,7 +48,7 @@ You may still find older official repo examples using `renderRsc` and older conf
 
 ### Old validation snippets
 
-If you see `.validator(z.object(...))` in an RSC example, rewrite it to `.inputValidator(z.object(...))` to match the current server function API.
+If you see `.validator(z.object(...))` in an RSC example, rewrite it to `.validator(z.object(...))` to match the current server function API.
 
 ### Old Vite config shapes
 

--- a/packages/react-start/skills/react-start/server-components/docs/debugging-review.md
+++ b/packages/react-start/skills/react-start/server-components/docs/debugging-review.md
@@ -15,7 +15,7 @@ Checks:
 
 - inspect `vite.config.*`
 - inspect imports from `@tanstack/react-start/rsc`
-- normalize to `renderServerComponent`, `createCompositeComponent`, `CompositeComponent`, `.inputValidator(...)`
+- normalize to `renderServerComponent`, `createCompositeComponent`, `CompositeComponent`, `.validator(...)`
 
 ### 2. Wrong environment failure
 

--- a/packages/react-start/skills/react-start/server-components/docs/sources.md
+++ b/packages/react-start/skills/react-start/server-components/docs/sources.md
@@ -34,6 +34,6 @@ Validated on 2026-04-13.
 ## Notes on drift observed during validation
 
 - Current RSC docs and blog use `renderServerComponent`, `createCompositeComponent`, `CompositeComponent`, and low-level Flight APIs from `@tanstack/react-start/rsc`.
-- Current Server Functions docs use `.inputValidator(...)`.
+- Current Server Functions docs use `.validator(...)`.
 - Some current RSC docs snippets still show older `.validator(...)`.
 - Older official repo examples may still show `renderRsc` and older config shapes. Prefer the current docs above.

--- a/packages/react-start/skills/react-start/server-components/examples/02-composite-slots.tsx
+++ b/packages/react-start/skills/react-start/server-components/examples/02-composite-slots.tsx
@@ -32,7 +32,7 @@ declare const db: {
 }
 
 const getPostCard = createServerFn({ method: 'GET' })
-  .inputValidator(z.object({ postId: z.string() }))
+  .validator(z.object({ postId: z.string() }))
   .handler(async ({ data }) => {
     const post = await db.posts.findById(data.postId)
 
@@ -93,7 +93,7 @@ function PostActions(props: { postId: string; authorId: string }) {
 
 // Component-prop slot variant
 const getProductCard = createServerFn({ method: 'GET' })
-  .inputValidator(z.object({ productId: z.string() }))
+  .validator(z.object({ productId: z.string() }))
   .handler(async ({ data }) => {
     const product = await db.products.findById(data.productId)
 

--- a/packages/react-start/skills/react-start/server-components/examples/03-query-owned-rsc.tsx
+++ b/packages/react-start/skills/react-start/server-components/examples/03-query-owned-rsc.tsx
@@ -27,7 +27,7 @@ declare const db: {
 }
 
 const getPostRsc = createServerFn({ method: 'GET' })
-  .inputValidator(z.object({ postId: z.string() }))
+  .validator(z.object({ postId: z.string() }))
   .handler(async ({ data }) => {
     const post = await db.posts.findById(data.postId)
 
@@ -45,7 +45,7 @@ const getPostRsc = createServerFn({ method: 'GET' })
   })
 
 const updatePost = createServerFn({ method: 'POST' })
-  .inputValidator(
+  .validator(
     z.object({
       postId: z.string(),
       title: z.string().optional(),

--- a/packages/react-start/skills/react-start/server-components/examples/05-ssr-false-browser-loader.tsx
+++ b/packages/react-start/skills/react-start/server-components/examples/05-ssr-false-browser-loader.tsx
@@ -7,7 +7,7 @@ import { renderServerComponent } from '@tanstack/react-start/rsc'
 import { z } from 'zod'
 
 const getDrawingTools = createServerFn({ method: 'POST' })
-  .inputValidator(z.object({ savedState: z.string().nullable() }))
+  .validator(z.object({ savedState: z.string().nullable() }))
   .handler(async ({ data }) => {
     const Tools = await renderServerComponent(
       <ToolPalette savedState={data.savedState} />,

--- a/packages/solid-start/skills/solid-start/SKILL.md
+++ b/packages/solid-start/skills/solid-start/SKILL.md
@@ -176,7 +176,7 @@ import { createServerFn, useServerFn } from '@tanstack/solid-start'
 import { createSignal } from 'solid-js'
 
 const updatePost = createServerFn({ method: 'POST' })
-  .inputValidator((data: { id: string; title: string }) => data)
+  .validator((data: { id: string; title: string }) => data)
   .handler(async ({ data }) => {
     await db.posts.update(data.id, { title: data.title })
     return { success: true }

--- a/packages/start-client-core/skills/_artifacts/domain_map.yaml
+++ b/packages/start-client-core/skills/_artifacts/domain_map.yaml
@@ -134,7 +134,7 @@ skills:
       - '@tanstack/start-server-core'
     covers:
       - createServerFn (GET/POST)
-      - inputValidator (Zod or function)
+      - validator (Zod or function)
       - useServerFn hook
       - Server context utilities (getRequest, getRequestHeader, setResponseHeader, setResponseStatus)
       - Error handling (throw errors, redirect, notFound)
@@ -229,7 +229,7 @@ skills:
       - Middleware factories
       - Fetch override precedence
       - Header merging
-      - Method order enforcement (middleware → inputValidator → client → server)
+      - Method order enforcement (middleware → validator → client → server)
     tasks:
       - 'Add authentication middleware'
       - 'Pass context through middleware chain'
@@ -247,7 +247,7 @@ skills:
 
       - mistake: 'Wrong middleware method order'
         mechanism: >-
-          TypeScript enforces method order: middleware → inputValidator
+          TypeScript enforces method order: middleware → validator
           → client → server. Wrong order causes type errors and
           runtime failures.
         source: 'docs/start/framework/react/guide/middleware.md'

--- a/packages/start-client-core/skills/_artifacts/skill_tree.yaml
+++ b/packages/start-client-core/skills/_artifacts/skill_tree.yaml
@@ -36,7 +36,7 @@ skills:
     path: 'skills/start-core/server-functions/SKILL.md'
     package: 'packages/start-client-core'
     description: >-
-      createServerFn (GET/POST), inputValidator (Zod or function),
+      createServerFn (GET/POST), validator (Zod or function),
       useServerFn hook, server context utilities (getRequest,
       getRequestHeader, setResponseHeader, setResponseStatus), error
       handling (throw errors, redirect, notFound), streaming

--- a/packages/start-client-core/skills/start-core/auth-server-primitives/SKILL.md
+++ b/packages/start-client-core/skills/start-core/auth-server-primitives/SKILL.md
@@ -31,7 +31,7 @@ This skill covers the **server half** of authentication: session storage, cookie
 ## Production Checklist
 
 - Enforce auth in every server function, server route, or API endpoint that reads or writes private user, tenant, or account data. Use route `beforeLoad` for page UX, not as the data boundary.
-- Use `.inputValidator()` on every server function that accepts input.
+- Use `.validator()` on every server function that accepts input.
 - Store sessions in `HttpOnly`, `Secure`, `SameSite` cookies. Do not store session tokens in `localStorage` or `sessionStorage`.
 - Hash passwords with bcrypt, scrypt, or Argon2. For missing users, verify against a dummy hash and return the same login/reset message.
 - Rate limit login, registration, and password-reset endpoints.
@@ -139,7 +139,7 @@ import { z } from 'zod'
 import { setSessionCookie } from './session'
 
 export const login = createServerFn({ method: 'POST' })
-  .inputValidator(z.object({ email: z.string().email(), password: z.string() }))
+  .validator(z.object({ email: z.string().email(), password: z.string() }))
   .handler(async ({ data }) => {
     const user = await db.users.findByEmail(data.email)
     // Always run verifyPasswordHash — even when the user doesn't exist —
@@ -237,7 +237,7 @@ import { createServerFn } from '@tanstack/react-start'
 import { z } from 'zod'
 
 export const requestPasswordReset = createServerFn({ method: 'POST' })
-  .inputValidator(z.object({ email: z.string().email() }))
+  .validator(z.object({ email: z.string().email() }))
   .handler(async ({ data }) => {
     const user = await db.users.findByEmail(data.email)
     if (user) {
@@ -369,7 +369,7 @@ A parsed UUID is _some_ workspace, not an _authorized_ workspace.
 // WRONG — UUID is well-formed but the user may not be a member
 const getWorkspaceData = createServerFn({ method: 'GET' })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ workspaceId: z.string().uuid() }))
+  .validator(z.object({ workspaceId: z.string().uuid() }))
   .handler(async ({ context, data }) => {
     return db.workspaces.findById(data.workspaceId) // missing membership check!
   })
@@ -377,7 +377,7 @@ const getWorkspaceData = createServerFn({ method: 'GET' })
 // CORRECT — verify the session principal has access to that workspace
 const getWorkspaceData = createServerFn({ method: 'GET' })
   .middleware([authMiddleware])
-  .inputValidator(z.object({ workspaceId: z.string().uuid() }))
+  .validator(z.object({ workspaceId: z.string().uuid() }))
   .handler(async ({ context, data }) => {
     const member = await db.memberships.find({
       userId: context.session.userId,

--- a/packages/start-client-core/skills/start-core/middleware/SKILL.md
+++ b/packages/start-client-core/skills/start-core/middleware/SKILL.md
@@ -29,7 +29,7 @@ Middleware customizes the behavior of server functions and server routes. It is 
 | ----------------- | -------------------------------------------- | ---------------------------------------- |
 | Scope             | All server requests (SSR, routes, functions) | Server functions only                    |
 | Methods           | `.server()`                                  | `.client()`, `.server()`                 |
-| Input validation  | No                                           | Yes (`.validator()`)                |
+| Input validation  | No                                           | Yes (`.validator()`)                     |
 | Client-side logic | No                                           | Yes                                      |
 | Created with      | `createMiddleware()`                         | `createMiddleware({ type: 'function' })` |
 

--- a/packages/start-client-core/skills/start-core/middleware/SKILL.md
+++ b/packages/start-client-core/skills/start-core/middleware/SKILL.md
@@ -20,7 +20,7 @@ sources:
 
 Middleware customizes the behavior of server functions and server routes. It is composable — middleware can depend on other middleware to form a chain.
 
-> **CRITICAL**: TypeScript enforces method order: `middleware()` → `inputValidator()` → `client()` → `server()`. Wrong order causes type errors.
+> **CRITICAL**: TypeScript enforces method order: `middleware()` → `validator()` → `client()` → `server()`. Wrong order causes type errors.
 > **CRITICAL**: Validating the _shape_ of `sendContext` (e.g. `z.string().uuid().parse(...)`) is NOT authorization. A parsed identifier is a well-formed identifier, not an authorized one. Always re-check access against the session principal before using a client-sent ID as a query key, filter, or path parameter.
 
 ## Two Types of Middleware
@@ -29,7 +29,7 @@ Middleware customizes the behavior of server functions and server routes. It is 
 | ----------------- | -------------------------------------------- | ---------------------------------------- |
 | Scope             | All server requests (SSR, routes, functions) | Server functions only                    |
 | Methods           | `.server()`                                  | `.client()`, `.server()`                 |
-| Input validation  | No                                           | Yes (`.inputValidator()`)                |
+| Input validation  | No                                           | Yes (`.validator()`)                |
 | Client-side logic | No                                           | Yes                                      |
 | Created with      | `createMiddleware()`                         | `createMiddleware({ type: 'function' })` |
 
@@ -160,7 +160,7 @@ import { z } from 'zod'
 import { zodValidator } from '@tanstack/zod-adapter'
 
 const workspaceMiddleware = createMiddleware({ type: 'function' })
-  .inputValidator(zodValidator(z.object({ workspaceId: z.string() })))
+  .validator(zodValidator(z.object({ workspaceId: z.string() })))
   .server(async ({ next, data }) => {
     console.log('Workspace:', data.workspaceId)
     return next()
@@ -382,10 +382,10 @@ createMiddleware({ type: 'function' })
   .server(() => { ... })
   .client(() => { ... })
 
-// CORRECT — middleware → inputValidator → client → server
+// CORRECT — middleware → validator → client → server
 createMiddleware({ type: 'function' })
   .middleware([dep])
-  .inputValidator(schema)
+  .validator(schema)
   .client(({ next }) => next())
   .server(({ next }) => next())
 ```

--- a/packages/start-client-core/skills/start-core/server-functions/SKILL.md
+++ b/packages/start-client-core/skills/start-core/server-functions/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: start-core/server-functions
 description: >-
-  createServerFn (GET/POST), inputValidator (Zod or function),
+  createServerFn (GET/POST), validator (Zod or function),
   useServerFn hook, server context utilities (getRequest,
   getRequestHeader, setResponseHeader, setResponseStatus), error
   handling (throw errors, redirect, notFound), streaming, FormData
@@ -75,7 +75,7 @@ Use the `useServerFn` hook to call server functions from event handlers:
 import { useServerFn } from '@tanstack/react-start'
 
 const deletePost = createServerFn({ method: 'POST' })
-  .inputValidator((data: { id: string }) => data)
+  .validator((data: { id: string }) => data)
   .handler(async ({ data }) => {
     await db.delete('posts').where({ id: data.id })
     return { success: true }
@@ -98,7 +98,7 @@ function DeleteButton({ postId }: { postId: string }) {
 
 ```tsx
 const greetUser = createServerFn({ method: 'GET' })
-  .inputValidator((data: { name: string }) => data)
+  .validator((data: { name: string }) => data)
   .handler(async ({ data }) => {
     return `Hello, ${data.name}!`
   })
@@ -112,7 +112,7 @@ await greetUser({ data: { name: 'John' } })
 import { z } from 'zod'
 
 const createUser = createServerFn({ method: 'POST' })
-  .inputValidator(
+  .validator(
     z.object({
       name: z.string().min(1),
       age: z.number().min(0),
@@ -127,7 +127,7 @@ const createUser = createServerFn({ method: 'POST' })
 
 ```tsx
 const submitForm = createServerFn({ method: 'POST' })
-  .inputValidator((data) => {
+  .validator((data) => {
     if (!(data instanceof FormData)) {
       throw new Error('Expected FormData')
     }
@@ -177,7 +177,7 @@ const requireAuth = createServerFn().handler(async () => {
 import { notFound } from '@tanstack/react-router'
 
 const getPost = createServerFn()
-  .inputValidator((data: { id: string }) => data)
+  .validator((data: { id: string }) => data)
   .handler(async ({ data }) => {
     const post = await db.findPost(data.id)
     if (!post) {
@@ -258,7 +258,7 @@ import { createServerFn } from '@tanstack/react-start'
 import { findUserById } from './users.server'
 
 export const getUser = createServerFn({ method: 'GET' })
-  .inputValidator((data: { id: string }) => data)
+  .validator((data: { id: string }) => data)
   .handler(async ({ data }) => {
     return findUserById(data.id)
   })

--- a/packages/start-client-core/src/createMiddleware.ts
+++ b/packages/start-client-core/src/createMiddleware.ts
@@ -36,6 +36,16 @@ export const createMiddleware: CreateMiddlewareFn<{}> = (options, __opts) => {
     type: 'request',
     ...(__opts || options),
   }
+  const setValidator = (validator: any) => {
+    return createMiddleware(
+      {},
+      Object.assign(resolvedOptions, {
+        validator,
+        // TODO remove upon stable
+        inputValidator: validator,
+      }),
+    )
+  }
 
   return {
     options: resolvedOptions,
@@ -45,12 +55,9 @@ export const createMiddleware: CreateMiddlewareFn<{}> = (options, __opts) => {
         Object.assign(resolvedOptions, { middleware }),
       )
     },
-    inputValidator: (inputValidator: any) => {
-      return createMiddleware(
-        {},
-        Object.assign(resolvedOptions, { inputValidator }),
-      )
-    },
+    validator: setValidator,
+    // TODO remove upon stable
+    inputValidator: setValidator,
     client: (client: any) => {
       return createMiddleware({}, Object.assign(resolvedOptions, { client }))
     },
@@ -170,6 +177,9 @@ export interface FunctionMiddlewareTypes<
     TMiddlewares,
     TClientSendContext
   >
+  validator: TInputValidator
+  // TODO remove upon stable
+  /** @deprecated Use `validator` instead. */
   inputValidator: TInputValidator
 }
 
@@ -379,6 +389,9 @@ export interface FunctionMiddlewareOptions<
   in out TClientContext,
 > {
   middleware?: TMiddlewares
+  validator?: ConstrainValidator<TRegister, 'GET', TInputValidator>
+  // TODO remove upon stable
+  /** @deprecated Use `validator` instead. */
   inputValidator?: ConstrainValidator<TRegister, 'GET', TInputValidator>
   client?: FunctionMiddlewareClientFn<
     TRegister,
@@ -668,8 +681,13 @@ export interface FunctionMiddlewareAfterClient<
     > {}
 
 export interface FunctionMiddlewareValidator<TRegister, TMiddlewares> {
+  validator: <TNewValidator>(
+    validator: ConstrainValidator<TRegister, 'GET', TNewValidator>,
+  ) => FunctionMiddlewareAfterValidator<TRegister, TMiddlewares, TNewValidator>
+  // TODO remove upon stable
+  /** @deprecated Use `validator` instead. */
   inputValidator: <TNewValidator>(
-    inputValidator: ConstrainValidator<TRegister, 'GET', TNewValidator>,
+    validator: ConstrainValidator<TRegister, 'GET', TNewValidator>,
   ) => FunctionMiddlewareAfterValidator<TRegister, TMiddlewares, TNewValidator>
 }
 

--- a/packages/start-client-core/src/createServerFn.ts
+++ b/packages/start-client-core/src/createServerFn.ts
@@ -506,12 +506,7 @@ export type ServerFnBaseOptions<
     TMiddlewares,
     ReadonlyArray<AnyFunctionMiddleware | AnyRequestMiddleware>
   >
-  validator?: ConstrainValidator<
-    TRegister,
-    TMethod,
-    TInputValidator,
-    TStrict
-  >
+  validator?: ConstrainValidator<TRegister, TMethod, TInputValidator, TStrict>
   // TODO remove upon stable
   /** @deprecated Use `validator` instead. */
   inputValidator?: ConstrainValidator<
@@ -657,12 +652,7 @@ export type ValidatorFn<
   TMiddlewares,
   TStrict extends ServerFnStrict,
 > = <TInputValidator>(
-  validator: ConstrainValidator<
-    TRegister,
-    TMethod,
-    TInputValidator,
-    TStrict
-  >,
+  validator: ConstrainValidator<TRegister, TMethod, TInputValidator, TStrict>,
 ) => ServerFnAfterValidator<
   TRegister,
   TMethod,

--- a/packages/start-client-core/src/createServerFn.ts
+++ b/packages/start-client-core/src/createServerFn.ts
@@ -85,6 +85,16 @@ export const createServerFn: CreateServerFn<Register> = (options, __opts) => {
     resolvedOptions.method = 'GET' as Method
   }
 
+  const setValidator = (validator: any) => {
+    // TODO remove upon stable
+    const newOptions = {
+      ...resolvedOptions,
+      validator,
+      inputValidator: validator,
+    }
+    return createServerFn(undefined, newOptions) as any
+  }
+
   const res: ServerFnBuilder<Register, Method, ServerFnStrict> = {
     options: resolvedOptions,
     middleware: (middleware) => {
@@ -110,10 +120,9 @@ export const createServerFn: CreateServerFn<Register> = (options, __opts) => {
       res[TSS_SERVER_FUNCTION_FACTORY] = true
       return res
     },
-    inputValidator: (inputValidator) => {
-      const newOptions = { ...resolvedOptions, inputValidator }
-      return createServerFn(undefined, newOptions) as any
-    },
+    validator: setValidator,
+    // TODO remove upon stable
+    inputValidator: setValidator,
     handler: (...args) => {
       // This function signature changes due to AST transformations
       // in the babel plugin. We need to cast it to the correct
@@ -249,16 +258,19 @@ export async function executeMiddleware(
 
     // Execute the middleware
     try {
-      if (
-        'inputValidator' in nextMiddleware.options &&
-        nextMiddleware.options.inputValidator &&
-        env === 'server'
-      ) {
+      let validator =
+        'validator' in nextMiddleware.options
+          ? nextMiddleware.options.validator
+          : undefined
+
+      // TODO remove upon stable
+      if (!validator && 'inputValidator' in nextMiddleware.options) {
+        validator = nextMiddleware.options.inputValidator
+      }
+
+      if (validator && env === 'server') {
         // Execute the middleware's input function
-        ctx.data = await execValidator(
-          nextMiddleware.options.inputValidator,
-          ctx.data,
-        )
+        ctx.data = await execValidator(validator as AnyValidator, ctx.data)
       }
 
       let middlewareFn: MiddlewareFn | undefined = undefined
@@ -494,6 +506,14 @@ export type ServerFnBaseOptions<
     TMiddlewares,
     ReadonlyArray<AnyFunctionMiddleware | AnyRequestMiddleware>
   >
+  validator?: ConstrainValidator<
+    TRegister,
+    TMethod,
+    TInputValidator,
+    TStrict
+  >
+  // TODO remove upon stable
+  /** @deprecated Use `validator` instead. */
   inputValidator?: ConstrainValidator<
     TRegister,
     TMethod,
@@ -637,7 +657,7 @@ export type ValidatorFn<
   TMiddlewares,
   TStrict extends ServerFnStrict,
 > = <TInputValidator>(
-  inputValidator: ConstrainValidator<
+  validator: ConstrainValidator<
     TRegister,
     TMethod,
     TInputValidator,
@@ -657,6 +677,9 @@ export interface ServerFnValidator<
   TMiddlewares,
   TStrict extends ServerFnStrict,
 > {
+  validator: ValidatorFn<TRegister, TMethod, TMiddlewares, TStrict>
+  // TODO remove upon stable
+  /** @deprecated Use `validator` instead. */
   inputValidator: ValidatorFn<TRegister, TMethod, TMiddlewares, TStrict>
 }
 
@@ -808,6 +831,9 @@ export interface ServerFnTypes<
   method: TMethod
   strict: TStrict
   middlewares: TMiddlewares
+  validator: TInputValidator
+  // TODO remove upon stable
+  /** @deprecated Use `validator` instead. */
   inputValidator: TInputValidator
   response: TResponse
   allServerContext: AssignAllServerFnContext<TRegister, TMiddlewares>
@@ -901,10 +927,14 @@ export async function execValidator(
 function serverFnBaseToMiddleware(
   options: ServerFnBaseOptions<any, any, any, any, any>,
 ): AnyFunctionMiddleware {
+  // TODO remove upon stable
+  const validator = options.validator ?? options.inputValidator
+
   return {
     '~types': undefined!,
     options: {
-      inputValidator: options.inputValidator,
+      // TODO remove upon stable
+      inputValidator: validator,
       client: async ({ next, sendContext, fetch, ...ctx }) => {
         const payload = {
           ...ctx,

--- a/packages/start-client-core/src/tests/createServerFn.test-d.ts
+++ b/packages/start-client-core/src/tests/createServerFn.test-d.ts
@@ -20,6 +20,8 @@ import type {
 test('createServerFn without middleware', () => {
   expectTypeOf(createServerFn()).toHaveProperty('handler')
   expectTypeOf(createServerFn()).toHaveProperty('middleware')
+  expectTypeOf(createServerFn()).toHaveProperty('validator')
+  // TODO remove upon stable
   expectTypeOf(createServerFn()).toHaveProperty('inputValidator')
 
   createServerFn({ method: 'GET' }).handler((options) => {
@@ -35,13 +37,13 @@ test('createServerFn without middleware', () => {
 test('createServerFn with validator function', () => {
   const fnAfterValidator = createServerFn({
     method: 'GET',
-  }).inputValidator((input: { input: string }) => ({
+  }).validator((input: { input: string }) => ({
     a: input.input,
   }))
 
   expectTypeOf(fnAfterValidator).toHaveProperty('handler')
   expectTypeOf(fnAfterValidator).toHaveProperty('middleware')
-  expectTypeOf(fnAfterValidator).not.toHaveProperty('inputValidator')
+  expectTypeOf(fnAfterValidator).not.toHaveProperty('validator')
 
   const fn = fnAfterValidator.handler((options) => {
     expectTypeOf(options).toEqualTypeOf<{
@@ -67,11 +69,11 @@ test('createServerFn with validator function', () => {
 test('createServerFn with async validator function', () => {
   const fnAfterValidator = createServerFn({
     method: 'GET',
-  }).inputValidator((input: string) => Promise.resolve(input))
+  }).validator((input: string) => Promise.resolve(input))
 
   expectTypeOf(fnAfterValidator).toHaveProperty('handler')
   expectTypeOf(fnAfterValidator).toHaveProperty('middleware')
-  expectTypeOf(fnAfterValidator).not.toHaveProperty('inputValidator')
+  expectTypeOf(fnAfterValidator).not.toHaveProperty('validator')
 
   const fn = fnAfterValidator.handler((options) => {
     expectTypeOf(options).toEqualTypeOf<{
@@ -95,13 +97,13 @@ test('createServerFn with async validator function', () => {
 test('createServerFn with validator with parse method', () => {
   const fnAfterValidator = createServerFn({
     method: 'GET',
-  }).inputValidator({
+  }).validator({
     parse: (input: string) => input,
   })
 
   expectTypeOf(fnAfterValidator).toHaveProperty('handler')
   expectTypeOf(fnAfterValidator).toHaveProperty('middleware')
-  expectTypeOf(fnAfterValidator).not.toHaveProperty('inputValidator')
+  expectTypeOf(fnAfterValidator).not.toHaveProperty('validator')
 
   const fn = fnAfterValidator.handler((options) => {
     expectTypeOf(options).toEqualTypeOf<{
@@ -125,13 +127,13 @@ test('createServerFn with validator with parse method', () => {
 test('createServerFn with async validator with parse method', () => {
   const fnAfterValidator = createServerFn({
     method: 'GET',
-  }).inputValidator({
+  }).validator({
     parse: (input: string) => Promise.resolve(input),
   })
 
   expectTypeOf(fnAfterValidator).toHaveProperty('handler')
   expectTypeOf(fnAfterValidator).toHaveProperty('middleware')
-  expectTypeOf(fnAfterValidator).not.toHaveProperty('inputValidator')
+  expectTypeOf(fnAfterValidator).not.toHaveProperty('validator')
 
   const fn = fnAfterValidator.handler((options) => {
     expectTypeOf(options).toEqualTypeOf<{
@@ -174,11 +176,11 @@ test('createServerFn with standard validator', () => {
 
   const fnAfterValidator = createServerFn({
     method: 'GET',
-  }).inputValidator(validator)
+  }).validator(validator)
 
   expectTypeOf(fnAfterValidator).toHaveProperty('handler')
   expectTypeOf(fnAfterValidator).toHaveProperty('middleware')
-  expectTypeOf(fnAfterValidator).not.toHaveProperty('inputValidator')
+  expectTypeOf(fnAfterValidator).not.toHaveProperty('validator')
 
   const fn = fnAfterValidator.handler((options) => {
     expectTypeOf(options).toEqualTypeOf<{
@@ -222,11 +224,11 @@ test('createServerFn with async standard validator', () => {
 
   const fnAfterValidator = createServerFn({
     method: 'GET',
-  }).inputValidator(validator)
+  }).validator(validator)
 
   expectTypeOf(fnAfterValidator).toHaveProperty('handler')
   expectTypeOf(fnAfterValidator).toHaveProperty('middleware')
-  expectTypeOf(fnAfterValidator).not.toHaveProperty('inputValidator')
+  expectTypeOf(fnAfterValidator).not.toHaveProperty('validator')
 
   const fn = fnAfterValidator.handler((options) => {
     expectTypeOf(options).toEqualTypeOf<{
@@ -285,7 +287,7 @@ test('createServerFn with middleware and context', () => {
   ])
 
   expectTypeOf(fnWithMiddleware).toHaveProperty('handler')
-  expectTypeOf(fnWithMiddleware).toHaveProperty('inputValidator')
+  expectTypeOf(fnWithMiddleware).toHaveProperty('validator')
 
   fnWithMiddleware.handler((options) => {
     expectTypeOf(options).toEqualTypeOf<{
@@ -303,14 +305,14 @@ test('createServerFn with middleware and context', () => {
 })
 
 describe('createServerFn with middleware and validator', () => {
-  const middleware1 = createMiddleware({ type: 'function' }).inputValidator(
+  const middleware1 = createMiddleware({ type: 'function' }).validator(
     (input: { readonly inputA: 'inputA' }) =>
       ({
         outputA: 'outputA',
       }) as const,
   )
 
-  const middleware2 = createMiddleware({ type: 'function' }).inputValidator(
+  const middleware2 = createMiddleware({ type: 'function' }).validator(
     (input: { readonly inputB: 'inputB' }) =>
       ({
         outputB: 'outputB',
@@ -325,7 +327,7 @@ describe('createServerFn with middleware and validator', () => {
   test(`response`, () => {
     const fn = createServerFn({ method: 'GET' })
       .middleware([middleware3])
-      .inputValidator(
+      .validator(
         (input: { readonly inputC: 'inputC' }) =>
           ({
             outputC: 'outputC',
@@ -368,7 +370,7 @@ describe('createServerFn with middleware and validator', () => {
 
 test('createServerFn overrides properties', () => {
   const middleware1 = createMiddleware({ type: 'function' })
-    .inputValidator(
+    .validator(
       () =>
         ({
           input: 'a' as 'a' | 'b' | 'c',
@@ -393,7 +395,7 @@ test('createServerFn overrides properties', () => {
 
   const middleware2 = createMiddleware({ type: 'function' })
     .middleware([middleware1])
-    .inputValidator(
+    .validator(
       () =>
         ({
           input: 'b' as 'b' | 'c',
@@ -416,7 +418,7 @@ test('createServerFn overrides properties', () => {
 
   createServerFn()
     .middleware([middleware2])
-    .inputValidator(
+    .validator(
       () =>
         ({
           input: 'c',
@@ -432,7 +434,7 @@ test('createServerFn overrides properties', () => {
 
 test('createServerFn where validator is a primitive', () => {
   createServerFn({ method: 'GET' })
-    .inputValidator(() => 'c' as const)
+    .validator(() => 'c' as const)
     .handler((options) => {
       expectTypeOf(options).toEqualTypeOf<{
         context: undefined
@@ -445,7 +447,7 @@ test('createServerFn where validator is a primitive', () => {
 
 test('createServerFn where validator is optional if object is optional', () => {
   const fn = createServerFn({ method: 'GET' })
-    .inputValidator((input: 'c' | undefined) => input)
+    .validator((input: 'c' | undefined) => input)
     .handler((options) => {
       expectTypeOf(options).toEqualTypeOf<{
         context: undefined
@@ -520,7 +522,7 @@ test('createServerFn cannot return function', () => {
 
 test('createServerFn strict false can validate and return function', () => {
   const fn = createServerFn({ method: 'GET', strict: false })
-    .inputValidator((input: { func: () => 'input' }) => ({
+    .validator((input: { func: () => 'input' }) => ({
       output: input.func(),
     }))
     .handler(({ data }) => {
@@ -551,7 +553,7 @@ test('createServerFn strict false factory preserves strictness', () => {
   })
 
   const myServerFn = createServerFnWithoutSerializationCheck()
-    .inputValidator((input: { func: () => 'input' }) => ({
+    .validator((input: { func: () => 'input' }) => ({
       output: input.func(),
     }))
     .handler(({ data }) => {
@@ -578,7 +580,7 @@ test('createServerFn strict false factory preserves strictness', () => {
 
 test('createServerFn strict input false can validate function', () => {
   const fn = createServerFn({ strict: { input: false } })
-    .inputValidator((input: { func: () => 'input' }) => ({
+    .validator((input: { func: () => 'input' }) => ({
       output: input.func(),
     }))
     .handler(({ data }) => {
@@ -644,7 +646,7 @@ test('ServerFnReturnType skips serialization when strict output is false', () =>
 })
 
 test('createServerFn cannot validate function', () => {
-  const validator = createServerFn().inputValidator<
+  const validator = createServerFn().validator<
     (input: { func: () => 'string' }) => { output: 'string' }
   >
 
@@ -665,7 +667,7 @@ test('createServerFn strict output false still checks input', () => {
   const validator = createServerFn({
     method: 'GET',
     strict: { output: false },
-  }).inputValidator<(input: { func: () => 'string' }) => { output: 'string' }>
+  }).validator<(input: { func: () => 'string' }) => { output: 'string' }>
 
   expectTypeOf(validator)
     .parameter(0)
@@ -681,7 +683,7 @@ test('createServerFn strict output false still checks input', () => {
 })
 
 test('createServerFn can validate Date', () => {
-  const validator = createServerFn().inputValidator<
+  const validator = createServerFn().validator<
     (input: Date) => { output: 'string' }
   >
 
@@ -693,7 +695,7 @@ test('createServerFn can validate Date', () => {
 })
 
 test('createServerFn can validate FormData', () => {
-  const validator = createServerFn({ method: 'POST' }).inputValidator<
+  const validator = createServerFn({ method: 'POST' }).validator<
     (input: FormData) => { output: 'string' }
   >
 
@@ -701,7 +703,7 @@ test('createServerFn can validate FormData', () => {
 })
 
 test('createServerFn cannot validate FormData for GET', () => {
-  const validator = createServerFn({ method: 'GET' }).inputValidator<
+  const validator = createServerFn({ method: 'GET' }).validator<
     (input: FormData) => { output: 'string' }
   >
 
@@ -740,7 +742,7 @@ test('ServerFnReturnType distributes Response union', () => {
 
 test('createServerFn can be used as a mutation function', () => {
   const serverFn = createServerFn()
-    .inputValidator((data: number) => data)
+    .validator((data: number) => data)
     .handler(() => 'foo')
 
   type MutationFunction<TData = unknown, TVariables = unknown> = (
@@ -757,7 +759,7 @@ test('createServerFn can be used as a mutation function', () => {
 
 test('createServerFn validator infers unknown for default input type', () => {
   const fn = createServerFn()
-    .inputValidator((input) => {
+    .validator((input) => {
       expectTypeOf(input).toEqualTypeOf<unknown>()
 
       if (typeof input === 'number') return 'success' as const
@@ -807,7 +809,7 @@ test('incrementally building createServerFn with multiple middleware calls', () 
   ])
 
   expectTypeOf(builderWithMw1).toHaveProperty('handler')
-  expectTypeOf(builderWithMw1).toHaveProperty('inputValidator')
+  expectTypeOf(builderWithMw1).toHaveProperty('validator')
   expectTypeOf(builderWithMw1).toHaveProperty('middleware')
 
   builderWithMw1.handler((options) => {
@@ -827,7 +829,7 @@ test('incrementally building createServerFn with multiple middleware calls', () 
   ])
 
   expectTypeOf(builderWithMw2).toHaveProperty('handler')
-  expectTypeOf(builderWithMw2).toHaveProperty('inputValidator')
+  expectTypeOf(builderWithMw2).toHaveProperty('validator')
   expectTypeOf(builderWithMw2).toHaveProperty('middleware')
 
   builderWithMw2.handler((options) => {
@@ -848,7 +850,7 @@ test('incrementally building createServerFn with multiple middleware calls', () 
   ])
 
   expectTypeOf(builderWithMw3).toHaveProperty('handler')
-  expectTypeOf(builderWithMw3).toHaveProperty('inputValidator')
+  expectTypeOf(builderWithMw3).toHaveProperty('validator')
   expectTypeOf(builderWithMw3).toHaveProperty('middleware')
 
   builderWithMw3.handler((options) => {
@@ -916,7 +918,7 @@ test('createServerFn with request middleware and function middleware', () => {
   })
 
   const funMw = createMiddleware({ type: 'function' })
-    .inputValidator((x: string) => x)
+    .validator((x: string) => x)
     .server(({ next }) => {
       return next({ context: { a: 'a' } as const })
     })
@@ -927,7 +929,7 @@ test('createServerFn with request middleware and function middleware', () => {
   expectTypeOf(fn({ data: 'a' })).toEqualTypeOf<Promise<{}>>()
 })
 
-test('createServerFn with inputValidator and request middleware', () => {
+test('createServerFn with validator and request middleware', () => {
   const loggingMiddleware = createMiddleware().server(async ({ next }) => {
     console.log('Logging middleware executed on the server')
     const result = await next()
@@ -936,7 +938,7 @@ test('createServerFn with inputValidator and request middleware', () => {
 
   const fn = createServerFn()
     .middleware([loggingMiddleware])
-    .inputValidator(({ userName }: { userName: string }) => {
+    .validator(({ userName }: { userName: string }) => {
       return { userName }
     })
     .handler(async ({ data }) => {

--- a/packages/start-client-core/src/tests/createServerMiddleware.test-d.ts
+++ b/packages/start-client-core/src/tests/createServerMiddleware.test-d.ts
@@ -10,17 +10,20 @@ test('createServeMiddleware removes middleware after middleware,', () => {
 
   expectTypeOf(middleware).toHaveProperty('middleware')
   expectTypeOf(middleware).toHaveProperty('server')
+  expectTypeOf(middleware).toHaveProperty('validator')
+  // TODO remove upon stable
   expectTypeOf(middleware).toHaveProperty('inputValidator')
 
   const middlewareAfterMiddleware = middleware.middleware([])
 
-  expectTypeOf(middlewareAfterMiddleware).toHaveProperty('inputValidator')
+  expectTypeOf(middlewareAfterMiddleware).toHaveProperty('validator')
   expectTypeOf(middlewareAfterMiddleware).toHaveProperty('server')
   expectTypeOf(middlewareAfterMiddleware).not.toHaveProperty('middleware')
 
-  const middlewareAfterInput = middleware.inputValidator(() => {})
+  const middlewareAfterInput = middleware.validator(() => {})
 
   expectTypeOf(middlewareAfterInput).toHaveProperty('server')
+  expectTypeOf(middlewareAfterInput).not.toHaveProperty('validator')
   expectTypeOf(middlewareAfterInput).not.toHaveProperty('middleware')
 
   const middlewareAfterServer = middleware.server(async (options) => {
@@ -43,6 +46,7 @@ test('createServeMiddleware removes middleware after middleware,', () => {
 
   expectTypeOf(middlewareAfterServer).not.toHaveProperty('server')
   expectTypeOf(middlewareAfterServer).not.toHaveProperty('input')
+  expectTypeOf(middlewareAfterServer).not.toHaveProperty('validator')
   expectTypeOf(middlewareAfterServer).not.toHaveProperty('middleware')
 })
 
@@ -257,7 +261,7 @@ test('createMiddleware merges client context and sends to the server', () => {
 
 test('createMiddleware merges input', () => {
   const middleware1 = createMiddleware({ type: 'function' })
-    .inputValidator(() => {
+    .validator(() => {
       return {
         a: 'a',
       } as const
@@ -269,7 +273,7 @@ test('createMiddleware merges input', () => {
 
   const middleware2 = createMiddleware({ type: 'function' })
     .middleware([middleware1])
-    .inputValidator(() => {
+    .validator(() => {
       return {
         b: 'b',
       } as const
@@ -281,7 +285,7 @@ test('createMiddleware merges input', () => {
 
   createMiddleware({ type: 'function' })
     .middleware([middleware2])
-    .inputValidator(() => ({ c: 'c' }) as const)
+    .validator(() => ({ c: 'c' }) as const)
     .server(({ next, data }) => {
       expectTypeOf(data).toEqualTypeOf<{
         readonly a: 'a'
@@ -595,7 +599,7 @@ test('createMiddleware sendContext cannot send a function', () => {
 })
 
 test('createMiddleware cannot validate function', () => {
-  const validator = createMiddleware({ type: 'function' }).inputValidator<
+  const validator = createMiddleware({ type: 'function' }).validator<
     (input: { func: () => 'string' }) => { output: 'string' }
   >
 
@@ -611,7 +615,7 @@ test('createMiddleware cannot validate function', () => {
 })
 
 test('createMiddleware can validate Date', () => {
-  const validator = createMiddleware({ type: 'function' }).inputValidator<
+  const validator = createMiddleware({ type: 'function' }).validator<
     (input: Date) => { output: 'string' }
   >
 
@@ -623,7 +627,7 @@ test('createMiddleware can validate Date', () => {
 })
 
 test('createMiddleware can validate FormData', () => {
-  const validator = createMiddleware({ type: 'function' }).inputValidator<
+  const validator = createMiddleware({ type: 'function' }).validator<
     (input: FormData) => { output: 'string' }
   >
 
@@ -639,7 +643,7 @@ test('createMiddleware can validate FormData', () => {
 })
 
 test('createMiddleware merging from parent with undefined validator', () => {
-  const middleware1 = createMiddleware({ type: 'function' }).inputValidator(
+  const middleware1 = createMiddleware({ type: 'function' }).validator(
     (input: { test: string }) => input.test,
   )
 
@@ -654,7 +658,7 @@ test('createMiddleware merging from parent with undefined validator', () => {
 
 test('createMiddleware validator infers unknown for default input type', () => {
   createMiddleware({ type: 'function' })
-    .inputValidator((input) => {
+    .validator((input) => {
       expectTypeOf(input).toEqualTypeOf<unknown>()
 
       if (typeof input === 'number') return 'success' as const

--- a/packages/start-plugin-core/src/rsbuild/start-compiler-host.ts
+++ b/packages/start-plugin-core/src/rsbuild/start-compiler-host.ts
@@ -37,6 +37,9 @@ import type {
 type RsbuildTransformContext = Parameters<
   Parameters<RsbuildPluginAPI['transform']>[1]
 >[0]
+type WarnableRsbuildTransformContext = RsbuildTransformContext & {
+  emitWarning?: (warning: Error) => void
+}
 type RsbuildInputFileSystem = NonNullable<Rspack.Compiler['inputFileSystem']>
 type ServerFnMetadataById = Map<string, ServerFnBuildInfo>
 type StartCompilerEnvironment = {
@@ -100,6 +103,13 @@ function setServerFnBuildInfoLoaderContext(
       module.buildInfo[SERVER_FN_BUILD_INFO_FIELD] = EMPTY_SERVER_FN_BUILD_INFO
     }
   }
+}
+
+function warnTransformContext(
+  ctx: WarnableRsbuildTransformContext,
+  message: string,
+): void {
+  ctx.emitWarning?.(new Error(message))
 }
 
 export interface StartCompilerHostOptions {
@@ -366,6 +376,7 @@ export function registerStartCompilerTransforms(
                 id,
                 code: nextCode,
                 detectedKinds,
+                warn: (message) => warnTransformContext(ctx, message),
               })
             } finally {
               activeServerFnMetadata = undefined

--- a/packages/start-plugin-core/src/start-compiler/compiler.ts
+++ b/packages/start-plugin-core/src/start-compiler/compiler.ts
@@ -560,6 +560,7 @@ export class StartCompiler {
       compilerTransforms?: Array<StartCompilerImportTransform> | undefined
       compilerPlugins?: Array<StartCompilerPlugin> | undefined
       serverFnProviderModuleDirectives?: ReadonlyArray<string> | undefined
+      warn?: (message: string) => void
       /**
        * Returns the currently known server functions from previous builds.
        * Used by server callers to look up canonical extracted filenames.
@@ -979,12 +980,14 @@ export class StartCompiler {
     id,
     parserFilename,
     detectedKinds,
+    warn,
   }: {
     code: string
     id: string
     parserFilename?: string
     /** Pre-detected kinds present in this file. If not provided, all valid kinds are checked. */
     detectedKinds?: Set<LookupKind>
+    warn?: (message: string) => void
   }) {
     if (!this.initialized) {
       await this.init()
@@ -999,6 +1002,7 @@ export class StartCompiler {
     // Always parse and extract module info upfront.
     // This ensures the module is cached for import resolution even if no candidates are found.
     const ast = this.ingestModule({ code, id, parserFilename }).ast
+    const warnFn = warn ?? this.options.warn
     let astHasChanges = false
 
     builtInTransforms: {
@@ -1292,6 +1296,8 @@ export class StartCompiler {
         // Collect method chain paths by walking DOWN from root through the chain
         const methodChain: MethodChainPaths = {
           middleware: null,
+          validator: null,
+          // TODO remove upon stable
           inputValidator: null,
           handler: null,
           server: null,
@@ -1359,6 +1365,7 @@ export class StartCompiler {
           babel.template.expression(expressionCode, {
             placeholderPattern: false,
           })() as t.Expression,
+        warn: warnFn,
 
         generateFunctionId: (opts) => this.generateFunctionId(opts),
         getKnownServerFns: this.options.getKnownServerFns,
@@ -1413,6 +1420,7 @@ export class StartCompiler {
           code,
           id,
           transforms: astTransformPlugins,
+          warn: warnFn,
         }) || astHasChanges
     }
 
@@ -1459,11 +1467,13 @@ export class StartCompiler {
     code,
     id,
     transforms,
+    warn,
   }: {
     ast: ParsedAst
     code: string
     id: string
     transforms: Array<StartCompilerAstPlugin>
+    warn?: (message: string) => void
   }): boolean {
     let modified = false
 
@@ -1483,6 +1493,7 @@ export class StartCompiler {
           babel.template.expression(expressionCode, {
             placeholderPattern: false,
           })() as t.Expression,
+        warn,
       }
 
       modified = plugin.transformAst(context) || modified

--- a/packages/start-plugin-core/src/start-compiler/handleCreateMiddleware.ts
+++ b/packages/start-plugin-core/src/start-compiler/handleCreateMiddleware.ts
@@ -1,5 +1,24 @@
 import { stripMethodCall } from './utils'
-import type { CompilationContext, RewriteCandidate } from './types'
+import type {
+  CompilationContext,
+  MethodCallInfo,
+  RewriteCandidate,
+} from './types'
+
+// TODO remove upon stable
+function warnInputValidatorDeprecation(
+  context: CompilationContext,
+  inputValidator: MethodCallInfo,
+): void {
+  const loc = inputValidator.callPath.node.loc?.start
+  const location = loc
+    ? `${context.id}:${loc.line}:${loc.column + 1} `
+    : `${context.id} `
+
+  context.warn?.(
+    `${location}createMiddleware().inputValidator() is deprecated. Use createMiddleware().validator() instead.`,
+  )
+}
 
 /**
  * Handles createMiddleware transformations for a batch of candidates.
@@ -16,19 +35,32 @@ export function handleCreateMiddleware(
   }
 
   for (const candidate of candidates) {
-    const { inputValidator, server } = candidate.methodChain
+    const { validator, inputValidator, server } = candidate.methodChain
 
+    // TODO remove upon stable
     if (inputValidator) {
-      const innerInputExpression = inputValidator.callPath.node.arguments[0]
+      warnInputValidatorDeprecation(context, inputValidator)
+    }
+
+    for (const [methodName, methodCall] of [
+      ['validator', validator],
+      // TODO remove upon stable
+      ['inputValidator', inputValidator],
+    ] as const) {
+      if (!methodCall) {
+        continue
+      }
+
+      const innerInputExpression = methodCall.callPath.node.arguments[0]
 
       if (!innerInputExpression) {
         throw new Error(
-          'createMiddleware().inputValidator() must be called with a validator!',
+          `createMiddleware().${methodName}() must be called with a validator!`,
         )
       }
 
       // remove the validator call expression
-      stripMethodCall(inputValidator.callPath)
+      stripMethodCall(methodCall.callPath)
     }
 
     if (server) {

--- a/packages/start-plugin-core/src/start-compiler/handleCreateServerFn.ts
+++ b/packages/start-plugin-core/src/start-compiler/handleCreateServerFn.ts
@@ -4,7 +4,12 @@ import { hasKeys } from '@tanstack/router-core'
 import { getVariableDeclaratorForExpressionPath } from '@tanstack/router-utils'
 import path from 'pathe'
 import { cleanId, codeFrameError, stripMethodCall } from './utils'
-import type { CompilationContext, RewriteCandidate, ServerFn } from './types'
+import type {
+  CompilationContext,
+  MethodCallInfo,
+  RewriteCandidate,
+  ServerFn,
+} from './types'
 import type { CompileStartFrameworkOptions } from '../types'
 
 const TSS_SERVERFN_SPLIT_PARAM = 'tss-serverfn-split'
@@ -41,6 +46,21 @@ const clientRpcTemplate = babel.template.expression(
 const ssrRpcManifestTemplate = babel.template.expression(
   `createSsrRpc(%%functionId%%)`,
 )
+
+// TODO remove upon stable
+function warnInputValidatorDeprecation(
+  context: CompilationContext,
+  inputValidator: MethodCallInfo,
+): void {
+  const loc = inputValidator.callPath.node.loc?.start
+  const location = loc
+    ? `${context.id}:${loc.line}:${loc.column + 1} `
+    : `${context.id} `
+
+  context.warn?.(
+    `${location}createServerFn().inputValidator() is deprecated. Use createServerFn().validator() instead.`,
+  )
+}
 
 // ============================================================================
 // Runtime code cache (cached per framework to avoid repeated AST generation)
@@ -221,7 +241,7 @@ export function handleCreateServerFn(
 
   for (const candidate of candidates) {
     const { path: candidatePath, methodChain } = candidate
-    const { inputValidator, handler } = methodChain
+    const { validator, inputValidator, handler } = methodChain
 
     const candidateVariableDeclarator = getVariableDeclaratorForExpressionPath(
       candidatePath as babel.NodePath<t.Expression>,
@@ -274,19 +294,32 @@ export function handleCreateServerFn(
     const canonicalExtractedFilename =
       knownFn?.extractedFilename ?? extractedFilename
 
-    // Handle input validator - remove on client
+    // TODO remove upon stable
     if (inputValidator) {
-      const innerInputExpression = inputValidator.callPath.node.arguments[0]
+      warnInputValidatorDeprecation(context, inputValidator)
+    }
+
+    // Handle validators - remove on client
+    for (const [methodName, methodCall] of [
+      ['validator', validator],
+      // TODO remove upon stable
+      ['inputValidator', inputValidator],
+    ] as const) {
+      if (!methodCall) {
+        continue
+      }
+
+      const innerInputExpression = methodCall.callPath.node.arguments[0]
 
       if (!innerInputExpression) {
         throw new Error(
-          'createServerFn().inputValidator() must be called with a validator!',
+          `createServerFn().${methodName}() must be called with a validator!`,
         )
       }
 
       // If we're on the client, remove the validator call expression
       if (context.env === 'client') {
-        stripMethodCall(inputValidator.callPath)
+        stripMethodCall(methodCall.callPath)
       }
     }
 

--- a/packages/start-plugin-core/src/start-compiler/host.ts
+++ b/packages/start-plugin-core/src/start-compiler/host.ts
@@ -24,6 +24,7 @@ export interface CreateStartCompilerOptions {
   compilerTransforms?: Array<StartCompilerImportTransform> | undefined
   compilerPlugins?: Array<StartCompilerPlugin> | undefined
   serverFnProviderModuleDirectives?: ReadonlyArray<string> | undefined
+  warn?: (message: string) => void
   onServerFnsById?: (d: Record<string, ServerFn>) => void
   getKnownServerFns: () => Record<string, ServerFn>
   encodeModuleSpecifierInDev?: DevServerFnModuleSpecifierEncoder
@@ -54,6 +55,7 @@ export function createStartCompiler(
     compilerTransforms: options.compilerTransforms,
     compilerPlugins: options.compilerPlugins,
     serverFnProviderModuleDirectives: options.serverFnProviderModuleDirectives,
+    warn: options.warn,
     getKnownServerFns: options.getKnownServerFns,
     devServerFnModuleSpecifierEncoder: options.encodeModuleSpecifierInDev,
     loadModule: options.loadModule,

--- a/packages/start-plugin-core/src/start-compiler/types.ts
+++ b/packages/start-plugin-core/src/start-compiler/types.ts
@@ -48,6 +48,8 @@ export interface MethodCallInfo {
  */
 export interface MethodChainPaths {
   middleware: MethodCallInfo | null
+  validator: MethodCallInfo | null
+  // TODO remove upon stable
   inputValidator: MethodCallInfo | null
   handler: MethodCallInfo | null
   server: MethodCallInfo | null

--- a/packages/start-plugin-core/src/start-compiler/utils.ts
+++ b/packages/start-plugin-core/src/start-compiler/utils.ts
@@ -39,7 +39,7 @@ export function cleanId(id: string): string {
  * E.g., `foo().bar()` -> `foo()`
  *
  * This is a common pattern used when removing method calls from chains
-  * (e.g., removing .server() from middleware on client, or .validator() on client).
+ * (e.g., removing .server() from middleware on client, or .validator() on client).
  *
  * @param callPath - The path to the CallExpression to strip
  */

--- a/packages/start-plugin-core/src/start-compiler/utils.ts
+++ b/packages/start-plugin-core/src/start-compiler/utils.ts
@@ -39,7 +39,7 @@ export function cleanId(id: string): string {
  * E.g., `foo().bar()` -> `foo()`
  *
  * This is a common pattern used when removing method calls from chains
- * (e.g., removing .server() from middleware on client, or .inputValidator() on client).
+  * (e.g., removing .server() from middleware on client, or .validator() on client).
  *
  * @param callPath - The path to the CallExpression to strip
  */

--- a/packages/start-plugin-core/src/types.ts
+++ b/packages/start-plugin-core/src/types.ts
@@ -46,6 +46,7 @@ export interface StartCompilerTransformContext {
   readonly providerEnvName: string
   readonly types: typeof t
   parseExpression: (code: string) => t.Expression
+  warn?: (message: string) => void
 }
 
 export interface StartCompilerImportTransform {

--- a/packages/start-plugin-core/src/vite/start-compiler-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/vite/start-compiler-plugin/plugin.ts
@@ -384,6 +384,7 @@ export function startCompilerPlugin(
             id,
             code,
             detectedKinds,
+            warn: (message) => this.warn(message),
           })
 
           return result

--- a/packages/start-plugin-core/tests/createMiddleware/createMiddleware.test.ts
+++ b/packages/start-plugin-core/tests/createMiddleware/createMiddleware.test.ts
@@ -22,6 +22,7 @@ async function compile(opts: {
   env: 'client' | 'server'
   code: string
   id: string
+  warn?: (message: string) => void
 }) {
   const compiler = new StartCompiler({
     ...opts,
@@ -42,6 +43,7 @@ async function compile(opts: {
         kind: 'Root',
       },
     ],
+    warn: opts.warn,
     getKnownServerFns: () => ({}),
     resolveId: async (id) => {
       return id
@@ -71,6 +73,54 @@ describe('createMiddleware compiles correctly', async () => {
         `./snapshots/client/${filename}`,
       )
     })
+  })
+
+  test('should compile validator method', async () => {
+    const code = `
+      import { createMiddleware } from '@tanstack/react-start'
+      const myMiddleware = createMiddleware({ type: 'function' })
+        .validator((input: string) => input)
+        .server(async ({ next }) => {
+          return next()
+        })`
+
+    const result = await compile({
+      env: 'client',
+      code,
+      id: 'test.ts',
+    })
+
+    expect(result!.code).toMatchInlineSnapshot(`
+      "import { createMiddleware } from '@tanstack/react-start';
+      const myMiddleware = createMiddleware({
+        type: 'function'
+      });"
+    `)
+  })
+
+  // TODO remove upon stable
+  test('should warn for deprecated inputValidator method', async () => {
+    const warn = vi.fn()
+    const code = `
+      import { createMiddleware } from '@tanstack/react-start'
+      const myMiddleware = createMiddleware({ type: 'function' })
+        .inputValidator((input: string) => input)
+        .server(async ({ next }) => {
+          return next()
+        })`
+
+    await compile({
+      env: 'client',
+      code,
+      id: 'test.ts',
+      warn,
+    })
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'createMiddleware().inputValidator() is deprecated. Use createMiddleware().validator() instead.',
+      ),
+    )
   })
 
   test('should use fast path for direct imports from known library (no extra resolveId calls)', async () => {

--- a/packages/start-plugin-core/tests/createMiddleware/test-files/createMiddlewareValidator.tsx
+++ b/packages/start-plugin-core/tests/createMiddleware/test-files/createMiddlewareValidator.tsx
@@ -4,5 +4,5 @@ import { z } from 'zod'
 export const withUseServer = createMiddleware({
   id: 'test',
 })
-  .inputValidator(z.number())
+  .validator(z.number())
   .server(({ input }) => input + 1)

--- a/packages/start-plugin-core/tests/createServerFn/createServerFn.test.ts
+++ b/packages/start-plugin-core/tests/createServerFn/createServerFn.test.ts
@@ -26,6 +26,7 @@ async function compile(opts: {
   parserFilename?: string
   isProviderFile: boolean
   mode: 'dev' | 'build'
+  warn?: (message: string) => void
 }) {
   // Use an absolute path inside the test root to ensure consistent filename output
   let id = '/test/src/test.ts'
@@ -48,6 +49,7 @@ async function compile(opts: {
         kind: 'Root',
       },
     ],
+    warn: opts.warn,
     getKnownServerFns: () => ({}),
     resolveId: async (id) => {
       return id
@@ -93,6 +95,51 @@ describe('createServerFn compiles correctly', async () => {
         `./snapshots/${folder}/${filename}`,
       )
     })
+  })
+
+  test('should compile validator method', async () => {
+    const code = `
+        import { createServerFn } from '@tanstack/react-start'
+        const myServerFn = createServerFn()
+          .validator((input: string) => input)
+          .handler(({ input }) => input)`
+
+    const compiledResultClient = await compile({
+      code,
+      env: 'client',
+      isProviderFile: false,
+      mode: 'build',
+    })
+
+    expect(compiledResultClient!.code).toMatchInlineSnapshot(`
+      "import { createClientRpc } from '@tanstack/react-start/client-rpc';
+      import { createServerFn } from '@tanstack/react-start';
+      const myServerFn = createServerFn().handler(createClientRpc(\"2c205add8e6755de551521133ddff3d48859b1631add5f1bbe5c48a5664f319b\"));"
+    `)
+  })
+
+  // TODO remove upon stable
+  test('should warn for deprecated inputValidator method', async () => {
+    const warn = vi.fn()
+    const code = `
+        import { createServerFn } from '@tanstack/react-start'
+        const myServerFn = createServerFn()
+          .inputValidator((input: string) => input)
+          .handler(({ input }) => input)`
+
+    await compile({
+      code,
+      env: 'client',
+      isProviderFile: false,
+      mode: 'build',
+      warn,
+    })
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'createServerFn().inputValidator() is deprecated. Use createServerFn().validator() instead.',
+      ),
+    )
   })
 
   test('should work with identifiers of functions', async () => {

--- a/packages/start-plugin-core/tests/createServerFn/snapshots/server-caller/createServerFnDestructured.tsx
+++ b/packages/start-plugin-core/tests/createServerFn/snapshots/server-caller/createServerFnDestructured.tsx
@@ -21,4 +21,4 @@ export const withZodValidator = createServerFn({
 }).handler(createSsrRpc("43606a369c85444a332f701d6399564b6a3691aabab63dfc9a0b7c341fb798f3"));
 export const withValidatorFn = createServerFn({
   method: 'GET'
-}).inputValidator(z.number()).handler(createSsrRpc("5cf922ac733d835fee496964cbf0b4b4067cb43d51f2efa484d072e6bb7dae44"));
+}).validator(z.number()).handler(createSsrRpc("5cf922ac733d835fee496964cbf0b4b4067cb43d51f2efa484d072e6bb7dae44"));

--- a/packages/start-plugin-core/tests/createServerFn/snapshots/server-caller/createServerFnValidator.tsx
+++ b/packages/start-plugin-core/tests/createServerFn/snapshots/server-caller/createServerFnValidator.tsx
@@ -3,4 +3,4 @@ import { createServerFn } from '@tanstack/react-start';
 import { z } from 'zod';
 export const withUseServer = createServerFn({
   method: 'GET'
-}).inputValidator(z.number()).handler(createSsrRpc("b6fe31e85836ae6c65d8ab262dd1af6a68620aeef609029d50127f4cceaaf320"));
+}).validator(z.number()).handler(createSsrRpc("b6fe31e85836ae6c65d8ab262dd1af6a68620aeef609029d50127f4cceaaf320"));

--- a/packages/start-plugin-core/tests/createServerFn/snapshots/server-caller/isomorphic-fns.tsx
+++ b/packages/start-plugin-core/tests/createServerFn/snapshots/server-caller/isomorphic-fns.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 const getEnv = createIsomorphicFn().server(() => 'server').client(() => 'client');
 const getServerEnv = createServerFn().handler(createSsrRpc("6049dd46bc00e0980e387f3e74924b40e92f37634a3fe74a1a1facda9e9207c2"));
 const getEcho = createIsomorphicFn().server((input: string) => 'server received ' + input).client(input => 'client received ' + input);
-const getServerEcho = createServerFn().inputValidator((input: string) => input).handler(createSsrRpc("ebb82e0293952b7b1dde3f664dec4c139471c046d06d4dc4ca172f4f45e386d1"));
+const getServerEcho = createServerFn().validator((input: string) => input).handler(createSsrRpc("ebb82e0293952b7b1dde3f664dec4c139471c046d06d4dc4ca172f4f45e386d1"));
 export const Route = createFileRoute('/isomorphic-fns')({
   component: RouteComponent,
   loader() {

--- a/packages/start-plugin-core/tests/createServerFn/snapshots/server-provider/createServerFnDestructured.tsx
+++ b/packages/start-plugin-core/tests/createServerFn/snapshots/server-provider/createServerFnDestructured.tsx
@@ -78,7 +78,7 @@ const withValidatorFn_createServerFn_handler = createServerRpc({
 }, opts => withValidatorFn.__executeServer(opts));
 const withValidatorFn = createServerFn({
   method: 'GET'
-}).inputValidator(z.number()).handler(withValidatorFn_createServerFn_handler, async ({
+}).validator(z.number()).handler(withValidatorFn_createServerFn_handler, async ({
   input
 }) => {
   return null;

--- a/packages/start-plugin-core/tests/createServerFn/snapshots/server-provider/createServerFnValidator.tsx
+++ b/packages/start-plugin-core/tests/createServerFn/snapshots/server-provider/createServerFnValidator.tsx
@@ -8,7 +8,7 @@ const withUseServer_createServerFn_handler = createServerRpc({
 }, opts => withUseServer.__executeServer(opts));
 const withUseServer = createServerFn({
   method: 'GET'
-}).inputValidator(z.number()).handler(withUseServer_createServerFn_handler, ({
+}).validator(z.number()).handler(withUseServer_createServerFn_handler, ({
   input
 }) => input + 1);
 export { withUseServer_createServerFn_handler };

--- a/packages/start-plugin-core/tests/createServerFn/snapshots/server-provider/isomorphic-fns.tsx
+++ b/packages/start-plugin-core/tests/createServerFn/snapshots/server-provider/isomorphic-fns.tsx
@@ -13,7 +13,7 @@ const getServerEcho_createServerFn_handler = createServerRpc({
   name: "getServerEcho",
   filename: "src/test.ts"
 }, opts => getServerEcho.__executeServer(opts));
-const getServerEcho = createServerFn().inputValidator((input: string) => input).handler(getServerEcho_createServerFn_handler, ({
+const getServerEcho = createServerFn().validator((input: string) => input).handler(getServerEcho_createServerFn_handler, ({
   data
 }) => getEcho(data));
 export { getServerEnv_createServerFn_handler, getServerEcho_createServerFn_handler };

--- a/packages/start-plugin-core/tests/createServerFn/test-files/createServerFnDestructured.tsx
+++ b/packages/start-plugin-core/tests/createServerFn/test-files/createServerFnDestructured.tsx
@@ -61,7 +61,7 @@ export const withZodValidator = createServerFn({
 export const withValidatorFn = createServerFn({
   method: 'GET',
 })
-  .inputValidator(z.number())
+  .validator(z.number())
   .handler(async ({ input }) => {
     return null
   })

--- a/packages/start-plugin-core/tests/createServerFn/test-files/createServerFnValidator.tsx
+++ b/packages/start-plugin-core/tests/createServerFn/test-files/createServerFnValidator.tsx
@@ -4,5 +4,5 @@ import { z } from 'zod'
 export const withUseServer = createServerFn({
   method: 'GET',
 })
-  .inputValidator(z.number())
+  .validator(z.number())
   .handler(({ input }) => input + 1)

--- a/packages/start-plugin-core/tests/createServerFn/test-files/isomorphic-fns.tsx
+++ b/packages/start-plugin-core/tests/createServerFn/test-files/isomorphic-fns.tsx
@@ -13,7 +13,7 @@ const getEcho = createIsomorphicFn()
   .client((input) => 'client received ' + input)
 
 const getServerEcho = createServerFn()
-  .inputValidator((input: string) => input)
+  .validator((input: string) => input)
   .handler(({ data }) => getEcho(data))
 
 export const Route = createFileRoute('/isomorphic-fns')({

--- a/packages/start-server-core/skills/start-server-core/SKILL.md
+++ b/packages/start-server-core/skills/start-server-core/SKILL.md
@@ -157,7 +157,7 @@ const getUser = createServerFn({ method: 'GET' }).handler(async () => {
 
 // Update session
 const login = createServerFn({ method: 'POST' })
-  .inputValidator((data: { userId: string }) => data)
+  .validator((data: { userId: string }) => data)
   .handler(async ({ data }) => {
     await updateSession(sessionConfig, { userId: data.userId })
     return { success: true }

--- a/packages/vue-start/skills/vue-start/SKILL.md
+++ b/packages/vue-start/skills/vue-start/SKILL.md
@@ -175,7 +175,7 @@ import { createServerFn, useServerFn } from '@tanstack/vue-start'
 import { ref } from 'vue'
 
 const updatePost = createServerFn({ method: 'POST' })
-  .inputValidator((data: { id: string; title: string }) => data)
+  .validator((data: { id: string; title: string }) => data)
   .handler(async ({ data }) => {
     await db.posts.update(data.id, { title: data.title })
     return { success: true }


### PR DESCRIPTION
inputValidator is deprecated and will be removed soon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `validator()` as the canonical method for server function and middleware input validation.

* **Deprecations**
  * `inputValidator()` is now deprecated; use `validator()` instead. Compiler warnings are emitted for remaining uses.

* **Documentation**
  * Updated all guides and examples to use the new `validator()` API across React, Solid, and Vue frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->