### PR TITLE
fix(router-core): preserve element scroll restoration in scrollToTopSelectors

### DIFF
--- a/.changeset/preserve-element-scroll-restoration.md
+++ b/.changeset/preserve-element-scroll-restoration.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+fix(router-core): preserve element scroll restoration in `scrollToTopSelectors`. An element whose scroll position was just restored is no longer reset to the top by the scroll-to-top fallback, mirroring how `windowRestored` suppresses the reset for the window.

--- a/packages/router-core/src/scroll-restoration.ts
+++ b/packages/router-core/src/scroll-restoration.ts
@@ -319,6 +319,7 @@ export function setupScrollRestoration(router: AnyRouter, force?: boolean) {
       const hashScrollIntoViewOptions =
         event.toLocation.state.__hashScrollIntoViewOptions ?? true
       let windowRestored = false
+      const restoredElements = new Set<Element>()
 
       if (shouldResetScroll) {
         const action = locationHistoryActions.get(event.toLocation)
@@ -351,6 +352,7 @@ export function setupScrollRestoration(router: AnyRouter, force?: boolean) {
               if (element) {
                 element.scrollLeft = scrollX
                 element.scrollTop = scrollY
+                restoredElements.add(element)
               }
             }
           }
@@ -367,6 +369,13 @@ export function setupScrollRestoration(router: AnyRouter, force?: boolean) {
           if (scrollToTopSelectors) {
             scrollToTopElements ??= getScrollToTopElements(scrollToTopSelectors)
             for (const element of scrollToTopElements) {
+              // A successful element scroll restoration must suppress the
+              // scroll-to-top fallback for that element, mirroring how
+              // `windowRestored` suppresses it for the window. Otherwise the
+              // just-restored scroll position is immediately reset to 0.
+              if (restoredElements.has(element)) {
+                continue
+              }
               element.scrollTo(scrollOptions)
             }
           }

--- a/packages/router-core/tests/scroll-restoration.test.ts
+++ b/packages/router-core/tests/scroll-restoration.test.ts
@@ -86,7 +86,10 @@ describe('element scroll restoration', () => {
     vi.spyOn(window, 'scrollTo').mockImplementation(() => {})
 
     const rootRoute = new BaseRootRoute({})
-    const indexRoute = new BaseRoute({ getParentRoute: () => rootRoute, path: '/' })
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
     const pageRoute = new BaseRoute({
       getParentRoute: () => rootRoute,
       path: '/page',

--- a/packages/router-core/tests/scroll-restoration.test.ts
+++ b/packages/router-core/tests/scroll-restoration.test.ts
@@ -45,6 +45,103 @@ describe('setupScrollRestoration', () => {
 
     window.history.scrollRestoration = previousScrollRestoration
   })
+})
+
+describe('element scroll restoration', () => {
+  const SELECTOR = '[data-scroll-restoration-id="container"]'
+
+  function createScrollableElement() {
+    const el = document.createElement('div')
+    el.setAttribute('data-scroll-restoration-id', 'container')
+
+    // jsdom has no layout, so back scrollTop/scrollLeft with real storage and
+    // make `scrollTo` actually apply, so we can assert the user-visible result.
+    let top = 0
+    let left = 0
+    Object.defineProperty(el, 'scrollTop', {
+      configurable: true,
+      get: () => top,
+      set: (v: number) => {
+        top = v
+      },
+    })
+    Object.defineProperty(el, 'scrollLeft', {
+      configurable: true,
+      get: () => left,
+      set: (v: number) => {
+        left = v
+      },
+    })
+    const scrollTo = vi.fn((opts: { top?: number; left?: number }) => {
+      if (opts.top !== undefined) top = opts.top
+      if (opts.left !== undefined) left = opts.left
+    })
+    ;(el as any).scrollTo = scrollTo
+
+    document.body.appendChild(el)
+    return { el, scrollTo }
+  }
+
+  test('does not reset a restored element that is also in scrollToTopSelectors', async () => {
+    vi.spyOn(window, 'scrollTo').mockImplementation(() => {})
+
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({ getParentRoute: () => rootRoute, path: '/' })
+    const pageRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/page',
+    })
+
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute, pageRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+      scrollRestoration: true,
+      // Key by pathname so revisiting `/page` restores its cached scroll.
+      getScrollRestorationKey: (location) => location.pathname,
+      scrollToTopSelectors: [SELECTOR],
+    })
+
+    await router.load()
+
+    const { el, scrollTo } = createScrollableElement()
+
+    const homeLocation = router.buildLocation({ to: '/' })
+    const pageLocation = router.buildLocation({ to: '/page' })
+
+    // Simulate the user scrolling the element on `/page`.
+    el.scrollTop = 100
+    el.dispatchEvent(new Event('scroll'))
+
+    // Navigating away snapshots the element's scroll position under `/page`.
+    router.emit({
+      type: 'onBeforeLoad',
+      fromLocation: pageLocation,
+      toLocation: homeLocation,
+      pathChanged: true,
+      hrefChanged: true,
+      hashChanged: false,
+    })
+
+    // Re-render `/page` with a scroll-resetting navigation (PUSH).
+    router._scroll.next = true
+    router.emit({
+      type: 'onRendered',
+      fromLocation: homeLocation,
+      toLocation: pageLocation,
+      pathChanged: true,
+      hrefChanged: true,
+      hashChanged: false,
+    })
+
+    // The element's restored scroll position must survive: the scroll-to-top
+    // fallback should not reset an element that was just restored.
+    expect(el.scrollTop).toBe(100)
+    expect(scrollTo).not.toHaveBeenCalledWith(
+      expect.objectContaining({ top: 0 }),
+    )
+
+    el.remove()
+  })
 
   test.each([
     ['omitted', undefined],


### PR DESCRIPTION
## Summary

Fixes #7687.

When a scroll container element is **both** a scroll-restoration target and listed in `scrollToTopSelectors`, its restored scroll position was immediately reset to `0`.

In the `onRendered` handler of `setupScrollRestoration` the scroll-to-top fallback was only suppressed for the window (via the `windowRestored` flag). After an element was successfully restored (`element.scrollTop = scrollY`), the fallback loop still ran `element.scrollTo({ top: 0 })` on that same element, wiping the just-restored position.

## Fix

Track successfully restored elements in a `restoredElements` set and `continue` past them in the scroll-to-top fallback loop — mirroring exactly how `windowRestored` already guards the window. Minimal and surgical: no behavior change for elements that are only in `scrollToTopSelectors` (and were not restored), which are still scrolled to top as before.

## Validation

- Added a regression test in `packages/router-core/tests/scroll-restoration.test.ts` that drives `onBeforeLoad` + `onRendered` with an element that is both restored and present in `scrollToTopSelectors`. It asserts the restored `scrollTop` (100) survives.
  - **Confirmed the test fails without the source change** (`expected +0 to be 100`) and passes with it.
- `vitest run` for `@tanstack/router-core`: **1179 passed, 3 expected-fail (pre-existing), 0 type errors** (39 files).
- `eslint` on both changed files: clean.

## Not a duplicate

No open PR addresses #7687. Related open scroll PRs target different concerns: #7332 (hash precedence), #7335 (carrying nested positions across *new* restoration keys), #7574 (docs), #4059 (feature to disable restoration). This fixes the fallback-vs-restore ordering for elements specifically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll restoration so per-element restored scroll positions are no longer overwritten by the automatic “scroll to top” fallback when elements match `scrollToTopSelectors`.
  * Preserved scroll position for scrollable page elements during navigation, including targeted top-scroll scenarios.
* **Tests**
  * Added coverage for restoring scroll state on individual elements and ensuring the “scroll to top” behavior is skipped after successful restoration.
* **Documentation**
  * Added a patch-level changeset describing the fix for element scroll restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->