### PR TITLE
fix(router-plugin): escape single quotes in code-split importer paths

### DIFF
--- a/.changeset/fix-code-splitter-quote-escaping.md
+++ b/.changeset/fix-code-splitter-quote-escaping.md
@@ -1,0 +1,9 @@
+---
+'@tanstack/router-plugin': patch
+---
+
+fix(router-plugin): escape single quotes in code-split importer paths
+
+The code splitter now escapes `'` and `\` when interpolating the split url into the generated `import('...')` statement, so projects whose absolute path contains an apostrophe (e.g. `/Users/dev/it's a repro/...`) compile instead of failing to parse on every route.
+
+Fixes #7754.

--- a/packages/router-plugin/src/core/code-splitter/compilers.ts
+++ b/packages/router-plugin/src/core/code-splitter/compilers.ts
@@ -124,6 +124,13 @@ function removeSplitSearchParamFromFilename(filename: string) {
   return bareFilename!
 }
 
+// Escapes a value so it can be safely interpolated into a single-quoted
+// string literal, e.g. filenames containing `'` would otherwise produce
+// unparsable code (#7754)
+function escapeSingleQuotedString(value: string) {
+  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+}
+
 export function addSharedSearchParamToFilename(filename: string) {
   const [bareFilename] = filename.split('?')
   return `${bareFilename}?${tsrShared}=1`
@@ -623,7 +630,7 @@ export function compileCodeSplitReferenceRoute(
                         ) {
                           programPath.unshiftContainer('body', [
                             template.statement(
-                              `const ${splitNodeMeta.localImporterIdent} = () => import('${splitUrl}')`,
+                              `const ${splitNodeMeta.localImporterIdent} = () => import('${escapeSingleQuotedString(splitUrl)}')`,
                             )(),
                           ])
                         }
@@ -719,7 +726,7 @@ export function compileCodeSplitReferenceRoute(
                         ) {
                           programPath.unshiftContainer('body', [
                             template.statement(
-                              `const ${splitNodeMeta.localImporterIdent} = () => import('${splitUrl}')`,
+                              `const ${splitNodeMeta.localImporterIdent} = () => import('${escapeSingleQuotedString(splitUrl)}')`,
                             )(),
                           ])
                         }

--- a/packages/router-plugin/tests/code-splitter-path-escaping.test.ts
+++ b/packages/router-plugin/tests/code-splitter-path-escaping.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { parseAst } from '@tanstack/router-utils'
+
+import { compileCodeSplitReferenceRoute } from '../src/core/code-splitter/compilers'
+import { defaultCodeSplitGroupings } from '../src/core/constants'
+import { getReferenceRouteCompilerPlugins } from '../src/core/code-splitter/plugins/framework-plugins'
+import { frameworks } from './constants'
+
+/**
+ * Collects the string argument of every generated split-route importer,
+ * i.e. `const $$splitXImporter = () => import('...')`, from compiled code.
+ */
+function getImporterUrls(code: string): Array<string> {
+  const ast = parseAst({ code })
+  const urls: Array<string> = []
+
+  for (const statement of ast.program.body) {
+    if (statement.type !== 'VariableDeclaration') continue
+    for (const declaration of statement.declarations) {
+      const init = declaration.init
+      if (
+        init?.type === 'ArrowFunctionExpression' &&
+        init.body.type === 'CallExpression' &&
+        init.body.callee.type === 'Import' &&
+        init.body.arguments[0]?.type === 'StringLiteral'
+      ) {
+        urls.push(init.body.arguments[0].value)
+      }
+    }
+  }
+
+  return urls
+}
+
+// https://github.com/TanStack/router/issues/7754
+describe('code-splitter handles special characters in the file path', () => {
+  describe.each(frameworks)('FRAMEWORK=%s', (framework) => {
+    it('compiles a route whose absolute path contains a single quote', () => {
+      const filename = "/Users/dev/it's a repro/app/src/routes/index.tsx"
+      const code = `
+import { createFileRoute } from '@tanstack/${framework}-router'
+
+export const Route = createFileRoute('/')({
+  component: () => 'Hello',
+})
+`
+
+      // Without escaping, this throws while parsing the generated
+      // `import('...')` statement, since `'` terminates the literal early
+      const compileResult = compileCodeSplitReferenceRoute({
+        code,
+        filename,
+        id: filename,
+        addHmr: false,
+        codeSplitGroupings: defaultCodeSplitGroupings,
+        targetFramework: framework,
+        compilerPlugins: getReferenceRouteCompilerPlugins({
+          targetFramework: framework,
+          addHmr: false,
+        }),
+      })
+
+      // The importer URL must round-trip the filename exactly
+      expect(getImporterUrls(compileResult.code)).toContain(
+        `${filename}?tsr-split=component`,
+      )
+    })
+  })
+})


### PR DESCRIPTION
when the project path contains a single quote (e.g. `/Users/dev/it's a repro/...`), the code-splitter interpolates the filename straight into `import('<path>?tsr-split=...')`, so the apostrophe terminates the string literal early and babel throws while parsing the generated statement — every route in the project fails to compile.

fixed by escaping `'` and `\` before interpolating. kept the single-quoted style instead of e.g. `JSON.stringify` so the existing snapshots stay byte-identical (tried stringify first, it churned all 177 of them for no reason).

added a test that compiles a route from such a path for both react and solid — it fails without the fix, and the full router-plugin suite is unchanged with it.

fixes #7754


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed route code-splitting to correctly escape special characters in generated dynamic import URLs, including apostrophes (`'`) and backslashes (`\`).
  * Preserved the original file path and `?tsr-split=component` query so compiled routes generate valid output.

* **Tests**
  * Added automated coverage to verify split-route generation keeps special characters intact in the produced `import('...')` specifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->