### PR TITLE
docs(router): drop the broken "LLM Assistance Support" nav entry

### DIFF
--- a/docs/router/config.json
+++ b/docs/router/config.json
@@ -26,10 +26,6 @@
           "to": "decisions-on-dx"
         },
         {
-          "label": "LLM Assistance Support",
-          "to": "llm-support"
-        },
-        {
           "label": "Comparison",
           "to": "comparison"
         },


### PR DESCRIPTION
## Summary

Closes #7615.

The router's docs config (`docs/router/config.json`) lists an `LLM Assistance Support` entry pointing to `/router/latest/docs/llm-support`, but no markdown file at that path was ever added. Every sibling entry in the same **Getting Started** section has a matching `docs/router/<name>.md`:

```
docs/router/overview.md         ✓
docs/router/quick-start.md      ✓
docs/router/devtools.md         ✓
docs/router/decisions-on-dx.md  ✓
docs/router/llm-support.md      ✗  (missing)
docs/router/comparison.md       ✓
docs/router/faq.md              ✓
```

Visitors clicking the nav item hit a 404 with no recovery path — that's the user-visible bug in #7615.

## Fix

```diff
         {
           "label": "Decisions on DX",
           "to": "decisions-on-dx"
         },
-        {
-          "label": "LLM Assistance Support",
-          "to": "llm-support"
-        },
         {
           "label": "Comparison",
           "to": "comparison"
         },
```

The 404 stops being advertised. When the missing page is actually written, the entry can be re-added alongside the new `docs/router/llm-support.md`.

## Alternative considered

I started by drafting a stub `docs/router/llm-support.md` so the link would resolve to *something*. Walked it back because:

- The intended scope of "LLM Assistance Support" isn't documented anywhere in the repo. (It could be `llms.txt` patterns for the router, Cursor / Claude rules, agent SDK integration, or something else entirely.)
- A stub committing the project to one interpretation could box-canyon whoever was going to write the real page.
- TanStack Start ships a related but distinct concept (`docs/start/framework/react/guide/llmo.md`, focused on LLMO/AIO/GEO for app content) — copy-pasting that into router would mislead.

Happy to send a follow-up with a stub if maintainers would prefer to keep the nav entry placeholdered.

## Test plan

- [x] `cat docs/router/config.json | python -c "import sys, json; json.load(sys.stdin)"` — valid JSON
- [x] Sibling nav entries remain intact; order preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Getting Started navigation in the documentation: replaced "LLM Assistance Support" with "Decisions on DX".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->