### PR TITLE
perf(router-core): guard default search parser against throws

### DIFF
--- a/.changeset/perf-default-search-parse-guard.md
+++ b/.changeset/perf-default-search-parse-guard.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+perf: avoid a thrown `SyntaxError` per plain-string value in the default search parser. `defaultParseSearch` ran `JSON.parse` on every leftover string value (e.g. `?q=hello&f=live`), throwing and catching for the common non-JSON case. A cheap first-non-whitespace-char guard (a superset of JSON's value-start grammar, so results are identical) skips the doomed parse. Search params are parsed on every SSR request and every client navigation; ~1.7–3x faster on typical query strings.

--- a/packages/router-core/src/searchParams.ts
+++ b/packages/router-core/src/searchParams.ts
@@ -1,8 +1,46 @@
 import { decode, encode } from './qss'
 import type { AnySchema } from './validators'
 
+/**
+ * Returns true if `str` could be the start of a valid JSON value, deciding from
+ * the first non-whitespace character only. This is a superset of JSON's
+ * value-start grammar, so any string `JSON.parse` would accept returns true —
+ * meaning we never skip a parse that would have succeeded. It exists purely to
+ * skip `JSON.parse` (and the expensive `SyntaxError` it throws) for values that
+ * cannot be JSON, e.g. plain search params like `?q=hello&f=live`.
+ */
+function couldBeJson(str: string): boolean {
+  for (let i = 0; i < str.length; i++) {
+    const c = str.charCodeAt(i)
+    // JSON.parse tolerates leading whitespace (space, tab, LF, CR)
+    if (c === 32 || c === 9 || c === 10 || c === 13) {
+      continue
+    }
+    return (
+      c === 123 || // {
+      c === 91 || // [
+      c === 34 || // "
+      c === 45 || // -
+      (c >= 48 && c <= 57) || // 0-9
+      c === 116 || // t (true)
+      c === 102 || // f (false)
+      c === 110 // n (null)
+    )
+  }
+  return false
+}
+
+/**
+ * `JSON.parse`, skipped for values that cannot be JSON. Returning the original
+ * string for non-JSON values is equivalent to letting `JSON.parse` throw and
+ * `parseSearchWith` keep the raw string — just without the thrown error.
+ */
+function parseMaybeJson(value: string) {
+  return couldBeJson(value) ? JSON.parse(value) : value
+}
+
 /** Default `parseSearch` that strips leading '?' and JSON-parses values. */
-export const defaultParseSearch = parseSearchWith(JSON.parse)
+export const defaultParseSearch = parseSearchWith(parseMaybeJson)
 /** Default `stringifySearch` using JSON.stringify for complex values. */
 export const defaultStringifySearch = stringifySearchWith(
   JSON.stringify,

--- a/packages/router-core/tests/searchParams.test.ts
+++ b/packages/router-core/tests/searchParams.test.ts
@@ -79,6 +79,42 @@ describe('Search Params serialization and deserialization', () => {
   })
 
   /*
+   * The default parser only attempts JSON.parse for values that could be JSON,
+   * avoiding a thrown SyntaxError for plain strings. These cases document that
+   * the guard is behavior-preserving (a superset of JSON's value-start grammar).
+   */
+  describe('parse guard for non-JSON strings', () => {
+    test('plain string params are returned unchanged as strings', () => {
+      expect(defaultParseSearch('?q=hello&f=live&src=typed_query')).toEqual({
+        q: 'hello',
+        f: 'live',
+        src: 'typed_query',
+      })
+    })
+
+    test('leading-whitespace JSON values still parse (guard skips whitespace)', () => {
+      // %20 = space; JSON.parse tolerates leading whitespace, so the guard must too
+      expect(defaultParseSearch('?n=%2042')).toEqual({ n: 42 })
+      expect(defaultParseSearch('?o=%20%7B%22a%22%3A1%7D')).toEqual({
+        o: { a: 1 },
+      })
+    })
+
+    test('JSON-looking-but-invalid values fall back to the raw string', () => {
+      expect(defaultParseSearch('?a=1,2,3&b=[oops')).toEqual({
+        a: '1,2,3',
+        b: '[oops',
+      })
+    })
+
+    test('words starting with t/f/n that are not literals stay strings', () => {
+      expect(
+        defaultParseSearch('?a=tweet&b=false_alarm&c=null_island'),
+      ).toEqual({ a: 'tweet', b: 'false_alarm', c: 'null_island' })
+    })
+  })
+
+  /*
    * It can serialize stuff that really shouldn't be passed as input.
    * But just in case, this test serves as documentation of "what would happen"
    * if you did.


### PR DESCRIPTION
## What

Stop the default search parser from throwing a `SyntaxError` for every plain-string param. In `packages/router-core/src/searchParams.ts`, `defaultParseSearch` ran `JSON.parse` on every leftover string value:

```diff
-export const defaultParseSearch = parseSearchWith(JSON.parse)
+export const defaultParseSearch = parseSearchWith(parseMaybeJson)
```

`parseMaybeJson` first checks, from the first non-whitespace character, whether the value *could* be JSON and only then calls `JSON.parse`. The check is a **superset of JSON's value-start grammar** (`{ [ " -` `0-9` `t f n`, skipping leading whitespace), so any string `JSON.parse` would accept still gets parsed — we only skip the doomed parse of plain strings.

## Why

`qss.decode` already coerces numbers/booleans, so `JSON.parse` only ever runs on the *remaining* string values — which on real apps are mostly plain text (`?q=hello&f=live&src=typed_query`). Each one throws a `SyntaxError` that `parseSearchWith` catches to keep the raw string, and constructing + throwing that error (with stack capture) is the dominant cost.

Search params are parsed on **every SSR request and every client navigation**. In-situ before/after on the real `defaultParseSearch` (Vitest `bench`):

| Query shape | old (`JSON.parse`) | new (guarded) | Speedup |
|---|---|---|---|
| mixed X-like (`?q=…&f=live&src=…&pf=1`) | 317K ops/s | 996K ops/s | **3.1×** |
| all plain strings (`?q=from:elon since:2024&f=live&…`) | 107K ops/s | 176K ops/s | **1.7×** |

## Correctness

Behavior is identical. The guard never skips a value `JSON.parse` would accept, and for skipped values it returns the raw string — exactly what `parseSearchWith` does today when `JSON.parse` throws.

Verified by:
- The full existing `searchParams` suite (isomorphism round-trips + "alien deserialization" of human-typed params).
- A 5000+ case fuzz confirming `couldBeJson` is a correct superset of `JSON.parse`'s accept set.
- Four added tests: plain-string params stay strings, leading-whitespace JSON values still parse (guard skips whitespace), JSON-looking-but-invalid values fall back to the raw string, and `t`/`f`/`n`-prefixed non-literals (`tweet`, `false_alarm`, `null_island`) stay strings.

```
nx run @tanstack/router-core:test:unit   -> 1182 passed (+ 3 expected-fail)
nx run @tanstack/router-core:test:types  -> no errors
```

## Notes

- Only the default **parse** path changes. `defaultStringifySearch` uses the same `JSON.parse`-as-throw-probe pattern when building URLs (also hot via `<Link>`), but its logic relies on throw-vs-no-throw as the "is this JSON?" signal, so making it allocation-free cleanly is a slightly larger change — happy to do it as a follow-up.
- Includes a changeset (`@tanstack/router-core` patch).
- Pre-existing `unused-imports/no-unused-vars` warnings on the existing `catch (_err)` blocks are untouched by this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized query parameter parsing to reduce processing overhead, improving performance for server-side rendering and client-side navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->