### PR TITLE
Add bugs.url package metadata

### DIFF
--- a/packages/eslint-plugin-router/package.json
+++ b/packages/eslint-plugin-router/package.json
@@ -10,6 +10,9 @@
     "directory": "packages/eslint-plugin-router"
   },
   "homepage": "https://tanstack.com/router",
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
+  },
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"


### PR DESCRIPTION
## Summary
- adds missing npm support/discovery metadata for `@tanstack/eslint-plugin-router`
- updates only `packages/eslint-plugin-router/package.json`

## Metadata added
- `bugs.url`: `https://github.com/TanStack/router/issues`

## Validation
- parsed `packages/eslint-plugin-router/package.json` as JSON after the change
- confirmed the changed manifest still has `name: @tanstack/eslint-plugin-router`
- checked this is metadata-only: no runtime code, dependencies, exports, generated assets, or build behavior changed

This small metadata fix makes the published npm package point users to the project README and/or public issue tracker once the package is next released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced package metadata to include a direct link to the issue tracker for bug reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->