### PR TITLE
fix(start-plugin-core): keep prerender trailing slash off the query string

### DIFF
--- a/.changeset/prerender-trailing-slash-query.md
+++ b/.changeset/prerender-trailing-slash-query.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/start-plugin-core': patch
+---
+
+fix(start-plugin-core): keep the prerender trailing slash off the query string
+
+The crawler applied `withTrailingSlash` to the full path including the query string, so the slash landed inside the last search-param value and, with `crawlLinks` enabled, sent the crawl into an infinite loop. Passing ufo's `respectQueryAndFragment` flag keeps the slash on the path.

--- a/packages/start-plugin-core/src/prerender.ts
+++ b/packages/start-plugin-core/src/prerender.ts
@@ -137,7 +137,7 @@ export async function prerender({
 
         try {
           const res = await requestWithRedirects(
-            withTrailingSlash(withBase(page.path, routerBasePath)),
+            withTrailingSlash(withBase(page.path, routerBasePath), true),
             {
               headers: {
                 ...(prerenderOptions.headers ?? {}),


### PR DESCRIPTION
# fix(start-plugin-core): keep prerender trailing slash off the query string

## Summary

The prerender crawler applied `withTrailingSlash` to the full request path including the query string. Without `ufo`'s `respectQueryAndFragment` option, `withTrailingSlash` appends the slash to the end of the string, so it lands inside the last search-param value rather than on the path:

```ts
withTrailingSlash('/posts?page=2')       // "/posts?page=2/"   (before)
withTrailingSlash('/posts?page=2', true) // "/posts/?page=2"   (after)
```

With `crawlLinks` enabled, this corrupts any crawled link that carries a search param and turns it into an infinite loop. Each round appends one more slash to the value. Because every URL is unique the crawler's `seen` set never dedups, so the queue grows without bound and the build hangs.

## Change

`packages/start-plugin-core/src/prerender.ts`:

```diff
-          const res = await requestWithRedirects(
-            withTrailingSlash(withBase(page.path, routerBasePath)),
+          const res = await requestWithRedirects(
+            withTrailingSlash(withBase(page.path, routerBasePath), true),
```

## Test plan

- Prerender an app whose crawled HTML contains an `<a href="/route?param=value">`.
- Before: the crawler loops on `/route?param=value%2F%2F…` and never finishes.
- After: the request goes to `/route/?param=value` with the query preserved. The crawl then converges and dedups.

Closes #7837


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed prerendering so trailing slashes remain part of the URL path instead of being appended to query parameters.
  * Prevented potential infinite crawl loops when link crawling is enabled.

* **Release**
  * Included in a patch release of the prerendering plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->