### PR TITLE
ci: pnpm trustPolicy no-downgrade exclude chokidar@4.0.3

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,9 @@ preferWorkspacePackages: true
 blockExoticSubdeps: true
 trustPolicy: 'no-downgrade'
 
+trustPolicyExclude:
+  - 'chokidar@4.0.3'
+
 packages:
   - 'packages/*'
   - 'benchmarks/*'


### PR DESCRIPTION
`chokidar` 4.0.3 (and 4.0.2) are known to be trust policy downgrades, but are safe. The maintainers do not plan on fixing this issue, to encourage the ecosystem to move to 5.0.0

However for us, it's also "the ecosystem" that is blocking us: we depend directly on 5.0.0, but transitively depend on 4.0.3 (`sass`, `prisma`, `netlify`, ...)

Because this problem is known, and 4.0.3 is known to be safe, and there should not be any more 4.x.x releases, we should be ok to just exclude `'chokidar@4.0.3'` exactly from pnpm's trust policy rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace dependency configuration to adjust trust policy handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->