### PR TITLE
fix(react-router): avoid throwing in useMatch selector

### DIFF
--- a/.changeset/empty-olives-melt.md
+++ b/.changeset/empty-olives-melt.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-router': patch
+---
+
+Perf improvement of useMatch and derived hooks when navigating away from previous match

--- a/packages/react-router/src/useMatch.tsx
+++ b/packages/react-router/src/useMatch.tsx
@@ -179,21 +179,23 @@ export function useMatch<
     useStructuralSharing(opts, router)
 
   // eslint-disable-next-line react-hooks/rules-of-hooks -- condition is static
-  return useStore(matchStore ?? dummyStore, (match) => {
-    if (!match) {
-      if (opts.shouldThrow ?? true) {
-        if (process.env.NODE_ENV !== 'production') {
-          throw new Error(
-            `Invariant failed: Could not find ${opts.from ? `an active match from "${opts.from}"` : 'a nearest match!'}`,
-          )
-        }
+  const matchSelection = useStore(matchStore ?? dummyStore, (match) =>
+    match ? selector(match as any) : dummyStore,
+  )
 
-        invariant()
-      }
+  if (matchSelection !== dummyStore) {
+    return matchSelection as any
+  }
 
-      return undefined
+  if (opts.shouldThrow ?? true) {
+    if (process.env.NODE_ENV !== 'production') {
+      throw new Error(
+        `Invariant failed: Could not find ${opts.from ? `an active match from "${opts.from}"` : 'a nearest match!'}`,
+      )
     }
 
-    return selector(match as any)
-  }) as any
+    invariant()
+  }
+
+  return undefined as any
 }

--- a/packages/react-router/src/useMatch.tsx
+++ b/packages/react-router/src/useMatch.tsx
@@ -184,7 +184,7 @@ export function useMatch<
   )
 
   if (matchSelection !== dummyStore) {
-    return matchSelection as any
+    return matchSelection
   }
 
   if (opts.shouldThrow ?? true) {

--- a/packages/react-router/tests/useMatch.test.tsx
+++ b/packages/react-router/tests/useMatch.test.tsx
@@ -74,6 +74,24 @@ describe('useMatch', () => {
         expect(postsTitle).toBeInTheDocument()
       },
     )
+
+    test('returns undefined from select when match is found', async () => {
+      const select = vi.fn(() => undefined)
+
+      function RootComponent() {
+        const match = useMatch({ from: '/posts', select })
+        expect(match).toBeUndefined()
+        return <Outlet />
+      }
+
+      setup({
+        RootComponent,
+        history: createMemoryHistory({ initialEntries: ['/posts'] }),
+      })
+      const postsTitle = await screen.findByText('PostsTitle')
+      expect(postsTitle).toBeInTheDocument()
+      expect(select).toHaveBeenCalled()
+    })
   })
 
   describe('when match is not found', () => {


### PR DESCRIPTION
## Summary
- Move the React useMatch missing-match invariant out of the store selector by returning the existing dummyStore sentinel.
- Preserve shouldThrow: false returning undefined and add coverage for selectors that legitimately return undefined.

## Verification
- CI=1 NX_DAEMON=false pnpm nx run @tanstack/react-router:test:unit --outputStyle=stream --skipRemoteCache -- tests/useMatch.test.tsx
- CI=1 NX_DAEMON=false pnpm nx run @tanstack/react-router:test:unit --outputStyle=stream --skipRemoteCache
- CI=1 NX_DAEMON=false pnpm nx run @tanstack/react-router:test:types --outputStyle=stream --skipRemoteCache
- React client-nav benchmark: verified pre-change production invariant branch was hit 17,856 times across 4,960 measured navigations; sentinel path removes those selector-time throws.
- Checked Solid/Vue adapters with temporary instrumentation; they had 0 missing-match throws in their client-nav benchmarks and do not need this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved match selection internals, yielding a performance improvement when navigating away from a previously matched route.

* **Tests**
  * Added coverage for an edge case where a match is found but a user-provided selector returns undefined, ensuring stable rendering and selector invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->