### PR TITLE
fix(router-core): preserve string search params that don't survive JSON.parse numeric round-trip

### DIFF
--- a/.changeset/parsesearch-numeric-roundtrip.md
+++ b/.changeset/parsesearch-numeric-roundtrip.md
@@ -1,0 +1,9 @@
+---
+'@tanstack/router-core': patch
+---
+
+fix(router-core): preserve string search params whose value is a valid JSON number but does not round-trip (e.g. `662E41`, large integers beyond safe range)
+
+`parseSearchWith(JSON.parse)` called `JSON.parse` on every string query-param value and kept the result whenever it parsed successfully — including scientific-notation forms like `662E41` (= 6.62e43) and integers beyond `Number.MAX_SAFE_INTEGER`. Because `String(6.62e+43) !== '662E41'`, the original string was irreversibly destroyed before `validateSearch` could run.
+
+The fix adds a numeric round-trip guard: if `JSON.parse` returns a `number` and `String(number) !== originalString`, the original string is kept instead.

--- a/packages/router-core/src/searchParams.ts
+++ b/packages/router-core/src/searchParams.ts
@@ -32,7 +32,15 @@ export function parseSearchWith(parser: (str: string) => any) {
       const value = query[key]
       if (typeof value === 'string') {
         try {
-          query[key] = parser(value)
+          const parsed = parser(value)
+          // Reject numeric parses that do not round-trip back to the original
+          // string (e.g. '662E41' → 6.62e+43, '723421968459640832' → precision
+          // loss). Keep the original string so callers receive what was in the URL.
+          if (typeof parsed === 'number' && String(parsed) !== value) {
+            // silent — keep original string
+          } else {
+            query[key] = parsed
+          }
         } catch (_err) {
           // silent
         }

--- a/packages/router-core/tests/searchParams.test.ts
+++ b/packages/router-core/tests/searchParams.test.ts
@@ -98,4 +98,17 @@ describe('Search Params serialization and deserialization', () => {
       '?foo=%222024-11-18T00%3A00%3A00.000Z%22',
     )
   })
+
+  test('numeric round-trip: strings that look like JSON numbers but do not survive round-trip should stay as strings', () => {
+    // '662E41' is valid JSON scientific notation (6.62e43), but String(6.62e43) !== '662E41'
+    expect(defaultParseSearch('?codAut=662E41')).toEqual({ codAut: '662E41' })
+    // Large integer beyond safe range — precision would be lost
+    expect(defaultParseSearch('?id=723421968459640832')).toEqual({
+      id: '723421968459640832',
+    })
+    // '9e3' parses as 9000 but String(9000) !== '9e3'
+    expect(defaultParseSearch('?n=9e3')).toEqual({ n: '9e3' })
+    // Regular integers that do round-trip cleanly should still parse as numbers
+    expect(defaultParseSearch('?count=42')).toEqual({ count: 42 })
+  })
 })


### PR DESCRIPTION
## Bug

`parseSearchWith(JSON.parse)` destructively coerces search-param strings whose raw value happens to be valid JSON scientific notation or a large integer:

```ts
defaultParseSearch('?codAut=662E41')
// actual:   { codAut: 6.62e+43 }    ← irreversible, lossy
// expected: { codAut: '662E41' }

defaultParseSearch('?id=723421968459640832')
// actual:   { id: 723421968459640800 }  ← precision loss
// expected: { id: '723421968459640832' }
```

The root cause: `JSON.parse('662E41')` succeeds (it is valid JSON scientific notation: 662 × 10⁴¹), but `String(6.62e+43) !== '662E41'`, so the original string is irrecoverably destroyed before `validateSearch` ever runs.

Fixes #7650.

## Fix

Add a numeric round-trip guard in `parseSearchWith`: after `parser(value)` returns a number, only accept it when `String(parsed) === value`. If the round-trip fails, the original string is kept instead.

Lossless cases like `'123' → 123` (where `String(123) === '123'`) are unaffected.

The fix is purely additive — no existing tests needed editing.

## Verification

```
pnpm --filter @tanstack/router-core exec vitest run tests/searchParams.test.ts
```

Test Files  1 passed (1)
Tests  41 passed (41) — 40 original + 1 new

> AI-assisted contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed query parameter parsing to preserve the original string format for numeric values that would not round-trip correctly (such as scientific notation or large integers). Values that change their representation when converted back to strings are now kept as original strings to prevent unintended data loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->