### PR TITLE
perf(ssr): reduce request cancellation overhead

### DIFF
--- a/packages/router-core/src/ssr/createRequestHandler.ts
+++ b/packages/router-core/src/ssr/createRequestHandler.ts
@@ -1,5 +1,4 @@
 import { createMemoryHistory } from '@tanstack/history'
-import { waitForReason } from '../await-signal'
 import { _getRenderedMatches } from '../rendered-matches'
 import { mergeHeaders } from './headers'
 import {
@@ -21,12 +20,77 @@ export type RequestHandler<TRouter extends AnyRouter> = (
   cb: HandlerCallback<TRouter>,
 ) => Promise<Response>
 
+type RequestWaiter = ((reason: unknown) => void) | undefined
+
+const requestWaiters = new WeakMap<AbortSignal, Array<RequestWaiter>>()
+
+function removeRequestWaiter(
+  waiters: Array<RequestWaiter>,
+  index: number,
+  reject: (reason: unknown) => void,
+) {
+  if (waiters[index] !== reject) {
+    return
+  }
+  if (index !== waiters.length - 1) {
+    waiters[index] = undefined
+    return
+  }
+
+  waiters.pop()
+  while (waiters.length && waiters[waiters.length - 1] === undefined) {
+    waiters.pop()
+  }
+}
+
 export function waitForRequest<T>(
   value: T | PromiseLike<T>,
   signal: AbortSignal,
   onLate?: (value: T) => void,
 ): Promise<T> {
-  return waitForReason(value, signal, onLate)
+  const promise = Promise.resolve(value)
+  if (signal.aborted) {
+    void promise.then(onLate, () => {})
+    return Promise.reject(signal.reason)
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    let waiters = requestWaiters.get(signal)
+    let index: number
+    if (waiters) {
+      index = waiters.push(reject) - 1
+    } else {
+      const newWaiters: Array<RequestWaiter> = [reject]
+      waiters = newWaiters
+      index = 0
+      requestWaiters.set(signal, newWaiters)
+      signal.addEventListener(
+        'abort',
+        () => {
+          requestWaiters.delete(signal)
+          for (const rejectWaiter of newWaiters) {
+            rejectWaiter?.(signal.reason)
+          }
+          newWaiters.length = 0
+        },
+        { once: true },
+      )
+    }
+    void promise.then(
+      (result) => {
+        removeRequestWaiter(waiters, index, reject)
+        if (signal.aborted) {
+          onLate?.(result)
+        } else {
+          resolve(result)
+        }
+      },
+      (error) => {
+        removeRequestWaiter(waiters, index, reject)
+        reject(error)
+      },
+    )
+  })
 }
 
 export function createRequestHandler<TRouter extends AnyRouter>({

--- a/packages/router-core/tests/load-client-wait-for.test.ts
+++ b/packages/router-core/tests/load-client-wait-for.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from 'vitest'
 import { waitForReason } from '../src/await-signal'
 import { waitFor } from '../src/load-client'
+import { waitForRequest } from '../src/ssr/createRequestHandler'
 
 describe('waitFor', () => {
   test('observes a rejected value when the signal is already aborted', async () => {
@@ -29,5 +30,180 @@ describe('waitFor', () => {
       reason,
     )
     await vi.waitFor(() => expect(onLate).toHaveBeenCalledWith('late response'))
+  })
+})
+
+describe('waitForRequest', () => {
+  test('shares one abort listener across concurrent and sequential waits', async () => {
+    const controller = new AbortController()
+    const addEventListener = vi.spyOn(controller.signal, 'addEventListener')
+    let resolveFirst!: (value: string) => void
+    let resolveSecond!: (value: string) => void
+    let resolveThird!: (value: string) => void
+    const first = new Promise<string>((resolve) => {
+      resolveFirst = resolve
+    })
+    const second = new Promise<string>((resolve) => {
+      resolveSecond = resolve
+    })
+    const third = new Promise<string>((resolve) => {
+      resolveThird = resolve
+    })
+
+    const firstResult = waitForRequest(first, controller.signal)
+    const secondResult = waitForRequest(second, controller.signal)
+
+    expect(addEventListener).toHaveBeenCalledTimes(1)
+    resolveFirst('first')
+    resolveSecond('second')
+    await expect(firstResult).resolves.toBe('first')
+    await expect(secondResult).resolves.toBe('second')
+
+    const thirdResult = waitForRequest(third, controller.signal)
+    expect(addEventListener).toHaveBeenCalledTimes(1)
+
+    const reason = new Error('request canceled')
+    controller.abort(reason)
+    await expect(thirdResult).rejects.toBe(reason)
+    resolveThird('third')
+    await Promise.resolve()
+  })
+
+  test('rejects all active waits and observes their late values', async () => {
+    const controller = new AbortController()
+    const reason = new Error('request canceled')
+    const onFirstLate = vi.fn()
+    const onSecondLate = vi.fn()
+    let resolveFirst!: (value: string) => void
+    let resolveSecond!: (value: string) => void
+    const first = new Promise<string>((resolve) => {
+      resolveFirst = resolve
+    })
+    const second = new Promise<string>((resolve) => {
+      resolveSecond = resolve
+    })
+    const firstResult = waitForRequest(first, controller.signal, onFirstLate)
+    const secondResult = waitForRequest(second, controller.signal, onSecondLate)
+
+    controller.abort(reason)
+    await expect(firstResult).rejects.toBe(reason)
+    await expect(secondResult).rejects.toBe(reason)
+
+    resolveFirst('first')
+    resolveSecond('second')
+    await vi.waitFor(() => {
+      expect(onFirstLate).toHaveBeenCalledWith('first')
+      expect(onSecondLate).toHaveBeenCalledWith('second')
+    })
+  })
+
+  test('aborts remaining waits after an out-of-order rejection', async () => {
+    const controller = new AbortController()
+    const reason = new Error('request canceled')
+    const failure = new Error('wait failed')
+    const onLate = vi.fn()
+    let resolveFirst!: (value: string) => void
+    let rejectSecond!: (error: Error) => void
+    let rejectThird!: (error: Error) => void
+    const first = new Promise<string>((resolve) => {
+      resolveFirst = resolve
+    })
+    const second = new Promise<string>((_, reject) => {
+      rejectSecond = reject
+    })
+    const third = new Promise<string>((_, reject) => {
+      rejectThird = reject
+    })
+    const firstResult = waitForRequest(first, controller.signal, onLate)
+    const secondResult = waitForRequest(second, controller.signal)
+    const thirdResult = waitForRequest(third, controller.signal)
+
+    rejectSecond(failure)
+    await expect(secondResult).rejects.toBe(failure)
+
+    controller.abort(reason)
+    await expect(firstResult).rejects.toBe(reason)
+    await expect(thirdResult).rejects.toBe(reason)
+
+    resolveFirst('late')
+    rejectThird(new Error('late failure'))
+    await vi.waitFor(() => expect(onLate).toHaveBeenCalledWith('late'))
+  })
+
+  test('isolates waits for different request signals', async () => {
+    const firstController = new AbortController()
+    const secondController = new AbortController()
+    const firstReason = new Error('first request canceled')
+    const firstAddEventListener = vi.spyOn(
+      firstController.signal,
+      'addEventListener',
+    )
+    const secondAddEventListener = vi.spyOn(
+      secondController.signal,
+      'addEventListener',
+    )
+    let resolveFirst!: (value: string) => void
+    let resolveSecond!: (value: string) => void
+    const first = new Promise<string>((resolve) => {
+      resolveFirst = resolve
+    })
+    const second = new Promise<string>((resolve) => {
+      resolveSecond = resolve
+    })
+    const firstResult = waitForRequest(first, firstController.signal)
+    const secondResult = waitForRequest(second, secondController.signal)
+
+    expect(firstAddEventListener).toHaveBeenCalledOnce()
+    expect(secondAddEventListener).toHaveBeenCalledOnce()
+
+    firstController.abort(firstReason)
+    await expect(firstResult).rejects.toBe(firstReason)
+
+    resolveSecond('second result')
+    await expect(secondResult).resolves.toBe('second result')
+    resolveFirst('late first result')
+    await Promise.resolve()
+  })
+
+  test('observes fulfilled and rejected values when already aborted', async () => {
+    const controller = new AbortController()
+    const reason = new Error('request canceled')
+    const lateError = new Error('late failure')
+    const onLate = vi.fn()
+    controller.abort(reason)
+
+    await expect(
+      waitForRequest(Promise.resolve('late'), controller.signal, onLate),
+    ).rejects.toBe(reason)
+    await expect(
+      waitForRequest(Promise.reject(lateError), controller.signal),
+    ).rejects.toBe(reason)
+
+    await vi.waitFor(() => expect(onLate).toHaveBeenCalledWith('late'))
+  })
+
+  test('handles an abort during listener registration', async () => {
+    const controller = new AbortController()
+    const reason = new Error('request canceled')
+    const onLate = vi.fn()
+    const addEventListener = controller.signal.addEventListener.bind(
+      controller.signal,
+    )
+    vi.spyOn(controller.signal, 'addEventListener').mockImplementation(
+      (type, listener, options) => {
+        addEventListener(type, listener, options)
+        controller.abort(reason)
+      },
+    )
+    let resolve!: (value: string) => void
+    const value = new Promise<string>((resolveValue) => {
+      resolve = resolveValue
+    })
+
+    const result = waitForRequest(value, controller.signal, onLate)
+    await expect(result).rejects.toBe(reason)
+
+    resolve('late')
+    await vi.waitFor(() => expect(onLate).toHaveBeenCalledWith('late'))
   })
 })

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -219,6 +219,10 @@ function disposeLateResponse(result: TODO, signal: AbortSignal): void {
   }
 }
 
+function isSignalAborted(signal: AbortSignal): boolean {
+  return signal.aborted
+}
+
 /**
  * Execute a middleware chain
  */
@@ -288,8 +292,18 @@ async function executeMiddleware(
     return response
   }
 
-  const next = async (nextCtx?: TODO): Promise<TODO> => {
-    signal.throwIfAborted()
+  let nextPromise: Promise<TODO> | undefined
+
+  function next(nextCtx?: TODO): Promise<TODO> {
+    const result = runNext(nextCtx)
+    nextPromise = result
+    return result
+  }
+
+  async function runNext(nextCtx?: TODO): Promise<TODO> {
+    if (signal.aborted) {
+      throw signal.reason
+    }
 
     // Merge context if provided using safeObjectMerge for prototype pollution prevention
     if (nextCtx) {
@@ -312,13 +326,25 @@ async function executeMiddleware(
 
     let result: TODO
     try {
-      result = await waitForRequest(
-        middleware({ ...ctx, next }),
-        signal,
-        (late) => disposeLateResponse(late, signal),
-      )
+      const pending = middleware({ ...ctx, next })
+      // A directly returned next() promise already propagates request aborts.
+      if (pending === nextPromise) {
+        nextPromise = undefined
+        result = await pending
+        if (isSignalAborted(signal)) {
+          disposeLateResponse(result, signal)
+          throw signal.reason
+        }
+      } else {
+        result = await waitForRequest(pending, signal, (late) =>
+          disposeLateResponse(late, signal),
+        )
+      }
     } catch (err) {
-      if (!signal.aborted && isSpecialResponse(err)) {
+      if (isSignalAborted(signal)) {
+        throw signal.reason
+      }
+      if (isSpecialResponse(err)) {
         setResponse(err)
         return ctx
       }
@@ -339,11 +365,13 @@ async function executeMiddleware(
   }
 
   try {
-    await next()
+    await runNext()
     const response = await waitForRequest(getFinalResponse(), signal, (late) =>
       disposeLateResponse(late, signal),
     )
-    signal.throwIfAborted()
+    if (signal.aborted) {
+      throw signal.reason
+    }
     return { ctx, response }
   } catch (err) {
     const disposal = disposeStreamResponse(signal.aborted ? signal.reason : err)

--- a/packages/start-server-core/tests/createStartHandler.test.ts
+++ b/packages/start-server-core/tests/createStartHandler.test.ts
@@ -623,8 +623,9 @@ describe('createStartHandler request cancellation', () => {
     const middlewareStarted = new Promise<void>((resolve) => {
       notifyMiddlewareStarted = resolve
     })
-    let releaseMiddleware!: (response: Response) => void
-    const middlewareResult = new Promise<Response>((resolve) => {
+    const dispose = vi.fn(() => Promise.resolve())
+    let releaseMiddleware!: (response: any) => void
+    const middlewareResult = new Promise<any>((resolve) => {
       releaseMiddleware = resolve
     })
     startMocks.requestMiddleware = [
@@ -648,8 +649,157 @@ describe('createStartHandler request cancellation', () => {
     expect((await response).status).toBe(500)
     expect(render).not.toHaveBeenCalled()
 
-    releaseMiddleware(new Response('late'))
-    await Promise.resolve()
+    releaseMiddleware({
+      response: new Response('late'),
+      serverSsrCleanup: 'stream',
+      dispose,
+    })
+    await vi.waitFor(() => expect(dispose).toHaveBeenCalledOnce())
+    expect(render).not.toHaveBeenCalled()
+  })
+
+  it('unwinds nested middleware when an inner operation ignores cancellation', async () => {
+    const router = makeRouter()
+    startMocks.router = router
+    const requestController = new AbortController()
+    const outerFinally = vi.fn()
+    let notifyInnerStarted!: () => void
+    const innerStarted = new Promise<void>((resolve) => {
+      notifyInnerStarted = resolve
+    })
+    const pending = new Promise<Response>(() => {})
+    startMocks.requestMiddleware = [
+      createMiddleware().server(({ next }) => next()),
+      createMiddleware().server(async ({ next }) => {
+        try {
+          return await next()
+        } finally {
+          outerFinally()
+        }
+      }),
+      createMiddleware().server(() => {
+        notifyInnerStarted()
+        return pending
+      }),
+    ]
+    const render = vi.fn(() => new Response('must not render'))
+    const handler = createStartHandler(render)
+    const response = handler(
+      new Request('http://localhost/', {
+        signal: requestController.signal,
+      }),
+      {},
+    )
+
+    await innerStarted
+    requestController.abort(new Error('request disconnected'))
+
+    expect((await response).status).toBe(500)
+    expect(outerFinally).toHaveBeenCalledOnce()
+    expect(render).not.toHaveBeenCalled()
+  })
+
+  it('cancels an all-synchronous direct next chain', async () => {
+    const router = makeRouter()
+    startMocks.router = router
+    const requestController = new AbortController()
+    let notifyInnerStarted!: () => void
+    const innerStarted = new Promise<void>((resolve) => {
+      notifyInnerStarted = resolve
+    })
+    startMocks.requestMiddleware = [
+      createMiddleware().server(({ next }) => next()),
+      createMiddleware().server(({ next }) => next()),
+      createMiddleware().server(() => {
+        notifyInnerStarted()
+        return new Promise<Response>(() => {})
+      }),
+    ]
+    const render = vi.fn(() => new Response('must not render'))
+    const handler = createStartHandler(render)
+    const response = handler(
+      new Request('http://localhost/', {
+        signal: requestController.signal,
+      }),
+      {},
+    )
+
+    await innerStarted
+    requestController.abort(new Error('request disconnected'))
+
+    expect((await response).status).toBe(500)
+    expect(render).not.toHaveBeenCalled()
+  })
+
+  it('preserves the abort reason when direct next rejects during abort', async () => {
+    const router = makeRouter()
+    startMocks.router = router
+    const requestController = new AbortController()
+    const reason = new Error('request disconnected')
+    startMocks.requestMiddleware = [
+      createMiddleware().server(({ next }) => next()),
+      createMiddleware().server(() => {
+        requestController.abort(reason)
+        throw new Response('must not escape', { status: 418 })
+      }),
+    ]
+    const render = vi.fn(() => new Response('must not render'))
+    const handler = createStartHandler(render)
+
+    const response = await handler(
+      new Request('http://localhost/', {
+        signal: requestController.signal,
+      }),
+      {},
+    )
+
+    expect(response.status).toBe(500)
+    expect(render).not.toHaveBeenCalled()
+  })
+
+  it('preserves aborts that race with a fulfilled direct next promise', async () => {
+    const router = makeRouter()
+    startMocks.router = router
+    const requestController = new AbortController()
+    const reason = new Error('request disconnected')
+    const observedErrors: Array<unknown> = []
+    const afterNext = vi.fn()
+    const ssrResponse = makeStreamResponse(router)
+    const dispose = vi.spyOn(ssrResponse as any, 'dispose')
+    startMocks.requestMiddleware = [
+      createMiddleware().server(async ({ next }) => {
+        try {
+          const result = await next()
+          afterNext()
+          return result
+        } catch (error) {
+          observedErrors.push(error)
+          throw error
+        }
+      }),
+      createMiddleware().server(({ next }) => {
+        const pending = next()
+        void Promise.resolve(pending).then(() =>
+          requestController.abort(reason),
+        )
+        return pending
+      }),
+      createMiddleware().server(() => ssrResponse as any),
+    ]
+    const render = vi.fn(() => new Response('must not render'))
+    const handler = createStartHandler(render)
+
+    const response = await handler(
+      new Request('http://localhost/', {
+        signal: requestController.signal,
+      }),
+      {},
+    )
+
+    expect(response.status).toBe(500)
+    await vi.waitFor(() => expect(observedErrors).toEqual([reason]))
+    await vi.waitFor(() => expect(dispose).toHaveBeenCalledWith(reason))
+    expect(afterNext).not.toHaveBeenCalled()
     expect(render).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

- share one abort listener across server waits for the same request signal while preserving late-result cleanup
- skip redundant cancellation wrappers when middleware directly returns `next()`, with guarded abort precedence and stream disposal
- cover concurrent waiters, signal isolation, registration races, nested middleware unwinding, and fulfilled/rejected abort races

## Performance

Controlled Solid SSR benchmarks:

| Scenario | Base branch | This PR | Change |
| --- | ---: | ---: | ---: |
| server route | 3.8324 ms | 3.4374 ms | 10.3% faster |
| middleware server route | 4.5093 ms | 3.5933 ms | 20.3% faster |

The final results are within 0.3% of the pre-regression route baseline and 0.2% of the pre-regression middleware baseline, both inside benchmark noise.

A same-worktree before/after run of all 17 client bundle scenarios reported exact zero deltas for gzip, initial gzip, raw, and Brotli sizes.

## Validation

- `@tanstack/router-core:test:unit`: 99 files, 1,454 tests passed or expected-fail
- `@tanstack/start-server-core:test:unit`: 7 files, 114 tests passed
- Router Core and Start Server Core type matrices passed on TypeScript 5.5 through 6.0
- package ESLint and build targets passed
- Solid aborted-request memory workload passed
- `git diff --check` passed