### PR TITLE
docs(start): fix ISR guide using non-existent `prerender.routes` option

### DIFF
--- a/docs/start/framework/react/guide/isr.md
+++ b/docs/start/framework/react/guide/isr.md
@@ -34,9 +34,14 @@ export default defineConfig({
   plugins: [
     tanstackStart({
       prerender: {
-        routes: ['/blog', '/blog/posts/*'],
+        enabled: true,
+        // Crawl links from prerendered pages to discover and prerender
+        // dynamic routes such as individual blog posts.
         crawlLinks: true,
       },
+      // List the entry pages to prerender. Additional paths are discovered
+      // automatically via `crawlLinks` above and merged with this list.
+      pages: [{ path: '/blog' }],
     }),
   ],
 })
@@ -54,9 +59,14 @@ export default defineConfig({
     pluginReact(),
     tanstackStart({
       prerender: {
-        routes: ['/blog', '/blog/posts/*'],
+        enabled: true,
+        // Crawl links from prerendered pages to discover and prerender
+        // dynamic routes such as individual blog posts.
         crawlLinks: true,
       },
+      // List the entry pages to prerender. Additional paths are discovered
+      // automatically via `crawlLinks` above and merged with this list.
+      pages: [{ path: '/blog' }],
     }),
   ],
 })
@@ -423,9 +433,14 @@ export default defineConfig({
   plugins: [
     tanstackStart({
       prerender: {
-        routes: ['/blog', '/blog/posts/*'],
+        enabled: true,
+        // Crawl links from prerendered pages to discover and prerender
+        // dynamic routes such as individual blog posts.
         crawlLinks: true,
       },
+      // List the entry pages to prerender. Additional paths are discovered
+      // automatically via `crawlLinks` above and merged with this list.
+      pages: [{ path: '/blog' }],
     }),
   ],
 })
@@ -443,9 +458,14 @@ export default defineConfig({
     pluginReact(),
     tanstackStart({
       prerender: {
-        routes: ['/blog', '/blog/posts/*'],
+        enabled: true,
+        // Crawl links from prerendered pages to discover and prerender
+        // dynamic routes such as individual blog posts.
         crawlLinks: true,
       },
+      // List the entry pages to prerender. Additional paths are discovered
+      // automatically via `crawlLinks` above and merged with this list.
+      pages: [{ path: '/blog' }],
     }),
   ],
 })


### PR DESCRIPTION
Closes #7580

### Problem
The [ISR guide](https://tanstack.com/start/latest/docs/framework/react/guide/isr) configures prerendering with a `prerender.routes` array:

```ts
tanstackStart({
  prerender: {
    routes: ['/blog', '/blog/posts/*'],
    crawlLinks: true,
  },
})
```

`routes` is **not** a field on the prerender schema ([`start-plugin-core/src/schema.ts`](https://github.com/TanStack/router/blob/main/packages/start-plugin-core/src/schema.ts) — top-level `prerender` only has `enabled`, `concurrency`, `filter`, `failOnError`, `autoStaticPathsDiscovery`, `maxRedirects` plus the shared `pagePrerenderOptionsSchema` fields). Following the guide produces an invalid config.

### Fix
Replace `prerender.routes` with the supported `pages` array (entry paths) plus `prerender.crawlLinks`, which discovers and prerenders the linked dynamic routes — matching the [Static Prerendering guide](https://tanstack.com/start/latest/docs/framework/react/guide/static-prerendering) and the schema:

```ts
tanstackStart({
  prerender: {
    enabled: true,
    crawlLinks: true,
  },
  pages: [{ path: '/blog' }],
})
```

Applied to all four occurrences (Vite + Rsbuild tabs, in both the time-based and "combine with static prerendering" sections). Docs-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ISR configuration examples for TanStack Start with new `prerender` setup options, including `enabled: true`, `crawlLinks: true`, and explicit page configuration, replacing the previous route-based approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->