### PR TITLE
Fix/server fn cross file manifest

### DIFF
--- a/.changeset/fix-server-fn-manifest-cross-file.md
+++ b/.changeset/fix-server-fn-manifest-cross-file.md
@@ -1,0 +1,19 @@
+---
+"@tanstack/start-plugin-core": patch
+---
+
+fix(start-plugin-core): register server functions reachable only from server-only code in the production manifest
+
+When SSR is the server-function provider (the Vite default), a server function
+reachable only from server-only code — e.g. a middleware `.server()` body or
+another server function's handler — could be omitted from the generated server
+function manifest. Calls then failed at runtime in production with
+`Server function info not found for <id>`, while dev builds worked. This happened
+because the resolver module is generated once and could be produced before those
+functions had been discovered.
+
+The server-function resolver now completes discovery of the reachable server
+module graph (including provider modules, so handler-nested and external-package
+server functions are covered) before generating the manifest.
+
+Fixes #7213.

--- a/e2e/react-router/basepath-file-based/package.json
+++ b/e2e/react-router/basepath-file-based/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",

--- a/e2e/react-router/basic-esbuild-file-based/package.json
+++ b/e2e/react-router/basic-esbuild-file-based/package.json
@@ -19,7 +19,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",

--- a/e2e/react-router/basic-file-based-code-splitting/package.json
+++ b/e2e/react-router/basic-file-based-code-splitting/package.json
@@ -21,7 +21,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",

--- a/e2e/react-router/basic-file-based/package.json
+++ b/e2e/react-router/basic-file-based/package.json
@@ -23,7 +23,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",

--- a/e2e/react-router/basic-react-query-file-based/package.json
+++ b/e2e/react-router/basic-react-query-file-based/package.json
@@ -24,7 +24,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",

--- a/e2e/react-router/basic-react-query/package.json
+++ b/e2e/react-router/basic-react-query/package.json
@@ -22,7 +22,7 @@
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",

--- a/e2e/react-router/basic-scroll-restoration/package.json
+++ b/e2e/react-router/basic-scroll-restoration/package.json
@@ -21,7 +21,7 @@
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",

--- a/e2e/react-router/basic-virtual-file-based/package.json
+++ b/e2e/react-router/basic-virtual-file-based/package.json
@@ -23,7 +23,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",

--- a/e2e/react-router/basic-virtual-named-export-config-file-based/package.json
+++ b/e2e/react-router/basic-virtual-named-export-config-file-based/package.json
@@ -23,7 +23,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",

--- a/e2e/react-router/basic/package.json
+++ b/e2e/react-router/basic/package.json
@@ -20,7 +20,7 @@
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",

--- a/e2e/react-router/escaped-special-strings/package.json
+++ b/e2e/react-router/escaped-special-strings/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",

--- a/e2e/react-router/generator-cli-only/package.json
+++ b/e2e/react-router/generator-cli-only/package.json
@@ -21,7 +21,7 @@
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",

--- a/e2e/react-router/i18n-paraglide/package.json
+++ b/e2e/react-router/i18n-paraglide/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@inlang/paraglide-js": "^2.4.0",
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@tanstack/router-plugin": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/react-router/js-only-file-based/package.json
+++ b/e2e/react-router/js-only-file-based/package.json
@@ -20,7 +20,7 @@
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@tanstack/router-plugin": "workspace:^",
     "@types/react": "^19.0.8",

--- a/e2e/react-router/match-params/package.json
+++ b/e2e/react-router/match-params/package.json
@@ -14,7 +14,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",

--- a/e2e/react-router/rspack-basic-file-based/package.json
+++ b/e2e/react-router/rspack-basic-file-based/package.json
@@ -17,7 +17,7 @@
     "redaxios": "^0.5.1"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@rsbuild/core": "^2.0.11",
     "@rsbuild/plugin-react": "^2.0.0",
     "@tailwindcss/postcss": "^4.2.2",

--- a/e2e/react-router/rspack-basic-virtual-named-export-config-file-based/package.json
+++ b/e2e/react-router/rspack-basic-virtual-named-export-config-file-based/package.json
@@ -17,7 +17,7 @@
     "redaxios": "^0.5.1"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@rsbuild/core": "^2.0.11",
     "@rsbuild/plugin-react": "^2.0.0",
     "@tailwindcss/postcss": "^4.2.2",

--- a/e2e/react-router/scroll-restoration-sandbox-vite/package.json
+++ b/e2e/react-router/scroll-restoration-sandbox-vite/package.json
@@ -25,7 +25,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",

--- a/e2e/react-router/sentry-integration/package.json
+++ b/e2e/react-router/sentry-integration/package.json
@@ -23,7 +23,7 @@
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",

--- a/e2e/react-router/view-transitions/package.json
+++ b/e2e/react-router/view-transitions/package.json
@@ -22,7 +22,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",

--- a/e2e/react-start/basic-auth/package.json
+++ b/e2e/react-start/basic-auth/package.json
@@ -25,7 +25,7 @@
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/react-start/basic-cloudflare/package.json
+++ b/e2e/react-start/basic-cloudflare/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.29.0",
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/react-start/basic-react-query/package.json
+++ b/e2e/react-start/basic-react-query/package.json
@@ -25,7 +25,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/react-start/basic/package.json
+++ b/e2e/react-start/basic/package.json
@@ -31,7 +31,7 @@
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@rsbuild/core": "^2.0.11",
     "@rsbuild/plugin-react": "^2.0.0",
     "@tailwindcss/postcss": "^4.2.2",

--- a/e2e/react-start/clerk-basic/package.json
+++ b/e2e/react-start/clerk-basic/package.json
@@ -21,7 +21,7 @@
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/react-start/csp/package.json
+++ b/e2e/react-start/csp/package.json
@@ -17,7 +17,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",
     "@types/react": "^19.0.8",

--- a/e2e/react-start/css-inline/package.json
+++ b/e2e/react-start/css-inline/package.json
@@ -23,7 +23,7 @@
     "srvx": "^0.11.9"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@rsbuild/core": "^2.0.11",
     "@rsbuild/plugin-react": "^2.0.0",
     "@tanstack/router-e2e-utils": "workspace:^",

--- a/e2e/react-start/css-modules/package.json
+++ b/e2e/react-start/css-modules/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.29.0",
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:*",
     "@types/node": "^22.10.2",
     "@types/react": "^19.0.8",

--- a/e2e/react-start/custom-basepath/package.json
+++ b/e2e/react-start/custom-basepath/package.json
@@ -20,7 +20,7 @@
     "redaxios": "^0.5.1"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/express": "^5.0.6",

--- a/e2e/react-start/custom-server-rsbuild/package.json
+++ b/e2e/react-start/custom-server-rsbuild/package.json
@@ -20,7 +20,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@rsbuild/core": "^2.0.11",
     "@rsbuild/plugin-react": "^2.0.0",
     "@tailwindcss/postcss": "^4.2.2",

--- a/e2e/react-start/dev-ssr-styles/package.json
+++ b/e2e/react-start/dev-ssr-styles/package.json
@@ -37,7 +37,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-core": "workspace:*",
     "@tanstack/router-e2e-utils": "workspace:*",
     "@types/node": "^22.10.2",

--- a/e2e/react-start/early-hints/package.json
+++ b/e2e/react-start/early-hints/package.json
@@ -19,7 +19,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",
     "@types/node-forge": "^1.3.14",

--- a/e2e/react-start/hmr/package.json
+++ b/e2e/react-start/hmr/package.json
@@ -20,7 +20,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@rsbuild/core": "^2.0.11",
     "@rsbuild/plugin-react": "^2.0.0",
     "@tailwindcss/postcss": "^4.2.2",

--- a/e2e/react-start/i18n-paraglide/package.json
+++ b/e2e/react-start/i18n-paraglide/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@inlang/paraglide-js": "^2.4.0",
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/react-start/import-protection-custom-config/package.json
+++ b/e2e/react-start/import-protection-custom-config/package.json
@@ -19,7 +19,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",
     "@types/react": "^19.0.8",

--- a/e2e/react-start/import-protection/package.json
+++ b/e2e/react-start/import-protection/package.json
@@ -24,7 +24,7 @@
     "react-tweet": "^3.3.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@rsbuild/core": "^2.0.11",
     "@rsbuild/plugin-react": "^2.0.0",
     "@tanstack/router-e2e-utils": "workspace:^",

--- a/e2e/react-start/query-integration/package.json
+++ b/e2e/react-start/query-integration/package.json
@@ -24,7 +24,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/react-start/rsc-deferred-hydration/package.json
+++ b/e2e/react-start/rsc-deferred-hydration/package.json
@@ -31,7 +31,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",
     "@types/react": "^19.0.8",

--- a/e2e/react-start/rsc-query/package.json
+++ b/e2e/react-start/rsc-query/package.json
@@ -22,7 +22,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",
     "@types/react": "^19.0.8",

--- a/e2e/react-start/rsc-rsbuild/package.json
+++ b/e2e/react-start/rsc-rsbuild/package.json
@@ -27,7 +27,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@rsbuild/core": "^2.0.8",
     "@rsbuild/plugin-react": "^2.0.0",
     "@tanstack/router-e2e-utils": "workspace:^",

--- a/e2e/react-start/rsc/package.json
+++ b/e2e/react-start/rsc/package.json
@@ -39,7 +39,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@rsbuild/core": "^2.0.11",
     "@rsbuild/plugin-react": "^2.0.0",
     "@tanstack/eslint-plugin-start": "workspace:^",

--- a/e2e/react-start/scroll-restoration/package.json
+++ b/e2e/react-start/scroll-restoration/package.json
@@ -22,7 +22,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/react-start/server-functions-global-middleware/package.json
+++ b/e2e/react-start/server-functions-global-middleware/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/react-start/server-functions-shared-lib/package.json
+++ b/e2e/react-start/server-functions-shared-lib/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@tanstack/react-start-e2e-shared-server-fns",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "peerDependencies": {
+    "@tanstack/react-start": "*"
+  },
+  "devDependencies": {
+    "@tanstack/react-start": "workspace:*"
+  }
+}

--- a/e2e/react-start/server-functions-shared-lib/src/index.ts
+++ b/e2e/react-start/server-functions-shared-lib/src/index.ts
@@ -1,0 +1,10 @@
+import { createServerFn } from '@tanstack/react-start'
+import { sharedInnerServerFn } from './internal'
+
+// Exported by a separate package and called from the consuming app. Its handler
+// calls `sharedInnerServerFn`, which is only reachable through this handler and
+// lives in the same (external) package.
+export const sharedServerFn = createServerFn().handler(async () => {
+  const inner = await sharedInnerServerFn()
+  return { outer: 'from-shared-package-outer', inner }
+})

--- a/e2e/react-start/server-functions-shared-lib/src/internal.ts
+++ b/e2e/react-start/server-functions-shared-lib/src/internal.ts
@@ -1,0 +1,9 @@
+import { createServerFn } from '@tanstack/react-start'
+
+// A server-only function defined inside a shared package. It is reached only
+// through the handler of the package's exported `sharedServerFn` (below), so it
+// lives outside the consuming app's root AND behind a handler boundary — the
+// case that the location-agnostic provider-module discovery exists to cover.
+export const sharedInnerServerFn = createServerFn().handler(() => {
+  return { secret: 'from-shared-package-inner' }
+})

--- a/e2e/react-start/server-functions/package.json
+++ b/e2e/react-start/server-functions/package.json
@@ -22,6 +22,7 @@
     "@tanstack/react-router-devtools": "workspace:^",
     "@tanstack/react-router-ssr-query": "workspace:^",
     "@tanstack/react-start": "workspace:^",
+    "@tanstack/react-start-e2e-shared-server-fns": "workspace:*",
     "js-cookie": "^3.0.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/e2e/react-start/server-functions/package.json
+++ b/e2e/react-start/server-functions/package.json
@@ -30,7 +30,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@rsbuild/core": "^2.0.11",
     "@rsbuild/plugin-react": "^2.0.0",
     "@tailwindcss/postcss": "^4.2.2",

--- a/e2e/react-start/server-functions/src/functions/chainLevelB.ts
+++ b/e2e/react-start/server-functions/src/functions/chainLevelB.ts
@@ -1,0 +1,9 @@
+import { createServerFn } from '@tanstack/react-start'
+import { chainLevelC } from './chainLevelC'
+
+// Middle link of the chain. Reached only through `chainLevelA`'s handler, and
+// calls `chainLevelC` from its own handler.
+export const chainLevelB = createServerFn().handler(async () => {
+  const c = await chainLevelC()
+  return { level: 'B', c }
+})

--- a/e2e/react-start/server-functions/src/functions/chainLevelC.ts
+++ b/e2e/react-start/server-functions/src/functions/chainLevelC.ts
@@ -1,0 +1,8 @@
+import { createServerFn } from '@tanstack/react-start'
+
+// Deepest link of a cross-file, server-only chain. Only reachable through
+// `chainLevelB`'s handler, so it is discovered only on the second pass of the
+// provider-module fixpoint (after chainLevelB itself is registered).
+export const chainLevelC = createServerFn().handler(() => {
+  return { level: 'C', value: 'deepest-chain-value' }
+})

--- a/e2e/react-start/server-functions/src/functions/serverFnCalledByMiddleware.ts
+++ b/e2e/react-start/server-functions/src/functions/serverFnCalledByMiddleware.ts
@@ -1,0 +1,9 @@
+import { createServerFn } from '@tanstack/react-start'
+
+// This server function lives in its own file and is only ever called from
+// within a middleware that lives in yet another file (see
+// `src/middleware/serverFnCallingMiddleware.ts`). It is never referenced
+// directly from client code or from the route file.
+export const serverFnCalledByMiddleware = createServerFn().handler(() => {
+  return { message: 'hello from server fn called by middleware', secret: 1234 }
+})

--- a/e2e/react-start/server-functions/src/middleware/serverFnCallingMiddleware.ts
+++ b/e2e/react-start/server-functions/src/middleware/serverFnCallingMiddleware.ts
@@ -1,0 +1,22 @@
+import { createMiddleware } from '@tanstack/react-start'
+import { serverFnCalledByMiddleware } from '~/functions/serverFnCalledByMiddleware'
+
+// This middleware lives in its own file and, from its `.server()` handler,
+// calls a server function that is defined in a *separate* file.
+//
+// Regression test for https://github.com/TanStack/router/issues/7213:
+// when this middleware is applied to a server function, production builds
+// used to fail at runtime with "Server function info not found for [ID]"
+// because the server function reached only through the middleware was not
+// registered in the server function manifest. Dev builds worked fine.
+export const serverFnCallingMiddleware = createMiddleware({
+  type: 'function',
+}).server(async ({ next }) => {
+  const result = await serverFnCalledByMiddleware()
+
+  return next({
+    context: {
+      fromMiddleware: result,
+    },
+  })
+})

--- a/e2e/react-start/server-functions/src/routeTree.gen.ts
+++ b/e2e/react-start/server-functions/src/routeTree.gen.ts
@@ -11,11 +11,13 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SubmitPostFormdataRouteImport } from './routes/submit-post-formdata'
 import { Route as StatusRouteImport } from './routes/status'
+import { Route as SharedPackageServerFnRouteImport } from './routes/shared-package-server-fn'
 import { Route as ServerOnlyFnRouteImport } from './routes/server-only-fn'
 import { Route as ServerFnInClientOnlyFnRouteImport } from './routes/server-fn-in-client-only-fn'
 import { Route as SerializeFormDataRouteImport } from './routes/serialize-form-data'
 import { Route as ReturnNullRouteImport } from './routes/return-null'
 import { Route as RawResponseRouteImport } from './routes/raw-response'
+import { Route as NestedServerFnsRouteImport } from './routes/nested-server-fns'
 import { Route as MultipartRouteImport } from './routes/multipart'
 import { Route as IsomorphicFnsRouteImport } from './routes/isomorphic-fns'
 import { Route as HeadersRouteImport } from './routes/headers'
@@ -40,6 +42,7 @@ import { Route as AbortSignalIndexRouteImport } from './routes/abort-signal/inde
 import { Route as RedirectTestTargetRouteImport } from './routes/redirect-test/target'
 import { Route as RedirectTestSsrTargetRouteImport } from './routes/redirect-test-ssr/target'
 import { Route as MiddlewareUnhandledExceptionRouteImport } from './routes/middleware/unhandled-exception'
+import { Route as MiddlewareServerfnInMiddlewareRouteImport } from './routes/middleware/serverfn-in-middleware'
 import { Route as MiddlewareServerImportMiddlewareRouteImport } from './routes/middleware/server-import-middleware'
 import { Route as MiddlewareSendServerFnRouteImport } from './routes/middleware/send-serverFn'
 import { Route as MiddlewareRequestMiddlewareRouteImport } from './routes/middleware/request-middleware'
@@ -62,6 +65,11 @@ const SubmitPostFormdataRoute = SubmitPostFormdataRouteImport.update({
 const StatusRoute = StatusRouteImport.update({
   id: '/status',
   path: '/status',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SharedPackageServerFnRoute = SharedPackageServerFnRouteImport.update({
+  id: '/shared-package-server-fn',
+  path: '/shared-package-server-fn',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ServerOnlyFnRoute = ServerOnlyFnRouteImport.update({
@@ -87,6 +95,11 @@ const ReturnNullRoute = ReturnNullRouteImport.update({
 const RawResponseRoute = RawResponseRouteImport.update({
   id: '/raw-response',
   path: '/raw-response',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const NestedServerFnsRoute = NestedServerFnsRouteImport.update({
+  id: '/nested-server-fns',
+  path: '/nested-server-fns',
   getParentRoute: () => rootRouteImport,
 } as any)
 const MultipartRoute = MultipartRouteImport.update({
@@ -210,6 +223,12 @@ const MiddlewareUnhandledExceptionRoute =
     path: '/middleware/unhandled-exception',
     getParentRoute: () => rootRouteImport,
   } as any)
+const MiddlewareServerfnInMiddlewareRoute =
+  MiddlewareServerfnInMiddlewareRouteImport.update({
+    id: '/middleware/serverfn-in-middleware',
+    path: '/middleware/serverfn-in-middleware',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const MiddlewareServerImportMiddlewareRoute =
   MiddlewareServerImportMiddlewareRouteImport.update({
     id: '/middleware/server-import-middleware',
@@ -296,11 +315,13 @@ export interface FileRoutesByFullPath {
   '/headers': typeof HeadersRoute
   '/isomorphic-fns': typeof IsomorphicFnsRoute
   '/multipart': typeof MultipartRoute
+  '/nested-server-fns': typeof NestedServerFnsRoute
   '/raw-response': typeof RawResponseRoute
   '/return-null': typeof ReturnNullRoute
   '/serialize-form-data': typeof SerializeFormDataRoute
   '/server-fn-in-client-only-fn': typeof ServerFnInClientOnlyFnRoute
   '/server-only-fn': typeof ServerOnlyFnRoute
+  '/shared-package-server-fn': typeof SharedPackageServerFnRoute
   '/status': typeof StatusRoute
   '/submit-post-formdata': typeof SubmitPostFormdataRoute
   '/abort-signal/$method': typeof AbortSignalMethodRoute
@@ -313,6 +334,7 @@ export interface FileRoutesByFullPath {
   '/middleware/request-middleware': typeof MiddlewareRequestMiddlewareRoute
   '/middleware/send-serverFn': typeof MiddlewareSendServerFnRoute
   '/middleware/server-import-middleware': typeof MiddlewareServerImportMiddlewareRoute
+  '/middleware/serverfn-in-middleware': typeof MiddlewareServerfnInMiddlewareRoute
   '/middleware/unhandled-exception': typeof MiddlewareUnhandledExceptionRoute
   '/redirect-test-ssr/target': typeof RedirectTestSsrTargetRoute
   '/redirect-test/target': typeof RedirectTestTargetRoute
@@ -342,11 +364,13 @@ export interface FileRoutesByTo {
   '/headers': typeof HeadersRoute
   '/isomorphic-fns': typeof IsomorphicFnsRoute
   '/multipart': typeof MultipartRoute
+  '/nested-server-fns': typeof NestedServerFnsRoute
   '/raw-response': typeof RawResponseRoute
   '/return-null': typeof ReturnNullRoute
   '/serialize-form-data': typeof SerializeFormDataRoute
   '/server-fn-in-client-only-fn': typeof ServerFnInClientOnlyFnRoute
   '/server-only-fn': typeof ServerOnlyFnRoute
+  '/shared-package-server-fn': typeof SharedPackageServerFnRoute
   '/status': typeof StatusRoute
   '/submit-post-formdata': typeof SubmitPostFormdataRoute
   '/abort-signal/$method': typeof AbortSignalMethodRoute
@@ -359,6 +383,7 @@ export interface FileRoutesByTo {
   '/middleware/request-middleware': typeof MiddlewareRequestMiddlewareRoute
   '/middleware/send-serverFn': typeof MiddlewareSendServerFnRoute
   '/middleware/server-import-middleware': typeof MiddlewareServerImportMiddlewareRoute
+  '/middleware/serverfn-in-middleware': typeof MiddlewareServerfnInMiddlewareRoute
   '/middleware/unhandled-exception': typeof MiddlewareUnhandledExceptionRoute
   '/redirect-test-ssr/target': typeof RedirectTestSsrTargetRoute
   '/redirect-test/target': typeof RedirectTestTargetRoute
@@ -389,11 +414,13 @@ export interface FileRoutesById {
   '/headers': typeof HeadersRoute
   '/isomorphic-fns': typeof IsomorphicFnsRoute
   '/multipart': typeof MultipartRoute
+  '/nested-server-fns': typeof NestedServerFnsRoute
   '/raw-response': typeof RawResponseRoute
   '/return-null': typeof ReturnNullRoute
   '/serialize-form-data': typeof SerializeFormDataRoute
   '/server-fn-in-client-only-fn': typeof ServerFnInClientOnlyFnRoute
   '/server-only-fn': typeof ServerOnlyFnRoute
+  '/shared-package-server-fn': typeof SharedPackageServerFnRoute
   '/status': typeof StatusRoute
   '/submit-post-formdata': typeof SubmitPostFormdataRoute
   '/abort-signal/$method': typeof AbortSignalMethodRoute
@@ -406,6 +433,7 @@ export interface FileRoutesById {
   '/middleware/request-middleware': typeof MiddlewareRequestMiddlewareRoute
   '/middleware/send-serverFn': typeof MiddlewareSendServerFnRoute
   '/middleware/server-import-middleware': typeof MiddlewareServerImportMiddlewareRoute
+  '/middleware/serverfn-in-middleware': typeof MiddlewareServerfnInMiddlewareRoute
   '/middleware/unhandled-exception': typeof MiddlewareUnhandledExceptionRoute
   '/redirect-test-ssr/target': typeof RedirectTestSsrTargetRoute
   '/redirect-test/target': typeof RedirectTestTargetRoute
@@ -437,11 +465,13 @@ export interface FileRouteTypes {
     | '/headers'
     | '/isomorphic-fns'
     | '/multipart'
+    | '/nested-server-fns'
     | '/raw-response'
     | '/return-null'
     | '/serialize-form-data'
     | '/server-fn-in-client-only-fn'
     | '/server-only-fn'
+    | '/shared-package-server-fn'
     | '/status'
     | '/submit-post-formdata'
     | '/abort-signal/$method'
@@ -454,6 +484,7 @@ export interface FileRouteTypes {
     | '/middleware/request-middleware'
     | '/middleware/send-serverFn'
     | '/middleware/server-import-middleware'
+    | '/middleware/serverfn-in-middleware'
     | '/middleware/unhandled-exception'
     | '/redirect-test-ssr/target'
     | '/redirect-test/target'
@@ -483,11 +514,13 @@ export interface FileRouteTypes {
     | '/headers'
     | '/isomorphic-fns'
     | '/multipart'
+    | '/nested-server-fns'
     | '/raw-response'
     | '/return-null'
     | '/serialize-form-data'
     | '/server-fn-in-client-only-fn'
     | '/server-only-fn'
+    | '/shared-package-server-fn'
     | '/status'
     | '/submit-post-formdata'
     | '/abort-signal/$method'
@@ -500,6 +533,7 @@ export interface FileRouteTypes {
     | '/middleware/request-middleware'
     | '/middleware/send-serverFn'
     | '/middleware/server-import-middleware'
+    | '/middleware/serverfn-in-middleware'
     | '/middleware/unhandled-exception'
     | '/redirect-test-ssr/target'
     | '/redirect-test/target'
@@ -529,11 +563,13 @@ export interface FileRouteTypes {
     | '/headers'
     | '/isomorphic-fns'
     | '/multipart'
+    | '/nested-server-fns'
     | '/raw-response'
     | '/return-null'
     | '/serialize-form-data'
     | '/server-fn-in-client-only-fn'
     | '/server-only-fn'
+    | '/shared-package-server-fn'
     | '/status'
     | '/submit-post-formdata'
     | '/abort-signal/$method'
@@ -546,6 +582,7 @@ export interface FileRouteTypes {
     | '/middleware/request-middleware'
     | '/middleware/send-serverFn'
     | '/middleware/server-import-middleware'
+    | '/middleware/serverfn-in-middleware'
     | '/middleware/unhandled-exception'
     | '/redirect-test-ssr/target'
     | '/redirect-test/target'
@@ -576,11 +613,13 @@ export interface RootRouteChildren {
   HeadersRoute: typeof HeadersRoute
   IsomorphicFnsRoute: typeof IsomorphicFnsRoute
   MultipartRoute: typeof MultipartRoute
+  NestedServerFnsRoute: typeof NestedServerFnsRoute
   RawResponseRoute: typeof RawResponseRoute
   ReturnNullRoute: typeof ReturnNullRoute
   SerializeFormDataRoute: typeof SerializeFormDataRoute
   ServerFnInClientOnlyFnRoute: typeof ServerFnInClientOnlyFnRoute
   ServerOnlyFnRoute: typeof ServerOnlyFnRoute
+  SharedPackageServerFnRoute: typeof SharedPackageServerFnRoute
   StatusRoute: typeof StatusRoute
   SubmitPostFormdataRoute: typeof SubmitPostFormdataRoute
   AbortSignalMethodRoute: typeof AbortSignalMethodRoute
@@ -593,6 +632,7 @@ export interface RootRouteChildren {
   MiddlewareRequestMiddlewareRoute: typeof MiddlewareRequestMiddlewareRoute
   MiddlewareSendServerFnRoute: typeof MiddlewareSendServerFnRoute
   MiddlewareServerImportMiddlewareRoute: typeof MiddlewareServerImportMiddlewareRoute
+  MiddlewareServerfnInMiddlewareRoute: typeof MiddlewareServerfnInMiddlewareRoute
   MiddlewareUnhandledExceptionRoute: typeof MiddlewareUnhandledExceptionRoute
   RedirectTestSsrTargetRoute: typeof RedirectTestSsrTargetRoute
   RedirectTestTargetRoute: typeof RedirectTestTargetRoute
@@ -628,6 +668,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof StatusRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/shared-package-server-fn': {
+      id: '/shared-package-server-fn'
+      path: '/shared-package-server-fn'
+      fullPath: '/shared-package-server-fn'
+      preLoaderRoute: typeof SharedPackageServerFnRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/server-only-fn': {
       id: '/server-only-fn'
       path: '/server-only-fn'
@@ -661,6 +708,13 @@ declare module '@tanstack/react-router' {
       path: '/raw-response'
       fullPath: '/raw-response'
       preLoaderRoute: typeof RawResponseRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/nested-server-fns': {
+      id: '/nested-server-fns'
+      path: '/nested-server-fns'
+      fullPath: '/nested-server-fns'
+      preLoaderRoute: typeof NestedServerFnsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/multipart': {
@@ -831,6 +885,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MiddlewareUnhandledExceptionRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/middleware/serverfn-in-middleware': {
+      id: '/middleware/serverfn-in-middleware'
+      path: '/middleware/serverfn-in-middleware'
+      fullPath: '/middleware/serverfn-in-middleware'
+      preLoaderRoute: typeof MiddlewareServerfnInMiddlewareRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/middleware/server-import-middleware': {
       id: '/middleware/server-import-middleware'
       path: '/middleware/server-import-middleware'
@@ -936,11 +997,13 @@ const rootRouteChildren: RootRouteChildren = {
   HeadersRoute: HeadersRoute,
   IsomorphicFnsRoute: IsomorphicFnsRoute,
   MultipartRoute: MultipartRoute,
+  NestedServerFnsRoute: NestedServerFnsRoute,
   RawResponseRoute: RawResponseRoute,
   ReturnNullRoute: ReturnNullRoute,
   SerializeFormDataRoute: SerializeFormDataRoute,
   ServerFnInClientOnlyFnRoute: ServerFnInClientOnlyFnRoute,
   ServerOnlyFnRoute: ServerOnlyFnRoute,
+  SharedPackageServerFnRoute: SharedPackageServerFnRoute,
   StatusRoute: StatusRoute,
   SubmitPostFormdataRoute: SubmitPostFormdataRoute,
   AbortSignalMethodRoute: AbortSignalMethodRoute,
@@ -953,6 +1016,7 @@ const rootRouteChildren: RootRouteChildren = {
   MiddlewareRequestMiddlewareRoute: MiddlewareRequestMiddlewareRoute,
   MiddlewareSendServerFnRoute: MiddlewareSendServerFnRoute,
   MiddlewareServerImportMiddlewareRoute: MiddlewareServerImportMiddlewareRoute,
+  MiddlewareServerfnInMiddlewareRoute: MiddlewareServerfnInMiddlewareRoute,
   MiddlewareUnhandledExceptionRoute: MiddlewareUnhandledExceptionRoute,
   RedirectTestSsrTargetRoute: RedirectTestSsrTargetRoute,
   RedirectTestTargetRoute: RedirectTestTargetRoute,

--- a/e2e/react-start/server-functions/src/routes/middleware/index.tsx
+++ b/e2e/react-start/server-functions/src/routes/middleware/index.tsx
@@ -66,6 +66,14 @@ function RouteComponent() {
             Function middleware receives functionId and filename
           </Route.Link>
         </li>
+        <li>
+          <Route.Link
+            to="./serverfn-in-middleware"
+            data-testid="serverfn-in-middleware-link"
+          >
+            Server function called from a middleware in a separate file
+          </Route.Link>
+        </li>
       </ul>
     </div>
   )

--- a/e2e/react-start/server-functions/src/routes/middleware/serverfn-in-middleware.tsx
+++ b/e2e/react-start/server-functions/src/routes/middleware/serverfn-in-middleware.tsx
@@ -1,0 +1,70 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { createServerFn } from '@tanstack/react-start'
+import * as React from 'react'
+import { serverFnCallingMiddleware } from '~/middleware/serverFnCallingMiddleware'
+
+/**
+ * Regression test for https://github.com/TanStack/router/issues/7213.
+ *
+ * A middleware defined in a separate file (`serverFnCallingMiddleware`) calls a
+ * server function defined in yet another separate file
+ * (`serverFnCalledByMiddleware`). That middleware is then applied to the server
+ * function below.
+ *
+ * In production builds this used to fail at runtime with
+ * "Server function info not found for [ID]" because the server function that is
+ * only reachable through the middleware was never registered in the server
+ * function manifest. It worked in development and when everything lived in a
+ * single file.
+ */
+const serverFnWithMiddleware = createServerFn()
+  .middleware([serverFnCallingMiddleware])
+  .handler(async ({ context }) => {
+    return { fromMiddleware: context.fromMiddleware }
+  })
+
+export const Route = createFileRoute('/middleware/serverfn-in-middleware')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const [result, setResult] = React.useState<{
+    fromMiddleware: { message: string; secret: number }
+  } | null>(null)
+  const [error, setError] = React.useState<string | null>(null)
+
+  async function handleClick() {
+    try {
+      const data = await serverFnWithMiddleware()
+      setResult(data)
+      setError(null)
+    } catch (e) {
+      setResult(null)
+      setError(e instanceof Error ? e.message : String(e))
+    }
+  }
+
+  return (
+    <div className="p-2 m-2 grid gap-2">
+      <h2>Server Function Called From Middleware (issue #7213)</h2>
+      <p>
+        A middleware in a separate file calls a server function in another
+        separate file, and that middleware is applied to this server function.
+      </p>
+      <button
+        onClick={handleClick}
+        data-testid="test-serverfn-in-middleware-btn"
+      >
+        Call server function with middleware
+      </button>
+      {result && (
+        <pre data-testid="serverfn-in-middleware-result">
+          {JSON.stringify(result)}
+        </pre>
+      )}
+      {error && (
+        <div data-testid="serverfn-in-middleware-error">Error: {error}</div>
+      )}
+    </div>
+  )
+}

--- a/e2e/react-start/server-functions/src/routes/nested-server-fns.tsx
+++ b/e2e/react-start/server-functions/src/routes/nested-server-fns.tsx
@@ -1,0 +1,49 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { createServerFn } from '@tanstack/react-start'
+import * as React from 'react'
+import { chainLevelB } from '~/functions/chainLevelB'
+
+/**
+ * Regression test for https://github.com/TanStack/router/issues/7213 exercising
+ * a multi-level cross-file chain:
+ *
+ *   chainLevelA (client-called) -> chainLevelB (handler) -> chainLevelC (handler)
+ *
+ * Each function lives in its own file; levelB and levelC are server-only. levelC
+ * is only reachable through levelB's handler, so it is discovered only after
+ * levelB is registered and its provider module is crawled — i.e. the discovery
+ * fixpoint must iterate more than once for this to end up in the manifest.
+ */
+const chainLevelA = createServerFn().handler(async () => {
+  return chainLevelB()
+})
+
+export const Route = createFileRoute('/nested-server-fns')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const [result, setResult] = React.useState<string | null>(null)
+  const [error, setError] = React.useState<string | null>(null)
+
+  async function handleClick() {
+    try {
+      setResult(JSON.stringify(await chainLevelA()))
+      setError(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+      setResult(null)
+    }
+  }
+
+  return (
+    <div className="p-2 m-2 grid gap-2">
+      <h2>Nested Cross-File Server Functions (issue #7213)</h2>
+      <button onClick={handleClick} data-testid="test-nested-server-fns-btn">
+        Call nested chain
+      </button>
+      {result && <pre data-testid="nested-server-fns-result">{result}</pre>}
+      {error && <div data-testid="nested-server-fns-error">Error: {error}</div>}
+    </div>
+  )
+}

--- a/e2e/react-start/server-functions/src/routes/shared-package-server-fn.tsx
+++ b/e2e/react-start/server-functions/src/routes/shared-package-server-fn.tsx
@@ -1,0 +1,44 @@
+import { createFileRoute } from '@tanstack/react-router'
+import * as React from 'react'
+import { sharedServerFn } from '@tanstack/react-start-e2e-shared-server-fns'
+
+/**
+ * Regression test for https://github.com/TanStack/router/issues/7213 covering
+ * server functions defined in a SEPARATE package.
+ *
+ * `sharedServerFn` is exported by a workspace package and called from the client
+ * here. Its handler calls `sharedInnerServerFn`, which lives in that same package
+ * and is only reachable through the handler — i.e. a server-only function defined
+ * outside the app root, behind a handler boundary. In production this used to
+ * fail at runtime with "Server function info not found" because the inner
+ * function was never registered in the manifest.
+ */
+export const Route = createFileRoute('/shared-package-server-fn')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const [result, setResult] = React.useState<string | null>(null)
+  const [error, setError] = React.useState<string | null>(null)
+
+  async function handleClick() {
+    try {
+      setResult(JSON.stringify(await sharedServerFn()))
+      setError(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+      setResult(null)
+    }
+  }
+
+  return (
+    <div className="p-2 m-2 grid gap-2">
+      <h2>Server Function From a Separate Package (issue #7213)</h2>
+      <button onClick={handleClick} data-testid="test-shared-package-btn">
+        Call shared-package server function
+      </button>
+      {result && <pre data-testid="shared-package-result">{result}</pre>}
+      {error && <div data-testid="shared-package-error">Error: {error}</div>}
+    </div>
+  )
+}

--- a/e2e/react-start/server-functions/tests/server-functions.spec.ts
+++ b/e2e/react-start/server-functions/tests/server-functions.spec.ts
@@ -718,6 +718,102 @@ test('server-only imports in middleware.server() are stripped from client build'
   ).toContainText('test-header-value')
 })
 
+test('server function reached only through a cross-file middleware is registered in the manifest (issue #7213)', async ({
+  page,
+}) => {
+  // Regression test for https://github.com/TanStack/router/issues/7213.
+  // A middleware defined in a separate file calls a server function defined in
+  // yet another separate file, and that middleware is applied to a server
+  // function. In production builds this used to fail at runtime with
+  // "Server function info not found for [ID]" because the server function that
+  // is only reachable through the middleware was never registered in the
+  // server function manifest. It worked in dev and when everything lived in a
+  // single file.
+  await page.goto('/middleware/serverfn-in-middleware')
+
+  await page.waitForLoadState('networkidle')
+
+  // Invoke the server function whose middleware calls a cross-file server fn.
+  await page.getByTestId('test-serverfn-in-middleware-btn').click()
+
+  // The middleware's server-fn call must resolve without a manifest lookup error.
+  await expect(
+    page.getByTestId('serverfn-in-middleware-result'),
+  ).toContainText('hello from server fn called by middleware')
+
+  // No "Server function info not found" (or any other) error should surface.
+  await expect(
+    page.getByTestId('serverfn-in-middleware-error'),
+  ).toHaveCount(0)
+})
+
+test('server function called only from another server function is registered in the manifest (issue #7213)', async ({
+  page,
+}) => {
+  // Sibling of the issue #7213 case: `fnOnlyCalledByServer` lives in its own
+  // file and is only ever invoked from inside `proxyFnThatCallsServerOnlyFn`'s
+  // handler (never from client code). Its handler-body reference is stripped
+  // from the caller module during the server transform, so — like the
+  // middleware case — it used to be absent from the production manifest and
+  // failed at runtime with "Server function info not found for [ID]".
+  await page.goto('/server-only-fn')
+
+  await page.waitForLoadState('networkidle')
+
+  await page.getByTestId('test-server-only-fn-btn').click()
+
+  // The nested server-only function must resolve and return its real result.
+  const expected = await page
+    .getByTestId('expected-server-only-fn-result')
+    .textContent()
+  await expect(page.getByTestId('server-only-fn-result')).toHaveText(
+    expected ?? '',
+  )
+  await expect(page.getByTestId('server-only-fn-result')).toContainText(
+    'hello from server-only function',
+  )
+})
+
+test('server functions discovered across a multi-level cross-file chain (issue #7213)', async ({
+  page,
+}) => {
+  // chainLevelA (client-called) -> chainLevelB (handler) -> chainLevelC (handler),
+  // each in its own file. levelC is only reachable through levelB's handler, so
+  // it is discovered only once the provider-module discovery fixpoint iterates a
+  // second time. If that didn't happen, the nested call would fail at runtime
+  // with "Server function info not found".
+  await page.goto('/nested-server-fns')
+
+  await page.waitForLoadState('networkidle')
+
+  await page.getByTestId('test-nested-server-fns-btn').click()
+
+  await expect(page.getByTestId('nested-server-fns-result')).toContainText(
+    'deepest-chain-value',
+  )
+  await expect(page.getByTestId('nested-server-fns-error')).toHaveCount(0)
+})
+
+test('server function in a separate package resolves its nested server-only fn (issue #7213)', async ({
+  page,
+}) => {
+  // `sharedServerFn` is exported by a separate workspace package and called from
+  // the client. Its handler calls `sharedInnerServerFn`, a server-only function
+  // in that same package — i.e. defined OUTSIDE the app root and reachable only
+  // through a handler. This used to fail in production with "Server function info
+  // not found" because functions outside the app root were not discovered.
+  await page.goto('/shared-package-server-fn')
+
+  await page.waitForLoadState('networkidle')
+
+  await page.getByTestId('test-shared-package-btn').click()
+
+  await expect(page.getByTestId('shared-package-result')).toContainText(
+    'from-shared-package-inner',
+  )
+  await expect(page.getByTestId('shared-package-error')).toHaveCount(0)
+})
+
 test('middleware factories with server-only imports are stripped from client build', async ({
   page,
 }) => {

--- a/e2e/react-start/server-routes-global-middleware/package.json
+++ b/e2e/react-start/server-routes-global-middleware/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/react-start/server-routes/package.json
+++ b/e2e/react-start/server-routes/package.json
@@ -25,7 +25,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/js-cookie": "^3.0.6",

--- a/e2e/react-start/split-base-and-basepath/package.json
+++ b/e2e/react-start/split-base-and-basepath/package.json
@@ -20,7 +20,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",
     "@types/react": "^19.0.8",

--- a/e2e/react-start/start-manifest/package.json
+++ b/e2e/react-start/start-manifest/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",
     "@types/react": "^19.0.8",

--- a/e2e/react-start/static-server-functions/package.json
+++ b/e2e/react-start/static-server-functions/package.json
@@ -20,7 +20,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:*",
     "@types/node": "^22.10.2",
     "@types/react": "^19.0.8",

--- a/e2e/react-start/streaming-ssr/package.json
+++ b/e2e/react-start/streaming-ssr/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",
     "@types/react": "^19.0.8",

--- a/e2e/react-start/transform-asset-urls/package.json
+++ b/e2e/react-start/transform-asset-urls/package.json
@@ -40,7 +40,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",
     "@types/react": "^19.0.8",

--- a/e2e/react-start/virtual-routes/package.json
+++ b/e2e/react-start/virtual-routes/package.json
@@ -23,7 +23,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/react-start/website/package.json
+++ b/e2e/react-start/website/package.json
@@ -22,7 +22,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/solid-router/basepath-file-based/package.json
+++ b/e2e/solid-router/basepath-file-based/package.json
@@ -17,7 +17,7 @@
     "solid-js": "^1.9.10"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite-plugin-solid": "^2.11.11",
     "vite": "^8.0.14"

--- a/e2e/solid-router/basic-esbuild-file-based/package.json
+++ b/e2e/solid-router/basic-esbuild-file-based/package.json
@@ -18,7 +18,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "esbuild": "^0.27.4",
     "esbuild-plugin-solid": "^0.6.0"

--- a/e2e/solid-router/basic-file-based-code-splitting/package.json
+++ b/e2e/solid-router/basic-file-based-code-splitting/package.json
@@ -20,7 +20,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
     "vite-plugin-solid": "^2.11.11"

--- a/e2e/solid-router/basic-file-based/package.json
+++ b/e2e/solid-router/basic-file-based/package.json
@@ -22,7 +22,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "combinate": "^1.1.11",
     "vite": "^8.0.14",

--- a/e2e/solid-router/basic-scroll-restoration/package.json
+++ b/e2e/solid-router/basic-scroll-restoration/package.json
@@ -20,7 +20,7 @@
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
     "vite-plugin-solid": "^2.11.11",

--- a/e2e/solid-router/basic-solid-query-file-based/package.json
+++ b/e2e/solid-router/basic-solid-query-file-based/package.json
@@ -23,7 +23,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
     "vite-plugin-solid": "^2.11.11"

--- a/e2e/solid-router/basic-solid-query/package.json
+++ b/e2e/solid-router/basic-solid-query/package.json
@@ -21,7 +21,7 @@
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
     "vite-plugin-solid": "^2.11.11"

--- a/e2e/solid-router/basic-virtual-file-based/package.json
+++ b/e2e/solid-router/basic-virtual-file-based/package.json
@@ -22,7 +22,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
     "vite-plugin-solid": "^2.11.11"

--- a/e2e/solid-router/basic-virtual-named-export-config-file-based/package.json
+++ b/e2e/solid-router/basic-virtual-named-export-config-file-based/package.json
@@ -22,7 +22,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
     "vite-plugin-solid": "^2.11.11"

--- a/e2e/solid-router/basic/package.json
+++ b/e2e/solid-router/basic/package.json
@@ -19,7 +19,7 @@
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
     "vite-plugin-solid": "^2.11.11"

--- a/e2e/solid-router/generator-cli-only/package.json
+++ b/e2e/solid-router/generator-cli-only/package.json
@@ -20,7 +20,7 @@
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite-plugin-solid": "^2.11.11",
     "vite": "^8.0.14"

--- a/e2e/solid-router/js-only-file-based/package.json
+++ b/e2e/solid-router/js-only-file-based/package.json
@@ -19,7 +19,7 @@
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@tanstack/router-plugin": "workspace:^",
     "vite-plugin-solid": "^2.11.11",

--- a/e2e/solid-router/rspack-basic-file-based/package.json
+++ b/e2e/solid-router/rspack-basic-file-based/package.json
@@ -16,7 +16,7 @@
     "solid-js": "^1.9.10"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@rsbuild/core": "^2.0.11",
     "@rsbuild/plugin-babel": "^1.1.2",
     "@rsbuild/plugin-solid": "^1.1.1",

--- a/e2e/solid-router/rspack-basic-virtual-named-export-config-file-based/package.json
+++ b/e2e/solid-router/rspack-basic-virtual-named-export-config-file-based/package.json
@@ -16,7 +16,7 @@
     "solid-js": "^1.9.10"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@rsbuild/core": "^2.0.11",
     "@rsbuild/plugin-babel": "^1.1.2",
     "@rsbuild/plugin-solid": "^1.1.1",

--- a/e2e/solid-router/scroll-restoration-sandbox-vite/package.json
+++ b/e2e/solid-router/scroll-restoration-sandbox-vite/package.json
@@ -24,7 +24,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
     "vite-plugin-solid": "^2.11.11"

--- a/e2e/solid-router/sentry-integration/package.json
+++ b/e2e/solid-router/sentry-integration/package.json
@@ -22,7 +22,7 @@
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite-plugin-solid": "^2.11.11",
     "vite": "^8.0.14"

--- a/e2e/solid-router/view-transitions/package.json
+++ b/e2e/solid-router/view-transitions/package.json
@@ -21,7 +21,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",

--- a/e2e/solid-start/basic-auth/package.json
+++ b/e2e/solid-start/basic-auth/package.json
@@ -24,7 +24,7 @@
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/solid-start/basic-cloudflare/package.json
+++ b/e2e/solid-start/basic-cloudflare/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.29.0",
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/solid-start/basic-solid-query/package.json
+++ b/e2e/solid-start/basic-solid-query/package.json
@@ -24,7 +24,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/solid-start/basic/package.json
+++ b/e2e/solid-start/basic/package.json
@@ -26,7 +26,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@rsbuild/core": "^2.0.11",
     "@rsbuild/plugin-babel": "^1.1.2",
     "@rsbuild/plugin-solid": "^1.1.1",

--- a/e2e/solid-start/csp/package.json
+++ b/e2e/solid-start/csp/package.json
@@ -16,7 +16,7 @@
     "solid-js": "^1.9.10"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",
     "srvx": "^0.11.9",

--- a/e2e/solid-start/css-modules/package.json
+++ b/e2e/solid-start/css-modules/package.json
@@ -19,7 +19,7 @@
     "solid-js": "^1.9.10"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:*",
     "@types/node": "^22.10.2",
     "sass": "^1.97.2",

--- a/e2e/solid-start/custom-basepath/package.json
+++ b/e2e/solid-start/custom-basepath/package.json
@@ -19,7 +19,7 @@
     "solid-js": "^1.9.10"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/express": "^5.0.6",

--- a/e2e/solid-start/query-integration/package.json
+++ b/e2e/solid-start/query-integration/package.json
@@ -23,7 +23,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/solid-start/scroll-restoration/package.json
+++ b/e2e/solid-start/scroll-restoration/package.json
@@ -21,7 +21,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/solid-start/server-functions/package.json
+++ b/e2e/solid-start/server-functions/package.json
@@ -24,7 +24,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/js-cookie": "^3.0.6",

--- a/e2e/solid-start/server-routes/package.json
+++ b/e2e/solid-start/server-routes/package.json
@@ -24,7 +24,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/js-cookie": "^3.0.6",

--- a/e2e/solid-start/solid-query-layout-suspense/package.json
+++ b/e2e/solid-start/solid-query-layout-suspense/package.json
@@ -16,7 +16,7 @@
     "solid-js": "^1.9.10"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",
     "typescript": "^6.0.2",

--- a/e2e/solid-start/start-manifest/package.json
+++ b/e2e/solid-start/start-manifest/package.json
@@ -15,7 +15,7 @@
     "solid-js": "^1.9.10"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",
     "srvx": "^0.11.9",

--- a/e2e/solid-start/virtual-routes/package.json
+++ b/e2e/solid-start/virtual-routes/package.json
@@ -22,7 +22,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/solid-start/website/package.json
+++ b/e2e/solid-start/website/package.json
@@ -21,7 +21,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/vue-router/basepath-file-based/package.json
+++ b/e2e/vue-router/basepath-file-based/package.json
@@ -22,7 +22,7 @@
     "vue": "^3.5.16"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@vitejs/plugin-vue": "^6.0.5",
     "@vitejs/plugin-vue-jsx": "^5.1.5",

--- a/e2e/vue-router/basic-esbuild-file-based/package.json
+++ b/e2e/vue-router/basic-esbuild-file-based/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@typescript-eslint/eslint-plugin": "^8.44.1",
     "@typescript-eslint/parser": "^8.44.1",

--- a/e2e/vue-router/basic-file-based-jsx/package.json
+++ b/e2e/vue-router/basic-file-based-jsx/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@typescript-eslint/eslint-plugin": "^8.44.1",
     "@typescript-eslint/parser": "^8.44.1",

--- a/e2e/vue-router/basic-file-based-sfc/package.json
+++ b/e2e/vue-router/basic-file-based-sfc/package.json
@@ -21,7 +21,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@vitejs/plugin-vue": "^6.0.5",
     "@vitejs/plugin-vue-jsx": "^5.1.5",

--- a/e2e/vue-router/basic-scroll-restoration/package.json
+++ b/e2e/vue-router/basic-scroll-restoration/package.json
@@ -20,7 +20,7 @@
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@vitejs/plugin-vue": "^6.0.5",
     "@vitejs/plugin-vue-jsx": "^5.1.5",

--- a/e2e/vue-router/basic-virtual-file-based/package.json
+++ b/e2e/vue-router/basic-virtual-file-based/package.json
@@ -23,7 +23,7 @@
     "vue": "^3.5.16"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@vitejs/plugin-vue": "^6.0.5",
     "@vitejs/plugin-vue-jsx": "^5.1.5",

--- a/e2e/vue-router/basic-virtual-named-export-config-file-based/package.json
+++ b/e2e/vue-router/basic-virtual-named-export-config-file-based/package.json
@@ -23,7 +23,7 @@
     "vue": "^3.5.16"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@vitejs/plugin-vue": "^6.0.5",
     "@vitejs/plugin-vue-jsx": "^5.1.5",

--- a/e2e/vue-router/basic-vue-query-file-based/package.json
+++ b/e2e/vue-router/basic-vue-query-file-based/package.json
@@ -23,7 +23,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@vitejs/plugin-vue": "^6.0.5",
     "@vitejs/plugin-vue-jsx": "^5.1.5",

--- a/e2e/vue-router/basic-vue-query/package.json
+++ b/e2e/vue-router/basic-vue-query/package.json
@@ -21,7 +21,7 @@
     "vue": "^3.5.16"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@vitejs/plugin-vue": "^6.0.5",
     "@vitejs/plugin-vue-jsx": "^5.1.5",

--- a/e2e/vue-router/basic/package.json
+++ b/e2e/vue-router/basic/package.json
@@ -19,7 +19,7 @@
     "vue": "^3.5.16"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@vitejs/plugin-vue-jsx": "^5.1.5",
     "typescript": "~5.8.3",

--- a/e2e/vue-router/generator-cli-only/package.json
+++ b/e2e/vue-router/generator-cli-only/package.json
@@ -20,7 +20,7 @@
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@vitejs/plugin-vue": "^6.0.5",
     "@vitejs/plugin-vue-jsx": "^5.1.5",

--- a/e2e/vue-router/js-only-file-based/package.json
+++ b/e2e/vue-router/js-only-file-based/package.json
@@ -22,7 +22,7 @@
     "vue": "^3.5.16"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@vitejs/plugin-vue": "^6.0.5",
     "@vitejs/plugin-vue-jsx": "^5.1.5",

--- a/e2e/vue-router/rspack-basic-file-based/package.json
+++ b/e2e/vue-router/rspack-basic-file-based/package.json
@@ -16,7 +16,7 @@
     "vue": "^3.5.16"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@rsbuild/core": "^2.0.11",
     "@rsbuild/plugin-babel": "^1.1.2",
     "@rsbuild/plugin-vue": "^1.2.7",

--- a/e2e/vue-router/rspack-basic-virtual-named-export-config-file-based/package.json
+++ b/e2e/vue-router/rspack-basic-virtual-named-export-config-file-based/package.json
@@ -16,7 +16,7 @@
     "vue": "^3.5.16"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@rsbuild/core": "^2.0.11",
     "@rsbuild/plugin-babel": "^1.1.2",
     "@rsbuild/plugin-vue": "^1.2.7",

--- a/e2e/vue-router/scroll-restoration-sandbox-vite/package.json
+++ b/e2e/vue-router/scroll-restoration-sandbox-vite/package.json
@@ -24,7 +24,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@vitejs/plugin-vue": "^6.0.5",
     "@vitejs/plugin-vue-jsx": "^5.1.5",

--- a/e2e/vue-router/sentry-integration/package.json
+++ b/e2e/vue-router/sentry-integration/package.json
@@ -22,7 +22,7 @@
     "vue": "^3.5.16"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@vitejs/plugin-vue-jsx": "^5.1.5",
     "typescript": "~5.8.3",

--- a/e2e/vue-router/view-transitions/package.json
+++ b/e2e/vue-router/view-transitions/package.json
@@ -22,7 +22,7 @@
     "vue": "^3.5.16"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@vitejs/plugin-vue": "^6.0.5",
     "@vitejs/plugin-vue-jsx": "^5.1.5",

--- a/e2e/vue-start/basic-auth/package.json
+++ b/e2e/vue-start/basic-auth/package.json
@@ -24,7 +24,7 @@
     "vue": "^3.5.25"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/vue-start/basic-cloudflare/package.json
+++ b/e2e/vue-start/basic-cloudflare/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.29.0",
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/vue-start/basic-vue-query/package.json
+++ b/e2e/vue-start/basic-vue-query/package.json
@@ -24,7 +24,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/vue-start/basic/package.json
+++ b/e2e/vue-start/basic/package.json
@@ -26,7 +26,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@rsbuild/core": "^2.0.11",
     "@rsbuild/plugin-babel": "^1.0.5",
     "@rsbuild/plugin-vue": "^1.2.2",

--- a/e2e/vue-start/css-modules/package.json
+++ b/e2e/vue-start/css-modules/package.json
@@ -19,7 +19,7 @@
     "vue": "^3.5.16"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:*",
     "@types/node": "^22.10.2",
     "@vitejs/plugin-vue-jsx": "^5.1.5",

--- a/e2e/vue-start/custom-basepath/package.json
+++ b/e2e/vue-start/custom-basepath/package.json
@@ -19,7 +19,7 @@
     "vue": "^3.5.25"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/express": "^5.0.6",

--- a/e2e/vue-start/query-integration/package.json
+++ b/e2e/vue-start/query-integration/package.json
@@ -23,7 +23,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/vue-start/scroll-restoration/package.json
+++ b/e2e/vue-start/scroll-restoration/package.json
@@ -21,7 +21,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/vue-start/server-functions/package.json
+++ b/e2e/vue-start/server-functions/package.json
@@ -24,7 +24,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/js-cookie": "^3.0.6",

--- a/e2e/vue-start/server-routes/package.json
+++ b/e2e/vue-start/server-routes/package.json
@@ -24,7 +24,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/js-cookie": "^3.0.6",

--- a/e2e/vue-start/start-manifest/package.json
+++ b/e2e/vue-start/start-manifest/package.json
@@ -15,7 +15,7 @@
     "vue": "^3.5.16"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",
     "@vitejs/plugin-vue-jsx": "^5.1.5",

--- a/e2e/vue-start/virtual-routes/package.json
+++ b/e2e/vue-start/virtual-routes/package.json
@@ -22,7 +22,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/e2e/vue-start/website/package.json
+++ b/e2e/vue-start/website/package.json
@@ -21,7 +21,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",

--- a/packages/start-plugin-core/src/vite/start-compiler-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/vite/start-compiler-plugin/plugin.ts
@@ -26,6 +26,7 @@ import {
   decodeViteDevServerModuleSpecifier,
 } from './module-specifier'
 import { mergeHotUpdateModules } from './hot-update'
+import { ensureServerModuleGraphTransformed } from './server-fn-graph-crawl'
 import type {
   CompileStartFrameworkOptions,
   StartCompilerImportTransform,
@@ -208,140 +209,6 @@ function parseIdQuery(id: string): {
   const [filename, rawQuery] = id.split(`?`, 2) as [string, string]
   const query = Object.fromEntries(new URLSearchParams(rawQuery))
   return { filename, query }
-}
-
-type ServerFnGraphCrawlContext = {
-  getModuleIds: () => IterableIterator<string>
-  load: (options: {
-    id: string
-    resolveDependencies?: boolean
-  }) => Promise<{
-    importedIds: ReadonlyArray<string>
-    dynamicallyImportedIds: ReadonlyArray<string>
-  } | null>
-}
-
-/**
- * Should this module be *walked* (loaded, then its imports followed) when
- * discovering server functions?
- *
- * The graph BFS is bounded to the application's own source. The framework
- * runtime — which is what imports the resolver virtual module and pulls in a
- * large dependency graph — lives in `node_modules` / outside the project root,
- * so this bound both keeps the walk cheap and, crucially, prevents it from
- * wandering into the framework and re-entering the resolver module that is
- * currently being generated.
- *
- * Note this only gates which modules' *imports we follow*. Server functions
- * defined outside the root (e.g. in a shared package) are still discovered —
- * see the provider-module phase in `ensureServerModuleGraphTransformed`.
- */
-function shouldWalkForServerFns(id: string, root: string): boolean {
-  const cleaned = cleanId(id)
-  if (cleaned.includes('/node_modules/')) {
-    return false
-  }
-  // Virtual modules (their resolved ids are prefixed with a NUL byte) never
-  // contain user server functions and can pull in the resolver itself.
-  if (cleaned.includes('\0')) {
-    return false
-  }
-  if (!cleaned.startsWith(root)) {
-    return false
-  }
-  return TRANSFORM_ID_REGEX.some((pattern) => {
-    pattern.lastIndex = 0
-    return pattern.test(cleaned)
-  })
-}
-
-/**
- * Eagerly transform the modules that can contribute server functions before the
- * caller snapshots `serverFnsById`.
- *
- * This does not change what ends up in the bundle (these modules are part of the
- * server build regardless) — it only forces the transform side effect, and thus
- * server-function discovery, to run before the one-shot resolver module is
- * generated. Without it, server functions reachable only from server-only code
- * (a middleware `.server()` body or another server function's handler) can be
- * discovered after the resolver has already been generated, leaving them out of
- * the manifest.
- */
-async function ensureServerModuleGraphTransformed(
-  ctx: ServerFnGraphCrawlContext,
-  selfId: string,
-  root: string,
-  serverFnsById: Record<string, ServerFn>,
-): Promise<void> {
-  const visited = new Set<string>([selfId])
-
-  // Phase 1 — walk the application's own source graph (bounded to avoid the
-  // framework runtime). `resolveDependencies` loads each module's direct imports,
-  // registering server functions referenced from bodies that survive the
-  // server-side transform (most notably middleware `.server()` handlers, which
-  // are not stripped on the server), and following imports reaches app modules
-  // not yet in the graph.
-  const queue = [...ctx.getModuleIds()].filter((id) =>
-    shouldWalkForServerFns(id, root),
-  )
-  while (queue.length > 0) {
-    const moduleId = queue.pop()!
-    if (visited.has(moduleId)) {
-      continue
-    }
-    visited.add(moduleId)
-
-    if (!shouldWalkForServerFns(moduleId, root)) {
-      continue
-    }
-
-    let info
-    try {
-      info = await ctx.load({ id: moduleId, resolveDependencies: true })
-    } catch {
-      // Unloadable ids are not part of server-fn discovery.
-      continue
-    }
-    if (!info) {
-      continue
-    }
-
-    for (const dep of info.importedIds) {
-      if (!visited.has(dep)) queue.push(dep)
-    }
-    for (const dep of info.dynamicallyImportedIds) {
-      if (!visited.has(dep)) queue.push(dep)
-    }
-  }
-
-  // Phase 2 — a server function invoked from a *handler* body is dropped from the
-  // caller module (the handler becomes an RPC stub), so Phase 1's imports miss
-  // it. Its `?tss-serverfn-split` provider module keeps the handler body intact,
-  // so loading that provider module (with its direct dependencies) registers the
-  // server functions it calls.
-  //
-  // Unlike Phase 1 this is NOT bounded by the project root: a provider id always
-  // refers to a user/shared server-function implementation (never the framework
-  // runtime), so it is safe and bounded to load regardless of where the function
-  // is defined — this is what lets server functions defined in external packages
-  // be discovered. We only load these modules (we do not follow their imports)
-  // to stay bounded, and iterate until no new server functions appear.
-  let previousCount = -1
-  while (Object.keys(serverFnsById).length !== previousCount) {
-    previousCount = Object.keys(serverFnsById).length
-    for (const fn of Object.values(serverFnsById)) {
-      const providerId = fn.extractedFilename
-      if (visited.has(providerId)) {
-        continue
-      }
-      visited.add(providerId)
-      try {
-        await ctx.load({ id: providerId, resolveDependencies: true })
-      } catch {
-        // Provider module not loadable in isolation — skip.
-      }
-    }
-  }
 }
 
 export interface StartCompilerPluginOptions {

--- a/packages/start-plugin-core/src/vite/start-compiler-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/vite/start-compiler-plugin/plugin.ts
@@ -210,6 +210,140 @@ function parseIdQuery(id: string): {
   return { filename, query }
 }
 
+type ServerFnGraphCrawlContext = {
+  getModuleIds: () => IterableIterator<string>
+  load: (options: {
+    id: string
+    resolveDependencies?: boolean
+  }) => Promise<{
+    importedIds: ReadonlyArray<string>
+    dynamicallyImportedIds: ReadonlyArray<string>
+  } | null>
+}
+
+/**
+ * Should this module be *walked* (loaded, then its imports followed) when
+ * discovering server functions?
+ *
+ * The graph BFS is bounded to the application's own source. The framework
+ * runtime — which is what imports the resolver virtual module and pulls in a
+ * large dependency graph — lives in `node_modules` / outside the project root,
+ * so this bound both keeps the walk cheap and, crucially, prevents it from
+ * wandering into the framework and re-entering the resolver module that is
+ * currently being generated.
+ *
+ * Note this only gates which modules' *imports we follow*. Server functions
+ * defined outside the root (e.g. in a shared package) are still discovered —
+ * see the provider-module phase in `ensureServerModuleGraphTransformed`.
+ */
+function shouldWalkForServerFns(id: string, root: string): boolean {
+  const cleaned = cleanId(id)
+  if (cleaned.includes('/node_modules/')) {
+    return false
+  }
+  // Virtual modules (their resolved ids are prefixed with a NUL byte) never
+  // contain user server functions and can pull in the resolver itself.
+  if (cleaned.includes('\0')) {
+    return false
+  }
+  if (!cleaned.startsWith(root)) {
+    return false
+  }
+  return TRANSFORM_ID_REGEX.some((pattern) => {
+    pattern.lastIndex = 0
+    return pattern.test(cleaned)
+  })
+}
+
+/**
+ * Eagerly transform the modules that can contribute server functions before the
+ * caller snapshots `serverFnsById`.
+ *
+ * This does not change what ends up in the bundle (these modules are part of the
+ * server build regardless) — it only forces the transform side effect, and thus
+ * server-function discovery, to run before the one-shot resolver module is
+ * generated. Without it, server functions reachable only from server-only code
+ * (a middleware `.server()` body or another server function's handler) can be
+ * discovered after the resolver has already been generated, leaving them out of
+ * the manifest.
+ */
+async function ensureServerModuleGraphTransformed(
+  ctx: ServerFnGraphCrawlContext,
+  selfId: string,
+  root: string,
+  serverFnsById: Record<string, ServerFn>,
+): Promise<void> {
+  const visited = new Set<string>([selfId])
+
+  // Phase 1 — walk the application's own source graph (bounded to avoid the
+  // framework runtime). `resolveDependencies` loads each module's direct imports,
+  // registering server functions referenced from bodies that survive the
+  // server-side transform (most notably middleware `.server()` handlers, which
+  // are not stripped on the server), and following imports reaches app modules
+  // not yet in the graph.
+  const queue = [...ctx.getModuleIds()].filter((id) =>
+    shouldWalkForServerFns(id, root),
+  )
+  while (queue.length > 0) {
+    const moduleId = queue.pop()!
+    if (visited.has(moduleId)) {
+      continue
+    }
+    visited.add(moduleId)
+
+    if (!shouldWalkForServerFns(moduleId, root)) {
+      continue
+    }
+
+    let info
+    try {
+      info = await ctx.load({ id: moduleId, resolveDependencies: true })
+    } catch {
+      // Unloadable ids are not part of server-fn discovery.
+      continue
+    }
+    if (!info) {
+      continue
+    }
+
+    for (const dep of info.importedIds) {
+      if (!visited.has(dep)) queue.push(dep)
+    }
+    for (const dep of info.dynamicallyImportedIds) {
+      if (!visited.has(dep)) queue.push(dep)
+    }
+  }
+
+  // Phase 2 — a server function invoked from a *handler* body is dropped from the
+  // caller module (the handler becomes an RPC stub), so Phase 1's imports miss
+  // it. Its `?tss-serverfn-split` provider module keeps the handler body intact,
+  // so loading that provider module (with its direct dependencies) registers the
+  // server functions it calls.
+  //
+  // Unlike Phase 1 this is NOT bounded by the project root: a provider id always
+  // refers to a user/shared server-function implementation (never the framework
+  // runtime), so it is safe and bounded to load regardless of where the function
+  // is defined — this is what lets server functions defined in external packages
+  // be discovered. We only load these modules (we do not follow their imports)
+  // to stay bounded, and iterate until no new server functions appear.
+  let previousCount = -1
+  while (Object.keys(serverFnsById).length !== previousCount) {
+    previousCount = Object.keys(serverFnsById).length
+    for (const fn of Object.values(serverFnsById)) {
+      const providerId = fn.extractedFilename
+      if (visited.has(providerId)) {
+        continue
+      }
+      visited.add(providerId)
+      try {
+        await ctx.load({ id: providerId, resolveDependencies: true })
+      } catch {
+        // Provider module not loadable in isolation — skip.
+      }
+    }
+  }
+}
+
 export interface StartCompilerPluginOptions {
   framework: CompileStartFrameworkOptions
   environments: Array<{
@@ -613,7 +747,7 @@ export function startCompilerPlugin(
       applyToEnvironment: (env) => {
         return appliedResolverEnvironments.has(env.name)
       },
-      load() {
+      async load(id) {
         if (this.environment.name !== opts.providerEnvName) {
           const mod = opts.environments.find(
             (e) => e.name === this.environment.name,
@@ -631,11 +765,30 @@ export function startCompilerPlugin(
           return getDevServerFnValidatorModule()
         }
 
-        // When SSR is the provider, server-only-referenced functions aren't in the manifest,
-        // so no isClientReferenced check is needed.
-        // When SSR is NOT the provider (custom provider env), server-only-referenced
-        // functions ARE in the manifest and need the isClientReferenced check to
-        // block direct client HTTP requests to server-only-referenced functions.
+        // When SSR is the provider, this resolver is generated inside the same
+        // server build that discovers server functions, and its one-shot `load`
+        // can run before the graph is fully transformed. Server functions only
+        // reachable from server-only code (a middleware `.server()` body, or
+        // another server function's handler) are registered into `serverFnsById`
+        // as a side effect of being transformed, so snapshotting now would leave
+        // them out of the manifest and calls would fail at runtime with
+        // "Server function info not found". Force the reachable server graph to be
+        // transformed first so discovery is complete before we snapshot.
+        //
+        // When SSR is NOT the provider, the provider environment builds after the
+        // client and SSR environments, so `serverFnsById` is already complete by
+        // the time this runs and no crawl is needed.
+        if (ssrIsProvider) {
+          await ensureServerModuleGraphTransformed(this, id, root, serverFnsById)
+        }
+
+        // When SSR is the provider, server functions are callable both in-process
+        // on the server (createSsrRpc, origin 'server') and directly from the
+        // client over HTTP, so no isClientReferenced gate is applied — matching
+        // the RSC/rsbuild behavior for this configuration.
+        // When SSR is NOT the provider (custom provider env), the isClientReferenced
+        // check is applied so direct client HTTP requests to server-only-referenced
+        // functions can be blocked at the provider layer.
         return generateServerFnResolverModule({
           serverFnsById,
           includeClientReferencedCheck: !ssrIsProvider,

--- a/packages/start-plugin-core/src/vite/start-compiler-plugin/server-fn-graph-crawl.ts
+++ b/packages/start-plugin-core/src/vite/start-compiler-plugin/server-fn-graph-crawl.ts
@@ -1,0 +1,147 @@
+import { TRANSFORM_ID_REGEX } from '../../constants'
+import { cleanId } from '../../start-compiler/utils'
+import type { ServerFn } from '../../start-compiler/types'
+
+/**
+ * The subset of the Rollup/Vite plugin context that the discovery crawl needs.
+ */
+export type ServerFnGraphCrawlContext = {
+  getModuleIds: () => IterableIterator<string>
+  load: (options: {
+    id: string
+    resolveDependencies?: boolean
+  }) => Promise<{
+    importedIds: ReadonlyArray<string>
+    dynamicallyImportedIds: ReadonlyArray<string>
+  } | null>
+}
+
+/**
+ * Should this module be *walked* (loaded, then its imports followed) when
+ * discovering server functions?
+ *
+ * The graph BFS is bounded to the application's own source. The framework
+ * runtime — which is what imports the resolver virtual module and pulls in a
+ * large dependency graph — lives in `node_modules` / outside the project root,
+ * so this bound both keeps the walk cheap and, crucially, prevents it from
+ * wandering into the framework and re-entering the resolver module that is
+ * currently being generated.
+ *
+ * Note this only gates which modules' *imports we follow*. Server functions
+ * defined outside the root (e.g. in a shared package) are still discovered —
+ * see the provider-module phase in `ensureServerModuleGraphTransformed`.
+ */
+export function shouldWalkForServerFns(id: string, root: string): boolean {
+  // Virtual modules (Vite/Rollup prefix their ids with a NUL byte) never
+  // contain user server functions and can pull in the resolver itself. Check
+  // the raw id, since `cleanId` strips the leading NUL byte.
+  if (id.startsWith('\0')) {
+    return false
+  }
+  const cleaned = cleanId(id)
+  if (cleaned.includes('/node_modules/')) {
+    return false
+  }
+  // Require a path boundary (`root/…`) so a sibling directory that merely shares
+  // a name prefix (e.g. `<root>-other`) is not treated as being under the root.
+  if (!cleaned.startsWith(`${root}/`)) {
+    return false
+  }
+  return TRANSFORM_ID_REGEX.some((pattern) => {
+    pattern.lastIndex = 0
+    return pattern.test(cleaned)
+  })
+}
+
+/**
+ * Eagerly transform the modules that can contribute server functions before the
+ * caller snapshots `serverFnsById`.
+ *
+ * This does not change what ends up in the bundle (these modules are part of the
+ * server build regardless) — it only forces the transform side effect, and thus
+ * server-function discovery, to run before the one-shot resolver module is
+ * generated. Without it, server functions reachable only from server-only code
+ * (a middleware `.server()` body or another server function's handler) can be
+ * discovered after the resolver has already been generated, leaving them out of
+ * the manifest.
+ */
+export async function ensureServerModuleGraphTransformed(
+  ctx: ServerFnGraphCrawlContext,
+  selfId: string,
+  root: string,
+  serverFnsById: Record<string, ServerFn>,
+): Promise<void> {
+  const visited = new Set<string>([selfId])
+
+  // Phase 1 — walk the application's own source graph (bounded to avoid the
+  // framework runtime). `resolveDependencies` loads each module's direct imports,
+  // registering server functions referenced from bodies that survive the
+  // server-side transform (most notably middleware `.server()` handlers, which
+  // are not stripped on the server), and following imports reaches app modules
+  // not yet in the graph.
+  const queue = [...ctx.getModuleIds()].filter((id) =>
+    shouldWalkForServerFns(id, root),
+  )
+  while (queue.length > 0) {
+    const moduleId = queue.pop()!
+    if (visited.has(moduleId)) {
+      continue
+    }
+    visited.add(moduleId)
+
+    if (!shouldWalkForServerFns(moduleId, root)) {
+      continue
+    }
+
+    let info
+    try {
+      info = await ctx.load({ id: moduleId, resolveDependencies: true })
+    } catch {
+      // Unloadable ids are not part of server-fn discovery.
+      continue
+    }
+    if (!info) {
+      continue
+    }
+
+    for (const dep of info.importedIds) {
+      if (!visited.has(dep)) {
+        queue.push(dep)
+      }
+    }
+    for (const dep of info.dynamicallyImportedIds) {
+      if (!visited.has(dep)) {
+        queue.push(dep)
+      }
+    }
+  }
+
+  // Phase 2 — a server function invoked from a *handler* body is dropped from the
+  // caller module (the handler becomes an RPC stub), so Phase 1's imports miss
+  // it. Its `?tss-serverfn-split` provider module keeps the handler body intact,
+  // so loading that provider module (with its direct dependencies) registers the
+  // server functions it calls.
+  //
+  // Unlike Phase 1 this is NOT bounded by the project root: a provider id always
+  // refers to a user/shared server-function implementation (never the framework
+  // runtime), so it is safe and bounded to load regardless of where the function
+  // is defined — this is what lets server functions defined in external packages
+  // be discovered. We only load these modules (we do not follow their imports)
+  // to stay bounded, and iterate until no new server functions appear.
+  let previousCount = -1
+  while (Object.keys(serverFnsById).length !== previousCount) {
+    previousCount = Object.keys(serverFnsById).length
+    for (const fn of Object.values(serverFnsById)) {
+      const providerId = fn.extractedFilename
+      if (visited.has(providerId)) {
+        continue
+      }
+      visited.add(providerId)
+      try {
+        await ctx.load({ id: providerId, resolveDependencies: true })
+      } catch {
+        // Provider module not loadable in isolation — skip.
+      }
+    }
+  }
+}

--- a/packages/start-plugin-core/tests/should-walk-for-server-fns.test.ts
+++ b/packages/start-plugin-core/tests/should-walk-for-server-fns.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'vitest'
+import { shouldWalkForServerFns } from '../src/vite/start-compiler-plugin/server-fn-graph-crawl'
+
+// `shouldWalkForServerFns` bounds the server-function discovery walk to the
+// application's own source. These cases pin the boundary behavior that the e2e
+// tests cannot observe (they pass regardless of which discovery phase resolves
+// a function).
+describe('shouldWalkForServerFns', () => {
+  const root = '/repo/e2e/react-start/server-functions'
+
+  test('walks transformable files beneath the root', () => {
+    expect(shouldWalkForServerFns(`${root}/src/routes/index.tsx`, root)).toBe(
+      true,
+    )
+    expect(shouldWalkForServerFns(`${root}/src/functions/fn.ts`, root)).toBe(
+      true,
+    )
+  })
+
+  test('does not walk a sibling directory that shares a name prefix', () => {
+    // Without a path boundary, `startsWith(root)` would wrongly match this
+    // sibling — which is exactly the layout of the e2e fixture package
+    // (`server-functions` vs `server-functions-shared-lib`).
+    expect(
+      shouldWalkForServerFns(`${root}-shared-lib/src/index.ts`, root),
+    ).toBe(false)
+  })
+
+  test('ignores query strings when checking the path', () => {
+    expect(
+      shouldWalkForServerFns(`${root}/src/fn.ts?tss-serverfn-split`, root),
+    ).toBe(true)
+  })
+
+  test('does not walk node_modules, virtual modules, or non-transformable files', () => {
+    expect(
+      shouldWalkForServerFns(`${root}/node_modules/pkg/index.js`, root),
+    ).toBe(false)
+    expect(
+      shouldWalkForServerFns(
+        '\0virtual:tanstack-start-server-fn-resolver',
+        root,
+      ),
+    ).toBe(false)
+    // A NUL-prefixed virtual id that mirrors a real path under the root would
+    // pass the root + extension checks once cleaned, so the guard must inspect
+    // the raw id.
+    expect(shouldWalkForServerFns(`\0${root}/src/virtual.ts`, root)).toBe(false)
+    expect(shouldWalkForServerFns(`${root}/src/app.css`, root)).toBe(false)
+  })
+
+  test('does not walk files outside the root', () => {
+    expect(shouldWalkForServerFns('/repo/some/other/place/fn.ts', root)).toBe(
+      false,
+    )
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2987,6 +2987,9 @@ importers:
       '@tanstack/react-start':
         specifier: workspace:*
         version: link:../../../packages/react-start
+      '@tanstack/react-start-e2e-shared-server-fns':
+        specifier: workspace:*
+        version: link:../server-functions-shared-lib
       js-cookie:
         specifier: ^3.0.5
         version: 3.0.5
@@ -3103,6 +3106,12 @@ importers:
       vite:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
+
+  e2e/react-start/server-functions-shared-lib:
+    devDependencies:
+      '@tanstack/react-start':
+        specifier: workspace:*
+        version: link:../../../packages/react-start
 
   e2e/react-start/server-routes:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   eslint: ^9.22.0
   vite: ^8.0.14
   '@types/node': 25.0.9
-  '@playwright/test': ^1.57.0
+  '@playwright/test': ^1.61.0
   '@tanstack/query-core': ^5.99.0
   '@tanstack/react-query': ^5.99.0
   '@tanstack/solid-query': ^5.99.0
@@ -80,8 +80,8 @@ importers:
         specifier: 22.7.5
         version: 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@6.0.2))(@swc/core@1.15.33(@swc/helpers@0.5.23))(debug@4.4.3))
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@swc-node/core':
         specifier: ^1.14.1
         version: 1.14.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(@swc/types@0.1.26)
@@ -566,8 +566,8 @@ importers:
         version: 19.2.3(react@19.2.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -609,8 +609,8 @@ importers:
         version: 4.2.2
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -652,8 +652,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -698,8 +698,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -747,8 +747,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -796,8 +796,8 @@ importers:
         version: 4.2.2
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -851,8 +851,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -897,8 +897,8 @@ importers:
         version: 4.2.2
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -952,8 +952,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -1004,8 +1004,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -1038,8 +1038,8 @@ importers:
         version: 19.2.3(react@19.2.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -1084,8 +1084,8 @@ importers:
         version: 4.2.2
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -1124,8 +1124,8 @@ importers:
         specifier: ^2.4.0
         version: 2.4.0(babel-plugin-macros@3.1.0)
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -1176,8 +1176,8 @@ importers:
         version: 4.2.2
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -1210,8 +1210,8 @@ importers:
         version: 19.2.3(react@19.2.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -1244,8 +1244,8 @@ importers:
         version: 0.5.1
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.0.11
         version: 2.0.14
@@ -1296,8 +1296,8 @@ importers:
         version: 0.5.1
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.0.11
         version: 2.0.14
@@ -1363,8 +1363,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -1415,8 +1415,8 @@ importers:
         version: 4.2.2
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -1464,8 +1464,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -1519,8 +1519,8 @@ importers:
         version: 3.6.0
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.0.11
         version: 2.0.14
@@ -1604,8 +1604,8 @@ importers:
         version: 3.6.0
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -1662,8 +1662,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.1(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))(workerd@1.20260317.1)(wrangler@4.75.0)
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -1732,8 +1732,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -1830,8 +1830,8 @@ importers:
         version: 3.6.0
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -1876,8 +1876,8 @@ importers:
         version: 19.2.3(react@19.2.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -1922,8 +1922,8 @@ importers:
         version: 0.11.15
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.0.11
         version: 2.0.14
@@ -1971,8 +1971,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.1(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))(workerd@1.20260317.1)(wrangler@4.75.0)
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:*
         version: link:../../e2e-utils
@@ -2032,8 +2032,8 @@ importers:
         version: 0.5.1
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -2093,8 +2093,8 @@ importers:
         version: 19.2.3(react@19.2.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.0.11
         version: 2.0.14
@@ -2197,8 +2197,8 @@ importers:
         version: 19.2.3(react@19.2.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-core':
         specifier: workspace:*
         version: link:../../../packages/router-core
@@ -2249,8 +2249,8 @@ importers:
         version: 19.2.3(react@19.2.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -2341,8 +2341,8 @@ importers:
         version: 19.2.3(react@19.2.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.0.11
         version: 2.0.14
@@ -2402,8 +2402,8 @@ importers:
         specifier: ^2.4.0
         version: 2.4.0(babel-plugin-macros@3.1.0)
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -2451,8 +2451,8 @@ importers:
         version: 3.3.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.0.11
         version: 2.0.14
@@ -2500,8 +2500,8 @@ importers:
         version: 19.2.3(react@19.2.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -2561,8 +2561,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -2610,8 +2610,8 @@ importers:
         version: 19.2.3(react@19.2.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.0.11
         version: 2.0.14
@@ -2671,8 +2671,8 @@ importers:
         version: 19.2.3(react@19.2.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -2729,8 +2729,8 @@ importers:
         version: 19.2.3(react@19.2.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -2775,8 +2775,8 @@ importers:
         version: 19.2.3(react@19.2.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.0.8
         version: 2.0.8
@@ -2830,8 +2830,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -3007,8 +3007,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.0.11
         version: 2.0.14
@@ -3071,8 +3071,8 @@ importers:
         version: 19.2.3(react@19.2.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -3141,8 +3141,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -3196,8 +3196,8 @@ importers:
         version: 19.2.3(react@19.2.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -3291,8 +3291,8 @@ importers:
         version: 19.2.3(react@19.2.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -3334,8 +3334,8 @@ importers:
         version: 19.2.3(react@19.2.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -3383,8 +3383,8 @@ importers:
         version: 19.2.3(react@19.2.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:*
         version: link:../../e2e-utils
@@ -3429,8 +3429,8 @@ importers:
         version: 19.2.3(react@19.2.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -3472,8 +3472,8 @@ importers:
         version: 19.2.3(react@19.2.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -3530,8 +3530,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -3594,8 +3594,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -3643,8 +3643,8 @@ importers:
         version: 1.9.12
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -3677,8 +3677,8 @@ importers:
         version: 4.2.2
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -3711,8 +3711,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -3751,8 +3751,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -3791,8 +3791,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -3828,8 +3828,8 @@ importers:
         version: 4.2.2
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -3871,8 +3871,8 @@ importers:
         version: 4.2.2
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -3917,8 +3917,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -3960,8 +3960,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -4003,8 +4003,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -4040,8 +4040,8 @@ importers:
         version: 4.2.2
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -4074,8 +4074,8 @@ importers:
         version: 4.2.2
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -4105,8 +4105,8 @@ importers:
         version: 1.9.12
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.0.11
         version: 2.0.14
@@ -4151,8 +4151,8 @@ importers:
         version: 1.9.12
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.0.11
         version: 2.0.14
@@ -4212,8 +4212,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -4255,8 +4255,8 @@ importers:
         version: 4.2.2
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -4295,8 +4295,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -4344,8 +4344,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.0.11
         version: 2.0.14
@@ -4420,8 +4420,8 @@ importers:
         version: 3.6.0
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4472,8 +4472,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.1(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))(workerd@1.20260317.1)(wrangler@4.75.0)
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4533,8 +4533,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4607,8 +4607,8 @@ importers:
         version: 1.9.12
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -4641,8 +4641,8 @@ importers:
         version: 1.9.12
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:*
         version: link:../../e2e-utils
@@ -4687,8 +4687,8 @@ importers:
         version: 1.9.12
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4794,8 +4794,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4843,8 +4843,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4987,8 +4987,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -5054,8 +5054,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -5103,8 +5103,8 @@ importers:
         version: 1.9.12
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -5171,8 +5171,8 @@ importers:
         version: 1.9.12
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -5220,8 +5220,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -5275,8 +5275,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -5333,8 +5333,8 @@ importers:
         version: 3.5.25(typescript@5.8.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -5376,8 +5376,8 @@ importers:
         version: 3.5.25(typescript@5.8.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -5422,8 +5422,8 @@ importers:
         specifier: ^9.36.0
         version: 9.36.0
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -5483,8 +5483,8 @@ importers:
         specifier: ^9.36.0
         version: 9.36.0
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -5544,8 +5544,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -5590,8 +5590,8 @@ importers:
         version: 3.5.25(typescript@5.9.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -5645,8 +5645,8 @@ importers:
         version: 3.5.25(typescript@5.8.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -5700,8 +5700,8 @@ importers:
         version: 3.5.25(typescript@5.8.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -5749,8 +5749,8 @@ importers:
         version: 3.5.25(typescript@5.8.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -5804,8 +5804,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -5850,8 +5850,8 @@ importers:
         version: 3.5.25(typescript@5.8.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -5902,8 +5902,8 @@ importers:
         version: 3.5.25(typescript@6.0.2)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -5933,8 +5933,8 @@ importers:
         version: 3.5.25(typescript@6.0.2)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.0.11
         version: 2.0.14
@@ -5988,8 +5988,8 @@ importers:
         version: 3.5.25(typescript@6.0.2)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.0.11
         version: 2.0.14
@@ -6055,8 +6055,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -6107,8 +6107,8 @@ importers:
         version: 3.5.25(typescript@5.8.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -6156,8 +6156,8 @@ importers:
         version: 3.5.25(typescript@5.8.3)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -6211,8 +6211,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.0.11
         version: 2.0.14
@@ -6293,8 +6293,8 @@ importers:
         version: 3.5.25(typescript@6.0.2)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -6348,8 +6348,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.1(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))(workerd@1.20260317.1)(wrangler@4.75.0)
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -6449,8 +6449,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -6492,8 +6492,8 @@ importers:
         version: 3.5.25(typescript@6.0.2)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:*
         version: link:../../e2e-utils
@@ -6538,8 +6538,8 @@ importers:
         version: 3.5.25(typescript@6.0.2)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -6608,8 +6608,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -6660,8 +6660,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -6816,8 +6816,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -6886,8 +6886,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -6975,8 +6975,8 @@ importers:
         version: 3.5.25(typescript@6.0.2)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -7024,8 +7024,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -7082,8 +7082,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.58.0
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -17180,8 +17180,8 @@ packages:
     engines: {node: '>=22.6.0'}
     hasBin: true
 
-  '@playwright/test@1.58.0':
-    resolution: {integrity: sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==}
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -24396,13 +24396,13 @@ packages:
     resolution: {integrity: sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==}
     engines: {node: '>=16.0.0'}
 
-  playwright-core@1.58.0:
-    resolution: {integrity: sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==}
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.58.0:
-    resolution: {integrity: sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==}
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -30656,9 +30656,9 @@ snapshots:
       pprof-to-md: 0.1.0
       react-pprof: 1.4.0
 
-  '@playwright/test@1.58.0':
+  '@playwright/test@1.61.1':
     dependencies:
-      playwright: 1.58.0
+      playwright: 1.61.1
 
   '@polka/url@1.0.0-next.28': {}
 
@@ -39105,11 +39105,11 @@ snapshots:
       pvutils: 1.1.3
       tslib: 2.8.1
 
-  playwright-core@1.58.0: {}
+  playwright-core@1.61.1: {}
 
-  playwright@1.58.0:
+  playwright@1.61.1:
     dependencies:
-      playwright-core: 1.58.0
+      playwright-core: 1.61.1
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,7 +40,7 @@ catalog:
   eslint: ^9.22.0
   vite: ^8.0.14
   '@types/node': 25.0.9
-  '@playwright/test': ^1.57.0
+  '@playwright/test': ^1.61.0
   '@tanstack/query-core': ^5.99.0
   '@tanstack/react-query': ^5.99.0
   '@tanstack/solid-query': ^5.99.0


### PR DESCRIPTION
# Fix: server functions missing from the production manifest (TanStack Start, issue #7213)

**Repository:** fork of `TanStack/router`
**Branch:** `fix/server-fn-cross-file-manifest`
**Commits:** `8b53769ee4` (Playwright bump) · `d33b368de7` (the fix)
**Upstream issue:** https://github.com/TanStack/router/issues/7213

---

## 1. Executive summary

TanStack Start lets you write **server functions** — functions that run on the server and are callable from the browser over HTTP (an RPC). In production builds, a whole category of server functions was silently left out of the server's lookup table ("the manifest"), so calling them crashed at runtime with:

> `Server function info not found for <id>`

Crucially, this only happened in **production builds**, not in development — so it was the kind of bug that passes local testing and breaks in production.

The affected category: any server function that is only ever reached from **server-side code** — for example, one called inside a middleware, or called by another server function. Organising code into separate files (a completely normal practice) reliably triggered it.

**The fix** makes the build finish discovering these server functions before it writes out the manifest. It is a **one-file change** to the build tooling (`@tanstack/start-plugin-core`), shipped as a patch. We validated it with new automated tests and the full existing test suite across all three supported frameworks (React, Solid, Vue). Build-time impact is negligible (single-digit milliseconds, within measurement noise). There is no security or API change.

---

## 2. Background

A server function is declared with `createServerFn().handler(...)`. At build time the tooling splits each one into two pieces: a small **client stub** (shipped to the browser, makes an HTTP call) and the **real implementation** (kept on the server). The server keeps a **manifest** — a map from a function's ID to its implementation — so that when a request arrives (or when server code calls the function in-process), it can find and run the right implementation. If a function is missing from that manifest, any attempt to resolve it throws `Server function info not found`.

---

## 3. The bug

**Symptom.** Production builds throw `Server function info not found for <id>` at runtime. Development works fine. Single-file setups work fine. The error appears once server functions and the code that uses them are split across files.

**What triggers it.** A server function that is reached **only through server-only code**. Two common shapes:
- A **middleware** whose `.server()` handler calls a server function defined in another file.
- A **server function whose handler calls another server function** in another file.

**Why it matters.** Both shapes are ordinary, encouraged patterns (shared middleware, shared server-side helpers, code organised into modules). The failure is production-only, so it evades local development and typically surfaces only after deploy. The error message is opaque (an internal ID, no source location).

**Where the error originates.** `packages/start-plugin-core/src/start-compiler/server-fn-resolver-module.ts:53` — the generated resolver throws when an ID is absent from the manifest.

---

## 4. Root cause

Three facts combine into a timing race.

**(a) A server function is registered only when its file is compiled.**
The build registers a server function into the shared registry (`serverFnsById`) as a side effect of compiling the file that defines it — see `packages/start-plugin-core/src/start-compiler/handleCreateServerFn.ts:350` and `:476`. If a definition file never gets compiled before the manifest is written, the function is absent.

**(b) The client build cannot see server-only functions.**
The browser build strips out server-only code: a middleware's `.server()` body is removed (`packages/start-plugin-core/src/start-compiler/handleCreateMiddleware.ts:68`), and a server function's handler body is replaced by a client stub. Dead-code elimination then drops the now-unused imports. So a function reached *only* from that stripped code never enters the client build's module graph, and is never registered during the client pass.

**(c) The manifest is generated once, mid-build, possibly too early.**
The manifest lives in a "resolver" virtual module that is generated exactly once, the first time the server runtime imports it — `packages/start-plugin-core/src/vite/start-compiler-plugin/plugin.ts:750` (the `load()` hook) calling `generateServerFnResolverModule(...)` at `:792`. The build order is: **client environment fully, then server environment** (`packages/start-plugin-core/src/vite/planning.ts:204` then `:208`). The resolver is imported early in the server build — *before* the server graph has transitively compiled every server-only definition file.

**Net effect:** the manifest ends up containing essentially "every server function the client references." Server-only functions are systematically excluded, because the client can't see them (b) and the server writes the manifest before it has finished finding them (c).

**Why dev works.** In development there is no pre-baked manifest; the dev resolver decodes the target from the request and imports it on demand, so nothing needs to be discovered ahead of time.

**Why it's specific to the default setup.** The bug is confined to the configuration where the SSR environment is also the server-function "provider" (`ssrIsProvider`, the Vite default). In the alternative setup (a separate provider environment, e.g. RSC), that environment builds *last* (`planning.ts:211+`), so discovery is already complete by the time it writes the manifest. We confirmed the reference `rsbuild` bundler is unaffected — it regenerates the resolver *after* the graph is fully built, which Vite did not do.

**Figure 1 — why the function goes missing:**

```mermaid
flowchart TB
    A["Server function in its own file,<br/>reached only from server-only code"]

    subgraph CB["Client build — runs first, in full"]
      C1["Strips server-only code, so this function<br/>is never compiled or registered"]
    end

    subgraph SB["Server build — runs second"]
      S1["Manifest generated once, early —<br/>before this function's file is compiled"]
    end

    A --> C1
    A --> S1
    C1 --> MISS["Function absent from the manifest"]
    S1 --> MISS
    MISS --> ERR["Production runtime error:<br/>Server function info not found"]

    classDef err fill:#fdecea,stroke:#d1352c,color:#611000
    class ERR err
```

---

## 5. The fix

**Idea:** before the server build writes the manifest, force the reachable server module graph to finish compiling, so discovery is complete.

All changes are in `packages/start-plugin-core/src/vite/start-compiler-plugin/plugin.ts`.

**Gate (only runs where the bug exists).** `plugin.ts:781` — the discovery step runs only when `ssrIsProvider`. For the separate-provider/RSC case it is skipped, because that environment already builds after discovery completes. This also avoids doing redundant work (and avoids running during RSC's throwaway "scan" build pass).

**Two-phase discovery** — `ensureServerModuleGraphTransformed(...)` at `plugin.ts:270`, awaited at `:782`:

- **Phase 1 — bounded walk of the app's own source** (`plugin.ts:278`). Starting from the app's already-known modules, it loads each one and follows its imports, which forces them to compile (and thus register their server functions). This is deliberately **bounded to the project's own source** via `shouldWalkForServerFns` (`plugin.ts:239`) — it excludes `node_modules`, virtual modules, and anything outside the project root. That bound is essential: it stops the walk from wandering into the framework runtime (which is large and, importantly, is what imports the resolver module we are in the middle of generating — walking into it would deadlock the build).

- **Phase 2 — location-agnostic sweep of provider modules** (`plugin.ts:317`). A function called from inside another function's *handler* is dropped from the normal (caller) module, so Phase 1 alone misses it. But its implementation lives in a dedicated "provider" module whose handler body is intact. Phase 2 loads the provider module of **every currently-known server function** and lets loading pull in its direct dependencies — registering the nested functions those handlers call. It repeats until no new functions appear. Because a provider module is *always* a user/shared server-function implementation (never the framework runtime), it is safe to load regardless of where it lives — which is what lets this correctly discover server functions defined in **separate packages**, without reintroducing the framework-walk problem that Phase 1's bound guards against.

**One comment refresh.** The surrounding comment at `plugin.ts:792` was updated to reflect that, in this configuration, server functions are intentionally callable both in-process on the server and directly from the client (see §6, Security), matching the reference `rsbuild`/RSC behavior.

**Figure 2 — the fix: finish discovery before writing the manifest:**

```mermaid
flowchart TB
    L["Resolver load(): before writing the manifest"]
    L --> G{"Is SSR the provider?<br/>(Vite default)"}
    G -->|"No — provider env builds last,<br/>already complete"| GEN
    G -->|Yes| P1

    subgraph P1["Phase 1 — bounded walk of app source"]
      P1a["Compile app modules and follow imports;<br/>skip framework runtime and node_modules"]
      P1b["Registers functions reached from intact<br/>server-only bodies, e.g. middleware .server()"]
      P1a --> P1b
    end

    subgraph P2["Phase 2 — provider-module fixpoint"]
      P2a["Load every known function's provider module<br/>(handler body intact; any location)"]
      P2b["Registers handler-nested and<br/>separate-package functions"]
      P2c["Repeat until no new functions appear"]
      P2a --> P2b --> P2c
    end

    P1 --> P2
    P2 --> GEN["Generate manifest — now complete"]

    classDef ok fill:#eaf7ea,stroke:#2e7d32,color:#143314
    class GEN ok
```

---

## 6. Implications

**Behavior — previously-broken patterns now work.** Server functions reached only via a middleware, only via another server function's handler, arbitrarily nested chains, and functions defined in a **separate shared package** are all now present in the production manifest and resolve correctly at runtime. Nothing that worked before changes.

**Security — no change; matches the reference implementation.** Server functions were already, by design, callable from the client (directly by ID, or via serialization — see `createSsrRpc.ts:10` for the in-process path and the resolver's client-origin gate at `server-fn-resolver-module.ts:42`). In the default `ssrIsProvider` configuration this gate is intentionally off in **both** Vite and the reference `rsbuild` bundler, and `rsbuild` already includes these functions in its manifest. Our fix brings Vite in line with that existing, intended behavior — it does not newly expose anything that `rsbuild` didn't already expose. (The library's documented intent: server functions are callable anywhere — over HTTP from the client, in-process on the server, skipping the network hop. Our change only fixes discovery; it does not touch dispatch, the client stub, or the origin gate.)

**Performance — negligible.** We measured production SSR build time with the discovery step ON vs OFF, several runs each: `website` ≈ +3ms, `basic` ≈ +27ms (~8%, within noise), `server-functions` (largest, 263 SSR modules) ≈ +10ms (~2%). The step largely front-loads work the build already does (module loads are cached), so its apparent internal cost (~400ms) is overwhelmingly overlapping, not additive. Caveat: our test apps top out at ~260 SSR modules; if a very large app ever shows cost, an easy follow-up is to parallelize the walk.

**Cross-framework.** The change is in the framework-agnostic core, so it applies to React, Solid, and Vue Start identically. All three were validated (see §7).

**Scope / limitations.** The change is confined to the `ssrIsProvider` Vite build path; dev, the RSC/custom-provider path, and the `rsbuild` bundler are untouched by construction and were verified unaffected.

---

## 7. Testing & validation

**New automated regression tests** (in `e2e/react-start/server-functions/tests/server-functions.spec.ts`), each reproducing a shape that was broken:
- `:721` — server function reached only through a cross-file **middleware**.
- `:750` — server function called only from **another server function's handler**.
- `:777` — a **multi-level cross-file chain** (A → B → C), which specifically exercises the Phase-2 loop iterating more than once.
- `:797` — a server function in a **separate package** whose handler calls a nested server-only function in that same package. Backed by a small fixture package, `e2e/react-start/server-functions-shared-lib/` (see `src/index.ts:7` and `src/internal.ts:7`).

All four fail on the original code (with the exact `Server function info not found` error) and pass with the fix.

**Full suite — all green:**
- Package gate (`nx affected`): `test:eslint`, `test:types`, `test:unit`, `test:build` — all pass.
- React Start e2e: `server-functions` 57, `rsc` 258, `basic` 134, `server-functions-global-middleware` 7, `static-server-functions` 5, `server-routes` 6, `serialization-adapters` 8.
- Solid Start e2e: `server-functions` 29, `server-routes` 2.
- Vue Start e2e: `server-functions` 27, `server-routes` 2.

No `Server function info not found` anywhere. The `serialization-adapters` suite passing is notable — it exercises the "return a server function to the client and call it" path, confirming the fix doesn't disturb the callable-anywhere behavior.

---

## 8. Risk assessment

- **Blast radius:** one file of build tooling; runtime dispatch, client code, and the public API are untouched.
- **Not a regression risk:** before the fix these functions were entirely missing (broken); the change strictly adds correct entries. Everything that already worked still works (verified by the full suite).
- **Deadlock/perf risks considered and closed:** Phase 1's project-root bound prevents walking into the framework runtime (which would deadlock on the in-progress resolver); Phase 2 only loads known server-function implementations, keeping it bounded. Both were validated on real builds, including the multi-environment RSC build.
- **Confined by a feature gate:** only the affected configuration runs the new code path.

---

## 9. How it's packaged

Two clean, separated commits on `fix/server-fn-cross-file-manifest`:

1. `8b53769ee4` — **`chore(deps)`**: bumps `@playwright/test` to `^1.61.0` across the workspace. Independent of the fix; resolves intermittent test-runner stalling. (117 files: package manifests + lockfile.)
2. `d33b368de7` — **`fix(start-plugin-core)`**: the one-file fix, a Changesets entry (`@tanstack/start-plugin-core` patch, `.changeset/fix-server-fn-manifest-cross-file.md`), the four regression tests, and the fixture package. (17 files.)

The Changesets entry means the fix will be released as a patch version of `@tanstack/start-plugin-core`, cascading patch bumps to the React/Solid/Vue Start packages automatically.

---

## 10. Key file reference (quick index)

| Concern | Location |
|---|---|
| Error thrown when a fn is missing | `packages/start-plugin-core/src/start-compiler/server-fn-resolver-module.ts:53` |
| Client-origin access gate | `.../server-fn-resolver-module.ts:42` |
| Where a server fn is registered | `.../start-compiler/handleCreateServerFn.ts:350`, `:476` |
| `.server()` body stripped on client | `.../start-compiler/handleCreateMiddleware.ts:68` |
| Build order (client → server) | `.../vite/planning.ts:204`, `:208`, `:211` |
| In-process server-to-server call | `packages/start-server-core/src/createSsrRpc.ts:10` |
| **The fix — discovery gate** | `.../vite/start-compiler-plugin/plugin.ts:781` |
| **The fix — two-phase discovery** | `.../start-compiler-plugin/plugin.ts:270` (Phase 1 `:278`, Phase 2 `:317`) |
| **The fix — walk bound** | `.../start-compiler-plugin/plugin.ts:239` |
| Manifest generation | `.../start-compiler-plugin/plugin.ts:792` |
| Regression tests | `e2e/react-start/server-functions/tests/server-functions.spec.ts:721,750,777,797` |
| Separate-package fixture | `e2e/react-start/server-functions-shared-lib/src/{index,internal}.ts` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production reliability of server-function manifest generation, preventing missing-function runtime errors.
  * Fixed edge cases where server functions reachable only through middleware, nested server-function chains, or separate shared packages could fail to be discovered/loaded.

* **Tests**
  * Added end-to-end regression coverage for middleware-invoked and nested/shared server functions in production scenarios.

* **Chores**
  * Updated Playwright (`@playwright/test`) to a newer version across the end-to-end test projects and workspace configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->