### PR TITLE
docs(start): add Hostinger as a hosting provider

### DIFF
--- a/docs/start/framework/react/guide/hosting.md
+++ b/docs/start/framework/react/guide/hosting.md
@@ -251,7 +251,7 @@ Follow the [`Nitro`](#nitro) deployment instructions to produce a Node.js server
     "start": "node .output/server/index.mjs"
 ```
 
-2. Push your project to a Git repository (GitHub, GitLab, or Bitbucket).
+2. Push your project to a GitHub repository.
 
 3. In [hPanel](https://hpanel.hostinger.com), create a Node.js application, connect your repository, and set:
 

--- a/docs/start/framework/react/guide/hosting.md
+++ b/docs/start/framework/react/guide/hosting.md
@@ -24,6 +24,7 @@ Once you've chosen a deployment target, you can follow the deployment guidelines
 - [`vercel`](#vercel): Deploy to Vercel
 - [`railway`](#nodejs--railway--docker): Deploy to Railway
 - [`node-server`](#nodejs--railway--docker): Deploy to a Node.js server
+- [`hostinger`](#hostinger): Deploy to Hostinger
 - [`bun`](#bun): Deploy to a Bun server
 - [`appwrite-sites`](#appwrite-sites): Deploy to Appwrite Sites
 - ... and more to come!
@@ -236,6 +237,28 @@ You can start your application by running:
 ```sh
 npm run start
 ```
+
+### Hostinger
+
+[Hostinger](https://www.hostinger.com) can host TanStack Start applications on its Node.js hosting.
+
+Follow the [`Nitro`](#nitro) deployment instructions to produce a Node.js server build. Nitro writes the output to `.output`, using `.output/server/index.mjs` as the server entry point.
+
+1. Ensure `build` and `start` scripts are present in your `package.json` file:
+
+```json
+    "build": "vite build",
+    "start": "node .output/server/index.mjs"
+```
+
+2. Push your project to a Git repository (GitHub, GitLab, or Bitbucket).
+
+3. In [hPanel](https://hpanel.hostinger.com), create a Node.js application, connect your repository, and set:
+
+   - **Build command:** `npm run build`
+   - **Entry point:** `.output/server/index.mjs`
+
+4. Deploy. Once the build completes, you can attach a custom domain and Hostinger will provision HTTPS automatically.
 
 ### Bun
 

--- a/docs/start/framework/solid/guide/hosting.md
+++ b/docs/start/framework/solid/guide/hosting.md
@@ -24,6 +24,7 @@ Once you've chosen a deployment target, you can follow the deployment guidelines
 - [`vercel`](#vercel): Deploy to Vercel
 - [`railway`](#nodejs--railway--docker): Deploy to Railway
 - [`node-server`](#nodejs--railway--docker): Deploy to a Node.js server
+- [`hostinger`](#hostinger): Deploy to Hostinger
 - [`bun`](#bun): Deploy to a Bun server
 - [`appwrite-sites`](#appwrite-sites): Deploy to Appwrite Sites
 - ... and more to come!
@@ -230,6 +231,28 @@ You can start your application by running:
 ```sh
 npm run start
 ```
+
+### Hostinger
+
+[Hostinger](https://www.hostinger.com) can host TanStack Start applications on its Node.js hosting.
+
+Follow the [`Nitro`](#nitro) deployment instructions to produce a Node.js server build. Nitro writes the output to `.output`, using `.output/server/index.mjs` as the server entry point.
+
+1. Ensure `build` and `start` scripts are present in your `package.json` file:
+
+```json
+    "build": "vite build",
+    "start": "node .output/server/index.mjs"
+```
+
+2. Push your project to a Git repository (GitHub, GitLab, or Bitbucket).
+
+3. In [hPanel](https://hpanel.hostinger.com), create a Node.js application, connect your repository, and set:
+
+   - **Build command:** `npm run build`
+   - **Entry point:** `.output/server/index.mjs`
+
+4. Deploy. Once the build completes, you can attach a custom domain and Hostinger will provision HTTPS automatically.
 
 ### Bun
 

--- a/docs/start/framework/solid/guide/hosting.md
+++ b/docs/start/framework/solid/guide/hosting.md
@@ -245,7 +245,7 @@ Follow the [`Nitro`](#nitro) deployment instructions to produce a Node.js server
     "start": "node .output/server/index.mjs"
 ```
 
-2. Push your project to a Git repository (GitHub, GitLab, or Bitbucket).
+2. Push your project to a GitHub repository.
 
 3. In [hPanel](https://hpanel.hostinger.com), create a Node.js application, connect your repository, and set:
 


### PR DESCRIPTION
## Summary

Adds [Hostinger](https://www.hostinger.com) to the list of hosting providers in the TanStack Start hosting guide.

TanStack Start's Nitro build produces a standard Node.js server output (`.output/server/index.mjs`), which runs on Hostinger's Node.js hosting. This PR documents that flow, mirroring the existing Nitro-based provider entries (Vercel, Railway).

## Changes

- Added a `hostinger` entry to the **Deployment** target list.
- Added a **Hostinger** section describing how to deploy a TanStack Start app to Hostinger's Node.js hosting (follow the Nitro instructions, then deploy the Node.js output).
- Applied the same additions to both the **React** and **Solid** hosting guides so they stay in sync.

## Notes

Docs-only change. The Hostinger section reuses the existing Nitro build output and introduces no new build configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Hostinger as a supported hosting option in the React and Solid deployment guides.
  * Included step-by-step instructions for generating the Nitro Node.js server build, setting `build`/`start` scripts, configuring the Hostinger app build command, and using the server entry point.
  * Clarified that attaching a custom domain enables automatic HTTPS after deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->