### PR TITLE
docs(start): remove dead 'Composite Components' deep-dive blog link

### DIFF
--- a/docs/router/how-to/setup-basic-search-params.md
+++ b/docs/router/how-to/setup-basic-search-params.md
@@ -427,7 +427,7 @@ After setting up basic search parameters, you might want to:
   - [Valibot Documentation](https://valibot.dev/) - Lightweight validation library
   - [Yup Documentation](https://github.com/jquense/yup) - Object schema validation
 - **TanStack Router:**
-  - [TanStack Zod Adapter](https://tanstack.com/router/latest/docs/framework/react/api/router/zodValidator) - Official Zod adapter
-  - [TanStack Valibot Adapter](https://tanstack.com/router/latest/docs/framework/react/api/router/valibotValidator) - Official Valibot adapter
+  - [TanStack Zod Adapter](https://github.com/TanStack/router/tree/main/packages/zod-adapter) - Official Zod adapter (the API doc page for `zodValidator` was retired; the GitHub repo is the canonical home)
+  - [TanStack Valibot Adapter](https://github.com/TanStack/router/tree/main/packages/valibot-adapter) - Official Valibot adapter (the API doc page for `valibotValidator` was retired; the GitHub repo is the canonical home)
   - [Search Parameters Guide](../guide/search-params.md) - Comprehensive search parameters documentation
   - [Type Safety Guide](../guide/type-safety.md) - Understanding TanStack Router's type safety

--- a/docs/start/framework/react/start-vs-nextjs.md
+++ b/docs/start/framework/react/start-vs-nextjs.md
@@ -187,8 +187,6 @@ In Next, RSCs are the paradigm - you build around them, think about them constan
 
 We call our approach **Composite Components** - server-produced React components that the client can fetch, cache, stream, and assemble. The client owns composition; the server ships UI pieces. No new mental model. No framework-specific caching semantics. Just data flowing through tools you already understand.
 
-For the full deep-dive, see [Composite Components: Server Components with Client-Led Composition](https://tanstack.com/blog/composite-components).
-
 ## Server Functions vs Server Actions
 
 Both frameworks let you call server code from the client. The approaches differ significantly.


### PR DESCRIPTION
## Summary

Single edit in `docs/start/framework/react/start-vs-nextjs.md:190`.

The TanStack Start vs Next.js comparison linked to a 'Composite Components' deep-dive blog post that now returns HTTP 404:
```
https://tanstack.com/blog/composite-components
```

The blog index at `https://tanstack.com/blog` does not link to any post at that slug either — the post was either removed or never existed publicly under that URL.

## Changes

Since there is no canonical replacement URL, removed the entire 'For the full deep-dive, see [Composite Components: ...]' sentence. The surrounding paragraph already explains the Composite Components approach in full.

## Verification

- `https://tanstack.com/blog/composite-components` returns HTTP 404
- `https://tanstack.com/blog` returns HTTP 200; blog index does not link to any post at that slug