### PR TITLE
fix(router-core): fire onBeforeNavigate after beforeLoad redirect

### DIFF
--- a/.changeset/fix-on-before-navigate-after-redirect.md
+++ b/.changeset/fix-on-before-navigate-after-redirect.md
@@ -1,0 +1,11 @@
+---
+'@tanstack/router-core': patch
+---
+
+fix(router-core): fire `onBeforeNavigate` on every navigation, including those following a `beforeLoad` `redirect(...)`
+
+`onBeforeNavigate` was gated on `stores.redirect` being unset, but that store was populated whenever `beforeLoad` threw `redirect(...)` and never cleared. As a result, every navigation after the first in-`beforeLoad` redirect silently skipped the `onBeforeNavigate` emission (`onBeforeLoad` next to it never had this gate). This broke Sentry's TanStack Router tracing integration and any userland pattern (e.g. form-state persistence) that hooks into `onBeforeNavigate`.
+
+The gate is removed so `onBeforeNavigate` now matches `onBeforeLoad` and fires on every navigation.
+
+Fixes #3920.

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -2483,12 +2483,10 @@ export class RouterCore<
           const prevLocation = this.stores.resolvedLocation.get()
           const locationChangeInfo = getLocationChangeInfo(next, prevLocation)
 
-          if (!this.stores.redirect.get()) {
-            this.emit({
-              type: 'onBeforeNavigate',
-              ...locationChangeInfo,
-            })
-          }
+          this.emit({
+            type: 'onBeforeNavigate',
+            ...locationChangeInfo,
+          })
 
           this.emit({
             type: 'onBeforeLoad',

--- a/packages/router-core/tests/callbacks.test.ts
+++ b/packages/router-core/tests/callbacks.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, test, vi } from 'vitest'
 import { createMemoryHistory } from '@tanstack/history'
-import { BaseRootRoute, BaseRoute } from '../src'
+import { BaseRootRoute, BaseRoute, redirect } from '../src'
 import { createTestRouter } from './routerTestUtils'
 
 describe('callbacks', () => {
@@ -284,6 +284,56 @@ describe('callbacks', () => {
       expect(events).toHaveLength(2)
       expect(events[0]).toMatchObject({ to: '/foo', pathChanged: true })
       expect(events[1]).toMatchObject({ to: '/bar', pathChanged: true })
+    })
+
+    // Regression test for https://github.com/TanStack/router/issues/3920
+    // After a `beforeLoad` throws `redirect(...)`, `stores.redirect` was left
+    // populated forever, so the `!stores.redirect.get()` gate around the
+    // `onBeforeNavigate` emission suppressed the event for every subsequent
+    // navigation. This broke Sentry's TanStack Router tracing integration and
+    // any userland pattern (e.g. form-state persistence) that hooks into
+    // `onBeforeNavigate`.
+    it('fires on subsequent navigations after a redirect in beforeLoad (#3920)', async () => {
+      const rootRoute = new BaseRootRoute({})
+      const fooRoute = new BaseRoute({
+        getParentRoute: () => rootRoute,
+        path: '/foo',
+        beforeLoad: () => {
+          throw redirect({ to: '/bar' })
+        },
+      })
+      const barRoute = new BaseRoute({
+        getParentRoute: () => rootRoute,
+        path: '/bar',
+      })
+      const bazRoute = new BaseRoute({
+        getParentRoute: () => rootRoute,
+        path: '/baz',
+      })
+      const router = createTestRouter({
+        routeTree: rootRoute.addChildren([fooRoute, barRoute, bazRoute]),
+        history: createMemoryHistory(),
+      })
+
+      const onBeforeNavigate = vi.fn()
+      router.subscribe('onBeforeNavigate', onBeforeNavigate)
+
+      // First navigation: /foo triggers a redirect to /bar in beforeLoad.
+      await router.navigate({ to: '/foo' })
+      expect(onBeforeNavigate).toHaveBeenCalled()
+      const callsAfterRedirect = onBeforeNavigate.mock.calls.length
+
+      // Second, unrelated navigation must still emit onBeforeNavigate.
+      await router.navigate({ to: '/baz' })
+      expect(onBeforeNavigate.mock.calls.length).toBeGreaterThan(
+        callsAfterRedirect,
+      )
+      expect(onBeforeNavigate).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          type: 'onBeforeNavigate',
+          pathChanged: true,
+        }),
+      )
     })
   })
 })


### PR DESCRIPTION
## Problem

`onBeforeNavigate` was gated on `!this.stores.redirect.get()` in `router-core`'s `load()`. `stores.redirect` is populated whenever `beforeLoad` throws `redirect(...)` (line 2629) and never cleared, so every navigation after the first in-`beforeLoad` redirect silently skipped the `onBeforeNavigate` emit. The neighbouring `onBeforeLoad` emit has no such gate and kept firing correctly.

Real-world impact: Sentry's TanStack Router tracing integration stops producing navigation spans once any route ever redirects in `beforeLoad` (getsentry/sentry-javascript#21966), and userland patterns that hook `onBeforeNavigate` (e.g. form-state persistence) go silent after the first redirect.

## Fix

Remove the `state.redirect` gate around the `onBeforeNavigate` emit so it matches `onBeforeLoad` and fires on every navigation. `stores.redirect` is still populated for `createRequestHandler` (SSR redirect headers) — nothing else reads it.

## Tests

Added `fires on subsequent navigations after a redirect in beforeLoad (#3920)` in `packages/router-core/tests/callbacks.test.ts`: sets up `/foo` whose `beforeLoad` throws `redirect({ to: '/bar' })`, then navigates `/foo` → `/baz` and asserts `onBeforeNavigate` still fires on `/baz`. Fails on `main`, passes with this change. Full `@tanstack/router-core` and `@tanstack/react-router` unit + type + eslint suites are green.

Fixes #3920.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation lifecycle events not firing after a route redirect.
  * `onBeforeNavigate` now consistently runs for every navigation, including navigations following a `beforeLoad` redirect.
  * Improved compatibility with integrations that rely on navigation events, such as tracing and monitoring tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->