### PR TITLE
refactor(react-router): useMatches skips useRef during SSR

### DIFF
--- a/.changeset/four-carrots-post.md
+++ b/.changeset/four-carrots-post.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-router': patch
+---
+
+useMatches can skip useRef for structural sharing during SSR

--- a/packages/react-router/src/Matches.tsx
+++ b/packages/react-router/src/Matches.tsx
@@ -234,10 +234,6 @@ export function useMatches<
     StructuralSharingOption<TRouter, TSelected, TStructuralSharing>,
 ): UseMatchesResult<TRouter, TSelected> {
   const router = useRouter<TRouter>()
-  const previousResult =
-    React.useRef<ValidateSelected<TRouter, TSelected, TStructuralSharing>>(
-      undefined,
-    )
 
   if (isServer ?? router.isServer) {
     const matches = router.stores.matches.get() as Array<
@@ -248,6 +244,12 @@ export function useMatches<
       TSelected
     >
   }
+
+  const previousResult =
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    React.useRef<ValidateSelected<TRouter, TSelected, TStructuralSharing>>(
+      undefined,
+    )
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   return useStore(router.stores.matches, (matches) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved structural sharing behavior in the `useMatches` hook during server-side rendering for better performance and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->