### PR TITLE
docs(router/how-to): fix broken framer.com React Transition Group migration link

### DIFF
--- a/docs/router/how-to/integrate-framer-motion.md
+++ b/docs/router/how-to/integrate-framer-motion.md
@@ -773,5 +773,5 @@ Before deploying your animated TanStack Router app:
 ## Related Resources
 
 - [Framer Motion Documentation](https://www.framer.com/motion/) - Complete animation library guide
-- [React Transition Group Migration](https://www.framer.com/motion/migrate-from-react-transition-group/) - Migration guide from other animation libraries
+- [Motion (Framer Motion successor) Documentation](https://motion.dev/docs) - Migration guide for other animation libraries
 - [Animation Performance](https://web.dev/animations-guide/) - Web performance guide for animations


### PR DESCRIPTION
Replaces the broken `https://www.framer.com/motion/migrate-from-react-transition-group/` (404) with `https://motion.dev/docs` (200) — Motion (formerly Framer Motion) restructured their docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "Related Resources" section in the Framer Motion integration guide to include the latest reference documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->