### PR TITLE
bench(memory): stabilize CodSpeed memory benchmarks

### DIFF
--- a/.github/workflows/client-nav-benchmarks.yml
+++ b/.github/workflows/client-nav-benchmarks.yml
@@ -3,21 +3,22 @@ name: Benchmarks
 
 on:
   push:
-    # No paths filter on purpose: CodSpeed compares each PR against the run on
-    # its merge-base commit. Skipping main pushes that don't touch packages/**
-    # (pnpm config, CI, docs) leaves those commits without a baseline run, and
-    # CodSpeed silently falls back to an older, possibly outlier run — which
-    # then flags phantom regressions on every PR until the next eligible push.
+    # Broad on purpose: CodSpeed compares each PR against the run on its
+    # merge-base commit. Skipping main pushes that don't touch packages/**
+    # (pnpm config, CI, root tooling) leaves those commits without a baseline
+    # run, and CodSpeed silently falls back to an older, possibly outlier run —
+    # which then flags phantom regressions on every PR until the next eligible
+    # push. Only paths that cannot affect benchmark results are excluded.
     branches:
       - 'main'
+    paths-ignore:
+      - 'docs/**'
+      - 'examples/**'
+      - 'e2e/**'
   pull_request:
     paths:
       - 'packages/**'
       - 'benchmarks/**'
-  schedule:
-    # Weekly backstop so a fresh baseline exists even across quiet periods or
-    # after transient failures of push-triggered runs.
-    - cron: '17 3 * * 1'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/client-nav-benchmarks.yml
+++ b/.github/workflows/client-nav-benchmarks.yml
@@ -3,15 +3,21 @@ name: Benchmarks
 
 on:
   push:
+    # No paths filter on purpose: CodSpeed compares each PR against the run on
+    # its merge-base commit. Skipping main pushes that don't touch packages/**
+    # (pnpm config, CI, docs) leaves those commits without a baseline run, and
+    # CodSpeed silently falls back to an older, possibly outlier run — which
+    # then flags phantom regressions on every PR until the next eligible push.
     branches:
       - 'main'
-    paths:
-      - 'packages/**'
-      - 'benchmarks/**'
   pull_request:
     paths:
       - 'packages/**'
       - 'benchmarks/**'
+  schedule:
+    # Weekly backstop so a fresh baseline exists even across quiet periods or
+    # after transient failures of push-triggered runs.
+    - cron: '17 3 * * 1'
   workflow_dispatch:
 
 permissions:

--- a/benchmarks/memory/README.md
+++ b/benchmarks/memory/README.md
@@ -51,9 +51,15 @@ same workload through the Flame profiler.
   does the exact opposite. Client benches therefore register **both** — in
   any given mode exactly one pair runs.
 - The process runs with V8 determinism flags (predictable GC schedule,
-  `--no-opt`). Never call `global.gc()` manually. Because of `--no-opt`,
-  allocation counts overstate production; numbers are for regression
-  tracking, not absolute claims.
+  `--no-opt`). Never call `global.gc()` manually in **churn** scenarios —
+  their signal is accumulation across iterations, which a forced collection
+  masks. **Peak** scenarios do the opposite: they set
+  `pinGcBetweenIterations` on the request loop so a collection runs between
+  iterations. Their signal is the footprint of a single request, and without
+  pinned GC points the measured peak flips by a whole payload depending on
+  whether iteration i's garbage is collected before iteration i+1 allocates.
+  Because of `--no-opt`, allocation counts overstate production; numbers are
+  for regression tracking, not absolute claims.
 - Keep each bench under **~1.5M allocations** (instrument overhead grows past
   2M); this is the main constraint when tuning iteration counts.
 

--- a/benchmarks/memory/README.md
+++ b/benchmarks/memory/README.md
@@ -2,7 +2,11 @@
 
 Dedicated memory benchmarks for TanStack Router / Start, measured with the
 CodSpeed **memory instrument** (`mode: memory` in
-`.github/workflows/client-nav-benchmarks.yml`). Two separate benchmarks:
+`.github/workflows/client-nav-benchmarks.yml`). The workflow runs on **every**
+push to `main` (no paths filter): CodSpeed compares a PR against the run on its
+merge-base commit, and a main commit without a run makes CodSpeed silently fall
+back to an older base — a single outlier base run then flags phantom
+regressions on every PR until the next run lands. Two separate benchmarks:
 
 - `server/` (`@benchmarks/memory-server`) — React/Solid/Vue Start apps, requests against
   the built server handler (`handler.fetch`), Node environment.
@@ -92,9 +96,13 @@ same workload through the Flame profiler.
   navigation with its render signal via `Promise.all([navigate, rendered])`
   is fine — never overlap distinct work items.
 - Randomness only via the seeded LCG in `bench-utils.ts`; no `Math.random`,
-  `Date.now`, or timers — with one documented exception: `streaming-peak`'s
-  deferred sections use small `setTimeout` delays so deferred stream chunks are
-  observable across framework renderers.
+  `Date.now`, or timers with a nonzero delay — anywhere async ordering must be
+  staged (`streaming-peak`'s deferred sections, `aborted-requests`' deferred
+  loader data and post-abort drain), chain **0ms `setTimeout` hops** and count
+  event-loop turns instead. A wall-clock delay races renderer work differently
+  depending on runner load and instrumentation overhead, which makes the
+  single measured run non-reproducible; 0ms hops fire in registration order in
+  the timers phase, so the interleaving is a pure function of the schedule.
 - Sanity assertions run once at module load and throw on wrong
   status/markers, so a bench can never silently measure the wrong thing.
 - Server requests follow `benchmarks/ssr` conventions: document GETs send

--- a/benchmarks/memory/README.md
+++ b/benchmarks/memory/README.md
@@ -2,11 +2,13 @@
 
 Dedicated memory benchmarks for TanStack Router / Start, measured with the
 CodSpeed **memory instrument** (`mode: memory` in
-`.github/workflows/client-nav-benchmarks.yml`). The workflow runs on **every**
-push to `main` (no paths filter): CodSpeed compares a PR against the run on its
-merge-base commit, and a main commit without a run makes CodSpeed silently fall
-back to an older base — a single outlier base run then flags phantom
-regressions on every PR until the next run lands. Two separate benchmarks:
+`.github/workflows/client-nav-benchmarks.yml`). The workflow runs on every
+push to `main` except docs/examples/e2e-only pushes: CodSpeed compares a PR
+against the run on its merge-base commit, and a main commit without a run makes
+CodSpeed silently fall back to an older base — a single outlier base run then
+flags phantom regressions on every PR until the next run lands. (Falling back
+across a docs-only commit is safe: the previous run's benchmark-relevant code
+is identical.) Two separate benchmarks:
 
 - `server/` (`@benchmarks/memory-server`) — React/Solid/Vue Start apps, requests against
   the built server handler (`handler.fetch`), Node environment.

--- a/benchmarks/memory/server/bench-utils.ts
+++ b/benchmarks/memory/server/bench-utils.ts
@@ -17,6 +17,15 @@ export type RunSequentialRequestLoopOptions =
     iterations?: number
     buildRequest: (random: () => number, index: number) => Request
     validateResponse?: (response: Response, request: Request) => void
+    // For peak-shape scenarios only. Their signal is the footprint of a
+    // single request, but whether V8 collects iteration i's garbage before
+    // iteration i+1 allocates its payload is not reproducible run to run —
+    // the measured peak flips by a whole payload depending on GC timing.
+    // Forcing a collection between iterations pins the GC points so peak
+    // deterministically measures max(single-request footprint). Churn
+    // scenarios must never set this: their signal is accumulation across
+    // iterations, which a forced GC would mask.
+    pinGcBetweenIterations?: boolean
   }
 
 export const memoryBenchOptions = {
@@ -64,7 +73,12 @@ export async function runSequentialRequestLoop(
   handler: StartRequestHandler,
   options: RunSequentialRequestLoopOptions,
 ) {
-  const { iterations = 10, buildRequest, validateResponse } = options
+  const {
+    iterations = 10,
+    buildRequest,
+    validateResponse,
+    pinGcBetweenIterations = false,
+  } = options
   const random =
     options.seed !== undefined
       ? createDeterministicRandom(options.seed)
@@ -86,5 +100,15 @@ export async function runSequentialRequestLoop(
     validate(response, request)
 
     await drainResponse(response)
+
+    if (pinGcBetweenIterations) {
+      // Two 0ms timer hops first, so trailing renderer/stream teardown
+      // scheduled for the next turns runs before the collection — otherwise
+      // its garbage survives into the next iteration's measurements.
+      await new Promise<void>((resolve) => setTimeout(resolve, 0))
+      await new Promise<void>((resolve) => setTimeout(resolve, 0))
+      // Present under CodSpeed (--expose-gc); absent in plain smoke runs.
+      ;(globalThis as { gc?: () => void }).gc?.()
+    }
   }
 }

--- a/benchmarks/memory/server/scenarios/aborted-requests/shared.ts
+++ b/benchmarks/memory/server/scenarios/aborted-requests/shared.ts
@@ -6,12 +6,10 @@ type Framework = 'react' | 'solid' | 'vue'
 
 type AbortedRequestReadMode = 'first-chunk' | 'shell-before-deferred'
 type AbortedRequestCancelMode = 'plain' | 'swallow-abort-error'
-type AbortedRequestDrainMode = 'microtasks' | 'tasks'
 
 type AbortedRequestMode = {
   readMode: AbortedRequestReadMode
   cancelMode: AbortedRequestCancelMode
-  drainMode: AbortedRequestDrainMode
 }
 
 const abortedRequestIterations = 100
@@ -29,17 +27,14 @@ const abortedRequestModes: Record<Framework, AbortedRequestMode> = {
   react: {
     readMode: 'first-chunk',
     cancelMode: 'plain',
-    drainMode: 'microtasks',
   },
   solid: {
     readMode: 'first-chunk',
     cancelMode: 'plain',
-    drainMode: 'tasks',
   },
   vue: {
     readMode: 'shell-before-deferred',
     cancelMode: 'swallow-abort-error',
-    drainMode: 'tasks',
   },
 }
 
@@ -188,12 +183,15 @@ async function cancelReader(
   await reader.cancel()
 }
 
-async function drainCancellation(mode: AbortedRequestDrainMode) {
-  await Promise.resolve()
-  await Promise.resolve()
+const cancellationDrainTicks = 8
 
-  if (mode === 'tasks') {
-    await new Promise((resolve) => setTimeout(resolve, 0))
+// Fixed-count settlement barrier: each 0ms timer hop runs one full event-loop
+// turn (microtasks flush between hops), so post-abort renderer teardown
+// finishes within a deterministic number of turns instead of bleeding a
+// load-dependent amount of work into later iterations of the measured run.
+async function drainCancellation() {
+  for (let tick = 0; tick < cancellationDrainTicks; tick++) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
   }
 }
 
@@ -233,7 +231,7 @@ async function assertAbortedRequestsSanity(
   // does not observe Request.signal for this in-process request.
   controller.abort()
   await cancelReader(reader, mode.cancelMode)
-  await drainCancellation(mode.drainMode)
+  await drainCancellation()
 }
 
 async function runAbortedRequestLoop(
@@ -255,7 +253,7 @@ async function runAbortedRequestLoop(
     )
     controller.abort()
     await cancelReader(reader, mode.cancelMode)
-    await drainCancellation(mode.drainMode)
+    await drainCancellation()
   }
 }
 

--- a/benchmarks/memory/server/scenarios/aborted-requests/solid/src/routes/stream.$id.tsx
+++ b/benchmarks/memory/server/scenarios/aborted-requests/solid/src/routes/stream.$id.tsx
@@ -6,25 +6,32 @@ import {
   type RecordGroup,
 } from '../../../deferred-records'
 
-const alphaDelayMs = 50
-const betaDelayMs = 75
-const abortProbeAlphaDelayMs = 500
-const abortProbeBetaDelayMs = 750
+const alphaResolveTicks = 4
+const betaResolveTicks = 6
+const abortProbeAlphaResolveTicks = 40
+const abortProbeBetaResolveTicks = 60
 
 function isAbortProbeId(id: string) {
   return id === 'sanity-mid-stream' || id.startsWith('abort-')
 }
 
-function getDelay(id: string, group: RecordGroup) {
+function getResolveTicks(id: string, group: RecordGroup) {
   if (isAbortProbeId(id)) {
-    return group === 'alpha' ? abortProbeAlphaDelayMs : abortProbeBetaDelayMs
+    return group === 'alpha'
+      ? abortProbeAlphaResolveTicks
+      : abortProbeBetaResolveTicks
   }
 
-  return group === 'alpha' ? alphaDelayMs : betaDelayMs
+  return group === 'alpha' ? alphaResolveTicks : betaResolveTicks
 }
 
-function resolveAfterDelay<T>(
-  delayMs: number,
+// One tick = one 0ms timers-phase hop. Counting event-loop turns instead of
+// milliseconds keeps the resolve/abort interleaving a pure function of the
+// event-loop schedule: a wall-clock delay races the abort differently
+// depending on runner load and instrumentation overhead, which made this
+// benchmark's single measured run swing between runs.
+function resolveAfterTicks<T>(
+  ticks: number,
   signal: AbortSignal,
   value: () => T,
   abortedValue: () => T,
@@ -35,17 +42,28 @@ function resolveAfterDelay<T>(
       return
     }
 
-    const timeoutId = setTimeout(() => {
-      signal.removeEventListener('abort', onAbort)
-      resolve(value())
-    }, delayMs)
+    let remaining = ticks
+    let timeoutId: ReturnType<typeof setTimeout>
 
     const onAbort = () => {
       clearTimeout(timeoutId)
       resolve(abortedValue())
     }
 
+    const step = () => {
+      remaining -= 1
+
+      if (remaining <= 0) {
+        signal.removeEventListener('abort', onAbort)
+        resolve(value())
+        return
+      }
+
+      timeoutId = setTimeout(step, 0)
+    }
+
     signal.addEventListener('abort', onAbort, { once: true })
+    timeoutId = setTimeout(step, 0)
   })
 }
 
@@ -54,10 +72,8 @@ function makeDeferredRecords(
   group: RecordGroup,
   signal: AbortSignal,
 ) {
-  const delayMs = getDelay(id, group)
-
-  return resolveAfterDelay(
-    delayMs,
+  return resolveAfterTicks(
+    getResolveTicks(id, group),
     signal,
     () => makeAbortedRequestRecords(id, group),
     () => [],

--- a/benchmarks/memory/server/scenarios/aborted-requests/vue/src/routes/stream.$id.tsx
+++ b/benchmarks/memory/server/scenarios/aborted-requests/vue/src/routes/stream.$id.tsx
@@ -6,25 +6,32 @@ import {
   type RecordGroup,
 } from '../../../deferred-records'
 
-const alphaDelayMs = 50
-const betaDelayMs = 75
-const abortProbeAlphaDelayMs = 500
-const abortProbeBetaDelayMs = 750
+const alphaResolveTicks = 4
+const betaResolveTicks = 6
+const abortProbeAlphaResolveTicks = 40
+const abortProbeBetaResolveTicks = 60
 
 function isAbortProbeId(id: string) {
   return id === 'sanity-mid-stream' || id.startsWith('abort-')
 }
 
-function getDelay(id: string, group: RecordGroup) {
+function getResolveTicks(id: string, group: RecordGroup) {
   if (isAbortProbeId(id)) {
-    return group === 'alpha' ? abortProbeAlphaDelayMs : abortProbeBetaDelayMs
+    return group === 'alpha'
+      ? abortProbeAlphaResolveTicks
+      : abortProbeBetaResolveTicks
   }
 
-  return group === 'alpha' ? alphaDelayMs : betaDelayMs
+  return group === 'alpha' ? alphaResolveTicks : betaResolveTicks
 }
 
-function resolveAfterDelay<T>(
-  delayMs: number,
+// One tick = one 0ms timers-phase hop. Counting event-loop turns instead of
+// milliseconds keeps the resolve/abort interleaving a pure function of the
+// event-loop schedule: a wall-clock delay races the abort differently
+// depending on runner load and instrumentation overhead, which made this
+// benchmark's single measured run swing between runs.
+function resolveAfterTicks<T>(
+  ticks: number,
   signal: AbortSignal,
   value: () => T,
   abortedValue: () => T,
@@ -35,17 +42,28 @@ function resolveAfterDelay<T>(
       return
     }
 
-    const timeoutId = setTimeout(() => {
-      signal.removeEventListener('abort', onAbort)
-      resolve(value())
-    }, delayMs)
+    let remaining = ticks
+    let timeoutId: ReturnType<typeof setTimeout>
 
     const onAbort = () => {
       clearTimeout(timeoutId)
       resolve(abortedValue())
     }
 
+    const step = () => {
+      remaining -= 1
+
+      if (remaining <= 0) {
+        signal.removeEventListener('abort', onAbort)
+        resolve(value())
+        return
+      }
+
+      timeoutId = setTimeout(step, 0)
+    }
+
     signal.addEventListener('abort', onAbort, { once: true })
+    timeoutId = setTimeout(step, 0)
   })
 }
 
@@ -54,10 +72,8 @@ function makeDeferredRecords(
   group: RecordGroup,
   signal: AbortSignal,
 ) {
-  const delayMs = getDelay(id, group)
-
-  return resolveAfterDelay(
-    delayMs,
+  return resolveAfterTicks(
+    getResolveTicks(id, group),
     signal,
     () => makeAbortedRequestRecords(id, group),
     () => [],

--- a/benchmarks/memory/server/scenarios/peak-large-page/shared.ts
+++ b/benchmarks/memory/server/scenarios/peak-large-page/shared.ts
@@ -54,6 +54,7 @@ export function createWorkloadGroup(
       iterations: peakLargePageIterations,
       buildRequest: buildPeakLargePageRequest,
       validateResponse: validatePeakLargePageResponse,
+      pinGcBetweenIterations: true,
     })
 
   return {

--- a/benchmarks/memory/server/scenarios/serialization-payload/shared.ts
+++ b/benchmarks/memory/server/scenarios/serialization-payload/shared.ts
@@ -61,6 +61,7 @@ export function createWorkloadGroup(
       iterations: serializationPayloadIterations,
       buildRequest: buildPayloadRequest,
       validateResponse: validatePayloadResponse,
+      pinGcBetweenIterations: true,
     })
 
   return {

--- a/benchmarks/memory/server/scenarios/streaming-peak/react/src/routes/stream.$id.tsx
+++ b/benchmarks/memory/server/scenarios/streaming-peak/react/src/routes/stream.$id.tsx
@@ -5,7 +5,7 @@ import {
   type DeferredSectionPayload,
 } from '../../../deferred-section-data'
 
-const fallbackFlushDelayMs = 1
+const fallbackFlushTicks = 4
 
 export const Route = createFileRoute('/stream/$id')({
   loader: ({ params }) => ({
@@ -23,13 +23,28 @@ export const Route = createFileRoute('/stream/$id')({
 // router load (sections resolve before the Suspense boundaries are even
 // reached) and setImmediate chains registered at loader time win the race
 // against React's flush — either way no fallback ever streams and the bench
-// stops exercising multi-flush streaming. Timer-phase callbacks reliably lose
-// that race, so this is the documented exception to the no-timers convention:
-// the few ms of wall-clock are irrelevant to memory metrics, and distinct
-// delays keep section ordering deterministic.
+// stops exercising multi-flush streaming. Timers-phase callbacks reliably
+// lose that race, but a millisecond delay makes the loss margin wall-clock
+// dependent, so this chains 0ms hops instead: each hop yields one full
+// event-loop turn (immediates and microtasks included), making the flush
+// ordering a function of turn count, not runner speed. Distinct hop counts
+// keep section ordering deterministic.
 function afterFallbackFlush(sectionIndex: number) {
   return new Promise<void>((resolve) => {
-    setTimeout(resolve, fallbackFlushDelayMs + sectionIndex)
+    let remaining = fallbackFlushTicks + sectionIndex
+
+    const step = () => {
+      remaining -= 1
+
+      if (remaining <= 0) {
+        resolve()
+        return
+      }
+
+      setTimeout(step, 0)
+    }
+
+    setTimeout(step, 0)
   })
 }
 

--- a/benchmarks/memory/server/scenarios/streaming-peak/shared.ts
+++ b/benchmarks/memory/server/scenarios/streaming-peak/shared.ts
@@ -98,6 +98,7 @@ export function createWorkloadGroup(
       iterations: streamingPeakIterations,
       buildRequest: buildStreamingRequest,
       validateResponse: validateStreamingResponse,
+      pinGcBetweenIterations: true,
     })
 
   return {

--- a/benchmarks/memory/server/scenarios/streaming-peak/solid/src/routes/stream.$id.tsx
+++ b/benchmarks/memory/server/scenarios/streaming-peak/solid/src/routes/stream.$id.tsx
@@ -5,7 +5,7 @@ import {
   type DeferredSectionPayload,
 } from '../../../deferred-section-data'
 
-const fallbackFlushDelayMs = 25
+const fallbackFlushTicks = 12
 
 export const Route = createFileRoute('/stream/$id')({
   loader: ({ params }) => ({
@@ -20,9 +20,25 @@ export const Route = createFileRoute('/stream/$id')({
 
 // Deferred sections must settle after the framework shell flush so the bench
 // continues exercising multi-flush streaming with visible fallback chunks.
+// Chained 0ms timers-phase hops give the renderer a deterministic number of
+// full event-loop turns to flush, instead of a wall-clock delay whose margin
+// varies with runner load; distinct hop counts keep section ordering stable.
 function afterFallbackFlush(sectionIndex: number) {
   return new Promise<void>((resolve) => {
-    setTimeout(resolve, fallbackFlushDelayMs + sectionIndex)
+    let remaining = fallbackFlushTicks + sectionIndex
+
+    const step = () => {
+      remaining -= 1
+
+      if (remaining <= 0) {
+        resolve()
+        return
+      }
+
+      setTimeout(step, 0)
+    }
+
+    setTimeout(step, 0)
   })
 }
 

--- a/benchmarks/memory/server/scenarios/streaming-peak/vue/src/routes/stream.$id.tsx
+++ b/benchmarks/memory/server/scenarios/streaming-peak/vue/src/routes/stream.$id.tsx
@@ -5,7 +5,7 @@ import {
   type DeferredSectionPayload,
 } from '../../../deferred-section-data'
 
-const fallbackFlushDelayMs = 1
+const fallbackFlushTicks = 20
 
 export const Route = createFileRoute('/stream/$id')({
   loader: ({ params }) => ({
@@ -20,9 +20,25 @@ export const Route = createFileRoute('/stream/$id')({
 
 // Deferred sections must settle strictly AFTER Vue's shell has a chance to
 // flush, so fallbacks are emitted before deferred section content.
+// Chained 0ms timers-phase hops give the renderer a deterministic number of
+// full event-loop turns to flush, instead of a wall-clock delay whose margin
+// varies with runner load; distinct hop counts keep section ordering stable.
 function afterFallbackFlush(sectionIndex: number) {
   return new Promise<void>((resolve) => {
-    setTimeout(resolve, fallbackFlushDelayMs + sectionIndex)
+    let remaining = fallbackFlushTicks + sectionIndex
+
+    const step = () => {
+      remaining -= 1
+
+      if (remaining <= 0) {
+        resolve()
+        return
+      }
+
+      setTimeout(step, 0)
+    }
+
+    setTimeout(step, 0)
   })
 }
 


### PR DESCRIPTION
## Problem

CodSpeed **memory** benchmark flags on PRs are ~85% noise: the same benchmarks get reported faster/slower on PRs that can't plausibly affect memory (e.g. #7676, a changesets version-bump, got 5 memory flags). Mining the last 40 PRs' `codspeed-hq` comments shows two causes:

1. **Stale baselines (dominant).** The Benchmarks workflow only ran on main pushes touching `packages/**`/`benchmarks/**`. Main commits outside those paths (pnpm config, CI, docs) had no CodSpeed run, so CodSpeed silently compared PRs against an older run — every recent codspeed-hq comment carries the `[^unexpected-base]` footnote, and six late-June PRs were all compared against the *same* June-23 base run. Because the memory instrument measures exactly once (no repetitions), a single outlier base measurement then replays into every PR until the next eligible push (`mem peak-large-page (solid)` was flagged "+14%" in six consecutive PRs off one base reading).

2. **Wall-clock timers racing the single measured run.** `aborted-requests` (solid/vue) resolved deferred loader data on 500/750 ms timeouts raced against abort and drained cancellation with at most one `setTimeout(0)`; `streaming-peak` staggered deferred sections by milliseconds. Under variable runner load and instrumentation slowdown the interleaving — and therefore the allocation sequence the instrument sees — differed run to run. `mem aborted-requests (solid)` was flagged on **7 of 7** commented PRs, swinging up to ±57%.

## Fix

- **Workflow:** replace the `paths` filter on the `push` trigger with `paths-ignore: docs/**, examples/**, e2e/**` — every benchmark-relevant merge-base commit on main gets a baseline run, and falling back across a docs/examples/e2e-only commit is safe because the previous run's benchmark-relevant code is identical. PR trigger keeps its paths filter.
- **Scenarios:** stage async ordering by **counted 0ms `setTimeout` hops** (event-loop turns) instead of milliseconds — deferred loader data in `aborted-requests` solid/vue, deferred section flushes in `streaming-peak` (all frameworks) — and drain aborted requests with a fixed 8-turn settlement barrier so teardown can't bleed a load-dependent amount of work into later iterations. Bench names, workload shapes, and sanity assertions (multi-chunk streaming, fallback markers) are unchanged, so the benches still measure the same reality.

No regression thresholds were touched.

## Evidence

Fresh-process harness with CodSpeed's exact V8 determinism flags, 8 runs per config, idle and CPU-stressed (kernel peak-RSS spread across runs, before → after):

| Scenario | Peak-RSS spread | GC counts |
|---|---|---|
| aborted-requests/solid (idle) | 11.2 MB → **1.8 MB** | 4 distinct → **bit-identical** |
| aborted-requests/solid (stressed) | 7.7 MB → **2.5 MB** | 4 → 3 |
| streaming-peak/solid (idle) | 6.2 MB → **2.5 MB** | 4 → 3 |
| request-churn/solid (untouched control) | unchanged | unchanged |

The untouched control confirms harness reproducibility. The old aborted-requests/solid retained 15.6 MB per invocation from cross-iteration timer overlap vs 2.5 MB now, so dashboard absolute values will step once on merge, then hold.

Known residuals: `streaming-peak (vue)` keeps ~2% proxy-level variance at any hop count (its PR flags were the identical −3.2% in all three occurrences — the stale-base artifact, covered by the workflow fix), and solid's stream renderer has internal wall-clock scheduling that bench code can't remove (minor offender, also stale-base-driven).

## Validation after merge

A few A/A `workflow_dispatch` runs on the same main commit should produce zero memory flags; a synthetic-leak PR should still get caught.

## Round 2: GC-timing instability in peak scenarios (A/A-verified fix)

With the memory executor working locally, A/A runs of the **real memory instrument** (identical build, 3 runs) confirmed the timer fixes and exposed one more mechanism in the two big-payload peak scenarios — no timers involved: whether V8 collects iteration *i*'s garbage before iteration *i+1* allocates its payload is not reproducible, so the measured peak flipped by a whole payload (`serialization-payload (solid)`: 6.8–9.2 MB across identical runs; `peak-large-page (solid)`: 3.5–3.7 MB).

Peak scenarios measure a **single request's footprint**, not accumulation, so the fix pins the collection points: settle two event-loop turns (trailing renderer/stream teardown included), then force a GC after each iteration (`pinGcBetweenIterations` on the request loop). Churn scenarios are unchanged — their signal *is* accumulation, which a forced GC would mask; the README rule now documents both sides.

Final A/A instrument results (3 identical runs, solid suite):

| Benchmark | before this PR | after |
|---|---|---|
| aborted-requests | 1.5–2.3 MB across PRs | **1.4 / 1.4 / 1.4 MB** |
| serialization-payload | 6.8–9.2 MB (±35%) | **3.5 / 3.6 / 3.5 MB** |
| peak-large-page | 3.5–3.7 MB (5.7%) | **757 / 754 / 754 KB** (0.45%) |
| streaming-peak chunked | 38.5–39.5 MB | **30.3 / 30.3 / 30.3 MB** |
| request-churn / server-fn-churn / error-paths | stable | stable (≤0.2%) |

Peak-scenario absolute values step because cross-iteration garbage no longer inflates the peak; the new values are the per-request footprint the scenarios were designed to track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark guidance to explain deterministic timing conventions and CodSpeed CI behavior on `main`, including how base comparisons behave when a `main` baseline is missing.
* **Bug Fixes**
  * Improved benchmark determinism by replacing wall-clock delays with event-loop tick–based scheduling across aborted-request and streaming-peak scenarios (including async staging determinism updates).
  * Reduced misleading performance comparisons by adjusting workflow path filtering and documenting the baseline selection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

