### PR TITLE
docs(start): clarify server functions vs server routes

### DIFF
--- a/docs/start/framework/react/guide/server-functions.md
+++ b/docs/start/framework/react/guide/server-functions.md
@@ -22,7 +22,7 @@ const time = await getServerTime()
 Server functions provide server capabilities (database access, environment variables, file system) while maintaining type safety across the network boundary.
 
 > [!NOTE]
-> Server functions are meant to be called by your TanStack Start application. They are easy to use from your app code, and Start handles serialization across the client/server boundary. If you need an endpoint that can be called by external consumers or third-party services, use [server routes](./server-routes) instead.
+> Server functions are meant to be called by your TanStack Start application. They are easy to use from your app code, and Start handles serialization across the client/server boundary. If you need an endpoint that can be called from outside your Start app, use [server routes](./server-routes) instead.
 
 ## Same-Origin Requests
 

--- a/docs/start/framework/react/guide/server-functions.md
+++ b/docs/start/framework/react/guide/server-functions.md
@@ -21,6 +21,9 @@ const time = await getServerTime()
 
 Server functions provide server capabilities (database access, environment variables, file system) while maintaining type safety across the network boundary.
 
+> [!NOTE]
+> Server functions are meant to be called by your TanStack Start application. They are easy to use from your app code, and Start handles serialization across the client/server boundary. If you need an endpoint that can be called by external consumers or third-party services, use [server routes](./server-routes) instead.
+
 ## Same-Origin Requests
 
 Server functions are same-origin RPC endpoints for your application. Browser requests to server functions should come from the same origin, verified with Fetch Metadata (`Sec-Fetch-Site`), `Origin`, or `Referer` headers. Use server routes for public APIs or endpoints that intentionally support cross-origin requests.

--- a/docs/start/framework/react/guide/server-routes.md
+++ b/docs/start/framework/react/guide/server-routes.md
@@ -24,6 +24,9 @@ export const Route = createFileRoute('/hello')({
 })
 ```
 
+> [!NOTE]
+> Server routes are meant for HTTP endpoints that can be called by external consumers, third-party services, or other clients outside your TanStack Start application. If you only need to call server-side logic from within your Start app and want Start to handle serialization for you, use [server functions](./server-functions) instead.
+
 ## Server Routes and App Routes
 
 Because server routes can be defined in the same directory as your app routes, you can even use the same file for both!

--- a/docs/start/framework/react/guide/server-routes.md
+++ b/docs/start/framework/react/guide/server-routes.md
@@ -25,7 +25,7 @@ export const Route = createFileRoute('/hello')({
 ```
 
 > [!NOTE]
-> Server routes are meant for HTTP endpoints that can be called by external consumers, third-party services, or other clients outside your TanStack Start application. If you only need to call server-side logic from within your Start app and want Start to handle serialization for you, use [server functions](./server-functions) instead.
+> Server routes are meant for HTTP endpoints that need to be called from outside your TanStack Start application. If you only need to call server-side logic from within your Start app and want Start to handle serialization for you, use [server functions](./server-functions) instead.
 
 ## Server Routes and App Routes
 


### PR DESCRIPTION
## Summary
- add guidance notes to the React Start server functions guide
- add matching guidance to the React Start server routes guide
- link each page to the other for choosing the right API

## Testing
- Not run (docs-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the distinction between server functions and server routes
  * Added guidance on when to use each approach based on application requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->