### PR TITLE
fix(router-core): detect Webpack/Rspack ChunkLoadError in isModuleNotFoundError

### DIFF
--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -487,17 +487,25 @@ export function createControlledPromise<T>(onResolve?: (value: T) => void) {
 
 /**
  * Heuristically detect dynamic import "module not found" errors
- * across major browsers for lazy route component handling.
+ * across major browsers and bundlers for lazy route component handling.
+ *
+ * Covers:
+ * - Chrome: "Failed to fetch dynamically imported module: …"
+ * - Firefox: "error loading dynamically imported module: …"
+ * - Safari: "Importing a module script failed."
+ * - Webpack / Rspack: ChunkLoadError, "Loading chunk … failed.\n(error: …)"
  */
 export function isModuleNotFoundError(error: any): boolean {
-  // chrome: "Failed to fetch dynamically imported module: http://localhost:5173/src/routes/posts.index.tsx?tsr-split"
-  // firefox: "error loading dynamically imported module: http://localhost:5173/src/routes/posts.index.tsx?tsr-split"
-  // safari: "Importing a module script failed."
+  // Webpack / Rspack throw a typed ChunkLoadError with a distinct name
+  if (error?.name === 'ChunkLoadError') return true
+
   if (typeof error?.message !== 'string') return false
+
   return (
     error.message.startsWith('Failed to fetch dynamically imported module') ||
     error.message.startsWith('error loading dynamically imported module') ||
-    error.message.startsWith('Importing a module script failed')
+    error.message.startsWith('Importing a module script failed') ||
+    error.message.startsWith('Loading chunk')
   )
 }
 

--- a/packages/router-core/tests/is-module-not-found-error.test.ts
+++ b/packages/router-core/tests/is-module-not-found-error.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { isModuleNotFoundError } from '../src/utils'
+
+describe('isModuleNotFoundError', () => {
+  it('detects Chrome dynamic import error', () => {
+    const error = new Error(
+      'Failed to fetch dynamically imported module: http://localhost:5173/src/routes/posts.index.tsx?tsr-split',
+    )
+    expect(isModuleNotFoundError(error)).toBe(true)
+  })
+
+  it('detects Firefox dynamic import error', () => {
+    const error = new Error(
+      'error loading dynamically imported module: http://localhost:5173/src/routes/posts.index.tsx?tsr-split',
+    )
+    expect(isModuleNotFoundError(error)).toBe(true)
+  })
+
+  it('detects Safari dynamic import error', () => {
+    const error = new Error('Importing a module script failed.')
+    expect(isModuleNotFoundError(error)).toBe(true)
+  })
+
+  it('detects Webpack ChunkLoadError by name', () => {
+    // Webpack throws a ChunkLoadError with a distinct name property
+    const error = new Error('Loading chunk 123 failed.\n(error: http://localhost:3333/js/123.abc123.chunk.js)')
+    error.name = 'ChunkLoadError'
+    expect(isModuleNotFoundError(error)).toBe(true)
+  })
+
+  it('detects Webpack-style error by message prefix when name is generic', () => {
+    // Fallback: even without ChunkLoadError name, the message prefix catches it
+    const error = new Error('Loading chunk abc123 failed.\n(error: http://localhost:3333/js/main.abc123.js)')
+    expect(isModuleNotFoundError(error)).toBe(true)
+  })
+
+  it('detects Rspack ChunkLoadError', () => {
+    const error = new Error('Loading chunk 456 failed.\n(error: http://localhost:3333/js/456.def456.chunk.js)')
+    error.name = 'ChunkLoadError'
+    expect(isModuleNotFoundError(error)).toBe(true)
+  })
+
+  it('returns false for null input', () => {
+    expect(isModuleNotFoundError(null)).toBe(false)
+  })
+
+  it('returns false for undefined input', () => {
+    expect(isModuleNotFoundError(undefined)).toBe(false)
+  })
+
+  it('returns false for non-error objects', () => {
+    expect(isModuleNotFoundError({})).toBe(false)
+    expect(isModuleNotFoundError('string error')).toBe(false)
+    expect(isModuleNotFoundError(42)).toBe(false)
+  })
+
+  it('returns false for unrelated errors', () => {
+    const error = new Error('Something went wrong')
+    expect(isModuleNotFoundError(error)).toBe(false)
+  })
+
+  it('returns false for errors without a message', () => {
+    const error = {}
+    expect(isModuleNotFoundError(error)).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #7633.

## Problem
`isModuleNotFoundError()` only detects browser-native ESM import errors. When lazy route chunks are bundled by Webpack or Rspack, a failed dynamic import throws `ChunkLoadError` with message `Loading chunk 123 failed...`. The auto-reload path in `lazyRouteComponent` is never triggered.

## Solution
Two additions:
1. Check `error.name === "ChunkLoadError"`
2. Check `error.message.startsWith("Loading chunk")`

## Testing
11 tests added covering Chrome, Firefox, Safari, Webpack, Rspack, and edge cases.