### PR TITLE
perf(router-core): faster enumerable-key collection in structural sharing

### DIFF
--- a/.changeset/perf-structural-sharing-enumerable-keys.md
+++ b/.changeset/perf-structural-sharing-enumerable-keys.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+perf: speed up structural sharing (`replaceEqualDeep`) by computing enumerable own keys with `Object.keys` + a length compare instead of `getOwnPropertyNames` followed by a `propertyIsEnumerable` call per key. This runs on every selector result on every state update when `defaultStructuralSharing` is enabled, and is ~1.3–1.5x faster on typical router state objects with identical behavior.

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -299,24 +299,25 @@ export function replaceEqualDeep<T>(
  * Optimized for the common case where objects have no symbol properties.
  */
 function getEnumerableOwnKeys(o: object) {
-  const names = Object.getOwnPropertyNames(o)
-
-  // Fast path: check all string property names are enumerable
-  for (const name of names) {
-    if (!isEnumerable.call(o, name)) return false
-  }
+  // `Object.keys` returns only enumerable own string keys natively (no per-key
+  // JS callback). If it has fewer entries than `getOwnPropertyNames` (all own
+  // string keys), the object has a non-enumerable own string prop and is not
+  // "clone-friendly" -> bail. This replaces an O(n) loop of
+  // `propertyIsEnumerable` calls with two native calls.
+  const keys = Object.keys(o)
+  if (keys.length !== Object.getOwnPropertyNames(o).length) return false
 
   // Only check symbols if the object has any (most plain objects don't)
   const symbols = Object.getOwnPropertySymbols(o)
 
-  // Fast path: no symbols, return names directly (avoids array allocation/concat)
-  if (symbols.length === 0) return names
+  // Fast path: no symbols, return enumerable string keys directly
+  if (symbols.length === 0) return keys
 
-  // Slow path: has symbols, need to check and merge
-  const keys: Array<string | symbol> = names
+  // Slow path: has symbols, include only enumerable ones, bail on any
+  // non-enumerable symbol so it round-trips like the string-key check above.
   for (const symbol of symbols) {
     if (!isEnumerable.call(o, symbol)) return false
-    keys.push(symbol)
+    ;(keys as Array<string | symbol>).push(symbol)
   }
   return keys
 }

--- a/packages/router-core/tests/utils.test.ts
+++ b/packages/router-core/tests/utils.test.ts
@@ -923,6 +923,53 @@ describe('getEnumerableOwnKeys behavior (via replaceEqualDeep)', () => {
       ]
       expect(replaceEqualDeep(prev, next)).toBe(prev)
     })
+
+    it('preserves identity of unchanged nested subtrees when one leaf changes', () => {
+      const prev = {
+        search: { q: 'hello', f: 'live' },
+        params: { username: 'elonmusk', tweetId: '123' },
+        loaderData: {
+          user: { id: '44196397', name: 'Elon' },
+          tabs: ['a', 'b'],
+        },
+      }
+      const next = {
+        search: { q: 'hello', f: 'live' },
+        params: { username: 'elonmusk', tweetId: '123' },
+        loaderData: {
+          user: { id: '44196397', name: 'Musk' },
+          tabs: ['a', 'b'],
+        },
+      }
+      const result = replaceEqualDeep(prev, next)
+      // user.name changed -> top object is new, but every unchanged subtree
+      // (including the array) keeps its previous reference for cheap memo checks.
+      expect(result).not.toBe(prev)
+      expect(result.search).toBe(prev.search)
+      expect(result.params).toBe(prev.params)
+      expect(result.loaderData.tabs).toBe(prev.loaderData.tabs)
+      expect(result.loaderData.user).not.toBe(prev.loaderData.user)
+      expect(result.loaderData.user.name).toBe('Musk')
+    })
+
+    it('bails to next for a nested object carrying a non-enumerable prop', () => {
+      const prevInner: Record<string, number> = { a: 1 }
+      Object.defineProperty(prevInner, 'hidden', {
+        value: 2,
+        enumerable: false,
+      })
+      const nextInner: Record<string, number> = { a: 1 }
+      Object.defineProperty(nextInner, 'hidden', {
+        value: 2,
+        enumerable: false,
+      })
+      const prev = { shared: { x: 1 }, inner: prevInner }
+      const next = { shared: { x: 1 }, inner: nextInner }
+      const result = replaceEqualDeep(prev, next)
+      // inner is not clone-friendly -> returns nextInner; sibling subtree shared.
+      expect(result.inner).toBe(nextInner)
+      expect(result.shared).toBe(prev.shared)
+    })
   })
 })
 


### PR DESCRIPTION
## What

Speed up `getEnumerableOwnKeys` — the helper that backs `replaceEqualDeep` (structural sharing) in `packages/router-core/src/utils.ts`.

It previously called `Object.getOwnPropertyNames(o)` and then invoked `propertyIsEnumerable` **once per key** to confirm every own string property is enumerable. This swaps that O(n) loop of JS method calls for `Object.keys(o)` (native, enumerable-only) plus a single length comparison against `getOwnPropertyNames(o)` to detect non-enumerable own string props. Symbol handling is unchanged.

```diff
-  const names = Object.getOwnPropertyNames(o)
-  for (const name of names) {
-    if (!isEnumerable.call(o, name)) return false
-  }
+  const keys = Object.keys(o)
+  if (keys.length !== Object.getOwnPropertyNames(o).length) return false
```

## Why

`replaceEqualDeep` runs on **every selector result on every state update** when `defaultStructuralSharing` is enabled, so `getEnumerableOwnKeys` is called for every plain object it walks. For selector-heavy apps this is a hot client path (it short-circuits on the server, so this is purely a client-side win).

Benchmark on the real function (Vitest `bench`, node env where `isServer` is false), deeply-equal new state object shaped like typical router state (search / params / nested loaderData / context):

| | ops/s |
|---|---|
| before | ~560K |
| after | ~762K |

≈ **1.36× faster** in-situ (an isolated A/B of just the key-collection step measured ~1.55×). The win grows with object key count, since the old path made one `propertyIsEnumerable` call per key.

## Correctness

Behavior is identical:
- Same returned keys in the same order. `Object.keys` and `Object.getOwnPropertyNames` follow the same `[[OwnPropertyKeys]]` ordering (integer indices ascending, then string keys in insertion order), and in the non-bail case every string key is enumerable, so the two orderings coincide.
- Still bails (returns `false`) for objects with any non-enumerable own string property (length mismatch) or any non-enumerable own symbol (existing per-symbol check).

Verified by:
- The existing `getEnumerableOwnKeys behavior (via replaceEqualDeep)` suite (non-enumerable strings/symbols, frozen/sealed, `Object.create(null)`, numeric keys, shadowing, mixed string+symbol).
- A 5000+ case fuzz comparing the new key-collection against the old.
- Two added tests: partial structural sharing on a nested object (unchanged subtrees keep their reference), and a nested object carrying a non-enumerable prop bailing to `next`.

```
nx run @tanstack/router-core:test:unit   -> 1180 passed (+ 3 expected-fail)
nx run @tanstack/router-core:test:types  -> no errors
```

## Notes

- Single-function change; `replaceEqualDeep` itself is untouched.
- Includes a changeset (`@tanstack/router-core` patch).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved selector performance through optimized structural sharing computation in router core

* **Tests**
  * Added test coverage for structural sharing behavior with nested objects and non-enumerable properties

<!-- end of auto-generated comment: release notes by coderabbit.ai -->