### PR TITLE
ci: bundle-size workdlow outputs its report to stdout

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -98,6 +98,7 @@ jobs:
             --output benchmarks/bundle-size/results/pr-comment.md \
             --base-sha "$BASE_SHA" \
             --dashboard-url "https://${REPOSITORY_OWNER}.github.io/${REPOSITORY_NAME}/benchmarks/bundle-size/"
+          cat benchmarks/bundle-size/results/pr-comment.md
 
       - name: Upsert Sticky PR Comment
         env:


### PR DESCRIPTION
this will allow us to see the results even if the workflow cannot post to the PR from a fork (and we can improve that later)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow visibility for development and debugging processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->