### PR TITLE
docs: add missing scroll restoration properties to RouterOptionsType.md and link to the official scroll restoration guide to their docstrings

### DIFF
--- a/docs/router/api/router/RouterOptionsType.md
+++ b/docs/router/api/router/RouterOptionsType.md
@@ -411,3 +411,41 @@ If you want to configure to remount all route components upon `params` change, u
 ```tsx
 remountDeps: ({ params }) => params
 ```
+
+### `scrollRestoration` property
+
+- Type: `boolean | ((opts: { location: ParsedLocation }) => boolean)`
+- Optional
+- Defaults to `false`
+- If `true`, scroll restoration will be enabled.
+- See the [Scroll Restoration Guide](../../guide/scroll-restoration.md/#scroll-restoration) for more information.
+
+---
+
+### `getScrollRestorationKey` property
+
+- Type: `(location: ParsedLocation) => string`
+- Optional
+- Defaults to `(location) => location.href`
+- A function that will be called to get the key for the scroll restoration cache.
+- See the [Scroll Restoration Guide](../../guide/scroll-restoration.md/#custom-cache-keys) for more information.
+
+---
+
+### `scrollRestorationBehavior` property
+
+- Type: `ScrollBehavior` (e.g., `'auto' | 'smooth'`)
+- Optional
+- Defaults to `'auto'`
+- The default behavior for scroll restoration.
+- See the [Scroll Restoration Guide](../../guide/scroll-restoration.md/#scroll-behavior) for more information.
+
+---
+
+### `scrollToTopSelectors` property
+
+- Type: `Array<string | (() => Element | null | undefined)>`
+- Optional
+- Defaults to `['window']`
+- An array of selectors that will be used to scroll to the top of the page in addition to `window`.
+- See the [Scroll Restoration Guide](../../guide/scroll-restoration.md/#hashtop-of-page-scrolling) for more information.

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -453,6 +453,7 @@ export interface RouterOptions<
    * If `true`, scroll restoration will be enabled
    *
    * @default false
+   * @link [Guide](https://tanstack.com/router/v1/docs/guide/scroll-restoration#scroll-restoration)
    */
   scrollRestoration?:
     | boolean
@@ -462,18 +463,21 @@ export interface RouterOptions<
    * A function that will be called to get the key for the scroll restoration cache.
    *
    * @default (location) => location.href
+   * @link [Guide](https://tanstack.com/router/v1/docs/guide/scroll-restoration#custom-cache-keys)
    */
   getScrollRestorationKey?: (location: ParsedLocation) => string
   /**
    * The default behavior for scroll restoration.
    *
    * @default 'auto'
+   * @link [Guide](https://tanstack.com/router/v1/docs/guide/scroll-restoration#scroll-behavior)
    */
   scrollRestorationBehavior?: ScrollBehavior
   /**
    * An array of selectors that will be used to scroll to the top of the page in addition to `window`
    *
    * @default ['window']
+   * @link [Guide](https://tanstack.com/router/v1/docs/guide/scroll-restoration#hashtop-of-page-scrolling)
    */
   scrollToTopSelectors?: Array<string | (() => Element | null | undefined)>
 


### PR DESCRIPTION
The [documentation ](https://tanstack.com/router/v1/docs/api/router/RouterOptionsType) for configuring a Router instance is missing these 4 properties: 
- scrollRestoration
- getScrollRestorationKey
- scrollRestorationBehavior
- scrollToTopSelectors

This PR
- adds documentation for them using the existing docstrings in router.ts, plus links to the official [scroll restoration guide](https://tanstack.com/router/v1/docs/guide/scroll-restoration)
- adds said links to their docstrings




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for four new scroll restoration configuration options: `scrollRestoration`, `getScrollRestorationKey`, `scrollRestorationBehavior`, and `scrollToTopSelectors`. These new options enable customizable scroll behavior and restoration key management for improved user navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->