### PR TITLE
fix(solid-router): resolve defaultNotFoundComponent at render time to avoid hydration desync

### DIFF
--- a/.changeset/tame-lions-hunt.md
+++ b/.changeset/tame-lions-hunt.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/solid-router': patch
+---
+
+Fix hydration desync by resolving `defaultNotFoundComponent` at render time instead of lazily mutating the boundary route's `options.notFoundComponent`. Route objects are module singletons shared across server requests, so once the server handled any 404, later SSRs of valid URLs wrapped the match in a `CatchNotFound` boundary the client didn't render, shifting hydration keys and leaving the subtree inert.

--- a/e2e/solid-start/query-integration/src/routeTree.gen.ts
+++ b/e2e/solid-start/query-integration/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as UseQueryRouteImport } from './routes/useQuery'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as NotFoundReloadIdRouteImport } from './routes/not-found-reload.$id'
 import { Route as LoaderFetchQueryTypeRouteImport } from './routes/loader-fetchQuery/$type'
 
 const UseQueryRoute = UseQueryRouteImport.update({
@@ -23,6 +24,11 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const NotFoundReloadIdRoute = NotFoundReloadIdRouteImport.update({
+  id: '/not-found-reload/$id',
+  path: '/not-found-reload/$id',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LoaderFetchQueryTypeRoute = LoaderFetchQueryTypeRouteImport.update({
   id: '/loader-fetchQuery/$type',
   path: '/loader-fetchQuery/$type',
@@ -33,30 +39,43 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/useQuery': typeof UseQueryRoute
   '/loader-fetchQuery/$type': typeof LoaderFetchQueryTypeRoute
+  '/not-found-reload/$id': typeof NotFoundReloadIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/useQuery': typeof UseQueryRoute
   '/loader-fetchQuery/$type': typeof LoaderFetchQueryTypeRoute
+  '/not-found-reload/$id': typeof NotFoundReloadIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/useQuery': typeof UseQueryRoute
   '/loader-fetchQuery/$type': typeof LoaderFetchQueryTypeRoute
+  '/not-found-reload/$id': typeof NotFoundReloadIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/useQuery' | '/loader-fetchQuery/$type'
+  fullPaths:
+    | '/'
+    | '/useQuery'
+    | '/loader-fetchQuery/$type'
+    | '/not-found-reload/$id'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/useQuery' | '/loader-fetchQuery/$type'
-  id: '__root__' | '/' | '/useQuery' | '/loader-fetchQuery/$type'
+  to: '/' | '/useQuery' | '/loader-fetchQuery/$type' | '/not-found-reload/$id'
+  id:
+    | '__root__'
+    | '/'
+    | '/useQuery'
+    | '/loader-fetchQuery/$type'
+    | '/not-found-reload/$id'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   UseQueryRoute: typeof UseQueryRoute
   LoaderFetchQueryTypeRoute: typeof LoaderFetchQueryTypeRoute
+  NotFoundReloadIdRoute: typeof NotFoundReloadIdRoute
 }
 
 declare module '@tanstack/solid-router' {
@@ -75,6 +94,13 @@ declare module '@tanstack/solid-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/not-found-reload/$id': {
+      id: '/not-found-reload/$id'
+      path: '/not-found-reload/$id'
+      fullPath: '/not-found-reload/$id'
+      preLoaderRoute: typeof NotFoundReloadIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/loader-fetchQuery/$type': {
       id: '/loader-fetchQuery/$type'
       path: '/loader-fetchQuery/$type'
@@ -89,6 +115,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   UseQueryRoute: UseQueryRoute,
   LoaderFetchQueryTypeRoute: LoaderFetchQueryTypeRoute,
+  NotFoundReloadIdRoute: NotFoundReloadIdRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/e2e/solid-start/query-integration/src/router.tsx
+++ b/e2e/solid-start/query-integration/src/router.tsx
@@ -10,6 +10,7 @@ export function getRouter() {
     context: { queryClient },
     scrollRestoration: true,
     defaultPreload: 'intent',
+    defaultNotFoundComponent: () => <div>Not Found</div>
   })
   setupRouterSsrQueryIntegration({
     router,

--- a/e2e/solid-start/query-integration/src/router.tsx
+++ b/e2e/solid-start/query-integration/src/router.tsx
@@ -10,7 +10,7 @@ export function getRouter() {
     context: { queryClient },
     scrollRestoration: true,
     defaultPreload: 'intent',
-    defaultNotFoundComponent: () => <div>Not Found</div>
+    defaultNotFoundComponent: () => <div>Not Found</div>,
   })
   setupRouterSsrQueryIntegration({
     router,

--- a/e2e/solid-start/query-integration/src/routes/not-found-reload.$id.tsx
+++ b/e2e/solid-start/query-integration/src/routes/not-found-reload.$id.tsx
@@ -1,0 +1,45 @@
+import { createFileRoute, notFound } from '@tanstack/solid-router'
+import { For } from 'solid-js'
+
+// Repro: `defaultNotFoundComponent` used to be applied by lazily mutating
+// `route.options.notFoundComponent` when a notFound was handled. Route objects
+// are module singletons shared across server requests, so after the server
+// handled a single 404 for this route, every later SSR of a *valid* URL
+// wrapped the match in a CatchNotFound boundary the freshly-hydrating client
+// doesn't have — shifting every _hk under the match and leaving the subtree
+// unclaimed (visible but inert SSR DOM).
+const ITEMS = ['one', 'two', 'three']
+
+export const Route = createFileRoute('/not-found-reload/$id')({
+  loader: ({ params }) => {
+    if (params.id === 'missing') throw notFound()
+    return { id: params.id }
+  },
+  head: ({ params }) => ({
+    meta: [{ title: `not-found-reload ${params.id}` }],
+  }),
+  component: NotFoundReloadComponent,
+})
+
+function NotFoundReloadComponent() {
+  const params = Route.useParams()
+
+  return (
+    <div class="p-2">
+      <h3 data-testid="not-found-reload-heading">id: {params().id}</h3>
+      <ul data-testid="not-found-reload-list">
+        <For each={ITEMS}>{(item) => <li>{item}</li>}</For>
+      </ul>
+      {/* Interactivity probe: if hydration failed to claim the SSR DOM
+          (hydration-id desync), no event handler is bound to this button
+          and clicking it does nothing. */}
+      <button
+        type="button"
+        data-testid="not-found-reload-button"
+        onClick={(e) => e.currentTarget.setAttribute('data-clicked', 'true')}
+      >
+        click me
+      </button>
+    </div>
+  )
+}

--- a/e2e/solid-start/query-integration/tests/not-found-reload.spec.ts
+++ b/e2e/solid-start/query-integration/tests/not-found-reload.spec.ts
@@ -1,0 +1,72 @@
+import { expect } from '@playwright/test'
+import { test } from '@tanstack/router-e2e-utils'
+
+// Regression test for defaultNotFoundComponent poisoning hydration: the
+// default used to be applied by lazily mutating the boundary route's
+// `options.notFoundComponent` when a notFound was handled (load-matches).
+// Route objects are module singletons shared across server requests, so once
+// the server had handled any 404, later SSRs of *valid* URLs wrapped the
+// route's Match in a CatchNotFound boundary that a freshly-hydrating client
+// (which never runs that mutation) doesn't render — every _hk under the match
+// shifted and hydration left the subtree unclaimed: visible but inert DOM.
+// Fixed by resolving defaultNotFoundComponent at render time in Match.tsx so
+// the boundary structure is deterministic on both server and client.
+test.describe('reload after the server handled a 404 (defaultNotFoundComponent)', () => {
+  test('direct visit after a 404 - SSR DOM is claimed and interactive', async ({
+    page,
+  }) => {
+    const hydrationWarnings: Array<string> = []
+    page.on('console', (msg) => {
+      if (msg.text().includes('unclaimed server-rendered')) {
+        hydrationWarnings.push(msg.text())
+      }
+    })
+
+    // Make the server handle a notFound for this route first. Before the fix
+    // this permanently mutated the route singleton on the server.
+    const notFoundResponse = await page.request.get('/not-found-reload/missing')
+    expect(notFoundResponse.status()).toBe(404)
+
+    // Now a direct visit (SSR + hydration) of a valid URL on the same route.
+    await page.goto('/not-found-reload/ok')
+
+    const heading = page.getByTestId('not-found-reload-heading')
+    await expect(heading).toHaveText('id: ok')
+    await expect(
+      page.getByTestId('not-found-reload-list').locator('li'),
+    ).toHaveCount(3)
+
+    // Dev-mode signal (no-op in production builds)
+    expect(hydrationWarnings).toEqual([])
+
+    // Interactivity probe: if hydration failed to claim the SSR DOM, no event
+    // handler is bound and the click does nothing.
+    const button = page.getByTestId('not-found-reload-button')
+    await button.click()
+    await expect(button).toHaveAttribute('data-clicked', 'true')
+  })
+
+  test.describe('404 page itself', () => {
+    // Navigating straight to a 404 URL logs the browser's own
+    // "Failed to load resource" console error for the document request.
+    test.use({
+      whitelistErrors: [/Failed to load resource.*404/],
+    })
+
+    test('reloading the 404 page itself hydrates the default not-found', async ({
+      page,
+    }) => {
+      const hydrationWarnings: Array<string> = []
+      page.on('console', (msg) => {
+        if (msg.text().includes('unclaimed server-rendered')) {
+          hydrationWarnings.push(msg.text())
+        }
+      })
+
+      await page.goto('/not-found-reload/missing')
+
+      await expect(page.getByText('Not Found')).toBeVisible()
+      expect(hydrationWarnings).toEqual([])
+    })
+  })
+})

--- a/packages/solid-router/src/Match.tsx
+++ b/packages/solid-router/src/Match.tsx
@@ -87,12 +87,21 @@ export const Match = (props: { matchId: string }) => {
           () => route().options.onCatch ?? router.options.defaultOnCatch,
         )
 
+        // `defaultNotFoundComponent` must be resolved here at render time, not
+        // via the lazy route-option mutation in load-matches (which only runs
+        // when a notFound is actually handled). Route objects are module
+        // singletons shared across server requests, so relying on that mutation
+        // makes the presence of the CatchNotFound boundary — and therefore
+        // Solid's hydration keys — depend on whether the server has previously
+        // served a 404, while a freshly-hydrating client never has it applied.
         const routeNotFoundComponent = Solid.createMemo(() =>
           route().isRoot
             ? // If it's the root route, use the globalNotFound option, with fallback to the notFoundRoute's component
               (route().options.notFoundComponent ??
-              router.options.notFoundRoute?.options.component)
-            : route().options.notFoundComponent,
+              router.options.notFoundRoute?.options.component ??
+              router.options.defaultNotFoundComponent)
+            : (route().options.notFoundComponent ??
+              router.options.defaultNotFoundComponent),
         )
 
         const resolvedNoSsr = Solid.createMemo(


### PR DESCRIPTION
## Problem

`defaultNotFoundComponent` used to be applied by lazily mutating the boundary route's `options.notFoundComponent` when a `notFound()` was handled (in load-matches). Route objects are module singletons shared across server requests, so once the server handled a single 404 for a route, every subsequent SSR of a **valid** URL on that route wrapped the match in a `CatchNotFound` boundary.

A freshly-hydrating client never runs that mutation, so it doesn't render the boundary — every `_hk` under the match shifts, hydration leaves the subtree unclaimed, and the result is visible but inert SSR DOM (no event handlers bound).

## Fix

Resolve `defaultNotFoundComponent` at render time in `Match.tsx` so the presence of the `CatchNotFound` boundary — and therefore Solid's hydration keys — is deterministic on both server and client, regardless of whether the server previously served a 404.

## Tests

Added an e2e regression test in `e2e/solid-start/query-integration`:

- After the server handles a 404 for a route, a direct visit to a valid URL on the same route hydrates correctly: no unclaimed-DOM hydration warnings and the page is interactive (click probe).
- Reloading the 404 URL itself hydrates the default not-found component without hydration warnings.