### PR TITLE
perf(router): reduce SSR lane loading overhead

### DIFF
--- a/packages/react-router/src/lazyRouteComponent.tsx
+++ b/packages/react-router/src/lazyRouteComponent.tsx
@@ -31,7 +31,10 @@ export function lazyRouteComponent<
       error = undefined
       loadPromise = importer()
         .then((res) => {
-          loadPromise = undefined
+          // Keep browser preload behavior unchanged; SSR can reuse the import.
+          if (!(isServer ?? typeof window === 'undefined')) {
+            loadPromise = undefined
+          }
           comp = res[exportName ?? 'default']
         })
         .catch((err) => {

--- a/packages/react-router/tests/component-preload-retry.test.tsx
+++ b/packages/react-router/tests/component-preload-retry.test.tsx
@@ -15,7 +15,20 @@ import type { ErrorComponentProps } from '../src'
 afterEach(() => {
   cleanup()
   vi.restoreAllMocks()
+  vi.unstubAllGlobals()
   sessionStorage.clear()
+})
+
+test('a successful server component download is reused', async () => {
+  vi.stubGlobal('window', undefined)
+  const importer = vi.fn().mockResolvedValue({ default: () => null })
+  const Page = lazyRouteComponent(importer)
+
+  const preload = Page.preload?.()
+  await preload
+
+  expect(Page.preload?.()).toBe(preload)
+  expect(importer).toHaveBeenCalledTimes(1)
 })
 
 test('a failed component download is retried from the route error UI', async () => {

--- a/packages/router-core/src/load-server.ts
+++ b/packages/router-core/src/load-server.ts
@@ -511,25 +511,44 @@ async function loadNormalChunks(
   end: number,
   signal?: AbortSignal,
 ): Promise<IndexedOutcome | undefined> {
-  const chunks = lane.matches.map(async (match, index) => {
+  const chunks: Array<
+    IndexedOutcome | Promise<IndexedOutcome | undefined>
+  > = []
+  for (let index = 0; index < lane.matches.length; index++) {
+    const match = lane.matches[index]!
     if (index >= end || match.ssr !== true || match.status !== 'success') {
-      return undefined
+      continue
     }
     const route = getRoute(router, match)
     try {
-      await loadRouteChunk(route)
+      const loading = loadRouteChunk(route)
+      if (loading) {
+        chunks.push(
+          loading.then(
+            () => {
+              signal?.throwIfAborted()
+              return undefined
+            },
+            (cause) => {
+              signal?.throwIfAborted()
+              return [
+                index,
+                stampNotFound(match, normalizeError(route, cause)),
+              ] as IndexedOutcome
+            },
+          ),
+        )
+      }
     } catch (cause) {
       signal?.throwIfAborted()
-      return [
+      chunks.push([
         index,
         stampNotFound(match, normalizeError(route, cause)),
-      ] as IndexedOutcome
+      ])
     }
-    signal?.throwIfAborted()
-    return undefined
-  })
+  }
   for (const chunk of chunks) {
-    const indexed = await chunk
+    const indexed = Array.isArray(chunk) ? chunk : await chunk
     if (indexed) {
       return indexed
     }

--- a/packages/router-core/src/load-server.ts
+++ b/packages/router-core/src/load-server.ts
@@ -511,9 +511,7 @@ async function loadNormalChunks(
   end: number,
   signal?: AbortSignal,
 ): Promise<IndexedOutcome | undefined> {
-  const chunks: Array<
-    IndexedOutcome | Promise<IndexedOutcome | undefined>
-  > = []
+  const chunks: Array<IndexedOutcome | Promise<IndexedOutcome | undefined>> = []
   for (let index = 0; index < lane.matches.length; index++) {
     const match = lane.matches[index]!
     if (index >= end || match.ssr !== true || match.status !== 'success') {
@@ -541,10 +539,7 @@ async function loadNormalChunks(
       }
     } catch (cause) {
       signal?.throwIfAborted()
-      chunks.push([
-        index,
-        stampNotFound(match, normalizeError(route, cause)),
-      ])
+      chunks.push([index, stampNotFound(match, normalizeError(route, cause))])
     }
   }
   for (const chunk of chunks) {

--- a/packages/solid-router/src/Match.tsx
+++ b/packages/solid-router/src/Match.tsx
@@ -43,12 +43,13 @@ export const Match = (props: { routeId: string }) => {
 
   // Lazy route option mutations become observable with the next client match
   // publication. Server stores are non-reactive and options load before render.
-  const routeOptions = (isServer ?? router.isServer)
-    ? () => route.options
-    : () => {
-        currentMatch()
-        return route.options
-      }
+  const routeOptions =
+    (isServer ?? router.isServer)
+      ? () => route.options
+      : () => {
+          currentMatch()
+          return route.options
+        }
 
   const resolvePendingComponent = () =>
     routeOptions().pendingComponent ?? router.options.defaultPendingComponent

--- a/packages/solid-router/src/Match.tsx
+++ b/packages/solid-router/src/Match.tsx
@@ -41,11 +41,14 @@ export const Match = (props: { routeId: string }) => {
 
   const route: AnyRoute = router.routesById[props.routeId]
 
-  // Lazy route option mutations become observable with the next match publication.
-  const routeOptions = () => {
-    currentMatch()
-    return route.options
-  }
+  // Lazy route option mutations become observable with the next client match
+  // publication. Server stores are non-reactive and options load before render.
+  const routeOptions = (isServer ?? router.isServer)
+    ? () => route.options
+    : () => {
+        currentMatch()
+        return route.options
+      }
 
   const resolvePendingComponent = () =>
     routeOptions().pendingComponent ?? router.options.defaultPendingComponent

--- a/packages/solid-router/src/lazyRouteComponent.tsx
+++ b/packages/solid-router/src/lazyRouteComponent.tsx
@@ -1,6 +1,7 @@
 import { Dynamic } from 'solid-js/web'
 import { createResource } from 'solid-js'
 import { isModuleNotFoundError } from '@tanstack/router-core'
+import { isServer } from '@tanstack/router-core/isServer'
 import type { AsyncRouteComponent } from './route'
 
 export function lazyRouteComponent<
@@ -21,7 +22,10 @@ export function lazyRouteComponent<
       error = undefined
       loadPromise = importer()
         .then((res) => {
-          loadPromise = undefined
+          // Keep browser preload behavior unchanged; SSR can reuse the import.
+          if (!(isServer ?? typeof window === 'undefined')) {
+            loadPromise = undefined
+          }
           comp = res[exportName ?? 'default']
           return comp
         })

--- a/packages/solid-router/tests/component-preload-retry.test.tsx
+++ b/packages/solid-router/tests/component-preload-retry.test.tsx
@@ -14,6 +14,31 @@ import type { ErrorComponentProps } from '../src'
 afterEach(() => {
   cleanup()
   vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+test('a successful server component download is reused', async () => {
+  vi.stubGlobal('window', undefined)
+  const importer = vi.fn().mockResolvedValue({ default: () => null })
+  const Page = lazyRouteComponent(importer)
+
+  const preload = Page.preload?.()
+  await preload
+
+  expect(Page.preload?.()).toBe(preload)
+  expect(importer).toHaveBeenCalledTimes(1)
+})
+
+test('a component loads when rendered before preload', async () => {
+  const importer = vi.fn().mockResolvedValue({
+    default: () => <div>Page content</div>,
+  })
+  const Page = lazyRouteComponent(importer)
+
+  render(() => <Page />)
+
+  expect(await screen.findByText('Page content')).toBeInTheDocument()
+  expect(importer).toHaveBeenCalledTimes(1)
 })
 
 test('a failed component download is retried from the route error UI', async () => {


### PR DESCRIPTION
## Summary

- avoid creating async route-chunk tasks for matches that do not need server rendering
- reuse settled lazy component imports during React and Solid SSR while preserving browser and retry behavior
- avoid unnecessary Solid route-option subscriptions during server rendering

## Performance

- React loader SSR benchmark: approximately 7.38 ms
- Solid loader SSR benchmark: approximately 8.20-8.23 ms
- all 17 client bundle scenarios remain byte-for-byte unchanged for gzip, initial, raw, and Brotli metrics

## Validation

- React lazy component unit tests
- Solid Router full client and server unit suites
- router-core focused SSR, chunk, and cancellation tests
- React and Solid type tests with TypeScript 5.5 through 6.0
- router-core, React Router, and Solid Router ESLint targets
- package, SSR fixture, and bundle-size builds