### PR TITLE
fix(start-server-core): copy immutable Response.redirect() headers when merging pending set-cookie values

### DIFF
--- a/.changeset/redirect-immutable-headers.md
+++ b/.changeset/redirect-immutable-headers.md
@@ -1,0 +1,9 @@
+---
+'@tanstack/start-server-core': patch
+---
+
+fix(start-server-core): merge pending set-cookie headers into `Response.redirect()` without throwing
+
+`Response.redirect()` returns a response whose headers are immutable per spec, so merging pending event cookies into it crashed the request with `TypeError: Headers are immutable`. The merge now copies the response when its headers can't be modified, so redirects returned from handlers keep their cookies instead of turning into a 500.
+
+Fixes #7755.

--- a/packages/start-server-core/src/request-response.ts
+++ b/packages/start-server-core/src/request-response.ts
@@ -78,24 +78,40 @@ function getSetCookieValues(headers: Headers): Array<string> {
   return value ? [value] : []
 }
 
-function mergeEventResponseHeaders(response: Response, event: H3Event): void {
+function mergeEventResponseHeaders(
+  response: Response,
+  event: H3Event,
+): Response {
   if (response.ok) {
-    return
+    return response
   }
 
   const eventSetCookies = getSetCookieValues(event.res.headers)
   if (eventSetCookies.length === 0) {
-    return
+    return response
   }
 
   const responseSetCookies = getSetCookieValues(response.headers)
-  response.headers.delete('set-cookie')
+  let target = response
+  try {
+    response.headers.delete('set-cookie')
+  } catch {
+    // Response.redirect() responses have immutable headers per spec,
+    // so merge into a mutable copy instead
+    target = new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    })
+    target.headers.delete('set-cookie')
+  }
   for (const cookie of responseSetCookies) {
-    response.headers.append('set-cookie', cookie)
+    target.headers.append('set-cookie', cookie)
   }
   for (const cookie of eventSetCookies) {
-    response.headers.append('set-cookie', cookie)
+    target.headers.append('set-cookie', cookie)
   }
+  return target
 }
 
 function attachResponseHeaders<T>(
@@ -105,14 +121,14 @@ function attachResponseHeaders<T>(
   if (isPromiseLike(value)) {
     return value.then((resolved) => {
       if (resolved instanceof Response) {
-        mergeEventResponseHeaders(resolved, event)
+        return mergeEventResponseHeaders(resolved, event) as T
       }
       return resolved
     })
   }
 
   if (value instanceof Response) {
-    mergeEventResponseHeaders(value, event)
+    return mergeEventResponseHeaders(value, event) as T
   }
 
   return value

--- a/packages/start-server-core/tests/request-response.test.ts
+++ b/packages/start-server-core/tests/request-response.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { requestHandler, setCookie } from '../src/request-response'
+
+// https://github.com/TanStack/router/issues/7755
+describe('requestHandler set-cookie merging', () => {
+  it('merges pending event cookies into a Response.redirect() without throwing', async () => {
+    const handler = requestHandler(() => {
+      setCookie('session', 'abc123')
+      // Response.redirect() has immutable headers per spec
+      return Response.redirect('https://example.com/next', 302)
+    })
+
+    const response = await handler(new Request('https://example.com/'), {})
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe('https://example.com/next')
+    expect(response.headers.getSetCookie()).toContain('session=abc123; Path=/')
+  })
+
+  it('still merges cookies into a mutable non-ok response', async () => {
+    const handler = requestHandler(() => {
+      setCookie('session', 'abc123')
+      return new Response(null, {
+        status: 302,
+        headers: { location: '/next', 'set-cookie': 'from-response=1' },
+      })
+    })
+
+    const response = await handler(new Request('https://example.com/'), {})
+
+    expect(response.status).toBe(302)
+    expect(response.headers.getSetCookie()).toEqual([
+      'from-response=1',
+      'session=abc123; Path=/',
+    ])
+  })
+})


### PR DESCRIPTION
returning `Response.redirect()` from a handler after calling `setCookie()` crashes the whole request — `mergeEventResponseHeaders` calls `.delete('set-cookie')` on the redirect's headers, which are immutable per spec, so the merge throws `TypeError: Headers are immutable` and the user gets a 500 instead of their redirect + cookie.

fixed by copying the response (same status/statusText/body, fresh mutable headers) when the in-place delete throws, and merging into the copy. mutable responses keep the exact in-place behavior they had before.

added two tests: the redirect case fails without the fix and passes with it, and a mutable non-ok response still merges the same way. the three test files already failing in this package (`createCsrfMiddleware`, `createStartHandler`, `frame-protocol`) fail identically on a clean checkout of main, so they're unrelated.

fixes #7755

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed redirects and other non-OK responses so cookies set during a request are preserved instead of causing a server error.
  * Improved handling of responses with immutable headers, preventing failed handler requests and keeping redirect destinations intact.

* **Tests**
  * Added coverage for cookie merging with redirect responses and other responses that already include headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->