### PR TITLE
ci: pnpm trustPolicy no-downgrade exclude semver@6.3.1

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,8 @@ blockExoticSubdeps: true
 trustPolicy: 'no-downgrade'
 
 trustPolicyExclude:
-  - 'chokidar@4.0.3'
+  - 'chokidar@4.0.3' # known to be safe, installed by sass, prisma, netlify... no planned releases in v4, packages is on v5 now
+  - 'semver@6.3.1' # installed by babel, ecosystem has been on v7 for 7 years now, but babel is horribly out of date, 6.3.1 is the latest v6 and was released 3 years ago
 
 packages:
   - 'packages/*'


### PR DESCRIPTION
`semver` v6.3.1 is the latest v6, and has been released 3 years ago

it is installed by latest babel. No choice but to exclude it, even though v7 would not have this problem and has been out for **seven years**

Tested the `vite-ecosystem-ci` (https://github.com/vitejs/vite-ecosystem-ci#via-shell-script) locally, after changing their `TanStack/router` config to target this branch, and we're now passing without a `trustPolicy` violation.