### PR TITLE
fix(ci): release workflow OOM increase node max-old-space

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
           commit: 'ci: changeset release'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_OPTIONS: --max-old-space-size=8192
       - name: Create GitHub Release
         if: steps.changesets.outputs.published == 'true'
         run: node scripts/create-github-release.mjs ${{ steps.dist-tag.outputs.prerelease == 'true' && '--prerelease' }} ${{ steps.dist-tag.outputs.latest == 'true' && '--latest' }}


### PR DESCRIPTION
Previous attempt did not fix the oom issue: https://github.com/TanStack/router/pull/7722

Still present here: https://github.com/TanStack/router/actions/runs/28546039597/job/84631471600

This new attempt is less elegant but should hopefully let us release now. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability of the release process by increasing available memory during automated versioning and publishing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->