### PR TITLE
docs: add missing bugs metadata to @tanstack/eslint-plugin-router

### DIFF
--- a/packages/eslint-plugin-router/package.json
+++ b/packages/eslint-plugin-router/package.json
@@ -62,5 +62,8 @@
   },
   "peerDependencies": {
     "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }


### PR DESCRIPTION
This PR fixes the following issue reported in charles-microbounties:
- Issue #1255: @tanstack/eslint-plugin-router lacks package support metadata

Changes:
- Added 'bugs': { 'url': 'https://github.com/TanStack/router/issues' } to packages/eslint-plugin-router/package.json.

Verified with publint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata to include bug reporting information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->