### PR TITLE
fix(router-core): safely format Standard Schema validation issues

### DIFF
--- a/packages/router-core/src/index.ts
+++ b/packages/router-core/src/index.ts
@@ -388,6 +388,8 @@ export type {
   ResolveValidatorOutput,
 } from './validators'
 
+export { formatValidationError } from './validationError'
+
 export type {
   UseRouteContextBaseOptions,
   UseRouteContextOptions,

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -104,6 +104,7 @@ import type {
   ManifestRouteAssets,
   RouterManagedTag,
 } from './manifest'
+import { formatValidationError } from './validationError'
 import type { AnySchema, AnyValidator } from './validators'
 import type { NavigateOptions, ResolveRelativePath, ToOptions } from './link'
 import type { NotFoundError } from './not-found'
@@ -3078,7 +3079,7 @@ function validateSearch(validateSearch: AnyValidator, input: unknown): unknown {
       throw new SearchParamError('Async validation not supported')
 
     if (result.issues)
-      throw new SearchParamError(JSON.stringify(result.issues, undefined, 2), {
+      throw new SearchParamError(formatValidationError(result.issues), {
         cause: result,
       })
 

--- a/packages/router-core/src/validationError.ts
+++ b/packages/router-core/src/validationError.ts
@@ -1,0 +1,63 @@
+import type { AnyStandardSchemaValidateIssue } from './validators'
+
+type IssuePathSegment = PropertyKey | { readonly key: PropertyKey }
+
+function formatIssuePathSegment(segment: IssuePathSegment): string {
+  const key =
+    typeof segment === 'object' && segment !== null && 'key' in segment
+      ? segment.key
+      : segment
+
+  if (typeof key === 'number') {
+    return `[${key}]`
+  }
+  if (typeof key === 'symbol') {
+    return `[${key.toString()}]`
+  }
+  // String keys are always bracketed and quoted. This keeps the path
+  // unambiguous when a key itself contains "." or "[" (so a literal key
+  // "a.b" can't be confused with the nested path a -> b), and it means a
+  // key such as "__proto__" is only ever rendered as text, never used to
+  // index into an object.
+  return `[${JSON.stringify(key)}]`
+}
+
+function formatIssuePath(
+  path: ReadonlyArray<IssuePathSegment> | undefined,
+): string {
+  if (!path || path.length === 0) {
+    return '(root)'
+  }
+  return path.map(formatIssuePathSegment).join('')
+}
+
+/**
+ * Format Standard Schema validation issues into a readable string.
+ *
+ * Issue objects can hold values that `JSON.stringify` cannot serialize
+ * (symbols in paths, circular references), in which case stringifying them
+ * throws and hides the original validation failure. This walks the issues
+ * defensively and only ever reads the message and path, so the real
+ * validation errors survive.
+ *
+ * Intended for internal use across router-core and start-client-core; it is
+ * not part of the documented public API.
+ */
+export function formatValidationError(
+  issues: ReadonlyArray<AnyStandardSchemaValidateIssue> | undefined,
+): string {
+  if (!issues || issues.length === 0) {
+    return 'Validation failed'
+  }
+
+  return issues
+    .map((issue) => {
+      const path = formatIssuePath(issue.path)
+      const message =
+        typeof issue.message === 'string'
+          ? issue.message
+          : String(issue.message)
+      return `${path}: ${message}`
+    })
+    .join('\n')
+}

--- a/packages/router-core/src/validators.ts
+++ b/packages/router-core/src/validators.ts
@@ -27,6 +27,9 @@ export interface AnyStandardSchemaValidateFailure {
 
 export interface AnyStandardSchemaValidateIssue {
   readonly message: string
+  readonly path?:
+    | ReadonlyArray<PropertyKey | { readonly key: PropertyKey }>
+    | undefined
 }
 
 export interface AnyStandardSchemaValidateInput {

--- a/packages/router-core/tests/validationError.test.ts
+++ b/packages/router-core/tests/validationError.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'vitest'
+import { formatValidationError } from '../src/validationError'
+import type { AnyStandardSchemaValidateIssue } from '../src/validators'
+
+describe('formatValidationError', () => {
+  test('falls back when there are no issues', () => {
+    expect(formatValidationError([])).toBe('Validation failed')
+    expect(formatValidationError(undefined)).toBe('Validation failed')
+  })
+
+  test('renders a root issue without a path', () => {
+    const issues: Array<AnyStandardSchemaValidateIssue> = [
+      { message: 'Required' },
+    ]
+    expect(formatValidationError(issues)).toBe('(root): Required')
+  })
+
+  test('renders a nested string path', () => {
+    const issues: Array<AnyStandardSchemaValidateIssue> = [
+      { message: 'Expected string', path: ['user', 'name'] },
+    ]
+    expect(formatValidationError(issues)).toBe(
+      '["user"]["name"]: Expected string',
+    )
+  })
+
+  test('renders numeric (array index) path segments', () => {
+    const issues: Array<AnyStandardSchemaValidateIssue> = [
+      { message: 'Expected number', path: ['scores', 0] },
+    ]
+    expect(formatValidationError(issues)).toBe('["scores"][0]: Expected number')
+  })
+
+  test('reads path segments given as { key } objects', () => {
+    const issues: Array<AnyStandardSchemaValidateIssue> = [
+      { message: 'Invalid', path: [{ key: 'a' }, { key: 1 }] },
+    ]
+    expect(formatValidationError(issues)).toBe('["a"][1]: Invalid')
+  })
+
+  test('does not confuse a literal dotted key with a nested path', () => {
+    const flat: Array<AnyStandardSchemaValidateIssue> = [
+      { message: 'x', path: ['a.b'] },
+    ]
+    const nested: Array<AnyStandardSchemaValidateIssue> = [
+      { message: 'x', path: ['a', 'b'] },
+    ]
+    expect(formatValidationError(flat)).not.toBe(formatValidationError(nested))
+    expect(formatValidationError(flat)).toBe('["a.b"]: x')
+  })
+
+  test('renders a prototype-named key as text without indexing into objects', () => {
+    const issues: Array<AnyStandardSchemaValidateIssue> = [
+      { message: 'nope', path: ['__proto__', 'polluted'] },
+    ]
+    expect(formatValidationError(issues)).toBe(
+      '["__proto__"]["polluted"]: nope',
+    )
+  })
+
+  test('renders symbol path segments instead of throwing', () => {
+    const sym = Symbol('id')
+    const issues: Array<AnyStandardSchemaValidateIssue> = [
+      { message: 'bad symbol key', path: [sym] },
+    ]
+    expect(formatValidationError(issues)).toBe(
+      `[${sym.toString()}]: bad symbol key`,
+    )
+  })
+
+  test('joins multiple issues on separate lines', () => {
+    const issues: Array<AnyStandardSchemaValidateIssue> = [
+      { message: 'Required', path: ['a'] },
+      { message: 'Too short', path: ['b', 2] },
+    ]
+    expect(formatValidationError(issues)).toBe(
+      '["a"]: Required\n["b"][2]: Too short',
+    )
+  })
+
+  test('does not throw on a circular issue object', () => {
+    const circular: any = { message: 'circular' }
+    circular.self = circular
+    expect(() => formatValidationError([circular])).not.toThrow()
+    expect(formatValidationError([circular])).toBe('(root): circular')
+  })
+})

--- a/packages/start-client-core/src/createServerFn.ts
+++ b/packages/start-client-core/src/createServerFn.ts
@@ -1,6 +1,10 @@
 import { mergeHeaders } from '@tanstack/router-core/ssr/client'
 
-import { isRedirect, parseRedirect } from '@tanstack/router-core'
+import {
+  formatValidationError,
+  isRedirect,
+  parseRedirect,
+} from '@tanstack/router-core'
 import { TSS_SERVER_FUNCTION_FACTORY } from './constants'
 import { getStartOptions } from './getStartOptions'
 import { getStartContextServerOnly } from './getStartContextServerOnly'
@@ -897,8 +901,7 @@ export async function execValidator(
   if ('~standard' in validator) {
     const result = await validator['~standard'].validate(input)
 
-    if (result.issues)
-      throw new Error(JSON.stringify(result.issues, undefined, 2))
+    if (result.issues) throw new Error(formatValidationError(result.issues))
 
     return result.value
   }


### PR DESCRIPTION
Closes #7779.

## Problem

Two places serialize Standard Schema validator issues the same way:

- `execValidator` in `start-client-core/src/createServerFn.ts` did `throw new Error(JSON.stringify(result.issues, undefined, 2))`.
- `validateSearch` in `router-core/src/router.ts` did `throw new SearchParamError(JSON.stringify(result.issues, undefined, 2), { cause: result })`.

The Standard Schema spec allows an issue `path` to contain any `PropertyKey`, and a segment can be either a raw key or a `{ key }` object. `JSON.stringify` throws on a `symbol` key or a `bigint`, and on any circular reference an issue object happens to carry. When that happens the thrown error is the serializer's error, not the validation failure, so the actual reason the input was rejected is lost right at the point a developer needs it.

## Approach

I started by looking at what a "safe" version of the existing output would be, and a plain `JSON.stringify` with a replacer that drops non-serializable values felt wrong: it keeps the JSON shape but still leaks the whole internal issue object, and the output is noisy. The useful information in an issue is really just the message and the path, so I settled on a small formatter that reads only those two fields and never touches anything else on the object. That also sidesteps the circular-reference case for free, because it never walks into arbitrary properties.

The path rendering took a couple of tries. A dot path like `user.name` reads well until a key legitimately contains a dot or a bracket, at which point `a.b` is ambiguous between one key `"a.b"` and the nested path `a -> b`. So each segment is bracketed and quoted with `JSON.stringify` of the key: `["user"]["name"][0]`. Numbers render as `[0]` so array indices stay readable, and symbols render via `String(key)` instead of throwing. Because every string key goes through `JSON.stringify` rather than being used to index into an object, a key named `__proto__` is only ever printed as text and can never walk the prototype chain. Root issues with no path render as `(root)`.

The formatter lives in `router-core` (`src/validationError.ts`) so both call sites share one implementation. The issue asks to avoid growing the public `router-core` surface unless there is a supported use case. `start-client-core` consumes it across the package boundary through `workspace:*`, which resolves through the published `exports` map, so it does need to be reachable. I exported it from the main entry to match how existing shared helpers like `isRedirect` and `parseRedirect` are shared today. If you would rather keep it off the primary barrel and expose it through a dedicated subpath instead, I am happy to move it.

I also added an optional `path` field to `AnyStandardSchemaValidateIssue` in `validators.ts` so the formatter can read it in a typed way. It is optional, so it does not change any existing usage.

## Tests

`packages/router-core/tests/validationError.test.ts` covers:

- root issues with no path,
- nested string paths,
- numeric (array index) segments,
- `{ key }` object segments,
- a literal dotted key vs a real nested path (to prove they do not collide),
- `__proto__` rendered as text without prototype access,
- symbol segments,
- multiple issues joined on separate lines,
- a circular issue object, which previously threw and now formats cleanly.

I have not added the server-function E2E scenarios across multiple Standard Schema libraries or the bundle-size run mentioned in the issue, since those touch a wider surface. Happy to follow up in a separate PR if you would like them in here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer validation error messages with readable field paths, including nested fields and list items.
  * Exposed a validation-error formatting utility for consistent error presentation.

* **Bug Fixes**
  * Validation errors from server functions and asynchronous checks are now formatted consistently instead of displayed as raw JSON.
  * Improved handling for root-level, symbol-based, and unusual field names without causing additional errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->