### PR TITLE
perf(start-server-core): skip update for server context

### DIFF
--- a/.changeset/large-insects-own.md
+++ b/.changeset/large-insects-own.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/start-server-core': patch
+---
+
+Skip a full router.update for faster createStartHandler

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -584,7 +584,9 @@ export function createStartHandler<TRegister = Register>(
             getStartContext({ throwIfNotFound: false })?.requestAssets,
         })
 
-        routerInstance.update({ additionalContext: { serverContext } })
+        // `additionalContext` is request-scoped and only read from router.options
+        // during load; avoid a full router.update() and redundant location parse.
+        routerInstance.options.additionalContext = { serverContext }
         await routerInstance.load()
 
         if (routerInstance.state.redirect) {


### PR DESCRIPTION
## Summary
- Set request-scoped additionalContext directly before router.load()
- Avoid an unnecessary router.update() and redundant location parse during SSR

## Tests
- CI=1 NX_DAEMON=false pnpm nx run @tanstack/start-server-core:test:types --outputStyle=stream --skipRemoteCache
- CI=1 NX_DAEMON=false pnpm nx run @tanstack/start-server-core:test:unit --outputStyle=stream --skipRemoteCache

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved server-side startup path to reduce SSR overhead, resulting in faster initial responses and lower latency during server rendering. Delivered as a minor patch with no public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->