### PR TITLE
docs(start): explain that layout routes must render <Outlet>

### DIFF
--- a/docs/start/framework/react/guide/routing.md
+++ b/docs/start/framework/react/guide/routing.md
@@ -172,6 +172,8 @@ The component tree would look like this:
 </Root>
 ```
 
+For this tree to render, the `posts.tsx` layout route's component must render an [`<Outlet />`](#defining-routes) — that's where the matching child route (`<Post />`) is displayed. Without `<Outlet />`, only the `<Posts>` component renders and the child route will not appear.
+
 ## Types of Routes
 
 There are a few different types of routes that you can create in your project.
@@ -201,6 +203,27 @@ To create a route, create a new file that corresponds to the path of the route y
 | `/posts/`        | `posts/index.tsx`   | Index Route    |
 | `/posts/:postId` | `posts/$postId.tsx` | Dynamic Route  |
 | `/rest/*`        | `rest/$.tsx`        | Wildcard Route |
+
+> [!NOTE]
+> A file like `posts.tsx` is a **layout route** that wraps its child routes (`posts/index.tsx`, `posts/$postId.tsx`). Its component **must render an [`<Outlet />`](#defining-routes)** for the matching child route to appear. The route generator creates a placeholder component for `posts.tsx` that does not include `<Outlet />`, so when you intend `posts.tsx` to be a layout you need to add it manually — otherwise navigating to `/posts/123` renders only the `posts.tsx` component and the child never shows up.
+>
+> ```tsx
+> // src/routes/posts.tsx
+> import { Outlet, createFileRoute } from '@tanstack/react-router'
+>
+> export const Route = createFileRoute('/posts')({
+>   component: PostsLayoutComponent,
+> })
+>
+> function PostsLayoutComponent() {
+>   return (
+>     <div>
+>       <h1>Posts</h1>
+>       <Outlet />
+>     </div>
+>   )
+> }
+> ```
 
 ## Defining Routes
 


### PR DESCRIPTION
## Summary

Closes #5351 — new users following the "build from scratch" getting-started flow get stuck because the guide never connects the **layout route** concept to the `<Outlet />` component.

The "Creating File Routes" table lists `posts.tsx` as a "Layout" route, and the "Nested Routing" section shows the component tree `<Root><Posts><Post /></Posts></Root>` — but the route generator creates a placeholder component for `posts.tsx` that **does not include `<Outlet />`**. So when a user follows the guide and navigates to `/posts/123`, only the `posts.tsx` component renders and the child route never appears. The `<Outlet />` component is documented elsewhere in the same guide but isn't bridged to the layout-route concept in the flow new users actually follow.

## The fix

Two small additions to `docs/start/framework/react/guide/routing.md`:

1. A `> [!NOTE]` callout after the "Creating File Routes" table explaining that a layout route's component must render `<Outlet />`, with a runnable `posts.tsx` example.
2. A line under "Nested Routing" stating that the `posts.tsx` layout component must render `<Outlet />` for `<Post />` to display.

Both link to the existing `#defining-routes` anchor where `<Outlet />` is shown.

## Note

I see there's a draft PR (#7831) touching this area — happy to coordinate or withdraw if that one progresses; this PR is an independent, self-contained docs addition.

## AI usage

An AI assistant was used to help locate the relevant code and draft this change. I have reviewed and understand every line of the diff, and I am the sole author of this contribution.

Closes #5351

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified nested routing behavior and the requirement to render an `<Outlet />` for child routes to appear.
  * Added guidance explaining layout routes and route generator behavior.
  * Included a practical example of using `<Outlet />` in a layout route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->