### PR TITLE
chore: add npm bugs metadata to all published packages

### DIFF
--- a/packages/arktype-adapter/package.json
+++ b/packages/arktype-adapter/package.json
@@ -75,5 +75,8 @@
   "peerDependencies": {
     "arktype": ">=2.0.0-rc <3",
     "@tanstack/react-router": ">=1.43.2"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/eslint-plugin-router/package.json
+++ b/packages/eslint-plugin-router/package.json
@@ -62,5 +62,8 @@
   },
   "peerDependencies": {
     "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/eslint-plugin-start/package.json
+++ b/packages/eslint-plugin-start/package.json
@@ -63,5 +63,8 @@
   "peerDependencies": {
     "eslint": "^8.57.0 || ^9.0.0",
     "typescript": ">=4.7.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -60,5 +60,8 @@
   },
   "devDependencies": {
     "vite": "*"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/nitro-v2-vite-plugin/package.json
+++ b/packages/nitro-v2-vite-plugin/package.json
@@ -65,5 +65,8 @@
   },
   "peerDependencies": {
     "vite": ">=7.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/react-router-devtools/package.json
+++ b/packages/react-router-devtools/package.json
@@ -81,5 +81,8 @@
     "@tanstack/router-core": {
       "optional": true
     }
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/react-router-ssr-query/package.json
+++ b/packages/react-router-ssr-query/package.json
@@ -80,5 +80,8 @@
     "@tanstack/query-core": ">=5.90.0",
     "@tanstack/react-router": ">=1.127.0",
     "@tanstack/react-query": ">=5.90.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -111,5 +111,8 @@
   "peerDependencies": {
     "react": ">=18.0.0 || >=19.0.0",
     "react-dom": ">=18.0.0 || >=19.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/react-start-client/package.json
+++ b/packages/react-start-client/package.json
@@ -84,5 +84,8 @@
   "peerDependencies": {
     "react": ">=18.0.0 || >=19.0.0",
     "react-dom": ">=18.0.0 || >=19.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/react-start-rsc/package.json
+++ b/packages/react-start-rsc/package.json
@@ -131,5 +131,8 @@
     "react-server-dom-rspack": {
       "optional": true
     }
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/react-start-server/package.json
+++ b/packages/react-start-server/package.json
@@ -72,5 +72,8 @@
   "peerDependencies": {
     "react": ">=18.0.0 || >=19.0.0",
     "react-dom": ">=18.0.0 || >=19.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/react-start/package.json
+++ b/packages/react-start/package.json
@@ -190,5 +190,8 @@
   "devDependencies": {
     "@rsbuild/core": "^2.0.8",
     "@types/node": ">=20"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/router-cli/package.json
+++ b/packages/router-cli/package.json
@@ -74,5 +74,8 @@
     "@types/node": ">=20",
     "@types/yargs": "^17.0.33",
     "vite": "*"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/router-core/package.json
+++ b/packages/router-core/package.json
@@ -192,5 +192,8 @@
     "@types/node": "25.0.9",
     "esbuild": "^0.27.4",
     "vite": "*"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/router-devtools-core/package.json
+++ b/packages/router-devtools-core/package.json
@@ -78,5 +78,8 @@
     "csstype": {
       "optional": true
     }
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/router-devtools/package.json
+++ b/packages/router-devtools/package.json
@@ -80,5 +80,8 @@
     "csstype": {
       "optional": true
     }
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/router-generator/package.json
+++ b/packages/router-generator/package.json
@@ -78,5 +78,8 @@
     "@tanstack/react-router": "workspace:*",
     "@types/node": ">=20",
     "vite": "*"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/router-plugin/package.json
+++ b/packages/router-plugin/package.json
@@ -155,5 +155,8 @@
     "webpack": {
       "optional": true
     }
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/router-ssr-query-core/package.json
+++ b/packages/router-ssr-query-core/package.json
@@ -71,5 +71,8 @@
   "peerDependencies": {
     "@tanstack/router-core": ">=1.127.0",
     "@tanstack/query-core": ">=5.90.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/router-utils/package.json
+++ b/packages/router-utils/package.json
@@ -76,5 +76,8 @@
     "@types/babel__generator": "^7.27.0",
     "vite": "*",
     "@types/node": ">=20"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/router-vite-plugin/package.json
+++ b/packages/router-vite-plugin/package.json
@@ -68,5 +68,8 @@
   },
   "devDependencies": {
     "vite": "*"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/solid-router-devtools/package.json
+++ b/packages/solid-router-devtools/package.json
@@ -83,5 +83,8 @@
     "@tanstack/router-core": {
       "optional": true
     }
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/solid-router-ssr-query/package.json
+++ b/packages/solid-router-ssr-query/package.json
@@ -79,5 +79,8 @@
     "@tanstack/solid-query": ">=5.90.0",
     "@tanstack/solid-router": ">=1.127.0",
     "solid-js": "^1.9.10"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/solid-router/package.json
+++ b/packages/solid-router/package.json
@@ -122,5 +122,8 @@
   },
   "peerDependencies": {
     "solid-js": "^1.9.10"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/solid-start-client/package.json
+++ b/packages/solid-start-client/package.json
@@ -82,5 +82,8 @@
   },
   "peerDependencies": {
     "solid-js": ">=1.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/solid-start-server/package.json
+++ b/packages/solid-start-server/package.json
@@ -70,5 +70,8 @@
   },
   "peerDependencies": {
     "solid-js": "^1.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/solid-start/package.json
+++ b/packages/solid-start/package.json
@@ -144,5 +144,8 @@
     "vite": {
       "optional": true
     }
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/start-client-core/package.json
+++ b/packages/start-client-core/package.json
@@ -114,5 +114,8 @@
   "devDependencies": {
     "vite": "*",
     "@types/node": ">=20"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/start-fn-stubs/package.json
+++ b/packages/start-fn-stubs/package.json
@@ -58,5 +58,8 @@
   },
   "devDependencies": {
     "vite": "*"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/start-plugin-core/package.json
+++ b/packages/start-plugin-core/package.json
@@ -125,5 +125,8 @@
     "vite": {
       "optional": true
     }
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/start-server-core/package.json
+++ b/packages/start-server-core/package.json
@@ -100,5 +100,8 @@
     "cookie-es": "^3.0.0",
     "vite": "*",
     "@types/node": ">=20"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/start-static-server-functions/package.json
+++ b/packages/start-static-server-functions/package.json
@@ -77,5 +77,8 @@
     "@tanstack/solid-start": {
       "optional": true
     }
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/start-storage-context/package.json
+++ b/packages/start-storage-context/package.json
@@ -64,5 +64,8 @@
   "devDependencies": {
     "vite": "*",
     "@types/node": ">=20"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/valibot-adapter/package.json
+++ b/packages/valibot-adapter/package.json
@@ -75,5 +75,8 @@
   "peerDependencies": {
     "valibot": "^1.0.0 || ^1.0.0-beta.5 || ^1.0.0-rc",
     "@tanstack/react-router": ">=1.43.2"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/virtual-file-routes/package.json
+++ b/packages/virtual-file-routes/package.json
@@ -59,5 +59,8 @@
   },
   "devDependencies": {
     "vite": "*"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/vue-router-devtools/package.json
+++ b/packages/vue-router-devtools/package.json
@@ -74,5 +74,8 @@
     "@tanstack/router-core": {
       "optional": true
     }
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/vue-router-ssr-query/package.json
+++ b/packages/vue-router-ssr-query/package.json
@@ -72,5 +72,8 @@
     "@tanstack/vue-query": ">=5.90.0",
     "@tanstack/vue-router": ">=1.127.0",
     "vue": "^3.3.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/vue-router/package.json
+++ b/packages/vue-router/package.json
@@ -91,5 +91,8 @@
   },
   "peerDependencies": {
     "vue": "^3.3.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/vue-start-client/package.json
+++ b/packages/vue-start-client/package.json
@@ -70,5 +70,8 @@
   },
   "peerDependencies": {
     "vue": "^3.3.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/vue-start-server/package.json
+++ b/packages/vue-start-server/package.json
@@ -70,5 +70,8 @@
   },
   "peerDependencies": {
     "vue": "^3.3.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/vue-start/package.json
+++ b/packages/vue-start/package.json
@@ -140,5 +140,8 @@
     "vite": {
       "optional": true
     }
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/zod-adapter/package.json
+++ b/packages/zod-adapter/package.json
@@ -75,5 +75,8 @@
   "peerDependencies": {
     "zod": "^3.23.8",
     "@tanstack/react-router": ">=1.43.2"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }


### PR DESCRIPTION
## Summary

All `@tanstack/router-*`, `@tanstack/react-router`, `@tanstack/vue-router`, and related packages (42 total) are missing the `bugs` field in their npm metadata.

## Changes

Added to each published package's `package.json`:
```json
"bugs": {
  "url": "https://github.com/TanStack/router/issues"
}
```

## Verification

```sh
npm view @tanstack/react-router bugs  # currently empty
npm view @tanstack/router-core bugs    # currently empty
npm view @tanstack/vue-router bugs     # currently empty
```

No runtime code, dependencies, tests, or build configuration are changed. This is a metadata-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added bug reporting metadata to all package manifests, enabling users to easily report issues through the designated issues page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->