### PR TITLE
docs: add 🟡 (Experimental) for TanStack Start RSC support

### DIFF
--- a/docs/router/comparison.md
+++ b/docs/router/comparison.md
@@ -80,7 +80,7 @@ Feature/Capability Key:
 | React Server Function Middleware               | ✅                                               | 🛑                                                    | 🛑                                                    |
 | API Routes                                     | ✅                                               | ✅                                                    | ✅                                                    |
 | API Middleware                                 | ✅                                               | ✅                                                    | ✅                                                    |
-| React Server Components                        | 🛑                                               | 🟡 (Experimental)                                     | ✅                                                    |
+| React Server Components                        | 🟡 (Experimental)                                | 🟡 (Experimental)                                     | ✅                                                    |
 | `<Form>` API                                   | 🛑                                               | ✅                                                    | ✅                                                    |
 
 [bp-tanstack-router]: https://badgen.net/bundlephobia/minzip/@tanstack/react-router


### PR DESCRIPTION
## Changes

- Updated the React Server Components status for TanStack Start from `🛑` to `🟡 (Experimental)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated comparison documentation to reflect experimental support for React Server Components in TanStack Router/Start.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->