### PR TITLE
fix(router-core): fall back to CSR when SSR bootstrap data is missing during hydration

### DIFF
--- a/.changeset/hydrate-missing-bootstrap-fallback.md
+++ b/.changeset/hydrate-missing-bootstrap-fallback.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/router-core': patch
+---
+
+fall back to client-side rendering when SSR bootstrap data is missing during hydration
+
+`hydrate()` previously threw `Invariant failed` (crashing the whole app through the error boundary) when `window.$_TSR` or `window.$_TSR.router` was absent. That data can legitimately be missing when the streamed HTML is truncated or the inline bootstrap script never runs — aborted navigations, crawlers, in-app webviews, and CSP/extension-blocked inline scripts. Hydration now bails out and lets the client render from scratch (the Transitioner runs `router.load()` on mount when no SSR state is present) instead of taking down the page.

--- a/packages/router-core/src/ssr/ssr-client.ts
+++ b/packages/router-core/src/ssr/ssr-client.ts
@@ -38,14 +38,22 @@ function hydrateMatch(
 }
 
 export async function hydrate(router: AnyRouter): Promise<any> {
+  // The server injects SSR bootstrap data via an inline script that runs while
+  // the streamed HTML is parsed. It can be absent at hydration time when the
+  // stream was truncated or the inline script never executed (aborted
+  // navigations, crawlers, in-app webviews, CSP/extension-blocked inline
+  // scripts). Bail out instead of throwing a fatal invariant that takes down
+  // the whole app: leaving `router.ssr` unset makes the client render from
+  // scratch, since the Transitioner runs `router.load()` on mount when it sees
+  // no SSR state.
   if (!window.$_TSR) {
     if (process.env.NODE_ENV !== 'production') {
-      throw new Error(
-        'Invariant failed: Expected to find bootstrap data on window.$_TSR, but we did not. Please file an issue!',
+      console.warn(
+        'TanStack Router: no SSR bootstrap data found on window.$_TSR; falling back to client-side rendering.',
       )
     }
 
-    invariant()
+    return
   }
 
   const serializationAdapters = router.options.serializationAdapters as
@@ -64,12 +72,12 @@ export async function hydrate(router: AnyRouter): Promise<any> {
 
   if (!window.$_TSR.router) {
     if (process.env.NODE_ENV !== 'production') {
-      throw new Error(
-        'Invariant failed: Expected to find a dehydrated data on window.$_TSR.router, but we did not. Please file an issue!',
+      console.warn(
+        'TanStack Router: no dehydrated router found on window.$_TSR.router; falling back to client-side rendering.',
       )
     }
 
-    invariant()
+    return
   }
 
   const dehydratedRouter = window.$_TSR.router

--- a/packages/router-core/tests/hydrate.test.ts
+++ b/packages/router-core/tests/hydrate.test.ts
@@ -56,13 +56,24 @@ describe('hydrate', () => {
     delete (global as any).window
   })
 
-  it('should throw error if window.$_TSR is not available', async () => {
-    await expect(hydrate(mockRouter)).rejects.toThrow(
-      'Expected to find bootstrap data on window.$_TSR, but we did not. Please file an issue!',
-    )
+  it('should fall back to client-side rendering if window.$_TSR is not available', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const matchRoutesSpy = vi.spyOn(mockRouter, 'matchRoutes')
+
+    await expect(hydrate(mockRouter)).resolves.toBeUndefined()
+
+    // No SSR state is applied, so the client renders from scratch via the
+    // Transitioner's router.load() on mount (it only skips that when router.ssr
+    // is set).
+    expect(matchRoutesSpy).not.toHaveBeenCalled()
+    expect(mockRouter.ssr).toBeUndefined()
+    expect(warnSpy).toHaveBeenCalled()
   })
 
-  it('should throw error if window.$_TSR.router is not available', async () => {
+  it('should fall back to client-side rendering if window.$_TSR.router is not available', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const matchRoutesSpy = vi.spyOn(mockRouter, 'matchRoutes')
+
     mockWindow.$_TSR = {
       c: vi.fn(),
       p: vi.fn(),
@@ -71,9 +82,11 @@ describe('hydrate', () => {
       // router is missing
     } as any
 
-    await expect(hydrate(mockRouter)).rejects.toThrow(
-      'Expected to find a dehydrated data on window.$_TSR.router, but we did not. Please file an issue!',
-    )
+    await expect(hydrate(mockRouter)).resolves.toBeUndefined()
+
+    expect(matchRoutesSpy).not.toHaveBeenCalled()
+    expect(mockRouter.ssr).toBeUndefined()
+    expect(warnSpy).toHaveBeenCalled()
   })
 
   it('should initialize serialization adapters when provided', async () => {


### PR DESCRIPTION
## Summary

`hydrate()` throws `Invariant failed` and crashes the **entire app** (the error propagates through `Await` / `useAwaited` to the nearest error boundary) when the SSR bootstrap global is missing:

```ts
// packages/router-core/src/ssr/ssr-client.ts
if (!window.$_TSR) {
  // ...dev throw...
  invariant() // prod: throw new Error('Invariant failed')
}
// ...
if (!window.$_TSR.router) {
  invariant()
}
```

`window.$_TSR` is populated by an inline `<script>` that the server streams with the HTML. It can legitimately be **absent at hydration time** when:

- the streamed HTML is **truncated** (aborted navigation, flaky mobile, the client disconnecting mid-stream),
- the inline bootstrap script **never executes** — link-preview crawlers / social bots, in-app webviews (TikTok, Instagram, etc.), CSP, or extensions that strip inline scripts.

In all of these cases the right behavior is to render on the client, not to white-screen. Today the hard `invariant()` turns a recoverable condition into a full app crash.

This is the same class of problem reported in #7524 ("the `$_TSR` is deleted too early, and ends up undefined"). That PR tried to delay teardown and was reverted in #7533 in favor of immediate teardown — so the absence of `$_TSR` still surfaces as a fatal invariant rather than being handled.

## Fix

When the bootstrap data is missing, bail out of hydration instead of throwing. Leaving `router.ssr` unset means the `Transitioner` runs `router.load()` on mount — exactly the path a pure client-side app uses:

```ts
// packages/react-router/src/Transitioner.tsx
useLayoutEffect(() => {
  if (
    // if we are hydrating from SSR, loading is triggered in ssr-client
    (typeof window !== 'undefined' && router.ssr) || /* ... */
  ) {
    return
  }
  // ...
  await router.load()
}, [router])
```

So the page recovers with a normal client render instead of crashing. A dev-only `console.warn` is logged so genuine SSR misconfiguration is still easy to spot (the message is stripped from prod bundles by the existing `process.env.NODE_ENV` guard).

This lives in core `hydrate()`, so the React / Solid / Vue start clients all benefit.

## Behavior change

- **Before:** missing `window.$_TSR` / `window.$_TSR.router` → `Invariant failed` thrown → app crashes to the error boundary.
- **After:** missing data → hydration is skipped → client renders via `router.load()`; dev-only warning logged.

## Tests

- Updated `hydrate.test.ts`: the two cases that asserted a throw now assert graceful fallback (`hydrate` resolves, `matchRoutes` is not called, `router.ssr` stays unset, a dev warning is emitted).
- Full `@tanstack/router-core` unit suite passes (1178 passed, 3 expected-fail), no type errors, eslint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hydration no longer fails when server-side rendering bootstrap data is unavailable. The application now gracefully falls back to client-side rendering instead of throwing an error, improving robustness for edge cases like truncated HTML streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->