### PR TITLE
fix(router): address lane loader regressions

### DIFF
--- a/packages/react-router/src/Scripts.tsx
+++ b/packages/react-router/src/Scripts.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@tanstack/react-store'
-import { _getRenderedMatches, deepEqual } from '@tanstack/router-core'
+import { _getAssetMatches, deepEqual } from '@tanstack/router-core'
 import { isServer } from '@tanstack/router-core/isServer'
 import { Asset } from './Asset'
 import { useRouter } from './useRouter'
@@ -18,7 +18,7 @@ export const Scripts = () => {
   const nonce = router.options.ssr?.nonce
 
   const getScripts = (matches: Array<any>) => {
-    matches = _getRenderedMatches(matches)
+    matches = _getAssetMatches(matches)
     const scripts = matches
       .flatMap((match) => match.scripts ?? [])
       .filter(Boolean)

--- a/packages/react-router/src/Transitioner.tsx
+++ b/packages/react-router/src/Transitioner.tsx
@@ -34,16 +34,47 @@ export function Transitioner() {
       current[1](true)
     }
   }
-  router.startTransition = (fn, expected, urgent) =>
-    new Promise((resolve) => {
-      acknowledgement.current?.[1](false)
-      acknowledgement.current = [expected, resolve]
-      if (urgent) {
-        fn()
-      } else {
-        React.startTransition(fn)
-      }
-    })
+  if (process.env.NODE_ENV === 'production') {
+    router.startTransition = (fn, expected, urgent) =>
+      new Promise((resolve) => {
+        acknowledgement.current?.[1](false)
+        acknowledgement.current = [expected, resolve]
+        if (urgent) {
+          fn()
+        } else {
+          React.startTransition(fn)
+        }
+      })
+  } else {
+    router.startTransition = (fn, expected, urgent) =>
+      new Promise((resolve, reject) => {
+        acknowledgement.current?.[1](false)
+        const next: NonNullable<typeof acknowledgement.current> = [
+          expected,
+          resolve,
+        ]
+        acknowledgement.current = next
+        try {
+          if (urgent) {
+            fn()
+          } else {
+            React.startTransition(fn)
+          }
+        } catch (cause) {
+          if (acknowledgement.current === next) {
+            acknowledgement.current = undefined
+          }
+          reject(cause)
+        }
+      })
+    ;(
+      router as typeof router & { _cancelTransition?: () => void }
+    )._cancelTransition = () => {
+      const current = acknowledgement.current
+      acknowledgement.current = undefined
+      current?.[1](false)
+    }
+  }
 
   // Subscribe before canonicalizing so the initial URL has exactly one load.
   useLayoutEffect(() => {
@@ -74,7 +105,11 @@ export function Transitioner() {
       trimPathRight(location.publicHref) !==
       trimPathRight(nextLocation.publicHref)
     ) {
-      router.commitLocation({ ...nextLocation, replace: true })
+      router.commitLocation({
+        ...nextLocation,
+        replace: true,
+        ignoreBlocker: true,
+      })
       return process.env.NODE_ENV !== 'production' ? unsub : undefined
     }
 

--- a/packages/react-router/src/headContentUtils.tsx
+++ b/packages/react-router/src/headContentUtils.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useStore } from '@tanstack/react-store'
 import {
-  _getRenderedMatches,
+  _getAssetMatches,
   appendUniqueUserTags,
   deepEqual,
   escapeHtml,
@@ -23,7 +23,7 @@ function buildTagsFromMatches(
   matches: Array<AnyRouteMatch>,
   assetCrossOrigin?: AssetCrossOriginConfig,
 ): Array<RouterManagedTag> {
-  matches = _getRenderedMatches(matches)
+  matches = _getAssetMatches(matches)
   const routeMeta = matches
     .map((match) => match.meta)
     .filter((meta) => meta !== undefined)

--- a/packages/react-router/tests/Scripts.test.tsx
+++ b/packages/react-router/tests/Scripts.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 import {
   act,
   cleanup,
@@ -9,11 +9,14 @@ import {
 } from '@testing-library/react'
 import { createPortal } from 'react-dom'
 import ReactDOMServer from 'react-dom/server'
+import { hydrate } from '@tanstack/router-core/ssr/client'
+import { dehydrateSsrMatchId } from '../../router-core/src/ssr/ssr-match-id'
 
 import {
   HeadContent,
   Link,
   Outlet,
+  RouterContextProvider,
   RouterProvider,
   createBrowserHistory,
   createMemoryHistory,
@@ -57,6 +60,7 @@ afterEach(() => {
   cleanup()
   browserHistories.splice(0).forEach((history) => history.destroy())
   window.history.replaceState(null, 'root', '/')
+  delete window.$_TSR
 })
 
 describe('ssr scripts', () => {
@@ -334,6 +338,119 @@ describe('scripts with async/defer attributes', () => {
 })
 
 describe('ssr HeadContent', () => {
+  test('renders descendant assets during a data-only hydration handoff', async () => {
+    const rootRoute = createRootRoute({})
+    const dataOnlyRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/report',
+      ssr: 'data-only',
+      loader: () => 'report',
+    })
+    const childRoute = createRoute({
+      getParentRoute: () => dataOnlyRoute,
+      path: '/details',
+      loader: () => 'details',
+      head: () => ({
+        meta: [{ name: 'data-only-child', content: 'visible' }],
+        links: [{ rel: 'preload', href: '/data-only-head-link.js' }],
+        styles: [
+          {
+            id: 'data-only-route-style',
+            children: '.data-only-child { color: green }',
+          },
+        ],
+        scripts: [
+          {
+            id: 'data-only-head-script',
+            type: 'application/json',
+            children: '{"source":"head"}',
+          },
+        ],
+      }),
+      scripts: () => [
+        {
+          id: 'data-only-body-script',
+          type: 'application/json',
+          children: '{"source":"body"}',
+        },
+      ],
+    })
+    const router = createRouter({
+      history: createMemoryHistory({
+        initialEntries: ['/report/details'],
+      }),
+      routeTree: rootRoute.addChildren([
+        dataOnlyRoute.addChildren([childRoute]),
+      ]),
+    })
+    const matches = router.matchRoutes(router.latestLocation)
+    window.$_TSR = {
+      router: {
+        dehydratedData: {},
+        manifest: {
+          routes: {
+            [childRoute.id]: {
+              css: ['/data-only-manifest.css'],
+              preloads: ['/data-only-manifest.js'],
+              scripts: [
+                {
+                  attrs: {
+                    id: 'data-only-manifest-script',
+                    type: 'application/json',
+                  },
+                  children: '{"source":"manifest"}',
+                },
+              ],
+            },
+          },
+        },
+        matches: matches.map((match, index) => ({
+          i: dehydrateSsrMatchId(match.id),
+          s: 'success',
+          ssr: index === 1 ? 'data-only' : true,
+          l: index ? (index === 1 ? 'report' : 'details') : undefined,
+          u: Date.now(),
+        })),
+      },
+      h: vi.fn(),
+      e: vi.fn(),
+      c: vi.fn(),
+      p: vi.fn(),
+      buffer: [],
+    }
+
+    await hydrate(router)
+
+    expect(router.state.matches.map((match) => match.status)).toEqual([
+      'success',
+      'pending',
+      'success',
+    ])
+    render(
+      <RouterContextProvider router={router}>
+        <HeadContent />
+        <Scripts />
+      </RouterContextProvider>,
+    )
+
+    expect(
+      document.querySelector('meta[name="data-only-child"]'),
+    ).not.toBeNull()
+    expect(
+      document.querySelector('link[href="/data-only-head-link.js"]'),
+    ).not.toBeNull()
+    expect(document.querySelector('#data-only-route-style')).not.toBeNull()
+    expect(document.querySelector('#data-only-head-script')).not.toBeNull()
+    expect(document.querySelector('#data-only-body-script')).not.toBeNull()
+    expect(
+      document.querySelector('link[href="/data-only-manifest.css"]'),
+    ).not.toBeNull()
+    expect(
+      document.querySelector('link[href="/data-only-manifest.js"]'),
+    ).not.toBeNull()
+    expect(document.querySelector('#data-only-manifest-script')).not.toBeNull()
+  })
+
   test('derives title, dedupes meta, and allows non-loader HeadContent', async () => {
     const rootRoute = createRootRoute({
       loader: () =>

--- a/packages/react-router/tests/issue-6371-search-default-normalization-abort.test.tsx
+++ b/packages/react-router/tests/issue-6371-search-default-normalization-abort.test.tsx
@@ -127,3 +127,45 @@ test('#6371: initial search defaults produce one live canonical loader', async (
     })
   }
 })
+
+test('initial canonicalization bypasses existing navigation blockers', async () => {
+  const loader = vi.fn(
+    ({ location }: { location: { href: string } }) => location.href,
+  )
+  const rootRoute = createRootRoute({
+    component: () => <Outlet />,
+  })
+  const aboutRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/about',
+    validateSearch: (search: Record<string, unknown>) => ({
+      page: typeof search.page === 'number' ? search.page : 1,
+    }),
+    loader,
+    component: () => <div>{aboutRoute.useLoaderData()}</div>,
+  })
+  const history = createMemoryHistory({ initialEntries: ['/about'] })
+  const blockerFn = vi.fn(() => true)
+  const unblock = history.block({
+    blockerFn,
+    enableBeforeUnload: false,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([aboutRoute]),
+    history,
+  })
+
+  try {
+    render(<RouterProvider router={router} />)
+
+    expect(await screen.findByText('/about?page=1')).toBeInTheDocument()
+    expect(loader).toHaveBeenCalledTimes(1)
+    expect(history.location.href).toBe('/about?page=1')
+    expect(router.latestLocation.href).toBe('/about?page=1')
+    expect(router.state.location.href).toBe('/about?page=1')
+    expect(router.state.resolvedLocation?.href).toBe('/about?page=1')
+    expect(blockerFn).not.toHaveBeenCalled()
+  } finally {
+    unblock()
+  }
+})

--- a/packages/router-core/src/Matches.ts
+++ b/packages/router-core/src/Matches.ts
@@ -138,6 +138,8 @@ export interface RouteMatch<
   searchError: unknown
   updatedAt: number
   loaderData?: TLoaderData
+  /** @internal Exclusive end of the SSR-verified asset prefix. */
+  _dataOnlyAssetEnd?: number
   /** @internal */
   _ctx?: Record<string, unknown>
   /** @internal */

--- a/packages/router-core/src/Matches.ts
+++ b/packages/router-core/src/Matches.ts
@@ -139,7 +139,7 @@ export interface RouteMatch<
   updatedAt: number
   loaderData?: TLoaderData
   /** @internal Exclusive end of the SSR-verified asset prefix. */
-  _dataOnlyAssetEnd?: number
+  _assetEnd?: number
   /** @internal */
   _ctx?: Record<string, unknown>
   /** @internal */

--- a/packages/router-core/src/hydrate.ts
+++ b/packages/router-core/src/hydrate.ts
@@ -326,7 +326,7 @@ export async function hydrate(router: AnyRouter): Promise<void> {
       ...boundary,
       status: 'pending',
       ssr: boundary.ssr === 'data-only' ? 'data-only' : false,
-      _dataOnlyAssetEnd: dataOnlyAssetEnd,
+      _assetEnd: dataOnlyAssetEnd,
     }
   }
 
@@ -366,19 +366,11 @@ export async function hydrate(router: AnyRouter): Promise<void> {
           }
         }
       }
-      transferMatchResources(
-        router,
-        matches.splice(
-          0,
-          prefix,
-          ...committedMatches.map((match, index) => ({
-            ...match,
-            ...(index === pendingBoundary && handoffAssetEnd !== undefined
-              ? { _dataOnlyAssetEnd: handoffAssetEnd }
-              : undefined),
-          })),
-        ),
-      )
+      const clones = committedMatches.map((match) => ({ ...match }))
+      if (handoffAssetEnd !== undefined) {
+        clones[pendingBoundary!]!._assetEnd = handoffAssetEnd
+      }
+      transferMatchResources(router, matches.splice(0, prefix, ...clones))
       for (let index = prefix; index < matches.length; index++) {
         const match = matches[index]!
         const hydrated = candidates[index]

--- a/packages/router-core/src/hydrate.ts
+++ b/packages/router-core/src/hydrate.ts
@@ -104,7 +104,10 @@ export async function hydrate(router: AnyRouter): Promise<void> {
   }
   const committed: Array<AnyRouteMatch> = []
   let pendingBoundary: number | undefined
+  let verifiedAssetEnd = 0
   const retryFrom = (index: number) => {
+    // The failing route's identity is still verified, but no descendant is.
+    verifiedAssetEnd = Math.min(verifiedAssetEnd, index + 1)
     const removed = committed.splice(index)
     for (const match of removed) {
       if (
@@ -145,12 +148,19 @@ export async function hydrate(router: AnyRouter): Promise<void> {
       pendingBoundary ??= index
       break
     }
-    if ('l' in dehydrated) {
+    verifiedAssetEnd = index + 1
+    const route = getRoute(router, candidate)
+    if (
+      'l' in dehydrated ||
+      (dehydrated.s === 'success' &&
+        dehydrated.e === undefined &&
+        route.options.loader)
+    ) {
       candidate.loaderData = dehydrated.l
     }
     candidate.status = dehydrated.s
     candidate.ssr = dehydrated.ssr
-    getRoute(router, candidate).options.ssr = candidate.ssr
+    route.options.ssr = candidate.ssr
     candidate.updatedAt = dehydrated.u
     candidate.error = dehydrated.e
     candidate._notFound ||= dehydrated.g
@@ -176,6 +186,7 @@ export async function hydrate(router: AnyRouter): Promise<void> {
       pendingBoundary ??= index
     }
   }
+  let verifiedContextEnd = verifiedAssetEnd
 
   if (
     !isTerminal &&
@@ -226,15 +237,18 @@ export async function hydrate(router: AnyRouter): Promise<void> {
     return
   }
   if (chunkFailure < committed.length) {
+    verifiedContextEnd = Math.min(verifiedContextEnd, chunkFailure)
     retryFrom(chunkFailure)
   }
 
   // The first pending match is already visible, so prepare its route context
   // without granting its beforeLoad or loader any hydration authority.
-  const contextEnd =
+  const contextEnd = Math.max(
     pendingBoundary === committed.length
       ? committed.length + 1
-      : committed.length
+      : committed.length,
+    verifiedContextEnd,
+  )
   for (let index = 0; index < contextEnd; index++) {
     const match = candidates[index]!
     const route = getRoute(router, match)
@@ -286,7 +300,7 @@ export async function hydrate(router: AnyRouter): Promise<void> {
     [location, candidates] as any,
     controller.signal,
     0,
-    committed.length,
+    verifiedAssetEnd,
   )
   if (!isCurrent()) {
     return
@@ -296,13 +310,23 @@ export async function hydrate(router: AnyRouter): Promise<void> {
   const committedMatches =
     isTerminal && committed.length === shared ? candidates : committed
   let presented = needsClientLoad ? candidates : committedMatches
+  let dataOnlyAssetEnd: number | undefined
   if (needsClientLoad && pendingBoundary !== undefined) {
+    const boundary = presented[pendingBoundary]!
+    dataOnlyAssetEnd =
+      boundary.status === 'success' &&
+      boundary.ssr === 'data-only' &&
+      boundary.error === undefined &&
+      !boundary._notFound &&
+      verifiedAssetEnd > pendingBoundary + 1
+        ? verifiedAssetEnd
+        : undefined
     presented = presented.slice()
     presented[pendingBoundary] = {
-      ...presented[pendingBoundary]!,
+      ...boundary,
       status: 'pending',
-      ssr:
-        presented[pendingBoundary]!.ssr === 'data-only' ? 'data-only' : false,
+      ssr: boundary.ssr === 'data-only' ? 'data-only' : false,
+      _dataOnlyAssetEnd: dataOnlyAssetEnd,
     }
   }
 
@@ -332,12 +356,27 @@ export async function hydrate(router: AnyRouter): Promise<void> {
         controller.abort()
         return
       }
+      let handoffAssetEnd = dataOnlyAssetEnd
+      if (handoffAssetEnd !== undefined) {
+        for (let index = prefix; index < handoffAssetEnd; index++) {
+          if (candidates[index]?.id !== matches[index]?.id) {
+            handoffAssetEnd =
+              index > (pendingBoundary ?? -1) + 1 ? index : undefined
+            break
+          }
+        }
+      }
       transferMatchResources(
         router,
         matches.splice(
           0,
           prefix,
-          ...committedMatches.map((match) => ({ ...match })),
+          ...committedMatches.map((match, index) => ({
+            ...match,
+            ...(index === pendingBoundary && handoffAssetEnd !== undefined
+              ? { _dataOnlyAssetEnd: handoffAssetEnd }
+              : undefined),
+          })),
         ),
       )
       for (let index = prefix; index < matches.length; index++) {

--- a/packages/router-core/src/index.ts
+++ b/packages/router-core/src/index.ts
@@ -103,7 +103,7 @@ export {
   resolveManifestCssLink,
 } from './manifest'
 export { isMatch } from './Matches'
-export { _getRenderedMatches } from './rendered-matches'
+export { _getAssetMatches, _getRenderedMatches } from './rendered-matches'
 export type {
   AnyMatchAndValue,
   FindValueByIndex,

--- a/packages/router-core/src/load-client.ts
+++ b/packages/router-core/src/load-client.ts
@@ -97,6 +97,9 @@ export type LoadTransaction = [
   matches: Array<AnyRouteMatch>,
   startedAt: number,
   done: Promise<void>,
+  refresh?: true,
+  refreshPresentation?: Array<AnyRouteMatch>,
+  refreshHandoff?: NonNullable<AnyRouter['_handoff']>,
 ]
 
 export type PendingSession = [
@@ -112,6 +115,17 @@ export type PendingSession = [
 type CoordinatorRouter = AnyRouter & {
   /** Whole speculative lanes that a matching navigation may adopt. */
   _preloads?: Map<string, ActivePreload>
+  _refreshNextLoad?: boolean
+  _rollbackRefresh?: () => void
+  _cancelTransition?: () => void
+}
+
+type PublicationCheckpoint = {
+  previousMatches: Array<AnyRouteMatch>
+  previousPresentation: Array<AnyRouteMatch>
+  previousCache: Map<string, AnyRouteMatch>
+  commitPromise: CoordinatorRouter['_commitPromise']
+  published: boolean
 }
 
 type LoaderTask = [
@@ -1331,11 +1345,15 @@ function commitMatches(
   router: CoordinatorRouter,
   tx: LoadTransaction,
   matches: Array<AnyRouteMatch>,
+  resolvedPrefix?: number,
 ): void {
   const previous = router._committed
   const previousCached = router._cache
   for (const match of matches) {
     match.preload = false
+    if (resolvedPrefix) {
+      match._dataOnlyAssetEnd = undefined
+    }
   }
   const rendered = _getRenderedMatches(matches)
   const cached = new Map<string, AnyRouteMatch>()
@@ -1382,6 +1400,155 @@ function commitMatches(
     [...matches, ...cached.values()],
   )
   runRouteLifecycle(router, previous, matches, () => router._tx === tx)
+}
+
+function commitRefreshMatches(
+  router: CoordinatorRouter,
+  tx: LoadTransaction,
+  matches: Array<AnyRouteMatch>,
+  checkpoint: PublicationCheckpoint,
+): void {
+  const previous = router._committed
+  const previousCached = router._cache
+  for (const match of matches) {
+    match.preload = false
+  }
+  const cached = new Map<string, AnyRouteMatch>()
+  // Delay releasing the previous owners until the HMR render is acknowledged.
+  // Old generations must not become reusable cache entries after refresh.
+  tx[3] = []
+  router._cache = cached
+  checkpoint.previousMatches = previous
+  checkpoint.previousCache = previousCached
+  checkpoint.published = true
+  publishMatches(router, matches)
+  if (!checkpoint.published || router._tx !== tx) {
+    return
+  }
+  runRouteLifecycle(router, previous, matches, () => router._tx === tx)
+}
+
+function settlePublication(
+  router: CoordinatorRouter,
+  checkpoint: PublicationCheckpoint,
+): void {
+  if (!checkpoint.published) {
+    return
+  }
+  checkpoint.published = false
+  transferMatchResources(
+    router,
+    [...checkpoint.previousCache.values(), ...checkpoint.previousMatches],
+    [...router._cache.values(), ...router._committed],
+  )
+}
+
+function rollbackPublication(
+  router: CoordinatorRouter,
+  tx: LoadTransaction,
+  lane: ProjectedLane,
+  checkpoint: PublicationCheckpoint,
+): boolean {
+  if (
+    !checkpoint.published ||
+    router._tx !== tx ||
+    router._committed !== lane[1]
+  ) {
+    settlePublication(router, checkpoint)
+    return false
+  }
+
+  const discarded = [...router._cache.values(), ...router._committed]
+  const restored = [
+    ...checkpoint.previousCache.values(),
+    ...checkpoint.previousMatches,
+  ]
+  router._cache = checkpoint.previousCache
+  router._committed = checkpoint.previousMatches
+  checkpoint.published = false
+
+  for (const match of discarded as Array<WorkMatch>) {
+    if (
+      !restored.includes(match) &&
+      match._flight &&
+      router._flights?.get(match.id) === match._flight
+    ) {
+      router._flights.delete(match.id)
+    }
+  }
+
+  finishPending(router, tx)
+  router.batch(() => {
+    router.stores.status.set('idle')
+    router.stores.setMatches(checkpoint.previousPresentation)
+  })
+  tx[0].abort()
+  transferMatchResources(router, discarded, restored)
+  discardBackground(router, lane)
+  if (router._tx === tx && router._commitPromise === checkpoint.commitPromise) {
+    router._commitPromise?.resolve()
+    router._commitPromise = undefined
+  }
+  return true
+}
+
+async function transitionRefresh(
+  router: CoordinatorRouter,
+  tx: LoadTransaction,
+  lane: ProjectedLane,
+  changeInfo: ReturnType<typeof getLocationChangeInfo>,
+): Promise<boolean | undefined> {
+  const checkpoint: PublicationCheckpoint = {
+    previousMatches: router._committed,
+    previousPresentation: tx[7] ?? router.stores.matches.get(),
+    previousCache: router._cache,
+    commitPromise: router._commitPromise,
+    published: false,
+  }
+  const commit = () => {
+    finishPending(router, tx)
+    router._rollbackRefresh = rollback
+    commitRefreshMatches(router, tx, lane[1], checkpoint)
+    if (!checkpoint.published || router._tx !== tx) {
+      return
+    }
+    router.emit({ type: 'onLoad', ...changeInfo })
+    if (router._tx === tx) {
+      router.emit({ type: 'onBeforeRouteMount', ...changeInfo })
+    }
+  }
+  const rollback = () => {
+    if (router._rollbackRefresh === rollback) {
+      router._rollbackRefresh = undefined
+    }
+    const restored = rollbackPublication(router, tx, lane, checkpoint)
+    router._cancelTransition?.()
+    return restored
+  }
+  try {
+    const rendered = await router.startTransition(commit, lane[1])
+    if (router._rollbackRefresh === rollback) {
+      router._rollbackRefresh = undefined
+    }
+    if (checkpoint.published) {
+      const handoff = tx[8]
+      if (handoff && router._handoff === handoff) {
+        handoff[1]()
+      }
+      if (router._tx === tx) {
+        tx[6] = undefined
+        tx[7] = undefined
+        tx[8] = undefined
+      }
+    }
+    settlePublication(router, checkpoint)
+    return rendered
+  } catch (cause) {
+    if (rollback()) {
+      return
+    }
+    throw cause
+  }
 }
 
 async function awaitCurrent(
@@ -1543,6 +1710,9 @@ async function runClientTransaction(
       transferMatchResources(router, tx[3])
       tx[3] = []
       if (router._tx === tx) {
+        if (process.env.NODE_ENV !== 'production' && tx[6]) {
+          router._refreshNextLoad = true
+        }
         await followRedirect(router, tx, result[1])
       }
     } else {
@@ -1603,7 +1773,7 @@ async function runClientTransaction(
     }
     const commit = () => {
       finishPending(router, tx)
-      commitMatches(router, tx, result[1])
+      commitMatches(router, tx, result[1], resolvedPrefix)
       if (router._tx !== tx) {
         return
       }
@@ -1612,7 +1782,17 @@ async function runClientTransaction(
         router.emit({ type: 'onBeforeRouteMount', ...changeInfo })
       }
     }
-    const rendered = await router.startTransition(commit, result[1])
+    const rendered =
+      process.env.NODE_ENV !== 'production' && tx[6]
+        ? await transitionRefresh(router, tx, result, changeInfo)
+        : await router.startTransition(commit, result[1])
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      tx[6] &&
+      rendered === undefined
+    ) {
+      return
+    }
     if (router._tx !== tx) {
       discardBackground(router, result)
       return
@@ -1647,6 +1827,14 @@ export async function loadClientRoute(
   router: CoordinatorRouter,
   opts?: { sync?: boolean },
 ): Promise<void> {
+  let rematerialize = false
+  if (process.env.NODE_ENV !== 'production') {
+    router._rollbackRefresh?.()
+    rematerialize = !!router._refreshNextLoad || !!router._tx?.[6]
+  }
+  const refreshPresentation = rematerialize
+    ? router.stores.matches.get()
+    : undefined
   const previousOwner = router._tx
   const resolvedLocation = router.stores.resolvedLocation.get()
   const previousLocation = resolvedLocation ?? router.stores.location.get()
@@ -1659,11 +1847,11 @@ export async function loadClientRoute(
       ? (pendingLocation._redirects ?? 0)
       : 0
   const handoff = router._handoff
-  const hydrationController = handoff?.[0]()
+  const hydrationController = rematerialize ? undefined : handoff?.[0]()
   const preflight = new AbortController()
   const previousPreflight = router._preflight
   router._preflight = preflight
-  if (!hydrationController) {
+  if (!rematerialize && !hydrationController) {
     handoff?.[1]()
   }
   previousPreflight?.abort()
@@ -1685,6 +1873,16 @@ export async function loadClientRoute(
   const sameHref = previousLocation.href === location.href
   let adopted = router._preloads?.get(location.href)
   let retained: ActivePreload | undefined
+  if (rematerialize && adopted) {
+    router._preloads!.delete(location.href)
+    discardPreload(router, adopted)
+    adopted = undefined
+    if (preflight.signal.aborted || router._tx !== previousOwner) {
+      preflight.abort()
+      await awaitCurrent(router, previousOwner)
+      return
+    }
+  }
   if (
     adopted &&
     (hydrationController ||
@@ -1710,7 +1908,13 @@ export async function loadClientRoute(
     router._preloads!.delete(location.href)
   } else {
     try {
-      matches = router.matchRoutes(location, { _controller: preflight })
+      matches =
+        process.env.NODE_ENV !== 'production' && rematerialize
+          ? router.matchRoutes(location, {
+              _controller: preflight,
+              _rematerialize: true,
+            })
+          : router.matchRoutes(location, { _controller: preflight })
       acquireMatchResources(matches)
     } catch (cause) {
       preflight.abort()
@@ -1718,6 +1922,9 @@ export async function loadClientRoute(
         discardPreload(router, retained)
       }
       if (!isRedirect(cause)) {
+        if (process.env.NODE_ENV !== 'production' && rematerialize) {
+          router._refreshNextLoad = undefined
+        }
         await awaitCurrent(router)
         router._commitPromise?.resolve()
         router._commitPromise = undefined
@@ -1771,8 +1978,14 @@ export async function loadClientRoute(
         }
       }),
   ]
+  if (process.env.NODE_ENV !== 'production' && rematerialize) {
+    tx[6] = true
+    tx[7] = refreshPresentation
+    tx[8] = handoff
+    router._refreshNextLoad = undefined
+  }
   router._tx = tx
-  if (router._handoff === handoff) {
+  if (!rematerialize && router._handoff === handoff) {
     router._handoff = undefined
   }
   if (previousOwner) {
@@ -1806,20 +2019,22 @@ export async function loadClientRoute(
   }
 }
 
-export function refreshClientRoute(router: CoordinatorRouter): Promise<void> {
-  if (router._flights) {
-    const flights = [...router._flights.values()]
-    router._flights.clear()
-    for (const flight of flights) {
-      flight[1].abort()
+export async function refreshClientRoute(
+  router: CoordinatorRouter,
+): Promise<void> {
+  router._rollbackRefresh?.()
+  const pending = router._tx
+  if (pending && !pending[6] && router.stores.status.get() === 'pending') {
+    await pending[5]
+    if (router._tx !== pending) {
+      await awaitCurrent(router, pending)
     }
   }
-  const committed = router._committed
-  router._committed = []
+  // Existing owners remain alive for rollback but cannot donate stale work.
+  router._flights?.clear()
   router.clearCache()
-  transferMatchResources(router, committed)
-
-  return router.load({ sync: true })
+  router._refreshNextLoad = true
+  await loadClientRoute(router, { sync: true })
 }
 
 function followPreloadRedirect(
@@ -1855,6 +2070,12 @@ export async function preloadClientRoute(
     return
   }
   const owner = router._tx
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    (router._refreshNextLoad || owner?.[6])
+  ) {
+    return
+  }
   const location = opts._builtLocation ?? router.buildLocation(opts)
   const base = router._committed
   const controller = new AbortController()

--- a/packages/router-core/src/load-client.ts
+++ b/packages/router-core/src/load-client.ts
@@ -1352,7 +1352,7 @@ function commitMatches(
   for (const match of matches) {
     match.preload = false
     if (resolvedPrefix) {
-      match._dataOnlyAssetEnd = undefined
+      match._assetEnd = undefined
     }
   }
   const rendered = _getRenderedMatches(matches)

--- a/packages/router-core/src/load-server.ts
+++ b/packages/router-core/src/load-server.ts
@@ -521,21 +521,22 @@ async function loadNormalChunks(
     try {
       const loading = loadRouteChunk(route)
       if (loading) {
-        chunks.push(
-          loading.then(
-            () => {
-              signal?.throwIfAborted()
-              return undefined
-            },
-            (cause) => {
-              signal?.throwIfAborted()
-              return [
-                index,
-                stampNotFound(match, normalizeError(route, cause)),
-              ] as IndexedOutcome
-            },
-          ),
+        const chunk = loading.then(
+          () => {
+            signal?.throwIfAborted()
+            return undefined
+          },
+          (cause) => {
+            signal?.throwIfAborted()
+            return [
+              index,
+              stampNotFound(match, normalizeError(route, cause)),
+            ] as IndexedOutcome
+          },
         )
+        // Route-order reduction can return before later chunks settle.
+        void chunk.catch(() => {})
+        chunks.push(chunk)
       }
     } catch (cause) {
       signal?.throwIfAborted()

--- a/packages/router-core/src/rendered-matches.ts
+++ b/packages/router-core/src/rendered-matches.ts
@@ -10,3 +10,28 @@ export function _getRenderedMatches(
     ) + 1
   return end && end < matches.length ? matches.slice(0, end) : matches
 }
+
+/** Return the lane whose document assets belong to the current presentation. */
+export function _getAssetMatches(
+  matches: Array<AnyRouteMatch>,
+): Array<AnyRouteMatch> {
+  let end = matches.length
+  for (let index = 0; index < end; index++) {
+    const match = matches[index]!
+    if (
+      match.status === 'pending' &&
+      match.ssr === 'data-only' &&
+      match.error === undefined &&
+      !match._notFound &&
+      match._dataOnlyAssetEnd !== undefined
+    ) {
+      end = Math.min(end, Math.max(index + 1, match._dataOnlyAssetEnd))
+      continue
+    }
+    if (match.status !== 'success' || match._notFound) {
+      end = index + 1
+      break
+    }
+  }
+  return end && end < matches.length ? matches.slice(0, end) : matches
+}

--- a/packages/router-core/src/rendered-matches.ts
+++ b/packages/router-core/src/rendered-matches.ts
@@ -18,14 +18,11 @@ export function _getAssetMatches(
   let end = matches.length
   for (let index = 0; index < end; index++) {
     const match = matches[index]!
-    if (
-      match.status === 'pending' &&
-      match.ssr === 'data-only' &&
-      match.error === undefined &&
-      !match._notFound &&
-      match._dataOnlyAssetEnd !== undefined
-    ) {
-      end = Math.min(end, Math.max(index + 1, match._dataOnlyAssetEnd))
+    // `_assetEnd` is only ever set on hydration presentation clones that are
+    // `status: 'pending'`, `ssr: 'data-only'`, error-free, and not not-found
+    // (see hydrate.ts), and commits clear it — so its presence alone is the guard.
+    if (match._assetEnd !== undefined) {
+      end = Math.min(end, Math.max(index + 1, match._assetEnd))
       continue
     }
     if (match.status !== 'success' || match._notFound) {
@@ -33,5 +30,6 @@ export function _getAssetMatches(
       break
     }
   }
-  return end && end < matches.length ? matches.slice(0, end) : matches
+  // `end` only ever shrinks to `index + 1 >= 1`, so no zero guard is needed.
+  return end < matches.length ? matches.slice(0, end) : matches
 }

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -626,6 +626,8 @@ export interface MatchRoutesOpts {
   throwOnError?: boolean
   /** @internal */
   _controller?: AbortController
+  /** @internal */
+  _rematerialize?: boolean
 }
 
 function routeNeedsLoad(route: AnyRoute): unknown {
@@ -1629,8 +1631,10 @@ export class RouterCore<
 
       const previousMatch = previousAt(route, index)
       const existingMatch =
-        this._cache.get(matchId) ??
-        (previousMatch?.id === matchId ? previousMatch : undefined)
+        process.env.NODE_ENV !== 'production' && opts?._rematerialize
+          ? undefined
+          : (this._cache.get(matchId) ??
+            (previousMatch?.id === matchId ? previousMatch : undefined))
 
       const strictParams = existingMatch?._strictParams ?? usedParams
 

--- a/packages/router-core/tests/hmr-refresh-lifecycle.test.ts
+++ b/packages/router-core/tests/hmr-refresh-lifecycle.test.ts
@@ -1,0 +1,462 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import {
+  BaseRootRoute,
+  BaseRoute,
+  createControlledPromise,
+  redirect,
+} from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+beforeEach(() => {
+  vi.spyOn(window, 'scrollTo').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('HMR route refresh', () => {
+  test('reloads retained routes with onStay lifecycle semantics', async () => {
+    let generation = 1
+    const loader = vi.fn(() => generation)
+    const onEnter = vi.fn()
+    const onLeave = vi.fn()
+    const order: Array<string> = []
+    const onStay = vi.fn(() => order.push('onStay'))
+    const rootRoute = new BaseRootRoute({})
+    const pageRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/page',
+      loader,
+      onEnter,
+      onLeave,
+      onStay,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([pageRoute]),
+      history: createMemoryHistory({ initialEntries: ['/page'] }),
+    })
+
+    await router.load()
+    const unsubLoad = router.subscribe('onLoad', () => order.push('onLoad'))
+    const unsubMount = router.subscribe('onBeforeRouteMount', () =>
+      order.push('onBeforeRouteMount'),
+    )
+    generation = 2
+    await router._refreshRoute!()
+
+    expect(loader).toHaveBeenCalledTimes(2)
+    expect(router.state.matches.at(-1)?.loaderData).toBe(2)
+    expect(onEnter).toHaveBeenCalledTimes(1)
+    expect(onLeave).not.toHaveBeenCalled()
+    expect(onStay).toHaveBeenCalledTimes(1)
+    expect(order).toEqual(['onStay', 'onLoad', 'onBeforeRouteMount'])
+    unsubLoad()
+    unsubMount()
+  })
+
+  test('retires refresh mode after an acknowledged publication', async () => {
+    const otherLoader = vi.fn(() => 'other data')
+    const rootRoute = new BaseRootRoute({})
+    const pageRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/page',
+    })
+    const otherRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/other',
+      loader: otherLoader,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([pageRoute, otherRoute]),
+      history: createMemoryHistory({ initialEntries: ['/page'] }),
+    })
+
+    await router.load()
+    await router._refreshRoute!()
+    await router.preloadRoute({ to: '/other' })
+
+    expect(router._tx?.[6]).toBeUndefined()
+    expect(otherLoader).toHaveBeenCalledOnce()
+  })
+
+  test('passes rematerialization to a reentrant preflight load', async () => {
+    let generation = 1
+    const loader = vi.fn(() => generation)
+    const rootRoute = new BaseRootRoute({})
+    const pageRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/page',
+      staleTime: Infinity,
+      loader,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([pageRoute]),
+      history: createMemoryHistory({ initialEntries: ['/page'] }),
+    })
+
+    await router.load()
+    generation = 2
+    let reenter = true
+    let reentrantLoad: Promise<void> | undefined
+    const unsubscribe = router.subscribe('onBeforeNavigate', () => {
+      if (reenter) {
+        reenter = false
+        reentrantLoad = router.load({ sync: true })
+      }
+    })
+    try {
+      await router._refreshRoute!()
+      await reentrantLoad
+    } finally {
+      unsubscribe()
+    }
+
+    expect(loader).toHaveBeenCalledTimes(2)
+    expect(router.state.matches.at(-1)?.loaderData).toBe(2)
+  })
+
+  test('passes rematerialization to a load that supersedes refresh work', async () => {
+    let generation = 1
+    let reenter = false
+    let reentrantLoad: Promise<void> | undefined
+    let router!: ReturnType<typeof createTestRouter>
+    const loader = vi.fn(() => {
+      if (reenter) {
+        reenter = false
+        reentrantLoad = router.load({ sync: true })
+      }
+      return generation
+    })
+    const rootRoute = new BaseRootRoute({})
+    const pageRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/page',
+      staleTime: Infinity,
+      loader,
+    })
+    router = createTestRouter({
+      routeTree: rootRoute.addChildren([pageRoute]),
+      history: createMemoryHistory({ initialEntries: ['/page'] }),
+    })
+
+    await router.load()
+    generation = 2
+    reenter = true
+    await router._refreshRoute!()
+    await reentrantLoad
+
+    expect(loader).toHaveBeenCalledTimes(3)
+    expect(router.state.matches.at(-1)?.loaderData).toBe(2)
+  })
+
+  test('passes rematerialization through a refresh redirect', async () => {
+    let generation = 1
+    let shouldRedirect = false
+    const rootLoader = vi.fn(() => generation)
+    const rootRoute = new BaseRootRoute({
+      staleTime: Infinity,
+      loader: rootLoader,
+    })
+    const sourceRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/source',
+      beforeLoad: () => {
+        if (shouldRedirect) {
+          throw redirect({ to: '/target' })
+        }
+      },
+    })
+    const targetRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/target',
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([sourceRoute, targetRoute]),
+      history: createMemoryHistory({ initialEntries: ['/source'] }),
+    })
+
+    await router.load()
+    generation = 2
+    shouldRedirect = true
+    await router._refreshRoute!()
+
+    expect(router.state.location.pathname).toBe('/target')
+    expect(rootLoader).toHaveBeenCalledTimes(2)
+    expect(router.state.matches[0]?.loaderData).toBe(2)
+  })
+
+  test('restores the committed presentation when publication fails', async () => {
+    let generation = 1
+    const rootRoute = new BaseRootRoute({})
+    const pageRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/page',
+      loader: () => generation,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([pageRoute]),
+      history: createMemoryHistory({ initialEntries: ['/page'] }),
+    })
+
+    await router.load()
+    const previousMatches = router.state.matches
+    generation = 2
+    const startTransition = router.startTransition
+    router.startTransition = async (fn) => {
+      fn()
+      router.clearCache()
+      throw new Error('render failed')
+    }
+
+    await router._refreshRoute!()
+
+    expect(router.state.status).toBe('idle')
+    expect(router.state.matches).toHaveLength(previousMatches.length)
+    expect(router.state.matches.at(-1)?.loaderData).toBe(1)
+
+    router.startTransition = startTransition
+    generation = 3
+    await router._refreshRoute!()
+    expect(router.state.matches.at(-1)?.loaderData).toBe(3)
+  })
+
+  test('keeps the rendered generation alive until refresh is acknowledged', async () => {
+    let generation = 1
+    const signals: Array<AbortSignal> = []
+    const rootRoute = new BaseRootRoute({})
+    const pageRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/page',
+      loader: ({ abortController }) => {
+        signals.push(abortController.signal)
+        return generation
+      },
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([pageRoute]),
+      history: createMemoryHistory({ initialEntries: ['/page'] }),
+    })
+
+    await router.load()
+    const renderedSignal = signals[0]!
+    generation = 2
+    const startTransition = router.startTransition
+    router.startTransition = async (fn) => {
+      fn()
+      throw new Error('render failed')
+    }
+
+    await router._refreshRoute!()
+
+    expect(renderedSignal.aborted).toBe(false)
+    expect(signals[1]?.aborted).toBe(true)
+    expect(router.state.matches.at(-1)?.loaderData).toBe(1)
+
+    router.startTransition = startTransition
+    generation = 3
+    await router._refreshRoute!()
+    expect(renderedSignal.aborted).toBe(true)
+    expect(router.state.matches.at(-1)?.loaderData).toBe(3)
+  })
+
+  test('rolls overlapping refreshes back to the last acknowledged generation', async () => {
+    let generation = 1
+    const rootRoute = new BaseRootRoute({})
+    const pageRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/page',
+      loader: () => generation,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([pageRoute]),
+      history: createMemoryHistory({ initialEntries: ['/page'] }),
+    })
+
+    await router.load()
+    let transitionCount = 0
+    let supersedeFirst!: () => void
+    router.startTransition = (fn) => {
+      transitionCount++
+      fn()
+      if (transitionCount === 1) {
+        return new Promise<boolean>((resolve) => {
+          supersedeFirst = () => resolve(false)
+        })
+      }
+      return Promise.reject(new Error('replacement render failed'))
+    }
+    ;(
+      router as typeof router & { _cancelTransition?: () => void }
+    )._cancelTransition = () => supersedeFirst()
+
+    generation = 2
+    const firstRefresh = router._refreshRoute!()
+    await vi.waitFor(() => expect(transitionCount).toBe(1))
+
+    generation = 3
+    const secondRefresh = router._refreshRoute!()
+    await Promise.all([firstRefresh, secondRefresh])
+
+    expect(router.state.status).toBe('idle')
+    expect(router.state.matches.at(-1)?.loaderData).toBe(1)
+  })
+
+  test('does not resolve a superseding navigation promise during rollback', async () => {
+    let generation = 1
+    const destinationGate = createControlledPromise<void>()
+    const rootRoute = new BaseRootRoute({})
+    const pageRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/page',
+      loader: () => generation,
+    })
+    const destinationRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/destination',
+      loader: () => destinationGate,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([pageRoute, destinationRoute]),
+      history: createMemoryHistory({ initialEntries: ['/page'] }),
+    })
+
+    await router.load()
+    let transitionCount = 0
+    let cancelRefresh!: () => void
+    router.startTransition = (fn) => {
+      transitionCount++
+      fn()
+      if (transitionCount === 1) {
+        return new Promise<boolean>((resolve) => {
+          cancelRefresh = () => resolve(false)
+        })
+      }
+      return Promise.resolve(true)
+    }
+    ;(
+      router as typeof router & { _cancelTransition?: () => void }
+    )._cancelTransition = () => cancelRefresh()
+
+    generation = 2
+    const refresh = router._refreshRoute!()
+    await vi.waitFor(() => expect(transitionCount).toBe(1))
+
+    const navigationSettled = vi.fn()
+    const navigation = router
+      .navigate({ to: '/destination' })
+      .then(navigationSettled)
+    await vi.waitFor(() =>
+      expect(router.state.location.pathname).toBe('/destination'),
+    )
+    expect(navigationSettled).not.toHaveBeenCalled()
+
+    destinationGate.resolve()
+    await Promise.all([refresh, navigation])
+    expect(navigationSettled).toHaveBeenCalledOnce()
+    expect(router.state.matches.at(-1)?.routeId).toBe(destinationRoute.id)
+  })
+
+  test('waits for an ordinary pending navigation before refreshing', async () => {
+    const destinationGate = createControlledPromise<void>()
+    const rootRoute = new BaseRootRoute({})
+    const pageRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/page',
+    })
+    const destinationRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/destination',
+      pendingMs: 0,
+      pendingMinMs: 0,
+      pendingComponent: () => null,
+      loader: () => destinationGate,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([pageRoute, destinationRoute]),
+      history: createMemoryHistory({ initialEntries: ['/page'] }),
+    })
+
+    await router.load()
+    const navigation = router.navigate({ to: '/destination' })
+    await vi.waitFor(() => {
+      expect(router.state.status).toBe('pending')
+      expect(router.state.matches.at(-1)?.routeId).toBe(destinationRoute.id)
+    })
+    destinationRoute.options.onStay = () => {
+      throw new Error('refreshed destination failed')
+    }
+    const refreshSettled = vi.fn()
+    const refresh = router._refreshRoute!().then(refreshSettled)
+    await Promise.resolve()
+    expect(refreshSettled).not.toHaveBeenCalled()
+
+    destinationGate.resolve()
+    await Promise.all([navigation, refresh])
+
+    expect(router.state.status).toBe('idle')
+    expect(router.state.matches.at(-1)).toMatchObject({
+      routeId: destinationRoute.id,
+      status: 'success',
+    })
+    expect(refreshSettled).toHaveBeenCalledOnce()
+  })
+
+  test('rolls back when an HMR lifecycle callback throws', async () => {
+    let generation = 1
+    const rootRoute = new BaseRootRoute({})
+    const pageRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/page',
+      loader: () => generation,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([pageRoute]),
+      history: createMemoryHistory({ initialEntries: ['/page'] }),
+    })
+
+    await router.load()
+    generation = 2
+    pageRoute.options.onStay = () => {
+      throw new Error('lifecycle failed')
+    }
+
+    await router._refreshRoute!()
+
+    expect(router.state.status).toBe('idle')
+    expect(router.state.matches.at(-1)?.loaderData).toBe(1)
+
+    pageRoute.options.onStay = undefined
+    generation = 3
+    await router._refreshRoute!()
+    expect(router.state.matches.at(-1)?.loaderData).toBe(3)
+  })
+
+  test('does not adopt a preload created by HMR preflight hooks', async () => {
+    let generation = 1
+    const rootRoute = new BaseRootRoute({})
+    const pageRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/page',
+      loader: () => generation,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([pageRoute]),
+      history: createMemoryHistory({ initialEntries: ['/page'] }),
+    })
+
+    await router.load()
+    generation = 2
+    const unsubscribe = router.subscribe('onBeforeLoad', () => {
+      void router.preloadRoute({ to: '/page' })
+    })
+    try {
+      await router._refreshRoute!()
+    } finally {
+      unsubscribe()
+    }
+
+    expect(router.state.matches.at(-1)?.loaderData).toBe(2)
+  })
+})

--- a/packages/router-core/tests/hydrate.test.ts
+++ b/packages/router-core/tests/hydrate.test.ts
@@ -4,6 +4,7 @@ import { createMemoryHistory } from '@tanstack/history'
 import {
   BaseRootRoute,
   BaseRoute,
+  _getAssetMatches,
   createSerializationAdapter,
   isNotFound,
   notFound,
@@ -218,7 +219,7 @@ describe('hydrate', () => {
     expect(clientLoader).not.toHaveBeenCalled()
   })
 
-  it('omits undefined loader data from hydrated matches', async () => {
+  it('restores undefined loader data without serializing it', async () => {
     const serverRootRoute = new BaseRootRoute({})
     const serverRoute = new BaseRoute({
       getParentRoute: () => serverRootRoute,
@@ -255,7 +256,71 @@ describe('hydrate', () => {
       routeId: clientRoute.id,
       status: 'success',
     })
-    expect(match).not.toHaveProperty('loaderData')
+    expect(match).toHaveProperty('loaderData', undefined)
+  })
+
+  it('preserves successful undefined loader data when selecting a later failure', async () => {
+    const serverRootRoute = new BaseRootRoute({})
+    const serverParentRoute = new BaseRoute({
+      getParentRoute: () => serverRootRoute,
+      path: '/parent',
+      loader: () => undefined,
+    })
+    const serverChildRoute = new BaseRoute({
+      getParentRoute: () => serverParentRoute,
+      path: '/child',
+    })
+    const serverRouter = createTestRouter({
+      routeTree: serverRootRoute.addChildren([
+        serverParentRoute.addChildren([serverChildRoute]),
+      ]),
+      history: createMemoryHistory({ initialEntries: ['/parent/child'] }),
+      isServer: true,
+    })
+
+    mockWindow.$_TSR = await dehydrateToBootstrap(serverRouter)
+    expect(mockWindow.$_TSR.router?.matches[1]).not.toHaveProperty('l')
+
+    const parentError = new Error('parent reload failed')
+    const childError = new Error('child guard failed')
+    const clientRootRoute = new BaseRootRoute({})
+    const clientParentRoute = new BaseRoute({
+      getParentRoute: () => clientRootRoute,
+      path: '/parent',
+      loader: () => {
+        throw parentError
+      },
+      errorComponent: () => null,
+    })
+    const clientChildRoute = new BaseRoute({
+      getParentRoute: () => clientParentRoute,
+      path: '/child',
+      beforeLoad: () => {
+        throw childError
+      },
+      errorComponent: () => null,
+    })
+    const clientRouter = createTestRouter({
+      routeTree: clientRootRoute.addChildren([
+        clientParentRoute.addChildren([clientChildRoute]),
+      ]),
+      history: createMemoryHistory({ initialEntries: ['/parent/child'] }),
+      isServer: false,
+    })
+
+    await hydrate(clientRouter)
+    await clientRouter.invalidate()
+
+    expect(
+      clientRouter.state.matches.find(
+        (match) => match.routeId === clientParentRoute.id,
+      ),
+    ).toMatchObject({ status: 'success', error: undefined })
+    expect(
+      clientRouter.state.matches.find(
+        (match) => match.routeId === clientChildRoute.id,
+      ),
+    ).toMatchObject({ status: 'error', error: childError })
   })
 
   it.each([
@@ -372,6 +437,11 @@ describe('hydrate', () => {
     })
     expect(childContext).not.toHaveBeenCalled()
     expect(clientParentLoader).not.toHaveBeenCalled()
+    expect(
+      _getAssetMatches(clientRouter.state.matches).map(
+        (match) => match.routeId,
+      ),
+    ).toEqual([clientRootRoute.id, clientParentRoute.id])
 
     await clientRouter.load()
 

--- a/packages/router-core/tests/hydration-currentness.test.ts
+++ b/packages/router-core/tests/hydration-currentness.test.ts
@@ -225,7 +225,7 @@ describe('hydration asset currentness', () => {
     let continuationAssetEnd: number | undefined
     let router!: AnyRouter
     const childLoader = vi.fn(() => {
-      continuationAssetEnd = router._tx?.[3][1]?._dataOnlyAssetEnd
+      continuationAssetEnd = router._tx?.[3][1]?._assetEnd
       return childLoaderResult
     })
     const rootRoute = new BaseRootRoute({})
@@ -260,12 +260,12 @@ describe('hydration asset currentness', () => {
     expect(
       _getAssetMatches(router.state.matches).map((match) => match.routeId),
     ).toEqual([rootRoute.id, parentRoute.id, childRoute.id])
-    expect(router.state.matches[1]?._dataOnlyAssetEnd).toBe(3)
+    expect(router.state.matches[1]?._assetEnd).toBe(3)
 
     childLoaderResult.resolve('client child data')
     await load
 
-    expect(router.state.matches[1]?._dataOnlyAssetEnd).toBeUndefined()
+    expect(router.state.matches[1]?._assetEnd).toBeUndefined()
     expect(router.state.matches[2]).toMatchObject({
       status: 'success',
       loaderData: 'client child data',

--- a/packages/router-core/tests/hydration-currentness.test.ts
+++ b/packages/router-core/tests/hydration-currentness.test.ts
@@ -1,12 +1,17 @@
 import { runInNewContext } from 'node:vm'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { createMemoryHistory } from '@tanstack/history'
-import { BaseRootRoute, BaseRoute, createControlledPromise } from '../src'
+import {
+  BaseRootRoute,
+  BaseRoute,
+  _getAssetMatches,
+  createControlledPromise,
+} from '../src'
 import { hydrate } from '../src/ssr/client'
 import { attachRouterServerSsrUtils } from '../src/ssr/ssr-server'
 import { dehydrateSsrMatchId } from '../src/ssr/ssr-match-id'
 import { createTestRouter } from './routerTestUtils'
-import type { AnyRouter, NavigateFn } from '../src'
+import type { AnyRouteMatch, AnyRouter, NavigateFn } from '../src'
 import type { DehydratedRouter, TsrSsrGlobal } from '../src/ssr/types'
 import type { ServerManifest } from '../src/manifest'
 
@@ -111,6 +116,160 @@ describe('hydration asset currentness', () => {
     })
     expect(router.state.resolvedLocation).toBeUndefined()
     expect(childLoader).not.toHaveBeenCalled()
+  })
+
+  test('includes an identity-verified ssr:false boundary in a data-only asset prefix', async () => {
+    const serverChildLoader = vi.fn(() => 'server child data')
+    const serverRootRoute = new BaseRootRoute({})
+    const serverParentRoute = new BaseRoute({
+      getParentRoute: () => serverRootRoute,
+      path: '/parent',
+      ssr: 'data-only',
+    })
+    const serverChildRoute = new BaseRoute({
+      getParentRoute: () => serverParentRoute,
+      path: '/child',
+      ssr: false,
+      loader: serverChildLoader,
+    })
+    const serverTailRoute = new BaseRoute({
+      getParentRoute: () => serverChildRoute,
+      path: '/tail',
+    })
+    const serverRouter = createTestRouter({
+      routeTree: serverRootRoute.addChildren([
+        serverParentRoute.addChildren([
+          serverChildRoute.addChildren([serverTailRoute]),
+        ]),
+      ]),
+      history: createMemoryHistory({
+        initialEntries: ['/parent/child/tail'],
+      }),
+      isServer: true,
+    })
+    mockWindow.$_TSR = await dehydrateToBootstrap(serverRouter)
+    expect(serverChildLoader).not.toHaveBeenCalled()
+
+    const childContext = vi.fn(() => ({ assetSource: 'child context' }))
+    const childHead = vi.fn(({ match }: { match: AnyRouteMatch }) => ({
+      meta: [
+        {
+          name: 'ssr-false-boundary',
+          content: (match.context as { assetSource?: string }).assetSource,
+        },
+      ],
+    }))
+    const rootRoute = new BaseRootRoute({})
+    const parentRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/parent',
+      ssr: 'data-only',
+    })
+    const childRoute = new BaseRoute({
+      getParentRoute: () => parentRoute,
+      path: '/child',
+      ssr: false,
+      loader: () => 'client child data',
+      context: childContext,
+      head: childHead,
+    })
+    const tailRoute = new BaseRoute({
+      getParentRoute: () => childRoute,
+      path: '/tail',
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([
+        parentRoute.addChildren([childRoute.addChildren([tailRoute])]),
+      ]),
+      history: createMemoryHistory({
+        initialEntries: ['/parent/child/tail'],
+      }),
+      isServer: false,
+    })
+
+    await hydrate(router)
+
+    expect(
+      _getAssetMatches(router.state.matches).map((match) => match.routeId),
+    ).toEqual([rootRoute.id, parentRoute.id, childRoute.id])
+    expect(childContext).toHaveBeenCalledOnce()
+    expect(childHead).toHaveBeenCalledOnce()
+    expect(router.state.matches[2]?.meta).toEqual([
+      { name: 'ssr-false-boundary', content: 'child context' },
+    ])
+  })
+
+  test('preserves a verified data-only asset prefix through its client continuation', async () => {
+    const serverRootRoute = new BaseRootRoute({})
+    const serverParentRoute = new BaseRoute({
+      getParentRoute: () => serverRootRoute,
+      path: '/parent',
+      ssr: 'data-only',
+    })
+    const serverChildRoute = new BaseRoute({
+      getParentRoute: () => serverParentRoute,
+      path: '/child',
+      ssr: false,
+      loader: () => 'server child data',
+    })
+    const serverRouter = createTestRouter({
+      routeTree: serverRootRoute.addChildren([
+        serverParentRoute.addChildren([serverChildRoute]),
+      ]),
+      history: createMemoryHistory({ initialEntries: ['/parent/child'] }),
+      isServer: true,
+    })
+    mockWindow.$_TSR = await dehydrateToBootstrap(serverRouter)
+
+    const childLoaderResult = createControlledPromise<string>()
+    let continuationAssetEnd: number | undefined
+    let router!: AnyRouter
+    const childLoader = vi.fn(() => {
+      continuationAssetEnd = router._tx?.[3][1]?._dataOnlyAssetEnd
+      return childLoaderResult
+    })
+    const rootRoute = new BaseRootRoute({})
+    const parentRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/parent',
+      ssr: 'data-only',
+      pendingComponent: () => null,
+      pendingMs: 0,
+      pendingMinMs: 0,
+    })
+    const childRoute = new BaseRoute({
+      getParentRoute: () => parentRoute,
+      path: '/child',
+      ssr: false,
+      loader: childLoader,
+    })
+    router = createTestRouter({
+      routeTree: rootRoute.addChildren([parentRoute.addChildren([childRoute])]),
+      history: createMemoryHistory({ initialEntries: ['/parent/child'] }),
+      isServer: false,
+    })
+
+    await hydrate(router)
+    const load = router.load()
+
+    await vi.waitFor(() => {
+      expect(childLoader).toHaveBeenCalledOnce()
+      expect(router.state.status).toBe('pending')
+    })
+    expect(continuationAssetEnd).toBe(3)
+    expect(
+      _getAssetMatches(router.state.matches).map((match) => match.routeId),
+    ).toEqual([rootRoute.id, parentRoute.id, childRoute.id])
+    expect(router.state.matches[1]?._dataOnlyAssetEnd).toBe(3)
+
+    childLoaderResult.resolve('client child data')
+    await load
+
+    expect(router.state.matches[1]?._dataOnlyAssetEnd).toBeUndefined()
+    expect(router.state.matches[2]).toMatchObject({
+      status: 'success',
+      loaderData: 'client child data',
+    })
   })
 
   test('settles when navigation supersedes a pending custom hydrate hook', async () => {
@@ -269,6 +428,65 @@ describe('hydration asset currentness', () => {
     expect(childLoader).toHaveBeenCalledTimes(1)
   })
 
+  test('failed HMR restores a partial hydration presentation and handoff', async () => {
+    let hydrationController: AbortController | undefined
+    const childLoader = vi.fn(() => 'client child data')
+    const rootRoute = new BaseRootRoute({
+      context: ({ abortController }: { abortController: AbortController }) => {
+        hydrationController ??= abortController
+      },
+    })
+    const childRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/child',
+      ssr: false,
+      loader: childLoader,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([childRoute]),
+      history: createMemoryHistory({ initialEntries: ['/child'] }),
+      isServer: false,
+    })
+    const matches = router.matchRoutes(router.stores.location.get())
+    installHydrationPayload(mockWindow, [
+      {
+        i: dehydrateSsrMatchId(matches[0]!.id),
+        s: 'success',
+        ssr: true,
+        u: Date.now(),
+      },
+    ])
+
+    await hydrate(router)
+    const handoff = router._handoff
+    const startTransition = router.startTransition
+    router.startTransition = async (fn) => {
+      fn()
+      throw new Error('HMR render failed')
+    }
+
+    await router._refreshRoute!()
+
+    expect(router.state.matches.map((match) => match.routeId)).toEqual([
+      rootRoute.id,
+      childRoute.id,
+    ])
+    expect(router.state.matches[1]).toMatchObject({
+      status: 'pending',
+      ssr: false,
+    })
+    expect(router._handoff).toBe(handoff)
+    expect(hydrationController?.signal.aborted).toBe(false)
+
+    router.startTransition = startTransition
+    await router.load()
+    expect(router.state.matches[1]).toMatchObject({
+      status: 'success',
+      loaderData: 'client child data',
+    })
+    expect(childLoader).toHaveBeenCalledTimes(2)
+  })
+
   test('a synchronous context navigation prevents stale hydration assets from running', async () => {
     const oldHead = vi.fn(() => ({ meta: [{ title: 'Old route' }] }))
     const oldScripts = vi.fn(() => [
@@ -423,6 +641,9 @@ describe('hydration asset currentness', () => {
     expect(parentBeforeLoad).not.toHaveBeenCalled()
     expect(childBeforeLoad).not.toHaveBeenCalled()
     expect(childLoader).not.toHaveBeenCalled()
+    expect(
+      _getAssetMatches(router.state.matches).map((match) => match.routeId),
+    ).toEqual([rootRoute.id, parentRoute.id])
 
     await router.load()
 

--- a/packages/router-core/tests/rendered-matches.test.ts
+++ b/packages/router-core/tests/rendered-matches.test.ts
@@ -19,7 +19,7 @@ describe('_getAssetMatches', () => {
       {
         status: 'pending',
         ssr: 'data-only',
-        _dataOnlyAssetEnd: 3,
+        _assetEnd: 3,
       },
       { status: 'success' },
       { status: 'success' },

--- a/packages/router-core/tests/rendered-matches.test.ts
+++ b/packages/router-core/tests/rendered-matches.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'vitest'
+import { _getAssetMatches } from '../src'
+import type { AnyRouteMatch } from '../src'
+
+describe('_getAssetMatches', () => {
+  test('does not cross an ordinary data-only pending boundary', () => {
+    const matches = [
+      { status: 'success' },
+      { status: 'pending', ssr: 'data-only' },
+      { status: 'success' },
+    ] as Array<AnyRouteMatch>
+
+    expect(_getAssetMatches(matches)).toEqual(matches.slice(0, 2))
+  })
+
+  test('limits a hydration handoff to its verified asset prefix', () => {
+    const matches = [
+      { status: 'success' },
+      {
+        status: 'pending',
+        ssr: 'data-only',
+        _dataOnlyAssetEnd: 3,
+      },
+      { status: 'success' },
+      { status: 'success' },
+    ] as Array<AnyRouteMatch>
+
+    expect(_getAssetMatches(matches)).toEqual(matches.slice(0, 3))
+  })
+})

--- a/packages/router-core/tests/routerTestUtils.ts
+++ b/packages/router-core/tests/routerTestUtils.ts
@@ -50,10 +50,14 @@ export function createTestRouter<
 }
 
 /** Materialize the request-local server result as the HTTP response users see. */
-export function loadServerResponse(router: AnyRouter, path: string) {
+export function loadServerResponse(
+  router: AnyRouter,
+  path: string,
+  signal?: AbortSignal,
+) {
   return createRequestHandler({
     createRouter: () => router,
-    request: new Request(`http://localhost${path}`),
+    request: new Request(`http://localhost${path}`, { signal }),
   })(({ router: loadedRouter, responseHeaders }) => {
     const result = loadedRouter._serverResult
     return new Response(null, {

--- a/packages/router-core/tests/server-chunk-failure-lifecycle.test.ts
+++ b/packages/router-core/tests/server-chunk-failure-lifecycle.test.ts
@@ -144,6 +144,67 @@ describe('server route chunk failure lifecycle', () => {
     })
   })
 
+  test('does not leave later chunk rejections unhandled after request abort', async () => {
+    const rootError = new Error('root component failed')
+    const abortError = new Error('request closed')
+    const rootChunkGate = createControlledPromise<void>()
+    const childChunkGate = createControlledPromise<void>()
+    const rootChunkStarted = createControlledPromise<void>()
+    const childChunkStarted = createControlledPromise<void>()
+    const RootComponent = Object.assign(() => null, {
+      preload: () => {
+        rootChunkStarted.resolve()
+        return rootChunkGate
+      },
+    })
+    const ChildComponent = Object.assign(() => null, {
+      preload: () => {
+        childChunkStarted.resolve()
+        return childChunkGate
+      },
+    })
+    const rootRoute = new BaseRootRoute({
+      component: RootComponent as any,
+      errorComponent: () => null,
+    })
+    const childRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/child',
+      component: ChildComponent as any,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([childRoute]),
+      history: createMemoryHistory({ initialEntries: ['/child'] }),
+      isServer: true,
+    })
+    const controller = new AbortController()
+    const unhandled: Array<unknown> = []
+    const onUnhandled = (error: unknown) => {
+      unhandled.push(error)
+    }
+    process.on('unhandledRejection', onUnhandled)
+
+    try {
+      const responsePromise = loadServerResponse(
+        router,
+        '/child',
+        controller.signal,
+      )
+      await Promise.all([rootChunkStarted, childChunkStarted])
+
+      rootChunkGate.reject(rootError)
+      await expect(responsePromise).resolves.toMatchObject({ status: 500 })
+
+      controller.abort(abortError)
+      childChunkGate.resolve()
+      await new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+      expect(unhandled).not.toContain(abortError)
+    } finally {
+      process.off('unhandledRejection', onUnhandled)
+    }
+  })
+
   test('a required ancestor lazy chunk failure wins over a deeper loader notFound', async () => {
     const chunkError = new Error('ancestor lazy chunk failed')
     const rootRoute = new BaseRootRoute({})

--- a/packages/router-devtools-core/package.json
+++ b/packages/router-devtools-core/package.json
@@ -25,7 +25,8 @@
   ],
   "scripts": {
     "clean": "rimraf ./dist && rimraf ./coverage",
-    "test:eslint": "eslint ./src",
+    "test:eslint": "eslint ./src ./tests",
+    "test:unit": "vitest",
     "test:types": "pnpm run \"/^test:types:ts[0-9]{2}$/\"",
     "test:types:ts55": "node ../../node_modules/typescript55/lib/tsc.js",
     "test:types:ts56": "node ../../node_modules/typescript56/lib/tsc.js",
@@ -66,6 +67,7 @@
     "goober": "^2.1.16"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
     "solid-js": "^1.9.10",
     "vite": "*",
     "vite-plugin-solid": "^2.11.10"

--- a/packages/router-devtools-core/src/BaseTanStackRouterDevtoolsPanel.tsx
+++ b/packages/router-devtools-core/src/BaseTanStackRouterDevtoolsPanel.tsx
@@ -289,17 +289,27 @@ export const BaseTanStackRouterDevtoolsPanel =
         : []
     }
     let cache = router()._cache
-    let cacheSize = cache.size
-    const [cachedMatches, setCachedMatches] = createSignal([...cache.values()])
+    let cacheMatches = [...cache.values()]
+    const [cachedMatches, setCachedMatches] = createSignal(cacheMatches)
 
     createEffect(() => {
       const refreshCache = () => {
         const next = router()._cache
-        // Core replaces the map for writes and only deletes entries in place.
-        if (next !== cache || next.size !== cacheSize) {
+        let valuesChanged = next.size !== cacheMatches.length
+        if (!valuesChanged) {
+          let index = 0
+          for (const match of next.values()) {
+            if (match !== cacheMatches[index++]) {
+              valuesChanged = true
+              break
+            }
+          }
+        }
+
+        if (next !== cache || valuesChanged) {
           cache = next
-          cacheSize = next.size
-          setCachedMatches([...next.values()])
+          cacheMatches = [...next.values()]
+          setCachedMatches(cacheMatches)
         }
       }
       refreshCache()

--- a/packages/router-devtools-core/tests/cache-replacement.test.ts
+++ b/packages/router-devtools-core/tests/cache-replacement.test.ts
@@ -30,6 +30,8 @@ describe('cached matches', () => {
   })
 
   it('refreshes when an existing cache entry is replaced', async () => {
+    // Keep this cache-polling test independent of Vite's lazy transform time.
+    await import('../src/BaseTanStackRouterDevtoolsPanel')
     vi.useFakeTimers()
 
     const route = {

--- a/packages/router-devtools-core/tests/cache-replacement.test.ts
+++ b/packages/router-devtools-core/tests/cache-replacement.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { TanStackRouterDevtoolsPanelCore } from '../src/TanStackRouterDevtoolsPanelCore'
+import type { AnyRouteMatch, AnyRouter } from '@tanstack/router-core'
+
+function createCachedMatch(loaderData: string): AnyRouteMatch {
+  return {
+    id: 'cached-match',
+    routeId: '/cached',
+    pathname: '/cached',
+    params: {},
+    search: {},
+    status: 'success',
+    isFetching: false,
+    updatedAt: Date.now(),
+    loaderData,
+  } as AnyRouteMatch
+}
+
+describe('cached matches', () => {
+  let panel: TanStackRouterDevtoolsPanelCore | undefined
+
+  afterEach(() => {
+    panel?.unmount()
+    panel = undefined
+    document.body.innerHTML = ''
+    try {
+      window.localStorage.clear()
+    } catch {}
+    vi.useRealTimers()
+  })
+
+  it('refreshes when an existing cache entry is replaced', async () => {
+    vi.useFakeTimers()
+
+    const route = {
+      id: '/cached',
+      path: 'cached',
+      fullPath: '/cached',
+      rank: 0,
+      children: [],
+      options: { loader: () => undefined },
+    }
+    const routeTree = {
+      id: '__root__',
+      path: '/',
+      fullPath: '/',
+      rank: 0,
+      children: [route],
+      options: {},
+    }
+    const cache = new Map([['cached-match', createCachedMatch('old data')]])
+    const router = {
+      _cache: cache,
+      routeTree,
+      routesById: {
+        __root__: routeTree,
+        '/cached': route,
+      },
+      options: {},
+      navigate: vi.fn(),
+    } as unknown as AnyRouter
+    const routerState = {
+      location: {
+        href: '/',
+        pathname: '/',
+        search: {},
+        searchStr: '',
+        hash: '',
+      },
+      matches: [],
+    }
+    const container = document.createElement('div')
+    document.body.append(container)
+
+    panel = new TanStackRouterDevtoolsPanelCore({ router, routerState })
+    panel.mount(container)
+
+    await vi.waitFor(() => {
+      expect(
+        container.querySelector(
+          '[aria-label="Open match details for cached-match"]',
+        ),
+      ).not.toBeNull()
+    })
+
+    const cachedMatch = container.querySelector(
+      '[aria-label="Open match details for cached-match"]',
+    ) as HTMLElement
+    cachedMatch.click()
+    expect(container.textContent).toContain('old data')
+
+    cache.set('cached-match', createCachedMatch('new data'))
+    await vi.advanceTimersByTimeAsync(500)
+
+    expect(container.textContent).toContain('new data')
+    expect(container.textContent).not.toContain('old data')
+  })
+})

--- a/packages/router-devtools-core/tsconfig.json
+++ b/packages/router-devtools-core/tsconfig.json
@@ -4,5 +4,5 @@
     "jsx": "preserve",
     "jsxImportSource": "solid-js"
   },
-  "include": ["src", "vite.config.ts"]
+  "include": ["src", "tests", "vite.config.ts"]
 }

--- a/packages/router-devtools-core/vite.config.ts
+++ b/packages/router-devtools-core/vite.config.ts
@@ -1,9 +1,23 @@
 import { defineConfig, mergeConfig } from 'vitest/config'
 import { tanstackViteConfig } from '@tanstack/vite-config'
 import solid from 'vite-plugin-solid'
+import packageJson from './package.json'
 
 const config = defineConfig({
   plugins: [solid()],
+  test: {
+    name: packageJson.name,
+    dir: './tests',
+    watch: false,
+    environment: 'jsdom',
+    typecheck: { enabled: true },
+    setupFiles: [],
+    server: {
+      deps: {
+        inline: [/solid-js/],
+      },
+    },
+  },
 })
 
 const merged = mergeConfig(

--- a/packages/solid-router/src/Scripts.tsx
+++ b/packages/solid-router/src/Scripts.tsx
@@ -1,5 +1,5 @@
 import * as Solid from 'solid-js'
-import { _getRenderedMatches, replaceEqualDeep } from '@tanstack/router-core'
+import { _getAssetMatches, replaceEqualDeep } from '@tanstack/router-core'
 import { isServer } from '@tanstack/router-core/isServer'
 import { Asset } from './Asset'
 import { useRouter } from './useRouter'
@@ -11,7 +11,7 @@ export const Scripts = () => {
 
   const scripts = Solid.createMemo(
     (previous: Array<RouterManagedTag> | undefined) => {
-      const matches = _getRenderedMatches(router.stores.matches.get())
+      const matches = _getAssetMatches(router.stores.matches.get())
       const next: Array<RouterManagedTag> = []
       const assets: Array<RouterManagedTag> = []
       const manifest = router.ssr?.manifest

--- a/packages/solid-router/src/Transitioner.tsx
+++ b/packages/solid-router/src/Transitioner.tsx
@@ -47,7 +47,11 @@ export function Transitioner() {
       trimPathRight(router.latestLocation.publicHref) !==
       trimPathRight(nextLocation.publicHref)
     ) {
-      router.commitLocation({ ...nextLocation, replace: true })
+      router.commitLocation({
+        ...nextLocation,
+        replace: true,
+        ignoreBlocker: true,
+      })
       return
     }
 

--- a/packages/solid-router/src/headContentUtils.tsx
+++ b/packages/solid-router/src/headContentUtils.tsx
@@ -1,6 +1,6 @@
 import * as Solid from 'solid-js'
 import {
-  _getRenderedMatches,
+  _getAssetMatches,
   appendUniqueUserTags,
   escapeHtml,
   getAssetCrossOrigin,
@@ -21,7 +21,7 @@ export const useTags = (assetCrossOrigin?: AssetCrossOriginConfig) => {
   const router = useRouter()
   const nonce = router.options.ssr?.nonce
   return Solid.createMemo((prev: Array<RouterManagedTag> | undefined) => {
-    const matches = _getRenderedMatches(router.stores.matches.get())
+    const matches = _getAssetMatches(router.stores.matches.get())
     const resultMeta: Array<RouterManagedTag> = []
     const metaByAttribute: Record<string, true> = {}
     let title: RouterManagedTag | undefined

--- a/packages/solid-router/tests/Scripts.test.tsx
+++ b/packages/solid-router/tests/Scripts.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 import {
   cleanup,
   fireEvent,
@@ -6,11 +6,14 @@ import {
   screen,
   waitFor,
 } from '@solidjs/testing-library'
+import { hydrate } from '@tanstack/router-core/ssr/client'
+import { dehydrateSsrMatchId } from '../../router-core/src/ssr/ssr-match-id'
 
 import {
   HeadContent,
   Link,
   Outlet,
+  RouterContextProvider,
   RouterProvider,
   createBrowserHistory,
   createMemoryHistory,
@@ -47,6 +50,7 @@ afterEach(() => {
   cleanup()
   browserHistories.splice(0).forEach((history) => history.destroy())
   window.history.replaceState(null, 'root', '/')
+  delete window.$_TSR
 })
 
 describe('ssr scripts', () => {
@@ -507,6 +511,104 @@ describe('ssr scripts', () => {
 })
 
 describe('ssr HeadContent', () => {
+  test('renders descendant assets during a data-only hydration handoff', async () => {
+    const rootRoute = createRootRoute({})
+    const dataOnlyRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/report',
+      ssr: 'data-only',
+      loader: () => 'report',
+    })
+    const childRoute = createRoute({
+      getParentRoute: () => dataOnlyRoute,
+      path: '/details',
+      loader: () => 'details',
+      head: () => ({
+        meta: [{ name: 'solid-data-only-child', content: 'visible' }],
+      }),
+      scripts: () => [
+        {
+          id: 'solid-data-only-body-script',
+          type: 'application/json',
+          children: '{"source":"body"}',
+        },
+      ],
+    })
+    const router = createRouter({
+      history: createMemoryHistory({
+        initialEntries: ['/report/details'],
+      }),
+      routeTree: rootRoute.addChildren([
+        dataOnlyRoute.addChildren([childRoute]),
+      ]),
+    })
+    const matches = router.matchRoutes(router.latestLocation)
+    window.$_TSR = {
+      router: {
+        dehydratedData: {},
+        manifest: {
+          routes: {
+            [childRoute.id]: {
+              preloads: ['/solid-data-only-manifest.js'],
+              scripts: [
+                {
+                  attrs: {
+                    id: 'solid-data-only-manifest-script',
+                    type: 'application/json',
+                  },
+                  children: '{"source":"manifest"}',
+                },
+              ],
+            },
+          },
+        },
+        matches: matches.map((match, index) => ({
+          i: dehydrateSsrMatchId(match.id),
+          s: 'success',
+          ssr: index === 1 ? 'data-only' : true,
+          l: index ? (index === 1 ? 'report' : 'details') : undefined,
+          u: Date.now(),
+        })),
+      },
+      h: vi.fn(),
+      e: vi.fn(),
+      c: vi.fn(),
+      p: vi.fn(),
+      buffer: [],
+    }
+
+    await hydrate(router)
+
+    expect(router.state.matches.map((match) => match.status)).toEqual([
+      'success',
+      'pending',
+      'success',
+    ])
+    render(() => (
+      <RouterContextProvider router={router}>
+        {() => (
+          <>
+            <HeadContent />
+            <Scripts />
+          </>
+        )}
+      </RouterContextProvider>
+    ))
+
+    expect(
+      document.querySelector('meta[name="solid-data-only-child"]'),
+    ).not.toBeNull()
+    expect(
+      document.querySelector('link[href="/solid-data-only-manifest.js"]'),
+    ).not.toBeNull()
+    expect(
+      document.querySelector('#solid-data-only-body-script'),
+    ).not.toBeNull()
+    expect(
+      document.querySelector('#solid-data-only-manifest-script'),
+    ).not.toBeNull()
+  })
+
   test('derives title, dedupes meta, and allows non-loader HeadContent', async () => {
     const rootRoute = createRootRoute({
       loader: () =>

--- a/packages/vue-router/src/Scripts.tsx
+++ b/packages/vue-router/src/Scripts.tsx
@@ -1,5 +1,5 @@
 import * as Vue from 'vue'
-import { _getRenderedMatches } from '@tanstack/router-core'
+import { _getAssetMatches } from '@tanstack/router-core'
 import { useStore } from '@tanstack/vue-store'
 import { isServer } from '@tanstack/router-core/isServer'
 import { Asset } from './Asset'
@@ -18,7 +18,7 @@ export const Scripts = Vue.defineComponent({
   setup() {
     const router = useRouter()
     const nonce = router.options.ssr?.nonce
-    const matches = useStore(router.stores.matches, _getRenderedMatches)
+    const matches = useStore(router.stores.matches, _getAssetMatches)
 
     const scripts = Vue.computed(() => {
       const userScripts: Array<RouterManagedTag> = []

--- a/packages/vue-router/src/Transitioner.tsx
+++ b/packages/vue-router/src/Transitioner.tsx
@@ -32,7 +32,11 @@ export function useTransitionerSetup() {
       trimPathRight(router.latestLocation.publicHref) !==
       trimPathRight(nextLocation.publicHref)
     ) {
-      router.commitLocation({ ...nextLocation, replace: true })
+      router.commitLocation({
+        ...nextLocation,
+        replace: true,
+        ignoreBlocker: true,
+      })
       return
     }
 

--- a/packages/vue-router/src/headContentUtils.tsx
+++ b/packages/vue-router/src/headContentUtils.tsx
@@ -1,6 +1,6 @@
 import * as Vue from 'vue'
 import {
-  _getRenderedMatches,
+  _getAssetMatches,
   appendUniqueUserTags,
   escapeHtml,
   getAssetCrossOrigin,
@@ -16,7 +16,7 @@ import type {
 
 export const useTags = (assetCrossOrigin?: AssetCrossOriginConfig) => {
   const router = useRouter()
-  const matches = useStore(router.stores.matches, _getRenderedMatches)
+  const matches = useStore(router.stores.matches, _getAssetMatches)
 
   const tags = Vue.computed<Array<RouterManagedTag>>(() => {
     const currentMatches = matches.value

--- a/packages/vue-router/src/useMatch.tsx
+++ b/packages/vue-router/src/useMatch.tsx
@@ -130,8 +130,15 @@ export function useMatch<
     }
   }
 
+  const ownsMatch =
+    nearestRouteId !== undefined &&
+    (opts.from ?? nearestRouteId) === nearestRouteId
+  let lastOwnedMatch: any
   const result = Vue.computed<any>(() => {
-    const selectedMatch = match.value
+    if (match.value !== undefined && ownsMatch) {
+      lastOwnedMatch = match.value
+    }
+    const selectedMatch = match.value ?? lastOwnedMatch
     if (selectedMatch === undefined) {
       if (opts.shouldThrow ?? true) {
         if (process.env.NODE_ENV !== 'production') {

--- a/packages/vue-router/tests/Scripts.test.tsx
+++ b/packages/vue-router/tests/Scripts.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 import {
   cleanup,
   fireEvent,
@@ -7,11 +7,14 @@ import {
   waitFor,
 } from '@testing-library/vue'
 import { Teleport } from 'vue'
+import { hydrate } from '@tanstack/router-core/ssr/client'
+import { dehydrateSsrMatchId } from '../../router-core/src/ssr/ssr-match-id'
 
 import {
   HeadContent,
   Link,
   Outlet,
+  RouterContextProvider,
   RouterProvider,
   createBrowserHistory,
   createMemoryHistory,
@@ -48,6 +51,7 @@ afterEach(() => {
   cleanup()
   browserHistories.splice(0).forEach((history) => history.destroy())
   window.history.replaceState(null, 'root', '/')
+  delete window.$_TSR
 })
 
 describe('ssr scripts', () => {
@@ -148,6 +152,98 @@ describe('ssr scripts', () => {
 })
 
 describe('ssr HeadContent', () => {
+  test('renders descendant assets during a data-only hydration handoff', async () => {
+    const rootRoute = createRootRoute({})
+    const dataOnlyRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/report',
+      ssr: 'data-only',
+      loader: () => 'report',
+    })
+    const childRoute = createRoute({
+      getParentRoute: () => dataOnlyRoute,
+      path: '/details',
+      loader: () => 'details',
+      head: () => ({
+        meta: [{ name: 'vue-data-only-child', content: 'visible' }],
+      }),
+      scripts: () => [
+        {
+          id: 'vue-data-only-body-script',
+          type: 'application/json',
+          children: '{"source":"body"}',
+        },
+      ],
+    })
+    const router = createRouter({
+      history: createMemoryHistory({
+        initialEntries: ['/report/details'],
+      }),
+      routeTree: rootRoute.addChildren([
+        dataOnlyRoute.addChildren([childRoute]),
+      ]),
+    })
+    const matches = router.matchRoutes(router.latestLocation)
+    window.$_TSR = {
+      router: {
+        dehydratedData: {},
+        manifest: {
+          routes: {
+            [childRoute.id]: {
+              preloads: ['/vue-data-only-manifest.js'],
+              scripts: [
+                {
+                  attrs: {
+                    id: 'vue-data-only-manifest-script',
+                    type: 'application/json',
+                  },
+                  children: '{"source":"manifest"}',
+                },
+              ],
+            },
+          },
+        },
+        matches: matches.map((match, index) => ({
+          i: dehydrateSsrMatchId(match.id),
+          s: 'success',
+          ssr: index === 1 ? 'data-only' : true,
+          l: index ? (index === 1 ? 'report' : 'details') : undefined,
+          u: Date.now(),
+        })),
+      },
+      h: vi.fn(),
+      e: vi.fn(),
+      c: vi.fn(),
+      p: vi.fn(),
+      buffer: [],
+    }
+
+    await hydrate(router)
+
+    expect(router.state.matches.map((match) => match.status)).toEqual([
+      'success',
+      'pending',
+      'success',
+    ])
+    render(
+      <RouterContextProvider router={router}>
+        <HeadContent />
+        <Scripts />
+      </RouterContextProvider>,
+    )
+
+    expect(
+      document.querySelector('meta[name="vue-data-only-child"]'),
+    ).not.toBeNull()
+    expect(
+      document.querySelector('link[href="/vue-data-only-manifest.js"]'),
+    ).not.toBeNull()
+    expect(document.querySelector('#vue-data-only-body-script')).not.toBeNull()
+    expect(
+      document.querySelector('#vue-data-only-manifest-script'),
+    ).not.toBeNull()
+  })
+
   test('applies assetCrossOrigin to manifest stylesheets and preloads', async () => {
     const history = createTestBrowserHistory()
 

--- a/packages/vue-router/tests/useMatch.test.tsx
+++ b/packages/vue-router/tests/useMatch.test.tsx
@@ -235,6 +235,44 @@ describe('useMatch', () => {
     }
   })
 
+  test('an outgoing component never observes its own match disappear', async () => {
+    const observedRouteIds: Array<string | undefined> = []
+    const rootRoute = createRootRoute({ component: () => <Outlet /> })
+    const firstRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/first',
+      component: Vue.defineComponent({
+        setup() {
+          const match = useMatch({
+            from: '/first',
+            shouldThrow: false,
+          })
+          Vue.watchEffect(() => observedRouteIds.push(match.value?.routeId), {
+            flush: 'sync',
+          })
+          return () => <div>First route</div>
+        },
+      }),
+    })
+    const nextRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/next',
+      component: () => <div>Next route</div>,
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([firstRoute, nextRoute]),
+      history: createMemoryHistory({ initialEntries: ['/first'] }),
+    })
+
+    render(<RouterProvider router={router} />)
+    expect(await screen.findByText('First route')).toBeInTheDocument()
+
+    await router.navigate({ to: '/next' })
+
+    expect(await screen.findByText('Next route')).toBeInTheDocument()
+    expect(observedRouteIds).not.toContain(undefined)
+  })
+
   describe('when match is not found', () => {
     test.each([undefined, true])(
       'throws if shouldThrow = %s',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13006,6 +13006,9 @@ importers:
         specifier: ^2.1.16
         version: 2.1.16(csstype@3.2.3)
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.6.3
       solid-js:
         specifier: 1.9.12
         version: 1.9.12


### PR DESCRIPTION
## Summary
- **Abandoned server chunks:** Server route loading can finish after an earlier route chunk fails while later chunk promises are still running. If the request aborts before those chunks settle, they can reject without an owner and trigger unhandled-rejection noise or process failures.
- **Successful `undefined` loader hydration:** Serialization omits an actual value for a loader that successfully returns `undefined`. Hydration could mistake that for a loader that never ran, losing its successful cache state and selecting or rerunning later failures incorrectly.
- **Selective-SSR head and script parity:** During hydration, a `data-only` or `ssr:false` boundary could make the client temporarily omit head tags, stylesheets, preloads, or scripts that the server rendered for verified descendant routes. This caused server/client head mismatches and transient tag removal or FOUC until the client load completed.
- **Transactional development HMR:** HMR could reuse stale route matches and release currently rendered resources before the replacement render was acknowledged. A failed or superseded refresh could blank or rewind the app, abort live loader signals, strand navigation promises, or fire `onEnter` instead of `onStay`.
- **Initial URL canonicalization:** The first URL-normalization replacement went through navigation blockers. A blocker could reject that replacement before the initial load, leaving the current URL idle and unrendered.
- **Vue outgoing matches:** During route teardown, an outgoing Vue component could briefly observe its own `useMatch` value become `undefined` before Vue unmounted it. This exposed impossible transient state to component effects and could trigger invariant failures or undefined property reads.
- **Devtools same-key cache replacement:** The devtools watched only cache `Map` identity and size. Replacing an existing key with a new match object changed neither, so the panel could permanently display stale loader data, status, and timestamps.
- **Scope:** This intentionally excludes Solid/Vue #4476 owner-retention machinery because the original Query `CancelledError` was not reproduced in those adapters. Avoiding that unproven parity contract also avoids shipping a large branch-retention runtime.

## Test plan
- full router-core, React Router, Solid Router, Vue Router, and router-devtools-core unit suites
- type and ESLint targets for router-core, React Router, Solid Router, Vue Router, router-devtools-core, and router-plugin
- router-plugin hot-update regression suite
- full 17-scenario bundle-size benchmark against the exact base

## Bundle size
- router minimal gzip: React `+27 B`, Solid `+25 B`, Vue `+67 B`
- router full gzip: React `+141 B`, Solid `+135 B`, Vue `+142 B`
- Start gzip: React `+265-351 B`, Solid `+273-292 B`, Vue `+290-339 B`
- production bundles contain no development HMR implementation