### PR TITLE
docs(router): fix broken swan-io/chicane link in overview.md

### DIFF
--- a/docs/router/overview.md
+++ b/docs/router/overview.md
@@ -131,7 +131,7 @@ TanStack Router builds on concepts and patterns popularized by many other OSS pr
 
 - [TRPC](https://trpc.io/)
 - [Remix](https://remix.run)
-- [Chicane](https://swan-io.github.io/chicane/)
+- [Chicane](https://github.com/swan-io/chicane) (the chicane docs site at swan-io.github.io/chicane is no longer deployed; the GitHub repo is the canonical home)
 - [Next.js](https://nextjs.org)
 
 We acknowledge the investment, risk and research that went into their development, but are excited to push the bar they have set even higher.


### PR DESCRIPTION
Replaces `https://swan-io.github.io/chicane/` (404, retired GitHub Pages deployment) with `https://github.com/swan-io/chicane` (200, canonical repo).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Chicane library acknowledgement in the router documentation to direct users to its official GitHub repository instead of a third-party reference. Added a clarification note that the previously referenced external documentation site is no longer deployed or available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->