### PR TITLE
fix(start-plugin-core): keep import-protection virtual ids resolvable in server-fn compiler

### DIFF
--- a/packages/start-plugin-core/src/vite/start-compiler-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/vite/start-compiler-plugin/plugin.ts
@@ -364,6 +364,15 @@ export function startCompilerPlugin(
 
                 if (r) {
                   if (!r.external) {
+                    // Keep import-protection's own virtual ids (e.g. mock-edge)
+                    // `\0`-prefixed: `loadModule`/`this.load()` routes them to the
+                    // import-protection `load` handler by matching on the `\0`
+                    // prefix. Stripping it via cleanId() makes the load fall
+                    // through to vite:load-fallback, which fs.readFile()s the
+                    // bare id and throws ENOENT in build mode (#7725).
+                    if (r.id.startsWith('\0tanstack-start-import-protection:')) {
+                      return r.id
+                    }
                     return cleanId(r.id)
                   }
                 }


### PR DESCRIPTION
Fixes #7725

## Problem

In build mode, when `createServerFn`'s static analysis (the server-fn `start-compiler-plugin`) recursively loads a module whose dependency chain resolves to import-protection's `mock-edge` virtual module, the build crashes:

```
[tanstack-start-core::server-fn:client] Could not load tanstack-start-import-protection:mock-edge:<base64>: ENOENT: no such file or directory
```

## Root cause

In `packages/start-plugin-core/src/vite/start-compiler-plugin/plugin.ts`, the `resolveId` callback ran every resolved id through `cleanId()`:

```ts
if (!r.external) return cleanId(r.id)
```

`cleanId()` strips the leading `\0` that marks a Rollup-internal virtual module. That's correct for filesystem-backed ids, but import-protection's own ids (e.g. `\0tanstack-start-import-protection:mock-edge:...`) need that `\0`: the cleaned id is passed to `loadModule` → `this.load({ id })`, and import-protection's `load` handler filters on the `\0`-prefixed matchers (`getResolvedVirtualModuleMatchers()`). Without the prefix the filter never matches, so Rollup falls through to `vite:load-fallback`, which `fs.readFile()`s the bare string and throws `ENOENT`.

## Fix

Preserve the `\0` prefix for import-protection virtual ids; everything else is cleaned as before:

```ts
if (r.id.startsWith('\0tanstack-start-import-protection:')) {
  return r.id
}
return cleanId(r.id)
```

This mirrors the discriminator already used elsewhere in the plugin (`import-protection-plugin/plugin.ts` special-cases `\0tanstack-start-import-protection:` too), and it fixes the build without disabling import-protection — the mock module resolves and loads exactly as designed.

Credit to the detailed root-cause analysis in #7725.

## Verification

- `nx run @tanstack/start-plugin-core:test:build` (package + 12 dependency tasks) green.
- `test:types` (tsc) clean.
- ESLint clean on the changed file.
- `vitest run`: 486/486 tests pass, no type errors.

The crash itself only reproduces in a full `vite build` of a Start app with a denied import in a server-fn's dependency chain (per #7725's repro), so it isn't covered by a unit test here; happy to add an e2e case if you'd like one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of special internal module references so they continue to resolve correctly instead of falling through to normal file loading.
  * This helps prevent build or import issues in cases involving protected virtual modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->