### PR TITLE
docs(router/comparison): fix broken tanstack.com/discord link

### DIFF
--- a/docs/router/comparison.md
+++ b/docs/router/comparison.md
@@ -105,6 +105,6 @@ Feature/Capability Key:
 
 ---
 
-We don't have a comparison table for Solid just yet. If you're interested in helping us create one, please reach out in the [TanStack Discord](https://tanstack.com/discord) or open a PR with your proposed comparison!
+We don't have a comparison table for Solid just yet. If you're interested in helping us create one, please reach out in the [TanStack Discord](https://discord.gg/tanstack) or open a PR with your proposed comparison!
 
 <!-- ::end:framework -->


### PR DESCRIPTION
Replaces `https://tanstack.com/discord` (404) with `https://discord.gg/tanstack` (200) — the TanStack Discord invite moved from the marketing site to a direct discord.gg invite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated the Discord community link in router comparison documentation to ensure users can access the correct community server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->