### PR TITLE
fix(examples): API route calls failing on server

### DIFF
--- a/docs/start/framework/react/guide/code-execution-patterns.md
+++ b/docs/start/framework/react/guide/code-execution-patterns.md
@@ -95,14 +95,14 @@ export const Route = createFileRoute('/users')({
   loader: () => {
     // This runs on BOTH server and client!
     const secret = process.env.SECRET // Exposed to client
-    return fetch(`/api/users?key=${secret}`)
+    return fetch(`https://api.example.com/api/users?key=${secret}`)
   },
 })
 
 // ✅ Use server function for server-only operations
 const getUsersSecurely = createServerFn().handler(() => {
   const secret = process.env.SECRET // Server-only
-  return fetch(`/api/users?key=${secret}`)
+  return fetch(`https://api.example.com/api/users?key=${secret}`)
 })
 
 export const Route = createFileRoute('/users')({

--- a/docs/start/framework/react/guide/execution-model.md
+++ b/docs/start/framework/react/guide/execution-model.md
@@ -22,7 +22,7 @@ function formatPrice(price: number) {
 export const Route = createFileRoute('/products')({
   loader: async () => {
     // This runs on server during SSR AND on client during navigation
-    const response = await fetch('/api/products')
+    const response = await fetch('https://api.example.com/api/products')
     return response.json()
   },
 })
@@ -223,14 +223,14 @@ export const Route = createFileRoute('/users')({
   loader: () => {
     // This runs on BOTH server and client!
     const secret = process.env.SECRET // Exposed to client
-    return fetch(`/api/users?key=${secret}`)
+    return fetch(`https://api.example.com/api/users?key=${secret}`)
   },
 })
 
 // ✅ Use server function for server-only operations
 const getUsersSecurely = createServerFn().handler(() => {
   const secret = process.env.SECRET // Server-only
-  return fetch(`/api/users?key=${secret}`)
+  return fetch(`https://api.example.com/api/users?key=${secret}`)
 })
 
 export const Route = createFileRoute('/users')({

--- a/docs/start/framework/solid/guide/code-execution-patterns.md
+++ b/docs/start/framework/solid/guide/code-execution-patterns.md
@@ -95,14 +95,14 @@ export const Route = createFileRoute('/users')({
   loader: () => {
     // This runs on BOTH server and client!
     const secret = process.env.SECRET // Exposed to client
-    return fetch(`/api/users?key=${secret}`)
+    return fetch(`https://api.example.com/api/users?key=${secret}`)
   },
 })
 
 // ✅ Use server function for server-only operations
 const getUsersSecurely = createServerFn().handler(() => {
   const secret = process.env.SECRET // Server-only
-  return fetch(`/api/users?key=${secret}`)
+  return fetch(`https://api.example.com/api/users?key=${secret}`)
 })
 
 export const Route = createFileRoute('/users')({

--- a/docs/start/framework/solid/guide/execution-model.md
+++ b/docs/start/framework/solid/guide/execution-model.md
@@ -22,7 +22,7 @@ function formatPrice(price: number) {
 export const Route = createFileRoute('/products')({
   loader: async () => {
     // This runs on server during SSR AND on client during navigation
-    const response = await fetch('/api/products')
+    const response = await fetch('https://api.example.com/api/products')
     return response.json()
   },
 })
@@ -211,14 +211,14 @@ export const Route = createFileRoute('/users')({
   loader: () => {
     // This runs on BOTH server and client!
     const secret = process.env.SECRET // Exposed to client
-    return fetch(`/api/users?key=${secret}`)
+    return fetch(`https://api.example.com/api/users?key=${secret}`)
   },
 })
 
 // ✅ Use server function for server-only operations
 const getUsersSecurely = createServerFn().handler(() => {
   const secret = process.env.SECRET // Server-only
-  return fetch(`/api/users?key=${secret}`)
+  return fetch(`https://api.example.com/api/users?key=${secret}`)
 })
 
 export const Route = createFileRoute('/users')({

--- a/examples/react/start-basic-cloudflare/src/routes/users.$userId.tsx
+++ b/examples/react/start-basic-cloudflare/src/routes/users.$userId.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { getRouterInstance } from '@tanstack/react-start'
 import { NotFound } from '../components/NotFound'
 import { UserErrorComponent } from '../components/UserError'
 import type { User } from '~/utils/users'
@@ -6,7 +7,8 @@ import type { User } from '~/utils/users'
 export const Route = createFileRoute('/users/$userId')({
   loader: async ({ params: { userId } }) => {
     try {
-      const res = await fetch('/api/users/' + userId)
+      const router = await getRouterInstance()
+      const res = await fetch(new URL('/api/users/' + userId, router.origin))
       if (!res.ok) {
         throw new Error('Unexpected status code')
       }

--- a/examples/react/start-basic-cloudflare/src/routes/users.tsx
+++ b/examples/react/start-basic-cloudflare/src/routes/users.tsx
@@ -1,9 +1,11 @@
 import { Link, Outlet, createFileRoute } from '@tanstack/react-router'
+import { getRouterInstance } from '@tanstack/react-start'
 import type { User } from '~/utils/users'
 
 export const Route = createFileRoute('/users')({
   loader: async () => {
-    const res = await fetch('/api/users')
+    const router = await getRouterInstance()
+    const res = await fetch(new URL('/api/users', router.origin))
 
     if (!res.ok) {
       throw new Error('Unexpected status code')

--- a/examples/react/start-basic/src/routes/users.$userId.tsx
+++ b/examples/react/start-basic/src/routes/users.$userId.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { getRouterInstance } from '@tanstack/react-start'
 import { NotFound } from '../components/NotFound'
 import { UserErrorComponent } from '../components/UserError'
 import type { User } from '../utils/users'
@@ -6,7 +7,8 @@ import type { User } from '../utils/users'
 export const Route = createFileRoute('/users/$userId')({
   loader: async ({ params: { userId } }) => {
     try {
-      const res = await fetch('/api/users/' + userId)
+      const router = await getRouterInstance()
+      const res = await fetch(new URL('/api/users/' + userId, router.origin))
       if (!res.ok) {
         throw new Error('Unexpected status code')
       }

--- a/examples/react/start-basic/src/routes/users.tsx
+++ b/examples/react/start-basic/src/routes/users.tsx
@@ -1,9 +1,11 @@
 import { Link, Outlet, createFileRoute } from '@tanstack/react-router'
+import { getRouterInstance } from '@tanstack/react-start'
 import type { User } from '../utils/users'
 
 export const Route = createFileRoute('/users')({
   loader: async () => {
-    const res = await fetch('/api/users')
+    const router = await getRouterInstance()
+    const res = await fetch(new URL('/api/users', router.origin))
 
     if (!res.ok) {
       throw new Error('Unexpected status code')

--- a/examples/solid/start-basic-cloudflare/src/routes/users.$userId.tsx
+++ b/examples/solid/start-basic-cloudflare/src/routes/users.$userId.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from '@tanstack/solid-router'
+import { getRouterInstance } from '@tanstack/solid-start'
 import { NotFound } from '../components/NotFound'
 import { UserErrorComponent } from '../components/UserError'
 import type { User } from '../utils/users'
@@ -6,7 +7,8 @@ import type { User } from '../utils/users'
 export const Route = createFileRoute('/users/$userId')({
   loader: async ({ params: { userId } }) => {
     try {
-      const res = await fetch('/api/users/' + userId)
+      const router = await getRouterInstance()
+      const res = await fetch(new URL('/api/users/' + userId, router.origin))
       if (!res.ok) {
         throw new Error('Unexpected status code')
       }

--- a/examples/solid/start-basic-cloudflare/src/routes/users.tsx
+++ b/examples/solid/start-basic-cloudflare/src/routes/users.tsx
@@ -1,9 +1,11 @@
 import { Link, Outlet, createFileRoute } from '@tanstack/solid-router'
+import { getRouterInstance } from '@tanstack/solid-start'
 import type { User } from '../utils/users'
 
 export const Route = createFileRoute('/users')({
   loader: async () => {
-    const res = await fetch('/api/users')
+    const router = await getRouterInstance()
+    const res = await fetch(new URL('/api/users', router.origin))
 
     if (!res.ok) {
       throw new Error('Unexpected status code')

--- a/examples/solid/start-basic-netlify/src/routes/users.$userId.tsx
+++ b/examples/solid/start-basic-netlify/src/routes/users.$userId.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from '@tanstack/solid-router'
+import { getRouterInstance } from '@tanstack/solid-start'
 import { NotFound } from '../components/NotFound'
 import { UserErrorComponent } from '../components/UserError'
 import type { User } from '../utils/users'
@@ -6,7 +7,8 @@ import type { User } from '../utils/users'
 export const Route = createFileRoute('/users/$userId')({
   loader: async ({ params: { userId } }) => {
     try {
-      const res = await fetch('/api/users/' + userId)
+      const router = await getRouterInstance()
+      const res = await fetch(new URL('/api/users/' + userId, router.origin))
       if (!res.ok) {
         throw new Error('Unexpected status code')
       }

--- a/examples/solid/start-basic-netlify/src/routes/users.tsx
+++ b/examples/solid/start-basic-netlify/src/routes/users.tsx
@@ -1,9 +1,11 @@
 import { Link, Outlet, createFileRoute } from '@tanstack/solid-router'
+import { getRouterInstance } from '@tanstack/solid-start'
 import type { User } from '../utils/users'
 
 export const Route = createFileRoute('/users')({
   loader: async () => {
-    const res = await fetch('/api/users')
+    const router = await getRouterInstance()
+    const res = await fetch(new URL('/api/users', router.origin))
 
     if (!res.ok) {
       throw new Error('Unexpected status code')

--- a/examples/solid/start-basic-nitro/src/routes/users.$userId.tsx
+++ b/examples/solid/start-basic-nitro/src/routes/users.$userId.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from '@tanstack/solid-router'
+import { getRouterInstance } from '@tanstack/solid-start'
 import { NotFound } from '../components/NotFound'
 import { UserErrorComponent } from '../components/UserError'
 import type { User } from '../utils/users'
@@ -6,7 +7,8 @@ import type { User } from '../utils/users'
 export const Route = createFileRoute('/users/$userId')({
   loader: async ({ params: { userId } }) => {
     try {
-      const res = await fetch('/api/users/' + userId)
+      const router = await getRouterInstance()
+      const res = await fetch(new URL('/api/users/' + userId, router.origin))
       if (!res.ok) {
         throw new Error('Unexpected status code')
       }

--- a/examples/solid/start-basic-nitro/src/routes/users.tsx
+++ b/examples/solid/start-basic-nitro/src/routes/users.tsx
@@ -1,9 +1,11 @@
 import { Link, Outlet, createFileRoute } from '@tanstack/solid-router'
+import { getRouterInstance } from '@tanstack/solid-start'
 import type { User } from '../utils/users'
 
 export const Route = createFileRoute('/users')({
   loader: async () => {
-    const res = await fetch('/api/users')
+    const router = await getRouterInstance()
+    const res = await fetch(new URL('/api/users', router.origin))
 
     if (!res.ok) {
       throw new Error('Unexpected status code')

--- a/examples/solid/start-basic/src/routes/users.$userId.tsx
+++ b/examples/solid/start-basic/src/routes/users.$userId.tsx
@@ -1,11 +1,13 @@
 import { createFileRoute } from '@tanstack/solid-router'
+import { getRouterInstance } from '@tanstack/solid-start'
 import { NotFound } from '../components/NotFound'
 import { UserErrorComponent } from '../components/UserError'
 
 export const Route = createFileRoute('/users/$userId')({
   loader: async ({ params: { userId } }) => {
     try {
-      const res = await fetch('/api/users/' + userId)
+      const router = await getRouterInstance()
+      const res = await fetch(new URL('/api/users/' + userId, router.origin))
       if (!res.ok) {
         throw new Error('Unexpected status code')
       }

--- a/examples/solid/start-basic/src/routes/users.tsx
+++ b/examples/solid/start-basic/src/routes/users.tsx
@@ -1,9 +1,11 @@
 import { Link, Outlet, createFileRoute } from '@tanstack/solid-router'
+import { getRouterInstance } from '@tanstack/solid-start'
 import type { User } from '../utils/users'
 
 export const Route = createFileRoute('/users')({
   loader: async () => {
-    const res = await fetch('/api/users')
+    const router = await getRouterInstance()
+    const res = await fetch(new URL('/api/users', router.origin))
 
     if (!res.ok) {
       throw new Error('Unexpected status code')


### PR DESCRIPTION
Hey there,
I was exploring the [start-basic](https://github.com/TanStack/router/tree/main/examples/react/start-basic) example locally, and noticed the issue with API routes calls from the server.

## The problem

Isomorphic calls to API routes fail on the server because of the relative URLs:

https://github.com/TanStack/router/blob/4a93cffffca34702e419bc47db827f964fd0cb65/examples/react/start-basic/src/routes/users.tsx#L4-L6

<img width="658" height="239" src="https://github.com/user-attachments/assets/e75ffdd7-d991-4cab-970a-ba835e6ad74b" />

## Possible solutions

1. Make URLs absolute. I've used `router.origin` for this purpose:
```tsx
import { getRouterInstance } from "@tanstack/react-start";
// ...
const router = await getRouterInstance();
const res = await fetch(new URL("/api/users/" + userId, router.origin));
```

2. Convert API routes to `createServerFn()` and call them via RPC

## The solution

I took the 1st approach, because I assume that the purpose of the API routes is to showcase that it's possible to have an API route and use it in route loader.

I've also updated some snippets in the docs that were using relative URLs in isomorphic functions, and used absolute URLs (relative URLs won't work on the server anyway). I didn't want to bring `route.origin` solution there to not distract from the main purpose of those snippets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated framework guides to clarify route loader execution patterns and demonstrate secure server-side data fetching practices.

* **Bug Fixes**
  * Updated starter project examples to construct API URLs using router origin instead of relative paths, improving reliability across React and Solid frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->