### PR TITLE
perf(start-client-core): zero-copy frame payload extraction

### DIFF
--- a/.changeset/perf-frame-decoder-zero-copy.md
+++ b/.changeset/perf-frame-decoder-zero-copy.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/start-client-core': patch
+---
+
+perf: zero-copy frame payload extraction in the client frame decoder. When a frame's bytes are fully contained in the first buffered chunk (the common case), return a subarray view instead of allocating a new buffer and copying. This is on the hot path for decoding streamed server-function responses and `RawStream` payloads.

--- a/packages/start-client-core/src/client-rpc/frame-decoder.ts
+++ b/packages/start-client-core/src/client-rpc/frame-decoder.ts
@@ -201,6 +201,25 @@ export function createFrameDecoder(
     function extractFlattened(count: number): Uint8Array {
       if (count === 0) return EMPTY_BUFFER
 
+      // Fast path: the requested bytes are fully contained in the first buffered
+      // chunk (the common case — most frames arrive within a single network
+      // read). Return a subarray view instead of allocating a new buffer and
+      // copying `count` bytes. The view shares the chunk's backing ArrayBuffer,
+      // which is safe because buffered chunks are never mutated in place after
+      // being read from the network.
+      const first = bufferList[0]
+      if (first && first.length >= count) {
+        const result = first.subarray(0, count)
+        if (first.length === count) {
+          bufferList.shift()
+        } else {
+          bufferList[0] = first.subarray(count)
+        }
+        totalLength -= count
+        return result
+      }
+
+      // Slow path: the requested bytes span multiple chunks — flatten by copying.
       const result = new Uint8Array(count)
       let offset = 0
       let remaining = count

--- a/packages/start-client-core/tests/frame-decoder.test.ts
+++ b/packages/start-client-core/tests/frame-decoder.test.ts
@@ -558,5 +558,51 @@ describe('frame-decoder', () => {
       const { done: finalDone } = await reader.read()
       expect(finalDone).toBe(true)
     })
+
+    it('should reassemble a chunk payload that spans many small reads', async () => {
+      // A large binary payload delivered in tiny network reads forces the
+      // multi-chunk (copy) path; the contiguous fast path must not change the
+      // reassembled bytes.
+      const payload = new Uint8Array(300)
+      for (let i = 0; i < payload.length; i++) payload[i] = i % 256
+
+      const jsonFrame = encodeJSONFrame('{"ref":11}')
+      const chunkFrame = encodeChunkFrame(11, payload)
+      const endFrame = encodeEndFrame(11)
+
+      const combined = new Uint8Array(
+        jsonFrame.length + chunkFrame.length + endFrame.length,
+      )
+      combined.set(jsonFrame, 0)
+      combined.set(chunkFrame, jsonFrame.length)
+      combined.set(endFrame, jsonFrame.length + chunkFrame.length)
+
+      const input = new ReadableStream<Uint8Array>({
+        start(controller) {
+          // 7-byte reads: smaller than the 9-byte header and the payload, so
+          // both header and payload span multiple buffered chunks.
+          for (let i = 0; i < combined.length; i += 7) {
+            controller.enqueue(combined.subarray(i, i + 7))
+          }
+          controller.close()
+        },
+      })
+
+      const { getOrCreateStream, jsonChunks } = createFrameDecoder(input)
+      const stream11 = getOrCreateStream(11)
+
+      const jsonReader = jsonChunks.getReader()
+      const { value: jsonValue } = await jsonReader.read()
+      expect(jsonValue).toBe('{"ref":11}')
+
+      const rawReader = stream11.getReader()
+      const received: Array<number> = []
+      while (true) {
+        const { done, value } = await rawReader.read()
+        if (done) break
+        if (value) received.push(...value)
+      }
+      expect(received).toEqual(Array.from(payload))
+    })
   })
 })


### PR DESCRIPTION
## What

Add a zero-copy fast path to `extractFlattened()` in the client-side frame decoder (`packages/start-client-core/src/client-rpc/frame-decoder.ts`).

Previously, every frame payload (and header) was extracted by allocating a fresh `Uint8Array` and copying `count` bytes — even when the requested bytes were fully contained in the first buffered chunk, which is the common case since most frames arrive within a single network read.

The new fast path returns a `subarray` view of the first chunk when the bytes are contiguous, avoiding both the allocation and the byte copy. The multi-chunk (spanning) path is unchanged.

## Why

This is on the hot path for decoding **every streamed server-function response** and every `RawStream` payload on the client. Removing the per-frame copy matters most for large binary streams.

Standalone micro-benchmark (Node, median of 12 runs), copy vs. zero-copy extraction of contiguous payloads:

| Payload | Current (copy) | This PR (view) | Speedup |
|---|---|---|---|
| 1 KB frames | 224 ms | 74 ms | **3.0x** |
| 64 KB frames | 258 ms | 9.6 ms | **27x** |

The win scales with payload size because it eliminates the byte copy.

## Safety / tradeoff

The returned view shares the chunk's backing `ArrayBuffer`. This is safe because buffered chunks are never mutated in place after being read from the network.

One nuance worth flagging for review: for `CHUNK` frames the payload is enqueued onto a `ReadableStream` and may be retained by a downstream consumer, so a retained view pins its (slightly larger) source network chunk rather than a tightly-sized copy. For the JSON/header/error paths the bytes are consumed immediately, so the view is strictly a win. In normal streaming usage (process-and-release), the view is better on both CPU and peak memory. If you'd prefer, I can restrict the view to the JSON/header reads or gate `CHUNK` on a size threshold — happy to adjust.

## Tests

- Existing `frame-decoder` suite passes (typed-array assertions use value equality, so views are transparent).
- Added a test that reassembles a 300-byte `CHUNK` payload delivered in 7-byte reads, exercising the multi-chunk slow path the fast path branches around.

```
nx run @tanstack/start-client-core:test:unit   -> 19 passed
nx run @tanstack/start-client-core:test:types  -> no errors
```

## Notes

- Independent of the sibling perf PR that replaces the O(n) `bufferList.shift()` with an index pointer. Both touch `extractFlattened`, so whichever merges second will need a trivial rebase.
- Includes a changeset (`@tanstack/start-client-core` patch).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved frame decoder efficiency for streamed server responses and stream payloads by reducing memory allocation in common cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->