### PR TITLE
docs: link start counter example to CodeSandbox

### DIFF
--- a/docs/start/framework/react/build-from-scratch.md
+++ b/docs/start/framework/react/build-from-scratch.md
@@ -14,7 +14,7 @@ This guide will help you build a **very** basic TanStack Start web application. 
 - Display a counter
 - Increment the counter on the server and client
 
-[Here is what that will look like](https://stackblitz.com/github/tanstack/router/tree/main/examples/react/start-counter)
+[Here is what that will look like](https://codesandbox.io/s/github/TanStack/router/tree/main/examples/react/start-counter)
 
 Let's create a new project directory and initialize it.
 


### PR DESCRIPTION
﻿## Summary

Updates the React “Build a Project from Scratch” guide to link the start-counter example to CodeSandbox instead of StackBlitz.

StackBlitz currently fails for this example because it does not support the AsyncLocalStorage runtime needed by TanStack Start.

## Validation

- Compared the modified doc against the current `main` version
- `git diff --no-index --check`

Fixes #7480


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the example link in the React "Build a Project from Scratch" guide to point to CodeSandbox.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->