### PR TITLE
bench(memory): prefix client and server benchmark names

### DIFF
--- a/benchmarks/memory/client/scenarios/interrupted-navigations/shared.ts
+++ b/benchmarks/memory/client/scenarios/interrupted-navigations/shared.ts
@@ -296,7 +296,7 @@ export function createWorkload(
   }
 
   return {
-    name: `mem interrupted-navigations (${framework})`,
+    name: `mem client interrupted-navigations (${framework})`,
     before,
     interrupt,
     async run() {

--- a/benchmarks/memory/client/scenarios/loader-data-retention/shared.ts
+++ b/benchmarks/memory/client/scenarios/loader-data-retention/shared.ts
@@ -163,7 +163,7 @@ export function createWorkload(
   }
 
   return {
-    name: `mem loader-data-retention (${framework})`,
+    name: `mem client loader-data-retention (${framework})`,
     before,
     navigate: (id: string) => navigateTo(id),
     async run() {

--- a/benchmarks/memory/client/scenarios/mount-unmount/shared.ts
+++ b/benchmarks/memory/client/scenarios/mount-unmount/shared.ts
@@ -58,7 +58,7 @@ export function createWorkload(
   }
 
   return {
-    name: `mem mount-unmount (${framework})`,
+    name: `mem client mount-unmount (${framework})`,
     cycle,
     async run() {
       for (let index = 0; index < mountUnmountIterations; index++) {

--- a/benchmarks/memory/client/scenarios/navigation-churn/shared.ts
+++ b/benchmarks/memory/client/scenarios/navigation-churn/shared.ts
@@ -105,7 +105,7 @@ export function createWorkload(
   }
 
   return {
-    name: `mem navigation-churn (${framework})`,
+    name: `mem client navigation-churn (${framework})`,
     before,
     navigate: (target: Target) => navigateTo(target),
     async run() {

--- a/benchmarks/memory/client/scenarios/preload-churn/shared.ts
+++ b/benchmarks/memory/client/scenarios/preload-churn/shared.ts
@@ -180,7 +180,7 @@ export function createWorkload(
   }
 
   return {
-    name: `mem preload-churn (${framework})`,
+    name: `mem client preload-churn (${framework})`,
     before,
     preload: (id: string) => preloadItem(id),
     evictPreloads,

--- a/benchmarks/memory/client/scenarios/unique-location-churn/shared.ts
+++ b/benchmarks/memory/client/scenarios/unique-location-churn/shared.ts
@@ -123,7 +123,7 @@ export function createWorkload(
   }
 
   return {
-    name: `mem unique-location-churn (${framework})`,
+    name: `mem client unique-location-churn (${framework})`,
     before,
     navigate: (location: ItemLocation) => navigateTo(location),
     async run() {

--- a/benchmarks/memory/server/scenarios/aborted-requests/shared.ts
+++ b/benchmarks/memory/server/scenarios/aborted-requests/shared.ts
@@ -268,7 +268,7 @@ export function createWorkloadGroup(
     sanity: () => assertAbortedRequestsSanity(handler, mode),
     workloads: [
       {
-        name: `mem aborted-requests (${framework})`,
+        name: `mem server aborted-requests (${framework})`,
         run,
       },
     ],

--- a/benchmarks/memory/server/scenarios/error-paths/shared.ts
+++ b/benchmarks/memory/server/scenarios/error-paths/shared.ts
@@ -172,19 +172,19 @@ export function createWorkloadGroup(
     sanity: () => assertErrorPathsSanity(handler),
     workloads: [
       {
-        name: `mem error-paths redirect (${framework})`,
+        name: `mem server error-paths redirect (${framework})`,
         run: runRedirect,
       },
       {
-        name: `mem error-paths not-found (${framework})`,
+        name: `mem server error-paths not-found (${framework})`,
         run: runNotFound,
       },
       {
-        name: `mem error-paths error (${framework})`,
+        name: `mem server error-paths error (${framework})`,
         run: runError,
       },
       {
-        name: `mem error-paths unmatched (${framework})`,
+        name: `mem server error-paths unmatched (${framework})`,
         run: runUnmatched,
       },
     ],

--- a/benchmarks/memory/server/scenarios/peak-large-page/shared.ts
+++ b/benchmarks/memory/server/scenarios/peak-large-page/shared.ts
@@ -61,7 +61,7 @@ export function createWorkloadGroup(
     sanity: () => assertPeakLargePageSanity(handler),
     workloads: [
       {
-        name: `mem peak-large-page (${framework})`,
+        name: `mem server peak-large-page (${framework})`,
         run,
       },
     ],

--- a/benchmarks/memory/server/scenarios/request-churn/shared.ts
+++ b/benchmarks/memory/server/scenarios/request-churn/shared.ts
@@ -74,7 +74,7 @@ export function createWorkloadGroup(
     sanity: () => assertRequestChurnSanity(handler),
     workloads: [
       {
-        name: `mem request-churn (${framework})`,
+        name: `mem server request-churn (${framework})`,
         run,
       },
     ],

--- a/benchmarks/memory/server/scenarios/serialization-payload/shared.ts
+++ b/benchmarks/memory/server/scenarios/serialization-payload/shared.ts
@@ -68,7 +68,7 @@ export function createWorkloadGroup(
     sanity: () => assertSerializationPayloadSanity(handler),
     workloads: [
       {
-        name: `mem serialization-payload (${framework})`,
+        name: `mem server serialization-payload (${framework})`,
         run,
       },
     ],

--- a/benchmarks/memory/server/scenarios/server-fn-churn/shared.ts
+++ b/benchmarks/memory/server/scenarios/server-fn-churn/shared.ts
@@ -224,7 +224,7 @@ export async function createWorkloadGroup(
     sanity: () => assertServerFnChurnSanity(handler, urls),
     workloads: [
       {
-        name: `mem server-fn-churn (${framework})`,
+        name: `mem server server-fn-churn (${framework})`,
         run,
       },
     ],

--- a/benchmarks/memory/server/scenarios/streaming-peak/shared.ts
+++ b/benchmarks/memory/server/scenarios/streaming-peak/shared.ts
@@ -105,7 +105,7 @@ export function createWorkloadGroup(
     sanity: () => assertStreamingPeakSanity(handler),
     workloads: [
       {
-        name: `mem streaming-peak chunked (${framework})`,
+        name: `mem server streaming-peak chunked (${framework})`,
         run,
       },
     ],


### PR DESCRIPTION
## Summary
- Prefix client memory benchmark workload labels with `mem client`
- Prefix server memory benchmark workload labels with `mem server`

## Tests
- `CI=1 NX_DAEMON=false pnpm nx run @benchmarks/memory-client:test:types --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @benchmarks/memory-server:test:types --outputStyle=stream --skipRemoteCache`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated benchmark labels across multiple memory test scenarios to clearly distinguish client and server workloads.
  * Standardized several scenario names with `client` or `server` prefixes, including navigation, loader data retention, mount/unmount, request churn, error paths, and streaming/serialization cases.
  * Refined one server scenario label to better reflect its workload naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->