### PR TITLE
fix(router-core): avoid null bytes in dehydrated SSR match ids

### DIFF
--- a/.changeset/ssr-match-id-null-byte.md
+++ b/.changeset/ssr-match-id-null-byte.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+Encode dehydrated SSR match IDs with the replacement character instead of a null byte, so the inlined hydration payload no longer contains U+0000 (which is invalid in HTML and rejected by markup validators)

--- a/packages/router-core/src/ssr/ssr-match-id.ts
+++ b/packages/router-core/src/ssr/ssr-match-id.ts
@@ -1,5 +1,5 @@
 export function dehydrateSsrMatchId(id: string): string {
-  return id.replaceAll('/', '\0')
+  return id.replaceAll('/', '\uFFFD')
 }
 
 export function hydrateSsrMatchId(id: string): string {

--- a/packages/router-core/tests/ssr-match-id.test.ts
+++ b/packages/router-core/tests/ssr-match-id.test.ts
@@ -23,4 +23,21 @@ describe('ssr match id codec', () => {
   it('decodes browser-normalized replacement chars back to slashes', () => {
     expect(hydrateSsrMatchId('\uFFFDposts\uFFFD1')).toBe('/posts/1')
   })
+
+  it('does not emit control characters that are invalid in SSR HTML', () => {
+    const dehydratedId = dehydrateSsrMatchId(
+      '/$orgId/projects/$projectId//acme/projects/dashboard/{}',
+    )
+
+    // U+0000 and the other C0 control characters trigger a
+    // control-character-in-input-stream parse error when the dehydrated id is
+    // inlined into the SSR <script> payload, so the codec must never emit them.
+    const nullChar = String.fromCharCode(0)
+    expect(dehydratedId).not.toContain(nullChar)
+
+    const hasControlChar = dehydratedId
+      .split('')
+      .some((char) => char.charCodeAt(0) <= 0x1f)
+    expect(hasControlChar).toBe(false)
+  })
 })

--- a/packages/router-core/tests/ssr-match-id.test.ts
+++ b/packages/router-core/tests/ssr-match-id.test.ts
@@ -24,6 +24,14 @@ describe('ssr match id codec', () => {
     expect(hydrateSsrMatchId('\uFFFDposts\uFFFD1')).toBe('/posts/1')
   })
 
+  it('still decodes legacy null-byte delimiters for backward compatibility', () => {
+    // Payloads emitted before the switch to U+FFFD encoded slashes as U+0000.
+    // hydrateSsrMatchId keeps the legacy decode branch so an in-flight payload
+    // from a previous deploy still hydrates correctly.
+    const nullChar = String.fromCharCode(0)
+    expect(hydrateSsrMatchId(`${nullChar}posts${nullChar}1`)).toBe('/posts/1')
+  })
+
   it('does not emit control characters that are invalid in SSR HTML', () => {
     const dehydratedId = dehydrateSsrMatchId(
       '/$orgId/projects/$projectId//acme/projects/dashboard/{}',


### PR DESCRIPTION
## Summary

`dehydrateSsrMatchId` encodes match IDs for the SSR hydration payload by replacing `/` with `\0`. That encoding came from #6739, so the dehydrated ids stop looking like relative URLs that crawlers pick up as phantom pages.

The catch is that U+0000 is forbidden in the HTML input stream (the `control-character-in-input-stream` parse error in the HTML spec). The dehydrated ids are inlined into the `$tsr-stream-barrier` `<script>`, so every SSR response ends up with raw null bytes and fails markup validation. `validator.w3.org` reports `Saw U+0000 in stream` (#7581). It only works in browsers today because the parser silently rewrites those null bytes to U+FFFD, which is exactly why `hydrateSsrMatchId` already carries a `� -> /` fallback.

This swaps the delimiter from `\0` to `�` (U+FFFD REPLACEMENT CHARACTER):

- it still contains no `/`, so the #6739 crawler fix holds
- U+FFFD is a valid HTML character, so the payload validates and the delimiter survives transport intact instead of depending on the parser to mangle it
- `hydrateSsrMatchId` already decodes `� -> /`, so the client side needs no change

The existing `\0 -> /` decode branch is left in place so any payload still carrying a null byte keeps round-tripping.

## Testing

Added a codec test asserting the dehydrated id has no C0 control characters. It fails on `main` and passes with this change.

- `nx run @tanstack/router-core:test:unit` (39 files, 1179 passed)
- `nx run @tanstack/router-core:test:types`
- `nx run @tanstack/router-core:test:eslint`
- `nx run @tanstack/router-core:build`

Fixes #7581


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side rendering hydration payload encoding by replacing null-byte delimiters with a safer sentinel character, preventing invalid U+0000 characters in inline markup and improving validator compatibility.

* **Tests**
  * Added new assertions to confirm legacy null-byte hydration payloads are still decoded for backward compatibility, and that newly generated payloads never include null bytes or other control characters that could break inline SSR content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->