### PR TITLE
chore(react-router): silence AbortError in renderRouterToStream

### DIFF
--- a/.changeset/upset-eagles-happen.md
+++ b/.changeset/upset-eagles-happen.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-router': patch
+---
+
+Silence AbortError in renderRouterToStream, this is normal operation

--- a/packages/react-router/src/ssr/renderRouterToStream.tsx
+++ b/packages/react-router/src/ssr/renderRouterToStream.tsx
@@ -35,6 +35,12 @@ async function waitForReadyOrAbort(
   }
 }
 
+// A client disconnecting mid-stream is normal operation, not a render
+// failure; don't let React's onError log it as one.
+const isAbortError = (request: Request, error: unknown) =>
+  (request.signal.aborted && error === request.signal.reason) ||
+  (error instanceof Error && error.name === 'AbortError')
+
 export const renderRouterToStream = async ({
   request,
   router,
@@ -51,6 +57,11 @@ export const renderRouterToStream = async ({
       signal: request.signal,
       nonce: router.options.ssr?.nonce,
       progressiveChunkSize: Number.POSITIVE_INFINITY,
+      onError: (error, info) => {
+        if (!isAbortError(request, error)) {
+          console.error('Error in renderToReadableStream:', error, info)
+        }
+      },
     })
 
     if (isbot(request.headers.get('User-Agent'))) {
@@ -151,7 +162,9 @@ export const renderRouterToStream = async ({
               },
             }),
         onError: (error, info) => {
-          console.error('Error in renderToPipeableStream:', error, info)
+          if (!isAbortError(request, error)) {
+            console.error('Error in renderToPipeableStream:', error, info)
+          }
           abortPipeable(error, { defaultError: true })
         },
       })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Server-side rendering no longer logs expected abort/disconnect errors to the console, providing cleaner output during normal operation while maintaining full error handling capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->