### PR TITLE
fix: use relative path for srvx static files

### DIFF
--- a/docs/start/framework/react/guide/hosting.md
+++ b/docs/start/framework/react/guide/hosting.md
@@ -298,7 +298,7 @@ npm install srvx
 
 ```json
     "build": "rsbuild build",
-    "start": "srvx --prod -s dist/client dist/server/index.js"
+    "start": "srvx --prod -s ../client dist/server/index.js"
 ```
 
 Express or any other custom Node.js server works too, as long as it serves the client assets and calls the server entry's `fetch` handler for dynamic requests.


### PR DESCRIPTION
Running `srvx --prod -s dist/client dist/server/index.js` didn't work because srvx@0.11.22 always responded with

```
srvx 0.11.21 · node 24.15.0 · prod
◆ Server handler: ./dist/server/index.js
◇ Static files:   (create public/ dir)
```

When changing to `srvx --prod -s ../client dist/server/index.js` the output is

```
srvx 0.11.21 · node 24.15.0 · prod
◆ Server handler: ./dist/server/index.js
◇ Static files:   ./dist/client/
```

and everything works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Rsbuild deployment instructions to serve the client files from the correct directory when using `srvx`.
  - Retained the server entry configuration for `dist/server/index.js`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->