### PR TITLE
fix(react-router): re-export PathParamError from framework packages

### DIFF
--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -275,7 +275,7 @@ export type {
 
 export { createRouter, Router } from './router'
 
-export { lazyFn, SearchParamError } from '@tanstack/router-core'
+export { lazyFn, SearchParamError, PathParamError } from '@tanstack/router-core'
 
 export { RouterProvider, RouterContextProvider } from './RouterProvider'
 export type { RouterProps } from './RouterProvider'

--- a/packages/react-router/tests/router.test.tsx
+++ b/packages/react-router/tests/router.test.tsx
@@ -12,6 +12,7 @@ import { composeRewrites, notFound } from '@tanstack/router-core'
 import {
   Link,
   Outlet,
+  PathParamError,
   RouterProvider,
   SearchParamError,
   createBrowserHistory,
@@ -1890,6 +1891,39 @@ describe('search params in URL', () => {
         expect(errorSpy).toBeInstanceOf(SearchParamError)
         expect(errorSpy?.cause).toBeInstanceOf(TestValidationError)
       })
+    })
+  })
+
+  describe('validates path params', () => {
+    it('wraps a failing params.parse error in PathParamError', async () => {
+      let errorSpy: Error | undefined
+      const rootRoute = createRootRoute()
+      const postRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/posts/$id',
+        params: {
+          parse: ({ id }: { id: string }) => {
+            if (Number.isNaN(Number(id))) {
+              throw new Error('id must be a number')
+            }
+            return { id: Number(id) }
+          },
+          stringify: ({ id }: { id: number }) => ({ id: String(id) }),
+        },
+        errorComponent: ({ error }) => {
+          errorSpy = error
+          return null
+        },
+      })
+      const routeTree = rootRoute.addChildren([postRoute])
+      const history = createMemoryHistory({
+        initialEntries: ['/posts/not-a-number'],
+      })
+      const router = createRouter({ routeTree, history })
+      render(<RouterProvider router={router} />)
+      await act(() => router.load())
+
+      expect(errorSpy).toBeInstanceOf(PathParamError)
     })
   })
 })

--- a/packages/solid-router/src/index.tsx
+++ b/packages/solid-router/src/index.tsx
@@ -277,7 +277,7 @@ export type {
 
 export { createRouter, Router } from './router'
 
-export { lazyFn, SearchParamError } from '@tanstack/router-core'
+export { lazyFn, SearchParamError, PathParamError } from '@tanstack/router-core'
 
 export { RouterProvider, RouterContextProvider } from './RouterProvider'
 export type { RouterProps } from './RouterProvider'

--- a/packages/vue-router/src/index.tsx
+++ b/packages/vue-router/src/index.tsx
@@ -271,7 +271,7 @@ export type {
 
 export { createRouter, Router } from './router'
 
-export { lazyFn, SearchParamError } from '@tanstack/router-core'
+export { lazyFn, SearchParamError, PathParamError } from '@tanstack/router-core'
 
 export { RouterProvider, RouterContextProvider } from './RouterProvider'
 export type { RouterProps } from './RouterProvider'


### PR DESCRIPTION
## Summary

Closes #7545.

`PathParamError` is exported from `@tanstack/router-core` but was absent from the re-export lists in `@tanstack/react-router`, `@tanstack/solid-router`, and `@tanstack/vue-router`. `SearchParamError` was already re-exported on that same line — `PathParamError` was simply never added alongside it.

The practical impact: users who want to distinguish path-param validation failures from other errors in an `onError` handler or `errorComponent` had to write:

```ts
import { PathParamError } from '@tanstack/router-core' // transitive dep, not a public package
```

After this fix they can write:

```ts
import { PathParamError } from '@tanstack/react-router'
// or @tanstack/solid-router / @tanstack/vue-router
```

## Changes

- `packages/react-router/src/index.tsx` — add `PathParamError` to the existing `SearchParamError` re-export
- `packages/solid-router/src/index.tsx` — same
- `packages/vue-router/src/index.tsx` — same
- `packages/react-router/tests/router.test.tsx` — new test verifying that a `params.parse` failure surfaces as `PathParamError` in the route's `errorComponent`, imported directly from `@tanstack/react-router`

## Test plan

- `pnpm --filter @tanstack/react-router test:unit` — all 44 test files pass (913 tests, +1 from baseline)
- No type errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `PathParamError` is now exported from React, Solid, and Vue router packages, enabling developers to handle path parameter validation errors more effectively.

* **Tests**
  * Added test coverage for path parameter validation error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->