### PR TITLE
fix(start-plugin-core): merge user router.plugins into Start generator plugins

### DIFF
--- a/.changeset/start-merge-user-generator-plugins.md
+++ b/.changeset/start-merge-user-generator-plugins.md
@@ -1,0 +1,9 @@
+---
+'@tanstack/start-plugin-core': patch
+---
+
+fix(start-plugin-core): merge user `router.plugins` into Start's generator plugins instead of overwriting them
+
+`tanstackStart({ router: { plugins: [...] } })` was dropping user generator plugins because Start built its internal plugin list after spreading `routerConfig`, which clobbered the user's `plugins` key. User plugins are now appended after Start's internals (vite + rsbuild).
+
+Fixes #7768.

--- a/packages/start-plugin-core/src/rsbuild/start-router-plugin.ts
+++ b/packages/start-plugin-core/src/rsbuild/start-router-plugin.ts
@@ -7,6 +7,7 @@ import {
 import { routesManifestPlugin } from '../start-router-plugin/generator-plugins/routes-manifest-plugin'
 import { prerenderRoutesPlugin } from '../start-router-plugin/generator-plugins/prerender-routes-plugin'
 import { buildRouteTreeFileFooterFromConfig } from '../start-router-plugin/route-tree-footer'
+import { mergeStartGeneratorPlugins } from '../start-router-plugin/merge-generator-plugins'
 import { RSBUILD_ENVIRONMENT_NAMES } from './planning'
 import type { RsbuildPluginAPI } from '@rsbuild/core'
 import type { GetConfigFn, TanStackStartCoreOptions } from '../types'
@@ -50,12 +51,15 @@ export function registerRouterPlugins(
               corePluginOpts: opts.corePluginOpts,
             })
           },
-          plugins: [
-            routesManifestPlugin(),
-            ...(opts.startPluginOpts.prerender?.enabled === true
-              ? [prerenderRoutesPlugin()]
-              : []),
-          ],
+          plugins: mergeStartGeneratorPlugins(
+            [
+              routesManifestPlugin(),
+              ...(opts.startPluginOpts.prerender?.enabled === true
+                ? [prerenderRoutesPlugin()]
+                : []),
+            ],
+            routerConfig.plugins,
+          ),
         },
         routerPluginContext,
       )

--- a/packages/start-plugin-core/src/start-router-plugin/merge-generator-plugins.ts
+++ b/packages/start-plugin-core/src/start-router-plugin/merge-generator-plugins.ts
@@ -1,0 +1,18 @@
+import type { GeneratorPlugin } from '@tanstack/router-generator'
+
+/**
+ * Build the generator plugin list for Start, keeping Start's internal
+ * plugins first and appending any user-supplied router.plugins.
+ *
+ * Without this merge, `plugins: internal` overwrites `...routerConfig.plugins`
+ * when the config object is assembled for tanstackRouterGenerator.
+ */
+export function mergeStartGeneratorPlugins(
+  internal: Array<GeneratorPlugin>,
+  userPlugins?: Array<GeneratorPlugin> | null,
+): Array<GeneratorPlugin> {
+  if (!userPlugins?.length) {
+    return internal
+  }
+  return [...internal, ...userPlugins]
+}

--- a/packages/start-plugin-core/src/vite/start-router-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/vite/start-router-plugin/plugin.ts
@@ -11,6 +11,7 @@ import { prerenderRoutesPlugin } from '../../start-router-plugin/generator-plugi
 import { buildRouteTreeFileFooterFromConfig } from '../../start-router-plugin/route-tree-footer'
 import { pruneServerOnlySubtrees } from '../../start-router-plugin/pruneServerOnlySubtrees'
 import { SERVER_PROP } from '../../start-router-plugin/constants'
+import { mergeStartGeneratorPlugins } from '../../start-router-plugin/merge-generator-plugins'
 import type { GetConfigFn } from '../../types'
 import type { TanStackStartVitePluginCoreOptions } from '../types'
 import type {
@@ -146,15 +147,21 @@ export function tanStackStartRouter(
     clientTreePlugin,
     tanstackRouterGenerator(() => {
       const routerConfig = getConfig().startConfig.router
-      const plugins = [clientTreeGeneratorPlugin, routesManifestPlugin()]
+      const internalPlugins = [
+        clientTreeGeneratorPlugin,
+        routesManifestPlugin(),
+      ]
       if (startPluginOpts.prerender?.enabled === true) {
-        plugins.push(prerenderRoutesPlugin())
+        internalPlugins.push(prerenderRoutesPlugin())
       }
       return {
         ...routerConfig,
         target: corePluginOpts.framework,
         routeTreeFileFooter: getRouteTreeFileFooter,
-        plugins,
+        plugins: mergeStartGeneratorPlugins(
+          internalPlugins,
+          routerConfig.plugins,
+        ),
       }
     }, routerPluginContext),
     tanStackRouterCodeSplitter(() => {

--- a/packages/start-plugin-core/tests/merge-generator-plugins.test.ts
+++ b/packages/start-plugin-core/tests/merge-generator-plugins.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest'
+import { mergeStartGeneratorPlugins } from '../src/start-router-plugin/merge-generator-plugins'
+import type { GeneratorPlugin } from '@tanstack/router-generator'
+
+function plugin(name: string): GeneratorPlugin {
+  return { name }
+}
+
+describe('mergeStartGeneratorPlugins', () => {
+  test('returns internal plugins when user plugins are absent', () => {
+    const internal = [plugin('a'), plugin('b')]
+
+    expect(mergeStartGeneratorPlugins(internal)).toEqual(internal)
+    expect(mergeStartGeneratorPlugins(internal, undefined)).toEqual(internal)
+    expect(mergeStartGeneratorPlugins(internal, null)).toEqual(internal)
+    expect(mergeStartGeneratorPlugins(internal, [])).toEqual(internal)
+  })
+
+  test('appends user plugins after Start internals (does not clobber)', () => {
+    const internal = [plugin('client-tree'), plugin('routes-manifest')]
+    const user = [plugin('probe'), plugin('custom')]
+
+    expect(mergeStartGeneratorPlugins(internal, user)).toEqual([
+      plugin('client-tree'),
+      plugin('routes-manifest'),
+      plugin('probe'),
+      plugin('custom'),
+    ])
+  })
+
+  test('does not mutate the internal array', () => {
+    const internal = [plugin('a')]
+    const user = [plugin('b')]
+    const merged = mergeStartGeneratorPlugins(internal, user)
+
+    expect(internal).toEqual([plugin('a')])
+    expect(merged).not.toBe(internal)
+  })
+})


### PR DESCRIPTION
`tanstackStart({ router: { plugins: [...] } })` was silently dropping generator plugins. Start builds its own internal plugin list and was setting `plugins` after spreading `routerConfig`, so the user key got overwritten.

fix appends user plugins after Start's internals on both the vite and rsbuild paths. added a small merge helper + unit tests (3/3).

Fixes #7768.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved user-configured router generator plugins when using TanStack Start.
  * User plugins are now combined with Start’s built-in plugins instead of being overwritten.

* **Tests**
  * Added coverage for plugin merging, including empty configurations and protection against modifying existing plugin lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->