### PR TITLE
fix(router-generator): make buildRouteTree route ordering deterministic

### DIFF
--- a/.changeset/deterministic-route-tree-sort.md
+++ b/.changeset/deterministic-route-tree-sort.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/router-generator": patch
+'@tanstack/router-generator': patch
 ---
 
 Make `buildRouteTree` route ordering deterministic. Its final sort tiebreaker compared whole route-node objects (`(d) => d`), which coerce to `"[object Object]"` and so never order — an inconsistent comparator that left routes tying on segment-count/index-token in an engine- and input-dependent order, producing non-deterministic `routeTree.gen.ts` diffs across machines. The tiebreaker now compares `routePath`, mirroring the pre-sort and giving a stable total order.

--- a/.changeset/deterministic-route-tree-sort.md
+++ b/.changeset/deterministic-route-tree-sort.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/router-generator": patch
+---
+
+Make `buildRouteTree` route ordering deterministic. Its final sort tiebreaker compared whole route-node objects (`(d) => d`), which coerce to `"[object Object]"` and so never order — an inconsistent comparator that left routes tying on segment-count/index-token in an engine- and input-dependent order, producing non-deterministic `routeTree.gen.ts` diffs across machines. The tiebreaker now compares `routePath`, mirroring the pre-sort and giving a stable total order.

--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -627,7 +627,7 @@ export class Generator {
         const last = segments[segments.length - 1] ?? ''
         return indexTokenSegmentRegex.test(last) ? -1 : 1
       },
-      (d) => d,
+      (d) => d.routePath,
     ])
 
     const routeImports: Array<ImportDeclaration> = []

--- a/packages/router-generator/src/generator.ts
+++ b/packages/router-generator/src/generator.ts
@@ -38,6 +38,7 @@ import {
   removeLayoutSegmentsAndUnderscoresWithEscape,
   removeTrailingSlash,
   replaceBackslash,
+  sortRouteNodes,
   trimPathLeft,
 } from './utils'
 import { fillTemplate, getTargetTemplate } from './template'
@@ -616,19 +617,10 @@ export class Generator {
         ? this.indexTokenSegmentRegex
         : createTokenRegex(config.indexToken, { type: 'segment' })
 
-    const sortedRouteNodes = multiSortBy(acc.routeNodes, [
-      (d) => (d.routePath?.includes(`/${rootPathId}`) ? -1 : 1),
-      (d) =>
-        d.routePath === undefined
-          ? undefined
-          : countSlashSeparatedParts(d.routePath),
-      (d) => {
-        const segments = d.routePath?.split('/').filter(Boolean) ?? []
-        const last = segments[segments.length - 1] ?? ''
-        return indexTokenSegmentRegex.test(last) ? -1 : 1
-      },
-      (d) => d.routePath,
-    ])
+    const sortedRouteNodes = sortRouteNodes(
+      acc.routeNodes,
+      indexTokenSegmentRegex,
+    )
 
     const routeImports: Array<ImportDeclaration> = []
     const virtualRouteNodes: Array<string> = []

--- a/packages/router-generator/src/index.ts
+++ b/packages/router-generator/src/index.ts
@@ -23,7 +23,6 @@ export {
   removeUnderscores,
   resetRegex,
   multiSortBy,
-  sortRouteNodes,
   writeIfDifferent,
   format,
   removeExt,

--- a/packages/router-generator/src/index.ts
+++ b/packages/router-generator/src/index.ts
@@ -23,6 +23,7 @@ export {
   removeUnderscores,
   resetRegex,
   multiSortBy,
+  sortRouteNodes,
   writeIfDifferent,
   format,
   removeExt,

--- a/packages/router-generator/src/utils.ts
+++ b/packages/router-generator/src/utils.ts
@@ -124,17 +124,9 @@ export function multiSortBy<T>(
 }
 
 /**
- * Sorts route nodes into the deterministic order used when generating the route
- * tree. Precedence: root (`__root`) first, then by slash-separated segment
- * count, then index segments before non-index, and finally — the tiebreaker —
- * by `routePath`.
- *
- * The `routePath` tiebreaker is load-bearing: `routePath` is unique per node, so
- * it gives the comparator a total order. Without it (e.g. comparing whole route
- * nodes), any nodes tying on every earlier key are left in an engine- and
- * input-order-dependent order by `Array.prototype.sort`, which makes the
- * generated route tree churn non-deterministically across machines and Node
- * versions.
+ * Sorts route nodes by root, path depth, index status, and finally `routePath`.
+ * The `routePath` comparison keeps the output consistent when the earlier
+ * values are the same.
  */
 export function sortRouteNodes(
   routeNodes: Array<RouteNode>,

--- a/packages/router-generator/src/utils.ts
+++ b/packages/router-generator/src/utils.ts
@@ -123,6 +123,38 @@ export function multiSortBy<T>(
   return result
 }
 
+/**
+ * Sorts route nodes into the deterministic order used when generating the route
+ * tree. Precedence: root (`__root`) first, then by slash-separated segment
+ * count, then index segments before non-index, and finally — the tiebreaker —
+ * by `routePath`.
+ *
+ * The `routePath` tiebreaker is load-bearing: `routePath` is unique per node, so
+ * it gives the comparator a total order. Without it (e.g. comparing whole route
+ * nodes), any nodes tying on every earlier key are left in an engine- and
+ * input-order-dependent order by `Array.prototype.sort`, which makes the
+ * generated route tree churn non-deterministically across machines and Node
+ * versions.
+ */
+export function sortRouteNodes(
+  routeNodes: Array<RouteNode>,
+  indexTokenSegmentRegex: RegExp,
+): Array<RouteNode> {
+  return multiSortBy(routeNodes, [
+    (d) => (d.routePath?.includes(`/${rootPathId}`) ? -1 : 1),
+    (d) =>
+      d.routePath === undefined
+        ? undefined
+        : countSlashSeparatedParts(d.routePath),
+    (d) => {
+      const segments = d.routePath?.split('/').filter(Boolean) ?? []
+      const last = segments[segments.length - 1] ?? ''
+      return indexTokenSegmentRegex.test(last) ? -1 : 1
+    },
+    (d) => d.routePath,
+  ])
+}
+
 export function cleanPath(path: string) {
   // remove double slashes
   return path.replace(/\/{2,}/g, '/')

--- a/packages/router-generator/tests/generator/add-extensions-custom/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/add-extensions-custom/routeTree.snapshot.ts
@@ -9,17 +9,17 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root.js'
-import { Route as PostsRouteImport } from './routes/posts.js'
 import { Route as IndexRouteImport } from './routes/index.js'
+import { Route as PostsRouteImport } from './routes/posts.js'
 
-const PostsRoute = PostsRouteImport.update({
-  id: '/posts',
-  path: '/posts',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PostsRoute = PostsRouteImport.update({
+  id: '/posts',
+  path: '/posts',
   getParentRoute: () => rootRouteImport,
 } as any)
 
@@ -51,18 +51,18 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/posts': {
-      id: '/posts'
-      path: '/posts'
-      fullPath: '/posts'
-      preLoaderRoute: typeof PostsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/': {
       id: '/'
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/posts': {
+      id: '/posts'
+      path: '/posts'
+      fullPath: '/posts'
+      preLoaderRoute: typeof PostsRouteImport
       parentRoute: typeof rootRouteImport
     }
   }

--- a/packages/router-generator/tests/generator/custom-scaffolding/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/custom-scaffolding/routeTree.snapshot.ts
@@ -16,16 +16,16 @@ import { Route as ApiBarRouteImport } from './routes/api/bar'
 
 const FooLazyRouteImport = createFileRoute('/foo')()
 
-const FooLazyRoute = FooLazyRouteImport.update({
-  id: '/foo',
-  path: '/foo',
-  getParentRoute: () => rootRouteImport,
-} as any).lazy(() => import('./routes/foo.lazy').then((d) => d.Route))
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const FooLazyRoute = FooLazyRouteImport.update({
+  id: '/foo',
+  path: '/foo',
+  getParentRoute: () => rootRouteImport,
+} as any).lazy(() => import('./routes/foo.lazy').then((d) => d.Route))
 const ApiBarRoute = ApiBarRouteImport.update({
   id: '/api/bar',
   path: '/api/bar',
@@ -64,18 +64,18 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/foo': {
-      id: '/foo'
-      path: '/foo'
-      fullPath: '/foo'
-      preLoaderRoute: typeof FooLazyRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/': {
       id: '/'
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/foo': {
+      id: '/foo'
+      path: '/foo'
+      fullPath: '/foo'
+      preLoaderRoute: typeof FooLazyRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/bar': {

--- a/packages/router-generator/tests/generator/custom-tokens/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/custom-tokens/routeTree.snapshot.ts
@@ -9,18 +9,18 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as PostsR0ut3RouteImport } from './routes/posts/_r0ut3_'
-import { Route as BlogR0ut3RouteImport } from './routes/blog/_r0ut3_'
 import { Route as R1nd3xRouteImport } from './routes/_1nd3x'
-import { Route as Posts1nd3xRouteImport } from './routes/posts/_1nd3x'
+import { Route as BlogR0ut3RouteImport } from './routes/blog/_r0ut3_'
+import { Route as PostsR0ut3RouteImport } from './routes/posts/_r0ut3_'
 import { Route as Blog1nd3xRouteImport } from './routes/blog/_1nd3x'
 import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
+import { Route as Posts1nd3xRouteImport } from './routes/posts/_1nd3x'
 import { Route as PostsPostId1nd3xRouteImport } from './routes/posts/$postId/_1nd3x'
 import { Route as PostsPostIdDeepRouteImport } from './routes/posts/$postId/deep'
 
-const PostsR0ut3Route = PostsR0ut3RouteImport.update({
-  id: '/posts',
-  path: '/posts',
+const R1nd3xRoute = R1nd3xRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const BlogR0ut3Route = BlogR0ut3RouteImport.update({
@@ -28,15 +28,10 @@ const BlogR0ut3Route = BlogR0ut3RouteImport.update({
   path: '/blog',
   getParentRoute: () => rootRouteImport,
 } as any)
-const R1nd3xRoute = R1nd3xRouteImport.update({
-  id: '/',
-  path: '/',
+const PostsR0ut3Route = PostsR0ut3RouteImport.update({
+  id: '/posts',
+  path: '/posts',
   getParentRoute: () => rootRouteImport,
-} as any)
-const Posts1nd3xRoute = Posts1nd3xRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => PostsR0ut3Route,
 } as any)
 const Blog1nd3xRoute = Blog1nd3xRouteImport.update({
   id: '/',
@@ -47,6 +42,11 @@ const BlogSlugRoute = BlogSlugRouteImport.update({
   id: '/$slug',
   path: '/$slug',
   getParentRoute: () => BlogR0ut3Route,
+} as any)
+const Posts1nd3xRoute = Posts1nd3xRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => PostsR0ut3Route,
 } as any)
 const PostsPostId1nd3xRoute = PostsPostId1nd3xRouteImport.update({
   id: '/$postId/',
@@ -127,11 +127,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/posts': {
-      id: '/posts'
-      path: '/posts'
-      fullPath: '/posts'
-      preLoaderRoute: typeof PostsR0ut3RouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof R1nd3xRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/blog': {
@@ -141,19 +141,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof BlogR0ut3RouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof R1nd3xRouteImport
+    '/posts': {
+      id: '/posts'
+      path: '/posts'
+      fullPath: '/posts'
+      preLoaderRoute: typeof PostsR0ut3RouteImport
       parentRoute: typeof rootRouteImport
-    }
-    '/posts/': {
-      id: '/posts/'
-      path: '/'
-      fullPath: '/posts/'
-      preLoaderRoute: typeof Posts1nd3xRouteImport
-      parentRoute: typeof PostsR0ut3Route
     }
     '/blog/': {
       id: '/blog/'
@@ -168,6 +161,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/blog/$slug'
       preLoaderRoute: typeof BlogSlugRouteImport
       parentRoute: typeof BlogR0ut3Route
+    }
+    '/posts/': {
+      id: '/posts/'
+      path: '/'
+      fullPath: '/posts/'
+      preLoaderRoute: typeof Posts1nd3xRouteImport
+      parentRoute: typeof PostsR0ut3Route
     }
     '/posts/$postId/': {
       id: '/posts/$postId/'

--- a/packages/router-generator/tests/generator/dot-escaped/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/dot-escaped/routeTree.snapshot.ts
@@ -9,25 +9,20 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as ScriptDotjsRouteImport } from './routes/script[.]js'
 import { Route as NestedDotjsRouteImport } from './routes/nested[.]js'
-import { Route as NestedDotjsScriptDotjsRouteImport } from './routes/nested[.]js.script[.]js'
+import { Route as ScriptDotjsRouteImport } from './routes/script[.]js'
 import { Route as NestedDotjsDoubleDotextDotjsRouteImport } from './routes/nested[.]js.double[.]ext[.]js'
+import { Route as NestedDotjsScriptDotjsRouteImport } from './routes/nested[.]js.script[.]js'
 
-const ScriptDotjsRoute = ScriptDotjsRouteImport.update({
-  id: '/script.js',
-  path: '/script.js',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const NestedDotjsRoute = NestedDotjsRouteImport.update({
   id: '/nested.js',
   path: '/nested.js',
   getParentRoute: () => rootRouteImport,
 } as any)
-const NestedDotjsScriptDotjsRoute = NestedDotjsScriptDotjsRouteImport.update({
+const ScriptDotjsRoute = ScriptDotjsRouteImport.update({
   id: '/script.js',
   path: '/script.js',
-  getParentRoute: () => NestedDotjsRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
 const NestedDotjsDoubleDotextDotjsRoute =
   NestedDotjsDoubleDotextDotjsRouteImport.update({
@@ -35,6 +30,11 @@ const NestedDotjsDoubleDotextDotjsRoute =
     path: '/double.ext.js',
     getParentRoute: () => NestedDotjsRoute,
   } as any)
+const NestedDotjsScriptDotjsRoute = NestedDotjsScriptDotjsRouteImport.update({
+  id: '/script.js',
+  path: '/script.js',
+  getParentRoute: () => NestedDotjsRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/nested.js': typeof NestedDotjsRouteWithChildren
@@ -83,13 +83,6 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/script.js': {
-      id: '/script.js'
-      path: '/script.js'
-      fullPath: '/script.js'
-      preLoaderRoute: typeof ScriptDotjsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/nested.js': {
       id: '/nested.js'
       path: '/nested.js'
@@ -97,18 +90,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof NestedDotjsRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/nested.js/script.js': {
-      id: '/nested.js/script.js'
+    '/script.js': {
+      id: '/script.js'
       path: '/script.js'
-      fullPath: '/nested.js/script.js'
-      preLoaderRoute: typeof NestedDotjsScriptDotjsRouteImport
-      parentRoute: typeof NestedDotjsRoute
+      fullPath: '/script.js'
+      preLoaderRoute: typeof ScriptDotjsRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/nested.js/double.ext.js': {
       id: '/nested.js/double.ext.js'
       path: '/double.ext.js'
       fullPath: '/nested.js/double.ext.js'
       preLoaderRoute: typeof NestedDotjsDoubleDotextDotjsRouteImport
+      parentRoute: typeof NestedDotjsRoute
+    }
+    '/nested.js/script.js': {
+      id: '/nested.js/script.js'
+      path: '/script.js'
+      fullPath: '/nested.js/script.js'
+      preLoaderRoute: typeof NestedDotjsScriptDotjsRouteImport
       parentRoute: typeof NestedDotjsRoute
     }
   }

--- a/packages/router-generator/tests/generator/escaped-custom-tokens/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/escaped-custom-tokens/routeTree.snapshot.ts
@@ -10,8 +10,8 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as Char91_1nd3xChar93RouteImport } from './routes/[_1nd3x]'
-import { Route as BlogR0ut3RouteImport } from './routes/blog._r0ut3_'
 import { Route as R1nd3xRouteImport } from './routes/_1nd3x'
+import { Route as BlogR0ut3RouteImport } from './routes/blog._r0ut3_'
 import { Route as NestedChar91_1nd3xChar93RouteImport } from './routes/nested.[_1nd3x]'
 import { Route as PostsChar91_r0ut3_Char93RouteImport } from './routes/posts.[_r0ut3_]'
 
@@ -20,14 +20,14 @@ const Char91_1nd3xChar93Route = Char91_1nd3xChar93RouteImport.update({
   path: '/_1nd3x',
   getParentRoute: () => rootRouteImport,
 } as any)
-const BlogR0ut3Route = BlogR0ut3RouteImport.update({
-  id: '/blog',
-  path: '/blog',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const R1nd3xRoute = R1nd3xRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BlogR0ut3Route = BlogR0ut3RouteImport.update({
+  id: '/blog',
+  path: '/blog',
   getParentRoute: () => rootRouteImport,
 } as any)
 const NestedChar91_1nd3xChar93Route =
@@ -96,18 +96,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof Char91_1nd3xChar93RouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/blog': {
-      id: '/blog'
-      path: '/blog'
-      fullPath: '/blog'
-      preLoaderRoute: typeof BlogR0ut3RouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/': {
       id: '/'
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof R1nd3xRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/blog': {
+      id: '/blog'
+      path: '/blog'
+      fullPath: '/blog'
+      preLoaderRoute: typeof BlogR0ut3RouteImport
       parentRoute: typeof rootRouteImport
     }
     '/nested/_1nd3x': {

--- a/packages/router-generator/tests/generator/escaped-special-strings/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/escaped-special-strings/routeTree.snapshot.ts
@@ -10,15 +10,15 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as Char91indexChar93RouteImport } from './routes/[index]'
-import { Route as Char91routeChar93RouteImport } from './routes/[route]'
-import { Route as Char91lazyChar93RouteImport } from './routes/[lazy]'
-import { Route as Foo_barRouteImport } from './routes/foo[_]bar'
-import { Route as BlogRouteImport } from './routes/blog[_]'
-import { Route as Api_v2_usersRouteImport } from './routes/api[_]v2[_]users'
-import { Route as Prefix_middle_suffixRouteImport } from './routes/[_]prefix[_]middle[_]suffix'
-import { Route as LayoutRouteImport } from './routes/[_]layout'
-import { Route as AuthRouteRouteImport } from './routes/[_]auth.route'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AuthRouteRouteImport } from './routes/[_]auth.route'
+import { Route as LayoutRouteImport } from './routes/[_]layout'
+import { Route as Prefix_middle_suffixRouteImport } from './routes/[_]prefix[_]middle[_]suffix'
+import { Route as Api_v2_usersRouteImport } from './routes/api[_]v2[_]users'
+import { Route as BlogRouteImport } from './routes/blog[_]'
+import { Route as Foo_barRouteImport } from './routes/foo[_]bar'
+import { Route as Char91lazyChar93RouteImport } from './routes/[lazy]'
+import { Route as Char91routeChar93RouteImport } from './routes/[route]'
 import { Route as NestedChar91indexChar93RouteImport } from './routes/nested.[index]'
 
 const Char91indexChar93Route = Char91indexChar93RouteImport.update({
@@ -26,39 +26,9 @@ const Char91indexChar93Route = Char91indexChar93RouteImport.update({
   path: '/index',
   getParentRoute: () => rootRouteImport,
 } as any)
-const Char91routeChar93Route = Char91routeChar93RouteImport.update({
-  id: '/route',
-  path: '/route',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const Char91lazyChar93Route = Char91lazyChar93RouteImport.update({
-  id: '/lazy',
-  path: '/lazy',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const Foo_barRoute = Foo_barRouteImport.update({
-  id: '/foo_bar',
-  path: '/foo_bar',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const BlogRoute = BlogRouteImport.update({
-  id: '/blog_',
-  path: '/blog_',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const Api_v2_usersRoute = Api_v2_usersRouteImport.update({
-  id: '/api_v2_users',
-  path: '/api_v2_users',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const Prefix_middle_suffixRoute = Prefix_middle_suffixRouteImport.update({
-  id: '/_prefix_middle_suffix',
-  path: '/_prefix_middle_suffix',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const LayoutRoute = LayoutRouteImport.update({
-  id: '/_layout',
-  path: '/_layout',
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthRouteRoute = AuthRouteRouteImport.update({
@@ -66,9 +36,39 @@ const AuthRouteRoute = AuthRouteRouteImport.update({
   path: '/_auth',
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+const LayoutRoute = LayoutRouteImport.update({
+  id: '/_layout',
+  path: '/_layout',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const Prefix_middle_suffixRoute = Prefix_middle_suffixRouteImport.update({
+  id: '/_prefix_middle_suffix',
+  path: '/_prefix_middle_suffix',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const Api_v2_usersRoute = Api_v2_usersRouteImport.update({
+  id: '/api_v2_users',
+  path: '/api_v2_users',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BlogRoute = BlogRouteImport.update({
+  id: '/blog_',
+  path: '/blog_',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const Foo_barRoute = Foo_barRouteImport.update({
+  id: '/foo_bar',
+  path: '/foo_bar',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const Char91lazyChar93Route = Char91lazyChar93RouteImport.update({
+  id: '/lazy',
+  path: '/lazy',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const Char91routeChar93Route = Char91routeChar93RouteImport.update({
+  id: '/route',
+  path: '/route',
   getParentRoute: () => rootRouteImport,
 } as any)
 const NestedChar91indexChar93Route = NestedChar91indexChar93RouteImport.update({
@@ -182,53 +182,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof Char91indexChar93RouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/route': {
-      id: '/route'
-      path: '/route'
-      fullPath: '/route'
-      preLoaderRoute: typeof Char91routeChar93RouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/lazy': {
-      id: '/lazy'
-      path: '/lazy'
-      fullPath: '/lazy'
-      preLoaderRoute: typeof Char91lazyChar93RouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/foo_bar': {
-      id: '/foo_bar'
-      path: '/foo_bar'
-      fullPath: '/foo_bar'
-      preLoaderRoute: typeof Foo_barRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/blog_': {
-      id: '/blog_'
-      path: '/blog_'
-      fullPath: '/blog_'
-      preLoaderRoute: typeof BlogRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api_v2_users': {
-      id: '/api_v2_users'
-      path: '/api_v2_users'
-      fullPath: '/api_v2_users'
-      preLoaderRoute: typeof Api_v2_usersRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_prefix_middle_suffix': {
-      id: '/_prefix_middle_suffix'
-      path: '/_prefix_middle_suffix'
-      fullPath: '/_prefix_middle_suffix'
-      preLoaderRoute: typeof Prefix_middle_suffixRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_layout': {
-      id: '/_layout'
-      path: '/_layout'
-      fullPath: '/_layout'
-      preLoaderRoute: typeof LayoutRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_auth': {
@@ -238,11 +196,53 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
+    '/_layout': {
+      id: '/_layout'
+      path: '/_layout'
+      fullPath: '/_layout'
+      preLoaderRoute: typeof LayoutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_prefix_middle_suffix': {
+      id: '/_prefix_middle_suffix'
+      path: '/_prefix_middle_suffix'
+      fullPath: '/_prefix_middle_suffix'
+      preLoaderRoute: typeof Prefix_middle_suffixRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api_v2_users': {
+      id: '/api_v2_users'
+      path: '/api_v2_users'
+      fullPath: '/api_v2_users'
+      preLoaderRoute: typeof Api_v2_usersRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/blog_': {
+      id: '/blog_'
+      path: '/blog_'
+      fullPath: '/blog_'
+      preLoaderRoute: typeof BlogRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/foo_bar': {
+      id: '/foo_bar'
+      path: '/foo_bar'
+      fullPath: '/foo_bar'
+      preLoaderRoute: typeof Foo_barRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/lazy': {
+      id: '/lazy'
+      path: '/lazy'
+      fullPath: '/lazy'
+      preLoaderRoute: typeof Char91lazyChar93RouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/route': {
+      id: '/route'
+      path: '/route'
+      fullPath: '/route'
+      preLoaderRoute: typeof Char91routeChar93RouteImport
       parentRoute: typeof rootRouteImport
     }
     '/nested/index': {

--- a/packages/router-generator/tests/generator/export-variations/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/export-variations/routeTree.snapshot.ts
@@ -9,20 +9,20 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as ExportWithAsRouteImport } from './routes/export-with-as'
 import { Route as ExportSeparateFromDeclarationRouteImport } from './routes/export-separate-from-declaration'
+import { Route as ExportWithAsRouteImport } from './routes/export-with-as'
 
-const ExportWithAsRoute = ExportWithAsRouteImport.update({
-  id: '/export-with-as',
-  path: '/export-with-as',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const ExportSeparateFromDeclarationRoute =
   ExportSeparateFromDeclarationRouteImport.update({
     id: '/export-separate-from-declaration',
     path: '/export-separate-from-declaration',
     getParentRoute: () => rootRouteImport,
   } as any)
+const ExportWithAsRoute = ExportWithAsRouteImport.update({
+  id: '/export-with-as',
+  path: '/export-with-as',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/export-separate-from-declaration': typeof ExportSeparateFromDeclarationRoute
@@ -52,18 +52,18 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/export-with-as': {
-      id: '/export-with-as'
-      path: '/export-with-as'
-      fullPath: '/export-with-as'
-      preLoaderRoute: typeof ExportWithAsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/export-separate-from-declaration': {
       id: '/export-separate-from-declaration'
       path: '/export-separate-from-declaration'
       fullPath: '/export-separate-from-declaration'
       preLoaderRoute: typeof ExportSeparateFromDeclarationRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/export-with-as': {
+      id: '/export-with-as'
+      path: '/export-with-as'
+      fullPath: '/export-with-as'
+      preLoaderRoute: typeof ExportWithAsRouteImport
       parentRoute: typeof rootRouteImport
     }
   }

--- a/packages/router-generator/tests/generator/file-modification/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/file-modification/routeTree.snapshot.ts
@@ -11,12 +11,12 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as testTemplateLiteralRouteImport } from './routes/(test)/template-literal'
-import { Route as testInitiallyLazyRouteImport } from './routes/(test)/initiallyLazy'
-import { Route as testInitiallyEmptyRouteImport } from './routes/(test)/initiallyEmpty'
-import { Route as testFooRouteImport } from './routes/(test)/foo'
-import { Route as testDuplicateImportRouteImport } from './routes/(test)/duplicate-import'
 import { Route as testDoubleQuotesRouteImport } from './routes/(test)/double-quotes'
+import { Route as testDuplicateImportRouteImport } from './routes/(test)/duplicate-import'
+import { Route as testFooRouteImport } from './routes/(test)/foo'
+import { Route as testInitiallyEmptyRouteImport } from './routes/(test)/initiallyEmpty'
+import { Route as testInitiallyLazyRouteImport } from './routes/(test)/initiallyLazy'
+import { Route as testTemplateLiteralRouteImport } from './routes/(test)/template-literal'
 import { Route as testFooBarRouteImport } from './routes/(test)/foo.bar'
 
 const testBarLazyRouteImport = createFileRoute('/(test)/bar')()
@@ -28,14 +28,19 @@ const testBarLazyRoute = testBarLazyRouteImport
     getParentRoute: () => rootRouteImport,
   } as any)
   .lazy(() => import('./routes/(test)/bar.lazy').then((d) => d.Route))
-const testTemplateLiteralRoute = testTemplateLiteralRouteImport.update({
-  id: '/(test)/template-literal',
-  path: '/template-literal',
+const testDoubleQuotesRoute = testDoubleQuotesRouteImport.update({
+  id: '/(test)/double-quotes',
+  path: '/double-quotes',
   getParentRoute: () => rootRouteImport,
 } as any)
-const testInitiallyLazyRoute = testInitiallyLazyRouteImport.update({
-  id: '/(test)/initiallyLazy',
-  path: '/initiallyLazy',
+const testDuplicateImportRoute = testDuplicateImportRouteImport.update({
+  id: '/(test)/duplicate-import',
+  path: '/duplicate-import',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const testFooRoute = testFooRouteImport.update({
+  id: '/(test)/foo',
+  path: '/foo',
   getParentRoute: () => rootRouteImport,
 } as any)
 const testInitiallyEmptyRoute = testInitiallyEmptyRouteImport
@@ -47,19 +52,14 @@ const testInitiallyEmptyRoute = testInitiallyEmptyRouteImport
   .lazy(() =>
     import('./routes/(test)/initiallyEmpty.lazy').then((d) => d.Route),
   )
-const testFooRoute = testFooRouteImport.update({
-  id: '/(test)/foo',
-  path: '/foo',
+const testInitiallyLazyRoute = testInitiallyLazyRouteImport.update({
+  id: '/(test)/initiallyLazy',
+  path: '/initiallyLazy',
   getParentRoute: () => rootRouteImport,
 } as any)
-const testDuplicateImportRoute = testDuplicateImportRouteImport.update({
-  id: '/(test)/duplicate-import',
-  path: '/duplicate-import',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const testDoubleQuotesRoute = testDoubleQuotesRouteImport.update({
-  id: '/(test)/double-quotes',
-  path: '/double-quotes',
+const testTemplateLiteralRoute = testTemplateLiteralRouteImport.update({
+  id: '/(test)/template-literal',
+  path: '/template-literal',
   getParentRoute: () => rootRouteImport,
 } as any)
 const testFooBarRoute = testFooBarRouteImport.update({
@@ -151,32 +151,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof testBarLazyRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/(test)/template-literal': {
-      id: '/(test)/template-literal'
-      path: '/template-literal'
-      fullPath: '/template-literal'
-      preLoaderRoute: typeof testTemplateLiteralRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/(test)/initiallyLazy': {
-      id: '/(test)/initiallyLazy'
-      path: '/initiallyLazy'
-      fullPath: '/initiallyLazy'
-      preLoaderRoute: typeof testInitiallyLazyRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/(test)/initiallyEmpty': {
-      id: '/(test)/initiallyEmpty'
-      path: '/initiallyEmpty'
-      fullPath: '/initiallyEmpty'
-      preLoaderRoute: typeof testInitiallyEmptyRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/(test)/foo': {
-      id: '/(test)/foo'
-      path: '/foo'
-      fullPath: '/foo'
-      preLoaderRoute: typeof testFooRouteImport
+    '/(test)/double-quotes': {
+      id: '/(test)/double-quotes'
+      path: '/double-quotes'
+      fullPath: '/double-quotes'
+      preLoaderRoute: typeof testDoubleQuotesRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/(test)/duplicate-import': {
@@ -186,11 +165,32 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof testDuplicateImportRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/(test)/double-quotes': {
-      id: '/(test)/double-quotes'
-      path: '/double-quotes'
-      fullPath: '/double-quotes'
-      preLoaderRoute: typeof testDoubleQuotesRouteImport
+    '/(test)/foo': {
+      id: '/(test)/foo'
+      path: '/foo'
+      fullPath: '/foo'
+      preLoaderRoute: typeof testFooRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/(test)/initiallyEmpty': {
+      id: '/(test)/initiallyEmpty'
+      path: '/initiallyEmpty'
+      fullPath: '/initiallyEmpty'
+      preLoaderRoute: typeof testInitiallyEmptyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/(test)/initiallyLazy': {
+      id: '/(test)/initiallyLazy'
+      path: '/initiallyLazy'
+      fullPath: '/initiallyLazy'
+      preLoaderRoute: typeof testInitiallyLazyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/(test)/template-literal': {
+      id: '/(test)/template-literal'
+      path: '/template-literal'
+      fullPath: '/template-literal'
+      preLoaderRoute: typeof testTemplateLiteralRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/(test)/foo/bar': {

--- a/packages/router-generator/tests/generator/flat-route-group/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/flat-route-group/routeTree.snapshot.ts
@@ -10,8 +10,8 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as AppRouteImport } from './routes/app'
-import { Route as AppcomprasComprasOrdenesRouteImport } from './routes/app.(compras)/compras_.ordenes'
 import { Route as AppcomprasCompras_masRouteImport } from './routes/app.(compras)/compras_._mas'
+import { Route as AppcomprasComprasOrdenesRouteImport } from './routes/app.(compras)/compras_.ordenes'
 import { Route as AppcomprasCompras_masDivisionesRouteImport } from './routes/app.(compras)/compras_._mas.divisiones'
 
 const AppRoute = AppRouteImport.update({
@@ -19,17 +19,17 @@ const AppRoute = AppRouteImport.update({
   path: '/app',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AppcomprasCompras_masRoute = AppcomprasCompras_masRouteImport.update({
+  id: '/(compras)/compras_/_mas',
+  path: '/compras',
+  getParentRoute: () => AppRoute,
+} as any)
 const AppcomprasComprasOrdenesRoute =
   AppcomprasComprasOrdenesRouteImport.update({
     id: '/(compras)/compras_/ordenes',
     path: '/compras/ordenes',
     getParentRoute: () => AppRoute,
   } as any)
-const AppcomprasCompras_masRoute = AppcomprasCompras_masRouteImport.update({
-  id: '/(compras)/compras_/_mas',
-  path: '/compras',
-  getParentRoute: () => AppRoute,
-} as any)
 const AppcomprasCompras_masDivisionesRoute =
   AppcomprasCompras_masDivisionesRouteImport.update({
     id: '/divisiones',
@@ -90,18 +90,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/app/(compras)/compras_/ordenes': {
-      id: '/app/(compras)/compras_/ordenes'
-      path: '/compras/ordenes'
-      fullPath: '/app/compras/ordenes'
-      preLoaderRoute: typeof AppcomprasComprasOrdenesRouteImport
-      parentRoute: typeof AppRoute
-    }
     '/app/(compras)/compras_/_mas': {
       id: '/app/(compras)/compras_/_mas'
       path: '/compras'
       fullPath: '/app/compras'
       preLoaderRoute: typeof AppcomprasCompras_masRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/app/(compras)/compras_/ordenes': {
+      id: '/app/(compras)/compras_/ordenes'
+      path: '/compras/ordenes'
+      fullPath: '/app/compras/ordenes'
+      preLoaderRoute: typeof AppcomprasComprasOrdenesRouteImport
       parentRoute: typeof AppRoute
     }
     '/app/(compras)/compras_/_mas/divisiones': {

--- a/packages/router-generator/tests/generator/flat/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/flat/routeTree.snapshot.ts
@@ -9,23 +9,23 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as PostsRouteRouteImport } from './routes/posts.route'
-import { Route as BlogRouteRouteImport } from './routes/blog.route'
 import { Route as IndexRouteImport } from './routes/index'
-import { Route as PostsIndexRouteImport } from './routes/posts.index'
+import { Route as BlogRouteRouteImport } from './routes/blog.route'
+import { Route as PostsRouteRouteImport } from './routes/posts.route'
 import { Route as BlogIndexRouteImport } from './routes/blog.index'
-import { Route as BlogStatsRouteImport } from './routes/blog_.stats'
 import { Route as BlogBlogIdRouteRouteImport } from './routes/blog_.$blogId.route'
-import { Route as PostsPostIdIndexRouteImport } from './routes/posts.$postId.index'
+import { Route as BlogStatsRouteImport } from './routes/blog_.stats'
+import { Route as PostsIndexRouteImport } from './routes/posts.index'
 import { Route as BlogSlugIndexRouteImport } from './routes/blog.$slug.index'
-import { Route as PostsPostIdDeepRouteImport } from './routes/posts.$postId.deep'
-import { Route as BlogBlogIdEditRouteImport } from './routes/blog_.$blogId_.edit'
 import { Route as BlogBlogIdSlugRouteRouteImport } from './routes/blog_.$blogId.$slug.route'
+import { Route as BlogBlogIdEditRouteImport } from './routes/blog_.$blogId_.edit'
+import { Route as PostsPostIdIndexRouteImport } from './routes/posts.$postId.index'
+import { Route as PostsPostIdDeepRouteImport } from './routes/posts.$postId.deep'
 import { Route as BlogBlogIdSlugBarRouteImport } from './routes/blog_.$blogId.$slug_.bar'
 
-const PostsRouteRoute = PostsRouteRouteImport.update({
-  id: '/posts',
-  path: '/posts',
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const BlogRouteRoute = BlogRouteRouteImport.update({
@@ -33,9 +33,24 @@ const BlogRouteRoute = BlogRouteRouteImport.update({
   path: '/blog',
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRoute = IndexRouteImport.update({
+const PostsRouteRoute = PostsRouteRouteImport.update({
+  id: '/posts',
+  path: '/posts',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BlogIndexRoute = BlogIndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => BlogRouteRoute,
+} as any)
+const BlogBlogIdRouteRoute = BlogBlogIdRouteRouteImport.update({
+  id: '/blog_/$blogId',
+  path: '/blog/$blogId',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BlogStatsRoute = BlogStatsRouteImport.update({
+  id: '/blog_/stats',
+  path: '/blog/stats',
   getParentRoute: () => rootRouteImport,
 } as any)
 const PostsIndexRoute = PostsIndexRouteImport.update({
@@ -43,19 +58,19 @@ const PostsIndexRoute = PostsIndexRouteImport.update({
   path: '/',
   getParentRoute: () => PostsRouteRoute,
 } as any)
-const BlogIndexRoute = BlogIndexRouteImport.update({
-  id: '/',
-  path: '/',
+const BlogSlugIndexRoute = BlogSlugIndexRouteImport.update({
+  id: '/$slug/',
+  path: '/$slug/',
   getParentRoute: () => BlogRouteRoute,
 } as any)
-const BlogStatsRoute = BlogStatsRouteImport.update({
-  id: '/blog_/stats',
-  path: '/blog/stats',
-  getParentRoute: () => rootRouteImport,
+const BlogBlogIdSlugRouteRoute = BlogBlogIdSlugRouteRouteImport.update({
+  id: '/$slug',
+  path: '/$slug',
+  getParentRoute: () => BlogBlogIdRouteRoute,
 } as any)
-const BlogBlogIdRouteRoute = BlogBlogIdRouteRouteImport.update({
-  id: '/blog_/$blogId',
-  path: '/blog/$blogId',
+const BlogBlogIdEditRoute = BlogBlogIdEditRouteImport.update({
+  id: '/blog_/$blogId_/edit',
+  path: '/blog/$blogId/edit',
   getParentRoute: () => rootRouteImport,
 } as any)
 const PostsPostIdIndexRoute = PostsPostIdIndexRouteImport.update({
@@ -63,25 +78,10 @@ const PostsPostIdIndexRoute = PostsPostIdIndexRouteImport.update({
   path: '/$postId/',
   getParentRoute: () => PostsRouteRoute,
 } as any)
-const BlogSlugIndexRoute = BlogSlugIndexRouteImport.update({
-  id: '/$slug/',
-  path: '/$slug/',
-  getParentRoute: () => BlogRouteRoute,
-} as any)
 const PostsPostIdDeepRoute = PostsPostIdDeepRouteImport.update({
   id: '/$postId/deep',
   path: '/$postId/deep',
   getParentRoute: () => PostsRouteRoute,
-} as any)
-const BlogBlogIdEditRoute = BlogBlogIdEditRouteImport.update({
-  id: '/blog_/$blogId_/edit',
-  path: '/blog/$blogId/edit',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const BlogBlogIdSlugRouteRoute = BlogBlogIdSlugRouteRouteImport.update({
-  id: '/$slug',
-  path: '/$slug',
-  getParentRoute: () => BlogBlogIdRouteRoute,
 } as any)
 const BlogBlogIdSlugBarRoute = BlogBlogIdSlugBarRouteImport.update({
   id: '/$slug_/bar',
@@ -190,11 +190,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/posts': {
-      id: '/posts'
-      path: '/posts'
-      fullPath: '/posts'
-      preLoaderRoute: typeof PostsRouteRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/blog': {
@@ -204,11 +204,32 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof BlogRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
+    '/posts': {
+      id: '/posts'
+      path: '/posts'
+      fullPath: '/posts'
+      preLoaderRoute: typeof PostsRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/blog/': {
+      id: '/blog/'
       path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
+      fullPath: '/blog/'
+      preLoaderRoute: typeof BlogIndexRouteImport
+      parentRoute: typeof BlogRouteRoute
+    }
+    '/blog_/$blogId': {
+      id: '/blog_/$blogId'
+      path: '/blog/$blogId'
+      fullPath: '/blog/$blogId'
+      preLoaderRoute: typeof BlogBlogIdRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/blog_/stats': {
+      id: '/blog_/stats'
+      path: '/blog/stats'
+      fullPath: '/blog/stats'
+      preLoaderRoute: typeof BlogStatsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/posts/': {
@@ -218,25 +239,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PostsIndexRouteImport
       parentRoute: typeof PostsRouteRoute
     }
-    '/blog/': {
-      id: '/blog/'
-      path: '/'
-      fullPath: '/blog/'
-      preLoaderRoute: typeof BlogIndexRouteImport
+    '/blog/$slug/': {
+      id: '/blog/$slug/'
+      path: '/$slug'
+      fullPath: '/blog/$slug/'
+      preLoaderRoute: typeof BlogSlugIndexRouteImport
       parentRoute: typeof BlogRouteRoute
     }
-    '/blog_/stats': {
-      id: '/blog_/stats'
-      path: '/blog/stats'
-      fullPath: '/blog/stats'
-      preLoaderRoute: typeof BlogStatsRouteImport
-      parentRoute: typeof rootRouteImport
+    '/blog_/$blogId/$slug': {
+      id: '/blog_/$blogId/$slug'
+      path: '/$slug'
+      fullPath: '/blog/$blogId/$slug'
+      preLoaderRoute: typeof BlogBlogIdSlugRouteRouteImport
+      parentRoute: typeof BlogBlogIdRouteRoute
     }
-    '/blog_/$blogId': {
-      id: '/blog_/$blogId'
-      path: '/blog/$blogId'
-      fullPath: '/blog/$blogId'
-      preLoaderRoute: typeof BlogBlogIdRouteRouteImport
+    '/blog_/$blogId_/edit': {
+      id: '/blog_/$blogId_/edit'
+      path: '/blog/$blogId/edit'
+      fullPath: '/blog/$blogId/edit'
+      preLoaderRoute: typeof BlogBlogIdEditRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/posts/$postId/': {
@@ -246,33 +267,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PostsPostIdIndexRouteImport
       parentRoute: typeof PostsRouteRoute
     }
-    '/blog/$slug/': {
-      id: '/blog/$slug/'
-      path: '/$slug'
-      fullPath: '/blog/$slug/'
-      preLoaderRoute: typeof BlogSlugIndexRouteImport
-      parentRoute: typeof BlogRouteRoute
-    }
     '/posts/$postId/deep': {
       id: '/posts/$postId/deep'
       path: '/$postId/deep'
       fullPath: '/posts/$postId/deep'
       preLoaderRoute: typeof PostsPostIdDeepRouteImport
       parentRoute: typeof PostsRouteRoute
-    }
-    '/blog_/$blogId_/edit': {
-      id: '/blog_/$blogId_/edit'
-      path: '/blog/$blogId/edit'
-      fullPath: '/blog/$blogId/edit'
-      preLoaderRoute: typeof BlogBlogIdEditRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/blog_/$blogId/$slug': {
-      id: '/blog_/$blogId/$slug'
-      path: '/$slug'
-      fullPath: '/blog/$blogId/$slug'
-      preLoaderRoute: typeof BlogBlogIdSlugRouteRouteImport
-      parentRoute: typeof BlogBlogIdRouteRoute
     }
     '/blog_/$blogId/$slug_/bar': {
       id: '/blog_/$blogId/$slug_/bar'

--- a/packages/router-generator/tests/generator/invalid-param-names/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/invalid-param-names/routeTree.snapshot.ts
@@ -9,13 +9,13 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as ValidParamRouteImport } from './routes/$validParam'
-import { Route as UserNameRouteImport } from './routes/$user-name'
 import { Route as R123RouteImport } from './routes/$123'
+import { Route as UserNameRouteImport } from './routes/$user-name'
+import { Route as ValidParamRouteImport } from './routes/$validParam'
 
-const ValidParamRoute = ValidParamRouteImport.update({
-  id: '/$validParam',
-  path: '/$validParam',
+const R123Route = R123RouteImport.update({
+  id: '/$123',
+  path: '/$123',
   getParentRoute: () => rootRouteImport,
 } as any)
 const UserNameRoute = UserNameRouteImport.update({
@@ -23,9 +23,9 @@ const UserNameRoute = UserNameRouteImport.update({
   path: '/$user-name',
   getParentRoute: () => rootRouteImport,
 } as any)
-const R123Route = R123RouteImport.update({
-  id: '/$123',
-  path: '/$123',
+const ValidParamRoute = ValidParamRouteImport.update({
+  id: '/$validParam',
+  path: '/$validParam',
   getParentRoute: () => rootRouteImport,
 } as any)
 
@@ -61,11 +61,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/$validParam': {
-      id: '/$validParam'
-      path: '/$validParam'
-      fullPath: '/$validParam'
-      preLoaderRoute: typeof ValidParamRouteImport
+    '/$123': {
+      id: '/$123'
+      path: '/$123'
+      fullPath: '/$123'
+      preLoaderRoute: typeof R123RouteImport
       parentRoute: typeof rootRouteImport
     }
     '/$user-name': {
@@ -75,11 +75,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof UserNameRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/$123': {
-      id: '/$123'
-      path: '/$123'
-      fullPath: '/$123'
-      preLoaderRoute: typeof R123RouteImport
+    '/$validParam': {
+      id: '/$validParam'
+      path: '/$validParam'
+      fullPath: '/$validParam'
+      preLoaderRoute: typeof ValidParamRouteImport
       parentRoute: typeof rootRouteImport
     }
   }

--- a/packages/router-generator/tests/generator/nested-layouts/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/nested-layouts/routeTree.snapshot.ts
@@ -9,36 +9,41 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as LayoutA2RouteImport } from './routes/_layout-a2'
-import { Route as LayoutA1RouteImport } from './routes/_layout-a1'
-import { Route as JestedRouteRouteImport } from './routes/jested/route'
 import { Route as IndexRouteImport } from './routes/index'
-import { Route as NestedLayoutB2RouteImport } from './routes/nested/_layout-b2'
-import { Route as NestedLayoutB1RouteImport } from './routes/nested/_layout-b1'
-import { Route as JestedLayoutB4RouteImport } from './routes/jested/_layout-b4'
-import { Route as JestedLayoutB3RouteImport } from './routes/jested/_layout-b3'
-import { Route as FooBarRouteImport } from './routes/foo/bar'
-import { Route as LayoutA2BarRouteImport } from './routes/_layout-a2/bar'
-import { Route as LayoutA1FooRouteImport } from './routes/_layout-a1/foo'
+import { Route as LayoutA1RouteImport } from './routes/_layout-a1'
+import { Route as LayoutA2RouteImport } from './routes/_layout-a2'
+import { Route as JestedRouteRouteImport } from './routes/jested/route'
 import { Route as folderInFolderRouteImport } from './routes/(folder)/in-folder'
+import { Route as LayoutA1FooRouteImport } from './routes/_layout-a1/foo'
+import { Route as LayoutA2BarRouteImport } from './routes/_layout-a2/bar'
 import { Route as FooLayoutB5RouteRouteImport } from './routes/foo/_layout-b5/route'
-import { Route as NestedLayoutB1IndexRouteImport } from './routes/nested/_layout-b1/index'
-import { Route as JestedLayoutB3IndexRouteImport } from './routes/jested/_layout-b3/index'
+import { Route as FooBarRouteImport } from './routes/foo/bar'
+import { Route as JestedLayoutB3RouteImport } from './routes/jested/_layout-b3'
+import { Route as JestedLayoutB4RouteImport } from './routes/jested/_layout-b4'
+import { Route as NestedLayoutB1RouteImport } from './routes/nested/_layout-b1'
+import { Route as NestedLayoutB2RouteImport } from './routes/nested/_layout-b2'
 import { Route as FooLayoutB5IndexRouteImport } from './routes/foo/_layout-b5/index'
-import { Route as NestedLayoutB2FooRouteImport } from './routes/nested/_layout-b2/foo'
-import { Route as NestedLayoutB1LayoutC1RouteImport } from './routes/nested/_layout-b1/_layout-c1'
-import { Route as JestedLayoutB4FooRouteImport } from './routes/jested/_layout-b4/foo'
-import { Route as JestedLayoutB3LayoutC2RouteImport } from './routes/jested/_layout-b3/_layout-c2'
 import { Route as FooLayoutB5IdRouteImport } from './routes/foo/_layout-b5/$id'
-import { Route as NestedLayoutB1LayoutC1BarRouteImport } from './routes/nested/_layout-b1/_layout-c1/bar'
+import { Route as JestedLayoutB3IndexRouteImport } from './routes/jested/_layout-b3/index'
+import { Route as JestedLayoutB3LayoutC2RouteImport } from './routes/jested/_layout-b3/_layout-c2'
+import { Route as JestedLayoutB4FooRouteImport } from './routes/jested/_layout-b4/foo'
+import { Route as NestedLayoutB1IndexRouteImport } from './routes/nested/_layout-b1/index'
+import { Route as NestedLayoutB1LayoutC1RouteImport } from './routes/nested/_layout-b1/_layout-c1'
+import { Route as NestedLayoutB2FooRouteImport } from './routes/nested/_layout-b2/foo'
 import { Route as JestedLayoutB3LayoutC2BarRouteImport } from './routes/jested/_layout-b3/_layout-c2/bar'
+import { Route as NestedLayoutB1LayoutC1BarRouteImport } from './routes/nested/_layout-b1/_layout-c1/bar'
 
-const LayoutA2Route = LayoutA2RouteImport.update({
-  id: '/_layout-a2',
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LayoutA1Route = LayoutA1RouteImport.update({
   id: '/_layout-a1',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LayoutA2Route = LayoutA2RouteImport.update({
+  id: '/_layout-a2',
   getParentRoute: () => rootRouteImport,
 } as any)
 const JestedRouteRoute = JestedRouteRouteImport.update({
@@ -46,9 +51,42 @@ const JestedRouteRoute = JestedRouteRouteImport.update({
   path: '/jested',
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+const folderInFolderRoute = folderInFolderRouteImport.update({
+  id: '/(folder)/in-folder',
+  path: '/in-folder',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LayoutA1FooRoute = LayoutA1FooRouteImport.update({
+  id: '/foo',
+  path: '/foo',
+  getParentRoute: () => LayoutA1Route,
+} as any)
+const LayoutA2BarRoute = LayoutA2BarRouteImport.update({
+  id: '/bar',
+  path: '/bar',
+  getParentRoute: () => LayoutA2Route,
+} as any)
+const FooLayoutB5RouteRoute = FooLayoutB5RouteRouteImport.update({
+  id: '/foo/_layout-b5',
+  path: '/foo',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const FooBarRoute = FooBarRouteImport.update({
+  id: '/foo/bar',
+  path: '/foo/bar',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const JestedLayoutB3Route = JestedLayoutB3RouteImport.update({
+  id: '/_layout-b3',
+  getParentRoute: () => JestedRouteRoute,
+} as any)
+const JestedLayoutB4Route = JestedLayoutB4RouteImport.update({
+  id: '/_layout-b4',
+  getParentRoute: () => JestedRouteRoute,
+} as any)
+const NestedLayoutB1Route = NestedLayoutB1RouteImport.update({
+  id: '/nested/_layout-b1',
+  path: '/nested',
   getParentRoute: () => rootRouteImport,
 } as any)
 const NestedLayoutB2Route = NestedLayoutB2RouteImport.update({
@@ -56,93 +94,55 @@ const NestedLayoutB2Route = NestedLayoutB2RouteImport.update({
   path: '/nested',
   getParentRoute: () => rootRouteImport,
 } as any)
-const NestedLayoutB1Route = NestedLayoutB1RouteImport.update({
-  id: '/nested/_layout-b1',
-  path: '/nested',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const JestedLayoutB4Route = JestedLayoutB4RouteImport.update({
-  id: '/_layout-b4',
-  getParentRoute: () => JestedRouteRoute,
-} as any)
-const JestedLayoutB3Route = JestedLayoutB3RouteImport.update({
-  id: '/_layout-b3',
-  getParentRoute: () => JestedRouteRoute,
-} as any)
-const FooBarRoute = FooBarRouteImport.update({
-  id: '/foo/bar',
-  path: '/foo/bar',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const LayoutA2BarRoute = LayoutA2BarRouteImport.update({
-  id: '/bar',
-  path: '/bar',
-  getParentRoute: () => LayoutA2Route,
-} as any)
-const LayoutA1FooRoute = LayoutA1FooRouteImport.update({
-  id: '/foo',
-  path: '/foo',
-  getParentRoute: () => LayoutA1Route,
-} as any)
-const folderInFolderRoute = folderInFolderRouteImport.update({
-  id: '/(folder)/in-folder',
-  path: '/in-folder',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const FooLayoutB5RouteRoute = FooLayoutB5RouteRouteImport.update({
-  id: '/foo/_layout-b5',
-  path: '/foo',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const NestedLayoutB1IndexRoute = NestedLayoutB1IndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => NestedLayoutB1Route,
-} as any)
-const JestedLayoutB3IndexRoute = JestedLayoutB3IndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => JestedLayoutB3Route,
-} as any)
 const FooLayoutB5IndexRoute = FooLayoutB5IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => FooLayoutB5RouteRoute,
-} as any)
-const NestedLayoutB2FooRoute = NestedLayoutB2FooRouteImport.update({
-  id: '/foo',
-  path: '/foo',
-  getParentRoute: () => NestedLayoutB2Route,
-} as any)
-const NestedLayoutB1LayoutC1Route = NestedLayoutB1LayoutC1RouteImport.update({
-  id: '/_layout-c1',
-  getParentRoute: () => NestedLayoutB1Route,
-} as any)
-const JestedLayoutB4FooRoute = JestedLayoutB4FooRouteImport.update({
-  id: '/foo',
-  path: '/foo',
-  getParentRoute: () => JestedLayoutB4Route,
-} as any)
-const JestedLayoutB3LayoutC2Route = JestedLayoutB3LayoutC2RouteImport.update({
-  id: '/_layout-c2',
-  getParentRoute: () => JestedLayoutB3Route,
 } as any)
 const FooLayoutB5IdRoute = FooLayoutB5IdRouteImport.update({
   id: '/$id',
   path: '/$id',
   getParentRoute: () => FooLayoutB5RouteRoute,
 } as any)
-const NestedLayoutB1LayoutC1BarRoute =
-  NestedLayoutB1LayoutC1BarRouteImport.update({
-    id: '/bar',
-    path: '/bar',
-    getParentRoute: () => NestedLayoutB1LayoutC1Route,
-  } as any)
+const JestedLayoutB3IndexRoute = JestedLayoutB3IndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => JestedLayoutB3Route,
+} as any)
+const JestedLayoutB3LayoutC2Route = JestedLayoutB3LayoutC2RouteImport.update({
+  id: '/_layout-c2',
+  getParentRoute: () => JestedLayoutB3Route,
+} as any)
+const JestedLayoutB4FooRoute = JestedLayoutB4FooRouteImport.update({
+  id: '/foo',
+  path: '/foo',
+  getParentRoute: () => JestedLayoutB4Route,
+} as any)
+const NestedLayoutB1IndexRoute = NestedLayoutB1IndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => NestedLayoutB1Route,
+} as any)
+const NestedLayoutB1LayoutC1Route = NestedLayoutB1LayoutC1RouteImport.update({
+  id: '/_layout-c1',
+  getParentRoute: () => NestedLayoutB1Route,
+} as any)
+const NestedLayoutB2FooRoute = NestedLayoutB2FooRouteImport.update({
+  id: '/foo',
+  path: '/foo',
+  getParentRoute: () => NestedLayoutB2Route,
+} as any)
 const JestedLayoutB3LayoutC2BarRoute =
   JestedLayoutB3LayoutC2BarRouteImport.update({
     id: '/bar',
     path: '/bar',
     getParentRoute: () => JestedLayoutB3LayoutC2Route,
+  } as any)
+const NestedLayoutB1LayoutC1BarRoute =
+  NestedLayoutB1LayoutC1BarRouteImport.update({
+    id: '/bar',
+    path: '/bar',
+    getParentRoute: () => NestedLayoutB1LayoutC1Route,
   } as any)
 
 export interface FileRoutesByFullPath {
@@ -275,11 +275,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/_layout-a2': {
-      id: '/_layout-a2'
-      path: ''
+    '/': {
+      id: '/'
+      path: '/'
       fullPath: '/'
-      preLoaderRoute: typeof LayoutA2RouteImport
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_layout-a1': {
@@ -289,6 +289,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutA1RouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_layout-a2': {
+      id: '/_layout-a2'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof LayoutA2RouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/jested': {
       id: '/jested'
       path: '/jested'
@@ -296,11 +303,60 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof JestedRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
+    '/(folder)/in-folder': {
+      id: '/(folder)/in-folder'
+      path: '/in-folder'
+      fullPath: '/in-folder'
+      preLoaderRoute: typeof folderInFolderRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_layout-a1/foo': {
+      id: '/_layout-a1/foo'
+      path: '/foo'
+      fullPath: '/foo'
+      preLoaderRoute: typeof LayoutA1FooRouteImport
+      parentRoute: typeof LayoutA1Route
+    }
+    '/_layout-a2/bar': {
+      id: '/_layout-a2/bar'
+      path: '/bar'
+      fullPath: '/bar'
+      preLoaderRoute: typeof LayoutA2BarRouteImport
+      parentRoute: typeof LayoutA2Route
+    }
+    '/foo/_layout-b5': {
+      id: '/foo/_layout-b5'
+      path: '/foo'
+      fullPath: '/foo'
+      preLoaderRoute: typeof FooLayoutB5RouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/foo/bar': {
+      id: '/foo/bar'
+      path: '/foo/bar'
+      fullPath: '/foo/bar'
+      preLoaderRoute: typeof FooBarRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/jested/_layout-b3': {
+      id: '/jested/_layout-b3'
+      path: ''
+      fullPath: '/jested'
+      preLoaderRoute: typeof JestedLayoutB3RouteImport
+      parentRoute: typeof JestedRouteRoute
+    }
+    '/jested/_layout-b4': {
+      id: '/jested/_layout-b4'
+      path: ''
+      fullPath: '/jested'
+      preLoaderRoute: typeof JestedLayoutB4RouteImport
+      parentRoute: typeof JestedRouteRoute
+    }
+    '/nested/_layout-b1': {
+      id: '/nested/_layout-b1'
+      path: '/nested'
+      fullPath: '/nested'
+      preLoaderRoute: typeof NestedLayoutB1RouteImport
       parentRoute: typeof rootRouteImport
     }
     '/nested/_layout-b2': {
@@ -310,110 +366,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof NestedLayoutB2RouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/nested/_layout-b1': {
-      id: '/nested/_layout-b1'
-      path: '/nested'
-      fullPath: '/nested'
-      preLoaderRoute: typeof NestedLayoutB1RouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/jested/_layout-b4': {
-      id: '/jested/_layout-b4'
-      path: ''
-      fullPath: '/jested'
-      preLoaderRoute: typeof JestedLayoutB4RouteImport
-      parentRoute: typeof JestedRouteRoute
-    }
-    '/jested/_layout-b3': {
-      id: '/jested/_layout-b3'
-      path: ''
-      fullPath: '/jested'
-      preLoaderRoute: typeof JestedLayoutB3RouteImport
-      parentRoute: typeof JestedRouteRoute
-    }
-    '/foo/bar': {
-      id: '/foo/bar'
-      path: '/foo/bar'
-      fullPath: '/foo/bar'
-      preLoaderRoute: typeof FooBarRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_layout-a2/bar': {
-      id: '/_layout-a2/bar'
-      path: '/bar'
-      fullPath: '/bar'
-      preLoaderRoute: typeof LayoutA2BarRouteImport
-      parentRoute: typeof LayoutA2Route
-    }
-    '/_layout-a1/foo': {
-      id: '/_layout-a1/foo'
-      path: '/foo'
-      fullPath: '/foo'
-      preLoaderRoute: typeof LayoutA1FooRouteImport
-      parentRoute: typeof LayoutA1Route
-    }
-    '/(folder)/in-folder': {
-      id: '/(folder)/in-folder'
-      path: '/in-folder'
-      fullPath: '/in-folder'
-      preLoaderRoute: typeof folderInFolderRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/foo/_layout-b5': {
-      id: '/foo/_layout-b5'
-      path: '/foo'
-      fullPath: '/foo'
-      preLoaderRoute: typeof FooLayoutB5RouteRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/nested/_layout-b1/': {
-      id: '/nested/_layout-b1/'
-      path: '/'
-      fullPath: '/nested/'
-      preLoaderRoute: typeof NestedLayoutB1IndexRouteImport
-      parentRoute: typeof NestedLayoutB1Route
-    }
-    '/jested/_layout-b3/': {
-      id: '/jested/_layout-b3/'
-      path: '/'
-      fullPath: '/jested/'
-      preLoaderRoute: typeof JestedLayoutB3IndexRouteImport
-      parentRoute: typeof JestedLayoutB3Route
-    }
     '/foo/_layout-b5/': {
       id: '/foo/_layout-b5/'
       path: '/'
       fullPath: '/foo/'
       preLoaderRoute: typeof FooLayoutB5IndexRouteImport
       parentRoute: typeof FooLayoutB5RouteRoute
-    }
-    '/nested/_layout-b2/foo': {
-      id: '/nested/_layout-b2/foo'
-      path: '/foo'
-      fullPath: '/nested/foo'
-      preLoaderRoute: typeof NestedLayoutB2FooRouteImport
-      parentRoute: typeof NestedLayoutB2Route
-    }
-    '/nested/_layout-b1/_layout-c1': {
-      id: '/nested/_layout-b1/_layout-c1'
-      path: ''
-      fullPath: '/nested'
-      preLoaderRoute: typeof NestedLayoutB1LayoutC1RouteImport
-      parentRoute: typeof NestedLayoutB1Route
-    }
-    '/jested/_layout-b4/foo': {
-      id: '/jested/_layout-b4/foo'
-      path: '/foo'
-      fullPath: '/jested/foo'
-      preLoaderRoute: typeof JestedLayoutB4FooRouteImport
-      parentRoute: typeof JestedLayoutB4Route
-    }
-    '/jested/_layout-b3/_layout-c2': {
-      id: '/jested/_layout-b3/_layout-c2'
-      path: ''
-      fullPath: '/jested'
-      preLoaderRoute: typeof JestedLayoutB3LayoutC2RouteImport
-      parentRoute: typeof JestedLayoutB3Route
     }
     '/foo/_layout-b5/$id': {
       id: '/foo/_layout-b5/$id'
@@ -422,12 +380,47 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof FooLayoutB5IdRouteImport
       parentRoute: typeof FooLayoutB5RouteRoute
     }
-    '/nested/_layout-b1/_layout-c1/bar': {
-      id: '/nested/_layout-b1/_layout-c1/bar'
-      path: '/bar'
-      fullPath: '/nested/bar'
-      preLoaderRoute: typeof NestedLayoutB1LayoutC1BarRouteImport
-      parentRoute: typeof NestedLayoutB1LayoutC1Route
+    '/jested/_layout-b3/': {
+      id: '/jested/_layout-b3/'
+      path: '/'
+      fullPath: '/jested/'
+      preLoaderRoute: typeof JestedLayoutB3IndexRouteImport
+      parentRoute: typeof JestedLayoutB3Route
+    }
+    '/jested/_layout-b3/_layout-c2': {
+      id: '/jested/_layout-b3/_layout-c2'
+      path: ''
+      fullPath: '/jested'
+      preLoaderRoute: typeof JestedLayoutB3LayoutC2RouteImport
+      parentRoute: typeof JestedLayoutB3Route
+    }
+    '/jested/_layout-b4/foo': {
+      id: '/jested/_layout-b4/foo'
+      path: '/foo'
+      fullPath: '/jested/foo'
+      preLoaderRoute: typeof JestedLayoutB4FooRouteImport
+      parentRoute: typeof JestedLayoutB4Route
+    }
+    '/nested/_layout-b1/': {
+      id: '/nested/_layout-b1/'
+      path: '/'
+      fullPath: '/nested/'
+      preLoaderRoute: typeof NestedLayoutB1IndexRouteImport
+      parentRoute: typeof NestedLayoutB1Route
+    }
+    '/nested/_layout-b1/_layout-c1': {
+      id: '/nested/_layout-b1/_layout-c1'
+      path: ''
+      fullPath: '/nested'
+      preLoaderRoute: typeof NestedLayoutB1LayoutC1RouteImport
+      parentRoute: typeof NestedLayoutB1Route
+    }
+    '/nested/_layout-b2/foo': {
+      id: '/nested/_layout-b2/foo'
+      path: '/foo'
+      fullPath: '/nested/foo'
+      preLoaderRoute: typeof NestedLayoutB2FooRouteImport
+      parentRoute: typeof NestedLayoutB2Route
     }
     '/jested/_layout-b3/_layout-c2/bar': {
       id: '/jested/_layout-b3/_layout-c2/bar'
@@ -435,6 +428,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/jested/bar'
       preLoaderRoute: typeof JestedLayoutB3LayoutC2BarRouteImport
       parentRoute: typeof JestedLayoutB3LayoutC2Route
+    }
+    '/nested/_layout-b1/_layout-c1/bar': {
+      id: '/nested/_layout-b1/_layout-c1/bar'
+      path: '/bar'
+      fullPath: '/nested/bar'
+      preLoaderRoute: typeof NestedLayoutB1LayoutC1BarRouteImport
+      parentRoute: typeof NestedLayoutB1LayoutC1Route
     }
   }
 }

--- a/packages/router-generator/tests/generator/nested-route-groups-with-layouts-before-physical/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/nested-route-groups-with-layouts-before-physical/routeTree.snapshot.ts
@@ -9,45 +9,45 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as groupCLayoutCRouteImport } from './routes/(group-c)/_layout-c'
-import { Route as groupBLayoutBRouteImport } from './routes/(group-b)/_layout-b'
 import { Route as groupALayoutARouteImport } from './routes/(group-a)/_layout-a'
-import { Route as groupCLayoutCIndexRouteImport } from './routes/(group-c)/_layout-c/index'
-import { Route as groupBLayoutBDashboardRouteImport } from './routes/(group-b)/_layout-b/dashboard'
-import { Route as groupALayoutASignupRouteImport } from './routes/(group-a)/_layout-a/signup'
+import { Route as groupBLayoutBRouteImport } from './routes/(group-b)/_layout-b'
+import { Route as groupCLayoutCRouteImport } from './routes/(group-c)/_layout-c'
 import { Route as groupALayoutALoginRouteImport } from './routes/(group-a)/_layout-a/login'
+import { Route as groupALayoutASignupRouteImport } from './routes/(group-a)/_layout-a/signup'
+import { Route as groupBLayoutBDashboardRouteImport } from './routes/(group-b)/_layout-b/dashboard'
+import { Route as groupCLayoutCIndexRouteImport } from './routes/(group-c)/_layout-c/index'
 
-const groupCLayoutCRoute = groupCLayoutCRouteImport.update({
-  id: '/(group-c)/_layout-c',
+const groupALayoutARoute = groupALayoutARouteImport.update({
+  id: '/(group-a)/_layout-a',
   getParentRoute: () => rootRouteImport,
 } as any)
 const groupBLayoutBRoute = groupBLayoutBRouteImport.update({
   id: '/(group-b)/_layout-b',
   getParentRoute: () => rootRouteImport,
 } as any)
-const groupALayoutARoute = groupALayoutARouteImport.update({
-  id: '/(group-a)/_layout-a',
+const groupCLayoutCRoute = groupCLayoutCRouteImport.update({
+  id: '/(group-c)/_layout-c',
   getParentRoute: () => rootRouteImport,
 } as any)
-const groupCLayoutCIndexRoute = groupCLayoutCIndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => groupCLayoutCRoute,
-} as any)
-const groupBLayoutBDashboardRoute = groupBLayoutBDashboardRouteImport.update({
-  id: '/dashboard',
-  path: '/dashboard',
-  getParentRoute: () => groupBLayoutBRoute,
+const groupALayoutALoginRoute = groupALayoutALoginRouteImport.update({
+  id: '/login',
+  path: '/login',
+  getParentRoute: () => groupALayoutARoute,
 } as any)
 const groupALayoutASignupRoute = groupALayoutASignupRouteImport.update({
   id: '/signup',
   path: '/signup',
   getParentRoute: () => groupALayoutARoute,
 } as any)
-const groupALayoutALoginRoute = groupALayoutALoginRouteImport.update({
-  id: '/login',
-  path: '/login',
-  getParentRoute: () => groupALayoutARoute,
+const groupBLayoutBDashboardRoute = groupBLayoutBDashboardRouteImport.update({
+  id: '/dashboard',
+  path: '/dashboard',
+  getParentRoute: () => groupBLayoutBRoute,
+} as any)
+const groupCLayoutCIndexRoute = groupCLayoutCIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => groupCLayoutCRoute,
 } as any)
 
 export interface FileRoutesByFullPath {
@@ -96,11 +96,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/(group-c)/_layout-c': {
-      id: '/(group-c)/_layout-c'
+    '/(group-a)/_layout-a': {
+      id: '/(group-a)/_layout-a'
       path: ''
       fullPath: ''
-      preLoaderRoute: typeof groupCLayoutCRouteImport
+      preLoaderRoute: typeof groupALayoutARouteImport
       parentRoute: typeof rootRouteImport
     }
     '/(group-b)/_layout-b': {
@@ -110,26 +110,19 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof groupBLayoutBRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/(group-a)/_layout-a': {
-      id: '/(group-a)/_layout-a'
+    '/(group-c)/_layout-c': {
+      id: '/(group-c)/_layout-c'
       path: ''
       fullPath: ''
-      preLoaderRoute: typeof groupALayoutARouteImport
+      preLoaderRoute: typeof groupCLayoutCRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/(group-c)/_layout-c/': {
-      id: '/(group-c)/_layout-c/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof groupCLayoutCIndexRouteImport
-      parentRoute: typeof groupCLayoutCRoute
-    }
-    '/(group-b)/_layout-b/dashboard': {
-      id: '/(group-b)/_layout-b/dashboard'
-      path: '/dashboard'
-      fullPath: '/dashboard'
-      preLoaderRoute: typeof groupBLayoutBDashboardRouteImport
-      parentRoute: typeof groupBLayoutBRoute
+    '/(group-a)/_layout-a/login': {
+      id: '/(group-a)/_layout-a/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof groupALayoutALoginRouteImport
+      parentRoute: typeof groupALayoutARoute
     }
     '/(group-a)/_layout-a/signup': {
       id: '/(group-a)/_layout-a/signup'
@@ -138,12 +131,19 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof groupALayoutASignupRouteImport
       parentRoute: typeof groupALayoutARoute
     }
-    '/(group-a)/_layout-a/login': {
-      id: '/(group-a)/_layout-a/login'
-      path: '/login'
-      fullPath: '/login'
-      preLoaderRoute: typeof groupALayoutALoginRouteImport
-      parentRoute: typeof groupALayoutARoute
+    '/(group-b)/_layout-b/dashboard': {
+      id: '/(group-b)/_layout-b/dashboard'
+      path: '/dashboard'
+      fullPath: '/dashboard'
+      preLoaderRoute: typeof groupBLayoutBDashboardRouteImport
+      parentRoute: typeof groupBLayoutBRoute
+    }
+    '/(group-c)/_layout-c/': {
+      id: '/(group-c)/_layout-c/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof groupCLayoutCIndexRouteImport
+      parentRoute: typeof groupCLayoutCRoute
     }
   }
 }

--- a/packages/router-generator/tests/generator/nested/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/nested/routeTree.snapshot.ts
@@ -9,29 +9,29 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as PathlessLayoutRouteImport } from './routes/_pathlessLayout'
-import { Route as PostsRouteRouteImport } from './routes/posts/route'
-import { Route as BlogRouteRouteImport } from './routes/blog/route'
 import { Route as IndexRouteImport } from './routes/index'
-import { Route as PostsIndexRouteImport } from './routes/posts/index'
-import { Route as BlogIndexRouteImport } from './routes/blog/index'
-import { Route as BlogStatsRouteImport } from './routes/blog_/stats'
-import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
+import { Route as PathlessLayoutRouteImport } from './routes/_pathlessLayout'
+import { Route as BlogRouteRouteImport } from './routes/blog/route'
+import { Route as PostsRouteRouteImport } from './routes/posts/route'
 import { Route as PathlessLayoutSettingsRouteImport } from './routes/_pathlessLayout/settings'
+import { Route as BlogIndexRouteImport } from './routes/blog/index'
+import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
 import { Route as BlogBlogIdRouteRouteImport } from './routes/blog_/$blogId/route'
+import { Route as BlogStatsRouteImport } from './routes/blog_/stats'
+import { Route as PostsIndexRouteImport } from './routes/posts/index'
+import { Route as BlogBlogIdSlugRouteRouteImport } from './routes/blog_/$blogId/$slug/route'
+import { Route as BlogBlogIdEditRouteImport } from './routes/blog_/$blogId_/edit'
 import { Route as PostsPostIdIndexRouteImport } from './routes/posts/$postId/index'
 import { Route as PostsPostIdDeepRouteImport } from './routes/posts/$postId/deep'
-import { Route as BlogBlogIdEditRouteImport } from './routes/blog_/$blogId_/edit'
-import { Route as BlogBlogIdSlugRouteRouteImport } from './routes/blog_/$blogId/$slug/route'
 import { Route as BlogBlogIdSlugBarRouteImport } from './routes/blog_/$blogId/$slug_/bar'
 
-const PathlessLayoutRoute = PathlessLayoutRouteImport.update({
-  id: '/_pathlessLayout',
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const PostsRouteRoute = PostsRouteRouteImport.update({
-  id: '/posts',
-  path: '/posts',
+const PathlessLayoutRoute = PathlessLayoutRouteImport.update({
+  id: '/_pathlessLayout',
   getParentRoute: () => rootRouteImport,
 } as any)
 const BlogRouteRoute = BlogRouteRouteImport.update({
@@ -39,9 +39,34 @@ const BlogRouteRoute = BlogRouteRouteImport.update({
   path: '/blog',
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRoute = IndexRouteImport.update({
+const PostsRouteRoute = PostsRouteRouteImport.update({
+  id: '/posts',
+  path: '/posts',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PathlessLayoutSettingsRoute = PathlessLayoutSettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => PathlessLayoutRoute,
+} as any)
+const BlogIndexRoute = BlogIndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => BlogRouteRoute,
+} as any)
+const BlogSlugRoute = BlogSlugRouteImport.update({
+  id: '/$slug',
+  path: '/$slug',
+  getParentRoute: () => BlogRouteRoute,
+} as any)
+const BlogBlogIdRouteRoute = BlogBlogIdRouteRouteImport.update({
+  id: '/blog_/$blogId',
+  path: '/blog/$blogId',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BlogStatsRoute = BlogStatsRouteImport.update({
+  id: '/blog_/stats',
+  path: '/blog/stats',
   getParentRoute: () => rootRouteImport,
 } as any)
 const PostsIndexRoute = PostsIndexRouteImport.update({
@@ -49,29 +74,14 @@ const PostsIndexRoute = PostsIndexRouteImport.update({
   path: '/',
   getParentRoute: () => PostsRouteRoute,
 } as any)
-const BlogIndexRoute = BlogIndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => BlogRouteRoute,
-} as any)
-const BlogStatsRoute = BlogStatsRouteImport.update({
-  id: '/blog_/stats',
-  path: '/blog/stats',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const BlogSlugRoute = BlogSlugRouteImport.update({
+const BlogBlogIdSlugRouteRoute = BlogBlogIdSlugRouteRouteImport.update({
   id: '/$slug',
   path: '/$slug',
-  getParentRoute: () => BlogRouteRoute,
+  getParentRoute: () => BlogBlogIdRouteRoute,
 } as any)
-const PathlessLayoutSettingsRoute = PathlessLayoutSettingsRouteImport.update({
-  id: '/settings',
-  path: '/settings',
-  getParentRoute: () => PathlessLayoutRoute,
-} as any)
-const BlogBlogIdRouteRoute = BlogBlogIdRouteRouteImport.update({
-  id: '/blog_/$blogId',
-  path: '/blog/$blogId',
+const BlogBlogIdEditRoute = BlogBlogIdEditRouteImport.update({
+  id: '/blog_/$blogId_/edit',
+  path: '/blog/$blogId/edit',
   getParentRoute: () => rootRouteImport,
 } as any)
 const PostsPostIdIndexRoute = PostsPostIdIndexRouteImport.update({
@@ -83,16 +93,6 @@ const PostsPostIdDeepRoute = PostsPostIdDeepRouteImport.update({
   id: '/$postId/deep',
   path: '/$postId/deep',
   getParentRoute: () => PostsRouteRoute,
-} as any)
-const BlogBlogIdEditRoute = BlogBlogIdEditRouteImport.update({
-  id: '/blog_/$blogId_/edit',
-  path: '/blog/$blogId/edit',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const BlogBlogIdSlugRouteRoute = BlogBlogIdSlugRouteRouteImport.update({
-  id: '/$slug',
-  path: '/$slug',
-  getParentRoute: () => BlogBlogIdRouteRoute,
 } as any)
 const BlogBlogIdSlugBarRoute = BlogBlogIdSlugBarRouteImport.update({
   id: '/$slug_/bar',
@@ -210,18 +210,18 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_pathlessLayout': {
       id: '/_pathlessLayout'
       path: ''
       fullPath: '/'
       preLoaderRoute: typeof PathlessLayoutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/posts': {
-      id: '/posts'
-      path: '/posts'
-      fullPath: '/posts'
-      preLoaderRoute: typeof PostsRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/blog': {
@@ -231,11 +231,46 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof BlogRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
+    '/posts': {
+      id: '/posts'
+      path: '/posts'
+      fullPath: '/posts'
+      preLoaderRoute: typeof PostsRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_pathlessLayout/settings': {
+      id: '/_pathlessLayout/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof PathlessLayoutSettingsRouteImport
+      parentRoute: typeof PathlessLayoutRoute
+    }
+    '/blog/': {
+      id: '/blog/'
       path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
+      fullPath: '/blog/'
+      preLoaderRoute: typeof BlogIndexRouteImport
+      parentRoute: typeof BlogRouteRoute
+    }
+    '/blog/$slug': {
+      id: '/blog/$slug'
+      path: '/$slug'
+      fullPath: '/blog/$slug'
+      preLoaderRoute: typeof BlogSlugRouteImport
+      parentRoute: typeof BlogRouteRoute
+    }
+    '/blog_/$blogId': {
+      id: '/blog_/$blogId'
+      path: '/blog/$blogId'
+      fullPath: '/blog/$blogId'
+      preLoaderRoute: typeof BlogBlogIdRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/blog_/stats': {
+      id: '/blog_/stats'
+      path: '/blog/stats'
+      fullPath: '/blog/stats'
+      preLoaderRoute: typeof BlogStatsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/posts/': {
@@ -245,39 +280,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PostsIndexRouteImport
       parentRoute: typeof PostsRouteRoute
     }
-    '/blog/': {
-      id: '/blog/'
-      path: '/'
-      fullPath: '/blog/'
-      preLoaderRoute: typeof BlogIndexRouteImport
-      parentRoute: typeof BlogRouteRoute
-    }
-    '/blog_/stats': {
-      id: '/blog_/stats'
-      path: '/blog/stats'
-      fullPath: '/blog/stats'
-      preLoaderRoute: typeof BlogStatsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/blog/$slug': {
-      id: '/blog/$slug'
+    '/blog_/$blogId/$slug': {
+      id: '/blog_/$blogId/$slug'
       path: '/$slug'
-      fullPath: '/blog/$slug'
-      preLoaderRoute: typeof BlogSlugRouteImport
-      parentRoute: typeof BlogRouteRoute
+      fullPath: '/blog/$blogId/$slug'
+      preLoaderRoute: typeof BlogBlogIdSlugRouteRouteImport
+      parentRoute: typeof BlogBlogIdRouteRoute
     }
-    '/_pathlessLayout/settings': {
-      id: '/_pathlessLayout/settings'
-      path: '/settings'
-      fullPath: '/settings'
-      preLoaderRoute: typeof PathlessLayoutSettingsRouteImport
-      parentRoute: typeof PathlessLayoutRoute
-    }
-    '/blog_/$blogId': {
-      id: '/blog_/$blogId'
-      path: '/blog/$blogId'
-      fullPath: '/blog/$blogId'
-      preLoaderRoute: typeof BlogBlogIdRouteRouteImport
+    '/blog_/$blogId_/edit': {
+      id: '/blog_/$blogId_/edit'
+      path: '/blog/$blogId/edit'
+      fullPath: '/blog/$blogId/edit'
+      preLoaderRoute: typeof BlogBlogIdEditRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/posts/$postId/': {
@@ -293,20 +307,6 @@ declare module '@tanstack/react-router' {
       fullPath: '/posts/$postId/deep'
       preLoaderRoute: typeof PostsPostIdDeepRouteImport
       parentRoute: typeof PostsRouteRoute
-    }
-    '/blog_/$blogId_/edit': {
-      id: '/blog_/$blogId_/edit'
-      path: '/blog/$blogId/edit'
-      fullPath: '/blog/$blogId/edit'
-      preLoaderRoute: typeof BlogBlogIdEditRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/blog_/$blogId/$slug': {
-      id: '/blog_/$blogId/$slug'
-      path: '/$slug'
-      fullPath: '/blog/$blogId/$slug'
-      preLoaderRoute: typeof BlogBlogIdSlugRouteRouteImport
-      parentRoute: typeof BlogBlogIdRouteRoute
     }
     '/blog_/$blogId/$slug_/bar': {
       id: '/blog_/$blogId/$slug_/bar'

--- a/packages/router-generator/tests/generator/numbers-in-path/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/numbers-in-path/routeTree.snapshot.ts
@@ -9,15 +9,15 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as AboutRouteImport } from './routes/about'
-import { Route as R03RouteImport } from './routes/03'
 import { Route as IndexRouteImport } from './routes/index'
-import { Route as R02IndexRouteImport } from './routes/02.index'
+import { Route as R03RouteImport } from './routes/03'
+import { Route as AboutRouteImport } from './routes/about'
 import { Route as R01ExampleIndexRouteImport } from './routes/01-example/index'
+import { Route as R02IndexRouteImport } from './routes/02.index'
 
-const AboutRoute = AboutRouteImport.update({
-  id: '/about',
-  path: '/about',
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const R03Route = R03RouteImport.update({
@@ -25,19 +25,19 @@ const R03Route = R03RouteImport.update({
   path: '/03',
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const R02IndexRoute = R02IndexRouteImport.update({
-  id: '/02/',
-  path: '/02/',
+const AboutRoute = AboutRouteImport.update({
+  id: '/about',
+  path: '/about',
   getParentRoute: () => rootRouteImport,
 } as any)
 const R01ExampleIndexRoute = R01ExampleIndexRouteImport.update({
   id: '/01-example/',
   path: '/01-example/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const R02IndexRoute = R02IndexRouteImport.update({
+  id: '/02/',
+  path: '/02/',
   getParentRoute: () => rootRouteImport,
 } as any)
 
@@ -81,11 +81,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/about': {
-      id: '/about'
-      path: '/about'
-      fullPath: '/about'
-      preLoaderRoute: typeof AboutRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/03': {
@@ -95,18 +95,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof R03RouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/02/': {
-      id: '/02/'
-      path: '/02'
-      fullPath: '/02/'
-      preLoaderRoute: typeof R02IndexRouteImport
+    '/about': {
+      id: '/about'
+      path: '/about'
+      fullPath: '/about'
+      preLoaderRoute: typeof AboutRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/01-example/': {
@@ -114,6 +107,13 @@ declare module '@tanstack/react-router' {
       path: '/01-example'
       fullPath: '/01-example/'
       preLoaderRoute: typeof R01ExampleIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/02/': {
+      id: '/02/'
+      path: '/02'
+      fullPath: '/02/'
+      preLoaderRoute: typeof R02IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
   }

--- a/packages/router-generator/tests/generator/physical-pathless-layout-escaped-underscore/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/physical-pathless-layout-escaped-underscore/routeTree.snapshot.ts
@@ -10,23 +10,23 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as Char91__rootIndexChar93IndexRouteImport } from './routes/[__root-index]/index'
-import { Route as LayoutRouteImport } from './routes/_layout'
-import { Route as FooRouteImport } from './routes/[_]foo'
-import { Route as Char91__literalChar93RouteImport } from './routes/[__literal]'
 import { Route as _layoutRouteImport } from './routes/__layout'
-import { Route as RootIndexIndexRouteImport } from './routes/[_]root-index/index'
-import { Route as LayoutNestedRouteImport } from './routes/_layout/_nested'
-import { Route as LayoutBarRouteImport } from './routes/_layout/[_]bar'
-import { Route as Layout_nested2RouteImport } from './routes/_layout/__nested2'
-import { Route as LayoutChar91__doubleChar93RouteImport } from './routes/_layout/[__double]'
+import { Route as Char91__literalChar93RouteImport } from './routes/[__literal]'
+import { Route as FooRouteImport } from './routes/[_]foo'
+import { Route as LayoutRouteImport } from './routes/_layout'
 import { Route as _layoutQuxRouteImport } from './routes/__layout/[_]qux'
-import { Route as LayoutNestedTrailingIndexRouteImport } from './routes/_layout/nested-trailing[_]/index'
-import { Route as LayoutNestedIndexIndexRouteImport } from './routes/_layout/[_]nested-index/index'
+import { Route as LayoutChar91__doubleChar93RouteImport } from './routes/_layout/[__double]'
+import { Route as Layout_nested2RouteImport } from './routes/_layout/__nested2'
+import { Route as LayoutBarRouteImport } from './routes/_layout/[_]bar'
+import { Route as LayoutNestedRouteImport } from './routes/_layout/_nested'
+import { Route as RootIndexIndexRouteImport } from './routes/[_]root-index/index'
 import { Route as LayoutChar91__doubleIndexChar93IndexRouteImport } from './routes/_layout/[__double-index]/index'
-import { Route as LayoutNestedBazRouteImport } from './routes/_layout/_nested/[_]baz'
-import { Route as LayoutNestedIndexIdRouteImport } from './routes/_layout/[_]nested-index/$id'
-import { Route as Layout_nested2DeepRouteImport } from './routes/_layout/__nested2/[_]deep'
 import { Route as LayoutChar91__doubleIndexChar93IdRouteImport } from './routes/_layout/[__double-index]/$id'
+import { Route as Layout_nested2DeepRouteImport } from './routes/_layout/__nested2/[_]deep'
+import { Route as LayoutNestedIndexIndexRouteImport } from './routes/_layout/[_]nested-index/index'
+import { Route as LayoutNestedIndexIdRouteImport } from './routes/_layout/[_]nested-index/$id'
+import { Route as LayoutNestedBazRouteImport } from './routes/_layout/_nested/[_]baz'
+import { Route as LayoutNestedTrailingIndexRouteImport } from './routes/_layout/nested-trailing[_]/index'
 import { Route as LayoutNestedDeepIndexIndexRouteImport } from './routes/_layout/_nested/[_]deep-index/index'
 
 const Char91__rootIndexChar93IndexRoute =
@@ -35,13 +35,8 @@ const Char91__rootIndexChar93IndexRoute =
     path: '/__root-index/',
     getParentRoute: () => rootRouteImport,
   } as any)
-const LayoutRoute = LayoutRouteImport.update({
-  id: '/_layout',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const FooRoute = FooRouteImport.update({
-  id: '/_foo',
-  path: '/_foo',
+const _layoutRoute = _layoutRouteImport.update({
+  id: '/__layout',
   getParentRoute: () => rootRouteImport,
 } as any)
 const Char91__literalChar93Route = Char91__literalChar93RouteImport.update({
@@ -49,27 +44,19 @@ const Char91__literalChar93Route = Char91__literalChar93RouteImport.update({
   path: '/__literal',
   getParentRoute: () => rootRouteImport,
 } as any)
-const _layoutRoute = _layoutRouteImport.update({
-  id: '/__layout',
+const FooRoute = FooRouteImport.update({
+  id: '/_foo',
+  path: '/_foo',
   getParentRoute: () => rootRouteImport,
 } as any)
-const RootIndexIndexRoute = RootIndexIndexRouteImport.update({
-  id: '/_root-index/',
-  path: '/_root-index/',
+const LayoutRoute = LayoutRouteImport.update({
+  id: '/_layout',
   getParentRoute: () => rootRouteImport,
 } as any)
-const LayoutNestedRoute = LayoutNestedRouteImport.update({
-  id: '/_nested',
-  getParentRoute: () => LayoutRoute,
-} as any)
-const LayoutBarRoute = LayoutBarRouteImport.update({
-  id: '/_bar',
-  path: '/_bar',
-  getParentRoute: () => LayoutRoute,
-} as any)
-const Layout_nested2Route = Layout_nested2RouteImport.update({
-  id: '/__nested2',
-  getParentRoute: () => LayoutRoute,
+const _layoutQuxRoute = _layoutQuxRouteImport.update({
+  id: '/_qux',
+  path: '/_qux',
+  getParentRoute: () => _layoutRoute,
 } as any)
 const LayoutChar91__doubleChar93Route =
   LayoutChar91__doubleChar93RouteImport.update({
@@ -77,21 +64,23 @@ const LayoutChar91__doubleChar93Route =
     path: '/__double',
     getParentRoute: () => LayoutRoute,
   } as any)
-const _layoutQuxRoute = _layoutQuxRouteImport.update({
-  id: '/_qux',
-  path: '/_qux',
-  getParentRoute: () => _layoutRoute,
-} as any)
-const LayoutNestedTrailingIndexRoute =
-  LayoutNestedTrailingIndexRouteImport.update({
-    id: '/nested-trailing_/',
-    path: '/nested-trailing_/',
-    getParentRoute: () => LayoutRoute,
-  } as any)
-const LayoutNestedIndexIndexRoute = LayoutNestedIndexIndexRouteImport.update({
-  id: '/_nested-index/',
-  path: '/_nested-index/',
+const Layout_nested2Route = Layout_nested2RouteImport.update({
+  id: '/__nested2',
   getParentRoute: () => LayoutRoute,
+} as any)
+const LayoutBarRoute = LayoutBarRouteImport.update({
+  id: '/_bar',
+  path: '/_bar',
+  getParentRoute: () => LayoutRoute,
+} as any)
+const LayoutNestedRoute = LayoutNestedRouteImport.update({
+  id: '/_nested',
+  getParentRoute: () => LayoutRoute,
+} as any)
+const RootIndexIndexRoute = RootIndexIndexRouteImport.update({
+  id: '/_root-index/',
+  path: '/_root-index/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const LayoutChar91__doubleIndexChar93IndexRoute =
   LayoutChar91__doubleIndexChar93IndexRouteImport.update({
@@ -99,25 +88,36 @@ const LayoutChar91__doubleIndexChar93IndexRoute =
     path: '/__double-index/',
     getParentRoute: () => LayoutRoute,
   } as any)
-const LayoutNestedBazRoute = LayoutNestedBazRouteImport.update({
-  id: '/_baz',
-  path: '/_baz',
-  getParentRoute: () => LayoutNestedRoute,
+const LayoutChar91__doubleIndexChar93IdRoute =
+  LayoutChar91__doubleIndexChar93IdRouteImport.update({
+    id: '/__double-index/$id',
+    path: '/__double-index/$id',
+    getParentRoute: () => LayoutRoute,
+  } as any)
+const Layout_nested2DeepRoute = Layout_nested2DeepRouteImport.update({
+  id: '/_deep',
+  path: '/_deep',
+  getParentRoute: () => Layout_nested2Route,
+} as any)
+const LayoutNestedIndexIndexRoute = LayoutNestedIndexIndexRouteImport.update({
+  id: '/_nested-index/',
+  path: '/_nested-index/',
+  getParentRoute: () => LayoutRoute,
 } as any)
 const LayoutNestedIndexIdRoute = LayoutNestedIndexIdRouteImport.update({
   id: '/_nested-index/$id',
   path: '/_nested-index/$id',
   getParentRoute: () => LayoutRoute,
 } as any)
-const Layout_nested2DeepRoute = Layout_nested2DeepRouteImport.update({
-  id: '/_deep',
-  path: '/_deep',
-  getParentRoute: () => Layout_nested2Route,
+const LayoutNestedBazRoute = LayoutNestedBazRouteImport.update({
+  id: '/_baz',
+  path: '/_baz',
+  getParentRoute: () => LayoutNestedRoute,
 } as any)
-const LayoutChar91__doubleIndexChar93IdRoute =
-  LayoutChar91__doubleIndexChar93IdRouteImport.update({
-    id: '/__double-index/$id',
-    path: '/__double-index/$id',
+const LayoutNestedTrailingIndexRoute =
+  LayoutNestedTrailingIndexRouteImport.update({
+    id: '/nested-trailing_/',
+    path: '/nested-trailing_/',
     getParentRoute: () => LayoutRoute,
   } as any)
 const LayoutNestedDeepIndexIndexRoute =
@@ -263,18 +263,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof Char91__rootIndexChar93IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/_layout': {
-      id: '/_layout'
+    '/__layout': {
+      id: '/__layout'
       path: ''
       fullPath: '/'
-      preLoaderRoute: typeof LayoutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_foo': {
-      id: '/_foo'
-      path: '/_foo'
-      fullPath: '/_foo'
-      preLoaderRoute: typeof FooRouteImport
+      preLoaderRoute: typeof _layoutRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/__literal': {
@@ -284,32 +277,32 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof Char91__literalChar93RouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/__layout': {
-      id: '/__layout'
-      path: ''
-      fullPath: '/'
-      preLoaderRoute: typeof _layoutRouteImport
+    '/_foo': {
+      id: '/_foo'
+      path: '/_foo'
+      fullPath: '/_foo'
+      preLoaderRoute: typeof FooRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/_root-index/': {
-      id: '/_root-index/'
-      path: '/_root-index'
-      fullPath: '/_root-index/'
-      preLoaderRoute: typeof RootIndexIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_layout/_nested': {
-      id: '/_layout/_nested'
+    '/_layout': {
+      id: '/_layout'
       path: ''
       fullPath: '/'
-      preLoaderRoute: typeof LayoutNestedRouteImport
-      parentRoute: typeof LayoutRoute
+      preLoaderRoute: typeof LayoutRouteImport
+      parentRoute: typeof rootRouteImport
     }
-    '/_layout/_bar': {
-      id: '/_layout/_bar'
-      path: '/_bar'
-      fullPath: '/_bar'
-      preLoaderRoute: typeof LayoutBarRouteImport
+    '/__layout/_qux': {
+      id: '/__layout/_qux'
+      path: '/_qux'
+      fullPath: '/_qux'
+      preLoaderRoute: typeof _layoutQuxRouteImport
+      parentRoute: typeof _layoutRoute
+    }
+    '/_layout/__double': {
+      id: '/_layout/__double'
+      path: '/__double'
+      fullPath: '/__double'
+      preLoaderRoute: typeof LayoutChar91__doubleChar93RouteImport
       parentRoute: typeof LayoutRoute
     }
     '/_layout/__nested2': {
@@ -319,33 +312,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof Layout_nested2RouteImport
       parentRoute: typeof LayoutRoute
     }
-    '/_layout/__double': {
-      id: '/_layout/__double'
-      path: '/__double'
-      fullPath: '/__double'
-      preLoaderRoute: typeof LayoutChar91__doubleChar93RouteImport
+    '/_layout/_bar': {
+      id: '/_layout/_bar'
+      path: '/_bar'
+      fullPath: '/_bar'
+      preLoaderRoute: typeof LayoutBarRouteImport
       parentRoute: typeof LayoutRoute
     }
-    '/__layout/_qux': {
-      id: '/__layout/_qux'
-      path: '/_qux'
-      fullPath: '/_qux'
-      preLoaderRoute: typeof _layoutQuxRouteImport
-      parentRoute: typeof _layoutRoute
-    }
-    '/_layout/nested-trailing_/': {
-      id: '/_layout/nested-trailing_/'
-      path: '/nested-trailing_'
-      fullPath: '/nested-trailing_/'
-      preLoaderRoute: typeof LayoutNestedTrailingIndexRouteImport
+    '/_layout/_nested': {
+      id: '/_layout/_nested'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof LayoutNestedRouteImport
       parentRoute: typeof LayoutRoute
     }
-    '/_layout/_nested-index/': {
-      id: '/_layout/_nested-index/'
-      path: '/_nested-index'
-      fullPath: '/_nested-index/'
-      preLoaderRoute: typeof LayoutNestedIndexIndexRouteImport
-      parentRoute: typeof LayoutRoute
+    '/_root-index/': {
+      id: '/_root-index/'
+      path: '/_root-index'
+      fullPath: '/_root-index/'
+      preLoaderRoute: typeof RootIndexIndexRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/_layout/__double-index/': {
       id: '/_layout/__double-index/'
@@ -354,18 +340,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutChar91__doubleIndexChar93IndexRouteImport
       parentRoute: typeof LayoutRoute
     }
-    '/_layout/_nested/_baz': {
-      id: '/_layout/_nested/_baz'
-      path: '/_baz'
-      fullPath: '/_baz'
-      preLoaderRoute: typeof LayoutNestedBazRouteImport
-      parentRoute: typeof LayoutNestedRoute
-    }
-    '/_layout/_nested-index/$id': {
-      id: '/_layout/_nested-index/$id'
-      path: '/_nested-index/$id'
-      fullPath: '/_nested-index/$id'
-      preLoaderRoute: typeof LayoutNestedIndexIdRouteImport
+    '/_layout/__double-index/$id': {
+      id: '/_layout/__double-index/$id'
+      path: '/__double-index/$id'
+      fullPath: '/__double-index/$id'
+      preLoaderRoute: typeof LayoutChar91__doubleIndexChar93IdRouteImport
       parentRoute: typeof LayoutRoute
     }
     '/_layout/__nested2/_deep': {
@@ -375,11 +354,32 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof Layout_nested2DeepRouteImport
       parentRoute: typeof Layout_nested2Route
     }
-    '/_layout/__double-index/$id': {
-      id: '/_layout/__double-index/$id'
-      path: '/__double-index/$id'
-      fullPath: '/__double-index/$id'
-      preLoaderRoute: typeof LayoutChar91__doubleIndexChar93IdRouteImport
+    '/_layout/_nested-index/': {
+      id: '/_layout/_nested-index/'
+      path: '/_nested-index'
+      fullPath: '/_nested-index/'
+      preLoaderRoute: typeof LayoutNestedIndexIndexRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/_nested-index/$id': {
+      id: '/_layout/_nested-index/$id'
+      path: '/_nested-index/$id'
+      fullPath: '/_nested-index/$id'
+      preLoaderRoute: typeof LayoutNestedIndexIdRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/_nested/_baz': {
+      id: '/_layout/_nested/_baz'
+      path: '/_baz'
+      fullPath: '/_baz'
+      preLoaderRoute: typeof LayoutNestedBazRouteImport
+      parentRoute: typeof LayoutNestedRoute
+    }
+    '/_layout/nested-trailing_/': {
+      id: '/_layout/nested-trailing_/'
+      path: '/nested-trailing_'
+      fullPath: '/nested-trailing_/'
+      preLoaderRoute: typeof LayoutNestedTrailingIndexRouteImport
       parentRoute: typeof LayoutRoute
     }
     '/_layout/_nested/_deep-index/': {

--- a/packages/router-generator/tests/generator/prefix-suffix/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/prefix-suffix/routeTree.snapshot.ts
@@ -9,15 +9,20 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as WildcardChar123Char125suffixRouteImport } from './routes/wildcard/{$}suffix'
-import { Route as WildcardChar123Char125DotsuffixRouteImport } from './routes/wildcard/{$}[.]suffix'
-import { Route as WildcardPrefixChar123Char125RouteImport } from './routes/wildcard/prefix{$}'
 import { Route as WildcardSplatRouteImport } from './routes/wildcard/$'
+import { Route as WildcardPrefixChar123Char125RouteImport } from './routes/wildcard/prefix{$}'
+import { Route as WildcardChar123Char125DotsuffixRouteImport } from './routes/wildcard/{$}[.]suffix'
+import { Route as WildcardChar123Char125suffixRouteImport } from './routes/wildcard/{$}suffix'
 
-const WildcardChar123Char125suffixRoute =
-  WildcardChar123Char125suffixRouteImport.update({
-    id: '/wildcard/{$}suffix',
-    path: '/wildcard/{$}suffix',
+const WildcardSplatRoute = WildcardSplatRouteImport.update({
+  id: '/wildcard/$',
+  path: '/wildcard/$',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const WildcardPrefixChar123Char125Route =
+  WildcardPrefixChar123Char125RouteImport.update({
+    id: '/wildcard/prefix{$}',
+    path: '/wildcard/prefix{$}',
     getParentRoute: () => rootRouteImport,
   } as any)
 const WildcardChar123Char125DotsuffixRoute =
@@ -26,17 +31,12 @@ const WildcardChar123Char125DotsuffixRoute =
     path: '/wildcard/{$}.suffix',
     getParentRoute: () => rootRouteImport,
   } as any)
-const WildcardPrefixChar123Char125Route =
-  WildcardPrefixChar123Char125RouteImport.update({
-    id: '/wildcard/prefix{$}',
-    path: '/wildcard/prefix{$}',
+const WildcardChar123Char125suffixRoute =
+  WildcardChar123Char125suffixRouteImport.update({
+    id: '/wildcard/{$}suffix',
+    path: '/wildcard/{$}suffix',
     getParentRoute: () => rootRouteImport,
   } as any)
-const WildcardSplatRoute = WildcardSplatRouteImport.update({
-  id: '/wildcard/$',
-  path: '/wildcard/$',
-  getParentRoute: () => rootRouteImport,
-} as any)
 
 export interface FileRoutesByFullPath {
   '/wildcard/$': typeof WildcardSplatRoute
@@ -87,18 +87,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/wildcard/{$}suffix': {
-      id: '/wildcard/{$}suffix'
-      path: '/wildcard/{$}suffix'
-      fullPath: '/wildcard/{$}suffix'
-      preLoaderRoute: typeof WildcardChar123Char125suffixRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/wildcard/{$}.suffix': {
-      id: '/wildcard/{$}.suffix'
-      path: '/wildcard/{$}.suffix'
-      fullPath: '/wildcard/{$}.suffix'
-      preLoaderRoute: typeof WildcardChar123Char125DotsuffixRouteImport
+    '/wildcard/$': {
+      id: '/wildcard/$'
+      path: '/wildcard/$'
+      fullPath: '/wildcard/$'
+      preLoaderRoute: typeof WildcardSplatRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/wildcard/prefix{$}': {
@@ -108,11 +101,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WildcardPrefixChar123Char125RouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/wildcard/$': {
-      id: '/wildcard/$'
-      path: '/wildcard/$'
-      fullPath: '/wildcard/$'
-      preLoaderRoute: typeof WildcardSplatRouteImport
+    '/wildcard/{$}.suffix': {
+      id: '/wildcard/{$}.suffix'
+      path: '/wildcard/{$}.suffix'
+      fullPath: '/wildcard/{$}.suffix'
+      preLoaderRoute: typeof WildcardChar123Char125DotsuffixRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/wildcard/{$}suffix': {
+      id: '/wildcard/{$}suffix'
+      path: '/wildcard/{$}suffix'
+      fullPath: '/wildcard/{$}suffix'
+      preLoaderRoute: typeof WildcardChar123Char125suffixRouteImport
       parentRoute: typeof rootRouteImport
     }
   }

--- a/packages/router-generator/tests/generator/regex-tokens-inline/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/regex-tokens-inline/routeTree.snapshot.ts
@@ -9,19 +9,19 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as DashboardMainLayoutRouteImport } from './routes/dashboard.main-layout'
 import { Route as IndexPageRouteImport } from './routes/index-page'
+import { Route as DashboardMainLayoutRouteImport } from './routes/dashboard.main-layout'
 import { Route as DashboardHomePageRouteImport } from './routes/dashboard.home-page'
 import { Route as DashboardSettingsRouteImport } from './routes/dashboard.settings'
 
-const DashboardMainLayoutRoute = DashboardMainLayoutRouteImport.update({
-  id: '/dashboard',
-  path: '/dashboard',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const IndexPageRoute = IndexPageRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DashboardMainLayoutRoute = DashboardMainLayoutRouteImport.update({
+  id: '/dashboard',
+  path: '/dashboard',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DashboardHomePageRoute = DashboardHomePageRouteImport.update({
@@ -68,18 +68,18 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/dashboard': {
-      id: '/dashboard'
-      path: '/dashboard'
-      fullPath: '/dashboard'
-      preLoaderRoute: typeof DashboardMainLayoutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/': {
       id: '/'
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexPageRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/dashboard': {
+      id: '/dashboard'
+      path: '/dashboard'
+      fullPath: '/dashboard'
+      preLoaderRoute: typeof DashboardMainLayoutRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/dashboard/': {

--- a/packages/router-generator/tests/generator/regex-tokens-json/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/regex-tokens-json/routeTree.snapshot.ts
@@ -9,19 +9,19 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as DashboardMainLayoutRouteImport } from './routes/dashboard.main-layout'
 import { Route as IndexPageRouteImport } from './routes/index-page'
+import { Route as DashboardMainLayoutRouteImport } from './routes/dashboard.main-layout'
 import { Route as DashboardHomePageRouteImport } from './routes/dashboard.home-page'
 import { Route as DashboardSettingsRouteImport } from './routes/dashboard.settings'
 
-const DashboardMainLayoutRoute = DashboardMainLayoutRouteImport.update({
-  id: '/dashboard',
-  path: '/dashboard',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const IndexPageRoute = IndexPageRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DashboardMainLayoutRoute = DashboardMainLayoutRouteImport.update({
+  id: '/dashboard',
+  path: '/dashboard',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DashboardHomePageRoute = DashboardHomePageRouteImport.update({
@@ -68,18 +68,18 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/dashboard': {
-      id: '/dashboard'
-      path: '/dashboard'
-      fullPath: '/dashboard'
-      preLoaderRoute: typeof DashboardMainLayoutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/': {
       id: '/'
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexPageRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/dashboard': {
+      id: '/dashboard'
+      path: '/dashboard'
+      fullPath: '/dashboard'
+      preLoaderRoute: typeof DashboardMainLayoutRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/dashboard/': {

--- a/packages/router-generator/tests/generator/regex-tokens-plus-json/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/regex-tokens-plus-json/routeTree.snapshot.ts
@@ -9,19 +9,19 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as DashboardChar43layoutRouteImport } from './routes/dashboard/+layout'
 import { Route as Char43pageRouteImport } from './routes/+page'
+import { Route as DashboardChar43layoutRouteImport } from './routes/dashboard/+layout'
 import { Route as DashboardChar43pageRouteImport } from './routes/dashboard/+page'
 import { Route as DashboardSettingsRouteImport } from './routes/dashboard/settings'
 
-const DashboardChar43layoutRoute = DashboardChar43layoutRouteImport.update({
-  id: '/dashboard',
-  path: '/dashboard',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const Char43pageRoute = Char43pageRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DashboardChar43layoutRoute = DashboardChar43layoutRouteImport.update({
+  id: '/dashboard',
+  path: '/dashboard',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DashboardChar43pageRoute = DashboardChar43pageRouteImport.update({
@@ -68,18 +68,18 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/dashboard': {
-      id: '/dashboard'
-      path: '/dashboard'
-      fullPath: '/dashboard'
-      preLoaderRoute: typeof DashboardChar43layoutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/': {
       id: '/'
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof Char43pageRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/dashboard': {
+      id: '/dashboard'
+      path: '/dashboard'
+      fullPath: '/dashboard'
+      preLoaderRoute: typeof DashboardChar43layoutRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/dashboard/': {

--- a/packages/router-generator/tests/generator/root-export-specifier/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/root-export-specifier/routeTree.snapshot.ts
@@ -9,17 +9,17 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AboutRouteImport } from './routes/about'
 
-const AboutRoute = AboutRouteImport.update({
-  id: '/about',
-  path: '/about',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AboutRoute = AboutRouteImport.update({
+  id: '/about',
+  path: '/about',
   getParentRoute: () => rootRouteImport,
 } as any)
 
@@ -51,18 +51,18 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/about': {
-      id: '/about'
-      path: '/about'
-      fullPath: '/about'
-      preLoaderRoute: typeof AboutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/': {
       id: '/'
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/about': {
+      id: '/about'
+      path: '/about'
+      fullPath: '/about'
+      preLoaderRoute: typeof AboutRouteImport
       parentRoute: typeof rootRouteImport
     }
   }

--- a/packages/router-generator/tests/generator/route-groups/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/route-groups/routeTree.snapshot.ts
@@ -12,13 +12,13 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as barBarRouteImport } from './routes/(bar)/_bar'
-import { Route as fooAsdfLayoutRouteImport } from './routes/(foo)/asdf/_layout'
 import { Route as barBarHelloRouteImport } from './routes/(bar)/_bar.hello'
-import { Route as fooAsdfLayoutFooRouteImport } from './routes/(foo)/asdf/_layout.foo'
-import { Route as fooAsdfbarIdRouteImport } from './routes/(foo)/asdf/(bar)/$id'
+import { Route as fooAsdfLayoutRouteImport } from './routes/(foo)/asdf/_layout'
 import { Route as fooAsdfanotherGroupLayoutRouteImport } from './routes/(foo)/asdf/(another-group)/_layout'
-import { Route as fooAsdfbarLayoutAboutRouteImport } from './routes/(foo)/asdf/(bar)/_layout.about'
+import { Route as fooAsdfbarIdRouteImport } from './routes/(foo)/asdf/(bar)/$id'
+import { Route as fooAsdfLayoutFooRouteImport } from './routes/(foo)/asdf/_layout.foo'
 import { Route as fooAsdfanotherGroupLayoutBazRouteImport } from './routes/(foo)/asdf/(another-group)/_layout.baz'
+import { Route as fooAsdfbarLayoutAboutRouteImport } from './routes/(foo)/asdf/(bar)/_layout.about'
 
 const fooAsdfbarLayoutXyzLazyRouteImport = createFileRoute(
   '/(foo)/asdf/(bar)/_layout/xyz',
@@ -28,24 +28,14 @@ const barBarRoute = barBarRouteImport.update({
   id: '/(bar)/_bar',
   getParentRoute: () => rootRouteImport,
 } as any)
-const fooAsdfLayoutRoute = fooAsdfLayoutRouteImport.update({
-  id: '/(foo)/asdf/_layout',
-  path: '/asdf',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const barBarHelloRoute = barBarHelloRouteImport.update({
   id: '/hello',
   path: '/hello',
   getParentRoute: () => barBarRoute,
 } as any)
-const fooAsdfLayoutFooRoute = fooAsdfLayoutFooRouteImport.update({
-  id: '/foo',
-  path: '/foo',
-  getParentRoute: () => fooAsdfLayoutRoute,
-} as any)
-const fooAsdfbarIdRoute = fooAsdfbarIdRouteImport.update({
-  id: '/(foo)/asdf/(bar)/$id',
-  path: '/asdf/$id',
+const fooAsdfLayoutRoute = fooAsdfLayoutRouteImport.update({
+  id: '/(foo)/asdf/_layout',
+  path: '/asdf',
   getParentRoute: () => rootRouteImport,
 } as any)
 const fooAsdfanotherGroupLayoutRoute =
@@ -54,6 +44,27 @@ const fooAsdfanotherGroupLayoutRoute =
     path: '/asdf',
     getParentRoute: () => rootRouteImport,
   } as any)
+const fooAsdfbarIdRoute = fooAsdfbarIdRouteImport.update({
+  id: '/(foo)/asdf/(bar)/$id',
+  path: '/asdf/$id',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const fooAsdfLayoutFooRoute = fooAsdfLayoutFooRouteImport.update({
+  id: '/foo',
+  path: '/foo',
+  getParentRoute: () => fooAsdfLayoutRoute,
+} as any)
+const fooAsdfanotherGroupLayoutBazRoute =
+  fooAsdfanotherGroupLayoutBazRouteImport.update({
+    id: '/baz',
+    path: '/baz',
+    getParentRoute: () => fooAsdfanotherGroupLayoutRoute,
+  } as any)
+const fooAsdfbarLayoutAboutRoute = fooAsdfbarLayoutAboutRouteImport.update({
+  id: '/(foo)/asdf/(bar)/_layout/about',
+  path: '/asdf/about',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const fooAsdfbarLayoutXyzLazyRoute = fooAsdfbarLayoutXyzLazyRouteImport
   .update({
     id: '/(foo)/asdf/(bar)/_layout/xyz',
@@ -63,17 +74,6 @@ const fooAsdfbarLayoutXyzLazyRoute = fooAsdfbarLayoutXyzLazyRouteImport
   .lazy(() =>
     import('./routes/(foo)/asdf/(bar)/_layout.xyz.lazy').then((d) => d.Route),
   )
-const fooAsdfbarLayoutAboutRoute = fooAsdfbarLayoutAboutRouteImport.update({
-  id: '/(foo)/asdf/(bar)/_layout/about',
-  path: '/asdf/about',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const fooAsdfanotherGroupLayoutBazRoute =
-  fooAsdfanotherGroupLayoutBazRouteImport.update({
-    id: '/baz',
-    path: '/baz',
-    getParentRoute: () => fooAsdfanotherGroupLayoutRoute,
-  } as any)
 
 export interface FileRoutesByFullPath {
   '/hello': typeof barBarHelloRoute
@@ -155,13 +155,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof barBarRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/(foo)/asdf/_layout': {
-      id: '/(foo)/asdf/_layout'
-      path: '/asdf'
-      fullPath: '/asdf'
-      preLoaderRoute: typeof fooAsdfLayoutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/(bar)/_bar/hello': {
       id: '/(bar)/_bar/hello'
       path: '/hello'
@@ -169,18 +162,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof barBarHelloRouteImport
       parentRoute: typeof barBarRoute
     }
-    '/(foo)/asdf/_layout/foo': {
-      id: '/(foo)/asdf/_layout/foo'
-      path: '/foo'
-      fullPath: '/asdf/foo'
-      preLoaderRoute: typeof fooAsdfLayoutFooRouteImport
-      parentRoute: typeof fooAsdfLayoutRoute
-    }
-    '/(foo)/asdf/(bar)/$id': {
-      id: '/(foo)/asdf/(bar)/$id'
-      path: '/asdf/$id'
-      fullPath: '/asdf/$id'
-      preLoaderRoute: typeof fooAsdfbarIdRouteImport
+    '/(foo)/asdf/_layout': {
+      id: '/(foo)/asdf/_layout'
+      path: '/asdf'
+      fullPath: '/asdf'
+      preLoaderRoute: typeof fooAsdfLayoutRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/(foo)/asdf/(another-group)/_layout': {
@@ -190,12 +176,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof fooAsdfanotherGroupLayoutRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/(foo)/asdf/(bar)/_layout/xyz': {
-      id: '/(foo)/asdf/(bar)/_layout/xyz'
-      path: '/asdf/xyz'
-      fullPath: '/asdf/xyz'
-      preLoaderRoute: typeof fooAsdfbarLayoutXyzLazyRouteImport
+    '/(foo)/asdf/(bar)/$id': {
+      id: '/(foo)/asdf/(bar)/$id'
+      path: '/asdf/$id'
+      fullPath: '/asdf/$id'
+      preLoaderRoute: typeof fooAsdfbarIdRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/(foo)/asdf/_layout/foo': {
+      id: '/(foo)/asdf/_layout/foo'
+      path: '/foo'
+      fullPath: '/asdf/foo'
+      preLoaderRoute: typeof fooAsdfLayoutFooRouteImport
+      parentRoute: typeof fooAsdfLayoutRoute
+    }
+    '/(foo)/asdf/(another-group)/_layout/baz': {
+      id: '/(foo)/asdf/(another-group)/_layout/baz'
+      path: '/baz'
+      fullPath: '/asdf/baz'
+      preLoaderRoute: typeof fooAsdfanotherGroupLayoutBazRouteImport
+      parentRoute: typeof fooAsdfanotherGroupLayoutRoute
     }
     '/(foo)/asdf/(bar)/_layout/about': {
       id: '/(foo)/asdf/(bar)/_layout/about'
@@ -204,12 +204,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof fooAsdfbarLayoutAboutRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/(foo)/asdf/(another-group)/_layout/baz': {
-      id: '/(foo)/asdf/(another-group)/_layout/baz'
-      path: '/baz'
-      fullPath: '/asdf/baz'
-      preLoaderRoute: typeof fooAsdfanotherGroupLayoutBazRouteImport
-      parentRoute: typeof fooAsdfanotherGroupLayoutRoute
+    '/(foo)/asdf/(bar)/_layout/xyz': {
+      id: '/(foo)/asdf/(bar)/_layout/xyz'
+      path: '/asdf/xyz'
+      fullPath: '/asdf/xyz'
+      preLoaderRoute: typeof fooAsdfbarLayoutXyzLazyRouteImport
+      parentRoute: typeof rootRouteImport
     }
   }
 }

--- a/packages/router-generator/tests/generator/routeFileIgnore/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/routeFileIgnore/routeTree.snapshot.ts
@@ -9,17 +9,17 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as BlogRouteRouteImport } from './routes/blog.route'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as BlogRouteRouteImport } from './routes/blog.route'
 
-const BlogRouteRoute = BlogRouteRouteImport.update({
-  id: '/blog',
-  path: '/blog',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BlogRouteRoute = BlogRouteRouteImport.update({
+  id: '/blog',
+  path: '/blog',
   getParentRoute: () => rootRouteImport,
 } as any)
 
@@ -51,18 +51,18 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/blog': {
-      id: '/blog'
-      path: '/blog'
-      fullPath: '/blog'
-      preLoaderRoute: typeof BlogRouteRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/': {
       id: '/'
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/blog': {
+      id: '/blog'
+      path: '/blog'
+      fullPath: '/blog'
+      preLoaderRoute: typeof BlogRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
   }

--- a/packages/router-generator/tests/generator/routeFilePrefix/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/routeFilePrefix/routeTree.snapshot.ts
@@ -9,17 +9,17 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/r&__root'
-import { Route as BlogRouteRouteImport } from './routes/r&blog.route'
 import { Route as IndexRouteImport } from './routes/r&index'
+import { Route as BlogRouteRouteImport } from './routes/r&blog.route'
 
-const BlogRouteRoute = BlogRouteRouteImport.update({
-  id: '/blog',
-  path: '/blog',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BlogRouteRoute = BlogRouteRouteImport.update({
+  id: '/blog',
+  path: '/blog',
   getParentRoute: () => rootRouteImport,
 } as any)
 
@@ -51,18 +51,18 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/blog': {
-      id: '/blog'
-      path: '/blog'
-      fullPath: '/blog'
-      preLoaderRoute: typeof BlogRouteRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/': {
       id: '/'
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/blog': {
+      id: '/blog'
+      path: '/blog'
+      fullPath: '/blog'
+      preLoaderRoute: typeof BlogRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
   }

--- a/packages/router-generator/tests/generator/single-level/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/single-level/routeTree.snapshot.ts
@@ -9,17 +9,17 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as PostsRouteImport } from './routes/posts'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as PostsRouteImport } from './routes/posts'
 
-const PostsRoute = PostsRouteImport.update({
-  id: '/posts',
-  path: '/posts',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PostsRoute = PostsRouteImport.update({
+  id: '/posts',
+  path: '/posts',
   getParentRoute: () => rootRouteImport,
 } as any)
 
@@ -51,18 +51,18 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/posts': {
-      id: '/posts'
-      path: '/posts'
-      fullPath: '/posts'
-      preLoaderRoute: typeof PostsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/': {
       id: '/'
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/posts': {
+      id: '/posts'
+      path: '/posts'
+      fullPath: '/posts'
+      preLoaderRoute: typeof PostsRouteImport
       parentRoute: typeof rootRouteImport
     }
   }

--- a/packages/router-generator/tests/generator/types-disabled/routeTree.snapshot.js
+++ b/packages/router-generator/tests/generator/types-disabled/routeTree.snapshot.js
@@ -9,30 +9,30 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as PostsRouteImport } from './routes/posts'
 import { Route as IndexRouteImport } from './routes/index'
-import { Route as UsersUserIdRouteImport } from './routes/users.$userId'
+import { Route as PostsRouteImport } from './routes/posts'
 import { Route as PostsPostIdRouteImport } from './routes/posts/$postId'
+import { Route as UsersUserIdRouteImport } from './routes/users.$userId'
 
-const PostsRoute = PostsRouteImport.update({
-  id: '/posts',
-  path: '/posts',
-  getParentRoute: () => rootRouteImport,
-})
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
 })
-const UsersUserIdRoute = UsersUserIdRouteImport.update({
-  id: '/users/$userId',
-  path: '/users/$userId',
+const PostsRoute = PostsRouteImport.update({
+  id: '/posts',
+  path: '/posts',
   getParentRoute: () => rootRouteImport,
 })
 const PostsPostIdRoute = PostsPostIdRouteImport.update({
   id: '/$postId',
   path: '/$postId',
   getParentRoute: () => PostsRoute,
+})
+const UsersUserIdRoute = UsersUserIdRouteImport.update({
+  id: '/users/$userId',
+  path: '/users/$userId',
+  getParentRoute: () => rootRouteImport,
 })
 
 const PostsRouteChildren = {

--- a/packages/router-generator/tests/generator/virtual-config-file-default-export/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/virtual-config-file-default-export/routeTree.snapshot.ts
@@ -9,25 +9,30 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/root'
-import { Route as layoutRouteImport } from './routes/layout'
 import { Route as indexRouteImport } from './routes/index'
-import { Route as dbDashboardRouteImport } from './routes/db/dashboard'
+import { Route as layoutRouteImport } from './routes/layout'
 import { Route as pagesRouteImport } from './routes/pages'
-import { Route as HelloIndexRouteImport } from './routes/subtree/index'
-import { Route as dbDashboardInvoicesRouteImport } from './routes/db/dashboard-invoices'
+import { Route as dbDashboardRouteImport } from './routes/db/dashboard'
 import { Route as dbDashboardIndexRouteImport } from './routes/db/dashboard-index'
+import { Route as dbDashboardInvoicesRouteImport } from './routes/db/dashboard-invoices'
+import { Route as HelloIndexRouteImport } from './routes/subtree/index'
+import { Route as dbInvoicesIndexRouteImport } from './routes/db/invoices-index'
+import { Route as dbInvoiceDetailRouteImport } from './routes/db/invoice-detail'
 import { Route as HelloFooIndexRouteImport } from './routes/subtree/foo/index'
 import { Route as HelloFooIdRouteImport } from './routes/subtree/foo/$id'
-import { Route as dbInvoiceDetailRouteImport } from './routes/db/invoice-detail'
-import { Route as dbInvoicesIndexRouteImport } from './routes/db/invoices-index'
 
+const indexRoute = indexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const layoutRoute = layoutRouteImport.update({
   id: '/_layout',
   getParentRoute: () => rootRouteImport,
 } as any)
-const indexRoute = indexRouteImport.update({
-  id: '/',
-  path: '/',
+const pagesRoute = pagesRouteImport.update({
+  id: '/$lang/',
+  path: '/$lang/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const dbDashboardRoute = dbDashboardRouteImport.update({
@@ -35,25 +40,30 @@ const dbDashboardRoute = dbDashboardRouteImport.update({
   path: '/dashboard',
   getParentRoute: () => layoutRoute,
 } as any)
-const pagesRoute = pagesRouteImport.update({
-  id: '/$lang/',
-  path: '/$lang/',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const HelloIndexRoute = HelloIndexRouteImport.update({
-  id: '/hello/',
-  path: '/hello/',
-  getParentRoute: () => layoutRoute,
+const dbDashboardIndexRoute = dbDashboardIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => dbDashboardRoute,
 } as any)
 const dbDashboardInvoicesRoute = dbDashboardInvoicesRouteImport.update({
   id: '/invoices',
   path: '/invoices',
   getParentRoute: () => dbDashboardRoute,
 } as any)
-const dbDashboardIndexRoute = dbDashboardIndexRouteImport.update({
+const HelloIndexRoute = HelloIndexRouteImport.update({
+  id: '/hello/',
+  path: '/hello/',
+  getParentRoute: () => layoutRoute,
+} as any)
+const dbInvoicesIndexRoute = dbInvoicesIndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => dbDashboardRoute,
+  getParentRoute: () => dbDashboardInvoicesRoute,
+} as any)
+const dbInvoiceDetailRoute = dbInvoiceDetailRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => dbDashboardInvoicesRoute,
 } as any)
 const HelloFooIndexRoute = HelloFooIndexRouteImport.update({
   id: '/hello/foo/',
@@ -64,16 +74,6 @@ const HelloFooIdRoute = HelloFooIdRouteImport.update({
   id: '/hello/foo/$id',
   path: '/hello/foo/$id',
   getParentRoute: () => layoutRoute,
-} as any)
-const dbInvoiceDetailRoute = dbInvoiceDetailRouteImport.update({
-  id: '/$id',
-  path: '/$id',
-  getParentRoute: () => dbDashboardInvoicesRoute,
-} as any)
-const dbInvoicesIndexRoute = dbInvoicesIndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => dbDashboardInvoicesRoute,
 } as any)
 
 export interface FileRoutesByFullPath {
@@ -158,6 +158,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof indexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_layout': {
       id: '/_layout'
       path: ''
@@ -165,11 +172,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof layoutRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof indexRouteImport
+    '/$lang/': {
+      id: '/$lang/'
+      path: '/$lang'
+      fullPath: '/$lang/'
+      preLoaderRoute: typeof pagesRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_layout/dashboard': {
@@ -179,19 +186,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof dbDashboardRouteImport
       parentRoute: typeof layoutRoute
     }
-    '/$lang/': {
-      id: '/$lang/'
-      path: '/$lang'
-      fullPath: '/$lang/'
-      preLoaderRoute: typeof pagesRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_layout/hello/': {
-      id: '/_layout/hello/'
-      path: '/hello'
-      fullPath: '/hello/'
-      preLoaderRoute: typeof HelloIndexRouteImport
-      parentRoute: typeof layoutRoute
+    '/_layout/dashboard/': {
+      id: '/_layout/dashboard/'
+      path: '/'
+      fullPath: '/dashboard/'
+      preLoaderRoute: typeof dbDashboardIndexRouteImport
+      parentRoute: typeof dbDashboardRoute
     }
     '/_layout/dashboard/invoices': {
       id: '/_layout/dashboard/invoices'
@@ -200,12 +200,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof dbDashboardInvoicesRouteImport
       parentRoute: typeof dbDashboardRoute
     }
-    '/_layout/dashboard/': {
-      id: '/_layout/dashboard/'
+    '/_layout/hello/': {
+      id: '/_layout/hello/'
+      path: '/hello'
+      fullPath: '/hello/'
+      preLoaderRoute: typeof HelloIndexRouteImport
+      parentRoute: typeof layoutRoute
+    }
+    '/_layout/dashboard/invoices/': {
+      id: '/_layout/dashboard/invoices/'
       path: '/'
-      fullPath: '/dashboard/'
-      preLoaderRoute: typeof dbDashboardIndexRouteImport
-      parentRoute: typeof dbDashboardRoute
+      fullPath: '/dashboard/invoices/'
+      preLoaderRoute: typeof dbInvoicesIndexRouteImport
+      parentRoute: typeof dbDashboardInvoicesRoute
+    }
+    '/_layout/dashboard/invoices/$id': {
+      id: '/_layout/dashboard/invoices/$id'
+      path: '/$id'
+      fullPath: '/dashboard/invoices/$id'
+      preLoaderRoute: typeof dbInvoiceDetailRouteImport
+      parentRoute: typeof dbDashboardInvoicesRoute
     }
     '/_layout/hello/foo/': {
       id: '/_layout/hello/foo/'
@@ -220,20 +234,6 @@ declare module '@tanstack/react-router' {
       fullPath: '/hello/foo/$id'
       preLoaderRoute: typeof HelloFooIdRouteImport
       parentRoute: typeof layoutRoute
-    }
-    '/_layout/dashboard/invoices/$id': {
-      id: '/_layout/dashboard/invoices/$id'
-      path: '/$id'
-      fullPath: '/dashboard/invoices/$id'
-      preLoaderRoute: typeof dbInvoiceDetailRouteImport
-      parentRoute: typeof dbDashboardInvoicesRoute
-    }
-    '/_layout/dashboard/invoices/': {
-      id: '/_layout/dashboard/invoices/'
-      path: '/'
-      fullPath: '/dashboard/invoices/'
-      preLoaderRoute: typeof dbInvoicesIndexRouteImport
-      parentRoute: typeof dbDashboardInvoicesRoute
     }
   }
 }

--- a/packages/router-generator/tests/generator/virtual-config-file-named-export/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/virtual-config-file-named-export/routeTree.snapshot.ts
@@ -9,25 +9,30 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/root'
-import { Route as layoutRouteImport } from './routes/layout'
 import { Route as indexRouteImport } from './routes/index'
-import { Route as dbDashboardRouteImport } from './routes/db/dashboard'
+import { Route as layoutRouteImport } from './routes/layout'
 import { Route as pagesRouteImport } from './routes/pages'
-import { Route as HelloIndexRouteImport } from './routes/subtree/index'
-import { Route as dbDashboardInvoicesRouteImport } from './routes/db/dashboard-invoices'
+import { Route as dbDashboardRouteImport } from './routes/db/dashboard'
 import { Route as dbDashboardIndexRouteImport } from './routes/db/dashboard-index'
+import { Route as dbDashboardInvoicesRouteImport } from './routes/db/dashboard-invoices'
+import { Route as HelloIndexRouteImport } from './routes/subtree/index'
+import { Route as dbInvoicesIndexRouteImport } from './routes/db/invoices-index'
+import { Route as dbInvoiceDetailRouteImport } from './routes/db/invoice-detail'
 import { Route as HelloFooIndexRouteImport } from './routes/subtree/foo/index'
 import { Route as HelloFooIdRouteImport } from './routes/subtree/foo/$id'
-import { Route as dbInvoiceDetailRouteImport } from './routes/db/invoice-detail'
-import { Route as dbInvoicesIndexRouteImport } from './routes/db/invoices-index'
 
+const indexRoute = indexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const layoutRoute = layoutRouteImport.update({
   id: '/_layout',
   getParentRoute: () => rootRouteImport,
 } as any)
-const indexRoute = indexRouteImport.update({
-  id: '/',
-  path: '/',
+const pagesRoute = pagesRouteImport.update({
+  id: '/$lang/',
+  path: '/$lang/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const dbDashboardRoute = dbDashboardRouteImport.update({
@@ -35,25 +40,30 @@ const dbDashboardRoute = dbDashboardRouteImport.update({
   path: '/dashboard',
   getParentRoute: () => layoutRoute,
 } as any)
-const pagesRoute = pagesRouteImport.update({
-  id: '/$lang/',
-  path: '/$lang/',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const HelloIndexRoute = HelloIndexRouteImport.update({
-  id: '/hello/',
-  path: '/hello/',
-  getParentRoute: () => layoutRoute,
+const dbDashboardIndexRoute = dbDashboardIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => dbDashboardRoute,
 } as any)
 const dbDashboardInvoicesRoute = dbDashboardInvoicesRouteImport.update({
   id: '/invoices',
   path: '/invoices',
   getParentRoute: () => dbDashboardRoute,
 } as any)
-const dbDashboardIndexRoute = dbDashboardIndexRouteImport.update({
+const HelloIndexRoute = HelloIndexRouteImport.update({
+  id: '/hello/',
+  path: '/hello/',
+  getParentRoute: () => layoutRoute,
+} as any)
+const dbInvoicesIndexRoute = dbInvoicesIndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => dbDashboardRoute,
+  getParentRoute: () => dbDashboardInvoicesRoute,
+} as any)
+const dbInvoiceDetailRoute = dbInvoiceDetailRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => dbDashboardInvoicesRoute,
 } as any)
 const HelloFooIndexRoute = HelloFooIndexRouteImport.update({
   id: '/hello/foo/',
@@ -64,16 +74,6 @@ const HelloFooIdRoute = HelloFooIdRouteImport.update({
   id: '/hello/foo/$id',
   path: '/hello/foo/$id',
   getParentRoute: () => layoutRoute,
-} as any)
-const dbInvoiceDetailRoute = dbInvoiceDetailRouteImport.update({
-  id: '/$id',
-  path: '/$id',
-  getParentRoute: () => dbDashboardInvoicesRoute,
-} as any)
-const dbInvoicesIndexRoute = dbInvoicesIndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => dbDashboardInvoicesRoute,
 } as any)
 
 export interface FileRoutesByFullPath {
@@ -158,6 +158,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof indexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_layout': {
       id: '/_layout'
       path: ''
@@ -165,11 +172,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof layoutRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof indexRouteImport
+    '/$lang/': {
+      id: '/$lang/'
+      path: '/$lang'
+      fullPath: '/$lang/'
+      preLoaderRoute: typeof pagesRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_layout/dashboard': {
@@ -179,19 +186,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof dbDashboardRouteImport
       parentRoute: typeof layoutRoute
     }
-    '/$lang/': {
-      id: '/$lang/'
-      path: '/$lang'
-      fullPath: '/$lang/'
-      preLoaderRoute: typeof pagesRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_layout/hello/': {
-      id: '/_layout/hello/'
-      path: '/hello'
-      fullPath: '/hello/'
-      preLoaderRoute: typeof HelloIndexRouteImport
-      parentRoute: typeof layoutRoute
+    '/_layout/dashboard/': {
+      id: '/_layout/dashboard/'
+      path: '/'
+      fullPath: '/dashboard/'
+      preLoaderRoute: typeof dbDashboardIndexRouteImport
+      parentRoute: typeof dbDashboardRoute
     }
     '/_layout/dashboard/invoices': {
       id: '/_layout/dashboard/invoices'
@@ -200,12 +200,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof dbDashboardInvoicesRouteImport
       parentRoute: typeof dbDashboardRoute
     }
-    '/_layout/dashboard/': {
-      id: '/_layout/dashboard/'
+    '/_layout/hello/': {
+      id: '/_layout/hello/'
+      path: '/hello'
+      fullPath: '/hello/'
+      preLoaderRoute: typeof HelloIndexRouteImport
+      parentRoute: typeof layoutRoute
+    }
+    '/_layout/dashboard/invoices/': {
+      id: '/_layout/dashboard/invoices/'
       path: '/'
-      fullPath: '/dashboard/'
-      preLoaderRoute: typeof dbDashboardIndexRouteImport
-      parentRoute: typeof dbDashboardRoute
+      fullPath: '/dashboard/invoices/'
+      preLoaderRoute: typeof dbInvoicesIndexRouteImport
+      parentRoute: typeof dbDashboardInvoicesRoute
+    }
+    '/_layout/dashboard/invoices/$id': {
+      id: '/_layout/dashboard/invoices/$id'
+      path: '/$id'
+      fullPath: '/dashboard/invoices/$id'
+      preLoaderRoute: typeof dbInvoiceDetailRouteImport
+      parentRoute: typeof dbDashboardInvoicesRoute
     }
     '/_layout/hello/foo/': {
       id: '/_layout/hello/foo/'
@@ -220,20 +234,6 @@ declare module '@tanstack/react-router' {
       fullPath: '/hello/foo/$id'
       preLoaderRoute: typeof HelloFooIdRouteImport
       parentRoute: typeof layoutRoute
-    }
-    '/_layout/dashboard/invoices/$id': {
-      id: '/_layout/dashboard/invoices/$id'
-      path: '/$id'
-      fullPath: '/dashboard/invoices/$id'
-      preLoaderRoute: typeof dbInvoiceDetailRouteImport
-      parentRoute: typeof dbDashboardInvoicesRoute
-    }
-    '/_layout/dashboard/invoices/': {
-      id: '/_layout/dashboard/invoices/'
-      path: '/'
-      fullPath: '/dashboard/invoices/'
-      preLoaderRoute: typeof dbInvoicesIndexRouteImport
-      parentRoute: typeof dbDashboardInvoicesRoute
     }
   }
 }

--- a/packages/router-generator/tests/generator/virtual-config-file-tsconfig-paths/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/virtual-config-file-tsconfig-paths/routeTree.snapshot.ts
@@ -9,25 +9,30 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/root'
-import { Route as layoutRouteImport } from './routes/layout'
 import { Route as indexRouteImport } from './routes/index'
-import { Route as dbDashboardRouteImport } from './routes/db/dashboard'
+import { Route as layoutRouteImport } from './routes/layout'
 import { Route as pagesRouteImport } from './routes/pages'
-import { Route as HelloIndexRouteImport } from './routes/subtree/index'
-import { Route as dbDashboardInvoicesRouteImport } from './routes/db/dashboard-invoices'
+import { Route as dbDashboardRouteImport } from './routes/db/dashboard'
 import { Route as dbDashboardIndexRouteImport } from './routes/db/dashboard-index'
+import { Route as dbDashboardInvoicesRouteImport } from './routes/db/dashboard-invoices'
+import { Route as HelloIndexRouteImport } from './routes/subtree/index'
+import { Route as dbInvoicesIndexRouteImport } from './routes/db/invoices-index'
+import { Route as dbInvoiceDetailRouteImport } from './routes/db/invoice-detail'
 import { Route as HelloFooIndexRouteImport } from './routes/subtree/foo/index'
 import { Route as HelloFooIdRouteImport } from './routes/subtree/foo/$id'
-import { Route as dbInvoiceDetailRouteImport } from './routes/db/invoice-detail'
-import { Route as dbInvoicesIndexRouteImport } from './routes/db/invoices-index'
 
+const indexRoute = indexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const layoutRoute = layoutRouteImport.update({
   id: '/_layout',
   getParentRoute: () => rootRouteImport,
 } as any)
-const indexRoute = indexRouteImport.update({
-  id: '/',
-  path: '/',
+const pagesRoute = pagesRouteImport.update({
+  id: '/$lang/',
+  path: '/$lang/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const dbDashboardRoute = dbDashboardRouteImport.update({
@@ -35,25 +40,30 @@ const dbDashboardRoute = dbDashboardRouteImport.update({
   path: '/dashboard',
   getParentRoute: () => layoutRoute,
 } as any)
-const pagesRoute = pagesRouteImport.update({
-  id: '/$lang/',
-  path: '/$lang/',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const HelloIndexRoute = HelloIndexRouteImport.update({
-  id: '/hello/',
-  path: '/hello/',
-  getParentRoute: () => layoutRoute,
+const dbDashboardIndexRoute = dbDashboardIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => dbDashboardRoute,
 } as any)
 const dbDashboardInvoicesRoute = dbDashboardInvoicesRouteImport.update({
   id: '/invoices',
   path: '/invoices',
   getParentRoute: () => dbDashboardRoute,
 } as any)
-const dbDashboardIndexRoute = dbDashboardIndexRouteImport.update({
+const HelloIndexRoute = HelloIndexRouteImport.update({
+  id: '/hello/',
+  path: '/hello/',
+  getParentRoute: () => layoutRoute,
+} as any)
+const dbInvoicesIndexRoute = dbInvoicesIndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => dbDashboardRoute,
+  getParentRoute: () => dbDashboardInvoicesRoute,
+} as any)
+const dbInvoiceDetailRoute = dbInvoiceDetailRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => dbDashboardInvoicesRoute,
 } as any)
 const HelloFooIndexRoute = HelloFooIndexRouteImport.update({
   id: '/hello/foo/',
@@ -64,16 +74,6 @@ const HelloFooIdRoute = HelloFooIdRouteImport.update({
   id: '/hello/foo/$id',
   path: '/hello/foo/$id',
   getParentRoute: () => layoutRoute,
-} as any)
-const dbInvoiceDetailRoute = dbInvoiceDetailRouteImport.update({
-  id: '/$id',
-  path: '/$id',
-  getParentRoute: () => dbDashboardInvoicesRoute,
-} as any)
-const dbInvoicesIndexRoute = dbInvoicesIndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => dbDashboardInvoicesRoute,
 } as any)
 
 export interface FileRoutesByFullPath {
@@ -158,6 +158,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof indexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_layout': {
       id: '/_layout'
       path: ''
@@ -165,11 +172,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof layoutRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof indexRouteImport
+    '/$lang/': {
+      id: '/$lang/'
+      path: '/$lang'
+      fullPath: '/$lang/'
+      preLoaderRoute: typeof pagesRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_layout/dashboard': {
@@ -179,19 +186,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof dbDashboardRouteImport
       parentRoute: typeof layoutRoute
     }
-    '/$lang/': {
-      id: '/$lang/'
-      path: '/$lang'
-      fullPath: '/$lang/'
-      preLoaderRoute: typeof pagesRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_layout/hello/': {
-      id: '/_layout/hello/'
-      path: '/hello'
-      fullPath: '/hello/'
-      preLoaderRoute: typeof HelloIndexRouteImport
-      parentRoute: typeof layoutRoute
+    '/_layout/dashboard/': {
+      id: '/_layout/dashboard/'
+      path: '/'
+      fullPath: '/dashboard/'
+      preLoaderRoute: typeof dbDashboardIndexRouteImport
+      parentRoute: typeof dbDashboardRoute
     }
     '/_layout/dashboard/invoices': {
       id: '/_layout/dashboard/invoices'
@@ -200,12 +200,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof dbDashboardInvoicesRouteImport
       parentRoute: typeof dbDashboardRoute
     }
-    '/_layout/dashboard/': {
-      id: '/_layout/dashboard/'
+    '/_layout/hello/': {
+      id: '/_layout/hello/'
+      path: '/hello'
+      fullPath: '/hello/'
+      preLoaderRoute: typeof HelloIndexRouteImport
+      parentRoute: typeof layoutRoute
+    }
+    '/_layout/dashboard/invoices/': {
+      id: '/_layout/dashboard/invoices/'
       path: '/'
-      fullPath: '/dashboard/'
-      preLoaderRoute: typeof dbDashboardIndexRouteImport
-      parentRoute: typeof dbDashboardRoute
+      fullPath: '/dashboard/invoices/'
+      preLoaderRoute: typeof dbInvoicesIndexRouteImport
+      parentRoute: typeof dbDashboardInvoicesRoute
+    }
+    '/_layout/dashboard/invoices/$id': {
+      id: '/_layout/dashboard/invoices/$id'
+      path: '/$id'
+      fullPath: '/dashboard/invoices/$id'
+      preLoaderRoute: typeof dbInvoiceDetailRouteImport
+      parentRoute: typeof dbDashboardInvoicesRoute
     }
     '/_layout/hello/foo/': {
       id: '/_layout/hello/foo/'
@@ -220,20 +234,6 @@ declare module '@tanstack/react-router' {
       fullPath: '/hello/foo/$id'
       preLoaderRoute: typeof HelloFooIdRouteImport
       parentRoute: typeof layoutRoute
-    }
-    '/_layout/dashboard/invoices/$id': {
-      id: '/_layout/dashboard/invoices/$id'
-      path: '/$id'
-      fullPath: '/dashboard/invoices/$id'
-      preLoaderRoute: typeof dbInvoiceDetailRouteImport
-      parentRoute: typeof dbDashboardInvoicesRoute
-    }
-    '/_layout/dashboard/invoices/': {
-      id: '/_layout/dashboard/invoices/'
-      path: '/'
-      fullPath: '/dashboard/invoices/'
-      preLoaderRoute: typeof dbInvoicesIndexRouteImport
-      parentRoute: typeof dbDashboardInvoicesRoute
     }
   }
 }

--- a/packages/router-generator/tests/generator/virtual-inside-nested/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/virtual-inside-nested/routeTree.snapshot.ts
@@ -11,8 +11,8 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as FooBarRouteImport } from './routes/foo/bar'
-import { Route as FooBarDetailsRouteImport } from './routes/foo/bar/details'
 import { Route as FooBarHomeRouteImport } from './routes/foo/bar/home'
+import { Route as FooBarDetailsRouteImport } from './routes/foo/bar/details'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -24,14 +24,14 @@ const FooBarRoute = FooBarRouteImport.update({
   path: '/foo/bar',
   getParentRoute: () => rootRouteImport,
 } as any)
-const FooBarDetailsRoute = FooBarDetailsRouteImport.update({
-  id: '/$id',
-  path: '/$id',
-  getParentRoute: () => FooBarRoute,
-} as any)
 const FooBarHomeRoute = FooBarHomeRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => FooBarRoute,
+} as any)
+const FooBarDetailsRoute = FooBarDetailsRouteImport.update({
+  id: '/$id',
+  path: '/$id',
   getParentRoute: () => FooBarRoute,
 } as any)
 
@@ -82,18 +82,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof FooBarRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/foo/bar/$id': {
-      id: '/foo/bar/$id'
-      path: '/$id'
-      fullPath: '/foo/bar/$id'
-      preLoaderRoute: typeof FooBarDetailsRouteImport
-      parentRoute: typeof FooBarRoute
-    }
     '/foo/bar/': {
       id: '/foo/bar/'
       path: '/'
       fullPath: '/foo/bar/'
       preLoaderRoute: typeof FooBarHomeRouteImport
+      parentRoute: typeof FooBarRoute
+    }
+    '/foo/bar/$id': {
+      id: '/foo/bar/$id'
+      path: '/$id'
+      fullPath: '/foo/bar/$id'
+      preLoaderRoute: typeof FooBarDetailsRouteImport
       parentRoute: typeof FooBarRoute
     }
   }

--- a/packages/router-generator/tests/generator/virtual-inside-with-escaped-underscore/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/virtual-inside-with-escaped-underscore/routeTree.snapshot.ts
@@ -10,18 +10,18 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
-import { Route as NestedCallbackRouteImport } from './routes/nested/callback'
-import { Route as NestedAuthRouteImport } from './routes/nested/auth'
 import { Route as NestedHomeRouteImport } from './routes/nested/home'
+import { Route as NestedAuthRouteImport } from './routes/nested/auth'
+import { Route as NestedCallbackRouteImport } from './routes/nested/callback'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const NestedCallbackRoute = NestedCallbackRouteImport.update({
-  id: '/nested/_callback',
-  path: '/nested/_callback',
+const NestedHomeRoute = NestedHomeRouteImport.update({
+  id: '/nested/',
+  path: '/nested/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const NestedAuthRoute = NestedAuthRouteImport.update({
@@ -29,9 +29,9 @@ const NestedAuthRoute = NestedAuthRouteImport.update({
   path: '/nested/_auth',
   getParentRoute: () => rootRouteImport,
 } as any)
-const NestedHomeRoute = NestedHomeRouteImport.update({
-  id: '/nested/',
-  path: '/nested/',
+const NestedCallbackRoute = NestedCallbackRouteImport.update({
+  id: '/nested/_callback',
+  path: '/nested/_callback',
   getParentRoute: () => rootRouteImport,
 } as any)
 
@@ -78,11 +78,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/nested/_callback': {
-      id: '/nested/_callback'
-      path: '/nested/_callback'
-      fullPath: '/nested/_callback'
-      preLoaderRoute: typeof NestedCallbackRouteImport
+    '/nested/': {
+      id: '/nested/'
+      path: '/nested'
+      fullPath: '/nested/'
+      preLoaderRoute: typeof NestedHomeRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/nested/_auth': {
@@ -92,11 +92,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof NestedAuthRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/nested/': {
-      id: '/nested/'
-      path: '/nested'
-      fullPath: '/nested/'
-      preLoaderRoute: typeof NestedHomeRouteImport
+    '/nested/_callback': {
+      id: '/nested/_callback'
+      path: '/nested/_callback'
+      fullPath: '/nested/_callback'
+      preLoaderRoute: typeof NestedCallbackRouteImport
       parentRoute: typeof rootRouteImport
     }
   }

--- a/packages/router-generator/tests/generator/virtual-nested-layouts-with-virtual-route/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/virtual-nested-layouts-with-virtual-route/routeTree.snapshot.ts
@@ -9,33 +9,33 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as layoutFirstLayoutRouteImport } from './routes/layout/first-layout'
 import { Route as homeRouteImport } from './routes/home'
+import { Route as layoutFirstLayoutRouteImport } from './routes/layout/first-layout'
 import { Route as layoutSecondLayoutRouteImport } from './routes/layout/second-layout'
-import { Route as bRouteImport } from './routes/b'
 import { Route as aRouteImport } from './routes/a'
+import { Route as bRouteImport } from './routes/b'
 
-const layoutFirstLayoutRoute = layoutFirstLayoutRouteImport.update({
-  id: '/_first',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const homeRoute = homeRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const layoutFirstLayoutRoute = layoutFirstLayoutRouteImport.update({
+  id: '/_first',
   getParentRoute: () => rootRouteImport,
 } as any)
 const layoutSecondLayoutRoute = layoutSecondLayoutRouteImport.update({
   id: '/_second-layout',
   getParentRoute: () => layoutFirstLayoutRoute,
 } as any)
-const bRoute = bRouteImport.update({
-  id: '/route-without-file/layout-b',
-  path: '/route-without-file/layout-b',
-  getParentRoute: () => layoutSecondLayoutRoute,
-} as any)
 const aRoute = aRouteImport.update({
   id: '/route-without-file/layout-a',
   path: '/route-without-file/layout-a',
+  getParentRoute: () => layoutSecondLayoutRoute,
+} as any)
+const bRoute = bRouteImport.update({
+  id: '/route-without-file/layout-b',
+  path: '/route-without-file/layout-b',
   getParentRoute: () => layoutSecondLayoutRoute,
 } as any)
 
@@ -81,18 +81,18 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/_first': {
-      id: '/_first'
-      path: ''
-      fullPath: '/'
-      preLoaderRoute: typeof layoutFirstLayoutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/': {
       id: '/'
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof homeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_first': {
+      id: '/_first'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof layoutFirstLayoutRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_first/_second-layout': {
@@ -102,18 +102,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof layoutSecondLayoutRouteImport
       parentRoute: typeof layoutFirstLayoutRoute
     }
-    '/_first/_second-layout/route-without-file/layout-b': {
-      id: '/_first/_second-layout/route-without-file/layout-b'
-      path: '/route-without-file/layout-b'
-      fullPath: '/route-without-file/layout-b'
-      preLoaderRoute: typeof bRouteImport
-      parentRoute: typeof layoutSecondLayoutRoute
-    }
     '/_first/_second-layout/route-without-file/layout-a': {
       id: '/_first/_second-layout/route-without-file/layout-a'
       path: '/route-without-file/layout-a'
       fullPath: '/route-without-file/layout-a'
       preLoaderRoute: typeof aRouteImport
+      parentRoute: typeof layoutSecondLayoutRoute
+    }
+    '/_first/_second-layout/route-without-file/layout-b': {
+      id: '/_first/_second-layout/route-without-file/layout-b'
+      path: '/route-without-file/layout-b'
+      fullPath: '/route-without-file/layout-b'
+      preLoaderRoute: typeof bRouteImport
       parentRoute: typeof layoutSecondLayoutRoute
     }
   }

--- a/packages/router-generator/tests/generator/virtual-pathless-layout-escaped-underscore/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/virtual-pathless-layout-escaped-underscore/routeTree.snapshot.ts
@@ -9,34 +9,30 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as layoutRouteImport } from './routes/layout'
-import { Route as fooRouteImport } from './routes/foo'
-import { Route as escapedRouteImport } from './routes/escaped'
 import { Route as doubleRouteImport } from './routes/double'
-import { Route as rootIdRouteImport } from './routes/root-id'
-import { Route as nestedLayoutRouteImport } from './routes/nested-layout'
-import { Route as innerLayoutRouteImport } from './routes/inner-layout'
-import { Route as escapedBarRouteImport } from './routes/escaped-bar'
-import { Route as barRouteImport } from './routes/bar'
+import { Route as escapedRouteImport } from './routes/escaped'
+import { Route as fooRouteImport } from './routes/foo'
+import { Route as layoutRouteImport } from './routes/layout'
 import { Route as doubleBarRouteImport } from './routes/double-bar'
+import { Route as barRouteImport } from './routes/bar'
+import { Route as escapedBarRouteImport } from './routes/escaped-bar'
+import { Route as innerLayoutRouteImport } from './routes/inner-layout'
+import { Route as nestedLayoutRouteImport } from './routes/nested-layout'
 import { Route as rootIndexRouteImport } from './routes/root-index'
-import { Route as bazRouteImport } from './routes/baz'
-import { Route as nestedIdRouteImport } from './routes/nested-id'
-import { Route as escapedIdRouteImport } from './routes/escaped-id'
-import { Route as doubleIdRouteImport } from './routes/double-id'
-import { Route as trailIndexRouteImport } from './routes/trail-index'
-import { Route as nestedIndexRouteImport } from './routes/nested-index'
-import { Route as escapedIndexRouteImport } from './routes/escaped-index'
+import { Route as rootIdRouteImport } from './routes/root-id'
 import { Route as doubleIndexRouteImport } from './routes/double-index'
+import { Route as doubleIdRouteImport } from './routes/double-id'
+import { Route as escapedIndexRouteImport } from './routes/escaped-index'
+import { Route as escapedIdRouteImport } from './routes/escaped-id'
+import { Route as nestedIndexRouteImport } from './routes/nested-index'
+import { Route as nestedIdRouteImport } from './routes/nested-id'
+import { Route as bazRouteImport } from './routes/baz'
+import { Route as trailIndexRouteImport } from './routes/trail-index'
 import { Route as deepIndexRouteImport } from './routes/deep-index'
 
-const layoutRoute = layoutRouteImport.update({
-  id: '/_layout',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const fooRoute = fooRouteImport.update({
-  id: '/_foo',
-  path: '/_foo',
+const doubleRoute = doubleRouteImport.update({
+  id: '/__double',
+  path: '/__double',
   getParentRoute: () => rootRouteImport,
 } as any)
 const escapedRoute = escapedRouteImport.update({
@@ -44,27 +40,18 @@ const escapedRoute = escapedRouteImport.update({
   path: '/_escaped',
   getParentRoute: () => rootRouteImport,
 } as any)
-const doubleRoute = doubleRouteImport.update({
-  id: '/__double',
-  path: '/__double',
+const fooRoute = fooRouteImport.update({
+  id: '/_foo',
+  path: '/_foo',
   getParentRoute: () => rootRouteImport,
 } as any)
-const rootIdRoute = rootIdRouteImport.update({
-  id: '/_root-index/$id',
-  path: '/_root-index/$id',
+const layoutRoute = layoutRouteImport.update({
+  id: '/_layout',
   getParentRoute: () => rootRouteImport,
 } as any)
-const nestedLayoutRoute = nestedLayoutRouteImport.update({
-  id: '/_nested',
-  getParentRoute: () => layoutRoute,
-} as any)
-const innerLayoutRoute = innerLayoutRouteImport.update({
-  id: '/_inner',
-  getParentRoute: () => layoutRoute,
-} as any)
-const escapedBarRoute = escapedBarRouteImport.update({
-  id: '/_escaped-bar',
-  path: '/_escaped-bar',
+const doubleBarRoute = doubleBarRouteImport.update({
+  id: '/__double-bar',
+  path: '/__double-bar',
   getParentRoute: () => layoutRoute,
 } as any)
 const barRoute = barRouteImport.update({
@@ -72,9 +59,17 @@ const barRoute = barRouteImport.update({
   path: '/_bar',
   getParentRoute: () => layoutRoute,
 } as any)
-const doubleBarRoute = doubleBarRouteImport.update({
-  id: '/__double-bar',
-  path: '/__double-bar',
+const escapedBarRoute = escapedBarRouteImport.update({
+  id: '/_escaped-bar',
+  path: '/_escaped-bar',
+  getParentRoute: () => layoutRoute,
+} as any)
+const innerLayoutRoute = innerLayoutRouteImport.update({
+  id: '/_inner',
+  getParentRoute: () => layoutRoute,
+} as any)
+const nestedLayoutRoute = nestedLayoutRouteImport.update({
+  id: '/_nested',
   getParentRoute: () => layoutRoute,
 } as any)
 const rootIndexRoute = rootIndexRouteImport.update({
@@ -82,19 +77,14 @@ const rootIndexRoute = rootIndexRouteImport.update({
   path: '/_root-index/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const bazRoute = bazRouteImport.update({
-  id: '/_baz',
-  path: '/_baz',
-  getParentRoute: () => nestedLayoutRoute,
+const rootIdRoute = rootIdRouteImport.update({
+  id: '/_root-index/$id',
+  path: '/_root-index/$id',
+  getParentRoute: () => rootRouteImport,
 } as any)
-const nestedIdRoute = nestedIdRouteImport.update({
-  id: '/_nested-index/$id',
-  path: '/_nested-index/$id',
-  getParentRoute: () => layoutRoute,
-} as any)
-const escapedIdRoute = escapedIdRouteImport.update({
-  id: '/_escaped-index/$id',
-  path: '/_escaped-index/$id',
+const doubleIndexRoute = doubleIndexRouteImport.update({
+  id: '/__double-index/',
+  path: '/__double-index/',
   getParentRoute: () => layoutRoute,
 } as any)
 const doubleIdRoute = doubleIdRouteImport.update({
@@ -102,9 +92,14 @@ const doubleIdRoute = doubleIdRouteImport.update({
   path: '/__double-index/$id',
   getParentRoute: () => layoutRoute,
 } as any)
-const trailIndexRoute = trailIndexRouteImport.update({
-  id: '/trail_/',
-  path: '/trail_/',
+const escapedIndexRoute = escapedIndexRouteImport.update({
+  id: '/_escaped-index/',
+  path: '/_escaped-index/',
+  getParentRoute: () => layoutRoute,
+} as any)
+const escapedIdRoute = escapedIdRouteImport.update({
+  id: '/_escaped-index/$id',
+  path: '/_escaped-index/$id',
   getParentRoute: () => layoutRoute,
 } as any)
 const nestedIndexRoute = nestedIndexRouteImport.update({
@@ -112,14 +107,19 @@ const nestedIndexRoute = nestedIndexRouteImport.update({
   path: '/_nested-index/',
   getParentRoute: () => layoutRoute,
 } as any)
-const escapedIndexRoute = escapedIndexRouteImport.update({
-  id: '/_escaped-index/',
-  path: '/_escaped-index/',
+const nestedIdRoute = nestedIdRouteImport.update({
+  id: '/_nested-index/$id',
+  path: '/_nested-index/$id',
   getParentRoute: () => layoutRoute,
 } as any)
-const doubleIndexRoute = doubleIndexRouteImport.update({
-  id: '/__double-index/',
-  path: '/__double-index/',
+const bazRoute = bazRouteImport.update({
+  id: '/_baz',
+  path: '/_baz',
+  getParentRoute: () => nestedLayoutRoute,
+} as any)
+const trailIndexRoute = trailIndexRouteImport.update({
+  id: '/trail_/',
+  path: '/trail_/',
   getParentRoute: () => layoutRoute,
 } as any)
 const deepIndexRoute = deepIndexRouteImport.update({
@@ -267,18 +267,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/_layout': {
-      id: '/_layout'
-      path: ''
-      fullPath: '/'
-      preLoaderRoute: typeof layoutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_foo': {
-      id: '/_foo'
-      path: '/_foo'
-      fullPath: '/_foo'
-      preLoaderRoute: typeof fooRouteImport
+    '/__double': {
+      id: '/__double'
+      path: '/__double'
+      fullPath: '/__double'
+      preLoaderRoute: typeof doubleRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_escaped': {
@@ -288,39 +281,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof escapedRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/__double': {
-      id: '/__double'
-      path: '/__double'
-      fullPath: '/__double'
-      preLoaderRoute: typeof doubleRouteImport
+    '/_foo': {
+      id: '/_foo'
+      path: '/_foo'
+      fullPath: '/_foo'
+      preLoaderRoute: typeof fooRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/_root-index/$id': {
-      id: '/_root-index/$id'
-      path: '/_root-index/$id'
-      fullPath: '/_root-index/$id'
-      preLoaderRoute: typeof rootIdRouteImport
+    '/_layout': {
+      id: '/_layout'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof layoutRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/_layout/_nested': {
-      id: '/_layout/_nested'
-      path: ''
-      fullPath: '/'
-      preLoaderRoute: typeof nestedLayoutRouteImport
-      parentRoute: typeof layoutRoute
-    }
-    '/_layout/_inner': {
-      id: '/_layout/_inner'
-      path: ''
-      fullPath: '/'
-      preLoaderRoute: typeof innerLayoutRouteImport
-      parentRoute: typeof layoutRoute
-    }
-    '/_layout/_escaped-bar': {
-      id: '/_layout/_escaped-bar'
-      path: '/_escaped-bar'
-      fullPath: '/_escaped-bar'
-      preLoaderRoute: typeof escapedBarRouteImport
+    '/_layout/__double-bar': {
+      id: '/_layout/__double-bar'
+      path: '/__double-bar'
+      fullPath: '/__double-bar'
+      preLoaderRoute: typeof doubleBarRouteImport
       parentRoute: typeof layoutRoute
     }
     '/_layout/_bar': {
@@ -330,11 +309,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof barRouteImport
       parentRoute: typeof layoutRoute
     }
-    '/_layout/__double-bar': {
-      id: '/_layout/__double-bar'
-      path: '/__double-bar'
-      fullPath: '/__double-bar'
-      preLoaderRoute: typeof doubleBarRouteImport
+    '/_layout/_escaped-bar': {
+      id: '/_layout/_escaped-bar'
+      path: '/_escaped-bar'
+      fullPath: '/_escaped-bar'
+      preLoaderRoute: typeof escapedBarRouteImport
+      parentRoute: typeof layoutRoute
+    }
+    '/_layout/_inner': {
+      id: '/_layout/_inner'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof innerLayoutRouteImport
+      parentRoute: typeof layoutRoute
+    }
+    '/_layout/_nested': {
+      id: '/_layout/_nested'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof nestedLayoutRouteImport
       parentRoute: typeof layoutRoute
     }
     '/_root-index/': {
@@ -344,25 +337,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof rootIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/_layout/_nested/_baz': {
-      id: '/_layout/_nested/_baz'
-      path: '/_baz'
-      fullPath: '/_baz'
-      preLoaderRoute: typeof bazRouteImport
-      parentRoute: typeof nestedLayoutRoute
+    '/_root-index/$id': {
+      id: '/_root-index/$id'
+      path: '/_root-index/$id'
+      fullPath: '/_root-index/$id'
+      preLoaderRoute: typeof rootIdRouteImport
+      parentRoute: typeof rootRouteImport
     }
-    '/_layout/_nested-index/$id': {
-      id: '/_layout/_nested-index/$id'
-      path: '/_nested-index/$id'
-      fullPath: '/_nested-index/$id'
-      preLoaderRoute: typeof nestedIdRouteImport
-      parentRoute: typeof layoutRoute
-    }
-    '/_layout/_escaped-index/$id': {
-      id: '/_layout/_escaped-index/$id'
-      path: '/_escaped-index/$id'
-      fullPath: '/_escaped-index/$id'
-      preLoaderRoute: typeof escapedIdRouteImport
+    '/_layout/__double-index/': {
+      id: '/_layout/__double-index/'
+      path: '/__double-index'
+      fullPath: '/__double-index/'
+      preLoaderRoute: typeof doubleIndexRouteImport
       parentRoute: typeof layoutRoute
     }
     '/_layout/__double-index/$id': {
@@ -372,11 +358,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof doubleIdRouteImport
       parentRoute: typeof layoutRoute
     }
-    '/_layout/trail_/': {
-      id: '/_layout/trail_/'
-      path: '/trail_'
-      fullPath: '/trail_/'
-      preLoaderRoute: typeof trailIndexRouteImport
+    '/_layout/_escaped-index/': {
+      id: '/_layout/_escaped-index/'
+      path: '/_escaped-index'
+      fullPath: '/_escaped-index/'
+      preLoaderRoute: typeof escapedIndexRouteImport
+      parentRoute: typeof layoutRoute
+    }
+    '/_layout/_escaped-index/$id': {
+      id: '/_layout/_escaped-index/$id'
+      path: '/_escaped-index/$id'
+      fullPath: '/_escaped-index/$id'
+      preLoaderRoute: typeof escapedIdRouteImport
       parentRoute: typeof layoutRoute
     }
     '/_layout/_nested-index/': {
@@ -386,18 +379,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof nestedIndexRouteImport
       parentRoute: typeof layoutRoute
     }
-    '/_layout/_escaped-index/': {
-      id: '/_layout/_escaped-index/'
-      path: '/_escaped-index'
-      fullPath: '/_escaped-index/'
-      preLoaderRoute: typeof escapedIndexRouteImport
+    '/_layout/_nested-index/$id': {
+      id: '/_layout/_nested-index/$id'
+      path: '/_nested-index/$id'
+      fullPath: '/_nested-index/$id'
+      preLoaderRoute: typeof nestedIdRouteImport
       parentRoute: typeof layoutRoute
     }
-    '/_layout/__double-index/': {
-      id: '/_layout/__double-index/'
-      path: '/__double-index'
-      fullPath: '/__double-index/'
-      preLoaderRoute: typeof doubleIndexRouteImport
+    '/_layout/_nested/_baz': {
+      id: '/_layout/_nested/_baz'
+      path: '/_baz'
+      fullPath: '/_baz'
+      preLoaderRoute: typeof bazRouteImport
+      parentRoute: typeof nestedLayoutRoute
+    }
+    '/_layout/trail_/': {
+      id: '/_layout/trail_/'
+      path: '/trail_'
+      fullPath: '/trail_/'
+      preLoaderRoute: typeof trailIndexRouteImport
       parentRoute: typeof layoutRoute
     }
     '/_layout/_inner/_deep-index/': {

--- a/packages/router-generator/tests/generator/virtual-physical-empty-path-merge/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/virtual-physical-empty-path-merge/routeTree.snapshot.ts
@@ -9,13 +9,13 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as ContactRouteImport } from './routes/merged/contact'
-import { Route as aboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/merged/index'
+import { Route as aboutRouteImport } from './routes/about'
+import { Route as ContactRouteImport } from './routes/merged/contact'
 
-const ContactRoute = ContactRouteImport.update({
-  id: '/contact',
-  path: '/contact',
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const aboutRoute = aboutRouteImport.update({
@@ -23,9 +23,9 @@ const aboutRoute = aboutRouteImport.update({
   path: '/about',
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+const ContactRoute = ContactRouteImport.update({
+  id: '/contact',
+  path: '/contact',
   getParentRoute: () => rootRouteImport,
 } as any)
 
@@ -61,11 +61,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/contact': {
-      id: '/contact'
-      path: '/contact'
-      fullPath: '/contact'
-      preLoaderRoute: typeof ContactRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/about': {
@@ -75,11 +75,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof aboutRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
+    '/contact': {
+      id: '/contact'
+      path: '/contact'
+      fullPath: '/contact'
+      preLoaderRoute: typeof ContactRouteImport
       parentRoute: typeof rootRouteImport
     }
   }

--- a/packages/router-generator/tests/generator/virtual-physical-layout-and-index/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/virtual-physical-layout-and-index/routeTree.snapshot.ts
@@ -9,18 +9,18 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as FeatureRouteRouteImport } from './routes/feature/route'
 import { Route as indexRouteImport } from './routes/index'
+import { Route as FeatureRouteRouteImport } from './routes/feature/route'
 import { Route as FeatureIndexRouteImport } from './routes/feature/index'
 
-const FeatureRouteRoute = FeatureRouteRouteImport.update({
-  id: '/feature',
-  path: '/feature',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const indexRoute = indexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const FeatureRouteRoute = FeatureRouteRouteImport.update({
+  id: '/feature',
+  path: '/feature',
   getParentRoute: () => rootRouteImport,
 } as any)
 const FeatureIndexRoute = FeatureIndexRouteImport.update({
@@ -59,18 +59,18 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/feature': {
-      id: '/feature'
-      path: '/feature'
-      fullPath: '/feature'
-      preLoaderRoute: typeof FeatureRouteRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/': {
       id: '/'
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof indexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/feature': {
+      id: '/feature'
+      path: '/feature'
+      fullPath: '/feature'
+      preLoaderRoute: typeof FeatureRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/feature/': {

--- a/packages/router-generator/tests/generator/virtual-physical-no-prefix/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/virtual-physical-no-prefix/routeTree.snapshot.ts
@@ -9,13 +9,13 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as ContactRouteImport } from './routes/merged/contact'
-import { Route as aboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/merged/index'
+import { Route as aboutRouteImport } from './routes/about'
+import { Route as ContactRouteImport } from './routes/merged/contact'
 
-const ContactRoute = ContactRouteImport.update({
-  id: '/contact',
-  path: '/contact',
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const aboutRoute = aboutRouteImport.update({
@@ -23,9 +23,9 @@ const aboutRoute = aboutRouteImport.update({
   path: '/about',
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+const ContactRoute = ContactRouteImport.update({
+  id: '/contact',
+  path: '/contact',
   getParentRoute: () => rootRouteImport,
 } as any)
 
@@ -61,11 +61,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/contact': {
-      id: '/contact'
-      path: '/contact'
-      fullPath: '/contact'
-      preLoaderRoute: typeof ContactRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/about': {
@@ -75,11 +75,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof aboutRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
+    '/contact': {
+      id: '/contact'
+      path: '/contact'
+      fullPath: '/contact'
+      preLoaderRoute: typeof ContactRouteImport
       parentRoute: typeof rootRouteImport
     }
   }

--- a/packages/router-generator/tests/generator/virtual-with-escaped-underscore/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/virtual-with-escaped-underscore/routeTree.snapshot.ts
@@ -11,8 +11,8 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as indexRouteImport } from './routes/index'
 import { Route as ApiIndexRouteImport } from './routes/physical-routes/index'
-import { Route as ApiChar91_Char93helloRouteImport } from './routes/physical-routes/[_]hello'
 import { Route as ApiChar91_Char93authDotrouteRouteImport } from './routes/physical-routes/[_]auth.route'
+import { Route as ApiChar91_Char93helloRouteImport } from './routes/physical-routes/[_]hello'
 
 const indexRoute = indexRouteImport.update({
   id: '/',
@@ -24,17 +24,17 @@ const ApiIndexRoute = ApiIndexRouteImport.update({
   path: '/api/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiChar91_Char93helloRoute = ApiChar91_Char93helloRouteImport.update({
-  id: '/api/_hello',
-  path: '/api/_hello',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const ApiChar91_Char93authDotrouteRoute =
   ApiChar91_Char93authDotrouteRouteImport.update({
     id: '/api/_auth',
     path: '/api/_auth',
     getParentRoute: () => rootRouteImport,
   } as any)
+const ApiChar91_Char93helloRoute = ApiChar91_Char93helloRouteImport.update({
+  id: '/api/_hello',
+  path: '/api/_hello',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof indexRoute
@@ -86,18 +86,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/_hello': {
-      id: '/api/_hello'
-      path: '/api/_hello'
-      fullPath: '/api/_hello'
-      preLoaderRoute: typeof ApiChar91_Char93helloRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/api/_auth': {
       id: '/api/_auth'
       path: '/api/_auth'
       fullPath: '/api/_auth'
       preLoaderRoute: typeof ApiChar91_Char93authDotrouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/_hello': {
+      id: '/api/_hello'
+      path: '/api/_hello'
+      fullPath: '/api/_hello'
+      preLoaderRoute: typeof ApiChar91_Char93helloRouteImport
       parentRoute: typeof rootRouteImport
     }
   }

--- a/packages/router-generator/tests/generator/virtual/routeTree.snapshot.ts
+++ b/packages/router-generator/tests/generator/virtual/routeTree.snapshot.ts
@@ -9,25 +9,30 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/root'
-import { Route as layoutRouteImport } from './routes/layout'
 import { Route as indexRouteImport } from './routes/index'
-import { Route as dbDashboardRouteImport } from './routes/db/dashboard'
+import { Route as layoutRouteImport } from './routes/layout'
 import { Route as pagesRouteImport } from './routes/pages'
-import { Route as HelloIndexRouteImport } from './routes/subtree/index'
-import { Route as dbDashboardInvoicesRouteImport } from './routes/db/dashboard-invoices'
+import { Route as dbDashboardRouteImport } from './routes/db/dashboard'
 import { Route as dbDashboardIndexRouteImport } from './routes/db/dashboard-index'
+import { Route as dbDashboardInvoicesRouteImport } from './routes/db/dashboard-invoices'
+import { Route as HelloIndexRouteImport } from './routes/subtree/index'
+import { Route as dbInvoicesIndexRouteImport } from './routes/db/invoices-index'
+import { Route as dbInvoiceDetailRouteImport } from './routes/db/invoice-detail'
 import { Route as HelloFooIndexRouteImport } from './routes/subtree/foo/index'
 import { Route as HelloFooIdRouteImport } from './routes/subtree/foo/$id'
-import { Route as dbInvoiceDetailRouteImport } from './routes/db/invoice-detail'
-import { Route as dbInvoicesIndexRouteImport } from './routes/db/invoices-index'
 
+const indexRoute = indexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const layoutRoute = layoutRouteImport.update({
   id: '/_layout',
   getParentRoute: () => rootRouteImport,
 } as any)
-const indexRoute = indexRouteImport.update({
-  id: '/',
-  path: '/',
+const pagesRoute = pagesRouteImport.update({
+  id: '/$lang/',
+  path: '/$lang/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const dbDashboardRoute = dbDashboardRouteImport.update({
@@ -35,25 +40,30 @@ const dbDashboardRoute = dbDashboardRouteImport.update({
   path: '/dashboard',
   getParentRoute: () => layoutRoute,
 } as any)
-const pagesRoute = pagesRouteImport.update({
-  id: '/$lang/',
-  path: '/$lang/',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const HelloIndexRoute = HelloIndexRouteImport.update({
-  id: '/hello/',
-  path: '/hello/',
-  getParentRoute: () => layoutRoute,
+const dbDashboardIndexRoute = dbDashboardIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => dbDashboardRoute,
 } as any)
 const dbDashboardInvoicesRoute = dbDashboardInvoicesRouteImport.update({
   id: '/invoices',
   path: '/invoices',
   getParentRoute: () => dbDashboardRoute,
 } as any)
-const dbDashboardIndexRoute = dbDashboardIndexRouteImport.update({
+const HelloIndexRoute = HelloIndexRouteImport.update({
+  id: '/hello/',
+  path: '/hello/',
+  getParentRoute: () => layoutRoute,
+} as any)
+const dbInvoicesIndexRoute = dbInvoicesIndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => dbDashboardRoute,
+  getParentRoute: () => dbDashboardInvoicesRoute,
+} as any)
+const dbInvoiceDetailRoute = dbInvoiceDetailRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => dbDashboardInvoicesRoute,
 } as any)
 const HelloFooIndexRoute = HelloFooIndexRouteImport.update({
   id: '/hello/foo/',
@@ -64,16 +74,6 @@ const HelloFooIdRoute = HelloFooIdRouteImport.update({
   id: '/hello/foo/$id',
   path: '/hello/foo/$id',
   getParentRoute: () => layoutRoute,
-} as any)
-const dbInvoiceDetailRoute = dbInvoiceDetailRouteImport.update({
-  id: '/$id',
-  path: '/$id',
-  getParentRoute: () => dbDashboardInvoicesRoute,
-} as any)
-const dbInvoicesIndexRoute = dbInvoicesIndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => dbDashboardInvoicesRoute,
 } as any)
 
 export interface FileRoutesByFullPath {
@@ -158,6 +158,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof indexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_layout': {
       id: '/_layout'
       path: ''
@@ -165,11 +172,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof layoutRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof indexRouteImport
+    '/$lang/': {
+      id: '/$lang/'
+      path: '/$lang'
+      fullPath: '/$lang/'
+      preLoaderRoute: typeof pagesRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_layout/dashboard': {
@@ -179,19 +186,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof dbDashboardRouteImport
       parentRoute: typeof layoutRoute
     }
-    '/$lang/': {
-      id: '/$lang/'
-      path: '/$lang'
-      fullPath: '/$lang/'
-      preLoaderRoute: typeof pagesRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_layout/hello/': {
-      id: '/_layout/hello/'
-      path: '/hello'
-      fullPath: '/hello/'
-      preLoaderRoute: typeof HelloIndexRouteImport
-      parentRoute: typeof layoutRoute
+    '/_layout/dashboard/': {
+      id: '/_layout/dashboard/'
+      path: '/'
+      fullPath: '/dashboard/'
+      preLoaderRoute: typeof dbDashboardIndexRouteImport
+      parentRoute: typeof dbDashboardRoute
     }
     '/_layout/dashboard/invoices': {
       id: '/_layout/dashboard/invoices'
@@ -200,12 +200,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof dbDashboardInvoicesRouteImport
       parentRoute: typeof dbDashboardRoute
     }
-    '/_layout/dashboard/': {
-      id: '/_layout/dashboard/'
+    '/_layout/hello/': {
+      id: '/_layout/hello/'
+      path: '/hello'
+      fullPath: '/hello/'
+      preLoaderRoute: typeof HelloIndexRouteImport
+      parentRoute: typeof layoutRoute
+    }
+    '/_layout/dashboard/invoices/': {
+      id: '/_layout/dashboard/invoices/'
       path: '/'
-      fullPath: '/dashboard/'
-      preLoaderRoute: typeof dbDashboardIndexRouteImport
-      parentRoute: typeof dbDashboardRoute
+      fullPath: '/dashboard/invoices/'
+      preLoaderRoute: typeof dbInvoicesIndexRouteImport
+      parentRoute: typeof dbDashboardInvoicesRoute
+    }
+    '/_layout/dashboard/invoices/$id': {
+      id: '/_layout/dashboard/invoices/$id'
+      path: '/$id'
+      fullPath: '/dashboard/invoices/$id'
+      preLoaderRoute: typeof dbInvoiceDetailRouteImport
+      parentRoute: typeof dbDashboardInvoicesRoute
     }
     '/_layout/hello/foo/': {
       id: '/_layout/hello/foo/'
@@ -220,20 +234,6 @@ declare module '@tanstack/react-router' {
       fullPath: '/hello/foo/$id'
       preLoaderRoute: typeof HelloFooIdRouteImport
       parentRoute: typeof layoutRoute
-    }
-    '/_layout/dashboard/invoices/$id': {
-      id: '/_layout/dashboard/invoices/$id'
-      path: '/$id'
-      fullPath: '/dashboard/invoices/$id'
-      preLoaderRoute: typeof dbInvoiceDetailRouteImport
-      parentRoute: typeof dbDashboardInvoicesRoute
-    }
-    '/_layout/dashboard/invoices/': {
-      id: '/_layout/dashboard/invoices/'
-      path: '/'
-      fullPath: '/dashboard/invoices/'
-      preLoaderRoute: typeof dbInvoicesIndexRouteImport
-      parentRoute: typeof dbDashboardInvoicesRoute
     }
   }
 }

--- a/packages/router-generator/tests/utils.test.ts
+++ b/packages/router-generator/tests/utils.test.ts
@@ -981,7 +981,9 @@ describe('sortRouteNodes', () => {
 
   /** Every distinct ordering of `arr` (Heap-free recursive permutation). */
   function permutations<T>(arr: Array<T>): Array<Array<T>> {
-    if (arr.length <= 1) return [arr]
+    if (arr.length <= 1) {
+      return [arr]
+    }
     const result: Array<Array<T>> = []
     arr.forEach((item, i) => {
       const rest = [...arr.slice(0, i), ...arr.slice(i + 1)]

--- a/packages/router-generator/tests/utils.test.ts
+++ b/packages/router-generator/tests/utils.test.ts
@@ -6,6 +6,7 @@ import {
   createRoutePathSegmentMetadata,
   createRouteNodesByFullPath,
   createRouteNodesByTo,
+  createTokenRegex,
   determineInitialRoutePath,
   hasEscapedLeadingUnderscore,
   hasEscapedTrailingUnderscore,
@@ -21,6 +22,7 @@ import {
   removeUnderscores,
   removeUnderscoresWithEscape,
   routePathToVariable,
+  sortRouteNodes,
 } from '../src/utils'
 import type { ImportDeclaration, RouteNode } from '../src/types'
 
@@ -963,5 +965,85 @@ describe('RoutePrefixMap', () => {
 
       expect(map.findParent('/users')).toBeNull()
     })
+  })
+})
+
+describe('sortRouteNodes', () => {
+  const indexTokenSegmentRegex = createTokenRegex('index', { type: 'segment' })
+
+  const node = (routePath: string): RouteNode =>
+    ({ routePath }) as unknown as RouteNode
+
+  const sortPaths = (routePaths: Array<string>): Array<string | undefined> =>
+    sortRouteNodes(routePaths.map(node), indexTokenSegmentRegex).map(
+      (n) => n.routePath,
+    )
+
+  /** Every distinct ordering of `arr` (Heap-free recursive permutation). */
+  function permutations<T>(arr: Array<T>): Array<Array<T>> {
+    if (arr.length <= 1) return [arr]
+    const result: Array<Array<T>> = []
+    arr.forEach((item, i) => {
+      const rest = [...arr.slice(0, i), ...arr.slice(i + 1)]
+      for (const perm of permutations(rest)) {
+        result.push([item, ...perm])
+      }
+    })
+    return result
+  }
+
+  it('orders tied siblings by routePath', () => {
+    // Same segment count, both non-index: they tie on every key before routePath.
+    const expected = ['/account/beta-features', '/account/busy-guard']
+    expect(
+      sortPaths(['/account/busy-guard', '/account/beta-features']),
+    ).toEqual(expected)
+    expect(
+      sortPaths(['/account/beta-features', '/account/busy-guard']),
+    ).toEqual(expected)
+  })
+
+  it('applies root, segment-count and index precedence before the routePath tiebreaker', () => {
+    const sorted = sortPaths([
+      '/posts',
+      '/account/busy-guard',
+      '/index',
+      '/__root',
+      '/account/beta-features',
+      '/about',
+      '/posts/index',
+    ])
+
+    expect(sorted).toEqual([
+      '/__root', // root always first
+      '/index', // depth 1, index segment before non-index
+      '/about', // depth 1, non-index, routePath tiebreak
+      '/posts', // depth 1, non-index, routePath tiebreak
+      '/posts/index', // depth 2, index segment before non-index
+      '/account/beta-features', // depth 2, non-index, routePath tiebreak
+      '/account/busy-guard', // depth 2, non-index, routePath tiebreak
+    ])
+  })
+
+  it('is deterministic for every input permutation (stable sort)', () => {
+    // Includes several sets that tie on all keys before routePath (the two
+    // `/account/*` leaves, `/about` vs `/posts`) — exactly the case that the
+    // former whole-object tiebreaker left in an engine- and input-order-
+    // dependent order. `sortRouteNodes` must map every permutation to the
+    // same output.
+    const routePaths = [
+      '/__root',
+      '/index',
+      '/about',
+      '/posts',
+      '/account/beta-features',
+      '/account/busy-guard',
+    ]
+
+    const reference = sortPaths(routePaths)
+
+    for (const permutation of permutations(routePaths)) {
+      expect(sortPaths(permutation)).toEqual(reference)
+    }
   })
 })


### PR DESCRIPTION
Fixes #7750.

### Problem

`buildRouteTree` sorts route nodes with `multiSortBy`, whose **final** accessor was `(d) => d` — comparing whole route-node objects:

```ts
const sortedRouteNodes = multiSortBy(acc.routeNodes, [
  (d) => (d.routePath?.includes(`/${rootPathId}`) ? -1 : 1),
  (d) => (d.routePath === undefined ? undefined : countSlashSeparatedParts(d.routePath)),
  (d) => { /* index-token check */ },
  (d) => d,            // <-- whole object
])
```

`multiSortBy`'s comparator ends with `return ao > bo ? 1 : -1`. For two distinct route-node objects, both coerce to `"[object Object]"`, so `ao === bo` is `false` and `ao > bo` is `false` → it returns `-1` for **both** `(a, b)` and `(b, a)`. That's an inconsistent comparator, so `Array.prototype.sort` leaves routes that tie on the earlier keys (same segment-count, same index-token status — e.g. `/account/beta-features` vs `/account/busy-guard`) in an order that depends on the engine's sort implementation, the input order, and the array size. The result: `routeTree.gen.ts` reorders non-deterministically across machines and Node versions, dirtying committed route trees with semantically-identical churn.

### Fix

Change the final tiebreaker from `(d) => d` to `(d) => d.routePath`, mirroring the pre-sort earlier in the same file (which already ends with `(d) => d.routePath`). `routePath` is unique per node, so this gives a total order and makes generation byte-identical regardless of Node version or route-set composition.

A changeset is included (`@tanstack/router-generator`, patch).

### Tests

The `buildRouteTree` tiebreaker sort is extracted into an exported pure `sortRouteNodes(routeNodes, indexTokenSegmentRegex)` helper (behavior-identical to the previous inline `multiSortBy` call) so it can be unit-tested directly. New tests in `router-generator/tests/utils.test.ts`:

- **Stable ordering** — feeds a route set that ties on every key before `routePath` (e.g. `/account/beta-features` vs `/account/busy-guard`, `/about` vs `/posts`) through **every** input permutation and asserts identical output, proving the sort is independent of input order, engine sort implementation, and array size. This test fails against the old `(d) => d` tiebreaker and passes against `(d) => d.routePath`.
- **Tiebreaker + precedence** — asserts tied siblings order by `routePath`, and that root / segment-count / index-token precedence still apply ahead of the tiebreaker.

### Regenerated snapshots

The deterministic tiebreaker changes the order in which route nodes are emitted, so the 38 committed `routeTree.snapshot.*` files under `tests/generator/` are regenerated. This is expected: the previous snapshots captured the *arbitrary* order the inconsistent comparator happened to produce on the machine that generated them. The buggy sort was stable run-to-run for a fixed input order and engine, so CI kept passing — the non-determinism only appeared *across* machines/Node versions (issue #7750).

The snapshot diffs are **pure emission-order reordering**: every route's `id`, `path`, and `parentRoute` is unchanged, and the route-tree structure (built from `acc.routeTree`, not the sorted list) is untouched — only the order of imports and route declarations shifts. In other words, the regenerated snapshots are exactly the semantically-identical churn this fix eliminates going forward, applied once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed non-deterministic route-tree generation when routes are equivalent, ensuring consistent ordering across runs and machines.
  * Stabilized tie-breaking so generated route outputs no longer vary based on engine/input quirks.
* **Tests**
  * Added new unit tests to validate deterministic sorting across permutations and tie scenarios.
  * Updated generated route-tree snapshots to match the new stable ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
