### PR TITLE
Update README for WorkOS example: change WORKOS_REDIRECT_URI to point…

### DIFF
--- a/examples/react/start-workos/README.md
+++ b/examples/react/start-workos/README.md
@@ -30,7 +30,7 @@ You will need a [WorkOS account](https://dashboard.workos.com/signup).
    WORKOS_CLIENT_ID=<YOUR_CLIENT_ID>
    WORKOS_API_KEY=<YOUR_API_SECRET_KEY>
    WORKOS_COOKIE_PASSWORD=<YOUR_COOKIE_PASSWORD>
-   WORKOS_REDIRECT_URI=http://localhost:3000/callback
+   WORKOS_REDIRECT_URI=http://localhost:3000/api/auth/callback
    ```
    `WORKOS_COOKIE_PASSWORD` is the private key used to encrypt the session cookie. It has to be at least 32 characters long. You can use the [1Password generator](https://1password.com/password-generator/) or the `openssl` library to generate a strong password via the command line:
    ```bash


### PR DESCRIPTION
Updated examples/react/start-workos/README.md so the WORKOS_REDIRECT_URI env example uses http://localhost:3000/api/auth/callback, matching .env.example, the WorkOS dashboard setup step, and the registered callback route at /api/auth/callback. Verified the example builds successfully.

Resolve #7790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the example app’s WorkOS redirect URI instructions to use the appropriate authentication callback URL.
  * Aligned the environment variable configuration with the setup steps described in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->