### PR TITLE
fix(router-devtools): apply React toggle button props

### DIFF
--- a/.changeset/bright-routers-smile.md
+++ b/.changeset/bright-routers-smile.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-devtools-core': patch
+---
+
+Apply and update React toggle button props in the router devtools.

--- a/e2e/react-router/basic/src/main.tsx
+++ b/e2e/react-router/basic/src/main.tsx
@@ -1,4 +1,5 @@
 import ReactDOM from 'react-dom/client'
+import { useState } from 'react'
 import {
   ErrorComponent,
   Link,
@@ -9,7 +10,7 @@ import {
   createRouter,
   redirect,
 } from '@tanstack/react-router'
-import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
+import { TanStackRouterDevtoolsInProd as TanStackRouterDevtools } from '@tanstack/react-router-devtools'
 import { NotFoundError, fetchPost, fetchPosts } from './posts'
 import './styles.css'
 import type { ErrorComponentProps } from '@tanstack/react-router'
@@ -27,6 +28,9 @@ const rootRoute = createRootRoute({
 })
 
 function RootComponent() {
+  const [usesUpdatedDevtoolsProps, setUsesUpdatedDevtoolsProps] =
+    useState(false)
+
   return (
     <>
       <div className="p-2 flex gap-2 text-lg border-b">
@@ -88,7 +92,20 @@ function RootComponent() {
         </div>
       </div>
       <Outlet />
-      <TanStackRouterDevtools position="bottom-right" />
+      <button type="button" onClick={() => setUsesUpdatedDevtoolsProps(true)}>
+        Update devtools props
+      </button>
+      <TanStackRouterDevtools
+        position="bottom-right"
+        toggleButtonProps={{
+          className: usesUpdatedDevtoolsProps
+            ? 'updated-devtools-toggle'
+            : 'initial-devtools-toggle',
+          'aria-label': usesUpdatedDevtoolsProps
+            ? 'Updated Router Devtools'
+            : 'Custom Router Devtools',
+        }}
+      />
     </>
   )
 }

--- a/e2e/react-router/basic/tests/app.spec.ts
+++ b/e2e/react-router/basic/tests/app.spec.ts
@@ -62,3 +62,20 @@ test('Link in SVG does not trigger a full page reload', async ({ page }) => {
 
   expect(fullPageLoad).toBeFalsy()
 })
+
+test('Applies and updates React props on the devtools toggle button', async ({
+  page,
+}) => {
+  const initialToggleButton = page.getByRole('button', {
+    name: 'Custom Router Devtools',
+  })
+
+  await expect(initialToggleButton).toHaveClass(/initial-devtools-toggle/)
+
+  await page.getByRole('button', { name: 'Update devtools props' }).click()
+
+  const updatedToggleButton = page.getByRole('button', {
+    name: 'Updated Router Devtools',
+  })
+  await expect(updatedToggleButton).toHaveClass(/updated-devtools-toggle/)
+})

--- a/packages/router-devtools-core/src/FloatingTanStackRouterDevtools.tsx
+++ b/packages/router-devtools-core/src/FloatingTanStackRouterDevtools.tsx
@@ -1,6 +1,6 @@
 import { clsx as cx } from 'clsx'
 
-import { createEffect, createMemo, createSignal } from 'solid-js'
+import { Show, createEffect, createMemo, createSignal } from 'solid-js'
 import { Dynamic } from 'solid-js/web'
 
 import { DevtoolsOnCloseContext } from './context'
@@ -32,9 +32,7 @@ export interface FloatingDevtoolsOptions {
   /**
    * Use this to add props to the toggle button. For example, you can add class, style (merge and override default style), onClick (extend default handler), etc.
    */
-  toggleButtonProps?: any & {
-    ref?: any
-  }
+  toggleButtonProps?: Accessor<any>
   /**
    * The position of the TanStack Router logo to open and close the devtools panel.
    * Defaults to 'bottom-left'.
@@ -61,7 +59,7 @@ export function FloatingTanStackRouterDevtools({
   initialIsOpen,
   panelProps = {},
   closeButtonProps = {},
-  toggleButtonProps = {},
+  toggleButtonProps = () => undefined,
   position = 'bottom-left',
   containerElement: Container = 'footer',
   router,
@@ -193,12 +191,6 @@ export function FloatingTanStackRouterDevtools({
     ...otherCloseButtonProps
   } = closeButtonProps
 
-  const {
-    onClick: onToggleClick,
-    class: toggleButtonClassName,
-    ...otherToggleButtonProps
-  } = toggleButtonProps
-
   // Do not render on the server
   if (!isMounted()) return null
 
@@ -222,15 +214,6 @@ export function FloatingTanStackRouterDevtools({
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       ...(panelStyle || {}),
     }
-  })
-
-  const buttonStyle = createMemo(() => {
-    return cx(
-      styles().mainCloseBtn,
-      styles().mainCloseBtnPosition(position),
-      styles().mainCloseBtnAnimation(!!isOpen()),
-      toggleButtonClassName,
-    )
   })
 
   return (
@@ -262,27 +245,47 @@ export function FloatingTanStackRouterDevtools({
         )} */}
       </DevtoolsOnCloseContext.Provider>
 
-      <button
-        type="button"
-        {...otherToggleButtonProps}
-        aria-label="Open TanStack Router Devtools"
-        onClick={(e) => {
-          setIsOpen(true)
-          onToggleClick && onToggleClick(e)
+      <Show keyed when={toggleButtonProps() ?? {}}>
+        {(resolvedToggleButtonProps) => {
+          const {
+            onClick: onToggleClick,
+            class: solidToggleButtonClassName,
+            // React uses className while Solid uses class for the same DOM attribute.
+            className: reactToggleButtonClassName,
+            ...otherToggleButtonProps
+          } = resolvedToggleButtonProps
+
+          return (
+            <button
+              type="button"
+              aria-label="Open TanStack Router Devtools"
+              {...otherToggleButtonProps}
+              onClick={(e) => {
+                setIsOpen(true)
+                onToggleClick && onToggleClick(e)
+              }}
+              class={cx(
+                styles().mainCloseBtn,
+                styles().mainCloseBtnPosition(position),
+                styles().mainCloseBtnAnimation(!!isOpen()),
+                solidToggleButtonClassName,
+                reactToggleButtonClassName,
+              )}
+            >
+              <div class={styles().mainCloseBtnIconContainer}>
+                <div class={styles().mainCloseBtnIconOuter}>
+                  <TanStackLogo />
+                </div>
+                <div class={styles().mainCloseBtnIconInner}>
+                  <TanStackLogo />
+                </div>
+              </div>
+              <div class={styles().mainCloseBtnDivider}>-</div>
+              <div class={styles().routerLogoCloseButton}>TanStack Router</div>
+            </button>
+          )
         }}
-        class={buttonStyle()}
-      >
-        <div class={styles().mainCloseBtnIconContainer}>
-          <div class={styles().mainCloseBtnIconOuter}>
-            <TanStackLogo />
-          </div>
-          <div class={styles().mainCloseBtnIconInner}>
-            <TanStackLogo />
-          </div>
-        </div>
-        <div class={styles().mainCloseBtnDivider}>-</div>
-        <div class={styles().routerLogoCloseButton}>TanStack Router</div>
-      </button>
+      </Show>
     </Dynamic>
   )
 }

--- a/packages/router-devtools-core/src/TanStackRouterDevtoolsCore.tsx
+++ b/packages/router-devtools-core/src/TanStackRouterDevtoolsCore.tsx
@@ -58,7 +58,7 @@ export class TanStackRouterDevtoolsCore {
 
   #panelProps: any
   #closeButtonProps: any
-  #toggleButtonProps: any
+  #toggleButtonProps: Signal<any>
   #containerElement?: string | any
 
   #isMounted = false
@@ -74,7 +74,7 @@ export class TanStackRouterDevtoolsCore {
 
     this.#panelProps = config.panelProps
     this.#closeButtonProps = config.closeButtonProps
-    this.#toggleButtonProps = config.toggleButtonProps
+    this.#toggleButtonProps = createSignal(config.toggleButtonProps)
     this.#containerElement = config.containerElement
   }
 
@@ -92,7 +92,7 @@ export class TanStackRouterDevtoolsCore {
 
       const panelProps = this.#panelProps
       const closeButtonProps = this.#closeButtonProps
-      const toggleButtonProps = this.#toggleButtonProps
+      const [toggleButtonProps] = this.#toggleButtonProps
       const containerElement = this.#containerElement
 
       let Devtools
@@ -156,6 +156,10 @@ export class TanStackRouterDevtoolsCore {
 
     if (options.containerElement !== undefined) {
       this.#containerElement = options.containerElement
+    }
+
+    if ('toggleButtonProps' in options) {
+      this.#toggleButtonProps[1](options.toggleButtonProps)
     }
   }
 }


### PR DESCRIPTION
## Overview

The React wrapper passed `className`, but the Solid-rendered core only consumed `class`. The core also stored `toggleButtonProps` as a non-reactive value, and its default `aria-label` overrode the user-provided value.

- support React `className` alongside Solid's `class` on the devtools toggle button
- let custom button attributes such as `aria-label` override defaults
- propagate `toggleButtonProps` updates without reloading the page
- add browser regression coverage for initial and updated React props

The core now stores these props in a Solid signal and recreates only the toggle button when the prop object changes, so arbitrary HTML props update together.

Fixes #4658.

## Checklist

- [x] `pnpm test:eslint -- --outputStyle=stream --skipRemoteCache`
- [x] `pnpm test:types -- --outputStyle=stream --skipRemoteCache`
- [x] `pnpm test:unit -- --outputStyle=stream --skipRemoteCache` (no affected unit-test targets)
- [x] `pnpm build -- --outputStyle=stream --skipRemoteCache`
- [x] React basic Playwright suite (25 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * React Router Devtools toggle button props can now be updated dynamically, including styling and accessibility labels.
  * The toggle button responds to runtime configuration changes.

* **Bug Fixes**
  * Improved handling of toggle button properties across supported integrations.

* **Tests**
  * Added end-to-end coverage verifying that updated toggle button properties are applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->