### PR TITLE
Fix element scroll restoration reset

### DIFF
--- a/.changeset/scroll-restoration-elements.md
+++ b/.changeset/scroll-restoration-elements.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+Fix element scroll restoration being reset by matching `scrollToTopSelectors`.

--- a/packages/router-core/src/scroll-restoration.ts
+++ b/packages/router-core/src/scroll-restoration.ts
@@ -319,6 +319,7 @@ export function setupScrollRestoration(router: AnyRouter, force?: boolean) {
       const hashScrollIntoViewOptions =
         event.toLocation.state.__hashScrollIntoViewOptions ?? true
       let windowRestored = false
+      let restoredElements: Set<Element> | undefined
 
       if (shouldResetScroll) {
         const action = locationHistoryActions.get(event.toLocation)
@@ -351,6 +352,8 @@ export function setupScrollRestoration(router: AnyRouter, force?: boolean) {
               if (element) {
                 element.scrollLeft = scrollX
                 element.scrollTop = scrollY
+                restoredElements ??= new Set()
+                restoredElements.add(element)
               }
             }
           }
@@ -367,6 +370,9 @@ export function setupScrollRestoration(router: AnyRouter, force?: boolean) {
           if (scrollToTopSelectors) {
             scrollToTopElements ??= getScrollToTopElements(scrollToTopSelectors)
             for (const element of scrollToTopElements) {
+              if (restoredElements?.has(element)) {
+                continue
+              }
               element.scrollTo(scrollOptions)
             }
           }

--- a/packages/router-core/tests/scroll-restoration.test.ts
+++ b/packages/router-core/tests/scroll-restoration.test.ts
@@ -3,7 +3,12 @@ import { afterEach, describe, expect, test, vi } from 'vitest'
 import { BaseRootRoute, BaseRoute } from '../src'
 import { createTestRouter } from './routerTestUtils'
 
-function createRouter(options: { scrollRestoration?: boolean } = {}) {
+function createRouter(
+  options: {
+    scrollRestoration?: boolean
+    scrollToTopSelectors?: Array<string | (() => Element | null | undefined)>
+  } = {},
+) {
   const rootRoute = new BaseRootRoute({})
   const indexRoute = new BaseRoute({
     getParentRoute: () => rootRoute,
@@ -19,6 +24,7 @@ function createRouter(options: { scrollRestoration?: boolean } = {}) {
 
 afterEach(() => {
   vi.restoreAllMocks()
+  document.body.innerHTML = ''
 })
 
 describe('setupScrollRestoration', () => {
@@ -81,4 +87,49 @@ describe('setupScrollRestoration', () => {
       window.history.scrollRestoration = previousScrollRestoration
     },
   )
+
+  test('does not reset a restored element through scrollToTopSelectors', () => {
+    vi.spyOn(window, 'scrollTo').mockImplementation(() => {})
+
+    const router = createRouter({
+      scrollRestoration: true,
+      scrollToTopSelectors: ['#main-content'],
+    })
+    const element = document.createElement('div')
+
+    element.id = 'main-content'
+    element.scrollTo = vi.fn((options?: ScrollToOptions) => {
+      element.scrollTop = options?.top ?? 0
+      element.scrollLeft = options?.left ?? 0
+    })
+    document.body.append(element)
+
+    element.scrollTop = 400
+    element.dispatchEvent(new Event('scroll', { bubbles: true }))
+
+    const location = router.latestLocation
+
+    router.emit({
+      type: 'onBeforeLoad',
+      toLocation: location,
+      fromLocation: location,
+      pathChanged: false,
+      hrefChanged: false,
+      hashChanged: false,
+    })
+
+    element.scrollTop = 0
+
+    router.emit({
+      type: 'onRendered',
+      toLocation: location,
+      fromLocation: location,
+      pathChanged: false,
+      hrefChanged: false,
+      hashChanged: false,
+    })
+
+    expect(element.scrollTop).toBe(400)
+    expect(element.scrollTo).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #7687.

When a non-window scroll target is restored from the scroll restoration cache, the later scroll-to-top fallback can still reset that same element if it is also listed in `scrollToTopSelectors`. This keeps track of restored elements during `onRendered` and skips those elements when applying the fallback reset.

## Validation

- `npm_config_cache=/tmp/codex-npm-cache npx -y pnpm@11.9.0 --filter @tanstack/history build`
- `npm_config_cache=/tmp/codex-npm-cache npx -y pnpm@11.9.0 --filter @tanstack/router-core exec vitest run tests/scroll-restoration.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed element scroll restoration so previously restored scroll positions are no longer overwritten by “scroll to top” behavior on the same render cycle.
  * Improved scroll handling for pages using both scroll restoration and scroll-to-top selectors, reducing unexpected jumps.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->