### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/eslint-plugin-router/package.json
+++ b/packages/eslint-plugin-router/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@tanstack/eslint-plugin-router",
   "version": "1.162.0",
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
+  },
   "description": "ESLint plugin for TanStack Router",
   "author": "Manuel Schiller",
   "license": "MIT",


### PR DESCRIPTION
Adds missing `bugs, repository, homepage` metadata to `packages/eslint-plugin-router/package.json`.

Fixes npm tooling unable to resolve package metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata to include issue tracking information, enabling users to easily report and track bugs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->