### PR TITLE
docs: fix typos in router guides

### DIFF
--- a/docs/router/guide/data-loading.md
+++ b/docs/router/guide/data-loading.md
@@ -387,7 +387,7 @@ export const Route = createFileRoute('/posts')({
 import { routeTree } from './routeTree.gen'
 
 // Use your routerContext to create a new router
-// This will require that you fullfil the type requirements of the routerContext
+// This will require that you fulfill the type requirements of the routerContext
 const router = createRouter({
   routeTree,
   context: {

--- a/docs/router/guide/type-utilities.md
+++ b/docs/router/guide/type-utilities.md
@@ -3,7 +3,7 @@ id: type-utilities
 title: Type Utilities
 ---
 
-Most types exposed by TanStack Router are internal, subject to breaking changes and not always easy to use. That is why TanStack Router has a subset of exposed types focused on ease of use with the intension to be used externally. These types provide the same type safe experience from TanStack Router's runtime concepts on the type level, with flexibility of where to provide type checking
+Most types exposed by TanStack Router are internal, subject to breaking changes and not always easy to use. That is why TanStack Router has a subset of exposed types focused on ease of use with the intention to be used externally. These types provide the same type safe experience from TanStack Router's runtime concepts on the type level, with flexibility of where to provide type checking
 
 ## Type checking Link options with `ValidateLinkOptions`
 

--- a/docs/router/how-to/use-environment-variables.md
+++ b/docs/router/how-to/use-environment-variables.md
@@ -568,7 +568,7 @@ Pass variables from the server down to the client:
 
 **Example**:
 
-You may use your prefered backend framework/libray, but here it is using Tanstack Start server functions:
+You may use your preferred backend framework/library, but here it is using Tanstack Start server functions:
 
 ```tsx
 const getRuntimeVar = createServerFn({ method: 'GET' }).handler(() => {


### PR DESCRIPTION
Fixes a few spelling typos in the router guides. Docs-only, no code changes.

- `docs/router/guide/data-loading.md` — `fullfil` → `fulfill`
- `docs/router/guide/type-utilities.md` — `intension` → `intention`
- `docs/router/how-to/use-environment-variables.md` — `prefered` → `preferred`, `libray` → `library`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed spelling and grammar errors across router documentation guides, including corrections to terminology and word choices for improved clarity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->