### PR TITLE
test: fix always-passing e2e assertions and missing awaits

### DIFF
--- a/e2e/react-router/basic-file-based/tests/params.spec.ts
+++ b/e2e/react-router/basic-file-based/tests/params.spec.ts
@@ -385,7 +385,7 @@ test.describe('Unicode params', () => {
     await fooLink.click()
     await page.waitForURL('/params-ps/named/foo%25%5C%2F%F0%9F%9A%80%EB%8C%80')
 
-    expect(page.url()).toBe(
+    await expect(page).toHaveURL(
       `${baseURL}/params-ps/named/foo%25%5C%2F%F0%9F%9A%80%EB%8C%80`,
     )
 
@@ -403,7 +403,7 @@ test.describe('Unicode params', () => {
       '/params-ps/named/foo%25%5C%2F%F0%9F%9A%80%EB%8C%80/%F0%9F%9A%80%252F%2Fabc%EB%8C%80',
     )
 
-    expect(page.url()).toBe(
+    await expect(page).toHaveURL(
       `${baseURL}/params-ps/named/foo%25%5C%2F%F0%9F%9A%80%EB%8C%80/%F0%9F%9A%80%252F%2Fabc%EB%8C%80`,
     )
 
@@ -441,7 +441,7 @@ test.describe('Unicode params', () => {
 
         const headingRootEl = page.getByTestId('unicode-heading')
 
-        expect(await headingRootEl.innerText()).toBe('Hello "/대한민국"!')
+        await expect(headingRootEl).toHaveText('Hello "/대한민국"!')
 
         const latinLink = page.getByTestId(`l-to-${name}-latin`)
         const unicodeLink = page.getByTestId(`l-to-${name}-unicode`)
@@ -453,7 +453,7 @@ test.describe('Unicode params', () => {
 
         await page.waitForURL(`${encodedChildRoutePath}/${latinParams}`)
 
-        expect(page.url()).toBe(
+        await expect(page).toHaveURL(
           `${baseURL}${encodedChildRoutePath}/${latinParams}`,
         )
 
@@ -463,10 +463,10 @@ test.describe('Unicode params', () => {
         const headingEl = page.getByTestId(`unicode-${name}-heading`)
         const paramsEl = page.getByTestId(`unicode-${name}-params`)
 
-        expect(await headingEl.innerText()).toBe(
+        await expect(headingEl).toHaveText(
           `Unicode ${pascalCaseName} Params`,
         )
-        expect(await paramsEl.innerText()).toBe(latinParams)
+        await expect(paramsEl).toHaveText(latinParams)
 
         await unicodeLink.click()
 
@@ -477,17 +477,17 @@ test.describe('Unicode params', () => {
 
         await page.waitForURL(`${encodedChildRoutePath}/${encodedParams}`)
 
-        expect(page.url()).toBe(
+        await expect(page).toHaveURL(
           `${baseURL}${encodedChildRoutePath}/${encodedParams}`,
         )
 
         await expect(latinLink).not.toContainClass('font-bold')
         await expect(unicodeLink).toContainClass('font-bold')
 
-        expect(await headingEl.innerText()).toBe(
+        await expect(headingEl).toHaveText(
           `Unicode ${pascalCaseName} Params`,
         )
-        expect(await paramsEl.innerText()).toBe(unicodeParams)
+        await expect(paramsEl).toHaveText(unicodeParams)
       })
     })
   })

--- a/e2e/react-start/basic-auth/tests/app.spec.ts
+++ b/e2e/react-start/basic-auth/tests/app.spec.ts
@@ -38,17 +38,17 @@ test('Posts redirects to login when not authenticated', async ({ page }) => {
 
 test('Login fails with user not found', async ({ page }) => {
   await login(page, 'bad@gmail.com', 'badpassword')
-  expect(page.getByText('User not found')).toBeTruthy()
+  await expect(page.getByText('User not found')).toBeVisible()
 })
 
 test('Login fails with incorrect password', async ({ page }) => {
   await signup(page, 'test@gmail.com', 'badpassword')
-  expect(page.getByText('Incorrect password')).toBeTruthy()
+  await expect(page.getByText('Incorrect password')).toBeVisible()
 })
 
 test('Can sign up from a not found user', async ({ page }) => {
   await login(page, 'test2@gmail.com', 'badpassword', true)
-  expect(page.getByText('test@gmail.com')).toBeTruthy()
+  await expect(page.getByText('test2@gmail.com')).toBeVisible()
 })
 
 test('Navigating to post after logging in', async ({ page }) => {

--- a/e2e/react-start/custom-basepath/tests/navigation.spec.ts
+++ b/e2e/react-start/custom-basepath/tests/navigation.spec.ts
@@ -49,16 +49,16 @@ test('client-side redirect', async ({ page, baseURL }) => {
   await page.getByTestId('link-to-throw-it').click()
   await page.waitForLoadState('networkidle')
 
-  expect(await page.getByTestId('post-view').isVisible()).toBe(true)
-  expect(page.url()).toBe(`${baseURL}/posts/1`)
+  await expect(page.getByTestId('post-view')).toBeVisible()
+  await expect(page).toHaveURL(`${baseURL}/posts/1`)
 })
 
 test('server-side redirect', async ({ page, baseURL }) => {
   await page.goto('/redirect/throw-it')
   await page.waitForLoadState('networkidle')
 
-  expect(await page.getByTestId('post-view').isVisible()).toBe(true)
-  expect(page.url()).toBe(`${baseURL}/posts/1`)
+  await expect(page.getByTestId('post-view')).toBeVisible()
+  await expect(page).toHaveURL(`${baseURL}/posts/1`)
 
   // do not follow redirects since we want to test the Location header
   // first go to the route WITHOUT the base path, this will just add the base path

--- a/e2e/solid-router/basic-file-based/tests/transition.spec.ts
+++ b/e2e/solid-router/basic-file-based/tests/transition.spec.ts
@@ -20,7 +20,7 @@ test('transitions/count/create-resource should keep old values visible during na
 
   // 1 click
 
-  page.getByTestId('increase-button').click()
+  await page.getByTestId('increase-button').click()
 
   await expect(page.getByTestId('n-value')).toContainText('n: 1', {
     timeout: 2_000,
@@ -40,8 +40,8 @@ test('transitions/count/create-resource should keep old values visible during na
 
   // 2 clicks
 
-  page.getByTestId('increase-button').click()
-  page.getByTestId('increase-button').click()
+  await page.getByTestId('increase-button').click()
+  await page.getByTestId('increase-button').click()
 
   await expect(page.getByTestId('n-value')).toContainText('n: 2', {
     timeout: 2000,
@@ -61,9 +61,9 @@ test('transitions/count/create-resource should keep old values visible during na
 
   // 3 clicks
 
-  page.getByTestId('increase-button').click()
-  page.getByTestId('increase-button').click()
-  page.getByTestId('increase-button').click()
+  await page.getByTestId('increase-button').click()
+  await page.getByTestId('increase-button').click()
+  await page.getByTestId('increase-button').click()
 
   await expect(page.getByTestId('n-value')).toContainText('n: 4', {
     timeout: 2000,


### PR DESCRIPTION
This PR strengthens existing Playwright E2E assertions. It does not add behavior or rename tests.

What changed:

- Replace `expect(locator).toBeTruthy()` checks in the basic auth fixture with `await expect(locator).toBeVisible()`. A Playwright `Locator` object is always truthy, so the previous checks did not verify the visible error text.
- Correct the signup assertion in the same auth fixture from `test@gmail.com` to `test2@gmail.com`, matching the address passed to `login(page, 'test2@gmail.com', ...)`. The dead truthy assertion was hiding that expected-value typo.
- Convert one-shot `page.url()`, `innerText()`, and `isVisible()` reads to web-first Playwright matchers (`toHaveURL`, `toHaveText`, `toBeVisible`).
- Add `await` to six `increase-button.click()` calls in the Solid transition fixture so the following assertions do not race the click actions.

Scope note:

I intentionally kept this to 4 files and one assertion-family migration. The same broad families still appear in sibling Solid, Vue, and React fixture suites. I can follow up separately if maintainers want the mirror suites swept too.

Blame check:

- The affected lines in these E2E fixtures trace at least as far back as cc12980e from 2026-03-06.

Verification:

- Re-fetched `origin/main` on 2026-06-13.
- Applied commit fdf325b01351dcc3de9489e3a048f6e8b1e4de4f to a temp worktree based on current `origin/main` and ran:
  `bash scripts/pr-preflight.sh tmp/preflight-tanstack-router e2e/react-router/basic-file-based/tests/params.spec.ts e2e/react-start/basic-auth/tests/app.spec.ts e2e/react-start/custom-basepath/tests/navigation.spec.ts e2e/solid-router/basic-file-based/tests/transition.spec.ts`
- Result: `PREFLIGHT 0 fail(s)` with scanner delta `total from 51 to 26, p0 from 26 to 1, ast from 10 to 0`; AST artifacts clean; diff hygiene clean; authoring clean with 0 added comments and no test renames.
- Not run locally: repo TypeScript, lint, or Playwright E2E. This clone has no `node_modules`, so preflight skipped tsc, eslint, and Playwright because local repo binaries were absent. The documented full path requires `pnpm install`, `pnpm exec playwright install`, and the repo build/dev setup.

---

Found while reviewing the test suite with [`e2e-skills/e2e-reviewer`](https://github.com/voidmatcha/e2e-skills#skill-2-e2e-reviewer--quality-review).
