### PR TITLE
docs(router): enhance router-context documentation with usage examples

### DIFF
--- a/docs/router/guide/router-context.md
+++ b/docs/router/guide/router-context.md
@@ -181,7 +181,29 @@ export const Route = createFileRoute('/todos')({
   component: Todos,
   loader: ({ context }) => fetchTodosByUserId(context.user.id),
 })
+
+function Todos() {
+  const { user } = Route.useRouteContext()
+
+  return <div>Todos for {user.id}</div>
+}
 ```
+
+`Route.useRouteContext()` is bound to the route's `Route` object, so TypeScript keeps the context narrowed to everything available at that route — including values merged from parent routes and anything returned from `beforeLoad`. Use it in components rendered within this route's match, such as the route component or other components defined in the same route file.
+
+To read context from another route — for example, a shared component that needs the root auth context — use the standalone [`useRouteContext`](../api/router/useRouteContextHook.md) hook with that route's id:
+
+```tsx
+import { useRouteContext, rootRouteId } from '@tanstack/react-router'
+
+function UserBadge() {
+  const { user } = useRouteContext({ from: rootRouteId })
+
+  return <span>{user.name}</span>
+}
+```
+
+This is useful when a component needs context from a parent route instead of the nearest active match.
 
 You can even inject data fetching and mutation implementations themselves! In fact, this is highly recommended 😜
 


### PR DESCRIPTION
Added examples demonstrating the use of `Route.useRouteContext()` and `useRouteContext` hooks for accessing route context in components. This clarifies how to retrieve context from both the current route and parent routes, improving the documentation for better developer understanding.

Closes #7792

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the Router Context guide with a `/todos` example showing how to access merged route context.
  * Clarified context type narrowing for the current route, including parent and preloading values.
  * Documented how to access context from a different or parent route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->