### PR TITLE
fix(start-plugin-core): prerender retries never re-run (dropped by the `seen` guard)

### DIFF
--- a/.changeset/spa-prerender-retry-reruns.md
+++ b/.changeset/spa-prerender-retry-reruns.md
@@ -1,0 +1,14 @@
+---
+"@tanstack/start-plugin-core": patch
+---
+
+fix(start-plugin-core): make prerender retries actually re-run
+
+The prerender crawler tracks visited paths in a `seen` set, and
+`addCrawlPageTask` early-returns for any path already in it. On a retry it
+re-invoked `addCrawlPageTask` for the same path, which the guard rejected, so
+the retry never re-ran — the page was silently dropped and `failOnError` was
+never reached. As a result `retryCount`/`retryDelay` had no effect, and a
+transient fetch failure (e.g. the preview server not yet accepting connections)
+produced "Prerendered 0 pages" while the build still exited 0. Delete the path
+from `seen` before re-queuing so retries genuinely re-fetch.

--- a/packages/start-plugin-core/src/prerender.ts
+++ b/packages/start-plugin-core/src/prerender.ts
@@ -219,6 +219,12 @@ export async function prerender({
             )
             await new Promise((resolve) => setTimeout(resolve, retryDelay))
             retriesByPath.set(page.path, retries + 1)
+            // `addCrawlPageTask` early-returns for any path already in `seen`
+            // (added on the first attempt), so without clearing it here the
+            // retry re-queue is a no-op: the task never re-runs, the page is
+            // silently dropped, and `failOnError` is never reached. Remove the
+            // path so the retry actually re-enqueues and re-fetches.
+            seen.delete(page.path)
             addCrawlPageTask(page)
           } else if (prerenderOptions.failOnError ?? true) {
             throw error

--- a/packages/start-plugin-core/tests/prerender-retry.test.ts
+++ b/packages/start-plugin-core/tests/prerender-retry.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest'
+import { prerender } from '../src/prerender'
+
+vi.mock('../src/utils', async () => {
+  const actual = await vi.importActual<any>('../src/utils')
+  return {
+    ...actual,
+    createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {} }),
+  }
+})
+
+// Prevent real file writes during prerender.
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<any>('node:fs')
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      mkdir: vi.fn().mockResolvedValue(undefined),
+      writeFile: vi.fn().mockResolvedValue(undefined),
+    },
+  }
+})
+
+function htmlResponse() {
+  return new Response('<html></html>', {
+    status: 200,
+    headers: { 'content-type': 'text/html' },
+  })
+}
+
+function makeStartConfig(pagePath: string, prerenderOverrides: object = {}) {
+  return {
+    prerender: {
+      enabled: true,
+      autoStaticPathsDiscovery: false,
+      concurrency: 1,
+      ...prerenderOverrides,
+    },
+    pages: [{ path: pagePath }],
+    router: { basepath: '' },
+    spa: {
+      enabled: false,
+      prerender: {
+        outputPath: '/_shell',
+        crawlLinks: false,
+        retryCount: 0,
+        enabled: true,
+      },
+    },
+  } as any
+}
+
+describe('prerender retries', () => {
+  it('re-runs the page task on retry instead of dropping it via the seen set', async () => {
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('connect ECONNREFUSED'))
+      .mockResolvedValue(htmlResponse())
+    const handler = { getClientOutputDirectory: () => '/client', request }
+    const startConfig = makeStartConfig('/about', {
+      retryCount: 1,
+      retryDelay: 0,
+    })
+
+    await expect(prerender({ startConfig, handler })).resolves.not.toThrow()
+    // First attempt fails; a working retry must re-fetch the same path. Before
+    // the fix the retry re-queue was swallowed by `seen`, so the task never
+    // re-ran and this stayed at 1.
+    expect(request).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Problem

The prerender crawler's retry mechanism (`retryCount` / `retryDelay`) never actually retries. A transient fetch failure — e.g. the SPA-mode preview server not yet accepting connections on its ephemeral port — logs `Prerendered 0 pages` and the page is silently dropped, **and the build still exits 0** (so a shell-less SPA build can ship). Setting `retryCount` has no effect.

## Root cause

In `packages/start-plugin-core/src/prerender.ts`, `addCrawlPageTask` early-returns for any path already in the `seen` set:

```ts
function addCrawlPageTask(page: Page) {
  if (seen.has(page.path)) return
  seen.add(page.path)
  ...
```

On a failure the retry branch calls `addCrawlPageTask(page)` again for the **same** path — but that path is already in `seen`, so the call is a no-op. The task is never re-queued, so:

- the retry never re-runs (so `retryCount`/`retryDelay` do nothing), and
- because the retry branch was taken, the `else if (prerenderOptions.failOnError ?? true) throw error` branch is never reached — the failure is swallowed.

```ts
} catch (error) {
  if (retries < (prerenderOptions.retryCount ?? 0)) {
    ...
    retriesByPath.set(page.path, retries + 1)
    addCrawlPageTask(page)          // no-op: page.path is still in `seen`
  } else if (prerenderOptions.failOnError ?? true) {
    throw error
  }
}
```

## Fix

Delete the path from `seen` before re-queuing, so the retry genuinely re-enqueues and re-fetches:

```ts
retriesByPath.set(page.path, retries + 1)
seen.delete(page.path)
addCrawlPageTask(page)
```

`retriesByPath` still bounds the attempts, so it stops at `retryCount` and then falls through to `failOnError` as intended.

## Test

Adds `tests/prerender-retry.test.ts` (mirrors the existing `prerender-ssrf.test.ts` mocking): the request fails once then succeeds with `retryCount: 1`. It asserts the request is made **twice** (the retry re-fetched). Verified red/green:
- without the fix: request called **1** time, page dropped → test fails
- with the fix: request called **2** times, page prerendered → test passes

Existing `prerender-ssrf.test.ts` still passes; `vitest` reports no type errors.

## Impact

Makes `retryCount`/`retryDelay` behave as documented and restores `failOnError` on exhaustion. This also fixes intermittent `ECONNREFUSED` failures in SPA mode where the single shell fetch races the preview server's readiness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed prerender retries so failed pages are retried properly instead of being skipped.
  * Improved retry behavior when prerendering encounters temporary errors, helping pages complete more reliably.
* **Tests**
  * Added coverage for prerender retry behavior to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->