### PR TITLE
Fix matchRoute trailing slash matching

### DIFF
--- a/.changeset/match-route-trailing-slash.md
+++ b/.changeset/match-route-trailing-slash.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+Fix `matchRoute` exact matching when only the trailing slash differs.

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -26,6 +26,7 @@ import {
   cleanPath,
   compileDecodeCharMap,
   interpolatePath,
+  removeTrailingSlash,
   resolvePath,
   trimPath,
   trimPathRight,
@@ -2982,11 +2983,18 @@ export class RouterCore<
       ? this.latestLocation
       : this.stores.resolvedLocation.get() || this.stores.location.get()
 
+    const matchTo = opts?.fuzzy
+      ? next.pathname
+      : removeTrailingSlash(next.pathname, this.basepath)
+    const matchFrom = opts?.fuzzy
+      ? baseLocation.pathname
+      : removeTrailingSlash(baseLocation.pathname, this.basepath)
+
     const match = findSingleMatch(
-      next.pathname,
+      matchTo,
       opts?.caseSensitive ?? false,
       opts?.fuzzy ?? false,
-      baseLocation.pathname,
+      matchFrom,
       this.processedTree,
     )
 

--- a/packages/router-core/tests/match-route.test.ts
+++ b/packages/router-core/tests/match-route.test.ts
@@ -1,0 +1,24 @@
+import { createMemoryHistory } from '@tanstack/history'
+import { describe, expect, test } from 'vitest'
+import { BaseRootRoute, BaseRoute } from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+describe('matchRoute', () => {
+  test('matches the current route when only the trailing slash differs', async () => {
+    const rootRoute = new BaseRootRoute({})
+    const nestedRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/nested',
+    })
+
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([nestedRoute]),
+      history: createMemoryHistory({ initialEntries: ['/nested/'] }),
+    })
+
+    await router.load()
+
+    expect(router.state.matches.at(-1)?.routeId).toBe('/nested')
+    expect(router.matchRoute({ to: '/nested' })).toEqual({})
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #7689.

`matchRoute` exact matching used the resolved target pathname and current pathname as-is, so `matchRoute({ to: '/nested' })` returned `false` when the current route was rendered at `/nested/`. The router itself resolves that URL to the same route, which made active-route checks inconsistent.

This normalizes trailing slashes for exact `matchRoute` comparisons while keeping fuzzy matching behavior unchanged.

## Validation

- `npm_config_cache=/tmp/codex-npm-cache npx -y pnpm@11.9.0 --filter @tanstack/router-core exec vitest run tests/match-route.test.ts`
- `npm_config_cache=/tmp/codex-npm-cache npx -y pnpm@11.9.0 --filter @tanstack/router-core exec vitest run tests/match-by-path.test.ts tests/path.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed route matching so paths that differ only by a trailing slash are handled correctly.
  * Improved matching behavior to avoid false positives when exact matching is expected.

* **Tests**
  * Added coverage for trailing-slash route matching to prevent regressions.

* **Chores**
  * Updated release metadata to include the patch change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->