### PR TITLE
fix(router-core): reset oldest pointer when evicting the sole LRU cache entry

### DIFF
--- a/packages/router-core/src/lru-cache.ts
+++ b/packages/router-core/src/lru-cache.ts
@@ -45,8 +45,8 @@ export function createLRUCache<TKey, TValue>(
       if (cache.size >= max && oldest) {
         const toDelete = oldest
         cache.delete(toDelete.key)
+        oldest = toDelete.next
         if (toDelete.next) {
-          oldest = toDelete.next
           toDelete.next.prev = undefined
         }
         if (toDelete === newest) {

--- a/packages/router-core/tests/lru.test.ts
+++ b/packages/router-core/tests/lru.test.ts
@@ -21,4 +21,14 @@ describe('LRU Cache', () => {
     expect(cache.get('b')).toBeUndefined()
     expect(cache.get('a')).toBe(1)
   })
+
+  it('respects max=1 across multiple replacements', () => {
+    const cache = createLRUCache<string, number>(1)
+    cache.set('a', 1)
+    cache.set('b', 2) // evicts 'a'
+    cache.set('c', 3) // evicts 'b'
+    expect(cache.get('a')).toBeUndefined()
+    expect(cache.get('b')).toBeUndefined()
+    expect(cache.get('c')).toBe(3)
+  })
 })


### PR DESCRIPTION
## What

When `set()` evicts the only entry in the LRU cache (`oldest === newest`), the node has no `next` pointer, so the branch that updated `oldest` was never taken. `oldest` kept a stale reference to the deleted node while `newest` was correctly set to `undefined`.

On the next `set()` call the stale `oldest` caused `cache.delete()` to run against a key that no longer existed — leaving the new entry untracked by `oldest`. Subsequent insertions then grew the cache silently beyond its max capacity.

## Root cause

```ts
// Before (buggy)
if (toDelete.next) {
  oldest = toDelete.next      // ← only set when a successor exists
  toDelete.next.prev = undefined
}
if (toDelete === newest) {
  newest = undefined          // ← correctly cleared
}
// When oldest === newest, toDelete.next is undefined → oldest is never cleared
```

## Fix

```ts
// After
oldest = toDelete.next        // always update oldest (undefined when no successor)
if (toDelete.next) {
  toDelete.next.prev = undefined
}
if (toDelete === newest) {
  newest = undefined
}
```

## Test

Added a test case `respects max=1 across multiple replacements` to `lru.test.ts` that reproduces the bug and passes with the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved least-recently-used cache eviction so the oldest entry is updated correctly when items are removed.
  * Fixed behavior for single-item caches to ensure older entries are evicted as new values are added.

* **Tests**
  * Added coverage for repeated replacements in a cache with a maximum size of 1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->