### PR TITLE
docs(start): rename LLM optimization guide to GEO

### DIFF
--- a/docs/start/config.json
+++ b/docs/start/config.json
@@ -190,8 +190,8 @@
               "to": "framework/react/guide/seo"
             },
             {
-              "label": "LLM Optimization (LLMO)",
-              "to": "framework/react/guide/llmo"
+              "label": "Generative Engine Optimization (GEO)",
+              "to": "framework/react/guide/geo"
             }
           ]
         },
@@ -307,8 +307,8 @@
               "to": "framework/solid/guide/seo"
             },
             {
-              "label": "LLM Optimization (LLMO)",
-              "to": "framework/solid/guide/llmo"
+              "label": "Generative Engine Optimization (GEO)",
+              "to": "framework/solid/guide/geo"
             }
           ]
         }

--- a/docs/start/framework/react/guide/geo.md
+++ b/docs/start/framework/react/guide/geo.md
@@ -1,31 +1,33 @@
 ---
-id: llmo
-title: LLM Optimization (LLMO)
+id: geo
+title: Generative Engine Optimization (GEO)
+redirect_from:
+  - /framework/react/guide/llmo
 ---
 
 > [!NOTE]
 > Looking for traditional search engine optimization? See the [SEO guide](./seo).
 
-## What is LLMO?
+## What is GEO?
 
-**LLM Optimization (LLMO)**, also known as **AI Optimization (AIO)** or **Generative Engine Optimization (GEO)**, is the practice of structuring your content and data so that AI systems—like ChatGPT, Claude, Perplexity, and other LLM-powered tools—can accurately understand, cite, and recommend your content.
+**Generative Engine Optimization (GEO)** is the practice of structuring your content and data so that AI systems—like ChatGPT, Claude, Perplexity, and other LLM-powered tools—can accurately understand, cite, and recommend your content.
 
-While traditional SEO focuses on ranking in search engine results pages, LLMO focuses on being accurately represented in AI-generated responses. As more users get information through AI assistants rather than traditional search, this is becoming increasingly important.
+While traditional SEO focuses on ranking in search engine results pages, GEO focuses on being accurately represented in AI-generated responses. As more users get information through AI assistants rather than traditional search, this is becoming increasingly important.
 
-## How LLMO Differs from SEO
+## How GEO Differs from SEO
 
-| Aspect             | SEO                         | LLMO                                 |
+| Aspect             | SEO                         | GEO                                  |
 | ------------------ | --------------------------- | ------------------------------------ |
 | **Goal**           | Rank in search results      | Be cited/recommended by AI           |
 | **Audience**       | Search engine crawlers      | LLM training & retrieval systems     |
 | **Key signals**    | Links, keywords, page speed | Structured data, clarity, authority  |
 | **Content format** | Optimized for snippets      | Optimized for extraction & synthesis |
 
-The good news: many LLMO best practices overlap with SEO. Clear structure, authoritative content, and good metadata help both.
+The good news: many GEO best practices overlap with SEO. Clear structure, authoritative content, and good metadata help both.
 
 ## What TanStack Start Provides
 
-TanStack Start's features that support LLMO:
+TanStack Start's features that support GEO:
 
 - **Server-Side Rendering** - Ensures AI crawlers see fully rendered content
 - **Structured Data** - JSON-LD support for machine-readable content
@@ -34,13 +36,13 @@ TanStack Start's features that support LLMO:
 
 ## Structured Data for AI
 
-Structured data using schema.org vocabulary helps AI systems understand your content's meaning and context. This is perhaps the most important LLMO technique.
+Structured data using schema.org vocabulary helps AI systems understand your content's meaning and context. This is perhaps the most important GEO technique.
 
 ### Article Schema
 
 ```tsx
 // src/routes/posts/$postId.tsx
-import { createFileRoute } from '@tanstack/solid-router'
+import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/posts/$postId')({
   loader: async ({ params }) => {
@@ -169,7 +171,7 @@ export const Route = createRootRoute({
 
 ### FAQ Schema
 
-FAQ schema is particularly effective for LLMO—AI systems often extract Q&A pairs:
+FAQ schema is particularly effective for GEO—AI systems often extract Q&A pairs:
 
 ```tsx
 export const Route = createFileRoute('/faq')({
@@ -207,7 +209,7 @@ Create API endpoints that AI systems and developers can consume directly:
 
 ```ts
 // src/routes/api/products.ts
-import { createFileRoute } from '@tanstack/solid-router'
+import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/api/products')({
   server: {
@@ -240,7 +242,7 @@ export const Route = createFileRoute('/api/products')({
 
 ## Content Best Practices
 
-Beyond technical implementation, content structure matters for LLMO:
+Beyond technical implementation, content structure matters for GEO:
 
 ### Clear, Factual Statements
 
@@ -248,14 +250,13 @@ AI systems extract factual claims. Make your key information explicit:
 
 ```tsx
 // Good: Clear, extractable facts
-function ProductDetails(props) {
+function ProductDetails({ product }) {
   return (
     <article>
-      <h1>{props.product.name}</h1>
+      <h1>{product.name}</h1>
       <p>
-        {props.product.name} is a {props.product.category} made by{' '}
-        {props.product.brand}. It costs ${props.product.price} and is available
-        in {props.product.colors.join(', ')}.
+        {product.name} is a {product.category} made by {product.brand}. It costs
+        ${product.price} and is available in {product.colors.join(', ')}.
       </p>
     </article>
   )
@@ -319,7 +320,7 @@ Some sites are adopting a `llms.txt` file (similar to `robots.txt`) to provide g
 
 ```ts
 // src/routes/llms[.]txt.ts
-import { createFileRoute } from '@tanstack/solid-router'
+import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/llms.txt')({
   server: {
@@ -356,7 +357,7 @@ export const Route = createFileRoute('/llms.txt')({
 
 ## Monitoring AI Citations
 
-Unlike traditional SEO with established analytics, LLMO monitoring is still evolving. Consider:
+Unlike traditional SEO with established analytics, GEO monitoring is still evolving. Consider:
 
 - **Test with AI assistants** - Ask ChatGPT, Claude, and Perplexity about your product/content
 - **Monitor brand mentions** - Track how AI systems describe your offerings

--- a/docs/start/framework/react/guide/seo.md
+++ b/docs/start/framework/react/guide/seo.md
@@ -4,7 +4,7 @@ title: SEO
 ---
 
 > [!NOTE]
-> Looking to optimize for AI assistants and LLMs? See the [LLM Optimization (LLMO) guide](./llmo).
+> Looking to optimize for AI assistants and LLMs? See the [Generative Engine Optimization (GEO) guide](./geo).
 
 ## What is SEO, really?
 

--- a/docs/start/framework/solid/guide/geo.md
+++ b/docs/start/framework/solid/guide/geo.md
@@ -1,31 +1,33 @@
 ---
-id: llmo
-title: LLM Optimization (LLMO)
+id: geo
+title: Generative Engine Optimization (GEO)
+redirect_from:
+  - /framework/solid/guide/llmo
 ---
 
 > [!NOTE]
 > Looking for traditional search engine optimization? See the [SEO guide](./seo).
 
-## What is LLMO?
+## What is GEO?
 
-**LLM Optimization (LLMO)**, also known as **AI Optimization (AIO)** or **Generative Engine Optimization (GEO)**, is the practice of structuring your content and data so that AI systems—like ChatGPT, Claude, Perplexity, and other LLM-powered tools—can accurately understand, cite, and recommend your content.
+**Generative Engine Optimization (GEO)** is the practice of structuring your content and data so that AI systems—like ChatGPT, Claude, Perplexity, and other LLM-powered tools—can accurately understand, cite, and recommend your content.
 
-While traditional SEO focuses on ranking in search engine results pages, LLMO focuses on being accurately represented in AI-generated responses. As more users get information through AI assistants rather than traditional search, this is becoming increasingly important.
+While traditional SEO focuses on ranking in search engine results pages, GEO focuses on being accurately represented in AI-generated responses. As more users get information through AI assistants rather than traditional search, this is becoming increasingly important.
 
-## How LLMO Differs from SEO
+## How GEO Differs from SEO
 
-| Aspect             | SEO                         | LLMO                                 |
+| Aspect             | SEO                         | GEO                                  |
 | ------------------ | --------------------------- | ------------------------------------ |
 | **Goal**           | Rank in search results      | Be cited/recommended by AI           |
 | **Audience**       | Search engine crawlers      | LLM training & retrieval systems     |
 | **Key signals**    | Links, keywords, page speed | Structured data, clarity, authority  |
 | **Content format** | Optimized for snippets      | Optimized for extraction & synthesis |
 
-The good news: many LLMO best practices overlap with SEO. Clear structure, authoritative content, and good metadata help both.
+The good news: many GEO best practices overlap with SEO. Clear structure, authoritative content, and good metadata help both.
 
 ## What TanStack Start Provides
 
-TanStack Start's features that support LLMO:
+TanStack Start's features that support GEO:
 
 - **Server-Side Rendering** - Ensures AI crawlers see fully rendered content
 - **Structured Data** - JSON-LD support for machine-readable content
@@ -34,13 +36,13 @@ TanStack Start's features that support LLMO:
 
 ## Structured Data for AI
 
-Structured data using schema.org vocabulary helps AI systems understand your content's meaning and context. This is perhaps the most important LLMO technique.
+Structured data using schema.org vocabulary helps AI systems understand your content's meaning and context. This is perhaps the most important GEO technique.
 
 ### Article Schema
 
 ```tsx
 // src/routes/posts/$postId.tsx
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/solid-router'
 
 export const Route = createFileRoute('/posts/$postId')({
   loader: async ({ params }) => {
@@ -169,7 +171,7 @@ export const Route = createRootRoute({
 
 ### FAQ Schema
 
-FAQ schema is particularly effective for LLMO—AI systems often extract Q&A pairs:
+FAQ schema is particularly effective for GEO—AI systems often extract Q&A pairs:
 
 ```tsx
 export const Route = createFileRoute('/faq')({
@@ -207,7 +209,7 @@ Create API endpoints that AI systems and developers can consume directly:
 
 ```ts
 // src/routes/api/products.ts
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/solid-router'
 
 export const Route = createFileRoute('/api/products')({
   server: {
@@ -240,7 +242,7 @@ export const Route = createFileRoute('/api/products')({
 
 ## Content Best Practices
 
-Beyond technical implementation, content structure matters for LLMO:
+Beyond technical implementation, content structure matters for GEO:
 
 ### Clear, Factual Statements
 
@@ -248,13 +250,14 @@ AI systems extract factual claims. Make your key information explicit:
 
 ```tsx
 // Good: Clear, extractable facts
-function ProductDetails({ product }) {
+function ProductDetails(props) {
   return (
     <article>
-      <h1>{product.name}</h1>
+      <h1>{props.product.name}</h1>
       <p>
-        {product.name} is a {product.category} made by {product.brand}. It costs
-        ${product.price} and is available in {product.colors.join(', ')}.
+        {props.product.name} is a {props.product.category} made by{' '}
+        {props.product.brand}. It costs ${props.product.price} and is available
+        in {props.product.colors.join(', ')}.
       </p>
     </article>
   )
@@ -318,7 +321,7 @@ Some sites are adopting a `llms.txt` file (similar to `robots.txt`) to provide g
 
 ```ts
 // src/routes/llms[.]txt.ts
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/solid-router'
 
 export const Route = createFileRoute('/llms.txt')({
   server: {
@@ -355,7 +358,7 @@ export const Route = createFileRoute('/llms.txt')({
 
 ## Monitoring AI Citations
 
-Unlike traditional SEO with established analytics, LLMO monitoring is still evolving. Consider:
+Unlike traditional SEO with established analytics, GEO monitoring is still evolving. Consider:
 
 - **Test with AI assistants** - Ask ChatGPT, Claude, and Perplexity about your product/content
 - **Monitor brand mentions** - Track how AI systems describe your offerings

--- a/docs/start/framework/solid/guide/seo.md
+++ b/docs/start/framework/solid/guide/seo.md
@@ -4,7 +4,7 @@ title: SEO
 ---
 
 > [!NOTE]
-> Looking to optimize for AI assistants and LLMs? See the [LLM Optimization (LLMO) guide](./llmo).
+> Looking to optimize for AI assistants and LLMs? See the [Generative Engine Optimization (GEO) guide](./geo).
 
 ## What is SEO, really?
 


### PR DESCRIPTION
## Summary
- Rename the Start LLM optimization docs slug to GEO for React and Solid
- Update sidebar labels and SEO guide links to use Generative Engine Optimization
- Preserve old /guide/llmo URLs through redirect_from

## Checks
- CI=1 pnpm test:docs
- CI=1 pnpm exec prettier --check docs/start/config.json docs/start/framework/react/guide/geo.md docs/start/framework/solid/guide/geo.md docs/start/framework/react/guide/seo.md docs/start/framework/solid/guide/seo.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guides to use "Generative Engine Optimization (GEO)" terminology instead of "LLM Optimization (LLMO)" across both React and Solid frameworks.
  * Added redirects from legacy LLMO guide paths to new GEO guides to maintain accessibility.
  * Updated cross-references between guides to point to the new GEO documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->