### PR TITLE
docs(router-cli,router-plugin): fix broken with-router-cli install doc links

### DIFF
--- a/packages/router-cli/README.md
+++ b/packages/router-cli/README.md
@@ -2,4 +2,4 @@
 
 # TanStack Router CLI
 
-See https://tanstack.com/router/latest/docs/framework/react/routing/installation/with-router-cli
+See https://tanstack.com/router/latest/docs/installation/with-router-cli

--- a/packages/router-plugin/README.md
+++ b/packages/router-plugin/README.md
@@ -10,4 +10,4 @@ See https://tanstack.com/router/latest/docs/framework/react/routing/file-based-r
 npm install -D @tanstack/router-plugin
 ```
 
-See https://tanstack.com/router/latest/docs/framework/react/routing/installation/with-router-cli for usage instructions.
+See https://tanstack.com/router/latest/docs/installation/with-router-cli for usage instructions.


### PR DESCRIPTION
Two broken `tanstack.com/router/latest/docs/framework/react/routing/installation/with-router-cli` links (307 redirect chain that hangs from the user's perspective) — the page moved out from under `/framework/react/routing/installation/` in a recent docs refactor. Canonical URL is now `/docs/installation/with-router-cli`.

Verified manually: the canonical URL returns 200 (and the framework-prefixed variant `/framework/react/installation/with-router-cli` 307-redirects to it cleanly).

These appear as the only link in `@tanstack/router-cli`'s README, and as the 'See ... for usage instructions' reference in `@tanstack/router-plugin`'s README. The `file-based-routing` link just above in the plugin README is also tagged with `framework/react/routing/` but that one 200s after a 307 redirect, so left alone.

(Note: opened as draft to work around the cross-fork `createPullRequest` GraphQL permission issue on this side — same token-rotation side effect as #7672, #7678, #7679, #7683.)