### PR TITLE
fix(router-core): don't resolve aborted match to success without loaderData

### DIFF
--- a/.changeset/fix-aborted-loader-undefined-loaderdata.md
+++ b/.changeset/fix-aborted-loader-undefined-loaderdata.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+Resolve a match to `error` instead of `success` when its loader is aborted before producing data. Previously an aborted loader could leave the match in `success` with `loaderData` undefined, so the route component rendered while `useLoaderData()` returned `undefined` despite its non-undefined type.

--- a/packages/react-router/tests/loaders.test.tsx
+++ b/packages/react-router/tests/loaders.test.tsx
@@ -751,10 +751,37 @@ test('throw abortError from loader upon initial load with basepath', async () =>
 
   render(<RouterProvider router={router} />)
 
-  const indexElement = await screen.findByText('Index route content')
-  expect(indexElement).toBeInTheDocument()
-  expect(screen.queryByTestId('index-error')).not.toBeInTheDocument()
+  const errorElement = await screen.findByTestId('index-error')
+  expect(errorElement).toBeInTheDocument()
+  expect(screen.queryByText('Index route content')).not.toBeInTheDocument()
   expect(window.location.pathname.startsWith('/app')).toBe(true)
+})
+
+test('aborted loader does not render the route component with undefined loaderData', async () => {
+  const rootRoute = createRootRoute({})
+
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    loader: async (): Promise<{ value: string }> => {
+      return Promise.reject(new DOMException('Aborted', 'AbortError'))
+    },
+    component: () => {
+      const data = indexRoute.useLoaderData()
+      return <div data-testid="index-content">value: {data.value}</div>
+    },
+    errorComponent: () => (
+      <div data-testid="index-error">indexErrorComponent</div>
+    ),
+  })
+
+  const routeTree = rootRoute.addChildren([indexRoute])
+  const router = createRouter({ routeTree, history })
+
+  render(<RouterProvider router={router} />)
+
+  expect(await screen.findByTestId('index-error')).toBeInTheDocument()
+  expect(screen.queryByTestId('index-content')).not.toBeInTheDocument()
 })
 
 test('cancelMatches after pending timeout', async () => {

--- a/packages/router-core/src/load-matches.ts
+++ b/packages/router-core/src/load-matches.ts
@@ -731,13 +731,19 @@ const runLoader = async (
           match._nonReactive.loaderPromise = undefined
           return
         }
-        inner.updateMatch(matchId, (prev) => ({
-          ...prev,
-          status: prev.status === 'pending' ? 'success' : prev.status,
-          isFetching: false,
-          context: buildMatchContext(inner, index),
-        }))
-        return
+        // a previous load already produced data, so keep showing it instead of
+        // surfacing the abort
+        if (inner.router.getMatch(matchId)?.status !== 'pending') {
+          inner.updateMatch(matchId, (prev) => ({
+            ...prev,
+            isFetching: false,
+            context: buildMatchContext(inner, index),
+          }))
+          return
+        }
+        // no loaderData yet: fall through to error handling rather than
+        // resolving to `success`, which would render the route component with
+        // loaderData undefined
       }
 
       const pendingPromise = match._nonReactive.minPendingPromise

--- a/packages/solid-router/tests/loaders.test.tsx
+++ b/packages/solid-router/tests/loaders.test.tsx
@@ -342,10 +342,37 @@ test('throw abortError from loader upon initial load with basepath', async () =>
 
   render(() => <RouterProvider router={router} />)
 
-  const indexElement = await screen.findByText('Index route content')
-  expect(indexElement).toBeInTheDocument()
-  expect(screen.queryByTestId('index-error')).not.toBeInTheDocument()
+  const errorElement = await screen.findByTestId('index-error')
+  expect(errorElement).toBeInTheDocument()
+  expect(screen.queryByText('Index route content')).not.toBeInTheDocument()
   expect(window.location.pathname.startsWith('/app')).toBe(true)
+})
+
+test('aborted loader does not render the route component with undefined loaderData', async () => {
+  const rootRoute = createRootRoute({})
+
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    loader: async (): Promise<{ value: string }> => {
+      return Promise.reject(new DOMException('Aborted', 'AbortError'))
+    },
+    component: () => {
+      const data = indexRoute.useLoaderData()
+      return <div data-testid="index-content">value: {data().value}</div>
+    },
+    errorComponent: () => (
+      <div data-testid="index-error">indexErrorComponent</div>
+    ),
+  })
+
+  const routeTree = rootRoute.addChildren([indexRoute])
+  const router = createRouter({ routeTree })
+
+  render(() => <RouterProvider router={router} />)
+
+  expect(await screen.findByTestId('index-error')).toBeInTheDocument()
+  expect(screen.queryByTestId('index-content')).not.toBeInTheDocument()
 })
 
 test('reproducer #4245', async () => {


### PR DESCRIPTION
## Summary

A route's `component` only renders when its match has `status === 'success'`, which is exactly why `useLoaderData()` is typed as non-undefined. However, when a loader is aborted mid-flight **before producing data**, the match was promoted from `pending` to `success` *without* `loaderData` being set. The component then rendered while `useLoaderData()` returned `undefined` at runtime, despite the type guaranteeing a value — leading to crashes such as `Cannot read properties of undefined`.

## Root cause

The `AbortError` branch in `runLoader` (`packages/router-core/src/load-matches.ts`) did:

```ts
status: prev.status === 'pending' ? 'success' : prev.status
```

For a first load (`pending`, no data yet) this fabricated a `success` state with `loaderData === undefined`, breaking the invariant that a successful match always carries loader data. This branch was introduced in #4570 to avoid flashing the error boundary on a spontaneous abort.

## Fix

In the `AbortError` branch, the three cases are now distinguished:

| Case | Behavior |
| --- | --- |
| The match's own `abortController` fired (rapid navigation) | Bail out without mutating state (unchanged, from #6426) |
| The loader aborted but a previous load already produced data | Keep showing it — stale-while-revalidate (unchanged) |
| The loader aborted with no data yet (`pending`) | Fall through to the normal error handling → `status: 'error'` (renders the `errorComponent`) |

This restores the invariant `success ⟹ loaderData defined`, so `useLoaderData()` inside a route component is genuinely non-undefined at both the type and runtime level.

## Behavior change

Previously a loader that threw `AbortError` on initial load rendered the route component with `loaderData` undefined (see #4570). It now renders the `errorComponent` instead — the designed mechanism for "no data available." The rapid-navigation abort path (#6426, reproducer for #6388) is unaffected, and stale-while-revalidate is preserved.

## Tests

- Updated `throw abortError from loader upon initial load with basepath` in both `react-router` and `solid-router` to assert the error boundary renders instead of the component.
- Added `aborted loader does not render the route component with undefined loaderData` in both `react-router` and `solid-router`, where the component reads `loaderData`.
- Full unit + type suites pass for `router-core`, `react-router`, `solid-router`, and `vue-router`; eslint is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the behavior of aborted loaders to properly resolve as errors. Routes with interrupted loaders now correctly display the error component instead of rendering with undefined loader data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->