### PR TITLE
docs: correct createBrowserHistory JSDoc option to parseLocation

### DIFF
--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -274,7 +274,7 @@ function assignKeyAndIndex(index: number, state: HistoryState | undefined) {
  * but if you need to ensure that the browser state is up to date, you can use the
  * `history.flush` method to immediately flush all pending state changes to the browser URL.
  * @param opts
- * @param opts.getHref A function that returns the current href (path + search + hash)
+ * @param opts.parseLocation A function that returns the current location as a `HistoryLocation`
  * @param opts.createHref A function that takes a path and returns a href (path + search + hash)
  * @returns A history instance
  */


### PR DESCRIPTION
The `createBrowserHistory` JSDoc documents an `opts.getHref` parameter, but no such option exists on the function. The actual option is `opts.parseLocation`, which returns the current location as a `HistoryLocation`. Corrected the `@param` name and description to match the signature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation for browser history configuration options to clarify parameter naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->