### PR TITLE
fix(router-core): use configured search serializer for loader dependency keys

### DIFF
--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1535,7 +1535,9 @@ export class RouterCore<
           search: preMatchSearch,
         }) ?? ''
 
-      const loaderDepsHash = loaderDeps ? JSON.stringify(loaderDeps) : ''
+      const loaderDepsHash = loaderDeps
+        ? this.options.stringifySearch(loaderDeps)
+        : ''
 
       const { interpolatedPath, usedParams } = interpolatePath({
         path: route.fullPath,

--- a/packages/router-core/tests/loader-deps-serializer.test.ts
+++ b/packages/router-core/tests/loader-deps-serializer.test.ts
@@ -47,9 +47,7 @@ describe('loaderDepsHash uses configured search serializer', () => {
     await router.navigate({ to: '/foo' })
 
     // Find the foo route match (not the root)
-    const fooMatch = router.state.matches.find(
-      (m) => m.routeId === fooRoute.id,
-    )
+    const fooMatch = router.state.matches.find((m) => m.routeId === fooRoute.id)
     expect(fooMatch).toBeDefined()
   })
 
@@ -61,7 +59,9 @@ describe('loaderDepsHash uses configured search serializer', () => {
     const fooRoute = new BaseRoute({
       getParentRoute: () => rootRoute,
       path: '/foo',
-      validateSearch: (input: any) => ({ filter: (input?.filter ?? '') as string }),
+      validateSearch: (input: any) => ({
+        filter: (input?.filter ?? '') as string,
+      }),
       loaderDeps: ({ search }) => ({
         filter: search.filter,
       }),

--- a/packages/router-core/tests/loader-deps-serializer.test.ts
+++ b/packages/router-core/tests/loader-deps-serializer.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import { BaseRootRoute, BaseRoute, stringifySearchWith } from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+describe('loaderDepsHash uses configured search serializer', () => {
+  it('uses stringifySearch for loaderDepsHash instead of JSON.stringify', async () => {
+    // Custom serializer that supports bigint (which JSON.stringify cannot handle)
+    const customStringify = (value: any): string => {
+      if (typeof value === 'bigint') {
+        return `"${value.toString()}n"`
+      }
+      if (typeof value === 'object' && value !== null) {
+        const entries = Object.entries(value).map(
+          ([k, v]) => `${k}:${customStringify(v as any)}`,
+        )
+        return `{${entries.join(',')}}`
+      }
+      return JSON.stringify(value)
+    }
+
+    const customStringifySearch = stringifySearchWith(customStringify)
+
+    const rootRoute = new BaseRootRoute({})
+
+    const fooRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/foo',
+      validateSearch: () => ({ count: 0n as bigint }),
+      loaderDeps: ({ search }) => ({
+        count: search.count,
+      }),
+      loader: () => 'loaded',
+    })
+
+    const routeTree = rootRoute.addChildren([fooRoute])
+
+    const router = createTestRouter({
+      routeTree,
+      history: createMemoryHistory(),
+      stringifySearch: customStringifySearch,
+    })
+
+    // This should not throw "Do not know how to serialize a BigInt"
+    // because the loaderDepsHash should use customStringifySearch
+    // instead of JSON.stringify
+    await router.navigate({ to: '/foo' })
+
+    // Find the foo route match (not the root)
+    const fooMatch = router.state.matches.find(
+      (m) => m.routeId === fooRoute.id,
+    )
+    expect(fooMatch).toBeDefined()
+  })
+
+  it('produces different match IDs for different serialized deps values', async () => {
+    const loaderCalls: Array<string> = []
+
+    const rootRoute = new BaseRootRoute({})
+
+    const fooRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/foo',
+      validateSearch: (input: any) => ({ filter: (input?.filter ?? '') as string }),
+      loaderDeps: ({ search }) => ({
+        filter: search.filter,
+      }),
+      loader: ({ deps }) => {
+        loaderCalls.push(deps.filter)
+        return 'loaded'
+      },
+    })
+
+    const routeTree = rootRoute.addChildren([fooRoute])
+
+    const router = createTestRouter({
+      routeTree,
+      history: createMemoryHistory(),
+    })
+
+    await router.navigate({ to: '/foo', search: { filter: 'all' } })
+    const firstFooMatch = router.state.matches.find(
+      (m) => m.routeId === fooRoute.id,
+    )
+    const firstMatchId = firstFooMatch?.id
+
+    await router.navigate({ to: '/foo', search: { filter: 'active' } })
+    const secondFooMatch = router.state.matches.find(
+      (m) => m.routeId === fooRoute.id,
+    )
+    const secondMatchId = secondFooMatch?.id
+
+    // Different deps should produce different match IDs (different hashes)
+    expect(firstMatchId).not.toBe(secondMatchId)
+    expect(loaderCalls).toEqual(['all', 'active'])
+  })
+})


### PR DESCRIPTION
## Description

The `loaderDepsHash` was hardcoded to `JSON.stringify`, ignoring the router's configured `stringifySearch` option. This meant custom search serializers that support values `JSON.stringify` cannot handle (e.g. `bigint`, `Set`, `Map`) would fail or produce incorrect hashes when those values were used in `loaderDeps`.

## Root Cause

In `packages/router-core/src/router.ts`, line 1538:

```ts
const loaderDepsHash = loaderDeps ? JSON.stringify(loaderDeps) : ''
```

`JSON.stringify` is used regardless of the `stringifySearch` option configured on the router. If a user configures a custom `stringifySearch` to support non-JSON-serializable values in search params, those same values cannot be used in `loaderDeps` because the hash will throw or produce incorrect results.

## Fix

Replace `JSON.stringify(loaderDeps)` with `this.options.stringifySearch(loaderDeps)` so the hash uses the same serializer configured for URL search state.

```diff
- const loaderDepsHash = loaderDeps ? JSON.stringify(loaderDeps) : ''
+ const loaderDepsHash = loaderDeps
+   ? this.options.stringifySearch(loaderDeps)
+   : ''
```

This continues the work started in #4713.

## Tests

Added `packages/router-core/tests/loader-deps-serializer.test.ts` with two regression tests:

1. **Custom serializer with bigint support** — verifies that a router configured with a custom `stringifySearch` supporting `bigint` can use `bigint` values in `loaderDeps` without throwing (which `JSON.stringify` would do with `TypeError: Do not know how to serialize a BigInt`).

2. **Different deps produce different match IDs** — verifies that changing `loaderDeps` values produces different match IDs, confirming the hash is still deterministic and distinguishable.

## Verification

- ✅ New tests pass
- ✅ Existing `callbacks.test.ts` (9 tests) — all pass
- ✅ Existing `match-params.test.ts` (23 tests) — all pass
- ⚠️ `load.test.ts` — 1 pre-existing flaky test fails (`skip if pending preload (redirect)`) — confirmed failing on `main` without this change

Fixes #7787

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route matching for loader dependencies by deriving the match identity from the router’s configured search serializer.
  * Prevented navigation failures when loader dependencies include values such as `bigint`.
  * Ensured route loaders refresh correctly when relevant search filter values change.
* **Tests**
  * Added coverage to verify search serialization behavior and correct loader invocation across differing search filter values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->