### PR TITLE
docs(router/how-to): fix broken Chakra UI links in integrate-chakra-ui.md

### DIFF
--- a/docs/router/how-to/integrate-chakra-ui.md
+++ b/docs/router/how-to/integrate-chakra-ui.md
@@ -817,7 +817,6 @@ Before deploying your Chakra UI + TanStack Router app:
 
 ## Related Resources
 
-- [Chakra UI Documentation](https://chakra-ui.com/getting-started) - Complete component library guide
-- [Chakra UI Recipes](https://chakra-ui.com/community/recipes) - Common patterns and recipes
+- [Chakra UI Documentation](https://chakra-ui.com/docs) - Complete component library guide
 - [TanStack Router createLink API](../api/router#createlink) - API documentation for component integration
 - [Emotion CSS-in-JS](https://emotion.sh/docs/introduction) - Styling library used by Chakra UI


### PR DESCRIPTION
## Summary
Two broken Chakra UI links in `docs/router/how-to/integrate-chakra-ui.md`:
- `https://chakra-ui.com/getting-started` (404) → `https://chakra-ui.com/docs` (200) — Chakra UI v3 restructured their docs root.
- `https://chakra-ui.com/community/recipes` (404) → removed — the community/recipes page was retired in the v3 migration; the /docs page lists the current recipe collection.

## Diff
```
 docs/router/how-to/integrate-chakra-ui.md | 3 +--
 1 file changed, 1 insertion(+), 2 deletions(-)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Chakra UI documentation reference link in the related resources section
  * Removed Chakra UI Recipes resource entry

<!-- end of auto-generated comment: release notes by coderabbit.ai -->