### PR TITLE
fix(start-plugin-core): re-try failed paths correctly

### DIFF
--- a/packages/start-plugin-core/src/prerender.ts
+++ b/packages/start-plugin-core/src/prerender.ts
@@ -219,6 +219,7 @@ export async function prerender({
             )
             await new Promise((resolve) => setTimeout(resolve, retryDelay))
             retriesByPath.set(page.path, retries + 1)
+            seen.delete(page.path)
             addCrawlPageTask(page)
           } else if (prerenderOptions.failOnError ?? true) {
             throw error

--- a/packages/start-plugin-core/tests/prerender-retry.test.ts
+++ b/packages/start-plugin-core/tests/prerender-retry.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest'
+import { prerender } from '../src/prerender'
+
+vi.mock('../src/utils', async () => {
+  const actual = await vi.importActual<any>('../src/utils')
+  return {
+    ...actual,
+    createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {} }),
+  }
+})
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<any>('node:fs')
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      mkdir: vi.fn().mockResolvedValue(undefined),
+      writeFile: vi.fn().mockResolvedValue(undefined),
+    },
+  }
+})
+
+function htmlResponse() {
+  return new Response('<html></html>', {
+    status: 200,
+    headers: { 'content-type': 'text/html' },
+  })
+}
+
+function makeStartConfig(pagePath: string, prerenderOverrides: object = {}) {
+  return {
+    prerender: {
+      enabled: true,
+      autoStaticPathsDiscovery: false,
+      concurrency: 1,
+      ...prerenderOverrides,
+    },
+    pages: [{ path: pagePath }],
+    router: { basepath: '' },
+    spa: {
+      enabled: false,
+      prerender: {
+        outputPath: '/_shell',
+        crawlLinks: false,
+        retryCount: 0,
+        enabled: true,
+      },
+    },
+  } as any
+}
+
+describe('prerender retries', () => {
+  it('re-fetches the page on retry', async () => {
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('connect ECONNREFUSED'))
+      .mockResolvedValue(htmlResponse())
+    const handler = { getClientOutputDirectory: () => '/client', request }
+    const startConfig = makeStartConfig('/about', {
+      retryCount: 1,
+      retryDelay: 0,
+    })
+
+    await expect(prerender({ startConfig, handler })).resolves.not.toThrow()
+    expect(request).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
retryCount / retryDelay on the prerender don't actually do anything right now.

We had a race condition where the service wasnt up yet so fetch failed, so adding a retry was a simple fix. The retry branch calls addCrawlPageTask(page) again, but that path is already in the seen set from the first attempt, so addCrawlPageTask early-returns and the task is never re-queued. The page just gets dropped. We never reach the failOnError throw, so the failure is swallowed and the build finishes with "Prerendered 0 pages" and exit code is 0 though some pages failed.

I ran into this in SPA mode, the shell prerender occasionally races the preview server and fails with ECONNREFUSED, and setting retryCount did nothing.

Fix is to drop the path from seen before re-queuing so the retry actually re-fetches. retriesByPath still bounds it, so it stops after retryCount attempts and falls through to failOnError.

Added a test that fails the first fetch with retryCount: 1 and checks the page is fetched twice.

Note: I used AI to debug and come up with this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prerender retry handling so pages that fail temporarily can be crawled again on retry.
  * Fixed an issue where retried pages could be skipped after an initial failed fetch.

* **Tests**
  * Added coverage for prerender retries to verify failed requests are retried successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->