### PR TITLE
docs(start): fix broken createServerFn doc links in reading-writing-file tutorials

### DIFF
--- a/docs/start/framework/react/tutorial/reading-writing-file.md
+++ b/docs/start/framework/react/tutorial/reading-writing-file.md
@@ -152,7 +152,7 @@ export type JokesData = Joke[]
 
 ### Step 1.3: Create Server Functions to Read the File
 
-Let's create a new file `src/serverActions/jokesActions.ts` to create a server function to perform a read-write operation. We will be creating a server function using [`createServerFn`](https://tanstack.com/start/latest/docs/framework/react/server-functions).
+Let's create a new file `src/serverActions/jokesActions.ts` to create a server function to perform a read-write operation. We will be creating a server function using [`createServerFn`](https://tanstack.com/start/latest/docs/framework/react/guide/server-functions).
 
 ```tsx
 // src/serverActions/jokesActions.ts

--- a/docs/start/framework/solid/tutorial/reading-writing-file.md
+++ b/docs/start/framework/solid/tutorial/reading-writing-file.md
@@ -152,7 +152,7 @@ export type JokesData = Joke[]
 
 ### Step 1.3: Create Server Functions to Read the File
 
-Let's create a new file `src/serverActions/jokesActions.ts` to create a server function to perform a read-write operation. We will be creating a server function using [`createServerFn`](https://tanstack.com/start/latest/docs/framework/solid/server-functions).
+Let's create a new file `src/serverActions/jokesActions.ts` to create a server function to perform a read-write operation. We will be creating a server function using [`createServerFn`](https://tanstack.com/start/latest/docs/framework/solid/guide/server-functions).
 
 ```tsx
 // src/serverActions/jokesActions.ts


### PR DESCRIPTION
Two broken `tanstack.com/start/latest/docs/framework/{react,solid}/server-functions` links (307 redirect chain that hangs from the user's perspective) — the page moved to `/guide/server-functions` in a recent docs refactor.

Verified manually: the new `/guide/server-functions` path returns 200 for both react and solid variants. The links appear in the file-reading/file-writing tutorial in Step 1.3 ("Create Server Functions to Read the File") where the user is introduced to `createServerFn`.

(Note: opened as draft to work around the cross-fork `createPullRequest` GraphQL permission issue on this side — same token-rotation side effect as #7672, #7678, #7679. Please mark ready-for-review when you start reviewing.)