### PR TITLE
Reduce postinstall wrangler noise

### DIFF
--- a/e2e/react-start/basic-cloudflare/package.json
+++ b/e2e/react-start/basic-cloudflare/package.json
@@ -9,7 +9,7 @@
     "build": "vite build && tsc --noEmit",
     "preview": "vite preview",
     "cf-typegen": "wrangler types",
-    "postinstall": "npm run cf-typegen",
+    "postinstall": "WRANGLER_LOG=warn npm run --silent cf-typegen",
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {

--- a/e2e/solid-start/basic-cloudflare/package.json
+++ b/e2e/solid-start/basic-cloudflare/package.json
@@ -9,7 +9,7 @@
     "build": "vite build && tsc --noEmit",
     "preview": "vite preview",
     "cf-typegen": "wrangler types",
-    "postinstall": "npm run cf-typegen",
+    "postinstall": "WRANGLER_LOG=warn npm run --silent cf-typegen",
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {

--- a/e2e/vue-start/basic-cloudflare/package.json
+++ b/e2e/vue-start/basic-cloudflare/package.json
@@ -9,7 +9,7 @@
     "build": "vite build && tsc --noEmit",
     "preview": "vite preview",
     "cf-typegen": "wrangler types",
-    "postinstall": "npm run cf-typegen",
+    "postinstall": "WRANGLER_LOG=warn npm run --silent cf-typegen",
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {

--- a/examples/react/start-basic-cloudflare/package.json
+++ b/examples/react/start-basic-cloudflare/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "deploy": "npm run build && wrangler deploy",
     "cf-typegen": "wrangler types",
-    "postinstall": "npm run cf-typegen"
+    "postinstall": "WRANGLER_LOG=warn npm run --silent cf-typegen"
   },
   "dependencies": {
     "@tanstack/react-router": "^1.170.16",

--- a/examples/solid/start-basic-cloudflare/package.json
+++ b/examples/solid/start-basic-cloudflare/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "deploy": "npm run build && wrangler deploy",
     "cf-typegen": "wrangler types",
-    "postinstall": "npm run cf-typegen"
+    "postinstall": "WRANGLER_LOG=warn npm run --silent cf-typegen"
   },
   "dependencies": {
     "@tanstack/solid-router": "^1.170.16",


### PR DESCRIPTION
on every `pnpm install` (which now also happens automatically sometimes when you run any pnpm command), we get 5 of those:
```
../../e2e/solid-start/basic-cloudflare postinstall$ npm run cf-typegen
[14 lines collapsed]
│ };
│ declare namespace NodeJS {
│ 	interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, "MY_VAR">> {}
│ }
│ Generating runtime types...
│ Runtime types generated.
│ ✨ Types written to worker-configuration.d.ts
│ 📖 Read about runtime types
│ https://developers.cloudflare.com/workers/languages/typescript/#generate-types
│ 📣 Remember to rerun 'wrangler types' after you change your wrangler.jsonc file.
```

This PR reduces that noise to 5 times this:
```
examples/react/start-basic-cloudflare postinstall$ WRANGLER_LOG=warn npm run --silen…
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated post-install setup across several starter templates to run more quietly.
  * Reduced command output and set a lower log level during automatic type generation, making installs less noisy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->