### PR TITLE
fix(react-router): prevent MatchInner from throwing undefined when a redirected match's loadPromise is cleared

### DIFF
--- a/packages/react-router/src/CatchBoundary.tsx
+++ b/packages/react-router/src/CatchBoundary.tsx
@@ -46,12 +46,16 @@ class CatchBoundaryImpl extends React.Component<{
 
   static getDerivedStateFromProps(
     props: { getResetKey: () => string | number },
-    state: { resetKey?: string | number; error: Error | null },
+    state: {
+      resetKey?: string | number
+      error: Error | null
+      hasError: boolean
+    },
   ) {
     const resetKey = props.getResetKey()
 
-    if (state.error && state.resetKey !== resetKey) {
-      return { resetKey, error: null }
+    if (state.hasError && state.resetKey !== resetKey) {
+      return { resetKey, error: null, hasError: false }
     }
 
     return { resetKey }

--- a/packages/react-router/src/CatchBoundary.tsx
+++ b/packages/react-router/src/CatchBoundary.tsx
@@ -38,7 +38,11 @@ class CatchBoundaryImpl extends React.Component<{
   }) => React.ReactNode
   onCatch?: (error: Error, errorInfo: ErrorInfo) => void
 }> {
-  state = { error: null } as { error: Error | null; resetKey?: string | number }
+  state = { error: null, hasError: false } as {
+    error: Error | null
+    hasError: boolean
+    resetKey?: string | number
+  }
 
   static getDerivedStateFromProps(
     props: { getResetKey: () => string | number },
@@ -53,10 +57,10 @@ class CatchBoundaryImpl extends React.Component<{
     return { resetKey }
   }
   static getDerivedStateFromError(error: Error) {
-    return { error }
+    return { error, hasError: true }
   }
   reset() {
-    this.setState({ error: null })
+    this.setState({ error: null, hasError: false })
   }
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     if (this.props.onCatch) {
@@ -65,7 +69,7 @@ class CatchBoundaryImpl extends React.Component<{
   }
   render() {
     return this.props.children({
-      error: this.state.error,
+      error: this.state.hasError ? this.state.error : null,
       reset: () => {
         this.reset()
       },

--- a/packages/react-router/src/Match.tsx
+++ b/packages/react-router/src/Match.tsx
@@ -338,15 +338,27 @@ export const MatchInner = React.memo(function MatchInnerImpl({
     const out = Comp ? <Comp key={key} /> : <Outlet />
 
     if (match._displayPending) {
-      throw getMatchPromise(match, 'displayPendingPromise')
+      const displayPendingPromise = getMatchPromise(
+        match,
+        'displayPendingPromise',
+      )
+      if (displayPendingPromise) {
+        throw displayPendingPromise
+      }
     }
 
     if (match._forcePending) {
-      throw getMatchPromise(match, 'minPendingPromise')
+      const minPendingPromise = getMatchPromise(match, 'minPendingPromise')
+      if (minPendingPromise) {
+        throw minPendingPromise
+      }
     }
 
     if (match.status === 'pending') {
-      throw getMatchPromise(match, 'loadPromise')
+      const loadPromise = getMatchPromise(match, 'loadPromise')
+      if (loadPromise) {
+        throw loadPromise
+      }
     }
 
     if (match.status === 'notFound') {
@@ -440,11 +452,20 @@ export const MatchInner = React.memo(function MatchInnerImpl({
   }, [key, route.options.component, router.options.defaultComponent])
 
   if (match._displayPending) {
-    throw getMatchPromise(match, 'displayPendingPromise')
+    const displayPendingPromise = getMatchPromise(
+      match,
+      'displayPendingPromise',
+    )
+    if (displayPendingPromise) {
+      throw displayPendingPromise
+    }
   }
 
   if (match._forcePending) {
-    throw getMatchPromise(match, 'minPendingPromise')
+    const minPendingPromise = getMatchPromise(match, 'minPendingPromise')
+    if (minPendingPromise) {
+      throw minPendingPromise
+    }
   }
 
   // see also hydrate() in packages/router-core/src/ssr/ssr-client.ts
@@ -469,7 +490,10 @@ export const MatchInner = React.memo(function MatchInnerImpl({
         }
       }
     }
-    throw getMatchPromise(match, 'loadPromise')
+    const loadPromise = getMatchPromise(match, 'loadPromise')
+    if (loadPromise) {
+      throw loadPromise
+    }
   }
 
   if (match.status === 'notFound') {

--- a/packages/react-router/src/Match.tsx
+++ b/packages/react-router/src/Match.tsx
@@ -368,7 +368,12 @@ export const MatchInner = React.memo(function MatchInnerImpl({
 
         invariant()
       }
-      throw getMatchPromise(match, 'loadPromise')
+
+      const loadPromise = getMatchPromise(match, 'loadPromise')
+
+      if (loadPromise) {
+        throw loadPromise
+      }
     }
 
     if (match.status === 'error') {
@@ -491,7 +496,17 @@ export const MatchInner = React.memo(function MatchInnerImpl({
       invariant()
     }
 
-    throw getMatchPromise(match, 'loadPromise')
+    const loadPromise = getMatchPromise(match, 'loadPromise')
+
+    // The loadPromise may have been cleared by the time this stale render
+    // runs (race: the redirect navigation settled before MatchInner
+    // re-rendered). Throwing undefined would escape CatchBoundary (falsy
+    // check) and unmount the whole app. Instead, let React render the
+    // component — the redirect has already been processed and the match
+    // will be replaced on the next store update.
+    if (loadPromise) {
+      throw loadPromise
+    }
   }
 
   if (match.status === 'error') {

--- a/packages/react-router/tests/issue-7753-redirect-loadPromise-race.test.tsx
+++ b/packages/react-router/tests/issue-7753-redirect-loadPromise-race.test.tsx
@@ -1,0 +1,123 @@
+import * as React from 'react'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, expect, test, vi } from 'vitest'
+
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  redirect,
+} from '../src'
+import { sleep } from './utils'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  cleanup()
+})
+
+// https://github.com/TanStack/router/issues/7753
+// MatchInner can throw undefined when a redirected match's loadPromise was
+// already cleared — escapes CatchBoundary and unmounts the whole app.
+//
+// The race: an async beforeLoad throws redirect(), pending UI renders
+// (defaultPendingMs: 0), and by the time MatchInner re-renders with
+// status === 'redirected', the loadPromise has been resolved and cleared
+// by load-matches.ts. Throwing undefined escapes CatchBoundary (falsy
+// check) and unmounts the app with a white screen.
+test('redirected match with cleared loadPromise does not throw undefined', async () => {
+  const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+  const rootRoute = createRootRoute({
+    component: () => <Outlet />,
+  })
+
+  const slowRedirectRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    beforeLoad: async () => {
+      // Simulate an async operation (e.g. token refresh) that takes long
+      // enough for pending UI to commit and the loadPromise to be cleared
+      await sleep(50)
+      throw redirect({ to: '/target', replace: true })
+    },
+    component: () => <div data-testid="source">Source</div>,
+  })
+
+  const targetRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/target',
+    component: () => <div data-testid="target">Target</div>,
+  })
+
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([slowRedirectRoute, targetRoute]),
+    defaultPendingMs: 0,
+    defaultPendingComponent: () => <div data-testid="pending">loading</div>,
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  render(<RouterProvider router={router} />)
+
+  // Should land on the target route, not white-screen
+  expect(
+    await screen.findByTestId('target', undefined, { timeout: 5_000 }),
+  ).toBeInTheDocument()
+  expect(router.state.location.pathname).toBe('/target')
+  // No console.error means CatchBoundary didn't receive an uncaught throw
+  expect(consoleError).not.toHaveBeenCalled()
+})
+
+// A more aggressive variant: multiple async beforeLoad redirects in a chain,
+// where each intermediate match's loadPromise may be cleared before the
+// next render. This exercises the race more broadly.
+test('chained async beforeLoad redirects with pending UI do not throw undefined', async () => {
+  const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+  const rootRoute = createRootRoute({
+    component: () => <Outlet />,
+  })
+
+  const firstRedirect = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    beforeLoad: async () => {
+      await sleep(20)
+      throw redirect({ to: '/middle', replace: true })
+    },
+    component: () => <div data-testid="first">First</div>,
+  })
+
+  const middleRedirect = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/middle',
+    beforeLoad: async () => {
+      await sleep(30)
+      throw redirect({ to: '/final', replace: true })
+    },
+    component: () => <div data-testid="middle">Middle</div>,
+  })
+
+  const finalRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/final',
+    component: () => <div data-testid="final">Final</div>,
+  })
+
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([firstRedirect, middleRedirect, finalRoute]),
+    defaultPendingMs: 0,
+    defaultPendingComponent: () => <div data-testid="pending">loading</div>,
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  render(<RouterProvider router={router} />)
+
+  expect(
+    await screen.findByTestId('final', undefined, { timeout: 5_000 }),
+  ).toBeInTheDocument()
+  expect(router.state.location.pathname).toBe('/final')
+  expect(consoleError).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
When an async `beforeLoad` throws `redirect()` and pending UI is enabled (`defaultPendingMs: 0`), a race can leave `MatchInner` rendering a match observed as `status === "redirected"` *after* the redirect navigation has already settled. At that point the match's `loadPromise` has been cleared (`undefined`), so `MatchInner` executes `throw getMatchPromise(match, "loadPromise")` — which evaluates to **`throw undefined`**.

The thrown `undefined` escapes `CatchBoundary` because its render callback checks truthiness of the error (`if (error)` — `undefined` is falsy). With React 19 the error reaches the root, the whole tree is unmounted, and the user gets a permanent white screen with `Uncaught undefined` in the console.

**The fix (two parts):**

1. **`MatchInner` (client + server branches):** guard the `throw` so a cleared `loadPromise` (`undefined`) is not thrown. The redirect has already been processed by the router at that point — React can safely render the component until the match store updates with the new route.

2. **`CatchBoundaryImpl`:** use a `hasError` sentinel instead of relying on error truthiness. This is defense in depth — if something else ever throws a falsy value, the boundary catches it instead of letting it unmount the app.

**Testing:**
- Added 2 tests that reproduce the race: a single async `beforeLoad` redirect and a chain of two async redirects, both with `defaultPendingMs: 0` to force pending publication mid-chain.
- All 919 existing tests pass (49 test files, 0 failures).

Fixes #7753

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error boundary handling so errors reset correctly when navigation state changes.
  * Prevented redirect and loading races from causing uncaught errors or unexpectedly unmounting the application.
  * Improved reliability for chained asynchronous redirects and pending UI transitions.

* **Tests**
  * Added regression coverage for asynchronous redirects, pending states, and multi-step navigation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->