### PR TITLE
fix(router-core): keep unsafe integer search param literals as strings

### DIFF
--- a/.changeset/big-integer-search-params.md
+++ b/.changeset/big-integer-search-params.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+fix: preserve integer search param literals beyond Number.MAX_SAFE_INTEGER as strings — JSON.parse silently rounds them (e.g. an 18-digit ad id `120247103250460643` becomes `120247103250460640`), corrupting the value on any redirect or link re-serialization

--- a/packages/router-core/src/searchParams.ts
+++ b/packages/router-core/src/searchParams.ts
@@ -1,12 +1,30 @@
 import { decode, encode } from './qss'
 import type { AnySchema } from './validators'
 
+const integerLiteralRegex = /^-?\d+$/
+
+/**
+ * `JSON.parse`, except integer literals beyond `Number.MAX_SAFE_INTEGER` are
+ * rejected (kept as strings by the callers below): parsing them to a float64
+ * silently rounds the value (e.g. "120247103250460643" becomes
+ * 120247103250460640), so any re-serialization corrupts the original — a
+ * common hazard with 18-digit ad/click ids in marketing URLs.
+ */
+function parseJsonPreservingUnsafeIntegers(str: string): any {
+  if (integerLiteralRegex.test(str) && !Number.isSafeInteger(Number(str))) {
+    throw new Error('Integer literal exceeds safe integer range')
+  }
+  return JSON.parse(str)
+}
+
 /** Default `parseSearch` that strips leading '?' and JSON-parses values. */
-export const defaultParseSearch = parseSearchWith(JSON.parse)
+export const defaultParseSearch = parseSearchWith(
+  parseJsonPreservingUnsafeIntegers,
+)
 /** Default `stringifySearch` using JSON.stringify for complex values. */
 export const defaultStringifySearch = stringifySearchWith(
   JSON.stringify,
-  JSON.parse,
+  parseJsonPreservingUnsafeIntegers,
 )
 
 /**

--- a/packages/router-core/tests/searchParams.test.ts
+++ b/packages/router-core/tests/searchParams.test.ts
@@ -99,3 +99,29 @@ describe('Search Params serialization and deserialization', () => {
     )
   })
 })
+
+describe('Unsafe integer literals', () => {
+  /*
+   * Integer literals beyond Number.MAX_SAFE_INTEGER cannot survive a trip
+   * through float64 — JSON.parse would silently round them (e.g. an 18-digit
+   * ad id "120247103250460643" becomes 120247103250460640). They are kept as
+   * strings so they round-trip losslessly.
+   */
+  test.each([
+    ['120247103250460643'],
+    ['-120247103250460643'],
+    ['9007199254740993'],
+  ])('unsafe integer literal %s is preserved as a string', (literal) => {
+    const parsed = defaultParseSearch(`?foo=${literal}`)
+    expect(parsed).toEqual({ foo: literal })
+    const restringified = defaultStringifySearch(parsed)
+    expect(defaultParseSearch(restringified)).toEqual({ foo: literal })
+  })
+
+  test('safe integer literals still parse as numbers', () => {
+    expect(defaultParseSearch('?foo=123')).toEqual({ foo: 123 })
+    expect(defaultParseSearch(`?foo=${Number.MAX_SAFE_INTEGER}`)).toEqual({
+      foo: Number.MAX_SAFE_INTEGER,
+    })
+  })
+})


### PR DESCRIPTION
## Problem

`defaultParseSearch` JSON-parses every search param value. Integer literals beyond `Number.MAX_SAFE_INTEGER` lose precision to float64 rounding:

```ts
JSON.parse('120247103250460643') // → 120247103250460640
```

Any `redirect` or `<Link>` that re-serializes the search then writes the corrupted value back into the URL. This silently breaks attribution for marketing landing pages: Meta/TikTok ad and campaign ids are 18–19 digit integers passed as `utm_campaign_id`/`utm_ad_id`/etc., so a route that redirects (e.g. `/landing` → `/landing/step-1`, carrying `search`) rounds every id before analytics SDKs read `location.search`. We found this in production after revenue couldn't be matched back to real ad ids — the stored ids all ended in float64-representable digits.

## Fix

Integer literals that fail `Number.isSafeInteger` are kept as strings. The same guard is applied to the parser used by `defaultStringifySearch`'s re-serialization symmetry check, so preserved literals round-trip **unquoted** (`?id=120247103250460643`, not `?id=%22120247103250460643%22`).

No working behavior is lost: values in this range were already being silently corrupted, so nothing could have depended on the (wrong) numeric result. Safe integers (`?page=2`, `?ts=1716854400`) parse to numbers exactly as before.

## Tests

- New cases: 18-digit positive/negative literals and `MAX_SAFE_INTEGER + 2` are preserved as strings and round-trip losslessly; safe integers still parse as numbers.
- Full `router-core` suite: 1203 passed, 3 pre-existing expected fails, no type errors.

Changeset included (`@tanstack/router-core`: patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved large integer search parameters as strings when they exceed JavaScript’s safe integer range.
  * Prevented oversized integer values from being silently rounded during parsing, redirects, or link re-serialization.
  * Continued parsing safe integers as numbers.

* **Tests**
  * Added coverage for safe and unsafe integer search parameters and lossless round-tripping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->