### PR TITLE
test: add regression coverage for existing router behavior

### DIFF
--- a/e2e/react-start/basic/src/routes/specialChars/search.tsx
+++ b/e2e/react-start/basic/src/routes/specialChars/search.tsx
@@ -7,6 +7,9 @@ export const Route = createFileRoute('/specialChars/search')({
   validateSearch: z.object({
     searchParam: z.string(),
   }),
+  beforeLoad: () => ({
+    beforeLoadOn: isBrowser ? 'client' : 'server',
+  }),
   loader: async () => {
     console.log(`[loader] Running on ${isBrowser ? 'client' : 'server'}`)
     return {
@@ -18,11 +21,15 @@ export const Route = createFileRoute('/specialChars/search')({
 
 function RouteComponent() {
   const search = Route.useSearch()
+  const { beforeLoadOn } = Route.useRouteContext()
   const { loadedOn } = Route.useLoaderData()
 
   return (
     <div>
       Hello "/specialChars/search"!
+      <div data-testid="special-search-before-load-info">
+        Before load on: {beforeLoadOn}
+      </div>
       <div data-testid="special-search-loaded-info">Loaded on: {loadedOn}</div>
       <span data-testid={'special-search-param'}>{search.searchParam}</span>
     </div>

--- a/e2e/react-start/basic/tests/special-characters.spec.ts
+++ b/e2e/react-start/basic/tests/special-characters.spec.ts
@@ -104,11 +104,16 @@ test.describe('Unicode route rendering', () => {
       const loadedOn = await page
         .getByTestId('special-search-loaded-info')
         .textContent()
+      const beforeLoadOn = await page
+        .getByTestId('special-search-before-load-info')
+        .textContent()
 
       if (isSpaMode) {
         expect(loadedOn).toBe('Loaded on: client')
+        expect(beforeLoadOn).toBe('Before load on: client')
       } else {
         expect(loadedOn).toBe('Loaded on: server')
+        expect(beforeLoadOn).toBe('Before load on: server')
       }
     })
 

--- a/e2e/react-start/selective-ssr/src/routeTree.gen.ts
+++ b/e2e/react-start/selective-ssr/src/routeTree.gen.ts
@@ -10,12 +10,18 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as Issue4614RouteImport } from './routes/issue-4614'
 import { Route as PostsRouteImport } from './routes/posts'
 import { Route as PostsPostIdRouteImport } from './routes/posts.$postId'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const Issue4614Route = Issue4614RouteImport.update({
+  id: '/issue-4614',
+  path: '/issue-4614',
   getParentRoute: () => rootRouteImport,
 } as any)
 const PostsRoute = PostsRouteImport.update({
@@ -31,30 +37,34 @@ const PostsPostIdRoute = PostsPostIdRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/issue-4614': typeof Issue4614Route
   '/posts': typeof PostsRouteWithChildren
   '/posts/$postId': typeof PostsPostIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/issue-4614': typeof Issue4614Route
   '/posts': typeof PostsRouteWithChildren
   '/posts/$postId': typeof PostsPostIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/issue-4614': typeof Issue4614Route
   '/posts': typeof PostsRouteWithChildren
   '/posts/$postId': typeof PostsPostIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/posts' | '/posts/$postId'
+  fullPaths: '/' | '/issue-4614' | '/posts' | '/posts/$postId'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/posts' | '/posts/$postId'
-  id: '__root__' | '/' | '/posts' | '/posts/$postId'
+  to: '/' | '/issue-4614' | '/posts' | '/posts/$postId'
+  id: '__root__' | '/' | '/issue-4614' | '/posts' | '/posts/$postId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  Issue4614Route: typeof Issue4614Route
   PostsRoute: typeof PostsRouteWithChildren
 }
 
@@ -65,6 +75,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/issue-4614': {
+      id: '/issue-4614'
+      path: '/issue-4614'
+      fullPath: '/issue-4614'
+      preLoaderRoute: typeof Issue4614RouteImport
       parentRoute: typeof rootRouteImport
     }
     '/posts': {
@@ -96,6 +113,7 @@ const PostsRouteWithChildren = PostsRoute._addFileChildren(PostsRouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  Issue4614Route: Issue4614Route,
   PostsRoute: PostsRouteWithChildren,
 }
 export const routeTree = rootRouteImport

--- a/e2e/react-start/selective-ssr/src/router.tsx
+++ b/e2e/react-start/selective-ssr/src/router.tsx
@@ -5,6 +5,9 @@ export function getRouter() {
   const router = createRouter({
     routeTree,
     scrollRestoration: true,
+    defaultPreload: 'intent',
+    defaultPreloadDelay: 0,
+    defaultPreloadStaleTime: 0,
   })
 
   return router

--- a/e2e/react-start/selective-ssr/src/routes/__root.tsx
+++ b/e2e/react-start/selective-ssr/src/routes/__root.tsx
@@ -30,7 +30,11 @@ export const Route = createRootRoute({
     ],
     links: [{ rel: 'stylesheet', href: appCss }],
   }),
-  validateSearch: z.object({ root: ssrSchema }),
+  validateSearch: z.object({
+    root: ssrSchema,
+    issue4614: z.string().optional(),
+  }),
+  loaderDeps: ({ search }) => ({ issue4614: search.issue4614 }),
   ssr: ({ search }) => {
     if (typeof window !== 'undefined') {
       const error = `ssr() for ${Route.id} should not be called on the client`
@@ -41,7 +45,7 @@ export const Route = createRootRoute({
       return search.value.root?.ssr
     }
   },
-  beforeLoad: ({ search }) => {
+  beforeLoad: ({ search, location, cause, preload }) => {
     console.log(
       `beforeLoad for ${Route.id} called on the ${typeof window !== 'undefined' ? 'client' : 'server'}`,
     )
@@ -53,9 +57,21 @@ export const Route = createRootRoute({
       console.error(error)
       throw new Error(error)
     }
+    const root = typeof window === 'undefined' ? 'server' : 'client'
+    const issue4614Context = `${root}:${search.issue4614 ?? 'cached'}`
+    if (typeof window !== 'undefined' && location.pathname === '/issue-4614') {
+      const calls = ((globalThis as any).__issue4614RootBeforeLoads ??= [])
+      calls.push({
+        cause,
+        preload,
+        root,
+        issue4614Context,
+      })
+    }
     return {
-      root: typeof window === 'undefined' ? 'server' : 'client',
+      root,
       search,
+      issue4614Context,
     }
   },
   loader: ({ context }) => {
@@ -132,6 +148,14 @@ function RootDocument({ children }: { children: React.ReactNode }) {
             }}
           >
             Home
+          </Link>
+          <Link
+            to="/issue-4614"
+            search={{ issue4614: 'reload' }}
+            preload="intent"
+            data-testid="issue-4614-reload-link"
+          >
+            Issue 4614 reloaded parent
           </Link>
         </div>
         <hr />

--- a/e2e/react-start/selective-ssr/src/routes/issue-4614.tsx
+++ b/e2e/react-start/selective-ssr/src/routes/issue-4614.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/issue-4614')({
+  ssr: false,
+  beforeLoad: ({ context, cause, preload, search }) => {
+    ;(globalThis as any).__issue4614TargetBeforeLoad = {
+      cause,
+      preload,
+      rootContext: context.root,
+      issue4614Context: context.issue4614Context,
+      scenario: search.issue4614 ?? 'cached',
+    }
+  },
+  component: () => <div data-testid="issue-4614-page">Issue 4614</div>,
+})

--- a/e2e/react-start/selective-ssr/tests/app.spec.ts
+++ b/e2e/react-start/selective-ssr/tests/app.spec.ts
@@ -4,6 +4,37 @@ import { test } from '@tanstack/router-e2e-utils'
 const testCount = 7
 
 test.describe('selective ssr', () => {
+  test('new loaderDeps match generation propagates fresh parent context to child (control)', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    await page.getByTestId('issue-4614-reload-link').hover()
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => (globalThis as any).__issue4614RootBeforeLoads),
+      )
+      .toEqual([
+        {
+          cause: 'preload',
+          preload: true,
+          root: 'client',
+          issue4614Context: 'client:reload',
+        },
+      ])
+    await expect
+      .poll(() =>
+        page.evaluate(() => (globalThis as any).__issue4614TargetBeforeLoad),
+      )
+      .toEqual({
+        cause: 'preload',
+        preload: true,
+        rootContext: 'client',
+        issue4614Context: 'client:reload',
+        scenario: 'reload',
+      })
+  })
+
   test('testcount matches', async ({ page }) => {
     await page.goto('/')
 

--- a/packages/react-router/tests/Matches.test.tsx
+++ b/packages/react-router/tests/Matches.test.tsx
@@ -1,6 +1,14 @@
 import { afterEach, describe, expect, test } from 'vitest'
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
 import { createMemoryHistory } from '@tanstack/history'
+import { createControlledPromise } from '@tanstack/router-core'
 import {
   Link,
   Outlet,
@@ -126,11 +134,11 @@ test('when filtering useMatches by loaderData', async () => {
 
 test('should show pendingComponent of root route', async () => {
   const root = createRootRoute({
-    pendingComponent: () => <div data-testId="root-pending" />,
+    pendingComponent: () => <div data-testid="root-pending" />,
     loader: async () => {
       await new Promise((r) => setTimeout(r, 50))
     },
-    component: () => <div data-testId="root-content" />,
+    component: () => <div data-testid="root-content" />,
   })
 
   const router = createRouter({
@@ -143,6 +151,134 @@ test('should show pendingComponent of root route', async () => {
 
   expect(await rendered.findByTestId('root-pending')).toBeInTheDocument()
   expect(await rendered.findByTestId('root-content')).toBeInTheDocument()
+})
+
+test('useMatchRoute follows superseding pending locations', async () => {
+  const aGate = createControlledPromise<void>()
+  const bGate = createControlledPromise<void>()
+
+  function Layout() {
+    const matchRoute = useMatchRoute()
+    return (
+      <div>
+        <span data-testid="pending-a">
+          {String(Boolean(matchRoute({ to: '/a', pending: true })))}
+        </span>
+        <span data-testid="pending-b">
+          {String(Boolean(matchRoute({ to: '/b', pending: true })))}
+        </span>
+        <span data-testid="resolved-b">
+          {String(Boolean(matchRoute({ to: '/b', pending: false })))}
+        </span>
+        <Outlet />
+      </div>
+    )
+  }
+
+  const root = createRootRoute({ component: Layout })
+  const index = createRoute({
+    getParentRoute: () => root,
+    path: '/',
+  })
+  const a = createRoute({
+    getParentRoute: () => root,
+    path: '/a',
+    loader: () => aGate,
+  })
+  const b = createRoute({
+    getParentRoute: () => root,
+    path: '/b',
+    loader: () => bGate,
+  })
+  const router = createRouter({
+    routeTree: root.addChildren([index, a, b]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+  render(<RouterProvider router={router} />)
+
+  await waitFor(() => {
+    expect(screen.getByTestId('pending-a')).toHaveTextContent('false')
+    expect(router.stores.status.get()).toBe('idle')
+    expect(router.stores.resolvedLocation.get()?.pathname).toBe('/')
+  })
+
+  let navigationA!: Promise<void>
+  act(() => {
+    navigationA = router.navigate({ to: '/a' })
+  })
+  await waitFor(() => {
+    expect(screen.getByTestId('pending-a')).toHaveTextContent('true')
+    expect(screen.getByTestId('resolved-b')).toHaveTextContent('false')
+  })
+
+  let navigationB!: Promise<void>
+  act(() => {
+    navigationB = router.navigate({ to: '/b' })
+  })
+  await waitFor(() => {
+    expect(screen.getByTestId('pending-a')).toHaveTextContent('false')
+    expect(screen.getByTestId('pending-b')).toHaveTextContent('true')
+    expect(screen.getByTestId('resolved-b')).toHaveTextContent('false')
+  })
+
+  await act(async () => {
+    aGate.resolve()
+    bGate.resolve()
+    await Promise.allSettled([navigationA, navigationB])
+  })
+  await waitFor(() => {
+    expect(screen.getByTestId('pending-b')).toHaveTextContent('false')
+    expect(screen.getByTestId('resolved-b')).toHaveTextContent('true')
+  })
+})
+
+test('legacy notFoundRoute drops a stale parent layout after navigation', async () => {
+  let legacyLoads = 0
+  const root = createRootRoute({ component: Outlet })
+  const parent = createRoute({
+    getParentRoute: () => root,
+    path: '/parent',
+    component: () => (
+      <div>
+        Parent layout
+        <Outlet />
+      </div>
+    ),
+  })
+  const known = createRoute({
+    getParentRoute: () => parent,
+    path: '/known',
+  })
+  const legacyNotFound = createRoute({
+    getParentRoute: () => root,
+    path: '/404',
+    loader: () => {
+      legacyLoads++
+      return 'not found'
+    },
+    component: () => <div>Legacy not found</div>,
+    staleTime: Infinity,
+    gcTime: Infinity,
+  })
+  const router = createRouter({
+    routeTree: root.addChildren([parent.addChildren([known])]),
+    history: createMemoryHistory({ initialEntries: ['/parent/missing'] }),
+    notFoundRoute: legacyNotFound,
+  })
+
+  const rendered = render(<RouterProvider router={router} />)
+  expect(await rendered.findByText('Parent layout')).toBeInTheDocument()
+  expect(await rendered.findByText('Legacy not found')).toBeInTheDocument()
+  expect(legacyLoads).toBe(1)
+
+  await act(async () => {
+    await router.navigate({ to: '/missing' } as any)
+  })
+
+  expect(rendered.queryByText('Parent layout')).not.toBeInTheDocument()
+  expect(await rendered.findByText('Legacy not found')).toBeInTheDocument()
+  expect(legacyLoads).toBe(1)
+  rendered.unmount()
 })
 
 describe('matching on different param types', () => {

--- a/packages/react-router/tests/Scripts.test.tsx
+++ b/packages/react-router/tests/Scripts.test.tsx
@@ -158,15 +158,12 @@ describe('ssr scripts', () => {
       { src: 'script3.js' },
     ])
 
-    const { container } = await act(() =>
-      render(<RouterProvider router={router} />),
+    const html = ReactDOMServer.renderToString(
+      <RouterProvider router={router} />,
     )
-    expect(await screen.findByTestId('root')).toBeInTheDocument()
-    expect(await screen.findByTestId('index')).toBeInTheDocument()
-
-    expect(container.innerHTML).toEqual(
-      `<div><div data-testid="root">root</div><div data-testid="index">index</div><script src="script.js"></script><script src="script3.js"></script></div>`,
-    )
+    expect(html).toContain('<script src="script.js"></script>')
+    expect(html).toContain('<script src="script3.js"></script>')
+    expect(html).not.toContain('script2.js')
   })
 })
 

--- a/packages/react-router/tests/component-preload-retry-pending-min.test.tsx
+++ b/packages/react-router/tests/component-preload-retry-pending-min.test.tsx
@@ -1,0 +1,40 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, expect, test } from 'vitest'
+import { createControlledPromise } from '@tanstack/router-core'
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+
+afterEach(() => {
+  cleanup()
+})
+
+test('delayed component preload reveals pending UI', async () => {
+  const componentGate = createControlledPromise<void>()
+  const Page = Object.assign(() => <div>Page content</div>, {
+    preload: () => componentGate,
+  })
+  const rootRoute = createRootRoute({})
+  const pageRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/page',
+    component: Page,
+    pendingMs: 10,
+    pendingComponent: () => <div>Loading page...</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([pageRoute]),
+    history: createMemoryHistory({ initialEntries: ['/page'] }),
+  })
+
+  render(<RouterProvider router={router} />)
+
+  expect(await screen.findByText('Loading page...')).toBeInTheDocument()
+  componentGate.resolve()
+  expect(await screen.findByText('Page content')).toBeInTheDocument()
+  expect(screen.queryByText('Loading page...')).not.toBeInTheDocument()
+})

--- a/packages/react-router/tests/errorComponent.test.tsx
+++ b/packages/react-router/tests/errorComponent.test.tsx
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
-import ReactDOMServer from 'react-dom/server'
 
 import {
   HeadContent,
@@ -8,6 +7,7 @@ import {
   Outlet,
   RouterProvider,
   createBrowserHistory,
+  createControlledPromise,
   createLazyRoute,
   createMemoryHistory,
   createRootRoute,
@@ -273,6 +273,109 @@ describe.each([true, false])(
   },
 )
 
+test('global catch boundary resets when a background child generation recovers', async () => {
+  const refresh = createControlledPromise<number>()
+  let loaderCalls = 0
+  const rootRoute = createRootRoute({ component: Outlet })
+  const childRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    loader: {
+      staleReloadMode: 'background',
+      handler: () => (++loaderCalls === 1 ? 1 : refresh),
+    },
+    component: () => {
+      const revision = childRoute.useLoaderData()
+      if (revision === 1) {
+        throw new Error('stale child render failed')
+      }
+      return <div>Recovered child revision {revision}</div>
+    },
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([childRoute]),
+    history,
+  })
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+
+  render(<RouterProvider router={router} />)
+  expect(
+    await screen.findByText('stale child render failed'),
+  ).toBeInTheDocument()
+
+  const invalidation = router.invalidate()
+  await vi.waitFor(() => expect(loaderCalls).toBe(2))
+  expect(screen.getByText('stale child render failed')).toBeInTheDocument()
+  expect(screen.queryByText(/Recovered child revision/)).not.toBeInTheDocument()
+  refresh.resolve(2)
+  await invalidation
+
+  expect(
+    await screen.findByText('Recovered child revision 2'),
+  ).toBeInTheDocument()
+  expect(
+    screen.queryByText('stale child render failed'),
+  ).not.toBeInTheDocument()
+})
+
+test('ancestor route errorComponent resets when a background child generation recovers', async () => {
+  const refresh = createControlledPromise<number>()
+  let loaderCalls = 0
+  const rootRoute = createRootRoute({
+    component: Outlet,
+    errorComponent: ({ error }) => <div>Ancestor error: {error.message}</div>,
+  })
+  const childRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    loader: {
+      staleReloadMode: 'background',
+      handler: () => (++loaderCalls === 1 ? 1 : refresh),
+    },
+    component: () => {
+      const revision = childRoute.useLoaderData()
+      if (revision === 1) {
+        throw new Error('stale child render failed')
+      }
+      return <div>Recovered child revision {revision}</div>
+    },
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([childRoute]),
+    history,
+  })
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+
+  let invalidation: Promise<void> | undefined
+  try {
+    render(<RouterProvider router={router} />)
+    expect(
+      await screen.findByText('Ancestor error: stale child render failed'),
+    ).toBeInTheDocument()
+
+    invalidation = router.invalidate({
+      filter: (match) => match.routeId === childRoute.id,
+    })
+    await vi.waitFor(() => expect(loaderCalls).toBe(2))
+    expect(
+      screen.getByText('Ancestor error: stale child render failed'),
+    ).toBeInTheDocument()
+    refresh.resolve(2)
+    await invalidation
+
+    expect(
+      await screen.findByText('Recovered child revision 2'),
+    ).toBeInTheDocument()
+  } finally {
+    refresh.resolve(2)
+    if (invalidation) {
+      await Promise.allSettled([invalidation])
+    }
+  }
+})
+
 test('errorComponent receives primitive errors thrown from beforeLoad', async () => {
   const rootRoute = createRootRoute()
   const indexRoute = createRoute({
@@ -320,7 +423,6 @@ test('errorComponent receives primitive errors thrown from beforeLoad', async ()
 })
 
 test('SSR errorComponent receives primitive errors thrown from beforeLoad', async () => {
-  const history = createMemoryHistory({ initialEntries: ['/about'] })
   const rootRoute = createRootRoute({
     component: function Root() {
       return <Outlet />
@@ -336,18 +438,232 @@ test('SSR errorComponent receives primitive errors thrown from beforeLoad', asyn
     errorComponent: ({ error }) => <div>Error: {String(error)}</div>,
   })
 
-  const router = createRouter({
-    routeTree: rootRoute.addChildren([aboutRoute]),
-    history,
+  const handler = createRequestHandler({
+    request: new Request('http://localhost/about'),
+    createRouter: () =>
+      createRouter({
+        routeTree: rootRoute.addChildren([aboutRoute]),
+        isServer: true,
+      }),
   })
-  router.isServer = true
 
-  await router.load()
+  const response = await handler(({ router, responseHeaders }) =>
+    renderRouterToString({
+      router,
+      responseHeaders,
+      children: <RouterServer router={router} />,
+    }),
+  )
 
-  expect(router.state.statusCode).toBe(500)
-  const html = ReactDOMServer.renderToString(<RouterProvider router={router} />)
+  expect(response.status).toBe(500)
+  const html = await response.text()
   expect(html).toContain('Error:')
   expect(html).toContain('primitive error thrown')
+})
+
+test('a later fresh ancestor loader failure owns the reachable boundary', async () => {
+  const parentStarted = createControlledPromise<void>()
+  const childStarted = createControlledPromise<void>()
+  const parentGate = createControlledPromise<void>()
+  const childGate = createControlledPromise<void>()
+  const childSettled = createControlledPromise<void>()
+  const rootRoute = createRootRoute({ component: Outlet })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <div>Home</div>,
+  })
+  const parentRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/parent',
+    component: Outlet,
+    loader: async () => {
+      parentStarted.resolve()
+      await parentGate
+      throw new Error('later parent failure')
+    },
+    errorComponent: () => <div>Parent error boundary</div>,
+  })
+  const childRoute = createRoute({
+    getParentRoute: () => parentRoute,
+    path: '/child',
+    loader: async () => {
+      childStarted.resolve()
+      await childGate
+      childSettled.resolve()
+      throw new Error('first child failure')
+    },
+    errorComponent: () => <div>Child error boundary</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([
+      indexRoute,
+      parentRoute.addChildren([childRoute]),
+    ]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  await router.load()
+  render(<RouterProvider router={router} />)
+
+  let navigation!: Promise<void>
+  await act(async () => {
+    navigation = router.navigate({ to: '/parent/child' })
+    await Promise.all([parentStarted, childStarted])
+  })
+  await act(async () => {
+    childGate.resolve()
+    await childSettled
+    parentGate.resolve()
+    await navigation
+  })
+
+  expect(screen.getByText('Parent error boundary')).toBeInTheDocument()
+  expect(screen.queryByText('Child error boundary')).not.toBeInTheDocument()
+})
+
+test('a fresh ancestor failure waits for lazy options before rendering its error', async () => {
+  const parentStarted = createControlledPromise<void>()
+  const childStarted = createControlledPromise<void>()
+  const parentGate = createControlledPromise<void>()
+  const childGate = createControlledPromise<void>()
+  const childSettled = createControlledPromise<void>()
+  const lazyParentOptions = createLazyRoute('/parent')({
+    component: () => (
+      <>
+        <div>Lazy parent shell</div>
+        <Outlet />
+      </>
+    ),
+  })
+  const parentChunk = createControlledPromise<typeof lazyParentOptions>()
+  const rootRoute = createRootRoute({ component: Outlet })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <div>Home</div>,
+  })
+  const parentRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/parent',
+    loader: async () => {
+      parentStarted.resolve()
+      await parentGate
+      throw new Error('later parent failure')
+    },
+    errorComponent: () => <div>Parent error boundary</div>,
+  }).lazy(() => parentChunk)
+  const childRoute = createRoute({
+    getParentRoute: () => parentRoute,
+    path: '/child',
+    loader: async () => {
+      childStarted.resolve()
+      await childGate
+      childSettled.resolve()
+      throw new Error('first child failure')
+    },
+    errorComponent: () => <div>Child error boundary</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([
+      indexRoute,
+      parentRoute.addChildren([childRoute]),
+    ]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  await router.load()
+  render(<RouterProvider router={router} />)
+
+  let navigation: Promise<void> | undefined
+  try {
+    await act(async () => {
+      navigation = router.navigate({ to: '/parent/child' })
+      await Promise.all([parentStarted, childStarted])
+    })
+    await act(async () => {
+      childGate.resolve()
+      await childSettled
+      parentGate.resolve()
+      await Promise.resolve()
+    })
+
+    expect(parentChunk.status).toBe('pending')
+    expect(screen.getByText('Home')).toBeInTheDocument()
+    expect(screen.queryByText('Parent error boundary')).not.toBeInTheDocument()
+    expect(screen.queryByText('Child error boundary')).not.toBeInTheDocument()
+    expect(screen.queryByText('Lazy parent shell')).not.toBeInTheDocument()
+  } finally {
+    await act(async () => {
+      childGate.resolve()
+      parentGate.resolve()
+      parentChunk.resolve(lazyParentOptions)
+      await navigation
+    })
+  }
+
+  expect(screen.getByText('Parent error boundary')).toBeInTheDocument()
+  expect(screen.queryByText('Lazy parent shell')).not.toBeInTheDocument()
+  expect(screen.queryByText('Child error boundary')).not.toBeInTheDocument()
+})
+
+test('SSR renders a later fresh ancestor loader failure', async () => {
+  const parentStarted = createControlledPromise<void>()
+  const childStarted = createControlledPromise<void>()
+  const parentGate = createControlledPromise<void>()
+  const childGate = createControlledPromise<void>()
+  const childSettled = createControlledPromise<void>()
+  const rootRoute = createRootRoute({ component: Outlet })
+  const parentRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/parent',
+    component: Outlet,
+    loader: async () => {
+      parentStarted.resolve()
+      await parentGate
+      throw new Error('later parent failure')
+    },
+    errorComponent: () => <div>Parent error boundary</div>,
+  })
+  const childRoute = createRoute({
+    getParentRoute: () => parentRoute,
+    path: '/child',
+    loader: async () => {
+      childStarted.resolve()
+      await childGate
+      childSettled.resolve()
+      throw new Error('first child failure')
+    },
+    errorComponent: () => <div>Child error boundary</div>,
+  })
+  const handler = createRequestHandler({
+    request: new Request('http://localhost/parent/child'),
+    createRouter: () =>
+      createRouter({
+        routeTree: rootRoute.addChildren([
+          parentRoute.addChildren([childRoute]),
+        ]),
+        isServer: true,
+      }),
+  })
+
+  const responsePromise = handler(({ router, responseHeaders }) =>
+    renderRouterToString({
+      router,
+      responseHeaders,
+      children: <RouterServer router={router} />,
+    }),
+  )
+  await Promise.all([parentStarted, childStarted])
+  childGate.resolve()
+  await childSettled
+  parentGate.resolve()
+  const response = await responsePromise
+  const html = await response.text()
+
+  expect(response.status).toBe(500)
+  expect(html).toContain('Parent error boundary')
+  expect(html).not.toContain('Child error boundary')
 })
 
 // https://github.com/TanStack/router/issues/4684
@@ -496,13 +812,11 @@ describe('notFoundComponent is rendered when an error is thrown in params.parse'
 
     render(<RouterProvider router={router} />)
 
-    await act(() => router.latestLoadPromise)
-    expect(rootLoader).toHaveBeenCalledTimes(1)
-
     const linkToRottenPizza = await screen.findByRole('link', {
       name: 'link to rotten pizza',
     })
 
+    expect(rootLoader).toHaveBeenCalledTimes(1)
     expect(linkToRottenPizza).toBeInTheDocument()
     await act(() => fireEvent.mouseOver(linkToRottenPizza))
     await act(() => fireEvent.click(linkToRottenPizza))

--- a/packages/react-router/tests/hydration-terminal-lane.test.tsx
+++ b/packages/react-router/tests/hydration-terminal-lane.test.tsx
@@ -1,0 +1,98 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { hydrate } from '@tanstack/router-core/ssr/client'
+import { dehydrateSsrMatchId } from '../../router-core/src/ssr/ssr-match-id'
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+import type { AnyRouteMatch } from '@tanstack/router-core'
+import type { TsrSsrGlobal } from '@tanstack/router-core/ssr/client'
+
+function bootstrap(
+  matches: Array<{
+    match: AnyRouteMatch
+    status: AnyRouteMatch['status']
+    ssr: AnyRouteMatch['ssr']
+    data?: unknown
+    error?: unknown
+  }>,
+): void {
+  window.$_TSR = {
+    router: {
+      manifest: undefined,
+      matches: matches.map(({ match, status, ssr, data, error }) => ({
+        i: dehydrateSsrMatchId(match.id),
+        l: data,
+        e: error,
+        s: status,
+        ssr,
+        u: Date.now(),
+      })),
+    },
+    h: vi.fn(),
+    e: vi.fn(),
+    c: vi.fn(),
+    p: vi.fn(),
+    buffer: [],
+  } as TsrSsrGlobal
+}
+
+afterEach(() => {
+  cleanup()
+  delete window.$_TSR
+})
+
+describe('hydration terminal lane', () => {
+  test('keeps server data while loading only the missing client suffix', async () => {
+    const parentLoader = vi.fn(() => 'client-parent')
+    const childLoader = vi.fn(() => 'client-child')
+    const rootRoute = createRootRoute({ component: Outlet })
+    const parentRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/parent',
+      loader: parentLoader,
+      component: () => (
+        <>
+          <div>{parentRoute.useLoaderData()}</div>
+          <Outlet />
+        </>
+      ),
+    })
+    const childRoute = createRoute({
+      getParentRoute: () => parentRoute,
+      path: '/child',
+      ssr: false,
+      loader: childLoader,
+      component: () => <div>{childRoute.useLoaderData()}</div>,
+    })
+    const router = createRouter({
+      history: createMemoryHistory({ initialEntries: ['/parent/child'] }),
+      routeTree: rootRoute.addChildren([parentRoute.addChildren([childRoute])]),
+    })
+    const matches = router.matchRoutes(router.state.location)
+    bootstrap([
+      { match: matches[0]!, status: 'success', ssr: true },
+      {
+        match: matches[1]!,
+        status: 'success',
+        ssr: true,
+        data: 'server-parent',
+      },
+      { match: matches[2]!, status: 'pending', ssr: false },
+    ])
+
+    await hydrate(router)
+    render(<RouterProvider router={router} />)
+
+    expect(await screen.findByText('server-parent')).toBeInTheDocument()
+    expect(await screen.findByText('client-child')).toBeInTheDocument()
+    expect(screen.queryByText('client-parent')).not.toBeInTheDocument()
+    expect(parentLoader).not.toHaveBeenCalled()
+    expect(childLoader).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/react-router/tests/loaders.test.tsx
+++ b/packages/react-router/tests/loaders.test.tsx
@@ -647,7 +647,7 @@ test('reproducer #4546', async () => {
   }
 })
 
-test('clears pendingTimeout when match resolves', async () => {
+test('does not show pending UI when loaders finish before their pending delays', async () => {
   const defaultPendingComponentOnMountMock = vi.fn()
   const nestedPendingComponentOnMountMock = vi.fn()
   const fooPendingComponentOnMountMock = vi.fn()
@@ -716,7 +716,6 @@ test('clears pendingTimeout when match resolves', async () => {
   })
 
   render(<RouterProvider router={router} />)
-  await act(() => router.latestLoadPromise)
   const linkToFoo = await screen.findByTestId('link-to-foo')
   fireEvent.click(linkToFoo)
   const fooElement = await screen.findByText('Nested Foo page')
@@ -757,7 +756,7 @@ test('throw abortError from loader upon initial load with basepath', async () =>
   expect(window.location.pathname.startsWith('/app')).toBe(true)
 })
 
-test('cancelMatches after pending timeout', async () => {
+test('navigating away from a pending route aborts its loader', async () => {
   function getPendingComponent(onMount: () => void) {
     const PendingComponent = () => {
       useEffect(() => {
@@ -770,6 +769,7 @@ test('cancelMatches after pending timeout', async () => {
   }
   const onAbortMock = vi.fn()
   const fooPendingComponentOnMountMock = vi.fn()
+  let fooSignal: AbortSignal | undefined
   const rootRoute = createRootRoute({
     component: () => (
       <div>
@@ -787,17 +787,18 @@ test('cancelMatches after pending timeout', async () => {
   const fooRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/foo',
-    pendingMs: WAIT_TIME * 20,
+    pendingMs: 0,
     loader: async ({ abortController }) => {
+      fooSignal = abortController.signal
       await new Promise<void>((resolve) => {
-        const timer = setTimeout(() => {
-          resolve()
-        }, WAIT_TIME * 40)
-        abortController.signal.addEventListener('abort', () => {
-          onAbortMock()
-          clearTimeout(timer)
-          resolve()
-        })
+        abortController.signal.addEventListener(
+          'abort',
+          () => {
+            onAbortMock()
+            resolve()
+          },
+          { once: true },
+        )
       })
     },
     pendingComponent: getPendingComponent(fooPendingComponentOnMountMock),
@@ -811,18 +812,22 @@ test('cancelMatches after pending timeout', async () => {
   const routeTree = rootRoute.addChildren([fooRoute, barRoute])
   const router = createRouter({ routeTree, history })
   render(<RouterProvider router={router} />)
-  await act(() => router.latestLoadPromise)
   const fooLink = await screen.findByTestId('link-to-foo')
   fireEvent.click(fooLink)
-  await sleep(WAIT_TIME * 30)
   const pendingElement = await screen.findByText('Pending...')
   expect(pendingElement).toBeInTheDocument()
-  const barLink = await screen.findByTestId('link-to-bar')
-  fireEvent.click(barLink)
-  const barElement = await screen.findByText('Bar page')
+  expect(fooSignal?.aborted).toBe(false)
+  await act(() => router.navigate({ to: '/bar' }))
+  const barElement = screen.getByText('Bar page')
   expect(barElement).toBeInTheDocument()
+
   expect(fooPendingComponentOnMountMock).toHaveBeenCalled()
-  expect(onAbortMock).toHaveBeenCalled()
+  expect(onAbortMock).toHaveBeenCalledTimes(1)
+  expect(fooSignal?.aborted).toBe(true)
+  expect(screen.queryByText('Pending...')).not.toBeInTheDocument()
+  expect(screen.queryByText('Foo page')).not.toBeInTheDocument()
+  expect(router.state.location.href).toBe('/bar')
+  expect(router.state.status).toBe('idle')
 })
 
 test('reproducer for #6388 - rapid navigation between parameterized routes should not trigger errorComponent', async () => {

--- a/packages/react-router/tests/not-found.test.tsx
+++ b/packages/react-router/tests/not-found.test.tsx
@@ -1,11 +1,12 @@
 import { afterEach, beforeEach, expect, test } from 'vitest'
-import { cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, render, screen } from '@testing-library/react'
 
 import {
   Link,
   Outlet,
   RouterProvider,
   createBrowserHistory,
+  createControlledPromise,
   createRootRoute,
   createRoute,
   createRouter,
@@ -25,6 +26,44 @@ afterEach(() => {
   history.destroy()
   window.history.replaceState(null, 'root', '/')
   cleanup()
+})
+
+test('navigating to an actively preloaded missing URL renders the global not-found boundary', async () => {
+  const missingLoaderStarted = createControlledPromise<void>()
+  const missingLoader = createControlledPromise<void>()
+  const rootRoute = createRootRoute({
+    component: Outlet,
+    notFoundComponent: () => <div>Missing URL boundary</div>,
+    loader: ({ location }) => {
+      if (location.pathname === '/missing') {
+        missingLoaderStarted.resolve()
+        return missingLoader
+      }
+      return
+    },
+    shouldReload: true,
+  })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <div>Home</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute]),
+    history,
+  })
+
+  render(<RouterProvider router={router} />)
+  expect(await screen.findByText('Home')).toBeInTheDocument()
+
+  const preload = router.preloadRoute({ to: '/missing' } as any)
+  await missingLoaderStarted
+  const navigation = router.navigate({ to: '/missing' } as any)
+  missingLoader.resolve()
+  await act(() => Promise.all([preload, navigation]))
+
+  expect(screen.getByText('Missing URL boundary')).toBeInTheDocument()
+  expect(screen.queryByText('Home')).not.toBeInTheDocument()
 })
 
 test.each([

--- a/packages/react-router/tests/public-presentation-lane-contract.test.tsx
+++ b/packages/react-router/tests/public-presentation-lane-contract.test.tsx
@@ -1,0 +1,133 @@
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, test } from 'vitest'
+import { createControlledPromise } from '@tanstack/router-core'
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('public presentation lane contracts', () => {
+  test('visible pending UI publishes every matched route and its loading state', async () => {
+    const parentGate = createControlledPromise<string>()
+
+    const rootRoute = createRootRoute({ component: Outlet })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => <div>Home</div>,
+    })
+    const parentRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/parent',
+      pendingMs: 0,
+      pendingComponent: () => <div>Loading parent</div>,
+      loader: () => parentGate,
+      component: Outlet,
+    })
+    const childRoute = createRoute({
+      getParentRoute: () => parentRoute,
+      path: '/child',
+      loader: () => 'child data',
+      component: () => <div>Child content</div>,
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([
+        indexRoute,
+        parentRoute.addChildren([childRoute]),
+      ]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    render(<RouterProvider router={router} />)
+    expect(await screen.findByText('Home')).toBeInTheDocument()
+    await waitFor(() => expect(router.state.status).toBe('idle'))
+
+    let navigation!: Promise<void>
+    await act(async () => {
+      navigation = router.navigate({ to: '/parent/child' })
+      await Promise.resolve()
+    })
+
+    expect(await screen.findByText('Loading parent')).toBeInTheDocument()
+    expect(screen.queryByText('Child content')).not.toBeInTheDocument()
+
+    expect(router.state.matches.map((match) => match.routeId)).toEqual([
+      rootRoute.id,
+      parentRoute.id,
+      childRoute.id,
+    ])
+    expect(
+      router.state.matches.find((match) => match.routeId === parentRoute.id),
+    ).toMatchObject({ status: 'pending', isFetching: 'loader' })
+
+    await act(async () => {
+      parentGate.resolve('parent data')
+      await navigation
+    })
+
+    expect(screen.getByText('Child content')).toBeInTheDocument()
+    expect(router.state.status).toBe('idle')
+  })
+
+  test('a reentrant navigation from onResolved suppresses the stale onRendered event', async () => {
+    const rootRoute = createRootRoute({ component: Outlet })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => <div>Home</div>,
+    })
+    const firstRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/first',
+      component: () => <div>First</div>,
+    })
+    const secondRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/second',
+      component: () => <div>Second</div>,
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, firstRoute, secondRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    render(<RouterProvider router={router} />)
+    expect(await screen.findByText('Home')).toBeInTheDocument()
+    await waitFor(() => expect(router.state.status).toBe('idle'))
+
+    const renderedPaths: Array<string> = []
+    let successor: Promise<void> | undefined
+    const unsubscribeResolved = router.subscribe('onResolved', (event) => {
+      if (event.toLocation.pathname === '/first') {
+        successor = router.navigate({ to: '/second' })
+      }
+    })
+    const unsubscribeRendered = router.subscribe('onRendered', (event) => {
+      if (event.toLocation.pathname !== '/') {
+        renderedPaths.push(event.toLocation.pathname)
+      }
+    })
+
+    try {
+      await act(() => router.navigate({ to: '/first' }))
+      await act(async () => {
+        await successor
+      })
+
+      expect(screen.getByText('Second')).toBeInTheDocument()
+      expect(screen.queryByText('First')).not.toBeInTheDocument()
+      expect(renderedPaths).toEqual(['/second'])
+    } finally {
+      unsubscribeResolved()
+      unsubscribeRendered()
+    }
+  })
+})

--- a/packages/react-router/tests/redirect.test.tsx
+++ b/packages/react-router/tests/redirect.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import {
+  act,
   cleanup,
   configure,
   fireEvent,
@@ -8,6 +9,7 @@ import {
 } from '@testing-library/react'
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { createControlledPromise } from '@tanstack/router-core'
 
 import {
   Link,
@@ -45,6 +47,35 @@ const WAIT_TIME = 100
 describe('redirect', () => {
   describe('SPA', () => {
     configure({ reactStrictMode: true })
+
+    test('allows a same-location redirect to settle after a side effect', async () => {
+      let firstLoad = true
+      const loader = vi.fn(() => {
+        if (firstLoad) {
+          firstLoad = false
+          throw redirect({ to: '/' })
+        }
+      })
+      const rootRoute = createRootRoute()
+      const indexRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/',
+        loader,
+        component: () => <div>Index page</div>,
+      })
+      const router = createRouter({
+        routeTree: rootRoute.addChildren([indexRoute]),
+        history,
+      })
+
+      render(<RouterProvider router={router} />)
+
+      expect(await screen.findByText('Index page')).toBeInTheDocument()
+      expect(window.location.pathname).toBe('/')
+      expect(loader).toHaveBeenCalledTimes(2)
+      expect(router.state.status).toBe('idle')
+    })
+
     test('when `redirect` is thrown in `beforeLoad`', async () => {
       const nestedLoaderMock = vi.fn()
       const nestedFooLoaderMock = vi.fn()
@@ -115,6 +146,7 @@ describe('redirect', () => {
 
     test('when root `beforeLoad` redirects while root pendingComponent is showing and the target route is lazy', async () => {
       let hasRedirected = false
+      const beforeLoad = createControlledPromise<void>()
       const consoleError = vi
         .spyOn(console, 'error')
         .mockImplementation(() => {})
@@ -124,7 +156,7 @@ describe('redirect', () => {
         pendingMs: 0,
         pendingComponent: () => <div data-testid="pending">loading</div>,
         beforeLoad: async () => {
-          await sleep(WAIT_TIME)
+          await beforeLoad
           if (!hasRedirected) {
             hasRedirected = true
             throw redirect({ to: '/posts' })
@@ -149,6 +181,14 @@ describe('redirect', () => {
       })
 
       render(<RouterProvider router={router} />)
+
+      try {
+        expect(await screen.findByTestId('pending')).toBeInTheDocument()
+      } finally {
+        await act(() => {
+          beforeLoad.resolve()
+        })
+      }
 
       // The lazy target route adds the async boundary that exposes the stale
       // redirected-match render path this regression is guarding.

--- a/packages/react-router/tests/renderRouterToStream.test.tsx
+++ b/packages/react-router/tests/renderRouterToStream.test.tsx
@@ -197,7 +197,7 @@ describe('renderRouterToStream - pipeable sync errors', () => {
     }
   })
 
-  test('request abort aborts pipeable and errors body', async () => {
+  test('request abort cancels pipeable rendering before the response body is consumed', async () => {
     const abort = vi.fn()
     reactDomServerMocks.renderToPipeableStream.mockImplementationOnce(
       (_children, opts) => {
@@ -220,13 +220,14 @@ describe('renderRouterToStream - pipeable sync errors', () => {
         }),
       )
 
+      expect(response.body).not.toBeNull()
       controller.abort(new Error('request-gone'))
+      await vi.waitFor(() => expect(abort).toHaveBeenCalledOnce())
       const terminated = await Promise.race<true | false>([
         expectBodyRejects(response, 'request-gone').then(() => true),
         new Promise<false>((resolve) => setTimeout(() => resolve(false), 2000)),
       ])
       expect(terminated).toBe(true)
-      expect(abort).toHaveBeenCalledOnce()
     } finally {
       router.serverSsr?.cleanup()
     }

--- a/packages/react-router/tests/routeContext.test.tsx
+++ b/packages/react-router/tests/routeContext.test.tsx
@@ -141,7 +141,7 @@ describe('context function', () => {
     })
 
     test('when loader deps change', async () => {
-      const mockContextFn = vi.fn()
+      let generation = 0
 
       const rootRoute = createRootRoute()
       const indexRoute = createRoute({
@@ -153,14 +153,21 @@ describe('context function', () => {
         path: '/',
         loaderDeps: ({ search }) => ({ foo: search.foo }),
         context: ({ deps }) => {
-          mockContextFn(deps)
+          return {
+            generation: ++generation,
+            deps: JSON.stringify(deps),
+          }
         },
         component: () => {
           const navigate = indexRoute.useNavigate()
+          const context = indexRoute.useRouteContext()
           return (
             <div>
               <h1>Index page</h1>
               <h2>search: {JSON.stringify(indexRoute.useSearch())}</h2>
+              <h3>
+                context: {context.generation}:{context.deps}
+              </h3>
               <button
                 onClick={() => {
                   navigate({ search: (p: any) => ({ ...p, foo: 'foo-1' }) })
@@ -208,44 +215,37 @@ describe('context function', () => {
 
       await findByText('Index page')
       await findByText(`search: ${JSON.stringify({})}`)
-
-      expect(mockContextFn).toHaveBeenCalledOnce()
-      expect(mockContextFn).toHaveBeenCalledWith({})
-      mockContextFn.mockClear()
+      await findByText('context: 1:{}')
 
       await clickButton('foo-1')
       await findByText(`search: ${JSON.stringify({ foo: 'foo-1' })}`)
-      expect(mockContextFn).toHaveBeenCalledOnce()
-      expect(mockContextFn).toHaveBeenCalledWith({ foo: 'foo-1' })
+      await findByText('context: 2:{"foo":"foo-1"}')
 
-      mockContextFn.mockClear()
       await clickButton('foo-1')
       await findByText(`search: ${JSON.stringify({ foo: 'foo-1' })}`)
-      expect(mockContextFn).not.toHaveBeenCalled()
+      await findByText('context: 2:{"foo":"foo-1"}')
 
       await clickButton('bar-1')
       await findByText(
         `search: ${JSON.stringify({ foo: 'foo-1', bar: 'bar-1' })}`,
       )
-      expect(mockContextFn).not.toHaveBeenCalled()
+      await findByText('context: 2:{"foo":"foo-1"}')
 
       await clickButton('foo-2')
       await findByText(
         `search: ${JSON.stringify({ foo: 'foo-2', bar: 'bar-1' })}`,
       )
-      expect(mockContextFn).toHaveBeenCalledWith({ foo: 'foo-2' })
-      mockContextFn.mockClear()
+      await findByText('context: 3:{"foo":"foo-2"}')
 
       await clickButton('bar-2')
       await findByText(
         `search: ${JSON.stringify({ foo: 'foo-2', bar: 'bar-2' })}`,
       )
-      expect(mockContextFn).not.toHaveBeenCalled()
+      await findByText('context: 3:{"foo":"foo-2"}')
 
       await clickButton('clear')
       await findByText(`search: ${JSON.stringify({})}`)
-      expect(mockContextFn).toHaveBeenCalledOnce()
-      expect(mockContextFn).toHaveBeenCalledWith({})
+      await findByText('context: 4:{}')
     })
   })
 

--- a/packages/react-router/tests/router.test.tsx
+++ b/packages/react-router/tests/router.test.tsx
@@ -8,7 +8,11 @@ import {
   waitFor,
 } from '@testing-library/react'
 import { z } from 'zod'
-import { composeRewrites, notFound } from '@tanstack/router-core'
+import {
+  composeRewrites,
+  createControlledPromise,
+  notFound,
+} from '@tanstack/router-core'
 import {
   Link,
   Outlet,
@@ -2205,22 +2209,26 @@ describe('does not strip search params if search validation fails', () => {
   })
 })
 
-describe('statusCode', () => {
-  it('should reset statusCode to 200 when navigating from 404 to valid route', async () => {
+describe('navigation outcomes', () => {
+  it('should recover from a not-found route when navigating to a valid route', async () => {
     const history = createMemoryHistory({ initialEntries: ['/'] })
 
-    const rootRoute = createRootRoute()
+    const rootRoute = createRootRoute({
+      notFoundComponent: () => (
+        <div data-testid="root-not-found">Not Found</div>
+      ),
+    })
 
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
       path: '/',
-      component: () => <div>Home</div>,
+      component: () => <div data-testid="home-page">Home</div>,
     })
 
     const validRoute = createRoute({
       getParentRoute: () => rootRoute,
       path: '/valid',
-      component: () => <div>Valid Route</div>,
+      component: () => <div data-testid="valid-page">Valid Route</div>,
     })
 
     const routeTree = rootRoute.addChildren([indexRoute, validRoute])
@@ -2228,27 +2236,28 @@ describe('statusCode', () => {
 
     render(<RouterProvider router={router} />)
 
-    expect(router.state.statusCode).toBe(200)
-
     await act(() => router.navigate({ to: '/' }))
-    expect(router.state.statusCode).toBe(200)
+    expect(await screen.findByTestId('home-page')).toBeInTheDocument()
 
     await act(() => router.navigate({ to: '/non-existing' }))
-    expect(router.state.statusCode).toBe(404)
+    expect(await screen.findByTestId('root-not-found')).toBeInTheDocument()
+    expect(screen.queryByTestId('home-page')).not.toBeInTheDocument()
 
     await act(() => router.navigate({ to: '/valid' }))
-    expect(router.state.statusCode).toBe(200)
+    expect(await screen.findByTestId('valid-page')).toBeInTheDocument()
+    expect(screen.queryByTestId('root-not-found')).not.toBeInTheDocument()
 
     await act(() => router.navigate({ to: '/another-non-existing' }))
-    expect(router.state.statusCode).toBe(404)
+    expect(await screen.findByTestId('root-not-found')).toBeInTheDocument()
+    expect(screen.queryByTestId('valid-page')).not.toBeInTheDocument()
   })
 
   describe.each([true, false])(
-    'status code is set when loader/beforeLoad throws (isAsync=%s)',
+    'loader and beforeLoad outcomes are rendered (isAsync=%s)',
     async (isAsync) => {
       const throwingFun = isAsync
         ? (toThrow: () => void) => async () => {
-            await new Promise((resolve) => setTimeout(resolve, 10))
+            await Promise.resolve()
             toThrow()
           }
         : (toThrow: () => void) => toThrow
@@ -2259,15 +2268,19 @@ describe('statusCode', () => {
       const throwError = throwingFun(() => {
         throw new Error('test-error')
       })
-      it('should set statusCode to 404 when a route loader throws a notFound()', async () => {
+      it('should render notFoundComponent when a route loader throws a notFound()', async () => {
         const history = createMemoryHistory({ initialEntries: ['/'] })
 
-        const rootRoute = createRootRoute()
+        const rootRoute = createRootRoute({
+          notFoundComponent: () => (
+            <div data-testid="root-not-found">Root Not Found</div>
+          ),
+        })
 
         const indexRoute = createRoute({
           getParentRoute: () => rootRoute,
           path: '/',
-          component: () => <div>Home</div>,
+          component: () => <div data-testid="home-page">Home</div>,
         })
 
         const loaderThrowsRoute = createRoute({
@@ -2278,7 +2291,7 @@ describe('statusCode', () => {
             <div data-testid="route-component">loader will throw</div>
           ),
           notFoundComponent: () => (
-            <div data-testid="not-found-component">Not Found</div>
+            <div data-testid="route-not-found">Route Not Found</div>
           ),
         })
 
@@ -2287,29 +2300,27 @@ describe('statusCode', () => {
 
         render(<RouterProvider router={router} />)
 
-        expect(router.state.statusCode).toBe(200)
-
+        expect(await screen.findByTestId('home-page')).toBeInTheDocument()
         await act(() => router.navigate({ to: '/loader-throws-not-found' }))
-        expect(router.state.statusCode).toBe(404)
-        expect(
-          await screen.findByTestId('not-found-component'),
-        ).toBeInTheDocument()
+        expect(await screen.findByTestId('route-not-found')).toBeInTheDocument()
+        expect(screen.queryByTestId('root-not-found')).not.toBeInTheDocument()
         expect(screen.queryByTestId('route-component')).not.toBeInTheDocument()
+        expect(screen.queryByTestId('home-page')).not.toBeInTheDocument()
       })
 
-      it('should set statusCode to 404 when a route beforeLoad throws a notFound()', async () => {
+      it('should render notFoundComponent when a route beforeLoad throws a notFound()', async () => {
         const history = createMemoryHistory({ initialEntries: ['/'] })
 
         const rootRoute = createRootRoute({
           notFoundComponent: () => (
-            <div data-testid="not-found-component">Not Found</div>
+            <div data-testid="root-not-found">Root Not Found</div>
           ),
         })
 
         const indexRoute = createRoute({
           getParentRoute: () => rootRoute,
           path: '/',
-          component: () => <div>Home</div>,
+          component: () => <div data-testid="home-page">Home</div>,
         })
 
         const beforeLoadThrowsRoute = createRoute({
@@ -2320,7 +2331,7 @@ describe('statusCode', () => {
             <div data-testid="route-component">beforeLoad will throw</div>
           ),
           notFoundComponent: () => (
-            <div data-testid="not-found-component">Not Found</div>
+            <div data-testid="route-not-found">Route Not Found</div>
           ),
         })
 
@@ -2332,17 +2343,15 @@ describe('statusCode', () => {
 
         render(<RouterProvider router={router} />)
 
-        expect(router.state.statusCode).toBe(200)
-
+        expect(await screen.findByTestId('home-page')).toBeInTheDocument()
         await act(() => router.navigate({ to: '/beforeload-throws-not-found' }))
-        expect(router.state.statusCode).toBe(404)
-        expect(
-          await screen.findByTestId('not-found-component'),
-        ).toBeInTheDocument()
+        expect(await screen.findByTestId('route-not-found')).toBeInTheDocument()
+        expect(screen.queryByTestId('root-not-found')).not.toBeInTheDocument()
         expect(screen.queryByTestId('route-component')).not.toBeInTheDocument()
+        expect(screen.queryByTestId('home-page')).not.toBeInTheDocument()
       })
 
-      it('should set statusCode to 500 when a route loader throws an Error', async () => {
+      it('should render errorComponent when a route loader throws an Error', async () => {
         const history = createMemoryHistory({ initialEntries: ['/'] })
 
         const rootRoute = createRootRoute()
@@ -2368,15 +2377,12 @@ describe('statusCode', () => {
 
         render(<RouterProvider router={router} />)
 
-        expect(router.state.statusCode).toBe(200)
-
         await act(() => router.navigate({ to: '/loader-throws-error' }))
-        expect(router.state.statusCode).toBe(500)
         expect(await screen.findByTestId('error-component')).toBeInTheDocument()
         expect(screen.queryByTestId('route-component')).not.toBeInTheDocument()
       })
 
-      it('should set statusCode to 500 when a route beforeLoad throws an Error', async () => {
+      it('should render errorComponent when a route beforeLoad throws an Error', async () => {
         const history = createMemoryHistory({ initialEntries: ['/'] })
 
         const rootRoute = createRootRoute()
@@ -2405,10 +2411,7 @@ describe('statusCode', () => {
 
         render(<RouterProvider router={router} />)
 
-        expect(router.state.statusCode).toBe(200)
-
         await act(() => router.navigate({ to: '/beforeload-throws-error' }))
-        expect(router.state.statusCode).toBe(500)
         expect(await screen.findByTestId('error-component')).toBeInTheDocument()
         expect(screen.queryByTestId('route-component')).not.toBeInTheDocument()
       })
@@ -2417,7 +2420,7 @@ describe('statusCode', () => {
 })
 
 describe('notFound in beforeLoad with pendingComponent', () => {
-  it('should transition router.state.status to idle when child beforeLoad throws notFound and parent has pendingComponent with pendingMs: 0', async () => {
+  it('renders notFound when child beforeLoad throws and parent has an immediate pending component', async () => {
     const history = createMemoryHistory({ initialEntries: ['/'] })
 
     const rootRoute = createRootRoute({
@@ -2472,23 +2475,26 @@ describe('notFound in beforeLoad with pendingComponent', () => {
 
     render(<RouterProvider router={router} />)
 
-    // Wait for initial load
-    await act(() => router.latestLoadPromise)
-    expect(router.state.status).toBe('idle')
-    expect(screen.getByTestId('home-page')).toBeInTheDocument()
+    expect(await screen.findByTestId('home-page')).toBeInTheDocument()
 
-    // Navigate to the child route that throws notFound in beforeLoad
     await act(() => router.navigate({ to: '/parent/child' }))
 
-    // The router status should eventually become idle
-    await waitFor(() => {
-      expect(router.state.status).toBe('idle')
-    })
-
-    expect(router.state.statusCode).toBe(404)
+    expect(await screen.findByTestId('parent-not-found')).toHaveTextContent(
+      'Parent Not Found',
+    )
+    expect(screen.queryByTestId('root-not-found')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('pending-component')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('child-component')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('home-page')).not.toBeInTheDocument()
+    expect(router.state.matches.map((match) => match.routeId)).toEqual([
+      rootRoute.id,
+      parentRoute.id,
+      childRoute.id,
+    ])
+    expect(router.state.status).toBe('idle')
   })
 
-  it('should transition router.state.status to idle when child beforeLoad throws notFound and parent has NO pendingComponent', async () => {
+  it('renders notFound when child beforeLoad throws without a pending component', async () => {
     const history = createMemoryHistory({ initialEntries: ['/'] })
 
     const rootRoute = createRootRoute({
@@ -2521,19 +2527,20 @@ describe('notFound in beforeLoad with pendingComponent', () => {
 
     render(<RouterProvider router={router} />)
 
-    await act(() => router.latestLoadPromise)
-    expect(router.state.status).toBe('idle')
+    expect(await screen.findByTestId('home-page')).toBeInTheDocument()
 
     await act(() => router.navigate({ to: '/child' }))
 
-    await waitFor(() => {
-      expect(router.state.status).toBe('idle')
-    })
-
-    expect(router.state.statusCode).toBe(404)
+    expect(await screen.findByTestId('child-not-found')).toHaveTextContent(
+      'Child Not Found',
+    )
+    expect(screen.queryByTestId('root-not-found')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('child-component')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('home-page')).not.toBeInTheDocument()
+    expect(router.state.status).toBe('idle')
   })
 
-  it('should transition router.state.status to idle when nested child beforeLoad throws notFound WITHOUT pendingComponent', async () => {
+  it('renders notFound when nested child beforeLoad throws without a pending component', async () => {
     const history = createMemoryHistory({ initialEntries: ['/'] })
 
     const rootRoute = createRootRoute({
@@ -2580,89 +2587,145 @@ describe('notFound in beforeLoad with pendingComponent', () => {
 
     render(<RouterProvider router={router} />)
 
-    await act(() => router.latestLoadPromise)
-    expect(router.state.status).toBe('idle')
+    expect(await screen.findByTestId('home-page')).toBeInTheDocument()
 
     await act(() => router.navigate({ to: '/parent/child' }))
 
-    await waitFor(() => {
-      expect(router.state.status).toBe('idle')
-    })
-
-    expect(router.state.statusCode).toBe(404)
-  })
-
-  it('should transition router.state.status to idle when child async beforeLoad throws notFound and parent has pendingComponent with pendingMs: 0', async () => {
-    const history = createMemoryHistory({ initialEntries: ['/'] })
-
-    const rootRoute = createRootRoute({
-      component: () => <Outlet />,
-      notFoundComponent: () => (
-        <div data-testid="root-not-found">Root Not Found</div>
-      ),
-    })
-
-    const indexRoute = createRoute({
-      getParentRoute: () => rootRoute,
-      path: '/',
-      component: () => (
-        <div data-testid="home-page">
-          <Link to="/parent/child">Go to child</Link>
-        </div>
-      ),
-    })
-
-    const parentRoute = createRoute({
-      getParentRoute: () => rootRoute,
-      path: '/parent',
-      pendingMs: 0,
-      pendingComponent: () => (
-        <div data-testid="pending-component">Loading...</div>
-      ),
-      component: () => (
-        <div data-testid="parent-component">
-          Parent
-          <Outlet />
-        </div>
-      ),
-      notFoundComponent: () => (
-        <div data-testid="parent-not-found">Parent Not Found</div>
-      ),
-    })
-
-    const childRoute = createRoute({
-      getParentRoute: () => parentRoute,
-      path: '/child',
-      beforeLoad: async () => {
-        await new Promise((resolve) => setTimeout(resolve, 10))
-        throw notFound()
-      },
-      component: () => <div data-testid="child-component">Child</div>,
-    })
-
-    const routeTree = rootRoute.addChildren([
-      indexRoute,
-      parentRoute.addChildren([childRoute]),
+    expect(await screen.findByTestId('parent-not-found')).toHaveTextContent(
+      'Parent Not Found',
+    )
+    expect(screen.queryByTestId('root-not-found')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('parent-component')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('child-component')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('home-page')).not.toBeInTheDocument()
+    expect(router.state.matches.map((match) => match.routeId)).toEqual([
+      rootRoute.id,
+      parentRoute.id,
+      childRoute.id,
     ])
-    const router = createRouter({ routeTree, history })
-
-    render(<RouterProvider router={router} />)
-
-    // Wait for initial load
-    await act(() => router.latestLoadPromise)
     expect(router.state.status).toBe('idle')
-    expect(screen.getByTestId('home-page')).toBeInTheDocument()
-
-    // Navigate to the child route that throws notFound in beforeLoad
-    await act(() => router.navigate({ to: '/parent/child' }))
-
-    // The router status should eventually become idle
-    await waitFor(() => {
-      expect(router.state.status).toBe('idle')
-    })
-
-    expect(router.state.statusCode).toBe(404)
   })
+
+  it.each(['ancestor', 'child'] as const)(
+    'renders the parent notFound after showing %s pending UI',
+    async (pendingOwner) => {
+      const history = createMemoryHistory({ initialEntries: ['/'] })
+      const beforeLoad = createControlledPromise<void>()
+
+      const rootRoute = createRootRoute({
+        component: () => <Outlet />,
+        notFoundComponent: () => (
+          <div data-testid="root-not-found">Root Not Found</div>
+        ),
+      })
+
+      const indexRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/',
+        component: () => <div data-testid="home-page">Home</div>,
+      })
+
+      const parentRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/parent',
+        ...(pendingOwner === 'ancestor'
+          ? {
+              beforeLoad: () => beforeLoad,
+              pendingMs: 0,
+              pendingComponent: () => (
+                <div data-testid="ancestor-pending">Loading ancestor...</div>
+              ),
+            }
+          : {}),
+        component: () => (
+          <div data-testid="parent-component">
+            Parent
+            <Outlet />
+          </div>
+        ),
+        notFoundComponent: () => (
+          <div data-testid="parent-not-found">Parent Not Found</div>
+        ),
+      })
+
+      const childRoute = createRoute({
+        getParentRoute: () => parentRoute,
+        path: '/child',
+        ...(pendingOwner === 'child'
+          ? {
+              pendingMs: 0,
+              pendingComponent: () => (
+                <div data-testid="child-pending">Loading child...</div>
+              ),
+            }
+          : {}),
+        beforeLoad: async () => {
+          if (pendingOwner === 'child') {
+            await beforeLoad
+          }
+          throw notFound()
+        },
+        component: () => <div data-testid="child-component">Child</div>,
+      })
+
+      const routeTree = rootRoute.addChildren([
+        indexRoute,
+        parentRoute.addChildren([childRoute]),
+      ])
+      const router = createRouter({
+        routeTree,
+        history,
+        defaultPendingMinMs: 0,
+      })
+
+      render(<RouterProvider router={router} />)
+
+      expect(await screen.findByTestId('home-page')).toBeInTheDocument()
+
+      vi.useFakeTimers()
+      let navigation!: Promise<void>
+      const pendingTestId = `${pendingOwner}-pending`
+      try {
+        await act(async () => {
+          navigation = router.navigate({ to: '/parent/child' })
+          await vi.advanceTimersByTimeAsync(0)
+        })
+
+        expect(screen.getByTestId(pendingTestId)).toBeInTheDocument()
+        if (pendingOwner === 'ancestor') {
+          expect(
+            screen.queryByTestId('parent-component'),
+          ).not.toBeInTheDocument()
+        } else {
+          expect(screen.getByTestId('parent-component')).toBeInTheDocument()
+        }
+      } finally {
+        try {
+          await act(async () => {
+            beforeLoad.resolve()
+            await navigation
+          })
+        } finally {
+          vi.useRealTimers()
+        }
+      }
+
+      expect(screen.getByTestId('parent-not-found')).toHaveTextContent(
+        'Parent Not Found',
+      )
+      expect(screen.queryByTestId('root-not-found')).not.toBeInTheDocument()
+      expect(screen.queryByTestId(pendingTestId)).not.toBeInTheDocument()
+      expect(screen.queryByTestId('parent-component')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('child-component')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('home-page')).not.toBeInTheDocument()
+      expect(router.state.matches.map((match) => match.routeId)).toEqual([
+        rootRoute.id,
+        parentRoute.id,
+        childRoute.id,
+      ])
+      expect(router.state.status).toBe('idle')
+    },
+  )
 })
 
 describe('Router rewrite functionality', () => {
@@ -2867,7 +2930,6 @@ describe('Router rewrite functionality', () => {
       },
     })
     render(<RouterProvider router={router} />)
-    await router.latestLoadPromise
     await waitFor(() => {
       expect(screen.getByTestId('component')).toHaveTextContent('test Users')
     })
@@ -3223,8 +3285,6 @@ describe('Router rewrite functionality', () => {
     const navigateBtn = await screen.findByTestId('navigate-btn')
 
     fireEvent.click(navigateBtn)
-    await router.latestLoadPromise
-
     await screen.findByTestId('dashboard')
 
     // Router internal state should show the internal path
@@ -3612,7 +3672,6 @@ describe('basepath', () => {
       })
 
       expect(router.state.location.pathname).toBe('/')
-      expect(router.state.statusCode).toBe(200)
     },
   )
 

--- a/packages/react-router/tests/transactional-loading.test.tsx
+++ b/packages/react-router/tests/transactional-loading.test.tsx
@@ -1,0 +1,97 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import {
+  Link,
+  Outlet,
+  RouterProvider,
+  createBrowserHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+import type { RouterHistory } from '../src'
+
+let history: RouterHistory
+
+beforeEach(() => {
+  history = createBrowserHistory()
+})
+
+afterEach(() => {
+  history.destroy()
+  window.history.replaceState(null, 'root', '/')
+  cleanup()
+})
+
+describe('transactional route loading', () => {
+  test('renders a leaf error at the leaf boundary when its background refresh fails', async () => {
+    let loads = 0
+    const rootRoute = createRootRoute({
+      component: () => (
+        <>
+          <div>Root shell</div>
+          <Outlet />
+        </>
+      ),
+    })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => <Link to="/parent/child">Open child</Link>,
+    })
+    const parentRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/parent',
+      component: () => (
+        <>
+          <div>Parent shell</div>
+          <Outlet />
+        </>
+      ),
+    })
+    const childRoute = createRoute({
+      getParentRoute: () => parentRoute,
+      path: '/child',
+      loader: {
+        staleReloadMode: 'background',
+        handler: () => {
+          loads++
+          if (loads > 1) {
+            throw new Error('background refresh failed')
+          }
+          return 'child data'
+        },
+      },
+      component: () => <div>{childRoute.useLoaderData()}</div>,
+      errorComponent: () => <div>Child refresh failed</div>,
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([
+        indexRoute,
+        parentRoute.addChildren([childRoute]),
+      ]),
+      history,
+    })
+
+    render(<RouterProvider router={router} />)
+    fireEvent.click(await screen.findByText('Open child'))
+    expect(await screen.findByText('child data')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(router.state.status).toBe('idle')
+      expect(router.state.resolvedLocation?.pathname).toBe('/parent/child')
+    })
+
+    await act(() => router.invalidate())
+
+    expect(await screen.findByText('Child refresh failed')).toBeInTheDocument()
+    expect(screen.getByText('Root shell')).toBeInTheDocument()
+    expect(screen.getByText('Parent shell')).toBeInTheDocument()
+  })
+})

--- a/packages/react-router/tests/transitioner-remount.test.tsx
+++ b/packages/react-router/tests/transitioner-remount.test.tsx
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+
+afterEach(() => {
+  cleanup()
+})
+
+function setup() {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <div>Index</div>,
+  })
+  const nextRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/next',
+    component: () => <div>Next</div>,
+  })
+  const history = createMemoryHistory({ initialEntries: ['/'] })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute, nextRoute]),
+    history,
+  })
+  return { history, router }
+}
+
+describe('Transitioner remount', () => {
+  // Zombie-router pin: once the provider unmounts, the history subscription
+  // must be torn down so a later history change never re-drives the router.
+  it('does not load after the provider unmounts', async () => {
+    const { history, router } = setup()
+    const loadSpy = vi.spyOn(router, 'load')
+
+    const first = render(<RouterProvider router={router} />)
+    expect(await screen.findByText('Index')).toBeInTheDocument()
+    await waitFor(() => expect(router.state.status).toBe('idle'))
+
+    first.unmount()
+    loadSpy.mockClear()
+
+    // A history change while unmounted must not reach the router.
+    history.push('/next')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(loadSpy).not.toHaveBeenCalled()
+    // Raw history advanced...
+    expect(router.history.location.pathname).toBe('/next')
+    // ...but the router never processed it, so its committed state stayed put.
+    expect(router.state.location.pathname).toBe('/')
+
+    loadSpy.mockRestore()
+  })
+
+  // Remounting the same router instance must re-establish the subscription so
+  // navigation keeps working, without leaving a stale duplicate behind.
+  it('re-subscribes and loads on remount with the same router', async () => {
+    const { history, router } = setup()
+    // Spy before the first mount so the subscription captures the spy by
+    // reference - both the first and second mounts subscribe with it.
+    const loadSpy = vi.spyOn(router, 'load')
+
+    const first = render(<RouterProvider router={router} />)
+    expect(await screen.findByText('Index')).toBeInTheDocument()
+    await waitFor(() => expect(router.state.status).toBe('idle'))
+
+    first.unmount()
+
+    render(<RouterProvider router={router} />)
+    expect(await screen.findByText('Index')).toBeInTheDocument()
+    await waitFor(() => expect(router.state.status).toBe('idle'))
+
+    // A push on the remounted provider must drive exactly one load, proving
+    // the subscription was re-established (and is singular).
+    loadSpy.mockClear()
+    history.push('/next')
+    expect(await screen.findByText('Next')).toBeInTheDocument()
+    expect(router.state.location.pathname).toBe('/next')
+    await waitFor(() => expect(loadSpy).toHaveBeenCalledTimes(1))
+
+    loadSpy.mockRestore()
+  })
+})

--- a/packages/react-router/tests/transitioner-render-ack.test.tsx
+++ b/packages/react-router/tests/transitioner-render-ack.test.tsx
@@ -1,0 +1,196 @@
+import { StrictMode, act } from 'react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, expect, test, vi } from 'vitest'
+import {
+  Outlet,
+  RouterProvider,
+  createControlledPromise,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+
+const testCleanups: Array<() => void> = []
+
+afterEach(() => {
+  while (testCleanups.length) {
+    testCleanups.pop()!()
+  }
+  cleanup()
+  vi.useRealTimers()
+})
+
+test('same-location invalidation resolves after its refreshed DOM commits', async () => {
+  let generation = 0
+  const rootRoute = createRootRoute({ component: Outlet })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    loader: {
+      staleReloadMode: 'blocking',
+      handler: () => ++generation,
+    },
+    component: () => <div>Generation {indexRoute.useLoaderData()}</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  render(<RouterProvider router={router} />)
+  expect(await screen.findByText('Generation 1')).toBeInTheDocument()
+  await waitFor(() => {
+    expect(router.state.status).toBe('idle')
+    expect(router.state.resolvedLocation?.pathname).toBe('/')
+  })
+
+  const refreshedDomWasVisible: Array<boolean> = []
+  const unsubscribe = router.subscribe('onResolved', () => {
+    refreshedDomWasVisible.push(screen.queryByText('Generation 2') !== null)
+  })
+  testCleanups.push(unsubscribe)
+
+  await act(() => router.invalidate())
+  expect(screen.getByText('Generation 2')).toBeInTheDocument()
+  expect(screen.queryByText('Generation 1')).not.toBeInTheDocument()
+  expect(refreshedDomWasVisible).toEqual([true])
+})
+
+test('an immediately completed background refresh cannot replace the acknowledged foreground generation', async () => {
+  let generation = 0
+  const rootRoute = createRootRoute({ component: Outlet })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    loader: {
+      staleReloadMode: 'background',
+      handler: () => ++generation,
+    },
+    component: () => <div>Generation {indexRoute.useLoaderData()}</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  render(<RouterProvider router={router} />)
+  expect(await screen.findByText('Generation 1')).toBeInTheDocument()
+  await waitFor(() => expect(router.state.status).toBe('idle'))
+
+  await act(() => router.invalidate())
+
+  expect(await screen.findByText('Generation 2')).toBeInTheDocument()
+  expect(router.state.status).toBe('idle')
+})
+
+test('a navigation started by route lifecycle keeps the pending minimum of its own render', async () => {
+  const slowLoader = createControlledPromise<void>()
+  let nestedNavigation: Promise<void> | undefined
+  const rootRoute = createRootRoute({ component: Outlet })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <div>Index</div>,
+  })
+  const redirectorRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/redirector',
+    onEnter: () => {
+      nestedNavigation = router.navigate({ to: '/slow' })
+    },
+    component: () => <div>Redirector</div>,
+  })
+  const slowRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/slow',
+    pendingMs: 0,
+    pendingMinMs: 100,
+    pendingComponent: () => <div>Slow pending</div>,
+    loader: () => slowLoader,
+    component: () => <div>Slow done</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute, redirectorRoute, slowRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  render(<RouterProvider router={router} />)
+  expect(await screen.findByText('Index')).toBeInTheDocument()
+  await waitFor(() => expect(router.state.status).toBe('idle'))
+  vi.useFakeTimers()
+
+  let firstNavigation!: Promise<void>
+  await act(async () => {
+    firstNavigation = router.navigate({ to: '/redirector' })
+    await vi.advanceTimersByTimeAsync(0)
+  })
+
+  expect(nestedNavigation).toBeDefined()
+  expect(screen.getByText('Slow pending')).toBeInTheDocument()
+
+  await act(async () => {
+    slowLoader.resolve()
+    await Promise.resolve()
+  })
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(99)
+  })
+  expect(screen.getByText('Slow pending')).toBeInTheDocument()
+
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(1)
+    await Promise.all([firstNavigation, nestedNavigation!])
+  })
+  expect(screen.queryByText('Slow pending')).not.toBeInTheDocument()
+  expect(screen.getByText('Slow done')).toBeInTheDocument()
+})
+
+test('StrictMode effect replay preserves renderer commit sequencing', async () => {
+  const rootRoute = createRootRoute({ component: Outlet })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <div>Index</div>,
+  })
+  const nextRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/next',
+    component: () => <div>Next</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute, nextRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  render(
+    <StrictMode>
+      <RouterProvider router={router} />
+    </StrictMode>,
+  )
+  expect(await screen.findByText('Index')).toBeInTheDocument()
+  await waitFor(() => {
+    expect(router.state.status).toBe('idle')
+    expect(router.state.resolvedLocation?.pathname).toBe('/')
+  })
+
+  const eventLog: Array<string> = []
+  const unsubscribers = [
+    router.subscribe('onResolved', (event) => {
+      if (event.toLocation.pathname === '/next') {
+        eventLog.push('onResolved:/next')
+      }
+    }),
+    router.subscribe('onRendered', (event) => {
+      if (event.toLocation.pathname === '/next') {
+        eventLog.push('onRendered:/next')
+      }
+    }),
+  ]
+  testCleanups.push(...unsubscribers)
+
+  await act(() => router.navigate({ to: '/next' }))
+  expect(eventLog).toEqual(['onResolved:/next', 'onRendered:/next'])
+  expect(screen.getByText('Next')).toBeInTheDocument()
+  expect(screen.queryByText('Index')).not.toBeInTheDocument()
+})

--- a/packages/react-router/tests/useMatch.test.tsx
+++ b/packages/react-router/tests/useMatch.test.tsx
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
 import {
   Link,
   Outlet,
@@ -92,6 +98,151 @@ describe('useMatch', () => {
       expect(postsTitle).toBeInTheDocument()
       expect(select).toHaveBeenCalled()
     })
+  })
+
+  test('tracks presentation generations across replacement and re-entry', async () => {
+    function RootComponent() {
+      const targetedRevision = useMatch({
+        from: '/item',
+        shouldThrow: false,
+        select: (match) => match.loaderData,
+      })
+
+      return (
+        <>
+          <div data-testid="targeted-match">
+            {targetedRevision === undefined
+              ? 'Targeted absent'
+              : `Targeted revision ${targetedRevision}`}
+          </div>
+          <Link to="/item" search={{ revision: 2 }}>
+            Revision 2
+          </Link>
+          <Link to="/item" search={{ revision: 3 }}>
+            Revision 3
+          </Link>
+          <Link to="/other">Other</Link>
+          <Outlet />
+        </>
+      )
+    }
+
+    function ItemComponent() {
+      const nearestRevision = useMatch({
+        strict: false,
+        shouldThrow: false,
+        select: (match) => match.loaderData as number,
+      })
+      return <div>Nearest revision {nearestRevision}</div>
+    }
+
+    const rootRoute = createRootRoute({ component: RootComponent })
+    const itemRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/item',
+      validateSearch: (search: Record<string, unknown>) => ({
+        revision: Number(search.revision),
+      }),
+      loaderDeps: ({ search }) => ({ revision: search.revision }),
+      loader: ({ deps }) => deps.revision,
+      component: ItemComponent,
+    })
+    const otherRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/other',
+      component: () => <div>Other route</div>,
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([itemRoute, otherRoute]),
+      history: createMemoryHistory({ initialEntries: ['/item?revision=1'] }),
+    })
+
+    render(<RouterProvider router={router} />)
+    expect(await screen.findByText('Nearest revision 1')).toBeInTheDocument()
+    expect(screen.getByTestId('targeted-match')).toHaveTextContent(
+      'Targeted revision 1',
+    )
+
+    fireEvent.click(screen.getByText('Revision 2'))
+    expect(await screen.findByText('Nearest revision 2')).toBeInTheDocument()
+    expect(screen.getByTestId('targeted-match')).toHaveTextContent(
+      'Targeted revision 2',
+    )
+
+    fireEvent.click(screen.getByText('Other'))
+    expect(await screen.findByText('Other route')).toBeInTheDocument()
+    expect(screen.getByTestId('targeted-match')).toHaveTextContent(
+      'Targeted absent',
+    )
+
+    fireEvent.click(screen.getByText('Revision 3'))
+    expect(await screen.findByText('Nearest revision 3')).toBeInTheDocument()
+    expect(screen.getByTestId('targeted-match')).toHaveTextContent(
+      'Targeted revision 3',
+    )
+  })
+
+  test('renders a route generation that re-enters before an intermediate route renders', async () => {
+    function RootComponent() {
+      return (
+        <>
+          <Link to="/other">Other</Link>
+          <Outlet />
+        </>
+      )
+    }
+
+    function ItemComponent() {
+      const revision = useMatch({
+        strict: false,
+        select: (match) => match.loaderData as number,
+      })
+      return <div>Item revision {revision}</div>
+    }
+
+    const rootRoute = createRootRoute({ component: RootComponent })
+    const itemRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/item',
+      validateSearch: (search: Record<string, unknown>) => ({
+        revision: Number(search.revision),
+      }),
+      loaderDeps: ({ search }) => ({ revision: search.revision }),
+      loader: ({ deps }) => deps.revision,
+      component: ItemComponent,
+    })
+    const otherRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/other',
+      component: () => <div>Other route</div>,
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([itemRoute, otherRoute]),
+      history: createMemoryHistory({ initialEntries: ['/item?revision=1'] }),
+    })
+
+    render(<RouterProvider router={router} />)
+    expect(await screen.findByText('Item revision 1')).toBeInTheDocument()
+
+    let returnNavigation: Promise<void> | undefined
+    const unsubscribe = router.subscribe('onLoad', (event) => {
+      if (event.toLocation.pathname === '/other') {
+        returnNavigation = router.navigate({
+          to: '/item',
+          search: { revision: 2 },
+        })
+      }
+    })
+    try {
+      fireEvent.click(screen.getByText('Other'))
+      await waitFor(() => expect(returnNavigation).toBeDefined())
+      await returnNavigation
+
+      expect(await screen.findByText('Item revision 2')).toBeInTheDocument()
+      expect(screen.queryByText('Other route')).not.toBeInTheDocument()
+    } finally {
+      unsubscribe()
+    }
   })
 
   describe('when match is not found', () => {

--- a/packages/react-router/tests/useNavigate.test.tsx
+++ b/packages/react-router/tests/useNavigate.test.tsx
@@ -7,6 +7,7 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
 } from '@testing-library/react'
 
 import { z } from 'zod'
@@ -2312,9 +2313,11 @@ describe.each([{ basepath: '' }, { basepath: '/basepath' }])(
         path: 'param/$param',
         component: function ParamRoute() {
           const navigate = useNavigate()
+          const params = paramRoute.useParams()
           return (
             <>
               <h1>Param Route</h1>
+              <span data-testid="param-value">{params.param}</span>
               <button
                 onClick={() =>
                   navigate({ from: paramRoute.fullPath, to: './a' })
@@ -2415,9 +2418,9 @@ describe.each([{ basepath: '' }, { basepath: '/basepath' }])(
 
       // Click the link and ensure the new location
       fireEvent.click(parentLink)
-      await router.latestLoadPromise
-
-      expect(window.location.pathname).toBe(`${basepath}/a`)
+      await waitFor(() => {
+        expect(window.location.pathname).toBe(`${basepath}/a`)
+      })
     })
 
     test('should navigate to the parent route and keep params', async () => {
@@ -2435,9 +2438,9 @@ describe.each([{ basepath: '' }, { basepath: '/basepath' }])(
 
       // Click the link and ensure the new location
       fireEvent.click(parentLink)
-      await router.latestLoadPromise
-
-      expect(window.location.pathname).toBe(`${basepath}/param/foo/a`)
+      await waitFor(() => {
+        expect(window.location.pathname).toBe(`${basepath}/param/foo/a`)
+      })
     })
 
     test('should navigate to the parent route and change params', async () => {
@@ -2457,9 +2460,9 @@ describe.each([{ basepath: '' }, { basepath: '/basepath' }])(
 
       // Click the link and ensure the new location
       fireEvent.click(parentLink)
-      await router.latestLoadPromise
-
-      expect(window.location.pathname).toBe(`${basepath}/param/bar/a`)
+      await waitFor(() => {
+        expect(window.location.pathname).toBe(`${basepath}/param/bar/a`)
+      })
     })
 
     test('should navigate to a relative link based on render location with basepath', async () => {
@@ -2476,9 +2479,9 @@ describe.each([{ basepath: '' }, { basepath: '/basepath' }])(
 
       // Click the link and ensure the new location
       fireEvent.click(relativeLink)
-      await router.latestLoadPromise
-
-      expect(window.location.pathname).toBe(`${basepath}/param/foo/a`)
+      await waitFor(() => {
+        expect(window.location.pathname).toBe(`${basepath}/param/foo/a`)
+      })
     })
 
     test('should navigate to a parent link based on render location', async () => {
@@ -2497,9 +2500,9 @@ describe.each([{ basepath: '' }, { basepath: '/basepath' }])(
 
       // Click the link and ensure the new location
       fireEvent.click(relativeLink)
-      await router.latestLoadPromise
-
-      expect(window.location.pathname).toBe(`${basepath}/param/foo`)
+      await waitFor(() => {
+        expect(window.location.pathname).toBe(`${basepath}/param/foo`)
+      })
     })
 
     test('should navigate to a parent link based on active location', async () => {
@@ -2515,9 +2518,9 @@ describe.each([{ basepath: '' }, { basepath: '/basepath' }])(
 
       // Click the link and ensure the new location
       fireEvent.click(relativeLink)
-      await router.latestLoadPromise
-
-      expect(window.location.pathname).toBe(`${basepath}/param/foo/a`)
+      await waitFor(() => {
+        expect(window.location.pathname).toBe(`${basepath}/param/foo/a`)
+      })
     })
 
     test('should navigate to same route with different params', async () => {
@@ -2527,15 +2530,18 @@ describe.each([{ basepath: '' }, { basepath: '/basepath' }])(
 
       await act(async () => {
         history.push(`${basepath}/param/foo/a/b`)
-        await router.latestLoadPromise
       })
-      expect(window.location.pathname).toBe(`${basepath}/param/foo/a/b`)
+      await waitFor(() => {
+        expect(window.location.pathname).toBe(`${basepath}/param/foo/a/b`)
+      })
+      expect(await screen.findByTestId('param-value')).toHaveTextContent('foo')
 
-      const btn = screen.getByTestId('btn-param-bar')
+      const btn = await screen.findByTestId('btn-param-bar')
       fireEvent.click(btn)
-      await router.latestLoadPromise
-
-      expect(window.location.pathname).toBe(`${basepath}/param/bar/a/b`)
+      await waitFor(() => {
+        expect(screen.getByTestId('param-value')).toHaveTextContent('bar')
+        expect(window.location.pathname).toBe(`${basepath}/param/bar/a/b`)
+      })
     })
   },
 )

--- a/packages/react-start-client/src/tests/hydrateStart.test.ts
+++ b/packages/react-start-client/src/tests/hydrateStart.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, expect, test, vi } from 'vitest'
+import { hydrateStart } from '../hydrateStart'
+
+const coreHydrateStart = vi.hoisted(() => vi.fn())
+
+vi.mock('@tanstack/start-client-core/client', () => ({
+  hydrateStart: coreHydrateStart,
+}))
+
+afterEach(() => {
+  delete window.$_TSR
+  coreHydrateStart.mockReset()
+})
+
+test('signals streaming cleanup after hydration succeeds', async () => {
+  const router = {}
+  coreHydrateStart.mockResolvedValue(router)
+  const hydrated = vi.fn()
+  window.$_TSR = { h: hydrated } as any
+
+  await expect(hydrateStart()).resolves.toBe(router)
+  expect(hydrated).toHaveBeenCalledTimes(1)
+})

--- a/packages/router-core/tests/background-trim-abort.test.ts
+++ b/packages/router-core/tests/background-trim-abort.test.ts
@@ -1,0 +1,128 @@
+import { expect, test, vi } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import { BaseRootRoute, BaseRoute } from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+test('a background boundary keeps the matched branch and its lifecycle stable', async () => {
+  let parentLoads = 0
+  const parentError = new Error('parent background reload failed')
+  const childOnEnter = vi.fn()
+  const childOnLeave = vi.fn()
+
+  const rootRoute = new BaseRootRoute({})
+  const parentRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/parent',
+    loader: () => {
+      if (++parentLoads === 2) {
+        throw parentError
+      }
+      return `parent data ${parentLoads}`
+    },
+    errorComponent: () => null,
+  })
+  const childRoute = new BaseRoute({
+    getParentRoute: () => parentRoute,
+    path: '/child',
+    loader: () => {
+      return 'child data'
+    },
+    onEnter: childOnEnter,
+    onLeave: childOnLeave,
+  })
+  const router = createTestRouter({
+    routeTree: rootRoute.addChildren([parentRoute.addChildren([childRoute])]),
+    history: createMemoryHistory({ initialEntries: ['/parent/child'] }),
+  })
+
+  await router.load()
+  await router.invalidate()
+
+  await expect.poll(() => router.state.matches[1]?.status).toBe('error')
+
+  expect(router.state.matches.map((match) => match.routeId)).toEqual([
+    rootRoute.id,
+    parentRoute.id,
+    childRoute.id,
+  ])
+  expect(router.state.matches[1]).toMatchObject({
+    status: 'error',
+    error: parentError,
+  })
+  expect(router.state.matches[2]).toMatchObject({
+    status: 'success',
+    loaderData: 'child data',
+  })
+  expect(childOnEnter).toHaveBeenCalledTimes(1)
+  expect(childOnLeave).not.toHaveBeenCalled()
+
+  await router.invalidate()
+  await expect.poll(() => router.state.matches[1]?.status).toBe('success')
+  expect(childOnEnter).toHaveBeenCalledTimes(1)
+  expect(childOnLeave).not.toHaveBeenCalled()
+})
+
+test('foreground supersession aborts every loader in a background batch', async () => {
+  let parentLoads = 0
+  let childLoads = 0
+  const backgroundSignals: Array<AbortSignal> = []
+
+  const waitForAbort = (signal: AbortSignal) =>
+    new Promise<never>((_resolve, reject) => {
+      signal.addEventListener(
+        'abort',
+        () => {
+          const error = new Error('aborted')
+          error.name = 'AbortError'
+          reject(error)
+        },
+        { once: true },
+      )
+    })
+
+  const rootRoute = new BaseRootRoute({})
+  const parentRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/parent',
+    loader: ({ abortController }) => {
+      if (++parentLoads > 1) {
+        backgroundSignals.push(abortController.signal)
+        return waitForAbort(abortController.signal)
+      }
+      return 'initial parent data'
+    },
+  })
+  const childRoute = new BaseRoute({
+    getParentRoute: () => parentRoute,
+    path: '/child',
+    loader: ({ abortController }) => {
+      if (++childLoads > 1) {
+        backgroundSignals.push(abortController.signal)
+        return waitForAbort(abortController.signal)
+      }
+      return 'initial child data'
+    },
+  })
+  const otherRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/other',
+  })
+  const router = createTestRouter({
+    routeTree: rootRoute.addChildren([
+      parentRoute.addChildren([childRoute]),
+      otherRoute,
+    ]),
+    history: createMemoryHistory({ initialEntries: ['/parent/child'] }),
+  })
+
+  await router.load()
+  const revalidation = router.invalidate()
+  await vi.waitFor(() => expect(backgroundSignals).toHaveLength(2))
+
+  await router.navigate({ to: '/other' })
+  await revalidation
+
+  expect(backgroundSignals[0]).not.toBe(backgroundSignals[1])
+  expect(backgroundSignals.every((signal) => signal.aborted)).toBe(true)
+  expect(router.state.matches.at(-1)?.routeId).toBe(otherRoute.id)
+})

--- a/packages/router-core/tests/blocked-navigation-current-load.test.ts
+++ b/packages/router-core/tests/blocked-navigation-current-load.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import { BaseRootRoute, BaseRoute, createControlledPromise } from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+/**
+ * A history blocker can discard a navigation commit AFTER
+ * buildAndCommitLocation set router._pendingLocation (it is cleared a
+ * microtask later). A continuation of the still-current in-flight load that
+ * resumes inside that window must not treat the merely-built location as
+ * ownership loss: a blocked commit never starts a replacement load, so
+ * abandoning the pass would leave the router with status 'pending',
+ * isLoading true, and a populated pending pool forever.
+ */
+
+describe('blocked navigation does not cancel the current load', () => {
+  test('loader continuation resuming while a blocked navigation is built still commits', async () => {
+    const loaderGate = createControlledPromise<string>()
+
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const slowRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/slow',
+      loader: () => loaderGate,
+    })
+    const otherRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/other',
+    })
+
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute, slowRoute, otherRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+
+    // Framework transitioners turn committed history changes into router
+    // loads. A blocked commit never reaches this subscriber.
+    const unsubscribe = router.history.subscribe(router.load)
+    let unblock: (() => void) | undefined
+
+    try {
+      const navigation = router.navigate({ to: '/slow' })
+
+      // Discard every later navigation commit. The blocker is async, so the
+      // discarded commit still sets _pendingLocation for one microtask.
+      unblock = router.history.block({ blockerFn: async () => true })
+
+      // Same tick: settle the loader, then issue a navigation the blocker
+      // discards. The loader continuation resumes inside the window where
+      // _pendingLocation still points at /other.
+      loaderGate.resolve('slow data')
+      const blockedNavigation = router.navigate({ to: '/other' })
+
+      await Promise.all([navigation, blockedNavigation])
+
+      expect(router.state.location.pathname).toBe('/slow')
+      expect(router.history.location.pathname).toBe('/slow')
+      expect(
+        router.state.matches.find((m) => m.routeId === slowRoute.id),
+      ).toMatchObject({
+        status: 'success',
+        loaderData: 'slow data',
+      })
+    } finally {
+      unblock?.()
+      unsubscribe()
+    }
+  })
+})

--- a/packages/router-core/tests/boundary-component-chunk.test.ts
+++ b/packages/router-core/tests/boundary-component-chunk.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import {
+  BaseRootRoute,
+  BaseRoute,
+  createControlledPromise,
+  notFound,
+} from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+const pendingGates: Array<ReturnType<typeof createControlledPromise<void>>> = []
+const pendingLoads: Array<Promise<unknown>> = []
+
+afterEach(async () => {
+  for (const gate of pendingGates) {
+    gate.resolve()
+  }
+
+  await Promise.allSettled(pendingLoads)
+
+  pendingGates.length = 0
+  pendingLoads.length = 0
+})
+
+describe('route boundary component preloads', () => {
+  test('a late normal component chunk cannot replace a selected not-found boundary', async () => {
+    const componentGate = createControlledPromise<void>()
+    const notFoundGate = createControlledPromise<void>()
+    const notFoundPreload = vi.fn(() => notFoundGate)
+    pendingGates.push(componentGate, notFoundGate)
+
+    const ParentComponent = Object.assign(() => null, {
+      preload: () => componentGate,
+    })
+    const NotFoundBoundary = Object.assign(() => null, {
+      preload: notFoundPreload,
+    })
+
+    const rootRoute = new BaseRootRoute({})
+    const parentRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/parent',
+      loader: () => 'ready',
+      component: ParentComponent as any,
+      notFoundComponent: NotFoundBoundary as any,
+    })
+    const childRoute = new BaseRoute({
+      getParentRoute: () => parentRoute,
+      path: '/child',
+      beforeLoad: () => {
+        throw notFound({ routeId: parentRoute.id })
+      },
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([parentRoute.addChildren([childRoute])]),
+      history: createMemoryHistory({ initialEntries: ['/parent/child'] }),
+    })
+
+    const loading = router.load()
+    pendingLoads.push(loading)
+    await vi.waitFor(() => expect(notFoundPreload).toHaveBeenCalledOnce())
+
+    componentGate.resolve()
+    await Promise.resolve()
+    notFoundGate.resolve()
+    await loading
+
+    expect(
+      router.state.matches.find((match) => match.routeId === parentRoute.id),
+    ).toMatchObject({
+      status: 'notFound',
+      loaderData: 'ready',
+    })
+  })
+})

--- a/packages/router-core/tests/callbacks.test.ts
+++ b/packages/router-core/tests/callbacks.test.ts
@@ -200,9 +200,6 @@ describe('callbacks', () => {
       )?.id
       expect(page2MatchId).toBeDefined()
       expect(page2MatchId).not.toBe(page1MatchId)
-      expect(
-        router.stores.cachedIds.get().some((id) => id === page1MatchId),
-      ).toBe(true)
 
       await router.navigate({ to: '/foo', search: { page: '1' } })
       expect(loader).toHaveBeenCalledTimes(2)
@@ -225,9 +222,6 @@ describe('callbacks', () => {
       )?.id
       expect(post2MatchId).toBeDefined()
       expect(post2MatchId).not.toBe(post1MatchId)
-      expect(
-        router.stores.cachedIds.get().some((id) => id === post1MatchId),
-      ).toBe(true)
 
       await router.navigate({ to: '/posts/$postId', params: { postId: '1' } })
       expect(loader).toHaveBeenCalledTimes(2)

--- a/packages/router-core/tests/client-lane-adversarial.test.ts
+++ b/packages/router-core/tests/client-lane-adversarial.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import { BaseRootRoute, BaseRoute, redirect } from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+describe('adversarial client lane ownership', () => {
+  test('a redirect aborts the discarded loader generation', async () => {
+    let redirectSignal: AbortSignal | undefined
+
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const sourceRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/source',
+      loader: ({ abortController }) => {
+        redirectSignal = abortController.signal
+        throw redirect({ to: '/target' })
+      },
+    })
+    const targetRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/target',
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute, sourceRoute, targetRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+    await router.navigate({ to: '/source' })
+
+    expect(router.state.location.pathname).toBe('/target')
+    expect(router.state.matches.at(-1)).toMatchObject({
+      routeId: targetRoute.id,
+      status: 'success',
+    })
+    expect(redirectSignal?.aborted).toBe(true)
+  })
+
+  test('keeps successful descendant data behind an ancestor boundary', async () => {
+    const parentError = new Error('parent failed')
+    const childData = { value: 'child data' }
+
+    const rootRoute = new BaseRootRoute({})
+    const parentRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/parent',
+      loader: () => {
+        throw parentError
+      },
+      errorComponent: () => null,
+    })
+    const childRoute = new BaseRoute({
+      getParentRoute: () => parentRoute,
+      path: '/child',
+      loader: () => childData,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([parentRoute.addChildren([childRoute])]),
+      history: createMemoryHistory({ initialEntries: ['/parent/child'] }),
+    })
+
+    await router.load()
+
+    expect(router.state.matches[1]).toMatchObject({
+      routeId: parentRoute.id,
+      status: 'error',
+      error: parentError,
+    })
+    expect(router.state.matches[2]).toMatchObject({
+      routeId: childRoute.id,
+      status: 'success',
+      loaderData: childData,
+    })
+  })
+})

--- a/packages/router-core/tests/error-boundary-cache-generation.test.ts
+++ b/packages/router-core/tests/error-boundary-cache-generation.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test, vi } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import { BaseRootRoute, BaseRoute, createControlledPromise } from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+describe('cache retention across an error-boundary commit', () => {
+  test('a superseded generation cannot shadow newer beyond-boundary data', async () => {
+    let parentFails = false
+    const parentGate = createControlledPromise<void>()
+    const parentLoader = vi.fn(async () => {
+      if (parentFails) {
+        await parentGate
+        throw new Error('parent boom')
+      }
+    })
+    let childVersion = 0
+    let wantChildReload = false
+    const childLoader = vi.fn(() => ({ version: ++childVersion }))
+
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const parentRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/p',
+      loader: parentLoader,
+      errorComponent: () => null,
+    })
+    const childRoute = new BaseRoute({
+      getParentRoute: () => parentRoute,
+      path: 'c',
+      shouldReload: () => wantChildReload,
+      loader: childLoader,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([
+        indexRoute,
+        parentRoute.addChildren([childRoute]),
+      ]),
+      history: createMemoryHistory({ initialEntries: ['/p/c'] }),
+      defaultStaleReloadMode: 'blocking',
+    })
+
+    await router.load()
+    expect(childLoader).toHaveBeenCalledTimes(1)
+
+    // Same-destination refresh where the child settles a newer generation
+    // before the parent fails at the boundary.
+    parentFails = true
+    wantChildReload = true
+    const refresh = router.navigate({ to: '/p/c' })
+    await vi.waitFor(() => expect(childLoader).toHaveBeenCalledTimes(2))
+    parentGate.resolve()
+    await refresh
+    expect(
+      router.state.matches.find((match) => match.routeId === parentRoute.id),
+    ).toMatchObject({ status: 'error' })
+
+    // Leave and return with reloads declined: the presented child data must
+    // be the newer generation, not the superseded one.
+    parentFails = false
+    wantChildReload = false
+    await router.navigate({ to: '/' })
+    await router.navigate({ to: '/p/c' })
+
+    const child = router.state.matches.find(
+      (match) => match.routeId === childRoute.id,
+    )
+    expect(childLoader).toHaveBeenCalledTimes(2)
+    expect(child).toMatchObject({
+      status: 'success',
+      loaderData: { version: 2 },
+    })
+  })
+})

--- a/packages/router-core/tests/granular-stores.test.ts
+++ b/packages/router-core/tests/granular-stores.test.ts
@@ -84,78 +84,33 @@ function createLoaderRouter({
 }
 
 describe('granular stores', () => {
-  test('keeps pool stores correct across active/pending/cached transitions', async () => {
+  test('keeps ordered route state current across match generations', async () => {
     const router = createRouter()
     await router.navigate({ to: '/posts/123' })
 
-    const activeMatches = router.state.matches
+    expect(router.state.location.pathname).toBe('/posts/123')
+    expect(router.state.matches.map((match) => match.routeId)).toEqual([
+      '__root__',
+      '/posts/$postId',
+    ])
+    expect(router.state.matches.at(-1)?.params).toMatchObject({ postId: '123' })
 
-    // Active pool contains all active matches with correct routeIds
-    expect(router.stores.matchesId.get()).toEqual(
-      activeMatches.map((match) => match.id),
-    )
-    activeMatches.forEach((match) => {
-      const store = router.stores.matchStores.get(match.id)
-      expect(store).toBeDefined()
-      expect(store!.routeId).toBe(match.routeId)
-      // getRouteMatchStore resolves to the same state
-      expect(router.stores.getRouteMatchStore(match.routeId).get()).toBe(
-        store!.get(),
-      )
-    })
+    await router.navigate({ to: '/posts/456' })
 
-    const pendingMatches = [...activeMatches].reverse().map((match, index) => ({
-      ...match,
-      id: `${match.id}__pending_${index}`,
-    }))
-    const cachedMatches = [...activeMatches].map((match, index) => ({
-      ...match,
-      id: `${match.id}__cached_${index}`,
-    }))
+    expect(router.state.location.pathname).toBe('/posts/456')
+    expect(router.state.matches.map((match) => match.routeId)).toEqual([
+      '__root__',
+      '/posts/$postId',
+    ])
+    expect(router.state.matches.at(-1)?.params).toMatchObject({ postId: '456' })
 
-    router.stores.setPending(pendingMatches)
-    router.stores.setCached(cachedMatches)
+    await router.navigate({ to: '/about' })
 
-    expect(router.stores.matchesId.get()).toEqual(
-      activeMatches.map((match) => match.id),
-    )
-    expect(router.stores.pendingIds.get()).toEqual(
-      pendingMatches.map((match) => match.id),
-    )
-    expect(router.stores.cachedIds.get()).toEqual(
-      cachedMatches.map((match) => match.id),
-    )
-
-    // Pending pool has correct routeIds
-    pendingMatches.forEach((match) => {
-      const pendingStore = router.stores.pendingMatchStores.get(match.id)
-      expect(pendingStore).toBeDefined()
-      expect(pendingStore!.routeId).toBe(match.routeId)
-      // Pending match is NOT in the active pool
-      expect(router.stores.matchStores.get(match.id)).toBeUndefined()
-      // Active pool still has a match for this routeId
-      expect(
-        router.stores.getRouteMatchStore(match.routeId).get(),
-      ).toBeDefined()
-    })
-
-    const nextActiveMatches = activeMatches.map((match, index) => ({
-      ...match,
-      id: `${match.id}__active_next_${index}`,
-    }))
-    router.stores.setMatches(nextActiveMatches)
-
-    expect(router.stores.matchesId.get()).toEqual(
-      nextActiveMatches.map((match) => match.id),
-    )
-    nextActiveMatches.forEach((match) => {
-      const store = router.stores.matchStores.get(match.id)
-      expect(store).toBeDefined()
-      expect(store!.routeId).toBe(match.routeId)
-      expect(router.stores.getRouteMatchStore(match.routeId).get()).toBe(
-        store!.get(),
-      )
-    })
+    expect(router.state.location.pathname).toBe('/about')
+    expect(router.state.matches.map((match) => match.routeId)).toEqual([
+      '__root__',
+      '/about',
+    ])
   })
 
   test('match store updates are isolated to the touched active match', async () => {

--- a/packages/router-core/tests/hydrate.test.ts
+++ b/packages/router-core/tests/hydrate.test.ts
@@ -1,16 +1,65 @@
+import { runInNewContext } from 'node:vm'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createMemoryHistory } from '@tanstack/history'
-import { BaseRootRoute, BaseRoute, notFound } from '../src'
+import {
+  BaseRootRoute,
+  BaseRoute,
+  createSerializationAdapter,
+  notFound,
+} from '../src'
 import { hydrate } from '../src/ssr/client'
-import { createTestRouter } from './routerTestUtils'
+import { attachRouterServerSsrUtils } from '../src/ssr/ssr-server'
 import { dehydrateSsrMatchId } from '../src/ssr/ssr-match-id'
-import type { LocationRewrite } from '../src'
+import { createTestRouter } from './routerTestUtils'
+import type { AnyRouteMatch, AnyRouter, LocationRewrite } from '../src'
+import type { ServerManifest } from '../src/manifest'
 import type { TsrSsrGlobal } from '../src/ssr/types'
-import type { AnyRouteMatch } from '../src'
-import type { Manifest } from '../src/manifest'
 
-const testManifest: Manifest = {
+const testManifest: ServerManifest = {
   routes: {},
+}
+
+function createMockBootstrap(
+  router?: NonNullable<TsrSsrGlobal['router']>,
+): TsrSsrGlobal {
+  return {
+    router,
+    h: vi.fn(),
+    e: vi.fn(),
+    c: vi.fn(),
+    p: vi.fn(),
+    buffer: [],
+    initialized: false,
+  }
+}
+
+async function dehydrateToBootstrap(
+  router: AnyRouter,
+  manifest: ServerManifest = testManifest,
+): Promise<TsrSsrGlobal> {
+  attachRouterServerSsrUtils({ router, manifest })
+  try {
+    await router.load()
+    await router.serverSsr!.dehydrate()
+
+    const script = router.serverSsr!.takeBufferedScripts()
+    expect(script?.children).toBeTruthy()
+
+    const context: Record<string, any> = {
+      document: {
+        currentScript: {
+          remove() {},
+        },
+      },
+    }
+    context.self = context
+    runInNewContext(script!.children!, context)
+
+    expect(context.$_TSR).toBeDefined()
+    return context.$_TSR
+  } finally {
+    router.serverSsr?.cleanup()
+  }
 }
 
 describe('hydrate', () => {
@@ -56,70 +105,90 @@ describe('hydrate', () => {
     delete (global as any).window
   })
 
-  it('should throw error if window.$_TSR is not available', async () => {
-    await expect(hydrate(mockRouter)).rejects.toThrow(
+  it.each([
+    [
+      'window.$_TSR',
+      () => {},
       'Expected to find bootstrap data on window.$_TSR, but we did not. Please file an issue!',
-    )
-  })
-
-  it('should throw error if window.$_TSR.router is not available', async () => {
-    mockWindow.$_TSR = {
-      c: vi.fn(),
-      p: vi.fn(),
-      buffer: [],
-      initialized: false,
-      // router is missing
-    } as any
-
-    await expect(hydrate(mockRouter)).rejects.toThrow(
+    ],
+    [
+      'window.$_TSR.router',
+      () => {
+        mockWindow.$_TSR = createMockBootstrap()
+      },
       'Expected to find a dehydrated data on window.$_TSR.router, but we did not. Please file an issue!',
-    )
+    ],
+  ])(
+    'throws a diagnostic when %s is unavailable',
+    async (_, setup, message) => {
+      setup()
+
+      await expect(hydrate(mockRouter)).rejects.toThrow(message)
+    },
+  )
+
+  it('clears hydration preflight when the custom hydrate hook rejects', async () => {
+    const error = new Error('custom hydration failed')
+    mockWindow.$_TSR = createMockBootstrap({
+      manifest: testManifest,
+      dehydratedData: {},
+      matches: [],
+    })
+    mockRouter.options.hydrate = () => Promise.reject(error)
+
+    await expect(hydrate(mockRouter)).rejects.toBe(error)
+
+    expect(mockRouter._preflight).toBeUndefined()
   })
 
-  it('should initialize serialization adapters when provided', async () => {
-    const mockSerializer = {
-      key: 'testAdapter',
-      fromSerializable: vi.fn(),
-      toSerializable: vi.fn(),
-      test: vi.fn().mockReturnValue(true),
-      '~types': {
-        input: {},
-        output: {},
-        extends: {},
-      },
+  it('round-trips adapted loader data through the bootstrap protocol', async () => {
+    class AdaptedValue {
+      constructor(readonly value: string) {}
     }
 
-    mockRouter.options.serializationAdapters = [mockSerializer]
+    const adapter = createSerializationAdapter({
+      key: 'adapted-value',
+      test: (value: unknown): value is AdaptedValue =>
+        value instanceof AdaptedValue,
+      toSerializable: (value: AdaptedValue) => value.value,
+      fromSerializable: (value: string) => new AdaptedValue(value),
+    })
 
-    const mockMatches = [{ id: '/', routeId: '/', index: 0, _nonReactive: {} }]
-    mockRouter.matchRoutes = vi.fn().mockReturnValue(mockMatches)
-    mockRouter.state.matches = mockMatches
+    const serverRootRoute = new BaseRootRoute({})
+    const serverIndexRoute = new BaseRoute({
+      getParentRoute: () => serverRootRoute,
+      path: '/',
+      loader: () => new AdaptedValue('server loader data'),
+    })
+    const serverRouter = createTestRouter({
+      routeTree: serverRootRoute.addChildren([serverIndexRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+      isServer: true,
+    })
+    serverRouter.options.serializationAdapters = [adapter]
 
-    const mockBuffer = [vi.fn(), vi.fn()]
-    mockWindow.$_TSR = {
-      router: {
-        manifest: testManifest,
-        dehydratedData: {},
-        lastMatchId: '/',
-        matches: [],
-      },
-      h: vi.fn(),
-      e: vi.fn(),
-      c: vi.fn(),
-      p: vi.fn(),
-      buffer: mockBuffer,
-      initialized: false,
-    }
+    mockWindow.$_TSR = await dehydrateToBootstrap(serverRouter)
 
-    await hydrate(mockRouter)
+    const clientLoader = vi.fn(() => new AdaptedValue('client loader data'))
+    const clientRootRoute = new BaseRootRoute({})
+    const clientIndexRoute = new BaseRoute({
+      getParentRoute: () => clientRootRoute,
+      path: '/',
+      loader: clientLoader,
+    })
+    const clientRouter = createTestRouter({
+      routeTree: clientRootRoute.addChildren([clientIndexRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+      isServer: false,
+    })
+    clientRouter.options.serializationAdapters = [adapter]
 
-    expect(mockWindow.$_TSR.t).toBeInstanceOf(Map)
-    expect(mockWindow.$_TSR.t?.get('testAdapter')).toBe(
-      mockSerializer.fromSerializable,
-    )
-    expect(mockBuffer[0]).toHaveBeenCalled()
-    expect(mockBuffer[1]).toHaveBeenCalled()
-    expect(mockWindow.$_TSR.initialized).toBe(true)
+    await hydrate(clientRouter)
+
+    const loaderData = clientRouter.state.matches.at(-1)?.loaderData
+    expect(loaderData).toBeInstanceOf(AdaptedValue)
+    expect(loaderData).toEqual(new AdaptedValue('server loader data'))
+    expect(clientLoader).not.toHaveBeenCalled()
   })
 
   it('should handle empty serialization adapters', async () => {
@@ -146,82 +215,112 @@ describe('hydrate', () => {
     expect(mockWindow.$_TSR.initialized).toBe(true)
   })
 
-  it('should set manifest in router.ssr', async () => {
-    mockWindow.$_TSR = {
-      router: {
-        manifest: testManifest,
-        dehydratedData: {},
-        lastMatchId: '/',
-        matches: [],
+  it('round-trips the manifest and matches without running client loaders', async () => {
+    const serverRootRoute = new BaseRootRoute({})
+    const serverProductRoute = new BaseRoute({
+      getParentRoute: () => serverRootRoute,
+      path: '/products/$productId',
+      loader: ({ params }) => ({
+        productId: params.productId,
+        source: 'server',
+      }),
+    })
+    const serverRouter = createTestRouter({
+      routeTree: serverRootRoute.addChildren([serverProductRoute]),
+      history: createMemoryHistory({ initialEntries: ['/products/42'] }),
+      isServer: true,
+    })
+    const manifest: ServerManifest = {
+      routes: {
+        [serverRootRoute.id]: { preloads: ['/assets/root.js'] },
+        [serverProductRoute.id]: { preloads: ['/assets/product.js'] },
       },
-      h: vi.fn(),
-      e: vi.fn(),
-      c: vi.fn(),
-      p: vi.fn(),
-      buffer: [],
-      initialized: false,
     }
 
-    await hydrate(mockRouter)
+    mockWindow.$_TSR = await dehydrateToBootstrap(serverRouter, manifest)
 
-    expect(mockRouter.ssr).toEqual({
-      manifest: testManifest,
+    const serverMatches = serverRouter.state.matches
+    const clientLoader = vi.fn(() => ({
+      productId: 'client',
+      source: 'client',
+    }))
+    const clientRootRoute = new BaseRootRoute({})
+    const clientProductRoute = new BaseRoute({
+      getParentRoute: () => clientRootRoute,
+      path: '/products/$productId',
+      loader: clientLoader,
     })
+    const clientRouter = createTestRouter({
+      routeTree: clientRootRoute.addChildren([clientProductRoute]),
+      history: createMemoryHistory({ initialEntries: ['/products/42'] }),
+      isServer: false,
+    })
+
+    await hydrate(clientRouter)
+
+    expect(clientRouter.ssr?.manifest).toEqual(manifest)
+    expect(
+      clientRouter.state.matches.map((match) => ({
+        id: match.id,
+        routeId: match.routeId,
+        status: match.status,
+        loaderData: match.loaderData,
+        ssr: match.ssr,
+      })),
+    ).toEqual(
+      serverMatches.map((match) => ({
+        id: match.id,
+        routeId: match.routeId,
+        status: match.status,
+        loaderData: match.loaderData,
+        ssr: match.ssr,
+      })),
+    )
+    expect(clientRouter.state.matches.at(-1)?.loaderData).toEqual({
+      productId: '42',
+      source: 'server',
+    })
+    expect(clientLoader).not.toHaveBeenCalled()
   })
 
-  it('should hydrate matches', async () => {
-    const mockMatches = [
-      {
-        id: '/',
-        routeId: '/',
-        index: 0,
-        ssr: undefined,
-        _nonReactive: {},
-      },
-      {
-        id: '/other',
-        routeId: '/other',
-        index: 1,
-        ssr: undefined,
-        _nonReactive: {},
-      },
-    ]
+  it('restores undefined loader data without serializing it', async () => {
+    const serverRootRoute = new BaseRootRoute({})
+    const serverRoute = new BaseRoute({
+      getParentRoute: () => serverRootRoute,
+      path: '/page',
+      loader: () => undefined,
+    })
+    const serverRouter = createTestRouter({
+      routeTree: serverRootRoute.addChildren([serverRoute]),
+      history: createMemoryHistory({ initialEntries: ['/page'] }),
+      isServer: true,
+    })
 
-    const dehydratedMatches = [
-      {
-        i: '/',
-        l: { indexData: 'server-data' },
-        s: 'success' as const,
-        ssr: true,
-        u: Date.now(),
-      },
-    ]
+    mockWindow.$_TSR = await dehydrateToBootstrap(serverRouter)
+    expect(mockWindow.$_TSR.router?.matches[1]).not.toHaveProperty('l')
 
-    mockRouter.matchRoutes = vi.fn().mockReturnValue(mockMatches)
-    mockRouter.state.matches = mockMatches
+    const clientLoader = vi.fn(() => undefined)
+    const clientRootRoute = new BaseRootRoute({})
+    const clientRoute = new BaseRoute({
+      getParentRoute: () => clientRootRoute,
+      path: '/page',
+      loader: clientLoader,
+    })
+    const clientRouter = createTestRouter({
+      routeTree: clientRootRoute.addChildren([clientRoute]),
+      history: createMemoryHistory({ initialEntries: ['/page'] }),
+      isServer: false,
+    })
 
-    mockWindow.$_TSR = {
-      router: {
-        manifest: testManifest,
-        dehydratedData: {},
-        lastMatchId: '/',
-        matches: dehydratedMatches,
-      },
-      h: vi.fn(),
-      e: vi.fn(),
-      c: vi.fn(),
-      p: vi.fn(),
-      buffer: [],
-      initialized: false,
-    }
+    await hydrate(clientRouter)
 
-    await hydrate(mockRouter)
-
-    const { id, loaderData, ssr, status } = mockMatches[0] as AnyRouteMatch
-    expect(id).toBe('/')
-    expect(loaderData).toEqual({ indexData: 'server-data' })
-    expect(status).toBe('success')
-    expect(ssr).toBe(true)
+    expect(clientLoader).not.toHaveBeenCalled()
+    const match = clientRouter.state.matches[1]
+    expect(match).toMatchObject({
+      routeId: clientRoute.id,
+      status: 'success',
+    })
+    expect(match).toHaveProperty('loaderData', undefined)
   })
 
   it('should hydrate globalNotFound when dehydrated flag is present', async () => {
@@ -400,16 +499,7 @@ describe('hydrate', () => {
     expect((mockRouter.state.matches[0] as AnyRouteMatch).id).toBe('/')
   })
 
-  it('should run custom hydration before matching routes', async () => {
-    const history = createMemoryHistory({ initialEntries: ['/public'] })
-
-    const rootRoute = new BaseRootRoute({})
-    const internalRoute = new BaseRoute({
-      getParentRoute: () => rootRoute,
-      path: '/internal',
-      component: () => 'Internal',
-    })
-
+  it('applies round-tripped custom hydration before matching a rewritten location', async () => {
     const rewrite: LocationRewrite = {
       input: ({ url }) => {
         if (url.pathname === '/public') {
@@ -417,54 +507,75 @@ describe('hydrate', () => {
         }
         return url
       },
+      output: ({ url }) => {
+        if (url.pathname === '/internal') {
+          url.pathname = '/public'
+        }
+        return url
+      },
     }
 
-    mockRouter = createTestRouter({
-      routeTree: rootRoute.addChildren([internalRoute]),
-      history,
+    const serverRootRoute = new BaseRootRoute({})
+    const serverInternalRoute = new BaseRoute({
+      getParentRoute: () => serverRootRoute,
+      path: '/internal',
+      loader: () => 'server internal data',
+    })
+    const serverRouter = createTestRouter({
+      routeTree: serverRootRoute.addChildren([serverInternalRoute]),
+      history: createMemoryHistory({ initialEntries: ['/public'] }),
+      rewrite,
+      dehydrate: () => ({ rewrite: true }),
       isServer: true,
-      hydrate: (dehydrated: { rewrite?: boolean }) => {
-        if (dehydrated.rewrite) {
-          mockRouter.update({ rewrite })
-        }
-      },
     })
 
-    mockWindow.$_TSR = {
-      router: {
-        manifest: testManifest,
-        dehydratedData: { rewrite: true },
-        lastMatchId: '/internal/internal',
-        matches: [
-          {
-            i: '__root__/',
-            s: 'success',
-            ssr: true,
-            u: Date.now(),
-          },
-          {
-            i: '/internal/internal',
-            s: 'success',
-            ssr: true,
-            u: Date.now(),
-          },
-        ],
-      },
-      h: vi.fn(),
-      e: vi.fn(),
-      c: vi.fn(),
-      p: vi.fn(),
-      buffer: [],
-      initialized: false,
-    }
+    mockWindow.$_TSR = await dehydrateToBootstrap(serverRouter)
 
-    await hydrate(mockRouter)
+    const clientLoader = vi.fn(() => 'client internal data')
+    const clientRootRoute = new BaseRootRoute({})
+    const clientInternalRoute = new BaseRoute({
+      getParentRoute: () => clientRootRoute,
+      path: '/internal',
+      loader: clientLoader,
+    })
+    let clientRouter: AnyRouter
+    const customHydrate = vi.fn((dehydrated: { rewrite?: boolean }) => {
+      if (dehydrated.rewrite) {
+        clientRouter.update({ rewrite })
+      }
+    })
+    clientRouter = createTestRouter({
+      routeTree: clientRootRoute.addChildren([clientInternalRoute]),
+      history: createMemoryHistory({ initialEntries: ['/public'] }),
+      hydrate: customHydrate,
+      isServer: false,
+    })
 
-    expect(mockRouter.state.location.pathname).toBe('/internal')
-    expect(mockRouter.state.location.publicHref).toBe('/public')
+    await hydrate(clientRouter)
+
+    expect(customHydrate).toHaveBeenCalledOnce()
+    expect(customHydrate).toHaveBeenCalledWith({ rewrite: true })
+    expect(clientRouter.state.location.pathname).toBe('/internal')
+    expect(clientRouter.state.location.publicHref).toBe('/public')
     expect(
-      mockRouter.state.matches.map((match: AnyRouteMatch) => match.routeId),
-    ).toEqual(['__root__', '/internal'])
+      clientRouter.state.matches.map((match: AnyRouteMatch) => ({
+        routeId: match.routeId,
+        status: match.status,
+        loaderData: match.loaderData,
+      })),
+    ).toEqual([
+      {
+        routeId: clientRootRoute.id,
+        status: 'success',
+        loaderData: undefined,
+      },
+      {
+        routeId: clientInternalRoute.id,
+        status: 'success',
+        loaderData: 'server internal data',
+      },
+    ])
+    expect(clientLoader).not.toHaveBeenCalled()
   })
 
   it('should handle errors during route context hydration', async () => {

--- a/packages/router-core/tests/issue-5106-hydrated-notfound-boundary.test.ts
+++ b/packages/router-core/tests/issue-5106-hydrated-notfound-boundary.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createMemoryHistory } from '@tanstack/history'
 import { BaseRootRoute, BaseRoute, isNotFound } from '../src'
 import { hydrate } from '../src/ssr/client'
+import { dehydrateSsrMatchId } from '../src/ssr/ssr-match-id'
 import { createTestRouter } from './routerTestUtils'
 import type { TsrSsrGlobal } from '../src/ssr/types'
 import type { Manifest } from '../src/manifest'
@@ -76,20 +77,20 @@ describe('hydrated child-owned notFound boundary coverage', () => {
         // terminal prefix includes the child match.
         matches: [
           {
-            i: matches[0]!.id,
+            i: dehydrateSsrMatchId(matches[0]!.id),
             s: 'success' as const,
             ssr: true,
             u: Date.now(),
           },
           {
-            i: matches[1]!.id,
+            i: dehydrateSsrMatchId(matches[1]!.id),
             s: 'success' as const,
             l: 'posts-data',
             ssr: true,
             u: Date.now(),
           },
           {
-            i: matches[2]!.id,
+            i: dehydrateSsrMatchId(matches[2]!.id),
             s: 'notFound' as const,
             e: { isNotFound: true },
             ssr: true,

--- a/packages/router-core/tests/issue-6221-head-waits-for-loader.test.ts
+++ b/packages/router-core/tests/issue-6221-head-waits-for-loader.test.ts
@@ -1,0 +1,91 @@
+import { createMemoryHistory } from '@tanstack/history'
+import { describe, expect, test } from 'vitest'
+import {
+  BaseRootRoute,
+  BaseRoute,
+  createControlledPromise,
+  notFound,
+} from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+// https://github.com/TanStack/router/issues/6221
+describe('issue #6221: head does not run before loader data is ready', () => {
+  test('existing-behavior control: head sees fresh loaderData after a notFound visit', async () => {
+    let authed = false
+    const articleResponse = createControlledPromise<{ title: string }>()
+    const successfulLoadStarted = createControlledPromise<void>()
+
+    const articleLoader = async () => {
+      if (!authed) {
+        await Promise.resolve()
+        throw notFound()
+      }
+
+      successfulLoadStarted.resolve()
+      return articleResponse
+    }
+
+    const rootRoute = new BaseRootRoute({})
+    const dashboardRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/dashboard',
+    })
+    const articleRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/article',
+      loader: articleLoader,
+      notFoundComponent: () => 'Not found',
+      head: ({ loaderData }) => ({
+        meta: [{ title: loaderData?.title ?? 'Generic title' }],
+      }),
+    })
+
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([dashboardRoute, articleRoute]),
+      history: createMemoryHistory({ initialEntries: ['/article'] }),
+    })
+    const backLoadFinished = createControlledPromise<void>()
+    let backLoadStarted = false
+    let unsubscribe: (() => void) | undefined
+
+    try {
+      await router.load()
+      const notFoundMatch = router.state.matches.find(
+        (match) => match.routeId === articleRoute.id,
+      )
+      expect(notFoundMatch?.status).toBe('notFound')
+      expect(notFoundMatch?.meta).toEqual([{ title: 'Generic title' }])
+
+      // Model the reported auth redirect and browser Back without relying on a
+      // wall-clock loader delay.
+      authed = true
+      await router.navigate({ to: '/dashboard' })
+      unsubscribe = router.history.subscribe(() => {
+        backLoadStarted = true
+        void router.load().then(
+          () => backLoadFinished.resolve(),
+          (error) => backLoadFinished.reject(error),
+        )
+      })
+      router.history.back()
+      await successfulLoadStarted
+      expect(articleResponse.status).toBe('pending')
+
+      articleResponse.resolve({ title: 'Article 123' })
+      await backLoadFinished
+
+      const articleMatch = router.state.matches.find(
+        (match) => match.routeId === articleRoute.id,
+      )
+      expect(articleMatch?.status).toBe('success')
+      expect(articleMatch?.loaderData).toEqual({ title: 'Article 123' })
+      expect(articleMatch?.meta).toEqual([{ title: 'Article 123' }])
+    } finally {
+      articleResponse.resolve({ title: 'Article 123' })
+      if (backLoadStarted) {
+        await backLoadFinished.catch(() => undefined)
+      }
+      unsubscribe?.()
+    }
+  })
+})

--- a/packages/router-core/tests/load.test.ts
+++ b/packages/router-core/tests/load.test.ts
@@ -153,12 +153,7 @@ describe('beforeLoad skip or exec', () => {
   test('exec on regular nav', async () => {
     const beforeLoad = vi.fn(() => Promise.resolve({ hello: 'world' }))
     const router = setup({ beforeLoad })
-    const navigation = router.navigate({ to: '/foo' })
-    expect(beforeLoad).toHaveBeenCalledTimes(1)
-    expect(router.stores.pendingMatches.get()).toEqual(
-      expect.arrayContaining([expect.objectContaining({ id: '/foo/foo' })]),
-    )
-    await navigation
+    await router.navigate({ to: '/foo' })
     expect(router.state.location.pathname).toBe('/foo')
     expect(router.state.matches).toEqual(
       expect.arrayContaining([
@@ -181,7 +176,6 @@ describe('beforeLoad skip or exec', () => {
 
     await router.navigate({ to: '/foo' })
 
-    expect(router.state.statusCode).toBe(500)
     expect(router.state.matches).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -202,10 +196,9 @@ describe('beforeLoad skip or exec', () => {
 
     await router.navigate({ to: '/foo' })
 
-    expect(router.state.statusCode).toBe(500)
-    expect(router.state.matches.find((d) => d.id === '/foo/foo')?.error).toBe(
-      thrown,
-    )
+    const match = router.state.matches.find((d) => d.id === '/foo/foo')
+    expect(match?.status).toBe('error')
+    expect(match?.error).toBe(thrown)
     expect(thrown).toEqual({ type: 'domain-error' })
   })
 
@@ -213,12 +206,10 @@ describe('beforeLoad skip or exec', () => {
     const beforeLoad = vi.fn()
     const router = setup({ beforeLoad })
     await router.preloadRoute({ to: '/foo' })
-    expect(router.stores.cachedMatches.get()).toEqual(
-      expect.arrayContaining([expect.objectContaining({ id: '/foo/foo' })]),
-    )
     await sleep(10)
     await router.navigate({ to: '/foo' })
 
+    expect(router.state.location.pathname).toBe('/foo')
     expect(beforeLoad).toHaveBeenCalledTimes(2)
   })
 
@@ -274,16 +265,11 @@ describe('beforeLoad skip or exec', () => {
       beforeLoad,
     })
     await router.preloadRoute({ to: '/foo' })
-    expect(
-      router.stores.cachedMatches.get().some((d) => d.status === 'redirected'),
-    ).toBe(false)
     await sleep(10)
     await router.navigate({ to: '/foo' })
 
     expect(router.state.location.pathname).toBe('/foo')
-    expect(
-      router.stores.cachedMatches.get().some((d) => d.status === 'redirected'),
-    ).toBe(false)
+    expect(router.state.matches.at(-1)?.status).toBe('success')
     expect(beforeLoad).toHaveBeenCalledTimes(2)
   })
 
@@ -421,12 +407,7 @@ describe('loader skip or exec', () => {
   test('exec on regular nav', async () => {
     const loader = vi.fn(() => Promise.resolve({ hello: 'world' }))
     const router = setup({ loader })
-    const navigation = router.navigate({ to: '/foo' })
-    expect(loader).toHaveBeenCalledTimes(1)
-    expect(router.stores.pendingMatches.get()).toEqual(
-      expect.arrayContaining([expect.objectContaining({ id: '/foo/foo' })]),
-    )
-    await navigation
+    await router.navigate({ to: '/foo' })
     expect(router.state.location.pathname).toBe('/foo')
     expect(router.state.matches).toEqual(
       expect.arrayContaining([
@@ -458,12 +439,10 @@ describe('loader skip or exec', () => {
     const loader = vi.fn()
     const router = setup({ loader, staleTime: 1000 })
     await router.preloadRoute({ to: '/foo' })
-    expect(router.stores.cachedMatches.get()).toEqual(
-      expect.arrayContaining([expect.objectContaining({ id: '/foo/foo' })]),
-    )
     await sleep(10)
     await router.navigate({ to: '/foo' })
 
+    expect(router.state.location.pathname).toBe('/foo')
     expect(loader).toHaveBeenCalledTimes(1)
   })
 
@@ -472,11 +451,9 @@ describe('loader skip or exec', () => {
     const router = setup({ loader })
     router.preloadRoute({ to: '/foo' })
     await Promise.resolve()
-    expect(router.stores.cachedMatches.get()).toEqual(
-      expect.arrayContaining([expect.objectContaining({ id: '/foo/foo' })]),
-    )
     await router.navigate({ to: '/foo' })
 
+    expect(router.state.location.pathname).toBe('/foo')
     expect(loader).toHaveBeenCalledTimes(1)
   })
 
@@ -519,20 +496,15 @@ describe('loader skip or exec', () => {
       loader,
     })
     await router.preloadRoute({ to: '/foo' })
-    expect(
-      router.stores.cachedMatches.get().some((d) => d.status === 'redirected'),
-    ).toBe(false)
     await sleep(10)
     await router.navigate({ to: '/foo' })
 
     expect(router.state.location.pathname).toBe('/foo')
-    expect(
-      router.stores.cachedMatches.get().some((d) => d.status === 'redirected'),
-    ).toBe(false)
+    expect(router.state.matches.at(-1)?.status).toBe('success')
     expect(loader).toHaveBeenCalledTimes(2)
   })
 
-  test('skip if pending preload (redirect)', async () => {
+  test('exec if pending preload redirects', async () => {
     const loader: Loader = vi.fn(async ({ preload }) => {
       await sleep(100)
       if (preload) throw redirect({ to: '/bar' })
@@ -542,15 +514,10 @@ describe('loader skip or exec', () => {
     })
     router.preloadRoute({ to: '/foo' })
     await Promise.resolve()
-    expect(
-      router.stores.cachedMatches.get().some((d) => d.status === 'redirected'),
-    ).toBe(false)
     await router.navigate({ to: '/foo' })
 
     expect(router.state.location.pathname).toBe('/bar')
-    expect(
-      router.stores.cachedMatches.get().some((d) => d.status === 'redirected'),
-    ).toBe(false)
+    expect(router.state.matches.at(-1)?.status).toBe('success')
     expect(loader).toHaveBeenCalledTimes(1)
   })
 
@@ -1204,6 +1171,9 @@ test('cancelMatches after pending timeout', async () => {
 })
 
 describe('head execution', () => {
+  const getTitle = (match: { meta?: unknown }) =>
+    (match.meta as Array<{ title?: string }> | undefined)?.[0]?.title
+
   const setupBeforeLoadNotFoundHierarchy = (throwAtIndex: 1 | 2 | 3) => {
     const loaderResolvers: Array<(() => void) | undefined> = []
 
@@ -1280,14 +1250,12 @@ describe('head execution', () => {
     const heads = routes.map(
       (route) => route.options.head as ReturnType<typeof makeHead>,
     )
-
     return {
       router,
       routes,
       loaders,
       heads,
       loaderResolvers,
-      throwAtIndex,
     }
   }
 
@@ -1303,26 +1271,27 @@ describe('head execution', () => {
     await Promise.resolve()
     await Promise.resolve()
 
-    for (let i = 0; i < routes.length; i++) {
-      const loader = loaders[i]!
-      const expectedCalls = i < throwAtIndex ? 1 : 0
-      expect(loader).toHaveBeenCalledTimes(expectedCalls)
-    }
-
     expect(loadResolved).toBe(false)
 
+    await vi.waitFor(() => {
+      loaders.forEach((loader, index) => {
+        expect(loader).toHaveBeenCalledTimes(index < throwAtIndex ? 1 : 0)
+      })
+    })
     for (let i = 0; i < throwAtIndex; i++) {
-      expect(loaderResolvers[i]).toBeDefined()
       loaderResolvers[i]!()
     }
 
     await loadPromise
 
-    for (let i = 0; i < heads.length; i++) {
-      const head = heads[i]!
-      const expectedCalls = i <= throwAtIndex ? 1 : 0
-      expect(head).toHaveBeenCalledTimes(expectedCalls)
-    }
+    const titles = router.state.matches.map(getTitle)
+    expect(titles.slice(0, throwAtIndex + 1)).toEqual(
+      ['Root', 'Level 1', 'Level 2', 'Level 3'].slice(0, throwAtIndex + 1),
+    )
+    expect(titles.slice(throwAtIndex + 1).every((title) => !title)).toBe(true)
+    heads.forEach((head, index) => {
+      expect(head).toHaveBeenCalledTimes(index <= throwAtIndex ? 1 : 0)
+    })
 
     for (let i = 0; i < throwAtIndex; i++) {
       const route = routes[i]!
@@ -1343,7 +1312,7 @@ describe('head execution', () => {
     })
   })
 
-  test('executes head once when loader throws notFound', async () => {
+  test('projects head when loader throws notFound', async () => {
     const head = vi.fn(() => ({ meta: [{ title: 'Test' }] }))
     const rootRoute = new BaseRootRoute({})
     const testRoute = new BaseRoute({
@@ -1362,16 +1331,16 @@ describe('head execution', () => {
 
     await router.load()
 
-    expect(head).toHaveBeenCalledTimes(1)
     const match = router.state.matches.find((m) => m.routeId === testRoute.id)
     expect(match?.status).toBe('notFound')
+    expect(match?.meta).toEqual([{ title: 'Test' }])
+    expect(head).toHaveBeenCalledTimes(1)
   })
 
   test('propagates sync beforeLoad non-notFound error running ancestor loaders and heads', async () => {
     const beforeLoadError = new Error('beforeLoad-sync-error')
     const rootLoader = vi.fn(() => ({ level: 0 }))
     const rootHead = vi.fn(() => ({ meta: [{ title: 'Root' }] }))
-
     const rootRoute = new BaseRootRoute({
       loader: rootLoader,
       head: rootHead,
@@ -1379,7 +1348,6 @@ describe('head execution', () => {
 
     const childLoader = vi.fn(() => ({ level: 1 }))
     const childHead = vi.fn(() => ({ meta: [{ title: 'Child' }] }))
-
     const childRoute = new BaseRoute({
       getParentRoute: () => rootRoute,
       path: '/test',
@@ -1396,23 +1364,17 @@ describe('head execution', () => {
       history: createMemoryHistory({ initialEntries: ['/test'] }),
     })
 
-    const location = router.latestLocation
-    const matches = router.matchRoutes(location)
-    router.stores.setPending(matches)
+    await router.load()
 
-    await expect(
-      loadMatches({
-        router,
-        location,
-        matches,
-        updateMatch: router.updateMatch,
-      }),
-    ).rejects.toBe(beforeLoadError)
+    expect(
+      router.state.matches.find((match) => match.routeId === childRoute.id)
+        ?.error,
+    ).toBe(beforeLoadError)
 
+    expect(router.state.matches[0]?.loaderData).toEqual({ level: 0 })
+    expect(router.state.matches.map(getTitle)).toEqual(['Root', 'Child'])
     expect(rootLoader).toHaveBeenCalledTimes(1)
-    expect(childLoader).toHaveBeenCalledTimes(0)
-    // Head functions still run for ancestors up to the erroring match so that
-    // SSR produces valid <head> content (e.g. charset, viewport, stylesheets).
+    expect(childLoader).not.toHaveBeenCalled()
     expect(rootHead).toHaveBeenCalledTimes(1)
     expect(childHead).toHaveBeenCalledTimes(1)
   })
@@ -1421,7 +1383,6 @@ describe('head execution', () => {
     const beforeLoadError = new Error('beforeLoad-async-error')
     const rootLoader = vi.fn(() => ({ level: 0 }))
     const rootHead = vi.fn(() => ({ meta: [{ title: 'Root' }] }))
-
     const rootRoute = new BaseRootRoute({
       loader: rootLoader,
       head: rootHead,
@@ -1429,7 +1390,6 @@ describe('head execution', () => {
 
     const childLoader = vi.fn(() => ({ level: 1 }))
     const childHead = vi.fn(() => ({ meta: [{ title: 'Child' }] }))
-
     const childRoute = new BaseRoute({
       getParentRoute: () => rootRoute,
       path: '/test',
@@ -1447,23 +1407,17 @@ describe('head execution', () => {
       history: createMemoryHistory({ initialEntries: ['/test'] }),
     })
 
-    const location = router.latestLocation
-    const matches = router.matchRoutes(location)
-    router.stores.setPending(matches)
+    await router.load()
 
-    await expect(
-      loadMatches({
-        router,
-        location,
-        matches,
-        updateMatch: router.updateMatch,
-      }),
-    ).rejects.toBe(beforeLoadError)
+    expect(
+      router.state.matches.find((match) => match.routeId === childRoute.id)
+        ?.error,
+    ).toBe(beforeLoadError)
 
+    expect(router.state.matches[0]?.loaderData).toEqual({ level: 0 })
+    expect(router.state.matches.map(getTitle)).toEqual(['Root', 'Child'])
     expect(rootLoader).toHaveBeenCalledTimes(1)
-    expect(childLoader).toHaveBeenCalledTimes(0)
-    // Head functions still run for ancestors up to the erroring match so that
-    // SSR produces valid <head> content (e.g. charset, viewport, stylesheets).
+    expect(childLoader).not.toHaveBeenCalled()
     expect(rootHead).toHaveBeenCalledTimes(1)
     expect(childHead).toHaveBeenCalledTimes(1)
   })
@@ -1975,7 +1929,6 @@ describe('params.parse notFound', () => {
 
     const match = router.state.matches.find((m) => m.routeId === testRoute.id)
     expect(match?.status).toBe('success')
-    expect(router.state.statusCode).toBe(200)
   })
 })
 

--- a/packages/router-core/tests/loader-architecture-regressions.test.ts
+++ b/packages/router-core/tests/loader-architecture-regressions.test.ts
@@ -1,0 +1,257 @@
+import { expect, test, vi } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import {
+  BaseRootRoute,
+  BaseRoute,
+  createControlledPromise,
+  redirect,
+} from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+test('a child can redirect after observing its parent loader error', async () => {
+  const rootRoute = new BaseRootRoute({})
+  const parentRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/parent',
+    loader: () => {
+      throw new Error('parent failed')
+    },
+  })
+  const childRoute = new BaseRoute({
+    getParentRoute: () => parentRoute,
+    path: '/child',
+    loader: async ({ parentMatchPromise }) => {
+      const parent = await parentMatchPromise
+      if (parent.status === 'error') {
+        throw redirect({ to: '/target' })
+      }
+      return parent.status
+    },
+  })
+  const targetRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/target',
+  })
+  const router = createTestRouter({
+    routeTree: rootRoute.addChildren([
+      parentRoute.addChildren([childRoute]),
+      targetRoute,
+    ]),
+    history: createMemoryHistory({
+      initialEntries: ['/parent/child'],
+    }),
+  })
+
+  await router.load()
+
+  expect(router.state.location.pathname).toBe('/target')
+  expect(router.state.matches.at(-1)).toMatchObject({
+    routeId: targetRoute.id,
+    status: 'success',
+  })
+})
+
+test('a descendant self-abort cannot hide redirecting onError on the client', async () => {
+  const parentGate = createControlledPromise<void>()
+  const childGate = createControlledPromise<void>()
+  const parentOnError = vi.fn()
+  const childOnError = vi.fn(() => {
+    throw redirect({ to: '/target' })
+  })
+  const rootRoute = new BaseRootRoute({})
+  const parentRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/parent',
+    loader: async () => {
+      await parentGate
+      throw new Error('parent failed')
+    },
+    onError: parentOnError,
+  })
+  const childRoute = new BaseRoute({
+    getParentRoute: () => parentRoute,
+    path: '/child',
+    loader: async ({ abortController }) => {
+      await childGate
+      abortController.abort()
+      throw new Error('child failed')
+    },
+    onError: childOnError,
+  })
+  const targetRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/target',
+  })
+  const router = createTestRouter({
+    routeTree: rootRoute.addChildren([
+      parentRoute.addChildren([childRoute]),
+      targetRoute,
+    ]),
+    history: createMemoryHistory({ initialEntries: ['/parent/child'] }),
+    isServer: false,
+  })
+
+  const loading = router.load()
+  parentGate.resolve()
+  await vi.waitFor(() => expect(parentOnError).toHaveBeenCalledOnce())
+  childGate.resolve()
+  await vi.waitFor(() => expect(childOnError).toHaveBeenCalledOnce())
+
+  await loading
+  expect(router.state.location.pathname).toBe('/target')
+})
+
+test('invalidation reruns the loader with same-id route context', async () => {
+  let contextGeneration = 0
+  let loaderGeneration = 0
+  const rootRoute = new BaseRootRoute({})
+  const route = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    context: () => ({ generation: ++contextGeneration }),
+    loader: ({ context }) => ({
+      loader: ++loaderGeneration,
+      context: context.generation,
+    }),
+  })
+  const router = createTestRouter({
+    routeTree: rootRoute.addChildren([route]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  await router.load()
+  expect(router.state.matches.at(-1)?.loaderData).toEqual({
+    loader: 1,
+    context: 1,
+  })
+
+  await router.invalidate()
+
+  expect(router.state.matches.at(-1)?.loaderData).toEqual({
+    loader: 2,
+    context: 1,
+  })
+})
+
+test('a joined descendant loader redirect still wins after an ancestor loader fails', async () => {
+  const childStarted = createControlledPromise<void>()
+  const childRedirect = createControlledPromise<void>()
+  const ancestorFailure = new Error('navigation parent failed')
+  let childLoads = 0
+
+  const rootRoute = new BaseRootRoute({})
+  const indexRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+  })
+  const parentRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/parent',
+    validateSearch: (search: Record<string, unknown>) => ({
+      mode: String(search.mode ?? ''),
+    }),
+    loaderDeps: ({ search }) => ({ mode: search.mode }),
+    loader: ({ location }) => {
+      if ((location.search as { mode: string }).mode === 'navigation') {
+        throw ancestorFailure
+      }
+      return 'preload parent data'
+    },
+    errorComponent: () => null,
+  })
+  const childRoute = new BaseRoute({
+    getParentRoute: () => parentRoute,
+    path: '/child',
+    loader: async () => {
+      childLoads++
+      if (childLoads === 1) {
+        childStarted.resolve()
+        await childRedirect
+        throw redirect({ to: '/target' })
+      }
+      return 'retried child data'
+    },
+  })
+  const targetRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/target',
+  })
+  const router = createTestRouter({
+    routeTree: rootRoute.addChildren([
+      indexRoute,
+      parentRoute.addChildren([childRoute]),
+      targetRoute,
+    ]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  await router.load()
+  const preload = router.preloadRoute({
+    to: '/parent/child',
+    search: { mode: 'preload' },
+  })
+  await childStarted
+
+  const navigation = router.navigate({
+    to: '/parent/child',
+    search: { mode: 'navigation' },
+  })
+  childRedirect.resolve()
+  await Promise.all([preload, navigation])
+
+  expect(router.state.location.pathname).toBe('/target')
+  expect(router.state.matches.at(-1)).toMatchObject({
+    routeId: targetRoute.id,
+    status: 'success',
+  })
+  expect(childLoads).toBe(1)
+})
+
+test('a reentrant user navigation starts a fresh redirect chain', async () => {
+  let navigateFresh: () => void
+  const rootRoute = new BaseRootRoute({})
+  const chain = Array.from(
+    { length: 20 },
+    (_, index) =>
+      new BaseRoute({
+        getParentRoute: () => rootRoute,
+        path: `/chain-${index}`,
+        beforeLoad:
+          index < 19
+            ? () => {
+                throw redirect({ to: `/chain-${index + 1}` })
+              }
+            : () => navigateFresh(),
+      }),
+  )
+  const freshRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/fresh',
+    beforeLoad: () => {
+      throw redirect({ to: '/target' })
+    },
+  })
+  const targetRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/target',
+  })
+  const router = createTestRouter({
+    routeTree: rootRoute.addChildren([
+      ...(chain as any),
+      freshRoute,
+      targetRoute,
+    ]) as any,
+    history: createMemoryHistory({ initialEntries: ['/chain-0'] }),
+  })
+  navigateFresh = () => {
+    void router.navigate({ to: '/fresh' })
+  }
+
+  await router.load()
+
+  expect(router.state.location.pathname).toBe('/target')
+  expect(router.state.matches.at(-1)).toMatchObject({
+    routeId: targetRoute.id,
+    status: 'success',
+  })
+})

--- a/packages/router-core/tests/loader-self-abort.test.ts
+++ b/packages/router-core/tests/loader-self-abort.test.ts
@@ -1,0 +1,59 @@
+import { expect, test, vi } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import { BaseRootRoute, BaseRoute } from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+test('a loader can fulfill after aborting its controller with isServer=false', async () => {
+  const rootRoute = new BaseRootRoute({})
+  const pageRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/page',
+    loader: ({ abortController }) => {
+      abortController.abort()
+      return 'accepted data'
+    },
+  })
+  const router = createTestRouter({
+    routeTree: rootRoute.addChildren([pageRoute]),
+    history: createMemoryHistory({ initialEntries: ['/page'] }),
+    isServer: false,
+  })
+
+  await router.load()
+
+  expect(router.state.matches.at(-1)).toMatchObject({
+    routeId: pageRoute.id,
+    status: 'success',
+    loaderData: 'accepted data',
+  })
+})
+
+test('a loader rejection remains an error after aborting its controller with isServer=false', async () => {
+  const failure = new Error('loader failed after aborting its controller')
+  const onError = vi.fn()
+  const rootRoute = new BaseRootRoute({})
+  const pageRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/page',
+    loader: ({ abortController }) => {
+      abortController.abort()
+      throw failure
+    },
+    errorComponent: () => null,
+    onError,
+  })
+  const router = createTestRouter({
+    routeTree: rootRoute.addChildren([pageRoute]),
+    history: createMemoryHistory({ initialEntries: ['/page'] }),
+    isServer: false,
+  })
+
+  await router.load()
+
+  expect(router.state.matches.at(-1)).toMatchObject({
+    routeId: pageRoute.id,
+    status: 'error',
+    error: failure,
+  })
+  expect(onError).toHaveBeenCalledWith(failure)
+})

--- a/packages/router-core/tests/masked-location-state-commit.test.ts
+++ b/packages/router-core/tests/masked-location-state-commit.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import { BaseRootRoute, BaseRoute } from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+test('a same-href navigation clears an expired mask from history state', async () => {
+  const makeRoutes = () => {
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const realRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/real',
+    })
+    const prettyRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/pretty',
+    })
+    return rootRoute.addChildren([indexRoute, realRoute, prettyRoute])
+  }
+  const history = createMemoryHistory({ initialEntries: ['/'] })
+
+  const router1 = createTestRouter({
+    routeTree: makeRoutes(),
+    history,
+    unmaskOnReload: true,
+  })
+  await router1.load()
+  await router1.navigate({ to: '/real', mask: { to: '/pretty' } })
+  expect(history.location.state.__tempLocation).toBeDefined()
+
+  // A fresh router over the same history models a page reload: the
+  // per-session temp key no longer matches, so the mask has expired and the
+  // literal URL resolves.
+  const router2 = createTestRouter({
+    routeTree: makeRoutes(),
+    history,
+    unmaskOnReload: true,
+  })
+  await router2.load()
+  expect(router2.state.location.pathname).toBe('/pretty')
+
+  // Navigating to the same href must still commit so the expired mask
+  // payload is dropped from history state, matching pre-lane behavior.
+  await router2.navigate({ to: '/pretty' })
+  expect(history.location.state.__tempLocation).toBeUndefined()
+})

--- a/packages/router-core/tests/parent-match-promise.test.ts
+++ b/packages/router-core/tests/parent-match-promise.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import { BaseRootRoute, BaseRoute } from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+test.each([false, true])(
+  'parentMatchPromise exposes successful parent state during loading with isServer=%s',
+  async (isServer) => {
+    const seen: Array<unknown> = []
+    const rootRoute = new BaseRootRoute({})
+    const parentRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/parent',
+      loader: () => 'parent data',
+    })
+    const childRoute = new BaseRoute({
+      getParentRoute: () => parentRoute,
+      path: '/child',
+      loader: async ({ parentMatchPromise }) => {
+        seen.push(await parentMatchPromise)
+      },
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([parentRoute.addChildren([childRoute])]),
+      history: createMemoryHistory({ initialEntries: ['/parent/child'] }),
+      isServer,
+    })
+
+    await router.load()
+
+    expect(seen).toHaveLength(1)
+    expect(seen[0]).toMatchObject({
+      routeId: parentRoute.id,
+      loaderData: 'parent data',
+      status: 'success',
+      invalid: false,
+      preload: false,
+      isFetching: false,
+    })
+  },
+)
+
+test('server parentMatchPromise exposes the error selected by onError', async () => {
+  const original = new Error('original')
+  const selected = new Error('selected')
+  let seen: unknown
+  const rootRoute = new BaseRootRoute({})
+  const parentRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/parent',
+    loader: () => {
+      throw original
+    },
+    onError: () => {
+      throw selected
+    },
+  })
+  const childRoute = new BaseRoute({
+    getParentRoute: () => parentRoute,
+    path: '/child',
+    loader: async ({ parentMatchPromise }) => {
+      seen = await parentMatchPromise
+    },
+  })
+  const router = createTestRouter({
+    routeTree: rootRoute.addChildren([parentRoute.addChildren([childRoute])]),
+    history: createMemoryHistory({ initialEntries: ['/parent/child'] }),
+    isServer: true,
+  })
+
+  await router.load()
+
+  expect(seen).toMatchObject({
+    routeId: parentRoute.id,
+    status: 'error',
+    error: selected,
+  })
+})

--- a/packages/router-core/tests/preload-adoption.test.ts
+++ b/packages/router-core/tests/preload-adoption.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import { BaseRootRoute, BaseRoute, createControlledPromise } from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('preload adoption', () => {
+  test('navigation waits for fresh data from an in-flight stale preload revalidation', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+
+    const revalidationGate = createControlledPromise<{
+      notifications: Array<string>
+    }>()
+    const revalidationStarted = createControlledPromise<void>()
+    let loaderCalls = 0
+
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const notificationsRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/notifications',
+      staleTime: 0,
+      preloadStaleTime: 0,
+      gcTime: 60_000,
+      loader: {
+        staleReloadMode: 'blocking',
+        handler: () => {
+          loaderCalls++
+          if (loaderCalls === 1) {
+            return { notifications: ['old'] }
+          }
+
+          revalidationStarted.resolve()
+          return revalidationGate
+        },
+      },
+    })
+
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute, notificationsRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+    await router.preloadRoute({ to: '/notifications' } as any)
+
+    expect(loaderCalls).toBe(1)
+
+    // The cached successful preload is now stale. A second hover starts a
+    // genuine revalidation while the user clicks the link.
+    vi.setSystemTime(1)
+    const revalidation = router.preloadRoute({
+      to: '/notifications',
+    } as any)
+    await revalidationStarted
+    expect(loaderCalls).toBe(2)
+
+    let navigationSettled = false
+    const navigation = router.navigate({ to: '/notifications' }).then(() => {
+      navigationSettled = true
+    })
+    await Promise.resolve()
+
+    // The navigation may share the revalidation, but it must not treat the
+    // stale cached snapshot as the completed result while fresh work runs.
+    expect(revalidationGate.status).toBe('pending')
+    expect(navigationSettled).toBe(false)
+
+    revalidationGate.resolve({ notifications: ['fresh'] })
+    await Promise.all([revalidation, navigation])
+
+    // A fix may either share the fresh revalidation or run a navigation
+    // loader of its own; correctness only requires publishing fresh data.
+    expect(loaderCalls).toBeGreaterThanOrEqual(2)
+    expect(
+      router.state.matches.find(
+        (match) => match.routeId === notificationsRoute.id,
+      )?.loaderData,
+    ).toEqual({ notifications: ['fresh'] })
+  })
+
+  test('a fulfilled undefined loader result is adopted as success', async () => {
+    const loaderGate = createControlledPromise<undefined>()
+    const loaderStarted = createControlledPromise<void>()
+    const loader = vi.fn(() => {
+      loaderStarted.resolve()
+      return loaderGate
+    })
+
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const fooRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/foo',
+      beforeLoad: vi.fn(),
+      loader,
+    })
+
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute, fooRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+
+    const preload = router.preloadRoute({ to: '/foo' })
+    await loaderStarted
+    const navigation = router.navigate({ to: '/foo' })
+    await Promise.resolve()
+    expect(loaderGate.status).toBe('pending')
+    expect(loader).toHaveBeenCalledTimes(1)
+
+    loaderGate.resolve(undefined)
+    await Promise.all([preload, navigation])
+
+    expect(loader).toHaveBeenCalledTimes(1)
+    const match = router.state.matches.find(
+      (candidate) => candidate.routeId === fooRoute.id,
+    )
+    expect(match?.status).toBe('success')
+    expect(match?.loaderData).toBeUndefined()
+  })
+})

--- a/packages/router-core/tests/preload-background-parent-coherence.test.ts
+++ b/packages/router-core/tests/preload-background-parent-coherence.test.ts
@@ -1,0 +1,88 @@
+import { expect, test, vi } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import { BaseRootRoute, BaseRoute, createControlledPromise } from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+test('unrelated parent background work does not block a cacheable child preload', async () => {
+  const backgroundResponse = createControlledPromise<{ revision: number }>()
+  const childLoaderStarted = createControlledPromise<void>()
+  let parentLoadCount = 0
+
+  const parentLoader = vi.fn(() => {
+    parentLoadCount++
+    return parentLoadCount === 1 ? { revision: 1 } : backgroundResponse
+  })
+  const childLoader = vi.fn(async ({ parentMatchPromise }) => {
+    childLoaderStarted.resolve()
+    const parentMatch = await parentMatchPromise
+    return {
+      parentRevision: (parentMatch.loaderData as { revision: number }).revision,
+    }
+  })
+
+  const rootRoute = new BaseRootRoute({})
+  const parentRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/parent',
+    loader: parentLoader,
+    staleTime: Infinity,
+  })
+  const childRoute = new BaseRoute({
+    getParentRoute: () => parentRoute,
+    path: '/child',
+    loader: childLoader,
+    staleTime: Infinity,
+  })
+
+  const router = createTestRouter({
+    routeTree: rootRoute.addChildren([parentRoute.addChildren([childRoute])]),
+    history: createMemoryHistory({ initialEntries: ['/parent'] }),
+  })
+
+  await router.load()
+  expect(parentLoader).toHaveBeenCalledTimes(1)
+
+  // Invalidating a successful loader uses the default background revalidation
+  // mode. The public invalidate promise settles once that private reload has
+  // started; its network response can remain pending.
+  await router.invalidate({
+    filter: (match) => match.routeId === parentRoute.id,
+  })
+  expect(parentLoader).toHaveBeenCalledTimes(2)
+
+  const childPreload = router.preloadRoute({ to: '/parent/child' })
+
+  await childLoaderStarted
+  expect(backgroundResponse.status).toBe('pending')
+  expect(parentLoader).toHaveBeenCalledTimes(2)
+  await childPreload
+
+  // Loader data is deliberately reusable across context generations. The
+  // child preload may finish from the visible parent generation without
+  // waiting for unrelated background work to win publication.
+  expect(backgroundResponse.status).toBe('pending')
+  expect(childLoader).toHaveBeenCalledTimes(1)
+
+  backgroundResponse.resolve({ revision: 2 })
+  await vi.waitFor(() =>
+    expect(
+      router.state.matches.find((match) => match.routeId === parentRoute.id)
+        ?.loaderData,
+    ).toEqual({ revision: 2 }),
+  )
+  expect(parentLoader).toHaveBeenCalledTimes(2)
+
+  await router.navigate({ to: '/parent/child' })
+
+  const parentMatch = router.state.matches.find(
+    (match) => match.routeId === parentRoute.id,
+  )
+  const childMatch = router.state.matches.find(
+    (match) => match.routeId === childRoute.id,
+  )
+
+  expect(parentLoader).toHaveBeenCalledTimes(2)
+  expect(childLoader).toHaveBeenCalledTimes(1)
+  expect(parentMatch?.loaderData).toEqual({ revision: 2 })
+  expect(childMatch?.loaderData).toEqual({ parentRevision: 1 })
+})

--- a/packages/router-core/tests/preload-beforeload-reuse.test.ts
+++ b/packages/router-core/tests/preload-beforeload-reuse.test.ts
@@ -1,0 +1,443 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import { BaseRootRoute, BaseRoute, createControlledPromise } from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('preloaded loader reuse with fresh beforeLoad context', () => {
+  test('reruns nested context for navigation while reusing loader data', async () => {
+    const parentBeforeLoad = vi.fn(({ preload }: { preload: boolean }) => ({
+      parent: preload ? 'preloaded parent' : 'loaded parent',
+    }))
+    const childBeforeLoad = vi.fn(
+      ({
+        context,
+        preload,
+      }: {
+        context: { parent: string }
+        preload: boolean
+      }) => ({
+        child: `${context.parent}:${preload}`,
+      }),
+    )
+    const childLoader = vi.fn(
+      ({
+        context,
+        preload,
+      }: {
+        context: { parent: string; child: string }
+        preload: boolean
+      }) => ({ context, preload }),
+    )
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const parentRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/parent',
+      staleTime: Infinity,
+      beforeLoad: parentBeforeLoad,
+    })
+    const childRoute = new BaseRoute({
+      getParentRoute: () => parentRoute,
+      path: '/child',
+      staleTime: Infinity,
+      beforeLoad: childBeforeLoad,
+      loader: childLoader,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([
+        indexRoute,
+        parentRoute.addChildren([childRoute]),
+      ]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+    await router.preloadRoute({ to: '/parent/child' })
+    await router.navigate({ to: '/parent/child' })
+
+    expect(parentBeforeLoad).toHaveBeenCalledTimes(2)
+    expect(parentBeforeLoad).toHaveBeenLastCalledWith(
+      expect.objectContaining({ preload: false }),
+    )
+    expect(childBeforeLoad).toHaveBeenCalledTimes(2)
+    expect(childBeforeLoad).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({ parent: 'loaded parent' }),
+        preload: false,
+      }),
+    )
+    expect(childLoader).toHaveBeenCalledTimes(1)
+    const match = router.state.matches.find(
+      (candidate) => candidate.routeId === childRoute.id,
+    )
+    expect(match?.context).toEqual({
+      parent: 'loaded parent',
+      child: 'loaded parent:false',
+    })
+    expect(match?.loaderData).toEqual({
+      context: {
+        parent: 'preloaded parent',
+        child: 'preloaded parent:true',
+      },
+      preload: true,
+    })
+  })
+
+  test.each([
+    { age: 50, expected: [false, true, false], guard: 'loaded' },
+    { age: 100, expected: [false, true, false], guard: 'loaded' },
+  ])(
+    'reruns completed beforeLoad while retaining navigation-owned loader data at age $age',
+    async ({ age, expected, guard }) => {
+      vi.useFakeTimers()
+      vi.setSystemTime(1_000)
+      const beforeLoad = vi.fn(({ preload }: { preload: boolean }) => ({
+        guard: preload ? 'preloaded' : 'loaded',
+      }))
+      const loader = vi.fn(({ preload }: { preload: boolean }) => preload)
+      const rootRoute = new BaseRootRoute({})
+      const indexRoute = new BaseRoute({
+        getParentRoute: () => rootRoute,
+        path: '/',
+      })
+      const guardedRoute = new BaseRoute({
+        getParentRoute: () => rootRoute,
+        path: '/guarded',
+        staleTime: Infinity,
+        preloadStaleTime: 100,
+        beforeLoad,
+        shouldReload: false,
+        loader,
+      })
+      const router = createTestRouter({
+        routeTree: rootRoute.addChildren([indexRoute, guardedRoute]),
+        history: createMemoryHistory({ initialEntries: ['/'] }),
+      })
+
+      await router.load()
+      await router.navigate({ to: '/guarded' })
+      await router.navigate({ to: '/' })
+      vi.setSystemTime(5_000)
+      await router.preloadRoute({ to: '/guarded' })
+      vi.setSystemTime(5_000 + age)
+      await router.navigate({ to: '/guarded' })
+
+      expect(beforeLoad.mock.calls.map(([context]) => context.preload)).toEqual(
+        expected,
+      )
+      expect(loader.mock.calls.map(([context]) => context.preload)).toEqual([
+        false,
+      ])
+      expect(router.state.matches.at(-1)?.context).toEqual({ guard })
+    },
+  )
+
+  test('does not cache beforeLoad-only context across an unrelated navigation', async () => {
+    const beforeLoad = vi.fn(({ preload }: { preload: boolean }) => ({
+      guard: preload ? 'preloaded' : 'loaded',
+    }))
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const otherRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/other',
+    })
+    const guardedRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/guarded',
+      preloadStaleTime: Infinity,
+      preloadGcTime: Infinity,
+      beforeLoad,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute, otherRoute, guardedRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+    await router.preloadRoute({ to: '/guarded' })
+    await router.navigate({ to: '/other' })
+    await router.navigate({ to: '/guarded' })
+
+    expect(beforeLoad.mock.calls.map(([context]) => context.preload)).toEqual([
+      true,
+      false,
+    ])
+    expect(router.state.matches.at(-1)?.context).toEqual({
+      guard: 'loaded',
+    })
+  })
+
+  test('does not reuse child context under a different parent match', async () => {
+    const childBeforeLoad = vi.fn(
+      ({
+        context,
+        preload,
+      }: {
+        context: { version: number }
+        preload: boolean
+      }) => ({
+        childVersion: context.version,
+      }),
+    )
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const parentRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/parent',
+      validateSearch: (search: Record<string, unknown>) => ({
+        version: Number(search.version),
+      }),
+      loaderDeps: ({ search }) => ({
+        version: search.version,
+      }),
+      context: ({ deps }: { deps: { version: number } }) => ({
+        version: deps.version,
+      }),
+    })
+    const childRoute = new BaseRoute({
+      getParentRoute: () => parentRoute,
+      path: '/child',
+      preloadStaleTime: Infinity,
+      beforeLoad: childBeforeLoad,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([
+        indexRoute,
+        parentRoute.addChildren([childRoute]),
+      ]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+    await router.preloadRoute({
+      to: '/parent/child',
+      search: { version: 1 },
+    })
+    await router.navigate({
+      to: '/parent/child',
+      search: { version: 2 },
+    })
+
+    expect(
+      childBeforeLoad.mock.calls.map(([context]) => context.preload),
+    ).toEqual([true, false])
+    expect(router.state.matches.at(-1)?.context).toEqual({
+      version: 2,
+      childVersion: 2,
+    })
+  })
+
+  test('reruns beforeLoad when the completed preload reaches its stale boundary', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    const seen: Array<boolean> = []
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const guardedRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/guarded',
+      staleTime: Infinity,
+      preloadStaleTime: 100,
+      beforeLoad: ({ preload }) => {
+        seen.push(preload)
+        return { generation: preload ? 'preload' : 'navigation' }
+      },
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute, guardedRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+    await router.preloadRoute({ to: '/guarded' })
+    vi.setSystemTime(1_100)
+    await router.navigate({ to: '/guarded' })
+
+    expect(seen).toEqual([true, false])
+    expect(router.state.matches.at(-1)?.context).toEqual({
+      generation: 'navigation',
+    })
+  })
+
+  test('reruns descendant context after an ancestor becomes stale', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    const parentSeen: Array<boolean> = []
+    const childSeen: Array<boolean> = []
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const parentRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/parent',
+      staleTime: Infinity,
+      preloadStaleTime: 100,
+      beforeLoad: ({ preload }) => {
+        parentSeen.push(preload)
+        return { parent: preload ? 'preloaded parent' : 'loaded parent' }
+      },
+    })
+    const childRoute = new BaseRoute({
+      getParentRoute: () => parentRoute,
+      path: '/child',
+      staleTime: Infinity,
+      preloadStaleTime: 1_000,
+      beforeLoad: ({ context, preload }) => {
+        childSeen.push(preload)
+        return { child: `${context.parent}:${preload}` }
+      },
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([
+        indexRoute,
+        parentRoute.addChildren([childRoute]),
+      ]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+    await router.preloadRoute({ to: '/parent/child' })
+    vi.setSystemTime(1_100)
+    await router.navigate({ to: '/parent/child' })
+
+    expect(parentSeen).toEqual([true, false])
+    expect(childSeen).toEqual([true, false])
+    expect(router.state.matches.at(-1)?.context).toEqual({
+      parent: 'loaded parent',
+      child: 'loaded parent:false',
+    })
+  })
+
+  test('invalidation prevents reuse of completed preload context', async () => {
+    const seen: Array<boolean> = []
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const guardedRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/guarded',
+      staleTime: Infinity,
+      beforeLoad: ({ preload }) => {
+        seen.push(preload)
+      },
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute, guardedRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+    await router.preloadRoute({ to: '/guarded' })
+    await router.invalidate({
+      filter: (match) => match.routeId === guardedRoute.id,
+    })
+    await router.navigate({ to: '/guarded' })
+
+    expect(seen).toEqual([true, false])
+  })
+
+  test('invalidation prevents adoption of context from an active preload', async () => {
+    const loaderGate = createControlledPromise<string>()
+    let generation = 1
+    const beforeLoad = vi.fn(({ preload }: { preload: boolean }) => ({
+      generation,
+      preload,
+    }))
+    const loader = vi.fn(() => loaderGate)
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const guardedRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/guarded',
+      staleTime: Infinity,
+      preloadStaleTime: Infinity,
+      beforeLoad,
+      loader,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute, guardedRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+    const preload = router.preloadRoute({ to: '/guarded' })
+    await vi.waitFor(() => expect(loader).toHaveBeenCalledOnce())
+
+    generation = 2
+    await router.invalidate()
+    const navigation = router.navigate({ to: '/guarded' })
+    await vi.waitFor(() => expect(beforeLoad).toHaveBeenCalledTimes(2))
+    loaderGate.resolve('shared loader data')
+    await Promise.all([preload, navigation])
+
+    expect(beforeLoad.mock.calls.map(([context]) => context.preload)).toEqual([
+      true,
+      false,
+    ])
+    expect(loader).toHaveBeenCalledOnce()
+    expect(router.state.matches.at(-1)?.context).toEqual({
+      generation: 2,
+      preload: false,
+    })
+    expect(router.state.matches.at(-1)?.loaderData).toBe('shared loader data')
+  })
+
+  test('preload false does not cache beforeLoad context for navigation', async () => {
+    const seen: Array<boolean> = []
+    const loader = vi.fn()
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const guardedRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/guarded',
+      preload: false,
+      staleTime: Infinity,
+      beforeLoad: ({ preload }) => {
+        seen.push(preload)
+      },
+      loader,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute, guardedRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+    await router.preloadRoute({ to: '/guarded' })
+
+    expect(seen).toEqual([true])
+    expect(loader).not.toHaveBeenCalled()
+
+    await router.navigate({ to: '/guarded' })
+
+    expect(seen).toEqual([true, false])
+    expect(loader).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/router-core/tests/preload-navigation-adoption.test.ts
+++ b/packages/router-core/tests/preload-navigation-adoption.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test, vi } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import { BaseRootRoute, BaseRoute, createControlledPromise } from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+describe('navigation adopting an in-flight preload', () => {
+  test('reruns beforeLoad when router context changes during an active preload', async () => {
+    const loaderGate = createControlledPromise<string>()
+    const beforeLoad = vi.fn(
+      ({
+        context,
+        preload,
+      }: {
+        context: { auth: boolean }
+        preload: boolean
+      }) => ({ authorization: `${context.auth}:${preload}` }),
+    )
+    const loader = vi.fn(() => loaderGate)
+    const rootRoute = new BaseRootRoute<any, undefined, { auth: boolean }>({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const guardedRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/guarded',
+      beforeLoad,
+      loader,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute, guardedRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+      context: { auth: false },
+    })
+
+    await router.load()
+    const preload = router.preloadRoute({ to: '/guarded' })
+    await vi.waitFor(() => expect(loader).toHaveBeenCalledTimes(1))
+
+    router.update({ ...router.options, context: { auth: true } })
+    const navigation = router.navigate({ to: '/guarded' })
+    await vi.waitFor(() => expect(beforeLoad).toHaveBeenCalledTimes(2))
+
+    expect(beforeLoad.mock.calls.map(([context]) => context.preload)).toEqual([
+      true,
+      false,
+    ])
+    expect(loader).toHaveBeenCalledTimes(1)
+
+    loaderGate.resolve('shared')
+    await Promise.all([preload, navigation])
+    expect(router.state.matches.at(-1)?.context).toEqual({
+      auth: true,
+      authorization: 'true:false',
+    })
+  })
+
+  test('reruns beforeLoad when user location state changes at the same href', async () => {
+    const loaderGate = createControlledPromise<string>()
+    const beforeLoad = vi.fn(
+      ({ location, preload }: { location: any; preload: boolean }) => ({
+        authorization: `${location.state.auth}:${preload}`,
+      }),
+    )
+    const loader = vi.fn(() => loaderGate)
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const guardedRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/guarded',
+      beforeLoad,
+      loader,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute, guardedRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+    const preload = router.preloadRoute({
+      to: '/guarded',
+      state: { auth: 'old' } as any,
+    })
+    await vi.waitFor(() => expect(loader).toHaveBeenCalledTimes(1))
+
+    const navigation = router.navigate({
+      to: '/guarded',
+      state: { auth: 'new' } as any,
+    })
+    await vi.waitFor(() => expect(beforeLoad).toHaveBeenCalledTimes(2))
+
+    expect(beforeLoad.mock.results.map((result) => result.value)).toEqual([
+      { authorization: 'old:true' },
+      { authorization: 'new:false' },
+    ])
+    expect(loader).toHaveBeenCalledTimes(1)
+
+    loaderGate.resolve('shared')
+    await Promise.all([preload, navigation])
+    expect(router.state.matches.at(-1)?.context).toMatchObject({
+      authorization: 'new:false',
+    })
+  })
+
+  test('reruns beforeLoad when the route tree changes during an active preload', async () => {
+    const loaderGate = createControlledPromise<string>()
+    const beforeLoad = vi.fn()
+    const loader = vi.fn(() => loaderGate)
+    const createRouteTree = () => {
+      const rootRoute = new BaseRootRoute({})
+      const indexRoute = new BaseRoute({
+        getParentRoute: () => rootRoute,
+        path: '/',
+      })
+      const guardedRoute = new BaseRoute({
+        getParentRoute: () => rootRoute,
+        path: '/guarded',
+        beforeLoad,
+        loader,
+      })
+      return rootRoute.addChildren([indexRoute, guardedRoute])
+    }
+    const router = createTestRouter({
+      routeTree: createRouteTree(),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+    const preload = router.preloadRoute({ to: '/guarded' })
+    await vi.waitFor(() => expect(loader).toHaveBeenCalledOnce())
+
+    router.update({ ...router.options, routeTree: createRouteTree() })
+    const navigation = router.navigate({ to: '/guarded' })
+    await vi.waitFor(() => expect(beforeLoad).toHaveBeenCalledTimes(2))
+
+    loaderGate.resolve('shared')
+    await Promise.all([preload, navigation])
+    expect(loader).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/router-core/tests/preload-public-cache-behavior.test.ts
+++ b/packages/router-core/tests/preload-public-cache-behavior.test.ts
@@ -1,0 +1,186 @@
+import { expect, test, vi } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import { BaseRootRoute, BaseRoute, createControlledPromise } from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+// Public contract: clearCache must remain authoritative even if an older
+// preload finishes unrelated asset work after the clear.
+test('clearCache during an in-flight preload cannot resurrect its borrowed data', async () => {
+  const headGate = createControlledPromise<{
+    meta: Array<{ title: string }>
+  }>()
+  let revision = 0
+  let headCalls = 0
+  const loader = vi.fn(() => ++revision)
+  const rootRoute = new BaseRootRoute({})
+  const homeRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+  })
+  const reportsRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/reports',
+    staleTime: Infinity,
+    preloadStaleTime: Infinity,
+    loader,
+    head: () => {
+      headCalls++
+      return headCalls === 1 ? { meta: [{ title: 'Reports' }] } : headGate
+    },
+  })
+  const router = createTestRouter({
+    routeTree: rootRoute.addChildren([homeRoute, reportsRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  await router.load()
+  await router.navigate({ to: '/reports' })
+  await router.navigate({ to: '/' })
+  expect(loader).toHaveBeenCalledTimes(1)
+
+  const preload = router.preloadRoute({ to: '/reports' })
+  await vi.waitFor(() => expect(headCalls).toBe(2))
+  expect(headGate.status).toBe('pending')
+  router.clearCache()
+  headGate.resolve({ meta: [{ title: 'Preloaded Reports' }] })
+  await preload
+
+  await router.navigate({ to: '/reports' })
+  expect(loader).toHaveBeenCalledTimes(2)
+  expect(
+    router.state.matches.find((match) => match.routeId === reportsRoute.id)
+      ?.loaderData,
+  ).toBe(2)
+})
+
+test('clearCache cancels a brand-new in-flight preload before it can populate the cache', async () => {
+  const firstLoad = createControlledPromise<string>()
+  const loader = vi
+    .fn<() => string | Promise<string>>()
+    .mockImplementationOnce(() => firstLoad)
+    .mockReturnValue('navigation data')
+  const rootRoute = new BaseRootRoute({})
+  const homeRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+  })
+  const reportsRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/reports',
+    preloadStaleTime: Infinity,
+    staleTime: Infinity,
+    loader,
+  })
+  const router = createTestRouter({
+    routeTree: rootRoute.addChildren([homeRoute, reportsRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  await router.load()
+  const preload = router.preloadRoute({ to: '/reports' })
+  await vi.waitFor(() => expect(loader).toHaveBeenCalledTimes(1))
+
+  router.clearCache()
+  firstLoad.resolve('obsolete preload data')
+  await preload
+  await router.navigate({ to: '/reports' })
+
+  expect(loader).toHaveBeenCalledTimes(2)
+  expect(
+    router.state.matches.find((match) => match.routeId === reportsRoute.id)
+      ?.loaderData,
+  ).toBe('navigation data')
+})
+
+// Probe, not a required cancellation policy: invalidating the accepted route
+// need not cancel unrelated private preload work, but the public operations
+// must both settle and leave navigation usable.
+test('invalidate and an unrelated in-flight preload both settle cleanly', async () => {
+  const loaderGate = createControlledPromise<string>()
+  const loader = vi.fn(() => loaderGate)
+  const rootRoute = new BaseRootRoute({})
+  const homeRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+  })
+  const targetRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/target',
+    preloadStaleTime: Infinity,
+    staleTime: Infinity,
+    loader,
+  })
+  const router = createTestRouter({
+    routeTree: rootRoute.addChildren([homeRoute, targetRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  await router.load()
+  const preload = router.preloadRoute({ to: '/target' })
+  await vi.waitFor(() => expect(loader).toHaveBeenCalledTimes(1))
+  expect(loaderGate.status).toBe('pending')
+  await router.invalidate()
+  expect(loaderGate.status).toBe('pending')
+  loaderGate.resolve('target data')
+  await preload
+
+  await router.navigate({ to: '/target' })
+  expect(router.state.location.pathname).toBe('/target')
+  expect(
+    router.state.matches.find((match) => match.routeId === targetRoute.id)
+      ?.loaderData,
+  ).toBe('target data')
+  expect(loader).toHaveBeenCalledTimes(1)
+})
+
+// Preload lanes are not cancelled by unrelated navigations: an in-flight
+// async beforeLoad runs to completion, its loader still executes and seeds
+// the cache, and a later navigation to the target reuses that work.
+test('an unrelated navigation does not cancel an in-flight preload beforeLoad', async () => {
+  const beforeLoadGate = createControlledPromise<{ token: string }>()
+  const beforeLoad = vi.fn(() => beforeLoadGate)
+  const loader = vi.fn(() => 'target data')
+  const rootRoute = new BaseRootRoute({})
+  const homeRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+  })
+  const otherRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/other',
+  })
+  const targetRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/target',
+    preloadStaleTime: Infinity,
+    staleTime: Infinity,
+    beforeLoad,
+    loader,
+  })
+  const router = createTestRouter({
+    routeTree: rootRoute.addChildren([homeRoute, otherRoute, targetRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  await router.load()
+  const preload = router.preloadRoute({ to: '/target' })
+  await vi.waitFor(() => expect(beforeLoad).toHaveBeenCalledTimes(1))
+
+  // Unrelated navigation commits while the preload's beforeLoad is pending.
+  await router.navigate({ to: '/other' })
+  expect(router.state.location.pathname).toBe('/other')
+
+  beforeLoadGate.resolve({ token: 'ctx' })
+  await preload
+  // The preload completed its work despite the navigation.
+  expect(loader).toHaveBeenCalledTimes(1)
+
+  // Navigating to the target consumes the seeded cache without a new load.
+  await router.navigate({ to: '/target' })
+  expect(router.state.location.pathname).toBe('/target')
+  expect(
+    router.state.matches.find((match) => match.routeId === targetRoute.id)
+      ?.loaderData,
+  ).toBe('target data')
+  expect(loader).toHaveBeenCalledTimes(1)
+})

--- a/packages/router-core/tests/public-client-loading-contract.test.ts
+++ b/packages/router-core/tests/public-client-loading-contract.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test, vi } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import {
+  BaseRootRoute,
+  BaseRoute,
+  createControlledPromise,
+  redirect,
+} from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+describe('public client loading contracts', () => {
+  test('blocking loading is observable through match isFetching', async () => {
+    const loaderGate = createControlledPromise<string>()
+    const loader = vi.fn(() => loaderGate)
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const targetRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/target',
+      pendingMs: 0,
+      pendingComponent: () => null,
+      loader,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute, targetRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+    const navigation = router.navigate({ to: '/target' })
+
+    await vi.waitFor(() => expect(loader).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() =>
+      expect(
+        router.state.matches.find((match) => match.routeId === targetRoute.id),
+      ).toMatchObject({ status: 'pending', isFetching: 'loader' }),
+    )
+
+    loaderGate.resolve('target data')
+    await navigation
+
+    expect(router.state.matches.at(-1)).toMatchObject({
+      routeId: targetRoute.id,
+      status: 'success',
+      isFetching: false,
+      loaderData: 'target data',
+    })
+  })
+
+  test('a background descendant redirect wins after a blocking ancestor loader fails', async () => {
+    const childStarted = createControlledPromise<void>()
+    const childRedirect = createControlledPromise<void>()
+    const parentError = new Error('parent failed')
+    let parentLoads = 0
+    let childLoads = 0
+
+    const rootRoute = new BaseRootRoute({})
+    const parentRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/parent',
+      loader: {
+        staleReloadMode: 'blocking',
+        handler: async () => {
+          if (++parentLoads === 1) {
+            return 'parent data'
+          }
+          await childStarted
+          throw parentError
+        },
+      },
+      errorComponent: () => null,
+    })
+    const childRoute = new BaseRoute({
+      getParentRoute: () => parentRoute,
+      path: '/child',
+      loader: async () => {
+        if (++childLoads === 1) {
+          return 'child data'
+        }
+        childStarted.resolve()
+        await childRedirect
+        throw redirect({ to: '/target' })
+      },
+    })
+    const targetRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/target',
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([
+        parentRoute.addChildren([childRoute]),
+        targetRoute,
+      ]),
+      history: createMemoryHistory({ initialEntries: ['/parent/child'] }),
+    })
+
+    await router.load()
+    const invalidation = router.invalidate()
+    await childStarted
+    childRedirect.resolve()
+    await invalidation
+
+    expect(router.state.location.pathname).toBe('/target')
+    expect(router.state.matches.at(-1)).toMatchObject({
+      routeId: targetRoute.id,
+      status: 'success',
+    })
+    expect(
+      router.state.matches.some((match) => match.error === parentError),
+    ).toBe(false)
+  })
+})

--- a/packages/router-core/tests/public-preload-lane-contract.test.ts
+++ b/packages/router-core/tests/public-preload-lane-contract.test.ts
@@ -1,0 +1,546 @@
+import { describe, expect, test, vi } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import {
+  BaseRootRoute,
+  BaseRoute,
+  createControlledPromise,
+  redirect,
+} from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+describe('public preload lane contracts', () => {
+  test.each([
+    {
+      difference: 'pathname',
+      preloadMask: { to: '/mask-a' },
+      navigationMask: { to: '/mask-b' },
+      preloadPathname: '/mask-a',
+      navigationPathname: '/mask-b',
+    },
+    {
+      difference: 'unmaskOnReload',
+      preloadMask: { to: '/mask-a' },
+      navigationMask: { to: '/mask-a', unmaskOnReload: true },
+      preloadPathname: '/mask-a',
+      navigationPathname: '/mask-a',
+    },
+    {
+      difference: 'search',
+      preloadMask: { to: '/mask-a', search: { source: 'preload' } },
+      navigationMask: { to: '/mask-a', search: { source: 'navigation' } },
+      preloadPathname: '/mask-a',
+      navigationPathname: '/mask-a',
+    },
+    {
+      difference: 'state',
+      preloadMask: { to: '/mask-a', state: { source: 'preload' } },
+      navigationMask: { to: '/mask-a', state: { source: 'navigation' } },
+      preloadPathname: '/mask-a',
+      navigationPathname: '/mask-a',
+    },
+  ])(
+    'navigation reruns beforeLoad for a different explicit mask $difference on the same destination',
+    async ({
+      preloadMask,
+      navigationMask,
+      preloadPathname,
+      navigationPathname,
+    }) => {
+      const beforeLoadGate = createControlledPromise<void>()
+      const loaderGate = createControlledPromise<string>()
+      const beforeLoad = vi.fn(
+        async (context: {
+          location: { maskedLocation?: { pathname: string } }
+          preload: boolean
+        }) => {
+          if (context.preload) {
+            await beforeLoadGate
+          }
+          return { source: context.preload ? 'preload' : 'navigation' }
+        },
+      )
+      const loader = vi.fn(() => loaderGate)
+      const rootRoute = new BaseRootRoute({})
+      const indexRoute = new BaseRoute({
+        getParentRoute: () => rootRoute,
+        path: '/',
+      })
+      const targetRoute = new BaseRoute({
+        getParentRoute: () => rootRoute,
+        path: '/target',
+        beforeLoad,
+        loader,
+      })
+      const maskARoute = new BaseRoute({
+        getParentRoute: () => rootRoute,
+        path: '/mask-a',
+      })
+      const maskBRoute = new BaseRoute({
+        getParentRoute: () => rootRoute,
+        path: '/mask-b',
+      })
+      const router = createTestRouter({
+        routeTree: rootRoute.addChildren([
+          indexRoute,
+          targetRoute,
+          maskARoute,
+          maskBRoute,
+        ]),
+        ...('search' in preloadMask ? { stringifySearch: () => '' } : {}),
+        history: createMemoryHistory({ initialEntries: ['/'] }),
+      })
+
+      let preload: Promise<unknown> | undefined
+      let navigation: Promise<unknown> | undefined
+      try {
+        await router.load()
+        preload = router.preloadRoute({
+          to: '/target',
+          mask: preloadMask as any,
+        })
+        await vi.waitFor(() => expect(beforeLoad).toHaveBeenCalledTimes(1))
+
+        beforeLoadGate.resolve()
+        await vi.waitFor(() => expect(loader).toHaveBeenCalledTimes(1))
+
+        navigation = router.navigate({
+          to: '/target',
+          mask: navigationMask as any,
+        })
+        await vi.waitFor(() =>
+          expect(
+            beforeLoad.mock.calls.map(([callContext]) => ({
+              preload: callContext.preload,
+              pathname: callContext.location.maskedLocation?.pathname,
+            })),
+          ).toEqual([
+            { preload: true, pathname: preloadPathname },
+            { preload: false, pathname: navigationPathname },
+          ]),
+        )
+
+        loaderGate.resolve('shared loader data')
+        await Promise.all([preload, navigation])
+
+        expect(router.state.matches.at(-1)?.context).toEqual({
+          source: 'navigation',
+        })
+        expect(router.history.location.pathname).toBe(navigationPathname)
+        expect(loader).toHaveBeenCalledTimes(1)
+      } finally {
+        beforeLoadGate.resolve()
+        loaderGate.resolve('shared loader data')
+        const activeWork: Array<Promise<unknown>> = []
+        if (preload) {
+          activeWork.push(preload)
+        }
+        if (navigation) {
+          activeWork.push(navigation)
+        }
+        await Promise.allSettled(activeWork)
+      }
+    },
+  )
+
+  test('navigation does not adopt beforeLoad from an active preload with different params', async () => {
+    const beforeLoadGate = createControlledPromise<void>()
+    const beforeLoad = vi.fn(async ({ preload }: { preload: boolean }) => {
+      await beforeLoadGate
+      return { preload }
+    })
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const itemsRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/items/$itemId',
+      beforeLoad,
+    })
+    const firstRoute = new BaseRoute({
+      getParentRoute: () => itemsRoute,
+      path: '/first',
+    })
+    const secondRoute = new BaseRoute({
+      getParentRoute: () => itemsRoute,
+      path: '/second',
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([
+        indexRoute,
+        itemsRoute.addChildren([firstRoute, secondRoute]),
+      ]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+    const preload = router.preloadRoute({
+      to: '/items/$itemId/first',
+      params: { itemId: 'one' },
+    })
+    await vi.waitFor(() => expect(beforeLoad).toHaveBeenCalledTimes(1))
+
+    const navigation = router.navigate({
+      to: '/items/$itemId/first',
+      params: { itemId: 'two' },
+    })
+    await vi.waitFor(() => expect(beforeLoad).toHaveBeenCalledTimes(2))
+
+    beforeLoadGate.resolve()
+    await Promise.all([preload, navigation])
+
+    expect(beforeLoad.mock.calls.map(([context]) => context.preload)).toEqual([
+      true,
+      false,
+    ])
+    expect(router.state.location.pathname).toBe('/items/two/first')
+    expect(router.state.location.search).toEqual({})
+    expect(router.state.matches.at(-1)?.context).toEqual({ preload: false })
+  })
+
+  test('a different full navigation lane reruns beforeLoad but reuses active same-id loader work', async () => {
+    const loaderGate = createControlledPromise<string>()
+    const beforeLoad = vi.fn(({ preload }: { preload: boolean }) => ({
+      source: preload ? 'preload' : 'navigation',
+    }))
+    const loader = vi.fn(() => loaderGate)
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const parentRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/parent',
+      beforeLoad,
+      loader,
+    })
+    const firstRoute = new BaseRoute({
+      getParentRoute: () => parentRoute,
+      path: '/first',
+    })
+    const secondRoute = new BaseRoute({
+      getParentRoute: () => parentRoute,
+      path: '/second',
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([
+        indexRoute,
+        parentRoute.addChildren([firstRoute, secondRoute]),
+      ]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+    const preload = router.preloadRoute({ to: '/parent/first' })
+    await vi.waitFor(() => expect(loader).toHaveBeenCalledTimes(1))
+
+    const navigation = router.navigate({ to: '/parent/second' })
+    await vi.waitFor(() => expect(beforeLoad).toHaveBeenCalledTimes(2))
+
+    expect(loader).toHaveBeenCalledTimes(1)
+    loaderGate.resolve('shared parent data')
+    await Promise.all([preload, navigation])
+
+    expect(beforeLoad.mock.calls.map(([context]) => context.preload)).toEqual([
+      true,
+      false,
+    ])
+    expect(loader).toHaveBeenCalledTimes(1)
+    expect(router.state.matches.at(-1)?.routeId).toBe(secondRoute.id)
+    expect(
+      router.state.matches.find((match) => match.routeId === parentRoute.id),
+    ).toMatchObject({
+      context: { source: 'navigation' },
+      loaderData: 'shared parent data',
+    })
+  })
+
+  test('different same-href preload lanes rerun beforeLoad but share loader work by match id', async () => {
+    const loaderGate = createControlledPromise<string>()
+    const beforeLoad = vi.fn()
+    const loader = vi.fn(() => loaderGate)
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const parentRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/parent',
+      validateSearch: (search: Record<string, unknown>) => ({
+        version: Number(search.version),
+      }),
+      beforeLoad,
+      loader,
+    })
+    const firstRoute = new BaseRoute({
+      getParentRoute: () => parentRoute,
+      path: '/first',
+    })
+    const secondRoute = new BaseRoute({
+      getParentRoute: () => parentRoute,
+      path: '/second',
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([
+        indexRoute,
+        parentRoute.addChildren([firstRoute, secondRoute]),
+      ]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+      stringifySearch: () => '',
+    })
+
+    await router.load()
+    const first = router.preloadRoute({
+      to: '/parent/first',
+      search: { version: 1 },
+    })
+    await vi.waitFor(() => expect(loader).toHaveBeenCalledTimes(1))
+    const second = router.preloadRoute({
+      to: '/parent/first',
+      search: { version: 2 },
+    })
+    await vi.waitFor(() => expect(beforeLoad).toHaveBeenCalledTimes(2))
+
+    expect(loader).toHaveBeenCalledTimes(1)
+    loaderGate.resolve('parent data')
+    await Promise.all([first, second])
+
+    expect(beforeLoad).toHaveBeenCalledTimes(2)
+    expect(loader).toHaveBeenCalledTimes(1)
+  })
+
+  test('completed preloads cache loader data but not beforeLoad context', async () => {
+    const beforeLoad = vi.fn(({ preload }: { preload: boolean }) => ({
+      source: preload ? 'preload' : 'navigation',
+    }))
+    const loader = vi.fn(
+      ({ context }: { context: { source: string } }) => context.source,
+    )
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const targetRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/target',
+      staleTime: Infinity,
+      preloadStaleTime: Infinity,
+      beforeLoad,
+      loader,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute, targetRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+    await router.preloadRoute({ to: '/target' })
+    await router.navigate({ to: '/target' })
+
+    expect(beforeLoad.mock.calls.map(([context]) => context.preload)).toEqual([
+      true,
+      false,
+    ])
+    expect(loader).toHaveBeenCalledTimes(1)
+    expect(router.state.matches.at(-1)).toMatchObject({
+      context: { source: 'navigation' },
+      loaderData: 'preload',
+    })
+  })
+
+  test('navigation retries an adopted preload lane that failed', async () => {
+    const preloadGate = createControlledPromise<void>()
+    const beforeLoad = vi.fn(async ({ preload }: { preload: boolean }) => {
+      if (preload) {
+        await preloadGate
+        throw new Error('preload failed')
+      }
+      return { source: 'navigation' }
+    })
+    const loader = vi.fn(() => 'navigation data')
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const targetRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/target',
+      beforeLoad,
+      loader,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute, targetRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+    const preload = router.preloadRoute({ to: '/target' })
+    await vi.waitFor(() => expect(beforeLoad).toHaveBeenCalledTimes(1))
+    const navigation = router.navigate({ to: '/target' })
+
+    preloadGate.resolve()
+    await Promise.all([preload, navigation])
+
+    expect(beforeLoad.mock.calls.map(([context]) => context.preload)).toEqual([
+      true,
+      false,
+    ])
+    expect(loader).toHaveBeenCalledTimes(1)
+    expect(router.state.matches.at(-1)).toMatchObject({
+      routeId: targetRoute.id,
+      status: 'success',
+      context: { source: 'navigation' },
+      loaderData: 'navigation data',
+    })
+  })
+
+  test('an expired same-id preload does not displace fresh unloaded data', async () => {
+    const loader = vi.fn(() => `loader data ${loader.mock.calls.length}`)
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const targetRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/target',
+      validateSearch: (search: Record<string, unknown>) => ({
+        revision: Number(search.revision ?? 1),
+      }),
+      shouldReload: ({ location }) =>
+        (location.search as { revision: number }).revision === 2,
+      preloadGcTime: 0,
+      gcTime: Infinity,
+      loader,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute, targetRoute]),
+      history: createMemoryHistory({
+        initialEntries: ['/target?revision=1'],
+      }),
+    })
+
+    await router.load()
+    await router.preloadRoute({
+      to: '/target',
+      search: { revision: 2 },
+    })
+    await router.navigate({ to: '/' })
+    await router.navigate({
+      to: '/target',
+      search: { revision: 1 },
+    })
+
+    expect(loader).toHaveBeenCalledTimes(2)
+    expect(router.state.matches.at(-1)?.loaderData).toBe('loader data 1')
+  })
+
+  test('filtered invalidation reloads every generation of the selected match id', async () => {
+    const loader = vi.fn(() => `loader data ${loader.mock.calls.length}`)
+    const rootRoute = new BaseRootRoute({})
+    const targetRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/target',
+      validateSearch: (search: Record<string, unknown>) => ({
+        revision: Number(search.revision ?? 1),
+      }),
+      shouldReload: ({ location }) =>
+        (location.search as { revision: number }).revision === 2
+          ? true
+          : undefined,
+      loader,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([targetRoute]),
+      history: createMemoryHistory({
+        initialEntries: ['/target?revision=1'],
+      }),
+    })
+
+    await router.load()
+    await router.preloadRoute({
+      to: '/target',
+      search: { revision: 2 },
+    })
+    await router.invalidate({
+      filter: (match) => (match.search as { revision?: number }).revision === 1,
+    })
+
+    expect(loader).toHaveBeenCalledTimes(3)
+    expect(router.state.matches.at(-1)?.loaderData).toBe('loader data 3')
+  })
+
+  test('preload false skips speculation but performs a blocking navigation load', async () => {
+    const loaderGate = createControlledPromise<string>()
+    const loader = vi.fn(() => loaderGate)
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const targetRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/target',
+      preload: false,
+      loader,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute, targetRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+    await router.preloadRoute({ to: '/target' })
+    expect(loader).not.toHaveBeenCalled()
+
+    let settled = false
+    const navigation = router.navigate({ to: '/target' }).then(() => {
+      settled = true
+    })
+    await vi.waitFor(() => expect(loader).toHaveBeenCalledTimes(1))
+    expect(settled).toBe(false)
+
+    loaderGate.resolve('target data')
+    await navigation
+
+    expect(router.state.matches.at(-1)).toMatchObject({
+      routeId: targetRoute.id,
+      status: 'success',
+      loaderData: 'target data',
+    })
+  })
+
+  test('forwards a document redirect at the redirect limit', async () => {
+    const beforeLoad = vi.fn(({ params }) => {
+      const hop = Number(params.hop)
+      throw redirect({
+        to: '/hop/$hop',
+        params: { hop: String(hop + 1) },
+        reloadDocument: hop === 20,
+      } as any)
+    })
+    const rootRoute = new BaseRootRoute({})
+    const hopRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/hop/$hop',
+      beforeLoad,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([hopRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    const matches = await router.preloadRoute({
+      to: '/hop/$hop',
+      params: { hop: '0' },
+    } as any)
+
+    expect(beforeLoad).toHaveBeenCalledTimes(21)
+    expect(matches).toBeUndefined()
+  })
+})

--- a/packages/router-core/tests/same-destination-navigation-join.test.ts
+++ b/packages/router-core/tests/same-destination-navigation-join.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test, vi } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import { BaseRootRoute, BaseRoute, createControlledPromise } from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+describe('same-destination navigation while one is in flight', () => {
+  function setup() {
+    const gate = createControlledPromise<string>()
+    const loader = vi.fn(() => gate)
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const targetRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/target',
+      loader,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute, targetRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+    return { router, loader, gate, targetRoute }
+  }
+
+  test('a second navigation to the same destination joins the in-flight load', async () => {
+    const { router, loader, gate, targetRoute } = setup()
+    await router.load()
+
+    const first = router.navigate({ to: '/target' })
+    await vi.waitFor(() => expect(loader).toHaveBeenCalledTimes(1))
+    const second = router.navigate({ to: '/target' })
+
+    gate.resolve('once')
+    await Promise.all([first, second])
+
+    expect(loader).toHaveBeenCalledTimes(1)
+    expect(router.state.matches.at(-1)).toMatchObject({
+      routeId: targetRoute.id,
+      status: 'success',
+      loaderData: 'once',
+    })
+  })
+
+  test('a double navigation in the same tick joins the in-flight load', async () => {
+    const { router, loader, gate, targetRoute } = setup()
+    await router.load()
+
+    const first = router.navigate({ to: '/target' })
+    const second = router.navigate({ to: '/target' })
+
+    gate.resolve('once')
+    await Promise.all([first, second])
+
+    expect(loader).toHaveBeenCalledTimes(1)
+    expect(router.state.matches.at(-1)).toMatchObject({
+      routeId: targetRoute.id,
+      status: 'success',
+      loaderData: 'once',
+    })
+  })
+
+  test('invalidate reruns the loader after the navigation settles', async () => {
+    const { router, loader, gate } = setup()
+    gate.resolve('data')
+    await router.load()
+    await router.navigate({ to: '/target' })
+    expect(loader).toHaveBeenCalledTimes(1)
+
+    await router.invalidate()
+
+    expect(loader).toHaveBeenCalledTimes(2)
+  })
+
+  test('a repeat navigation after settle reloads instead of joining', async () => {
+    const { router, loader, gate, targetRoute } = setup()
+    gate.resolve('data')
+    await router.load()
+    await router.navigate({ to: '/target' })
+
+    // Once the first navigation settles there is nothing to join: a repeat
+    // same-destination navigation keeps its refresh semantics.
+    await router.navigate({ to: '/target' })
+
+    expect(loader).toHaveBeenCalledTimes(2)
+    expect(router.state.matches.at(-1)).toMatchObject({
+      routeId: targetRoute.id,
+      status: 'success',
+    })
+  })
+})

--- a/packages/router-core/tests/serial-failure-foreground-prefix.test.ts
+++ b/packages/router-core/tests/serial-failure-foreground-prefix.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import { BaseRootRoute, BaseRoute } from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+/**
+ * When the serial beforeLoad phase records a failure, retained ancestor
+ * prefix loaders belong to the foreground failure lane: a stale ancestor
+ * must reload in the foreground commit rather than being deferred into a
+ * background batch that the boundary trim would discard.
+ */
+
+describe('serial failure keeps ancestor reloads in the foreground lane', () => {
+  test('a stale ancestor reloads with fresh data when a child beforeLoad fails', async () => {
+    let parentRuns = 0
+    let shouldFail = false
+
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const parentRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/parent',
+      staleTime: 0,
+      loader: () => `parent run ${++parentRuns}`,
+    })
+    const childRoute = new BaseRoute({
+      getParentRoute: () => parentRoute,
+      path: '/child',
+      errorComponent: {},
+      beforeLoad: () => {
+        if (shouldFail) {
+          throw new Error('child beforeLoad failed')
+        }
+      },
+    })
+
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([
+        indexRoute,
+        parentRoute.addChildren([childRoute]),
+      ]),
+      history: createMemoryHistory({ initialEntries: ['/parent/child'] }),
+    })
+
+    await router.load()
+    expect(parentRuns).toBe(1)
+
+    await router.navigate({ to: '/' })
+    shouldFail = true
+    await router.navigate({ to: '/parent/child' })
+
+    const parentMatch = router.state.matches.find(
+      (match) => match.routeId === parentRoute.id,
+    )
+    const childMatch = router.state.matches.find(
+      (match) => match.routeId === childRoute.id,
+    )
+
+    // The child committed its serial failure...
+    expect(childMatch?.status).toBe('error')
+    // ...and the stale parent reloaded in the SAME foreground lane: fresh
+    // loaderData is committed with the failure, not deferred to a discarded
+    // background batch.
+    expect(parentRuns).toBe(2)
+    expect(parentMatch?.loaderData).toBe('parent run 2')
+    expect(parentMatch?.status).toBe('success')
+  })
+})

--- a/packages/router-core/tests/server-beforeload-preload-flag.test.ts
+++ b/packages/router-core/tests/server-beforeload-preload-flag.test.ts
@@ -1,0 +1,25 @@
+import { createMemoryHistory } from '@tanstack/history'
+import { expect, test } from 'vitest'
+import { BaseRootRoute, BaseRoute } from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+test('server beforeLoad receives preload false', async () => {
+  const seen: Array<boolean> = []
+  const rootRoute = new BaseRootRoute({})
+  const childRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/child',
+    beforeLoad: ({ preload }) => {
+      seen.push(preload)
+    },
+  })
+  const router = createTestRouter({
+    routeTree: rootRoute.addChildren([childRoute]),
+    history: createMemoryHistory({ initialEntries: ['/child'] }),
+    isServer: true,
+  })
+
+  await router.load()
+
+  expect(seen).toEqual([false])
+})

--- a/packages/router-core/tests/server-loader-abort-error.test.ts
+++ b/packages/router-core/tests/server-loader-abort-error.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import { BaseRootRoute, BaseRoute } from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+describe('loader user-thrown abort values', () => {
+  test('treats a user-thrown AbortSignal as an ordinary route error (isServer=false)', async () => {
+    let matchSignal: AbortSignal | undefined
+    const rootRoute = new BaseRootRoute({})
+    const abortingRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/aborting',
+      loader: ({ abortController }) => {
+        matchSignal = abortController.signal
+        throw matchSignal
+      },
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([abortingRoute]),
+      history: createMemoryHistory({ initialEntries: ['/aborting'] }),
+      isServer: false,
+    })
+
+    await router.load()
+
+    const match = router.state.matches.find(
+      (item) => item.routeId === abortingRoute.id,
+    )
+    expect(matchSignal?.aborted).toBe(false)
+    expect(match?.status).toBe('error')
+    expect(match?.error).toBe(matchSignal)
+  })
+})

--- a/packages/router-core/tests/ssr-match-id.test.ts
+++ b/packages/router-core/tests/ssr-match-id.test.ts
@@ -21,6 +21,11 @@ describe('ssr match id codec', () => {
   })
 
   it('decodes browser-normalized replacement chars back to slashes', () => {
-    expect(hydrateSsrMatchId('\uFFFDposts\uFFFD1')).toBe('/posts/1')
+    const normalized = dehydrateSsrMatchId('/posts/1').replaceAll(
+      '\0',
+      '\uFFFD',
+    )
+
+    expect(hydrateSsrMatchId(normalized)).toBe('/posts/1')
   })
 })

--- a/packages/router-core/tests/superseded-load-await.test.ts
+++ b/packages/router-core/tests/superseded-load-await.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test, vi } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import { BaseRootRoute, BaseRoute, createControlledPromise } from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+/**
+ * Awaiting router.load() should remain a reliable synchronization point even
+ * when that load is superseded. If the abandoned load resolves immediately,
+ * callers can observe router state before the newer load has settled.
+ *
+ * This test starts a real public router.load() for /one, supersedes it with a
+ * real navigation to /two, and resolves only the abandoned /one loader. The
+ * original await should not settle until the superseding /two loader settles.
+ */
+
+const waitForMacrotask = () =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, 0)
+  })
+
+describe('superseded load await', () => {
+  test('router.load waits for a superseding navigation load to settle', async () => {
+    const firstLoaderGate = createControlledPromise<void>()
+    const secondLoaderGate = createControlledPromise<void>()
+    let firstLoaderCalls = 0
+    let secondLoaderCalls = 0
+    let secondLoaderSettled = false
+    let supersededLoadSettled = false
+
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const firstRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/one',
+      loader: async () => {
+        firstLoaderCalls++
+        await firstLoaderGate
+        return 'one'
+      },
+    })
+    const secondRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/two',
+      loader: async () => {
+        secondLoaderCalls++
+        await secondLoaderGate
+        secondLoaderSettled = true
+        return 'two'
+      },
+    })
+
+    const history = createMemoryHistory({ initialEntries: ['/'] })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute, firstRoute, secondRoute]),
+      history,
+    })
+
+    await router.load()
+
+    history.push('/one')
+    const supersededLoad = router.load().then(() => {
+      supersededLoadSettled = true
+    })
+    await vi.waitFor(() => expect(firstLoaderCalls).toBe(1))
+
+    const latestNavigation = router.navigate({ to: '/two' })
+    await vi.waitFor(() => expect(secondLoaderCalls).toBe(1))
+
+    firstLoaderGate.resolve()
+    await waitForMacrotask()
+
+    expect(secondLoaderSettled).toBe(false)
+    expect(supersededLoadSettled).toBe(false)
+
+    secondLoaderGate.resolve()
+    await Promise.all([supersededLoad, latestNavigation])
+
+    expect(secondLoaderSettled).toBe(true)
+    expect(supersededLoadSettled).toBe(true)
+    expect(router.state.location.pathname).toBe('/two')
+    expect(router.state.matches.at(-1)).toMatchObject({
+      routeId: secondRoute.id,
+      status: 'success',
+      loaderData: 'two',
+    })
+  })
+})

--- a/packages/router-plugin/tests/add-hmr.test.ts
+++ b/packages/router-plugin/tests/add-hmr.test.ts
@@ -105,7 +105,6 @@ describe('add-hmr works', () => {
     expect(output).toContain('webpackHot')
     expect(output).not.toContain('import.meta.hot')
     expect(output).toContain('oldHasShellComponent')
-    expect(output).toContain('__routeContext')
   })
 
   it('supports configurable Vite unsplittable HMR generation', async () => {

--- a/packages/router-plugin/tests/handle-route-update.test.ts
+++ b/packages/router-plugin/tests/handle-route-update.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 import {
   BaseRootRoute,
   BaseRoute,
@@ -6,9 +8,15 @@ import {
   createNonReactiveReadonlyStore,
   trimPathRight,
 } from '@tanstack/router-core'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { createMemoryHistory } from '../../history/src'
 import { getHandleRouteUpdateCode } from '../src/core/hmr'
 import type { AnyRoute, GetStoreConfig } from '@tanstack/router-core'
+
+vi.mock('@tanstack/router-core/isServer', async (importOriginal) => ({
+  ...(await importOriginal()),
+  isServer: undefined,
+}))
 
 const getStoreConfig: GetStoreConfig = () => ({
   createMutableStore: createNonReactiveMutableStore,
@@ -21,6 +29,10 @@ const getHandleRouteUpdate = () => {
     routeId: string,
     newRoute: AnyRoute,
   ) => void
+}
+
+function asAnyRoute<TRoute>(route: TRoute): TRoute & AnyRoute {
+  return route as unknown as TRoute & AnyRoute
 }
 
 function createTestHistory() {
@@ -51,10 +63,10 @@ function createTestHistory() {
   }
 }
 
-function createTestRouter(routeTree: AnyRoute) {
+function createTestRouter<TRouteTree>(routeTree: TRouteTree) {
   return new RouterCore(
     {
-      routeTree,
+      routeTree: asAnyRoute(routeTree),
       history: createTestHistory() as any,
       isServer: true,
     },
@@ -62,16 +74,49 @@ function createTestRouter(routeTree: AnyRoute) {
   )
 }
 
+function createClientTestRouter<TRouteTree>(
+  routeTree: TRouteTree,
+  initialEntry: string,
+) {
+  return new RouterCore(
+    {
+      routeTree: asAnyRoute(routeTree),
+      history: createMemoryHistory({ initialEntries: [initialEntry] }),
+      isServer: false,
+      origin: 'http://localhost',
+    },
+    getStoreConfig,
+  )
+}
+
 function withWindowRouter(router: RouterCore<any, any, any, any, any>) {
-  const previousWindow = (globalThis as any).window
-  ;(globalThis as any).window = { __TSR_ROUTER__: router }
+  const testWindow = globalThis.window as any
+  const hadOwnRouter = Object.prototype.hasOwnProperty.call(
+    testWindow,
+    '__TSR_ROUTER__',
+  )
+  const previousRouter = testWindow.__TSR_ROUTER__
+  testWindow.__TSR_ROUTER__ = router
 
   return () => {
-    if (previousWindow) {
-      ;(globalThis as any).window = previousWindow
+    if (hadOwnRouter) {
+      testWindow.__TSR_ROUTER__ = previousRouter
     } else {
-      delete (globalThis as any).window
+      delete testWindow.__TSR_ROUTER__
     }
+  }
+}
+
+function runHandleRouteUpdate<TRoute>(
+  router: RouterCore<any, any, any, any, any>,
+  routeId: string,
+  newRoute: TRoute,
+) {
+  const restoreWindow = withWindowRouter(router)
+  try {
+    getHandleRouteUpdate()(routeId, asAnyRoute(newRoute))
+  } finally {
+    restoreWindow()
   }
 }
 
@@ -86,25 +131,25 @@ describe('handleRouteUpdate', () => {
   it('keeps routesByPath pointed at an index route when a pathless layout updates', () => {
     const rootRoute = new BaseRootRoute({})
     const parentRoute = new BaseRoute({
-      getParentRoute: () => rootRoute,
+      getParentRoute: () => asAnyRoute(rootRoute),
       path: '/livestock/$farmId/medicine',
     })
     const pathlessRoute = new BaseRoute({
-      getParentRoute: () => parentRoute,
+      getParentRoute: () => asAnyRoute(parentRoute),
       id: '_form',
     })
     const newRoute = new BaseRoute({
-      getParentRoute: () => pathlessRoute,
+      getParentRoute: () => asAnyRoute(pathlessRoute),
       path: 'new',
     })
     const indexRoute = new BaseRoute({
-      getParentRoute: () => parentRoute,
+      getParentRoute: () => asAnyRoute(parentRoute),
       path: '/',
     })
     const routeTree = rootRoute.addChildren([
       parentRoute.addChildren([
-        pathlessRoute.addChildren([newRoute]),
-        indexRoute,
+        pathlessRoute.addChildren([asAnyRoute(newRoute)]),
+        asAnyRoute(indexRoute),
       ]),
     ])
     const router = createTestRouter(routeTree)
@@ -114,7 +159,10 @@ describe('handleRouteUpdate', () => {
 
     const restoreWindow = withWindowRouter(router)
     try {
-      getHandleRouteUpdate()(pathlessRoute.id, new BaseRoute({} as any))
+      getHandleRouteUpdate()(
+        pathlessRoute.id,
+        asAnyRoute(new BaseRoute({} as any)),
+      )
     } finally {
       restoreWindow()
     }
@@ -128,15 +176,15 @@ describe('handleRouteUpdate', () => {
   it('keeps an index route winning the trimmed path key when its parent updates', () => {
     const rootRoute = new BaseRootRoute({})
     const parentRoute = new BaseRoute({
-      getParentRoute: () => rootRoute,
+      getParentRoute: () => asAnyRoute(rootRoute),
       path: '/path',
     })
     const indexRoute = new BaseRoute({
-      getParentRoute: () => parentRoute,
+      getParentRoute: () => asAnyRoute(parentRoute),
       path: '/',
     })
     const routeTree = rootRoute.addChildren([
-      parentRoute.addChildren([indexRoute]),
+      parentRoute.addChildren([asAnyRoute(indexRoute)]),
     ])
     const router = createTestRouter(routeTree)
     const key = trimPathRight(indexRoute.fullPath)
@@ -145,7 +193,10 @@ describe('handleRouteUpdate', () => {
 
     const restoreWindow = withWindowRouter(router)
     try {
-      getHandleRouteUpdate()(parentRoute.id, new BaseRoute({} as any))
+      getHandleRouteUpdate()(
+        parentRoute.id,
+        asAnyRoute(new BaseRoute({} as any)),
+      )
     } finally {
       restoreWindow()
     }
@@ -159,7 +210,7 @@ describe('handleRouteUpdate', () => {
   it('refreshes matching data when params.parse changes', () => {
     const rootRoute = new BaseRootRoute({})
     const itemRoute = new BaseRoute({
-      getParentRoute: () => rootRoute,
+      getParentRoute: () => asAnyRoute(rootRoute),
       path: '/items/$itemId',
       params: {
         parse: ({ itemId }: { itemId: string }) => {
@@ -167,7 +218,7 @@ describe('handleRouteUpdate', () => {
         },
       },
     })
-    const routeTree = rootRoute.addChildren([itemRoute])
+    const routeTree = rootRoute.addChildren([asAnyRoute(itemRoute)])
     const router = createTestRouter(routeTree)
 
     expect(router.getMatchedRoutes('/items/abc').foundRoute?.id).toBeUndefined()
@@ -176,11 +227,13 @@ describe('handleRouteUpdate', () => {
     try {
       getHandleRouteUpdate()(
         itemRoute.id,
-        new BaseRoute({
-          params: {
-            parse: ({ itemId }: { itemId: string }) => ({ itemId }),
-          },
-        } as any),
+        asAnyRoute(
+          new BaseRoute({
+            params: {
+              parse: ({ itemId }: { itemId: string }) => ({ itemId }),
+            },
+          } as any),
+        ),
       )
     } finally {
       restoreWindow()
@@ -194,10 +247,10 @@ describe('handleRouteUpdate', () => {
   it('hydrates the hot module route export with generated route tree state', () => {
     const rootRoute = new BaseRootRoute({})
     const itemRoute = new BaseRoute({
-      getParentRoute: () => rootRoute,
+      getParentRoute: () => asAnyRoute(rootRoute),
       path: '/items/$itemId',
     })
-    const routeTree = rootRoute.addChildren([itemRoute])
+    const routeTree = rootRoute.addChildren([asAnyRoute(itemRoute)])
     const router = createTestRouter(routeTree)
     const newRoute = new BaseRoute({} as any)
 
@@ -205,7 +258,7 @@ describe('handleRouteUpdate', () => {
 
     const restoreWindow = withWindowRouter(router)
     try {
-      getHandleRouteUpdate()(itemRoute.id, newRoute)
+      getHandleRouteUpdate()(itemRoute.id, asAnyRoute(newRoute))
     } finally {
       restoreWindow()
     }
@@ -216,5 +269,115 @@ describe('handleRouteUpdate', () => {
     expect(newRoute.to).toBe(itemRoute.to)
     expect((newRoute as any).parentRoute).toBe(rootRoute)
     expect((newRoute as any).options).toBe((itemRoute as any).options)
+  })
+
+  it('removes stale loader data when a hot route removes its loader', async () => {
+    const rootRoute = new BaseRootRoute({})
+    const hotRoute = new BaseRoute({
+      getParentRoute: () => asAnyRoute(rootRoute),
+      path: '/hot',
+      loader: () => 'stale loader data',
+    })
+    const router = createClientTestRouter(
+      rootRoute.addChildren([asAnyRoute(hotRoute)]),
+      '/hot',
+    )
+    await router.load()
+
+    expect(router.state.matches.map((match) => match.routeId)).toEqual([
+      rootRoute.id,
+      hotRoute.id,
+    ])
+    expect(router.state.matches[1]!.loaderData).toBe('stale loader data')
+
+    const restoreWindow = withWindowRouter(router)
+    try {
+      getHandleRouteUpdate()(hotRoute.id, asAnyRoute(new BaseRoute({} as any)))
+      await vi.waitFor(() => {
+        expect(router.state.matches.map((match) => match.routeId)).toEqual([
+          rootRoute.id,
+          hotRoute.id,
+        ])
+        expect(router.state.matches[1]!.loaderData).toBeUndefined()
+      })
+    } finally {
+      restoreWindow()
+    }
+  })
+
+  it('does not run removed loader or beforeLoad callbacks on a later visit', async () => {
+    const beforeLoad = vi.fn(() => ({ hotBeforeLoad: true }))
+    const loader = vi.fn(() => 'hot loader data')
+    const rootRoute = new BaseRootRoute({})
+    const hotRoute = new BaseRoute({
+      getParentRoute: () => asAnyRoute(rootRoute),
+      path: '/hot',
+      beforeLoad,
+      loader,
+      staleTime: Infinity,
+      gcTime: Infinity,
+    })
+    const otherRoute = new BaseRoute({
+      getParentRoute: () => asAnyRoute(rootRoute),
+      path: '/other',
+    })
+    const router = createClientTestRouter(
+      rootRoute.addChildren([asAnyRoute(hotRoute), asAnyRoute(otherRoute)]),
+      '/hot',
+    )
+
+    await router.load()
+    await router.navigate({ to: '/other' })
+    expect(beforeLoad).toHaveBeenCalledTimes(1)
+    expect(loader).toHaveBeenCalledTimes(1)
+
+    runHandleRouteUpdate(router, hotRoute.id, new BaseRoute({} as any))
+    await router.navigate({ to: '/hot' })
+
+    const match = router.state.matches.find(
+      (candidate) => candidate.routeId === hotRoute.id,
+    )
+    expect(beforeLoad).toHaveBeenCalledTimes(1)
+    expect(loader).toHaveBeenCalledTimes(1)
+    expect(match).toBeDefined()
+    expect(match!.loaderData).toBeUndefined()
+    expect(match!.context).not.toHaveProperty('hotBeforeLoad')
+  })
+
+  it('does not cache an obsolete inactive preload that settles after a hot update', async () => {
+    let resolveOldLoader!: (value: string) => void
+    const oldLoaderResult = new Promise<string>((resolve) => {
+      resolveOldLoader = resolve
+    })
+    const oldLoader = vi.fn(() => oldLoaderResult)
+    const newLoader = vi.fn(() => 'hot')
+    const rootRoute = new BaseRootRoute({})
+    const hotRoute = new BaseRoute({
+      getParentRoute: () => asAnyRoute(rootRoute),
+      path: '/hot',
+      loader: oldLoader,
+      preloadStaleTime: Infinity,
+    })
+    const router = createClientTestRouter(
+      rootRoute.addChildren([asAnyRoute(hotRoute)]),
+      '/',
+    )
+
+    await router.load()
+    const preload = router.preloadRoute({ to: '/hot' })
+    await vi.waitFor(() => expect(oldLoader).toHaveBeenCalledOnce())
+
+    runHandleRouteUpdate(
+      router,
+      hotRoute.id,
+      new BaseRoute({ loader: newLoader } as any),
+    )
+
+    resolveOldLoader('obsolete')
+    await preload
+    await router.navigate({ to: '/hot' })
+
+    expect(newLoader).toHaveBeenCalledOnce()
+    expect(router.state.matches.at(-1)?.loaderData).toBe('hot')
   })
 })

--- a/packages/solid-router/tests/Matches.test.tsx
+++ b/packages/solid-router/tests/Matches.test.tsx
@@ -8,6 +8,7 @@ import {
   waitFor,
 } from '@solidjs/testing-library'
 import { createMemoryHistory } from '@tanstack/history'
+import { createControlledPromise } from '@tanstack/router-core'
 import {
   Link,
   MatchRoute,
@@ -152,6 +153,74 @@ test('should show pendingComponent of root route', async () => {
 
   expect(await rendered.findByTestId('root-pending')).toBeInTheDocument()
   expect(await rendered.findByTestId('root-content')).toBeInTheDocument()
+})
+
+test('useMatchRoute follows superseding pending locations', async () => {
+  const aGate = createControlledPromise<void>()
+  const bGate = createControlledPromise<void>()
+
+  function Layout() {
+    const matchRoute = useMatchRoute()
+    const pendingA = matchRoute({ to: '/a', pending: true })
+    const pendingB = matchRoute({ to: '/b', pending: true })
+    const resolvedB = matchRoute({ to: '/b', pending: false })
+    return (
+      <div>
+        <span data-testid="pending-a">{String(Boolean(pendingA()))}</span>
+        <span data-testid="pending-b">{String(Boolean(pendingB()))}</span>
+        <span data-testid="resolved-b">{String(Boolean(resolvedB()))}</span>
+        <Outlet />
+      </div>
+    )
+  }
+
+  const root = createRootRoute({ component: Layout })
+  const index = createRoute({
+    getParentRoute: () => root,
+    path: '/',
+  })
+  const a = createRoute({
+    getParentRoute: () => root,
+    path: '/a',
+    loader: () => aGate,
+  })
+  const b = createRoute({
+    getParentRoute: () => root,
+    path: '/b',
+    loader: () => bGate,
+  })
+  const router = createRouter({
+    routeTree: root.addChildren([index, a, b]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+  render(() => <RouterProvider router={router} />)
+
+  await waitFor(() => {
+    expect(screen.getByTestId('pending-a')).toHaveTextContent('false')
+    expect(router.stores.status.get()).toBe('idle')
+    expect(router.stores.resolvedLocation.get()?.pathname).toBe('/')
+  })
+
+  const navigationA = router.navigate({ to: '/a' })
+  await waitFor(() => {
+    expect(screen.getByTestId('pending-a')).toHaveTextContent('true')
+    expect(screen.getByTestId('resolved-b')).toHaveTextContent('false')
+  })
+
+  const navigationB = router.navigate({ to: '/b' })
+  await waitFor(() => {
+    expect(screen.getByTestId('pending-a')).toHaveTextContent('false')
+    expect(screen.getByTestId('pending-b')).toHaveTextContent('true')
+    expect(screen.getByTestId('resolved-b')).toHaveTextContent('false')
+  })
+
+  aGate.resolve()
+  bGate.resolve()
+  await Promise.allSettled([navigationA, navigationB])
+  await waitFor(() => {
+    expect(screen.getByTestId('pending-b')).toHaveTextContent('false')
+    expect(screen.getByTestId('resolved-b')).toHaveTextContent('true')
+  })
 })
 
 test('MatchRoute updates for navigation and reactive params changes', async () => {

--- a/packages/solid-router/tests/Transitioner.test.tsx
+++ b/packages/solid-router/tests/Transitioner.test.tsx
@@ -31,7 +31,6 @@ describe('Transitioner', () => {
     const loadSpy = vi.spyOn(router, 'load')
 
     render(() => <RouterProvider router={router} />)
-    await router.latestLoadPromise
 
     // Wait for the createRenderEffect to run and call router.load()
     await waitFor(() => {

--- a/packages/solid-router/tests/component-preload-retry.test.tsx
+++ b/packages/solid-router/tests/component-preload-retry.test.tsx
@@ -1,0 +1,21 @@
+import { afterEach, expect, test, vi } from 'vitest'
+import { cleanup, render, screen } from '@solidjs/testing-library'
+import { lazyRouteComponent } from '../src'
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+test('a component loads when rendered before preload', async () => {
+  const importer = vi.fn().mockResolvedValue({
+    default: () => <div>Page content</div>,
+  })
+  const Page = lazyRouteComponent(importer)
+
+  render(() => <Page />)
+
+  expect(await screen.findByText('Page content')).toBeInTheDocument()
+  expect(importer).toHaveBeenCalledTimes(1)
+})

--- a/packages/solid-router/tests/createLazyRoute.test.tsx
+++ b/packages/solid-router/tests/createLazyRoute.test.tsx
@@ -2,8 +2,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library'
 import {
   Link,
+  Outlet,
   RouterProvider,
   createBrowserHistory,
+  createControlledPromise,
+  createLazyRoute,
   createMemoryHistory,
   createRootRoute,
   createRoute,
@@ -92,4 +95,64 @@ describe('preload: matched routes', { timeout: 20000 }, () => {
     const lazyRoute = router.routesByPath['/heavy']
     expect(lazyRoute.options.component).toBeDefined()
   })
+})
+
+it('renders an eager loader error with a delayed lazy errorComponent', async () => {
+  const loader = createControlledPromise<void>()
+  const loaderErrorHandled = createControlledPromise<void>()
+  const loaderError = new Error('loader failed')
+  const lazyPageOptions = createLazyRoute('/page')({
+    component: () => <h1>Page</h1>,
+    errorComponent: ({ error }) => (
+      <p role="alert">Lazy error: {error.message}</p>
+    ),
+  })
+  const lazyOptions = createControlledPromise<typeof lazyPageOptions>()
+  const rootRoute = createRootRoute({ component: Outlet })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <h1>Index page</h1>,
+  })
+  const pageRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/page',
+    loader: async () => {
+      await loader
+      throw loaderError
+    },
+    onError: () => loaderErrorHandled.resolve(),
+  }).lazy(() => lazyOptions)
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute, pageRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+    defaultPendingMs: 0,
+    defaultPendingMinMs: 0,
+    defaultPendingComponent: () => <p role="status">Loading default</p>,
+  })
+  let navigation: Promise<void> | undefined
+
+  try {
+    render(() => <RouterProvider router={router} />)
+    expect(await screen.findByText('Index page')).toBeInTheDocument()
+
+    navigation = router.navigate({ to: '/page' })
+    expect(await screen.findByText('Loading default')).toBeInTheDocument()
+
+    loader.resolve()
+    await loaderErrorHandled
+    lazyOptions.resolve(lazyPageOptions)
+    await navigation
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Lazy error: loader failed',
+    )
+  } finally {
+    lazyOptions.resolve(lazyPageOptions)
+    loader.resolve()
+    loaderErrorHandled.resolve()
+    if (navigation) {
+      await Promise.allSettled([navigation])
+    }
+  }
 })

--- a/packages/solid-router/tests/link.test.tsx
+++ b/packages/solid-router/tests/link.test.tsx
@@ -574,6 +574,45 @@ describe('Link', () => {
       ).toHaveTextContent('false')
     })
 
+    test('updates href when link options change reactively', async () => {
+      const [to, setTo] = Solid.createSignal<'/a' | '/b'>('/a')
+      const rootRoute = createRootRoute({
+        component: () => (
+          <>
+            <button onClick={() => setTo('/b')}>Change destination</button>
+            <Link data-testid="dynamic-link" to={to()}>
+              Destination
+            </Link>
+          </>
+        ),
+      })
+      const aRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/a',
+      })
+      const bRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/b',
+      })
+      const router = createRouter({
+        routeTree: rootRoute.addChildren([aRoute, bRoute]),
+        history,
+      })
+
+      render(() => <RouterProvider router={router} />)
+
+      const link = await screen.findByTestId('dynamic-link')
+      expect(link).toHaveAttribute('href', '/a')
+
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Change destination' }),
+      )
+
+      await waitFor(() => {
+        expect(link).toHaveAttribute('href', '/b')
+      })
+    })
+
     test('updates exact and fuzzy active state before the next route renders', async () => {
       const postLoader = createControlledPromise()
 
@@ -1414,22 +1453,17 @@ describe('Link', () => {
       '/Dashboard/posts?page=2&filter=inactive',
     )
 
-    await fireEvent.click(updateSearchLink)
+    fireEvent.click(updateSearchLink)
 
-    // Wait for navigation to complete and search params to update
     await waitFor(() => {
+      expect(window.location.pathname).toBe('/Dashboard/posts')
       expect(window.location.search).toBe('?page=2&filter=inactive')
+      expect(screen.getByTestId('current-page')).toHaveTextContent('Page: 2')
+      expect(screen.getByTestId('current-filter')).toHaveTextContent(
+        'Filter: inactive',
+      )
     })
-
-    await screen.findByTestId('current-page')
-    // Verify search was updated
-    expect(window.location.pathname).toBe('/Dashboard/posts')
-    expect(window.location.search).toBe('?page=2&filter=inactive')
-
-    const updatedPage = await screen.findByTestId('current-page')
-    const updatedFilter = await screen.findByTestId('current-filter')
-    expect(updatedPage).toHaveTextContent('Page: 2')
-    expect(updatedFilter).toHaveTextContent('Filter: inactive')
+    await vi.waitFor(() => expect(router.state.status).toBe('idle'))
   })
 
   test('when navigating to /posts with invalid search', async () => {

--- a/packages/solid-router/tests/loaders.test.tsx
+++ b/packages/solid-router/tests/loaders.test.tsx
@@ -18,6 +18,7 @@ import {
 import { sleep } from './utils'
 
 afterEach(() => {
+  vi.useRealTimers()
   vi.resetAllMocks()
   window.history.replaceState(null, 'root', '/')
   cleanup()
@@ -617,7 +618,8 @@ test('reproducer #4546', async () => {
   fireEvent.click(indexLink)
 
   {
-    // Wait for navigation to complete before checking values
+    // beforeLoad is fresh for this navigation, while the cached loader data is
+    // allowed to remain visible until its background reload completes.
     await screen.findByText('Index route')
     const headerCounter = await screen.findByTestId('header-counter')
     expect(headerCounter).toHaveTextContent('3')
@@ -626,7 +628,7 @@ test('reproducer #4546', async () => {
     expect(routeContext).toHaveTextContent('3')
 
     const loaderData = await screen.findByTestId('index-loader-data')
-    expect(loaderData).toHaveTextContent('3')
+    await vi.waitFor(() => expect(loaderData).toHaveTextContent('3'))
   }
 
   fireEvent.click(invalidateRouterButton)
@@ -647,7 +649,7 @@ test('reproducer #4546', async () => {
   fireEvent.click(idLink)
 
   {
-    // Wait for navigation to complete before checking values
+    // This loader generation can likewise begin with reusable cached data.
     await screen.findByText('$id route')
     const headerCounter = await screen.findByTestId('header-counter')
     expect(headerCounter).toHaveTextContent('5')
@@ -656,11 +658,11 @@ test('reproducer #4546', async () => {
     expect(routeContext).toHaveTextContent('5')
 
     const loaderData = await screen.findByTestId('id-loader-data')
-    expect(loaderData).toHaveTextContent('5')
+    await vi.waitFor(() => expect(loaderData).toHaveTextContent('5'))
   }
 })
 
-test('clears pendingTimeout when match resolves', async () => {
+test('does not show pending UI when loaders finish before their pending delays', async () => {
   const defaultPendingComponentOnMountMock = vi.fn()
   const nestedPendingComponentOnMountMock = vi.fn()
   const fooPendingComponentOnMountMock = vi.fn()
@@ -728,13 +730,16 @@ test('clears pendingTimeout when match resolves', async () => {
   })
 
   render(() => <RouterProvider router={router} />)
-  await router.latestLoadPromise
-  const linkToFoo = await screen.findByTestId('link-to-foo')
-  fireEvent.click(linkToFoo)
-  const fooElement = await screen.findByText('Nested Foo page')
+  await screen.findByTestId('link-to-foo')
+  vi.useFakeTimers()
+  const navigation = router.navigate({ to: '/nested/foo' })
+  await vi.advanceTimersByTimeAsync(WAIT_TIME * 5)
+  await navigation
+  const fooElement = screen.getByText('Nested Foo page')
   expect(fooElement).toBeInTheDocument()
 
   expect(router.state.location.href).toBe('/nested/foo')
+  expect(router.state.status).toBe('idle')
 
   // none of the pending components should have been called
   expect(defaultPendingComponentOnMountMock).not.toHaveBeenCalled()
@@ -787,7 +792,7 @@ test('useLoaderData retains previous data while route match is pending', async (
   expect(screen.getByTestId('combined')).toHaveTextContent('6:0')
 })
 
-test('cancelMatches after pending timeout', async () => {
+test('navigating away from a pending route aborts its loader', async () => {
   function getPendingComponent(onMount: () => void) {
     const PendingComponent = () => {
       onMount()
@@ -797,6 +802,7 @@ test('cancelMatches after pending timeout', async () => {
   }
   const onAbortMock = vi.fn()
   const fooPendingComponentOnMountMock = vi.fn()
+  let fooSignal: AbortSignal | undefined
   const history = createMemoryHistory({ initialEntries: ['/'] })
   const rootRoute = createRootRoute({
     component: () => (
@@ -815,17 +821,18 @@ test('cancelMatches after pending timeout', async () => {
   const fooRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/foo',
-    pendingMs: WAIT_TIME * 20,
+    pendingMs: 0,
     loader: async ({ abortController }) => {
+      fooSignal = abortController.signal
       await new Promise<void>((resolve) => {
-        const timer = setTimeout(() => {
-          resolve()
-        }, WAIT_TIME * 40)
-        abortController.signal.addEventListener('abort', () => {
-          onAbortMock()
-          clearTimeout(timer)
-          resolve()
-        })
+        abortController.signal.addEventListener(
+          'abort',
+          () => {
+            onAbortMock()
+            resolve()
+          },
+          { once: true },
+        )
       })
     },
     pendingComponent: getPendingComponent(fooPendingComponentOnMountMock),
@@ -839,16 +846,20 @@ test('cancelMatches after pending timeout', async () => {
   const routeTree = rootRoute.addChildren([fooRoute, barRoute])
   const router = createRouter({ routeTree, history })
   render(() => <RouterProvider router={router} />)
-  await router.latestLoadPromise
   const fooLink = await screen.findByTestId('link-to-foo')
   fireEvent.click(fooLink)
-  await sleep(WAIT_TIME * 30)
   const pendingElement = await screen.findByText('Pending...')
   expect(pendingElement).toBeInTheDocument()
-  const barLink = await screen.findByTestId('link-to-bar')
-  fireEvent.click(barLink)
-  const barElement = await screen.findByText('Bar page')
+  expect(fooSignal?.aborted).toBe(false)
+  await router.navigate({ to: '/bar' })
+  const barElement = screen.getByText('Bar page')
   expect(barElement).toBeInTheDocument()
+
   expect(fooPendingComponentOnMountMock).toHaveBeenCalled()
-  expect(onAbortMock).toHaveBeenCalled()
+  expect(onAbortMock).toHaveBeenCalledTimes(1)
+  expect(fooSignal?.aborted).toBe(true)
+  expect(screen.queryByText('Pending...')).not.toBeInTheDocument()
+  expect(screen.queryByText('Foo page')).not.toBeInTheDocument()
+  expect(router.state.location.href).toBe('/bar')
+  expect(router.state.status).toBe('idle')
 })

--- a/packages/solid-router/tests/redirect.test.tsx
+++ b/packages/solid-router/tests/redirect.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library'
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { createControlledPromise } from '@tanstack/router-core'
 
 import {
   Link,
@@ -107,6 +108,7 @@ describe('redirect', () => {
 
     test('when root `beforeLoad` redirects while root pendingComponent is showing and the target route is lazy', async () => {
       let hasRedirected = false
+      const beforeLoad = createControlledPromise<void>()
       const consoleError = vi
         .spyOn(console, 'error')
         .mockImplementation(() => {})
@@ -116,7 +118,7 @@ describe('redirect', () => {
         pendingMs: 0,
         pendingComponent: () => <div data-testid="pending">loading</div>,
         beforeLoad: async () => {
-          await sleep(WAIT_TIME)
+          await beforeLoad
           if (!hasRedirected) {
             hasRedirected = true
             throw redirect({ to: '/posts' })
@@ -142,12 +144,20 @@ describe('redirect', () => {
 
       render(() => <RouterProvider router={router} />)
 
+      try {
+        expect(await screen.findByTestId('pending')).toBeInTheDocument()
+        expect(screen.queryByTestId('index-page')).not.toBeInTheDocument()
+      } finally {
+        beforeLoad.resolve()
+      }
+
       // The lazy target route adds the async boundary that exposes the stale
       // redirected-match render path this regression is guarding.
       expect(await screen.findByTestId('lazy-route-page')).toBeInTheDocument()
       expect(screen.queryByTestId('pending')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('index-page')).not.toBeInTheDocument()
       expect(router.state.location.href).toBe('/posts')
-      expect(router.state.status).toBe('idle')
+      await vi.waitFor(() => expect(router.state.status).toBe('idle'))
       expect(consoleError).not.toHaveBeenCalled()
     })
 

--- a/packages/solid-router/tests/renderRouterToStream.test.tsx
+++ b/packages/solid-router/tests/renderRouterToStream.test.tsx
@@ -56,7 +56,7 @@ function drainBody(response: Response) {
 }
 
 describe('renderRouterToStream - bot abort', () => {
-  test('request abort during bot wait returns and terminates response stream', async () => {
+  test('request abort during bot wait terminates before rendering starts', async () => {
     const neverReady = new Promise<void>(() => {})
     solidMocks.pipeTo.mockImplementationOnce(
       (writable: WritableStream<Uint8Array>) => {
@@ -99,6 +99,7 @@ describe('renderRouterToStream - bot abort', () => {
       expect(result).not.toBe(false)
       expect(solidMocks.pipeTo).not.toHaveBeenCalled()
       const response = unwrapResponse(result as Exclude<typeof result, false>)
+      expect(response.body).not.toBeNull()
 
       const terminated = await Promise.race([
         drainBody(response),

--- a/packages/solid-router/tests/routeContext.test.tsx
+++ b/packages/solid-router/tests/routeContext.test.tsx
@@ -133,7 +133,7 @@ describe('context function', () => {
     })
 
     test('when loader deps change', async () => {
-      const mockContextFn = vi.fn()
+      let generation = 0
 
       const rootRoute = createRootRoute()
       const indexRoute = createRoute({
@@ -145,14 +145,21 @@ describe('context function', () => {
         path: '/',
         loaderDeps: ({ search }) => ({ foo: search.foo }),
         context: ({ deps }) => {
-          mockContextFn(deps)
+          return {
+            generation: ++generation,
+            deps: JSON.stringify(deps),
+          }
         },
         component: () => {
           const navigate = indexRoute.useNavigate()
+          const context = indexRoute.useRouteContext()
           return (
             <div>
               <h1>Index page</h1>
               <h2>search: {JSON.stringify(indexRoute.useSearch()())}</h2>
+              <h3>
+                context: {context().generation}:{context().deps}
+              </h3>
               <button
                 onClick={() => {
                   navigate({ search: (p: any) => ({ ...p, foo: 'foo-1' }) })
@@ -200,44 +207,37 @@ describe('context function', () => {
 
       await findByText('Index page')
       await findByText(`search: ${JSON.stringify({})}`)
-
-      expect(mockContextFn).toHaveBeenCalledOnce()
-      expect(mockContextFn).toHaveBeenCalledWith({})
-      mockContextFn.mockClear()
+      await findByText('context: 1:{}')
 
       await clickButton('foo-1')
       await findByText(`search: ${JSON.stringify({ foo: 'foo-1' })}`)
-      expect(mockContextFn).toHaveBeenCalledOnce()
-      expect(mockContextFn).toHaveBeenCalledWith({ foo: 'foo-1' })
+      await findByText('context: 2:{"foo":"foo-1"}')
 
-      mockContextFn.mockClear()
       await clickButton('foo-1')
       await findByText(`search: ${JSON.stringify({ foo: 'foo-1' })}`)
-      expect(mockContextFn).not.toHaveBeenCalled()
+      await findByText('context: 2:{"foo":"foo-1"}')
 
       await clickButton('bar-1')
       await findByText(
         `search: ${JSON.stringify({ foo: 'foo-1', bar: 'bar-1' })}`,
       )
-      expect(mockContextFn).not.toHaveBeenCalled()
+      await findByText('context: 2:{"foo":"foo-1"}')
 
       await clickButton('foo-2')
       await findByText(
         `search: ${JSON.stringify({ foo: 'foo-2', bar: 'bar-1' })}`,
       )
-      expect(mockContextFn).toHaveBeenCalledWith({ foo: 'foo-2' })
-      mockContextFn.mockClear()
+      await findByText('context: 3:{"foo":"foo-2"}')
 
       await clickButton('bar-2')
       await findByText(
         `search: ${JSON.stringify({ foo: 'foo-2', bar: 'bar-2' })}`,
       )
-      expect(mockContextFn).not.toHaveBeenCalled()
+      await findByText('context: 3:{"foo":"foo-2"}')
 
       await clickButton('clear')
       await findByText(`search: ${JSON.stringify({})}`)
-      expect(mockContextFn).toHaveBeenCalledOnce()
-      expect(mockContextFn).toHaveBeenCalledWith({})
+      await findByText('context: 4:{}')
     })
   })
 

--- a/packages/solid-router/tests/router.test.tsx
+++ b/packages/solid-router/tests/router.test.tsx
@@ -1720,24 +1720,27 @@ describe('does not strip search params if search validation fails', () => {
   })
 })
 
-describe('statusCode reset on navigation', () => {
-  it('should reset statusCode to 200 when navigating from 404 to valid route', async () => {
+describe('navigation outcomes', () => {
+  it('should recover from a not-found route when navigating to a valid route', async () => {
     const history = createMemoryHistory({ initialEntries: ['/'] })
 
     const rootRoute = createRootRoute({
       component: () => <Outlet />,
+      notFoundComponent: () => (
+        <div data-testid="root-not-found">Not Found</div>
+      ),
     })
 
     const indexRoute = createRoute({
       getParentRoute: () => rootRoute,
       path: '/',
-      component: () => <div>Home</div>,
+      component: () => <div data-testid="home-page">Home</div>,
     })
 
     const validRoute = createRoute({
       getParentRoute: () => rootRoute,
       path: '/valid',
-      component: () => <div>Valid Route</div>,
+      component: () => <div data-testid="valid-page">Valid Route</div>,
     })
 
     const routeTree = rootRoute.addChildren([indexRoute, validRoute])
@@ -1745,27 +1748,29 @@ describe('statusCode reset on navigation', () => {
 
     render(() => <RouterProvider router={router} />)
 
-    expect(router.state.statusCode).toBe(200)
-
     await router.navigate({ to: '/' })
-    await waitFor(() => expect(router.state.statusCode).toBe(200))
+    expect(await screen.findByTestId('home-page')).toBeInTheDocument()
 
     await router.navigate({ to: '/non-existing' })
-    await waitFor(() => expect(router.state.statusCode).toBe(404))
+    expect(await screen.findByTestId('root-not-found')).toBeInTheDocument()
+    expect(screen.queryByTestId('home-page')).not.toBeInTheDocument()
 
     await router.navigate({ to: '/valid' })
-    await waitFor(() => expect(router.state.statusCode).toBe(200))
+    expect(await screen.findByTestId('valid-page')).toBeInTheDocument()
+    expect(screen.queryByTestId('root-not-found')).not.toBeInTheDocument()
 
     await router.navigate({ to: '/another-non-existing' })
-    await waitFor(() => expect(router.state.statusCode).toBe(404))
+    expect(await screen.findByTestId('root-not-found')).toBeInTheDocument()
+    expect(screen.queryByTestId('valid-page')).not.toBeInTheDocument()
+    expect(router.state.status).toBe('idle')
   })
 
   describe.each([true, false])(
-    'status code is set when loader/beforeLoad throws (isAsync=%s)',
+    'loader and beforeLoad outcomes are rendered (isAsync=%s)',
     (isAsync) => {
       const throwingFun = isAsync
         ? (toThrow: () => void) => async () => {
-            await new Promise((resolve) => setTimeout(resolve, 10))
+            await Promise.resolve()
             toThrow()
           }
         : (toThrow: () => void) => toThrow
@@ -1776,15 +1781,19 @@ describe('statusCode reset on navigation', () => {
       const throwError = throwingFun(() => {
         throw new Error('test-error')
       })
-      it('should set statusCode to 404 when a route loader throws a notFound()', async () => {
+      it('should render notFoundComponent when a route loader throws a notFound()', async () => {
         const history = createMemoryHistory({ initialEntries: ['/'] })
 
-        const rootRoute = createRootRoute()
+        const rootRoute = createRootRoute({
+          notFoundComponent: () => (
+            <div data-testid="root-not-found">Root Not Found</div>
+          ),
+        })
 
         const indexRoute = createRoute({
           getParentRoute: () => rootRoute,
           path: '/',
-          component: () => <div>Home</div>,
+          component: () => <div data-testid="home-page">Home</div>,
         })
 
         const loaderThrowsRoute = createRoute({
@@ -1795,7 +1804,7 @@ describe('statusCode reset on navigation', () => {
             <div data-testid="route-component">loader will throw</div>
           ),
           notFoundComponent: () => (
-            <div data-testid="not-found-component">Not Found</div>
+            <div data-testid="route-not-found">Route Not Found</div>
           ),
         })
 
@@ -1804,29 +1813,28 @@ describe('statusCode reset on navigation', () => {
 
         render(() => <RouterProvider router={router} />)
 
-        expect(router.state.statusCode).toBe(200)
-
+        expect(await screen.findByTestId('home-page')).toBeInTheDocument()
         await router.navigate({ to: '/loader-throws-not-found' })
-        await waitFor(() => expect(router.state.statusCode).toBe(404))
-        expect(
-          await screen.findByTestId('not-found-component'),
-        ).toBeInTheDocument()
+        expect(await screen.findByTestId('route-not-found')).toBeInTheDocument()
+        expect(screen.queryByTestId('root-not-found')).not.toBeInTheDocument()
         expect(screen.queryByTestId('route-component')).not.toBeInTheDocument()
+        expect(screen.queryByTestId('home-page')).not.toBeInTheDocument()
+        expect(router.state.status).toBe('idle')
       })
 
-      it('should set statusCode to 404 when a route beforeLoad throws a notFound()', async () => {
+      it('should render notFoundComponent when a route beforeLoad throws a notFound()', async () => {
         const history = createMemoryHistory({ initialEntries: ['/'] })
 
         const rootRoute = createRootRoute({
           notFoundComponent: () => (
-            <div data-testid="not-found-component">Not Found</div>
+            <div data-testid="root-not-found">Root Not Found</div>
           ),
         })
 
         const indexRoute = createRoute({
           getParentRoute: () => rootRoute,
           path: '/',
-          component: () => <div>Home</div>,
+          component: () => <div data-testid="home-page">Home</div>,
         })
 
         const beforeLoadThrowsRoute = createRoute({
@@ -1837,7 +1845,7 @@ describe('statusCode reset on navigation', () => {
             <div data-testid="route-component">beforeLoad will throw</div>
           ),
           notFoundComponent: () => (
-            <div data-testid="not-found-component">Not Found</div>
+            <div data-testid="route-not-found">Route Not Found</div>
           ),
         })
 
@@ -1849,25 +1857,26 @@ describe('statusCode reset on navigation', () => {
 
         render(() => <RouterProvider router={router} />)
 
-        expect(router.state.statusCode).toBe(200)
-
+        expect(await screen.findByTestId('home-page')).toBeInTheDocument()
         await router.navigate({ to: '/beforeload-throws-not-found' })
-        await waitFor(() => expect(router.state.statusCode).toBe(404))
-        expect(
-          await screen.findByTestId('not-found-component'),
-        ).toBeInTheDocument()
+        expect(await screen.findByTestId('route-not-found')).toBeInTheDocument()
+        expect(screen.queryByTestId('root-not-found')).not.toBeInTheDocument()
         expect(screen.queryByTestId('route-component')).not.toBeInTheDocument()
+        expect(screen.queryByTestId('home-page')).not.toBeInTheDocument()
+        expect(router.state.status).toBe('idle')
       })
 
-      it('should set statusCode to 500 when a route loader throws an Error', async () => {
+      it('should render errorComponent when a route loader throws an Error', async () => {
         const history = createMemoryHistory({ initialEntries: ['/'] })
 
-        const rootRoute = createRootRoute()
+        const rootRoute = createRootRoute({
+          errorComponent: () => <div data-testid="root-error">Root Error</div>,
+        })
 
         const indexRoute = createRoute({
           getParentRoute: () => rootRoute,
           path: '/',
-          component: () => <div>Home</div>,
+          component: () => <div data-testid="home-page">Home</div>,
         })
 
         const loaderThrowsRoute = createRoute({
@@ -1877,7 +1886,7 @@ describe('statusCode reset on navigation', () => {
           component: () => (
             <div data-testid="route-component">loader will throw</div>
           ),
-          errorComponent: () => <div data-testid="error-component">Error</div>,
+          errorComponent: () => <div data-testid="route-error">Error</div>,
         })
 
         const routeTree = rootRoute.addChildren([indexRoute, loaderThrowsRoute])
@@ -1885,23 +1894,26 @@ describe('statusCode reset on navigation', () => {
 
         render(() => <RouterProvider router={router} />)
 
-        expect(router.state.statusCode).toBe(200)
-
+        expect(await screen.findByTestId('home-page')).toBeInTheDocument()
         await router.navigate({ to: '/loader-throws-error' })
-        await waitFor(() => expect(router.state.statusCode).toBe(500))
-        expect(await screen.findByTestId('error-component')).toBeInTheDocument()
+        expect(await screen.findByTestId('route-error')).toBeInTheDocument()
+        expect(screen.queryByTestId('root-error')).not.toBeInTheDocument()
         expect(screen.queryByTestId('route-component')).not.toBeInTheDocument()
+        expect(screen.queryByTestId('home-page')).not.toBeInTheDocument()
+        expect(router.state.status).toBe('idle')
       })
 
-      it('should set statusCode to 500 when a route beforeLoad throws an Error', async () => {
+      it('should render errorComponent when a route beforeLoad throws an Error', async () => {
         const history = createMemoryHistory({ initialEntries: ['/'] })
 
-        const rootRoute = createRootRoute()
+        const rootRoute = createRootRoute({
+          errorComponent: () => <div data-testid="root-error">Root Error</div>,
+        })
 
         const indexRoute = createRoute({
           getParentRoute: () => rootRoute,
           path: '/',
-          component: () => <div>Home</div>,
+          component: () => <div data-testid="home-page">Home</div>,
         })
 
         const beforeLoadThrowsRoute = createRoute({
@@ -1911,7 +1923,7 @@ describe('statusCode reset on navigation', () => {
           component: () => (
             <div data-testid="route-component">beforeLoad will throw</div>
           ),
-          errorComponent: () => <div data-testid="error-component">Error</div>,
+          errorComponent: () => <div data-testid="route-error">Error</div>,
         })
 
         const routeTree = rootRoute.addChildren([
@@ -1922,12 +1934,13 @@ describe('statusCode reset on navigation', () => {
 
         render(() => <RouterProvider router={router} />)
 
-        expect(router.state.statusCode).toBe(200)
-
+        expect(await screen.findByTestId('home-page')).toBeInTheDocument()
         await router.navigate({ to: '/beforeload-throws-error' })
-        await waitFor(() => expect(router.state.statusCode).toBe(500))
-        expect(await screen.findByTestId('error-component')).toBeInTheDocument()
+        expect(await screen.findByTestId('route-error')).toBeInTheDocument()
+        expect(screen.queryByTestId('root-error')).not.toBeInTheDocument()
         expect(screen.queryByTestId('route-component')).not.toBeInTheDocument()
+        expect(screen.queryByTestId('home-page')).not.toBeInTheDocument()
+        expect(router.state.status).toBe('idle')
       })
     },
   )
@@ -2057,7 +2070,6 @@ describe('basepath', () => {
       })
 
       expect(router.state.location.pathname).toBe('/')
-      expect(router.state.statusCode).toBe(200)
     },
   )
 

--- a/packages/solid-router/tests/same-route-pending-blank.test.tsx
+++ b/packages/solid-router/tests/same-route-pending-blank.test.tsx
@@ -1,0 +1,100 @@
+import { cleanup, render, screen } from '@solidjs/testing-library'
+import { afterEach, expect, test, vi } from 'vitest'
+import { createControlledPromise } from '@tanstack/router-core'
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+
+/**
+ * Solid same-route pending replacement should not blank stale content
+ * before pending UI is ready. Core can expose a replacement pending match while
+ * the route has no pending fallback and a long pendingMs delay.
+ *
+ * This test renders a real Solid RouterProvider, navigates from page 1 to page
+ * 2 on the same route, and leaves the page 2 loader unresolved. Until pendingMs
+ * elapses, the previously committed page 1 content should remain visible.
+ */
+
+let resolvePendingPage2: (() => void) | undefined
+let pendingNavigation: Promise<unknown> | undefined
+
+afterEach(async () => {
+  resolvePendingPage2?.()
+  if (pendingNavigation) {
+    await Promise.allSettled([pendingNavigation])
+  }
+  resolvePendingPage2 = undefined
+  pendingNavigation = undefined
+  cleanup()
+  vi.useRealTimers()
+})
+
+test('same-route pending replacement without fallback keeps stale content until pendingMs', async () => {
+  const pendingMs = 100
+  const page2Gate = createControlledPromise<void>()
+  const page2Started = createControlledPromise<void>()
+  resolvePendingPage2 = page2Gate.resolve
+  const history = createMemoryHistory({ initialEntries: ['/posts?page=1'] })
+  const root = createRootRoute({
+    component: () => <Outlet />,
+  })
+
+  function Posts() {
+    const data = postsRoute.useLoaderData()
+    return <div data-testid="post-content">{data()}</div>
+  }
+
+  const postsRoute = createRoute({
+    getParentRoute: () => root,
+    path: '/posts',
+    validateSearch: (search) => ({
+      page: Number(search.page ?? 1),
+    }),
+    loaderDeps: ({ search }) => ({ page: search.page }),
+    pendingMs,
+    loader: async ({ deps }) => {
+      if (deps.page === 2) {
+        page2Started.resolve()
+        await page2Gate
+      }
+
+      return `Page ${deps.page}`
+    },
+    component: Posts,
+  })
+  const router = createRouter({
+    routeTree: root.addChildren([postsRoute]),
+    history,
+    defaultPendingMs: pendingMs,
+  })
+
+  render(() => <RouterProvider router={router} />)
+  expect(await screen.findByText('Page 1')).toBeInTheDocument()
+
+  vi.useFakeTimers()
+  const navigation = router.navigate({
+    to: '/posts',
+    search: { page: 2 },
+  })
+  pendingNavigation = navigation
+
+  await page2Started
+  await vi.advanceTimersByTimeAsync(pendingMs - 1)
+
+  expect(screen.getByTestId('post-content')).toHaveTextContent('Page 1')
+  expect(screen.queryByText('Page 2')).not.toBeInTheDocument()
+  expect(router.state.status).toBe('pending')
+
+  page2Gate.resolve()
+  await navigation
+  pendingNavigation = undefined
+
+  expect(screen.getByText('Page 2')).toBeInTheDocument()
+  expect(screen.queryByText('Page 1')).not.toBeInTheDocument()
+  expect(router.state.status).toBe('idle')
+})

--- a/packages/solid-router/tests/server/errorComponent.test.tsx
+++ b/packages/solid-router/tests/server/errorComponent.test.tsx
@@ -1,12 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { renderToStringAsync } from 'solid-js/web'
+import { createRootRoute, createRoute, createRouter } from '../../src'
 import {
-  RouterProvider,
-  createMemoryHistory,
-  createRootRoute,
-  createRoute,
-  createRouter,
-} from '../../src'
+  RouterServer,
+  createRequestHandler,
+  renderRouterToString,
+} from '../../src/ssr/server'
 
 describe('errorComponent (server)', () => {
   it('renders the route error component when a loader throws during SSR', async () => {
@@ -25,21 +23,21 @@ describe('errorComponent (server)', () => {
     })
 
     const routeTree = rootRoute.addChildren([indexRoute])
-    const router = createRouter({
-      routeTree,
-      history: createMemoryHistory({
-        initialEntries: ['/'],
-      }),
-      isServer: true,
+    const handler = createRequestHandler({
+      request: new Request('http://localhost/'),
+      createRouter: () => createRouter({ routeTree, isServer: true }),
     })
 
-    await router.load()
+    const response = await handler(({ router, responseHeaders }) =>
+      renderRouterToString({
+        router,
+        responseHeaders,
+        children: () => <RouterServer router={router} />,
+      }),
+    )
 
-    const html = await renderToStringAsync(() => (
-      <RouterProvider router={router} />
-    ))
-
-    expect(router.state.statusCode).toBe(500)
+    expect(response.status).toBe(500)
+    const html = await response.text()
     expect(html).toContain('data-testid="error-component"')
     expect(html).toContain('loader boom')
     expect(html).not.toContain('Index route')

--- a/packages/solid-router/tests/transitioner-remount.test.tsx
+++ b/packages/solid-router/tests/transitioner-remount.test.tsx
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@solidjs/testing-library'
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+
+afterEach(() => {
+  cleanup()
+})
+
+function setup() {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <div>Index</div>,
+  })
+  const nextRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/next',
+    component: () => <div>Next</div>,
+  })
+  const history = createMemoryHistory({ initialEntries: ['/'] })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute, nextRoute]),
+    history,
+  })
+  return { history, router }
+}
+
+describe('Transitioner remount', () => {
+  // Zombie-router pin: once the provider unmounts, the history subscription
+  // must be torn down so a later history change never re-drives the router.
+  it('does not load after the provider unmounts', async () => {
+    const { history, router } = setup()
+    const loadSpy = vi.spyOn(router, 'load')
+
+    const first = render(() => <RouterProvider router={router} />)
+    expect(await screen.findByText('Index')).toBeTruthy()
+    await waitFor(() => expect(router.state.status).toBe('idle'))
+
+    first.unmount()
+    loadSpy.mockClear()
+
+    // A history change while unmounted must not reach the router.
+    history.push('/next')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(loadSpy).not.toHaveBeenCalled()
+    // Raw history advanced...
+    expect(router.history.location.pathname).toBe('/next')
+    // ...but the router never processed it, so its committed state stayed put.
+    expect(router.state.location.pathname).toBe('/')
+
+    loadSpy.mockRestore()
+  })
+
+  // Remounting the same router instance must re-establish the subscription so
+  // navigation keeps working, without leaving a stale duplicate behind.
+  it('re-subscribes and loads on remount with the same router', async () => {
+    const { history, router } = setup()
+    // Spy before the first mount so the subscription captures the spy by
+    // reference — both the first and second mounts subscribe with it.
+    const loadSpy = vi.spyOn(router, 'load')
+
+    const first = render(() => <RouterProvider router={router} />)
+    expect(await screen.findByText('Index')).toBeTruthy()
+    await waitFor(() => expect(router.state.status).toBe('idle'))
+
+    first.unmount()
+
+    render(() => <RouterProvider router={router} />)
+    expect(await screen.findByText('Index')).toBeTruthy()
+    await waitFor(() => expect(router.state.status).toBe('idle'))
+
+    // A push on the remounted provider must drive exactly one load, proving
+    // the subscription was re-established (and is singular).
+    loadSpy.mockClear()
+    history.push('/next')
+    expect(await screen.findByText('Next')).toBeTruthy()
+    expect(router.state.location.pathname).toBe('/next')
+    await waitFor(() => expect(loadSpy).toHaveBeenCalledTimes(1))
+
+    loadSpy.mockRestore()
+  })
+})

--- a/packages/solid-router/tests/use-match-outgoing-transition.test.tsx
+++ b/packages/solid-router/tests/use-match-outgoing-transition.test.tsx
@@ -1,0 +1,126 @@
+import * as Solid from 'solid-js'
+import { cleanup, render, screen } from '@solidjs/testing-library'
+import { afterEach, expect, test } from 'vitest'
+import {
+  Outlet,
+  RouterProvider,
+  createControlledPromise,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  useMatch,
+} from '../src'
+
+afterEach(() => {
+  cleanup()
+})
+
+test('an outgoing component never observes its own active match disappear', async () => {
+  const observedRouteIds: Array<string | undefined> = []
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const firstRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/first',
+    component: () => {
+      const match = useMatch({ from: '/first', shouldThrow: false })
+      Solid.createRenderEffect(() => {
+        observedRouteIds.push(match()?.routeId)
+      })
+      return <div>First</div>
+    },
+  })
+  const nextRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/next',
+    component: () => <div>Next</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([firstRoute, nextRoute]),
+    history: createMemoryHistory({ initialEntries: ['/first'] }),
+  })
+
+  render(() => <RouterProvider router={router} />)
+  expect(await screen.findByText('First')).toBeInTheDocument()
+  expect(observedRouteIds).toContain('/first')
+
+  await router.navigate({ to: '/next' })
+  expect(await screen.findByText('Next')).toBeInTheDocument()
+  expect(screen.queryByText('First')).not.toBeInTheDocument()
+
+  expect(observedRouteIds).not.toContain(undefined)
+})
+
+test('a persistent observer releases an explicit match only with the destination render', async () => {
+  const nextLoader = createControlledPromise<void>()
+  const observations: Array<{
+    routeId: string | undefined
+    destinationRendered: boolean
+  }> = []
+
+  const rootRoute = createRootRoute({
+    component: () => {
+      const routeId = useMatch({
+        from: '/first',
+        shouldThrow: false,
+        select: (match) => match.routeId,
+      })
+      Solid.createRenderEffect(() => {
+        observations.push({
+          routeId: routeId(),
+          destinationRendered: screen.queryByText('Next') !== null,
+        })
+      })
+      return <Outlet />
+    },
+  })
+  const firstRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/first',
+    component: () => <div>First</div>,
+  })
+  const nextRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/next',
+    loader: () => nextLoader,
+    component: () => <div>Next</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([firstRoute, nextRoute]),
+    history: createMemoryHistory({ initialEntries: ['/first'] }),
+  })
+
+  render(() => <RouterProvider router={router} />)
+  expect(await screen.findByText('First')).toBeInTheDocument()
+
+  const navigation = router.navigate({ to: '/next' })
+  await Promise.resolve()
+  expect(screen.queryByText('Next')).toBeNull()
+  expect(observations).toContainEqual({
+    routeId: '/first',
+    destinationRendered: false,
+  })
+  expect(observations.some(({ routeId }) => routeId === undefined)).toBe(false)
+
+  nextLoader.resolve()
+  await navigation
+  expect(await screen.findByText('Next')).toBeInTheDocument()
+  expect(screen.queryByText('First')).not.toBeInTheDocument()
+
+  const retainedWhilePending = observations.findIndex(
+    ({ routeId, destinationRendered }) =>
+      routeId === '/first' && !destinationRendered,
+  )
+  const releasedWithDestination = observations.findIndex(
+    ({ routeId, destinationRendered }) =>
+      routeId === undefined && destinationRendered,
+  )
+  expect(retainedWhilePending).toBeGreaterThanOrEqual(0)
+  expect(releasedWithDestination).toBeGreaterThan(retainedWhilePending)
+  expect(
+    observations.some(
+      ({ routeId, destinationRendered }) =>
+        routeId === undefined && !destinationRendered,
+    ),
+  ).toBe(false)
+})

--- a/packages/solid-router/tests/useMatch.test.tsx
+++ b/packages/solid-router/tests/useMatch.test.tsx
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
-import { cleanup, render, screen, waitFor } from '@solidjs/testing-library'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@solidjs/testing-library'
 import {
   Link,
   Outlet,
@@ -72,6 +78,151 @@ describe('useMatch', () => {
         expect(postsTitle).toBeInTheDocument()
       },
     )
+  })
+
+  test('tracks presentation generations across replacement and re-entry', async () => {
+    function RootComponent() {
+      const targetedRevision = useMatch({
+        from: '/item',
+        shouldThrow: false,
+        select: (match) => match.loaderData,
+      })
+
+      return (
+        <>
+          <div data-testid="targeted-match">
+            {targetedRevision() === undefined
+              ? 'Targeted absent'
+              : `Targeted revision ${targetedRevision()}`}
+          </div>
+          <Link to="/item" search={{ revision: 2 }}>
+            Revision 2
+          </Link>
+          <Link to="/item" search={{ revision: 3 }}>
+            Revision 3
+          </Link>
+          <Link to="/other">Other</Link>
+          <Outlet />
+        </>
+      )
+    }
+
+    function ItemComponent() {
+      const nearestRevision = useMatch({
+        strict: false,
+        shouldThrow: false,
+        select: (match) => match.loaderData as number,
+      })
+      return <div>Nearest revision {nearestRevision()}</div>
+    }
+
+    const rootRoute = createRootRoute({ component: RootComponent })
+    const itemRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/item',
+      validateSearch: (search: Record<string, unknown>) => ({
+        revision: Number(search.revision),
+      }),
+      loaderDeps: ({ search }) => ({ revision: search.revision }),
+      loader: ({ deps }) => deps.revision,
+      component: ItemComponent,
+    })
+    const otherRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/other',
+      component: () => <div>Other route</div>,
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([itemRoute, otherRoute]),
+      history: createMemoryHistory({ initialEntries: ['/item?revision=1'] }),
+    })
+
+    render(() => <RouterProvider router={router} />)
+    expect(await screen.findByText('Nearest revision 1')).toBeInTheDocument()
+    expect(screen.getByTestId('targeted-match')).toHaveTextContent(
+      'Targeted revision 1',
+    )
+
+    await fireEvent.click(screen.getByText('Revision 2'))
+    expect(await screen.findByText('Nearest revision 2')).toBeInTheDocument()
+    expect(screen.getByTestId('targeted-match')).toHaveTextContent(
+      'Targeted revision 2',
+    )
+
+    await fireEvent.click(screen.getByText('Other'))
+    expect(await screen.findByText('Other route')).toBeInTheDocument()
+    expect(screen.getByTestId('targeted-match')).toHaveTextContent(
+      'Targeted absent',
+    )
+
+    await fireEvent.click(screen.getByText('Revision 3'))
+    expect(await screen.findByText('Nearest revision 3')).toBeInTheDocument()
+    expect(screen.getByTestId('targeted-match')).toHaveTextContent(
+      'Targeted revision 3',
+    )
+  })
+
+  test('renders a route generation that re-enters before an intermediate route renders', async () => {
+    function RootComponent() {
+      return (
+        <>
+          <Link to="/other">Other</Link>
+          <Outlet />
+        </>
+      )
+    }
+
+    function ItemComponent() {
+      const revision = useMatch({
+        strict: false,
+        select: (match) => match.loaderData as number,
+      })
+      return <div>Item revision {revision()}</div>
+    }
+
+    const rootRoute = createRootRoute({ component: RootComponent })
+    const itemRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/item',
+      validateSearch: (search: Record<string, unknown>) => ({
+        revision: Number(search.revision),
+      }),
+      loaderDeps: ({ search }) => ({ revision: search.revision }),
+      loader: ({ deps }) => deps.revision,
+      component: ItemComponent,
+    })
+    const otherRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/other',
+      component: () => <div>Other route</div>,
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([itemRoute, otherRoute]),
+      history: createMemoryHistory({ initialEntries: ['/item?revision=1'] }),
+    })
+
+    render(() => <RouterProvider router={router} />)
+    expect(await screen.findByText('Item revision 1')).toBeInTheDocument()
+
+    let returnNavigation: Promise<void> | undefined
+    const unsubscribe = router.subscribe('onLoad', (event) => {
+      if (event.toLocation.pathname === '/other') {
+        returnNavigation = router.navigate({
+          to: '/item',
+          search: { revision: 2 },
+        })
+      }
+    })
+    try {
+      await fireEvent.click(screen.getByText('Other'))
+      await waitFor(() => expect(returnNavigation).toBeDefined())
+      await returnNavigation
+
+      expect(await screen.findByText('Item revision 2')).toBeInTheDocument()
+      expect(screen.queryByText('Other route')).not.toBeInTheDocument()
+    } finally {
+      unsubscribe()
+    }
   })
 
   describe('when match is not found', () => {

--- a/packages/solid-start-client/src/tests/hydrateStart.test.ts
+++ b/packages/solid-start-client/src/tests/hydrateStart.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, expect, test, vi } from 'vitest'
+import { hydrateStart } from '../hydrateStart'
+
+const coreHydrateStart = vi.hoisted(() => vi.fn())
+
+vi.mock('@tanstack/start-client-core/client', () => ({
+  hydrateStart: coreHydrateStart,
+}))
+
+afterEach(() => {
+  delete window.$_TSR
+  coreHydrateStart.mockReset()
+})
+
+test('signals streaming cleanup after hydration succeeds', async () => {
+  const router = {}
+  coreHydrateStart.mockResolvedValue(router)
+  const hydrated = vi.fn()
+  window.$_TSR = { h: hydrated } as any
+
+  await expect(hydrateStart()).resolves.toBe(router)
+  expect(hydrated).toHaveBeenCalledTimes(1)
+})

--- a/packages/start-server-core/tests/createStartHandler.test.ts
+++ b/packages/start-server-core/tests/createStartHandler.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest'
 import { createMemoryHistory } from '@tanstack/history'
 import { createMiddleware } from '@tanstack/start-client-core'

--- a/packages/vue-router/tests/Matches.test.tsx
+++ b/packages/vue-router/tests/Matches.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from 'vitest'
+import * as Vue from 'vue'
 import {
   cleanup,
   fireEvent,
@@ -7,6 +8,7 @@ import {
   waitFor,
 } from '@testing-library/vue'
 import { createMemoryHistory } from '@tanstack/history'
+import { createControlledPromise } from '@tanstack/router-core'
 import {
   Link,
   Outlet,
@@ -134,7 +136,7 @@ test('when filtering useMatches by loaderData', async () => {
 // Vue Suspense requires async setup functions or top-level await to trigger fallback.
 // Since TanStack Router throws Promises from render (not setup), Vue doesn't show
 // the pending component during initial load. Navigation-triggered pending states
-// DO work - see loaders.test.tsx 'cancelMatches after pending timeout'.
+// DO work - see loaders.test.tsx 'navigating away from a pending route aborts its loader'.
 test('should show pendingComponent of root route', async () => {
   const root = createRootRoute({
     pendingComponent: () => <div data-testId="root-pending" />,
@@ -156,6 +158,78 @@ test('should show pendingComponent of root route', async () => {
   // In Vue, the initial render completes synchronously before async loaders,
   // so we verify the final content loads correctly
   expect(await rendered.findByTestId('root-content')).toBeInTheDocument()
+})
+
+test('useMatchRoute follows superseding pending locations', async () => {
+  const aGate = createControlledPromise<void>()
+  const bGate = createControlledPromise<void>()
+
+  const Layout = Vue.defineComponent({
+    setup() {
+      const matchRoute = useMatchRoute()
+      const pendingA = matchRoute({ to: '/a', pending: true })
+      const pendingB = matchRoute({ to: '/b', pending: true })
+      const resolvedB = matchRoute({ to: '/b', pending: false })
+      return () => (
+        <div>
+          <span data-testid="pending-a">{String(Boolean(pendingA.value))}</span>
+          <span data-testid="pending-b">{String(Boolean(pendingB.value))}</span>
+          <span data-testid="resolved-b">
+            {String(Boolean(resolvedB.value))}
+          </span>
+          <Outlet />
+        </div>
+      )
+    },
+  })
+
+  const root = createRootRoute({ component: Layout })
+  const index = createRoute({
+    getParentRoute: () => root,
+    path: '/',
+  })
+  const a = createRoute({
+    getParentRoute: () => root,
+    path: '/a',
+    loader: () => aGate,
+  })
+  const b = createRoute({
+    getParentRoute: () => root,
+    path: '/b',
+    loader: () => bGate,
+  })
+  const router = createRouter({
+    routeTree: root.addChildren([index, a, b]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+  render(<RouterProvider router={router} />)
+
+  await waitFor(() => {
+    expect(screen.getByTestId('pending-a')).toHaveTextContent('false')
+    expect(router.stores.status.get()).toBe('idle')
+    expect(router.stores.resolvedLocation.get()?.pathname).toBe('/')
+  })
+
+  const navigationA = router.navigate({ to: '/a' })
+  await waitFor(() => {
+    expect(screen.getByTestId('pending-a')).toHaveTextContent('true')
+    expect(screen.getByTestId('resolved-b')).toHaveTextContent('false')
+  })
+
+  const navigationB = router.navigate({ to: '/b' })
+  await waitFor(() => {
+    expect(screen.getByTestId('pending-a')).toHaveTextContent('false')
+    expect(screen.getByTestId('pending-b')).toHaveTextContent('true')
+    expect(screen.getByTestId('resolved-b')).toHaveTextContent('false')
+  })
+
+  aGate.resolve()
+  bGate.resolve()
+  await Promise.allSettled([navigationA, navigationB])
+  await waitFor(() => {
+    expect(screen.getByTestId('pending-b')).toHaveTextContent('false')
+    expect(screen.getByTestId('resolved-b')).toHaveTextContent('true')
+  })
 })
 
 describe('matching on different param types', () => {

--- a/packages/vue-router/tests/Transitioner.test.tsx
+++ b/packages/vue-router/tests/Transitioner.test.tsx
@@ -1,15 +1,19 @@
-import { describe, expect, it, vi } from 'vitest'
-import { render, waitFor } from '@testing-library/vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, waitFor } from '@testing-library/vue'
 import {
+  RouterProvider,
   createMemoryHistory,
   createRootRoute,
   createRoute,
   createRouter,
 } from '../src'
-import { RouterProvider } from '../src/RouterProvider'
+
+afterEach(() => {
+  cleanup()
+})
 
 describe('Transitioner', () => {
-  it('should call router.load() when Transitioner mounts on the client', async () => {
+  it('loads the initial route when the provider mounts', async () => {
     const loader = vi.fn()
     const rootRoute = createRootRoute()
     const indexRoute = createRoute({
@@ -27,18 +31,11 @@ describe('Transitioner', () => {
       }),
     })
 
-    // Mock router.load() to verify it gets called
-    const loadSpy = vi.spyOn(router, 'load')
+    const view = render(<RouterProvider router={router} />)
 
-    render(<RouterProvider router={router} />)
-    await router.latestLoadPromise
-
-    // Wait for the createRenderEffect to run and call router.load()
     await waitFor(() => {
-      expect(loadSpy).toHaveBeenCalledTimes(1)
       expect(loader).toHaveBeenCalledTimes(1)
+      expect(view.getByText('Index')).toBeInTheDocument()
     })
-
-    loadSpy.mockRestore()
   })
 })

--- a/packages/vue-router/tests/disableGlobalCatchBoundary.test.tsx
+++ b/packages/vue-router/tests/disableGlobalCatchBoundary.test.tsx
@@ -79,4 +79,32 @@ describe('disableGlobalCatchBoundary option', () => {
     )
     expect(externalErrorElement).toBeInTheDocument()
   })
+
+  test('the global boundary recovers when the same match is reloaded', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    let shouldThrow = true
+
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => {
+        if (shouldThrow) {
+          throw new Error('Temporary error')
+        }
+        return <div>Recovered</div>
+      },
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute]),
+    })
+
+    render(<RouterProvider router={router} />)
+    expect(await screen.findByText('Temporary error')).toBeInTheDocument()
+
+    shouldThrow = false
+    await router.invalidate()
+
+    expect(await screen.findByText('Recovered')).toBeInTheDocument()
+  })
 })

--- a/packages/vue-router/tests/errorComponent.test.tsx
+++ b/packages/vue-router/tests/errorComponent.test.tsx
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen } from '@testing-library/vue'
+import { createControlledPromise } from '@tanstack/router-core'
 
 import {
   Link,
+  Outlet,
   RouterProvider,
   createLazyRoute,
   createRootRoute,
@@ -160,3 +162,104 @@ describe.each([true, false])(
     )
   },
 )
+
+test('global catch boundary resets when a background child generation recovers', async () => {
+  const refresh = createControlledPromise<number>()
+  let loaderCalls = 0
+  const rootRoute = createRootRoute({ component: Outlet })
+  const childRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    loader: {
+      staleReloadMode: 'background',
+      handler: () => (++loaderCalls === 1 ? 1 : refresh),
+    },
+    component: () => {
+      const revision = childRoute.useLoaderData()
+      if (revision.value === 1) {
+        throw new Error('stale child render failed')
+      }
+      return <div>Recovered child revision {revision.value}</div>
+    },
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([childRoute]),
+  })
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+
+  render(<RouterProvider router={router} />)
+  expect(
+    await screen.findByText('stale child render failed'),
+  ).toBeInTheDocument()
+
+  const invalidation = router.invalidate()
+  await vi.waitFor(() => expect(loaderCalls).toBe(2))
+  expect(screen.getByText('stale child render failed')).toBeInTheDocument()
+  expect(screen.queryByText(/Recovered child revision/)).not.toBeInTheDocument()
+  refresh.resolve(2)
+  await invalidation
+
+  expect(
+    await screen.findByText('Recovered child revision 2'),
+  ).toBeInTheDocument()
+  expect(
+    screen.queryByText('stale child render failed'),
+  ).not.toBeInTheDocument()
+})
+
+test('ancestor route errorComponent resets when a background child generation recovers', async () => {
+  const refresh = createControlledPromise<number>()
+  let loaderCalls = 0
+  const rootRoute = createRootRoute({
+    component: Outlet,
+    errorComponent: ({ error }) => <div>Ancestor error: {error.message}</div>,
+  })
+  const childRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    loader: {
+      staleReloadMode: 'background',
+      handler: () => (++loaderCalls === 1 ? 1 : refresh),
+    },
+    component: () => {
+      const revision = childRoute.useLoaderData()
+      if (revision.value === 1) {
+        throw new Error('stale child render failed')
+      }
+      return <div>Recovered child revision {revision.value}</div>
+    },
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([childRoute]),
+  })
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+
+  let invalidation: Promise<void> | undefined
+  try {
+    render(<RouterProvider router={router} />)
+    expect(
+      await screen.findByText('Ancestor error: stale child render failed'),
+    ).toBeInTheDocument()
+
+    invalidation = router.invalidate({
+      filter: (match) => match.routeId === childRoute.id,
+    })
+    await vi.waitFor(() => expect(loaderCalls).toBe(2))
+    expect(
+      screen.getByText('Ancestor error: stale child render failed'),
+    ).toBeInTheDocument()
+    refresh.resolve(2)
+    await invalidation
+
+    expect(
+      await screen.findByText('Recovered child revision 2'),
+    ).toBeInTheDocument()
+  } finally {
+    refresh.resolve(2)
+    if (invalidation) {
+      await Promise.allSettled([invalidation])
+    }
+  }
+})

--- a/packages/vue-router/tests/link.test.tsx
+++ b/packages/vue-router/tests/link.test.tsx
@@ -1365,15 +1365,16 @@ describe('Link', () => {
       expect(window.location.search).toBe('?page=2&filter=inactive')
     })
 
-    const updatedPage = await screen.findByTestId('current-page')
-    const updatedFilter = await screen.findByTestId('current-filter')
-
     // Verify search was updated
     expect(window.location.pathname).toBe('/posts')
     expect(window.location.search).toBe('?page=2&filter=inactive')
 
-    expect(updatedPage).toHaveTextContent('Page: 2')
-    expect(updatedFilter).toHaveTextContent('Filter: inactive')
+    await waitFor(() => {
+      expect(screen.getByTestId('current-page')).toHaveTextContent('Page: 2')
+      expect(screen.getByTestId('current-filter')).toHaveTextContent(
+        'Filter: inactive',
+      )
+    })
   })
 
   test('when navigation to . from /posts while updating search from / and using base path', async () => {
@@ -1491,10 +1492,12 @@ describe('Link', () => {
     expect(window.location.pathname).toBe('/Dashboard/posts')
     expect(window.location.search).toBe('?page=2&filter=inactive')
 
-    const updatedPage = await screen.findByTestId('current-page')
-    const updatedFilter = await screen.findByTestId('current-filter')
-    expect(updatedPage).toHaveTextContent('Page: 2')
-    expect(updatedFilter).toHaveTextContent('Filter: inactive')
+    await waitFor(() => {
+      expect(screen.getByTestId('current-page')).toHaveTextContent('Page: 2')
+      expect(screen.getByTestId('current-filter')).toHaveTextContent(
+        'Filter: inactive',
+      )
+    })
   })
 
   test('when navigating to /posts with invalid search', async () => {

--- a/packages/vue-router/tests/loaders.test.tsx
+++ b/packages/vue-router/tests/loaders.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/vue'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/vue'
 
 import { afterEach, describe, expect, test, vi } from 'vitest'
 
@@ -601,7 +607,7 @@ test('reproducer #4546', async () => {
     expect(routeContext).toHaveTextContent('3')
 
     const loaderData = await screen.findByTestId('index-loader-data')
-    expect(loaderData).toHaveTextContent('3')
+    await waitFor(() => expect(loaderData).toHaveTextContent('3'))
   }
 
   fireEvent.click(invalidateRouterButton)
@@ -631,11 +637,11 @@ test('reproducer #4546', async () => {
     expect(routeContext).toHaveTextContent('5')
 
     const loaderData = await screen.findByTestId('id-loader-data')
-    expect(loaderData).toHaveTextContent('5')
+    await waitFor(() => expect(loaderData).toHaveTextContent('5'))
   }
 })
 
-test('clears pendingTimeout when match resolves', async () => {
+test('does not show pending UI when routes resolve before their thresholds', async () => {
   const defaultPendingComponentOnMountMock = vi.fn()
   const nestedPendingComponentOnMountMock = vi.fn()
   const fooPendingComponentOnMountMock = vi.fn()
@@ -703,7 +709,7 @@ test('clears pendingTimeout when match resolves', async () => {
   })
 
   render(<RouterProvider router={router} />)
-  await router.latestLoadPromise
+  await screen.findByText('Index page')
   const linkToFoo = await screen.findByTestId('link-to-foo')
   fireEvent.click(linkToFoo)
   const fooElement = await screen.findByText('Nested Foo page')
@@ -717,7 +723,7 @@ test('clears pendingTimeout when match resolves', async () => {
   expect(fooPendingComponentOnMountMock).not.toHaveBeenCalled()
 })
 
-test('cancelMatches after pending timeout', async () => {
+test('navigating away from pending UI aborts its loader', async () => {
   function getPendingComponent(onMount: () => void) {
     const PendingComponent = () => {
       onMount()
@@ -769,7 +775,7 @@ test('cancelMatches after pending timeout', async () => {
   const routeTree = rootRoute.addChildren([fooRoute, barRoute])
   const router = createRouter({ routeTree, history })
   render(<RouterProvider router={router} />)
-  await router.latestLoadPromise
+  await screen.findByText('Index page')
   const fooLink = await screen.findByTestId('link-to-foo')
   fireEvent.click(fooLink)
   await sleep(WAIT_TIME * 30)

--- a/packages/vue-router/tests/pending-fallback-promise-replacement.test.tsx
+++ b/packages/vue-router/tests/pending-fallback-promise-replacement.test.tsx
@@ -1,0 +1,78 @@
+import { cleanup, render, screen } from '@testing-library/vue'
+import { afterEach, expect, test, vi } from 'vitest'
+import { createControlledPromise } from '@tanstack/router-core'
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+} from '../src'
+
+const testCleanups: Array<() => void | Promise<void>> = []
+
+afterEach(async () => {
+  vi.useRealTimers()
+  while (testCleanups.length) {
+    await testCleanups.pop()!()
+  }
+  cleanup()
+})
+
+test('a continuously visible fallback keeps its deadline across replacement loads', async () => {
+  const firstReload = createControlledPromise<void>()
+  const secondReload = createControlledPromise<void>()
+  const reloads = [firstReload, secondReload]
+  let loaderCall = 0
+
+  const rootRoute = createRootRoute({
+    pendingMs: 0,
+    pendingMinMs: 100,
+    pendingComponent: () => <div data-testid="pending">Pending</div>,
+    loader: () => {
+      const generation = ++loaderCall
+      const gate = reloads[generation - 2]
+      return gate ? gate.then(() => generation) : generation
+    },
+    component: () => <div>Content</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute,
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  render(<RouterProvider router={router} />)
+  expect(await screen.findByText('Content')).toBeInTheDocument()
+
+  vi.useFakeTimers()
+  const firstInvalidation = router.invalidate({ forcePending: true })
+  const invalidations = [firstInvalidation]
+  testCleanups.push(async () => {
+    firstReload.resolve()
+    secondReload.resolve()
+    await Promise.allSettled(invalidations)
+  })
+  await vi.advanceTimersByTimeAsync(0)
+  expect(screen.getByTestId('pending')).toBeInTheDocument()
+
+  await vi.advanceTimersByTimeAsync(25)
+  let secondSettled = false
+  const secondInvalidation = router
+    .invalidate({ forcePending: true })
+    .then(() => {
+      secondSettled = true
+    })
+  invalidations.push(secondInvalidation)
+
+  firstReload.resolve()
+  secondReload.resolve()
+  await Promise.resolve()
+
+  await vi.advanceTimersByTimeAsync(74)
+  expect(secondSettled).toBe(false)
+  expect(screen.getByTestId('pending')).toBeInTheDocument()
+
+  await vi.advanceTimersByTimeAsync(1)
+  await Promise.all(invalidations)
+  expect(screen.getByText('Content')).toBeInTheDocument()
+  expect(screen.queryByTestId('pending')).not.toBeInTheDocument()
+})

--- a/packages/vue-router/tests/redirect.test.tsx
+++ b/packages/vue-router/tests/redirect.test.tsx
@@ -1,11 +1,12 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/vue'
 
-import { afterEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 import {
   Link,
   Outlet,
   RouterProvider,
+  createBrowserHistory,
   createMemoryHistory,
   createRootRoute,
   createRoute,
@@ -15,8 +16,17 @@ import {
 } from '../src'
 
 import { sleep } from './utils'
+import type { RouterHistory } from '../src'
+
+let history: RouterHistory
+
+beforeEach(() => {
+  history = createBrowserHistory()
+  expect(window.location.pathname).toBe('/')
+})
 
 afterEach(() => {
+  history.destroy()
   vi.clearAllMocks()
   vi.resetAllMocks()
   window.history.replaceState(null, 'root', '/')
@@ -74,7 +84,7 @@ describe('redirect', () => {
         aboutRoute,
         indexRoute,
       ])
-      const router = createRouter({ routeTree })
+      const router = createRouter({ routeTree, history })
 
       render(<RouterProvider router={router} />)
 
@@ -196,7 +206,7 @@ describe('redirect', () => {
         aboutRoute,
         indexRoute,
       ])
-      const router = createRouter({ routeTree })
+      const router = createRouter({ routeTree, history })
 
       render(<RouterProvider router={router} />)
 
@@ -274,7 +284,7 @@ describe('redirect', () => {
         indexRoute,
         finalRoute,
       ])
-      const router = createRouter({ routeTree })
+      const router = createRouter({ routeTree, history })
 
       render(<RouterProvider router={router} />)
 

--- a/packages/vue-router/tests/renderRouterToStream.test.tsx
+++ b/packages/vue-router/tests/renderRouterToStream.test.tsx
@@ -117,7 +117,7 @@ describe('renderRouterToStream - sync setup failures', () => {
     }
   })
 
-  test('request abort drops later Vue writes and terminates response stream', async () => {
+  test('request abort drops later Vue writes and terminates the response', async () => {
     let vueWriter: WritableStreamDefaultWriter<Uint8Array> | undefined
     rendererMocks.pipeToWebWritable.mockImplementationOnce(
       (
@@ -150,6 +150,7 @@ describe('renderRouterToStream - sync setup failures', () => {
       await expect(
         vueWriter!.write(new TextEncoder().encode('<div/>')),
       ).resolves.toBeUndefined()
+      expect(response.body).not.toBeNull()
 
       const terminated = await Promise.race([
         drainBody(response),

--- a/packages/vue-router/tests/router.test.tsx
+++ b/packages/vue-router/tests/router.test.tsx
@@ -1724,12 +1724,13 @@ describe('does not strip search params if search validation fails', () => {
   })
 })
 
-describe('statusCode reset on navigation', () => {
-  it('should reset statusCode to 200 when navigating from 404 to valid route', async () => {
+describe('route result reset on navigation', () => {
+  it('renders the requested route after navigating away from a not-found result', async () => {
     const history = createMemoryHistory({ initialEntries: ['/'] })
 
     const rootRoute = createRootRoute({
       component: () => <Outlet />,
+      notFoundComponent: () => <div>Not Found</div>,
     })
 
     const indexRoute = createRoute({
@@ -1749,23 +1750,23 @@ describe('statusCode reset on navigation', () => {
 
     render(<RouterProvider router={router} />)
 
-    expect(router.state.statusCode).toBe(200)
-
-    await router.navigate({ to: '/' })
-    await waitFor(() => expect(router.state.statusCode).toBe(200))
+    expect(await screen.findByText('Home')).toBeInTheDocument()
 
     await router.navigate({ to: '/non-existing' })
-    await waitFor(() => expect(router.state.statusCode).toBe(404))
+    expect(await screen.findByText('Not Found')).toBeInTheDocument()
+    expect(screen.queryByText('Home')).not.toBeInTheDocument()
 
     await router.navigate({ to: '/valid' })
-    await waitFor(() => expect(router.state.statusCode).toBe(200))
+    expect(await screen.findByText('Valid Route')).toBeInTheDocument()
+    expect(screen.queryByText('Not Found')).not.toBeInTheDocument()
 
     await router.navigate({ to: '/another-non-existing' })
-    await waitFor(() => expect(router.state.statusCode).toBe(404))
+    expect(await screen.findByText('Not Found')).toBeInTheDocument()
+    expect(screen.queryByText('Valid Route')).not.toBeInTheDocument()
   })
 
   describe.each([true, false])(
-    'status code is set when loader/beforeLoad throws (isAsync=%s)',
+    'load failures render their route boundary (isAsync=%s)',
     (isAsync) => {
       const throwingFun = isAsync
         ? (toThrow: () => void) => async () => {
@@ -1780,7 +1781,7 @@ describe('statusCode reset on navigation', () => {
       const throwError = throwingFun(() => {
         throw new Error('test-error')
       })
-      it('should set statusCode to 404 when a route loader throws a notFound()', async () => {
+      it('should render notFoundComponent when a route loader throws a notFound()', async () => {
         const history = createMemoryHistory({ initialEntries: ['/'] })
 
         const rootRoute = createRootRoute()
@@ -1808,17 +1809,14 @@ describe('statusCode reset on navigation', () => {
 
         render(<RouterProvider router={router} />)
 
-        expect(router.state.statusCode).toBe(200)
-
         await router.navigate({ to: '/loader-throws-not-found' })
-        await waitFor(() => expect(router.state.statusCode).toBe(404))
         expect(
           await screen.findByTestId('not-found-component'),
         ).toBeInTheDocument()
         expect(screen.queryByTestId('route-component')).not.toBeInTheDocument()
       })
 
-      it('should set statusCode to 404 when a route beforeLoad throws a notFound()', async () => {
+      it('should render notFoundComponent when a route beforeLoad throws a notFound()', async () => {
         const history = createMemoryHistory({ initialEntries: ['/'] })
 
         const rootRoute = createRootRoute({
@@ -1853,17 +1851,14 @@ describe('statusCode reset on navigation', () => {
 
         render(<RouterProvider router={router} />)
 
-        expect(router.state.statusCode).toBe(200)
-
         await router.navigate({ to: '/beforeload-throws-not-found' })
-        await waitFor(() => expect(router.state.statusCode).toBe(404))
         expect(
           await screen.findByTestId('not-found-component'),
         ).toBeInTheDocument()
         expect(screen.queryByTestId('route-component')).not.toBeInTheDocument()
       })
 
-      it('should set statusCode to 500 when a route loader throws an Error', async () => {
+      it('should render errorComponent when a route loader throws an Error', async () => {
         const history = createMemoryHistory({ initialEntries: ['/'] })
 
         const rootRoute = createRootRoute()
@@ -1889,15 +1884,12 @@ describe('statusCode reset on navigation', () => {
 
         render(<RouterProvider router={router} />)
 
-        expect(router.state.statusCode).toBe(200)
-
         await router.navigate({ to: '/loader-throws-error' })
-        await waitFor(() => expect(router.state.statusCode).toBe(500))
         expect(await screen.findByTestId('error-component')).toBeInTheDocument()
         expect(screen.queryByTestId('route-component')).not.toBeInTheDocument()
       })
 
-      it('should set statusCode to 500 when a route beforeLoad throws an Error', async () => {
+      it('should render errorComponent when a route beforeLoad throws an Error', async () => {
         const history = createMemoryHistory({ initialEntries: ['/'] })
 
         const rootRoute = createRootRoute()
@@ -1926,10 +1918,7 @@ describe('statusCode reset on navigation', () => {
 
         render(<RouterProvider router={router} />)
 
-        expect(router.state.statusCode).toBe(200)
-
         await router.navigate({ to: '/beforeload-throws-error' })
-        await waitFor(() => expect(router.state.statusCode).toBe(500))
         expect(await screen.findByTestId('error-component')).toBeInTheDocument()
         expect(screen.queryByTestId('route-component')).not.toBeInTheDocument()
       })
@@ -2061,7 +2050,6 @@ describe('basepath', () => {
       })
 
       expect(router.state.location.pathname).toBe('/')
-      expect(router.state.statusCode).toBe(200)
     },
   )
 

--- a/packages/vue-router/tests/transitioner-idle-after-render.test.tsx
+++ b/packages/vue-router/tests/transitioner-idle-after-render.test.tsx
@@ -1,0 +1,46 @@
+import { cleanup, render, screen } from '@testing-library/vue'
+import { afterEach, expect, test } from 'vitest'
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+
+afterEach(() => {
+  cleanup()
+})
+
+test('onResolved fires only after Vue commits the destination DOM', async () => {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <div>Index</div>,
+  })
+  const nextRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/next',
+    component: () => <div>Next</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute, nextRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  render(<RouterProvider router={router} />)
+  expect(await screen.findByText('Index')).toBeInTheDocument()
+
+  const destinationWasRenderedWhenResolved: Array<boolean> = []
+  const unsubscribe = router.subscribe('onResolved', () => {
+    destinationWasRenderedWhenResolved.push(screen.queryByText('Next') !== null)
+  })
+
+  await router.navigate({ to: '/next' })
+  expect(await screen.findByText('Next')).toBeInTheDocument()
+
+  expect(destinationWasRenderedWhenResolved).toEqual([true])
+  unsubscribe()
+})

--- a/packages/vue-router/tests/transitioner-remount-rendered.test.tsx
+++ b/packages/vue-router/tests/transitioner-remount-rendered.test.tsx
@@ -1,0 +1,56 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/vue'
+import { afterEach, expect, test, vi } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import {
+  Outlet,
+  RouterProvider,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+
+afterEach(() => {
+  cleanup()
+  document.body.innerHTML = ''
+})
+
+function setup() {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <div>Index</div>,
+  })
+  const nextRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/next',
+    component: () => <div>Next</div>,
+  })
+  const history = createMemoryHistory({ initialEntries: ['/'] })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute, nextRoute]),
+    history,
+  })
+  return router
+}
+
+test('onRendered runs after the destination DOM has committed', async () => {
+  const router = setup()
+  const initialRendered = vi.fn()
+  const unsubscribeInitial = router.subscribe('onRendered', initialRendered)
+  render(<RouterProvider router={router} />)
+  expect(await screen.findByText('Index')).toBeTruthy()
+  await waitFor(() => expect(initialRendered).toHaveBeenCalledTimes(1))
+  unsubscribeInitial()
+
+  const destinationWasRendered: Array<boolean> = []
+  const unsubscribe = router.subscribe('onRendered', () => {
+    destinationWasRendered.push(screen.queryByText('Next') !== null)
+  })
+
+  await router.navigate({ to: '/next' })
+  await waitFor(() => expect(destinationWasRendered).toHaveLength(1))
+  expect(destinationWasRendered).toEqual([true])
+
+  unsubscribe()
+})

--- a/packages/vue-router/tests/transitioner-remount.test.tsx
+++ b/packages/vue-router/tests/transitioner-remount.test.tsx
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/vue'
+import { createMemoryHistory } from '@tanstack/history'
+import {
+  Outlet,
+  RouterProvider,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+
+afterEach(() => {
+  cleanup()
+  document.body.innerHTML = ''
+})
+
+function setup() {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <div>Index</div>,
+  })
+  const nextRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/next',
+    component: () => <div>Next</div>,
+  })
+  const history = createMemoryHistory({ initialEntries: ['/'] })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute, nextRoute]),
+    history,
+  })
+  return { history, router }
+}
+
+describe('Transitioner remount', () => {
+  // Zombie-router pin: once the provider unmounts, the history subscription
+  // must be torn down so a later history change never re-drives the router.
+  it('does not load after the provider unmounts', async () => {
+    const { history, router } = setup()
+    const loadSpy = vi.spyOn(router, 'load')
+
+    const first = render(<RouterProvider router={router} />)
+    expect(await screen.findByText('Index')).toBeTruthy()
+    await waitFor(() => expect(router.state.status).toBe('idle'))
+
+    first.unmount()
+    loadSpy.mockClear()
+
+    // A history change while unmounted must not reach the router.
+    history.push('/next')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(loadSpy).not.toHaveBeenCalled()
+    // Raw history advanced...
+    expect(router.history.location.pathname).toBe('/next')
+    // ...but the router never processed it, so its committed state stayed put.
+    expect(router.state.location.pathname).toBe('/')
+
+    loadSpy.mockRestore()
+  })
+
+  // Remounting the same router instance must re-establish the subscription so
+  // navigation keeps working, without leaving a stale duplicate behind.
+  it('re-subscribes and loads on remount with the same router', async () => {
+    const { history, router } = setup()
+    // Spy before the first mount so the subscription captures the spy by
+    // reference - both the first and second mounts subscribe with it.
+    const loadSpy = vi.spyOn(router, 'load')
+
+    const first = render(<RouterProvider router={router} />)
+    expect(await screen.findByText('Index')).toBeTruthy()
+    await waitFor(() => expect(router.state.status).toBe('idle'))
+
+    first.unmount()
+
+    render(<RouterProvider router={router} />)
+    expect(await screen.findByText('Index')).toBeTruthy()
+    await waitFor(() => expect(router.state.status).toBe('idle'))
+
+    // A push on the remounted provider must drive exactly one load, proving
+    // the subscription was re-established (and is singular).
+    loadSpy.mockClear()
+    history.push('/next')
+    expect(await screen.findByText('Next')).toBeTruthy()
+    expect(router.state.location.pathname).toBe('/next')
+    await waitFor(() => expect(loadSpy).toHaveBeenCalledTimes(1))
+
+    loadSpy.mockRestore()
+  })
+})

--- a/packages/vue-router/tests/useMatch.test.tsx
+++ b/packages/vue-router/tests/useMatch.test.tsx
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
-import { cleanup, render, screen, waitFor } from '@testing-library/vue'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/vue'
+import * as Vue from 'vue'
 import {
   Link,
   Outlet,
@@ -72,6 +79,160 @@ describe('useMatch', () => {
         expect(postsTitle).toBeInTheDocument()
       },
     )
+  })
+
+  test('tracks presentation generations across replacement and re-entry', async () => {
+    const RootComponent = Vue.defineComponent({
+      setup() {
+        const targetedRevision = useMatch({
+          from: '/item',
+          shouldThrow: false,
+          select: (match) => match.loaderData,
+        })
+
+        return () => (
+          <>
+            <div data-testid="targeted-match">
+              {targetedRevision.value === undefined
+                ? 'Targeted absent'
+                : `Targeted revision ${targetedRevision.value}`}
+            </div>
+            <Link to="/item" search={{ revision: 2 }}>
+              Revision 2
+            </Link>
+            <Link to="/item" search={{ revision: 3 }}>
+              Revision 3
+            </Link>
+            <Link to="/other">Other</Link>
+            <Outlet />
+          </>
+        )
+      },
+    })
+
+    const ItemComponent = Vue.defineComponent({
+      setup() {
+        const nearestRevision = useMatch({
+          strict: false,
+          shouldThrow: false,
+          select: (match) => match.loaderData as number,
+        })
+        return () => <div>Nearest revision {nearestRevision.value}</div>
+      },
+    })
+
+    const rootRoute = createRootRoute({ component: RootComponent })
+    const itemRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/item',
+      validateSearch: (search: Record<string, unknown>) => ({
+        revision: Number(search.revision),
+      }),
+      loaderDeps: ({ search }) => ({ revision: search.revision }),
+      loader: ({ deps }) => deps.revision,
+      component: ItemComponent,
+    })
+    const otherRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/other',
+      component: () => <div>Other route</div>,
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([itemRoute, otherRoute]),
+      history: createMemoryHistory({ initialEntries: ['/item?revision=1'] }),
+    })
+
+    render(<RouterProvider router={router} />)
+    expect(await screen.findByText('Nearest revision 1')).toBeInTheDocument()
+    expect(screen.getByTestId('targeted-match')).toHaveTextContent(
+      'Targeted revision 1',
+    )
+
+    await fireEvent.click(screen.getByText('Revision 2'))
+    expect(await screen.findByText('Nearest revision 2')).toBeInTheDocument()
+    expect(screen.getByTestId('targeted-match')).toHaveTextContent(
+      'Targeted revision 2',
+    )
+
+    await fireEvent.click(screen.getByText('Other'))
+    expect(await screen.findByText('Other route')).toBeInTheDocument()
+    expect(screen.getByTestId('targeted-match')).toHaveTextContent(
+      'Targeted absent',
+    )
+
+    await fireEvent.click(screen.getByText('Revision 3'))
+    expect(await screen.findByText('Nearest revision 3')).toBeInTheDocument()
+    expect(screen.getByTestId('targeted-match')).toHaveTextContent(
+      'Targeted revision 3',
+    )
+  })
+
+  test('renders a route generation that re-enters before an intermediate route renders', async () => {
+    const RootComponent = Vue.defineComponent({
+      setup() {
+        return () => (
+          <>
+            <Link to="/other">Other</Link>
+            <Outlet />
+          </>
+        )
+      },
+    })
+    const ItemComponent = Vue.defineComponent({
+      setup() {
+        const revision = useMatch({
+          strict: false,
+          select: (match) => match.loaderData as number,
+        })
+        return () => <div>Item revision {revision.value}</div>
+      },
+    })
+
+    const rootRoute = createRootRoute({ component: RootComponent })
+    const itemRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/item',
+      validateSearch: (search: Record<string, unknown>) => ({
+        revision: Number(search.revision),
+      }),
+      loaderDeps: ({ search }) => ({ revision: search.revision }),
+      loader: ({ deps }) => deps.revision,
+      component: ItemComponent,
+    })
+    const otherRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/other',
+      component: Vue.defineComponent({
+        setup: () => () => <div>Other route</div>,
+      }),
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([itemRoute, otherRoute]),
+      history: createMemoryHistory({ initialEntries: ['/item?revision=1'] }),
+    })
+
+    render(<RouterProvider router={router} />)
+    expect(await screen.findByText('Item revision 1')).toBeInTheDocument()
+
+    let returnNavigation: Promise<void> | undefined
+    const unsubscribe = router.subscribe('onLoad', (event) => {
+      if (event.toLocation.pathname === '/other') {
+        returnNavigation = router.navigate({
+          to: '/item',
+          search: { revision: 2 },
+        })
+      }
+    })
+    try {
+      await fireEvent.click(screen.getByText('Other'))
+      await waitFor(() => expect(returnNavigation).toBeDefined())
+      await returnNavigation
+
+      expect(await screen.findByText('Item revision 2')).toBeInTheDocument()
+      expect(screen.queryByText('Other route')).not.toBeInTheDocument()
+    } finally {
+      unsubscribe()
+    }
   })
 
   describe('when match is not found', () => {


### PR DESCRIPTION
## Summary

- add 242 regression cases that were introduced or modified on the lane/match-loader branch and already pass against `main`
- cover router-core, React, Solid, Vue, Start, router-plugin HMR, and two Start E2E scenarios
- keep package implementation source unchanged; the only non-spec files are E2E app fixtures required by the Playwright cases

## Tests

- `CI=1 NX_DAEMON=false pnpm nx run-many --target=test:unit --projects=@tanstack/router-core,@tanstack/react-router,@tanstack/solid-router,@tanstack/vue-router,@tanstack/react-start-client,@tanstack/solid-start-client,@tanstack/start-server-core,@tanstack/router-plugin --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run-many --target=test:types --projects=@tanstack/router-core,@tanstack/react-router,@tanstack/solid-router,@tanstack/vue-router,@tanstack/react-start-client,@tanstack/solid-start-client,@tanstack/start-server-core,@tanstack/router-plugin --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run-many --target=test:eslint --projects=@tanstack/router-core,@tanstack/react-router,@tanstack/solid-router,@tanstack/vue-router,@tanstack/react-start-client,@tanstack/solid-start-client,@tanstack/start-server-core,@tanstack/router-plugin --outputStyle=stream --skipRemoteCache`
- selective SSR loaderDeps control E2E on Chromium
- React Start special-character direct-navigation E2E in Vite SSR and SPA modes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a selective SSR example route with preload and navigation coverage.
  * Improved handling of pending, background, and superseded navigations across React, Solid, and Vue integrations.
  * Enhanced route recovery for errors and not-found states.
  * Improved SSR hydration, streaming, redirects, and loader data handling.

* **Bug Fixes**
  * Fixed stale content, pending indicators, route boundaries, and loader results during rapid navigation.
  * Improved cancellation and recovery of in-progress loads.
  * Corrected route matching and context updates when parameters or dependencies change.

* **Tests**
  * Expanded end-to-end and integration coverage for routing, preloading, hydration, errors, and navigation transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->