### PR TITLE
docs: add missing bugs metadata to @tanstack/react-router

### DIFF
--- a/packages/eslint-plugin-router/package.json
+++ b/packages/eslint-plugin-router/package.json
@@ -62,5 +62,8 @@
   },
   "peerDependencies": {
     "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -111,5 +111,8 @@
   "peerDependencies": {
     "react": ">=18.0.0 || >=19.0.0",
     "react-dom": ">=18.0.0 || >=19.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/TanStack/router/issues"
   }
 }


### PR DESCRIPTION
This PR fixes the following issue reported in charles-microbounties:
- Issue #665: @tanstack/react-router npm package lacks bugs metadata

Changes:
- Added 'bugs': { 'url': 'https://github.com/TanStack/router/issues' } to packages/react-router/package.json.

Verified with publint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Route matching performance improved through caching of previously computed results. Repeated matches for the same location without state changes now reuse cached data for faster lookups.

* **Chores**
  * Added bug reporting URLs to package metadata in eslint-plugin-router and react-router packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->