### PR TITLE
Upgrade solidjs beta 25

### DIFF
--- a/.changeset/solid-js-beta-25.md
+++ b/.changeset/solid-js-beta-25.md
@@ -1,0 +1,10 @@
+---
+'@tanstack/solid-router-devtools': patch
+'@tanstack/solid-router-ssr-query': patch
+'@tanstack/solid-router': patch
+'@tanstack/solid-start-client': patch
+'@tanstack/solid-start-server': patch
+'@tanstack/solid-start': patch
+---
+
+Upgrade `solid-js` and `@solidjs/web` to `2.0.0-beta.25`

--- a/benchmarks/bundle-size/package.json
+++ b/benchmarks/bundle-size/package.json
@@ -50,6 +50,6 @@
     "@vitejs/plugin-vue-jsx": "^5.1.5",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/benchmarks/bundle-size/package.json
+++ b/benchmarks/bundle-size/package.json
@@ -27,7 +27,7 @@
     }
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/react-router": "workspace:^",
     "@tanstack/react-start": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
@@ -36,7 +36,7 @@
     "@tanstack/vue-start": "workspace:^",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "vue": "^3.5.16"
   },
   "devDependencies": {
@@ -50,6 +50,6 @@
     "@vitejs/plugin-vue-jsx": "^5.1.5",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/benchmarks/client-nav/package.json
+++ b/benchmarks/client-nav/package.json
@@ -19,14 +19,14 @@
     "test:types:vue": "tsc -p ./vue/tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/react-router": "workspace:^",
     "@tanstack/router-core": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/vue-router": "workspace:^",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "vue": "^3.5.16"
   },
   "devDependencies": {
@@ -40,7 +40,7 @@
     "@vitejs/plugin-vue-jsx": "^5.1.5",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vitest": "^4.1.4"
   },
   "nx": {

--- a/benchmarks/client-nav/package.json
+++ b/benchmarks/client-nav/package.json
@@ -40,7 +40,7 @@
     "@vitejs/plugin-vue-jsx": "^5.1.5",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vitest": "^4.1.4"
   },
   "nx": {

--- a/benchmarks/memory/client/package.json
+++ b/benchmarks/memory/client/package.json
@@ -12,14 +12,14 @@
     "#memory-client/lifecycle": "./lifecycle.ts"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/react-router": "workspace:*",
     "@tanstack/router-core": "workspace:*",
     "@tanstack/solid-router": "workspace:*",
     "@tanstack/vue-router": "workspace:*",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "vue": "^3.5.16"
   },
   "devDependencies": {
@@ -34,7 +34,7 @@
     "jsdom": "29.1.1",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vitest": "^4.1.4"
   },
   "nx": {

--- a/benchmarks/memory/client/package.json
+++ b/benchmarks/memory/client/package.json
@@ -34,7 +34,7 @@
     "jsdom": "29.1.1",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vitest": "^4.1.4"
   },
   "nx": {

--- a/benchmarks/memory/server/package.json
+++ b/benchmarks/memory/server/package.json
@@ -11,7 +11,7 @@
     "#memory-server/flame-runner": "./flame-runner.ts"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/react-router": "workspace:*",
     "@tanstack/react-start": "workspace:*",
     "@tanstack/solid-router": "workspace:*",
@@ -20,7 +20,7 @@
     "@tanstack/vue-start": "workspace:*",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "vue": "^3.5.16"
   },
   "devDependencies": {
@@ -31,7 +31,7 @@
     "@vitejs/plugin-vue-jsx": "^5.1.5",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vitest": "^4.1.4"
   },
   "nx": {

--- a/benchmarks/memory/server/package.json
+++ b/benchmarks/memory/server/package.json
@@ -31,7 +31,7 @@
     "@vitejs/plugin-vue-jsx": "^5.1.5",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vitest": "^4.1.4"
   },
   "nx": {

--- a/benchmarks/ssr/package.json
+++ b/benchmarks/ssr/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/react-router": "workspace:^",
     "@tanstack/react-start": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
@@ -12,7 +12,7 @@
     "@tanstack/vue-start": "workspace:^",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "vue": "^3.5.16"
   },
   "devDependencies": {
@@ -22,7 +22,7 @@
     "seroval": "^1.5.4",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vitest": "^4.1.4"
   },
   "nx": {

--- a/benchmarks/ssr/package.json
+++ b/benchmarks/ssr/package.json
@@ -22,7 +22,7 @@
     "seroval": "^1.5.4",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vitest": "^4.1.4"
   },
   "nx": {

--- a/e2e/solid-router/basepath-file-based/package.json
+++ b/e2e/solid-router/basepath-file-based/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@playwright/test": "^1.50.1",
     "@tanstack/router-e2e-utils": "workspace:^",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite": "^8.0.14"
   }
 }

--- a/e2e/solid-router/basepath-file-based/package.json
+++ b/e2e/solid-router/basepath-file-based/package.json
@@ -11,16 +11,16 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/router-plugin": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
     "@tanstack/router-e2e-utils": "workspace:^",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite": "^8.0.14"
   }
 }

--- a/e2e/solid-router/basic-esbuild-file-based/package.json
+++ b/e2e/solid-router/basic-esbuild-file-based/package.json
@@ -10,12 +10,12 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/router-plugin": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/e2e/solid-router/basic-file-based-code-splitting/package.json
+++ b/e2e/solid-router/basic-file-based-code-splitting/package.json
@@ -11,12 +11,12 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -24,6 +24,6 @@
     "@playwright/test": "^1.50.1",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/e2e/solid-router/basic-file-based-code-splitting/package.json
+++ b/e2e/solid-router/basic-file-based-code-splitting/package.json
@@ -24,6 +24,6 @@
     "@playwright/test": "^1.50.1",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/e2e/solid-router/basic-file-based/package.json
+++ b/e2e/solid-router/basic-file-based/package.json
@@ -12,13 +12,13 @@
     "test:e2e:default": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -27,6 +27,6 @@
     "@tanstack/router-e2e-utils": "workspace:^",
     "combinate": "^1.1.11",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/e2e/solid-router/basic-file-based/package.json
+++ b/e2e/solid-router/basic-file-based/package.json
@@ -27,6 +27,6 @@
     "@tanstack/router-e2e-utils": "workspace:^",
     "combinate": "^1.1.11",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/e2e/solid-router/basic-scroll-restoration/package.json
+++ b/e2e/solid-router/basic-scroll-restoration/package.json
@@ -24,7 +24,7 @@
     "@playwright/test": "^1.50.1",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "typescript": "~5.9.0"
   }
 }

--- a/e2e/solid-router/basic-scroll-restoration/package.json
+++ b/e2e/solid-router/basic-scroll-restoration/package.json
@@ -11,20 +11,20 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-virtual": "^3.13.0",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "typescript": "~5.9.0"
   }
 }

--- a/e2e/solid-router/basic-solid-query-file-based/package.json
+++ b/e2e/solid-router/basic-solid-query-file-based/package.json
@@ -11,7 +11,7 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "workspace:^",
     "@tanstack/solid-query": "^6.0.0-beta.5",
@@ -19,7 +19,7 @@
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -27,6 +27,6 @@
     "@playwright/test": "^1.50.1",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/e2e/solid-router/basic-solid-query-file-based/package.json
+++ b/e2e/solid-router/basic-solid-query-file-based/package.json
@@ -27,6 +27,6 @@
     "@playwright/test": "^1.50.1",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/e2e/solid-router/basic-solid-query/package.json
+++ b/e2e/solid-router/basic-solid-query/package.json
@@ -11,20 +11,20 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-query": "^6.0.0-beta.5",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.5",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/e2e/solid-router/basic-solid-query/package.json
+++ b/e2e/solid-router/basic-solid-query/package.json
@@ -25,6 +25,6 @@
     "@playwright/test": "^1.50.1",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/e2e/solid-router/basic-virtual-file-based/package.json
+++ b/e2e/solid-router/basic-virtual-file-based/package.json
@@ -26,6 +26,6 @@
     "@playwright/test": "^1.50.1",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/e2e/solid-router/basic-virtual-file-based/package.json
+++ b/e2e/solid-router/basic-virtual-file-based/package.json
@@ -11,14 +11,14 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/virtual-file-routes": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -26,6 +26,6 @@
     "@playwright/test": "^1.50.1",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/e2e/solid-router/basic-virtual-named-export-config-file-based/package.json
+++ b/e2e/solid-router/basic-virtual-named-export-config-file-based/package.json
@@ -26,6 +26,6 @@
     "@playwright/test": "^1.50.1",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/e2e/solid-router/basic-virtual-named-export-config-file-based/package.json
+++ b/e2e/solid-router/basic-virtual-named-export-config-file-based/package.json
@@ -11,14 +11,14 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/virtual-file-routes": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -26,6 +26,6 @@
     "@playwright/test": "^1.50.1",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/e2e/solid-router/basic/package.json
+++ b/e2e/solid-router/basic/package.json
@@ -23,6 +23,6 @@
     "@playwright/test": "^1.50.1",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/e2e/solid-router/basic/package.json
+++ b/e2e/solid-router/basic/package.json
@@ -11,18 +11,18 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/e2e/solid-router/generator-cli-only/package.json
+++ b/e2e/solid-router/generator-cli-only/package.json
@@ -11,19 +11,19 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-cli": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/e2e/solid-router/generator-cli-only/package.json
+++ b/e2e/solid-router/generator-cli-only/package.json
@@ -24,6 +24,6 @@
     "@playwright/test": "^1.50.1",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/e2e/solid-router/js-only-file-based/package.json
+++ b/e2e/solid-router/js-only-file-based/package.json
@@ -24,6 +24,6 @@
     "@tanstack/router-e2e-utils": "workspace:^",
     "@tanstack/router-plugin": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/e2e/solid-router/js-only-file-based/package.json
+++ b/e2e/solid-router/js-only-file-based/package.json
@@ -11,12 +11,12 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
@@ -24,6 +24,6 @@
     "@tanstack/router-e2e-utils": "workspace:^",
     "@tanstack/router-plugin": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/e2e/solid-router/rspack-basic-file-based/package.json
+++ b/e2e/solid-router/rspack-basic-file-based/package.json
@@ -10,11 +10,11 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",

--- a/e2e/solid-router/rspack-basic-virtual-named-export-config-file-based/package.json
+++ b/e2e/solid-router/rspack-basic-virtual-named-export-config-file-based/package.json
@@ -10,11 +10,11 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",

--- a/e2e/solid-router/scroll-restoration-sandbox-vite/package.json
+++ b/e2e/solid-router/scroll-restoration-sandbox-vite/package.json
@@ -28,6 +28,6 @@
     "@playwright/test": "^1.50.1",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/e2e/solid-router/scroll-restoration-sandbox-vite/package.json
+++ b/e2e/solid-router/scroll-restoration-sandbox-vite/package.json
@@ -14,13 +14,13 @@
     "test:e2e": "rm -rf port*.txt; pnpm run test:e2e:browser && pnpm run test:e2e:hash"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -28,6 +28,6 @@
     "@playwright/test": "^1.50.1",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/e2e/solid-router/sentry-integration/package.json
+++ b/e2e/solid-router/sentry-integration/package.json
@@ -14,18 +14,18 @@
     "@sentry/solid": "^10.32.0",
     "@sentry/tracing": "^7.120.4",
     "@sentry/vite-plugin": "^4.6.1",
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/e2e/solid-router/sentry-integration/package.json
+++ b/e2e/solid-router/sentry-integration/package.json
@@ -26,6 +26,6 @@
     "@playwright/test": "^1.50.1",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/e2e/solid-router/view-transitions/package.json
+++ b/e2e/solid-router/view-transitions/package.json
@@ -11,13 +11,13 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -26,6 +26,6 @@
     "@tanstack/router-e2e-utils": "workspace:^",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/e2e/solid-router/view-transitions/package.json
+++ b/e2e/solid-router/view-transitions/package.json
@@ -26,6 +26,6 @@
     "@tanstack/router-e2e-utils": "workspace:^",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/e2e/solid-start/basic-auth/package.json
+++ b/e2e/solid-start/basic-auth/package.json
@@ -34,7 +34,7 @@
     "srvx": "^0.11.9",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite": "^8.0.14"
   }
 }

--- a/e2e/solid-start/basic-auth/package.json
+++ b/e2e/solid-start/basic-auth/package.json
@@ -16,12 +16,12 @@
     "@libsql/client": "^0.15.15",
     "@prisma/adapter-libsql": "^7.0.0",
     "@prisma/client": "^7.0.0",
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
@@ -34,7 +34,7 @@
     "srvx": "^0.11.9",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite": "^8.0.14"
   }
 }

--- a/e2e/solid-start/basic-cloudflare/package.json
+++ b/e2e/solid-start/basic-cloudflare/package.json
@@ -28,7 +28,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "wrangler": "^4.74.0"
   }
 }

--- a/e2e/solid-start/basic-cloudflare/package.json
+++ b/e2e/solid-start/basic-cloudflare/package.json
@@ -13,11 +13,11 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.29.0",
@@ -28,7 +28,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "wrangler": "^4.74.0"
   }
 }

--- a/e2e/solid-start/basic-solid-query/package.json
+++ b/e2e/solid-start/basic-solid-query/package.json
@@ -32,7 +32,7 @@
     "srvx": "^0.11.9",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite": "^8.0.14"
   }
 }

--- a/e2e/solid-start/basic-solid-query/package.json
+++ b/e2e/solid-start/basic-solid-query/package.json
@@ -12,7 +12,7 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-query": "^6.0.0-beta.5",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.5",
     "@tanstack/solid-router": "workspace:^",
@@ -20,7 +20,7 @@
     "@tanstack/solid-router-ssr-query": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },
@@ -32,7 +32,7 @@
     "srvx": "^0.11.9",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite": "^8.0.14"
   }
 }

--- a/e2e/solid-start/basic-tsr-config/package.json
+++ b/e2e/solid-start/basic-tsr-config/package.json
@@ -11,18 +11,18 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25"
   },
   "devDependencies": {
     "@tanstack/router-e2e-utils": "workspace:^",
     "@types/node": "^22.10.2",
     "srvx": "^0.11.9",
     "typescript": "^6.0.2",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite": "^8.0.14"
   }
 }

--- a/e2e/solid-start/basic-tsr-config/package.json
+++ b/e2e/solid-start/basic-tsr-config/package.json
@@ -22,7 +22,7 @@
     "@types/node": "^22.10.2",
     "srvx": "^0.11.9",
     "typescript": "^6.0.2",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite": "^8.0.14"
   }
 }

--- a/e2e/solid-start/basic/package.json
+++ b/e2e/solid-start/basic/package.json
@@ -41,7 +41,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   },
   "nx": {
     "metadata": {

--- a/e2e/solid-start/basic/package.json
+++ b/e2e/solid-start/basic/package.json
@@ -14,7 +14,7 @@
     "test:e2e:local": "playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
@@ -22,7 +22,7 @@
     "http-proxy-middleware": "^3.0.5",
     "js-cookie": "^3.0.5",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },
@@ -41,7 +41,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   },
   "nx": {
     "metadata": {

--- a/e2e/solid-start/csp/package.json
+++ b/e2e/solid-start/csp/package.json
@@ -22,7 +22,7 @@
     "@types/node": "^22.10.2",
     "srvx": "^0.11.9",
     "typescript": "^6.0.2",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite": "^8.0.14"
   }
 }

--- a/e2e/solid-start/csp/package.json
+++ b/e2e/solid-start/csp/package.json
@@ -11,10 +11,10 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
@@ -22,7 +22,7 @@
     "@types/node": "^22.10.2",
     "srvx": "^0.11.9",
     "typescript": "^6.0.2",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite": "^8.0.14"
   }
 }

--- a/e2e/solid-start/css-modules/package.json
+++ b/e2e/solid-start/css-modules/package.json
@@ -14,10 +14,10 @@
     "test:e2e": "rm -rf port*.txt; pnpm run test:e2e:dev"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "workspace:*",
     "@tanstack/solid-start": "workspace:*",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
@@ -27,7 +27,7 @@
     "srvx": "^0.11.9",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/e2e/solid-start/css-modules/package.json
+++ b/e2e/solid-start/css-modules/package.json
@@ -27,7 +27,7 @@
     "srvx": "^0.11.9",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/e2e/solid-start/custom-basepath/package.json
+++ b/e2e/solid-start/custom-basepath/package.json
@@ -11,13 +11,13 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "express": "^5.2.1",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
@@ -31,7 +31,7 @@
     "tsx": "^4.20.3",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/e2e/solid-start/custom-basepath/package.json
+++ b/e2e/solid-start/custom-basepath/package.json
@@ -31,7 +31,7 @@
     "tsx": "^4.20.3",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/e2e/solid-start/deferred-hydration/package.json
+++ b/e2e/solid-start/deferred-hydration/package.json
@@ -32,7 +32,7 @@
     "srvx": "^0.11.9",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   },
   "nx": {
     "targets": {

--- a/e2e/solid-start/deferred-hydration/package.json
+++ b/e2e/solid-start/deferred-hydration/package.json
@@ -18,10 +18,10 @@
     "test:e2e": "playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25"
   },
   "devDependencies": {
     "@rsbuild/core": "^2.0.11",
@@ -32,7 +32,7 @@
     "srvx": "^0.11.9",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   },
   "nx": {
     "targets": {

--- a/e2e/solid-start/query-integration/package.json
+++ b/e2e/solid-start/query-integration/package.json
@@ -12,14 +12,14 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-query": "^6.0.0-beta.5",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.5",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-router-ssr-query": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },
@@ -30,7 +30,7 @@
     "@types/node": "^22.10.2",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite": "^8.0.14"
   }
 }

--- a/e2e/solid-start/query-integration/package.json
+++ b/e2e/solid-start/query-integration/package.json
@@ -30,7 +30,7 @@
     "@types/node": "^22.10.2",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite": "^8.0.14"
   }
 }

--- a/e2e/solid-start/scroll-restoration/package.json
+++ b/e2e/solid-start/scroll-restoration/package.json
@@ -30,7 +30,7 @@
     "srvx": "^0.11.9",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite": "^8.0.14"
   }
 }

--- a/e2e/solid-start/scroll-restoration/package.json
+++ b/e2e/solid-start/scroll-restoration/package.json
@@ -12,12 +12,12 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },
@@ -30,7 +30,7 @@
     "srvx": "^0.11.9",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite": "^8.0.14"
   }
 }

--- a/e2e/solid-start/selective-ssr/package.json
+++ b/e2e/solid-start/selective-ssr/package.json
@@ -12,10 +12,10 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -25,7 +25,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/e2e/solid-start/selective-ssr/package.json
+++ b/e2e/solid-start/selective-ssr/package.json
@@ -25,7 +25,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/e2e/solid-start/serialization-adapters/package.json
+++ b/e2e/solid-start/serialization-adapters/package.json
@@ -27,7 +27,7 @@
     "srvx": "^0.11.9",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite": "^8.0.14"
   }
 }

--- a/e2e/solid-start/serialization-adapters/package.json
+++ b/e2e/solid-start/serialization-adapters/package.json
@@ -12,11 +12,11 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "vite-tsconfig-paths": "^5.1.4",
     "zod": "^4.4.3"
   },
@@ -27,7 +27,7 @@
     "srvx": "^0.11.9",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite": "^8.0.14"
   }
 }

--- a/e2e/solid-start/server-functions/package.json
+++ b/e2e/solid-start/server-functions/package.json
@@ -12,7 +12,7 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-query": "^6.0.0-beta.5",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.5",
     "@tanstack/solid-router": "workspace:^",
@@ -21,7 +21,7 @@
     "@tanstack/solid-start": "workspace:^",
     "js-cookie": "^3.0.5",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },
@@ -35,7 +35,7 @@
     "srvx": "^0.11.9",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite": "^8.0.14"
   }
 }

--- a/e2e/solid-start/server-functions/package.json
+++ b/e2e/solid-start/server-functions/package.json
@@ -35,7 +35,7 @@
     "srvx": "^0.11.9",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite": "^8.0.14"
   }
 }

--- a/e2e/solid-start/server-routes/package.json
+++ b/e2e/solid-start/server-routes/package.json
@@ -34,7 +34,7 @@
     "srvx": "^0.11.9",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite": "^8.0.14"
   }
 }

--- a/e2e/solid-start/server-routes/package.json
+++ b/e2e/solid-start/server-routes/package.json
@@ -12,7 +12,7 @@
     "test:e2e": "playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-query": "^6.0.0-beta.5",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
@@ -20,7 +20,7 @@
     "@tanstack/solid-start": "workspace:^",
     "js-cookie": "^3.0.5",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },
@@ -34,7 +34,7 @@
     "srvx": "^0.11.9",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite": "^8.0.14"
   }
 }

--- a/e2e/solid-start/solid-query-layout-suspense/package.json
+++ b/e2e/solid-start/solid-query-layout-suspense/package.json
@@ -10,11 +10,11 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-query": "^6.0.0-beta.5",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
@@ -22,6 +22,6 @@
     "@types/node": "^22.10.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/e2e/solid-start/solid-query-layout-suspense/package.json
+++ b/e2e/solid-start/solid-query-layout-suspense/package.json
@@ -22,6 +22,6 @@
     "@types/node": "^22.10.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/e2e/solid-start/spa-mode/package.json
+++ b/e2e/solid-start/spa-mode/package.json
@@ -12,11 +12,11 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -25,7 +25,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/e2e/solid-start/spa-mode/package.json
+++ b/e2e/solid-start/spa-mode/package.json
@@ -25,7 +25,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/e2e/solid-start/start-manifest/package.json
+++ b/e2e/solid-start/start-manifest/package.json
@@ -22,7 +22,7 @@
     "srvx": "^0.11.9",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   },
   "nx": {
     "targets": {

--- a/e2e/solid-start/start-manifest/package.json
+++ b/e2e/solid-start/start-manifest/package.json
@@ -10,10 +10,10 @@
     "test:e2e": "playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",
@@ -22,7 +22,7 @@
     "srvx": "^0.11.9",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   },
   "nx": {
     "targets": {

--- a/e2e/solid-start/virtual-routes/package.json
+++ b/e2e/solid-start/virtual-routes/package.json
@@ -31,7 +31,7 @@
     "srvx": "^0.11.9",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite": "^8.0.14"
   }
 }

--- a/e2e/solid-start/virtual-routes/package.json
+++ b/e2e/solid-start/virtual-routes/package.json
@@ -12,13 +12,13 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "@tanstack/virtual-file-routes": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },
@@ -31,7 +31,7 @@
     "srvx": "^0.11.9",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite": "^8.0.14"
   }
 }

--- a/e2e/solid-start/website/package.json
+++ b/e2e/solid-start/website/package.json
@@ -12,12 +12,12 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },
@@ -29,7 +29,7 @@
     "srvx": "^0.11.9",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite": "^8.0.14"
   }
 }

--- a/e2e/solid-start/website/package.json
+++ b/e2e/solid-start/website/package.json
@@ -29,7 +29,7 @@
     "srvx": "^0.11.9",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite": "^8.0.14"
   }
 }

--- a/examples/solid/authenticated-routes-firebase/package.json
+++ b/examples/solid/authenticated-routes-firebase/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.168.19",
     "@tanstack/solid-router": "^2.0.0-beta.26",
@@ -17,13 +17,13 @@
     "firebase": "^11.4.0",
     "redaxios": "^0.5.1",
     "simple-icons": "^14.9.0",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/authenticated-routes-firebase/package.json
+++ b/examples/solid/authenticated-routes-firebase/package.json
@@ -24,6 +24,6 @@
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/authenticated-routes/package.json
+++ b/examples/solid/authenticated-routes/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/authenticated-routes/package.json
+++ b/examples/solid/authenticated-routes/package.json
@@ -9,19 +9,19 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.168.19",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/basic-default-search-params/package.json
+++ b/examples/solid/basic-default-search-params/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/basic-default-search-params/package.json
+++ b/examples/solid/basic-default-search-params/package.json
@@ -9,19 +9,19 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-query": "^6.0.0-beta.5",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/basic-devtools-panel/package.json
+++ b/examples/solid/basic-devtools-panel/package.json
@@ -9,17 +9,17 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/basic-devtools-panel/package.json
+++ b/examples/solid/basic-devtools-panel/package.json
@@ -20,6 +20,6 @@
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/basic-file-based/package.json
+++ b/examples/solid/basic-file-based/package.json
@@ -9,12 +9,12 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -22,6 +22,6 @@
     "@tanstack/router-plugin": "^1.168.19",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/basic-file-based/package.json
+++ b/examples/solid/basic-file-based/package.json
@@ -22,6 +22,6 @@
     "@tanstack/router-plugin": "^1.168.19",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/basic-non-nested-devtools/package.json
+++ b/examples/solid/basic-non-nested-devtools/package.json
@@ -22,6 +22,6 @@
     "@types/react-dom": "^19.0.3",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/basic-non-nested-devtools/package.json
+++ b/examples/solid/basic-non-nested-devtools/package.json
@@ -9,12 +9,12 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
@@ -22,6 +22,6 @@
     "@types/react-dom": "^19.0.3",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/basic-solid-query-file-based/package.json
+++ b/examples/solid/basic-solid-query-file-based/package.json
@@ -10,14 +10,14 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-query": "^6.0.0-beta.5",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.5",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -25,6 +25,6 @@
     "@tanstack/router-plugin": "^1.168.19",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/basic-solid-query-file-based/package.json
+++ b/examples/solid/basic-solid-query-file-based/package.json
@@ -25,6 +25,6 @@
     "@tanstack/router-plugin": "^1.168.19",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/basic-solid-query/package.json
+++ b/examples/solid/basic-solid-query/package.json
@@ -9,20 +9,20 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-query": "^6.0.0-beta.5",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.5",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@tanstack/router-plugin": "^1.168.19",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/basic-solid-query/package.json
+++ b/examples/solid/basic-solid-query/package.json
@@ -23,6 +23,6 @@
     "@tanstack/router-plugin": "^1.168.19",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/basic-ssr-file-based/package.json
+++ b/examples/solid/basic-ssr-file-based/package.json
@@ -11,20 +11,20 @@
     "debug": "node --inspect-brk server"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/router-plugin": "^1.168.19",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "compression": "^1.8.0",
     "express": "^5.2.1",
     "get-port": "^7.1.0",
     "node-fetch": "^3.3.2",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25"
   },
   "devDependencies": {
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "@types/express": "^5.0.6",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/basic-ssr-file-based/package.json
+++ b/examples/solid/basic-ssr-file-based/package.json
@@ -25,6 +25,6 @@
     "@types/express": "^5.0.6",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/basic-ssr-streaming-file-based/package.json
+++ b/examples/solid/basic-ssr-streaming-file-based/package.json
@@ -29,6 +29,6 @@
     "@types/express": "^5.0.6",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/basic-ssr-streaming-file-based/package.json
+++ b/examples/solid/basic-ssr-streaming-file-based/package.json
@@ -11,7 +11,7 @@
     "debug": "node --inspect-brk server"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
@@ -20,7 +20,7 @@
     "get-port": "^7.1.0",
     "node-fetch": "^3.3.2",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -29,6 +29,6 @@
     "@types/express": "^5.0.6",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/basic-virtual-file-based/package.json
+++ b/examples/solid/basic-virtual-file-based/package.json
@@ -9,20 +9,20 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.168.19",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "@tanstack/virtual-file-routes": "^1.162.0",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/basic-virtual-file-based/package.json
+++ b/examples/solid/basic-virtual-file-based/package.json
@@ -23,6 +23,6 @@
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/basic-virtual-inside-file-based/package.json
+++ b/examples/solid/basic-virtual-inside-file-based/package.json
@@ -9,20 +9,20 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.168.19",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "@tanstack/virtual-file-routes": "^1.162.0",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/basic-virtual-inside-file-based/package.json
+++ b/examples/solid/basic-virtual-inside-file-based/package.json
@@ -23,6 +23,6 @@
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/basic/package.json
+++ b/examples/solid/basic/package.json
@@ -22,6 +22,6 @@
     "@types/react-dom": "^19.0.3",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/basic/package.json
+++ b/examples/solid/basic/package.json
@@ -9,12 +9,12 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
@@ -22,6 +22,6 @@
     "@types/react-dom": "^19.0.3",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/deferred-data/package.json
+++ b/examples/solid/deferred-data/package.json
@@ -9,18 +9,18 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/deferred-data/package.json
+++ b/examples/solid/deferred-data/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/i18n-paraglide/package.json
+++ b/examples/solid/i18n-paraglide/package.json
@@ -22,6 +22,6 @@
     "@types/node": "^22.18.6",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/i18n-paraglide/package.json
+++ b/examples/solid/i18n-paraglide/package.json
@@ -10,11 +10,11 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.168.19",
     "@tanstack/solid-router": "^2.0.0-beta.26",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
@@ -22,6 +22,6 @@
     "@types/node": "^22.18.6",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/kitchen-sink-file-based/package.json
+++ b/examples/solid/kitchen-sink-file-based/package.json
@@ -9,13 +9,13 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "immer": "^10.1.1",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -23,6 +23,6 @@
     "@tanstack/router-plugin": "^1.168.19",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/kitchen-sink-file-based/package.json
+++ b/examples/solid/kitchen-sink-file-based/package.json
@@ -23,6 +23,6 @@
     "@tanstack/router-plugin": "^1.168.19",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/kitchen-sink-solid-query-file-based/package.json
+++ b/examples/solid/kitchen-sink-solid-query-file-based/package.json
@@ -25,6 +25,6 @@
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/kitchen-sink-solid-query-file-based/package.json
+++ b/examples/solid/kitchen-sink-solid-query-file-based/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.168.19",
     "@tanstack/solid-query": "^6.0.0-beta.5",
@@ -18,13 +18,13 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "immer": "^10.1.1",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/kitchen-sink-solid-query/package.json
+++ b/examples/solid/kitchen-sink-solid-query/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-query": "^6.0.0-beta.5",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.5",
@@ -17,13 +17,13 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "immer": "^10.1.1",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/kitchen-sink-solid-query/package.json
+++ b/examples/solid/kitchen-sink-solid-query/package.json
@@ -24,6 +24,6 @@
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/kitchen-sink/package.json
+++ b/examples/solid/kitchen-sink/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/kitchen-sink/package.json
+++ b/examples/solid/kitchen-sink/package.json
@@ -9,19 +9,19 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "immer": "^10.1.1",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/large-file-based/package.json
+++ b/examples/solid/large-file-based/package.json
@@ -11,20 +11,20 @@
     "test:types": "tsc --extendedDiagnostics"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.168.19",
     "@tanstack/solid-query": "^6.0.0-beta.5",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/large-file-based/package.json
+++ b/examples/solid/large-file-based/package.json
@@ -25,6 +25,6 @@
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/location-masking/package.json
+++ b/examples/solid/location-masking/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/location-masking/package.json
+++ b/examples/solid/location-masking/package.json
@@ -9,18 +9,18 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-query": "^6.0.0-beta.5",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/navigation-blocking/package.json
+++ b/examples/solid/navigation-blocking/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/navigation-blocking/package.json
+++ b/examples/solid/navigation-blocking/package.json
@@ -9,18 +9,18 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-query": "^6.0.0-beta.5",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/quickstart-esbuild-file-based/package.json
+++ b/examples/solid/quickstart-esbuild-file-based/package.json
@@ -9,12 +9,12 @@
     "start": "dev"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/router-plugin": "^1.168.19",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },

--- a/examples/solid/quickstart-file-based/package.json
+++ b/examples/solid/quickstart-file-based/package.json
@@ -9,12 +9,12 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -22,6 +22,6 @@
     "@tanstack/router-plugin": "^1.168.19",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/quickstart-file-based/package.json
+++ b/examples/solid/quickstart-file-based/package.json
@@ -22,6 +22,6 @@
     "@tanstack/router-plugin": "^1.168.19",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/quickstart-rspack-file-based/package.json
+++ b/examples/solid/quickstart-rspack-file-based/package.json
@@ -8,12 +8,12 @@
     "preview": "rsbuild preview"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/postcss": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "postcss": "^8.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {

--- a/examples/solid/quickstart-webpack-file-based/package.json
+++ b/examples/solid/quickstart-webpack-file-based/package.json
@@ -7,10 +7,10 @@
     "build": "webpack build && tsc --noEmit"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
@@ -18,7 +18,7 @@
     "@babel/preset-typescript": "^7.27.1",
     "@tanstack/router-plugin": "^1.168.19",
     "babel-loader": "^10.0.0",
-    "babel-preset-solid": "2.0.0-beta.21",
+    "babel-preset-solid": "2.0.0-beta.25",
     "css-loader": "^7.1.2",
     "html-webpack-plugin": "^5.6.3",
     "postcss": "^8.5.6",

--- a/examples/solid/quickstart/package.json
+++ b/examples/solid/quickstart/package.json
@@ -9,16 +9,16 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/quickstart/package.json
+++ b/examples/solid/quickstart/package.json
@@ -19,6 +19,6 @@
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/router-monorepo-simple-lazy/package.json
+++ b/examples/solid/router-monorepo-simple-lazy/package.json
@@ -20,7 +20,7 @@
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
     "vite-plugin-dts": "^4.5.4",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   },
   "keywords": [],
   "author": "",

--- a/examples/solid/router-monorepo-simple-lazy/package.json
+++ b/examples/solid/router-monorepo-simple-lazy/package.json
@@ -8,19 +8,19 @@
     "dev": "pnpm router build && pnpm post-feature build && pnpm app dev"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/router-plugin": "^1.168.19",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25"
   },
   "devDependencies": {
     "@types/node": "^22.7.4",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
     "vite-plugin-dts": "^4.5.4",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   },
   "keywords": [],
   "author": "",

--- a/examples/solid/router-monorepo-simple-lazy/packages/post-feature/package.json
+++ b/examples/solid/router-monorepo-simple-lazy/packages/post-feature/package.json
@@ -22,7 +22,7 @@
     "@solidjs/web": "2.0.0-beta.25"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
     "vite-plugin-dts": "^4.5.4"

--- a/examples/solid/router-monorepo-simple-lazy/packages/post-feature/package.json
+++ b/examples/solid/router-monorepo-simple-lazy/packages/post-feature/package.json
@@ -18,11 +18,11 @@
   "dependencies": {
     "@tanstack/solid-query": "^6.0.0-beta.5",
     "@router-solid-mono-simple-lazy/router": "workspace:*",
-    "solid-js": "2.0.0-beta.21",
-    "@solidjs/web": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25",
+    "@solidjs/web": "2.0.0-beta.25"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
     "vite-plugin-dts": "^4.5.4"

--- a/examples/solid/router-monorepo-simple-lazy/packages/router/package.json
+++ b/examples/solid/router-monorepo-simple-lazy/packages/router/package.json
@@ -13,11 +13,11 @@
     "@tanstack/router-plugin": "^1.168.19",
     "redaxios": "^0.5.1",
     "zod": "^4.4.3",
-    "solid-js": "2.0.0-beta.21",
-    "@solidjs/web": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25",
+    "@solidjs/web": "2.0.0-beta.25"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
     "vite-plugin-dts": "^4.5.4"

--- a/examples/solid/router-monorepo-simple-lazy/packages/router/package.json
+++ b/examples/solid/router-monorepo-simple-lazy/packages/router/package.json
@@ -17,7 +17,7 @@
     "@solidjs/web": "2.0.0-beta.25"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
     "vite-plugin-dts": "^4.5.4"

--- a/examples/solid/router-monorepo-simple/package.json
+++ b/examples/solid/router-monorepo-simple/package.json
@@ -20,7 +20,7 @@
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
     "vite-plugin-dts": "^4.5.4",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   },
   "keywords": [],
   "author": "",

--- a/examples/solid/router-monorepo-simple/package.json
+++ b/examples/solid/router-monorepo-simple/package.json
@@ -8,19 +8,19 @@
     "dev": "pnpm router build && pnpm post-feature build && pnpm app dev"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/router-plugin": "^1.168.19",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25"
   },
   "devDependencies": {
     "@types/node": "^22.7.4",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
     "vite-plugin-dts": "^4.5.4",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   },
   "keywords": [],
   "author": "",

--- a/examples/solid/router-monorepo-simple/packages/app/package.json
+++ b/examples/solid/router-monorepo-simple/packages/app/package.json
@@ -11,11 +11,11 @@
   "dependencies": {
     "@router-solid-mono-simple/post-feature": "workspace:*",
     "@router-solid-mono-simple/router": "workspace:*",
-    "solid-js": "2.0.0-beta.21",
-    "@solidjs/web": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25",
+    "@solidjs/web": "2.0.0-beta.25"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "typescript": "^6.0.2",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "vite": "^8.0.14",

--- a/examples/solid/router-monorepo-simple/packages/app/package.json
+++ b/examples/solid/router-monorepo-simple/packages/app/package.json
@@ -15,7 +15,7 @@
     "@solidjs/web": "2.0.0-beta.25"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "typescript": "^6.0.2",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "vite": "^8.0.14",

--- a/examples/solid/router-monorepo-simple/packages/post-feature/package.json
+++ b/examples/solid/router-monorepo-simple/packages/post-feature/package.json
@@ -13,7 +13,7 @@
     "@solidjs/web": "2.0.0-beta.25"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
     "vite-plugin-dts": "^4.5.4"

--- a/examples/solid/router-monorepo-simple/packages/post-feature/package.json
+++ b/examples/solid/router-monorepo-simple/packages/post-feature/package.json
@@ -9,11 +9,11 @@
   "types": "./dist/index.d.ts",
   "dependencies": {
     "@router-solid-mono-simple/router": "workspace:*",
-    "solid-js": "2.0.0-beta.21",
-    "@solidjs/web": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25",
+    "@solidjs/web": "2.0.0-beta.25"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
     "vite-plugin-dts": "^4.5.4"

--- a/examples/solid/router-monorepo-simple/packages/router/package.json
+++ b/examples/solid/router-monorepo-simple/packages/router/package.json
@@ -13,11 +13,11 @@
     "@tanstack/router-plugin": "^1.168.19",
     "redaxios": "^0.5.1",
     "zod": "^4.4.3",
-    "solid-js": "2.0.0-beta.21",
-    "@solidjs/web": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25",
+    "@solidjs/web": "2.0.0-beta.25"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
     "vite-plugin-dts": "^4.5.4"

--- a/examples/solid/router-monorepo-simple/packages/router/package.json
+++ b/examples/solid/router-monorepo-simple/packages/router/package.json
@@ -17,7 +17,7 @@
     "@solidjs/web": "2.0.0-beta.25"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
     "vite-plugin-dts": "^4.5.4"

--- a/examples/solid/router-monorepo-solid-query/package.json
+++ b/examples/solid/router-monorepo-solid-query/package.json
@@ -10,21 +10,21 @@
     "dev": "pnpm post-query build && pnpm router build && pnpm post-feature build && pnpm app dev"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/router-plugin": "^1.168.19",
     "@tanstack/solid-query": "^6.0.0-beta.5",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.5",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
     "vite-plugin-dts": "^4.5.4",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   },
   "keywords": [],
   "author": "",

--- a/examples/solid/router-monorepo-solid-query/package.json
+++ b/examples/solid/router-monorepo-solid-query/package.json
@@ -24,7 +24,7 @@
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
     "vite-plugin-dts": "^4.5.4",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   },
   "keywords": [],
   "author": "",

--- a/examples/solid/router-monorepo-solid-query/packages/app/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/app/package.json
@@ -16,7 +16,7 @@
     "@solidjs/web": "2.0.0-beta.25"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "typescript": "^6.0.2",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "tailwindcss": "^4.2.2",

--- a/examples/solid/router-monorepo-solid-query/packages/app/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/app/package.json
@@ -12,11 +12,11 @@
     "@tanstack/solid-query": "^6.0.0-beta.5",
     "@router-solid-mono-solid-query/post-feature": "workspace:*",
     "@router-solid-mono-solid-query/router": "workspace:*",
-    "solid-js": "2.0.0-beta.21",
-    "@solidjs/web": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25",
+    "@solidjs/web": "2.0.0-beta.25"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "typescript": "^6.0.2",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "tailwindcss": "^4.2.2",

--- a/examples/solid/router-monorepo-solid-query/packages/post-feature/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/post-feature/package.json
@@ -11,11 +11,11 @@
     "@tanstack/solid-query": "^6.0.0-beta.5",
     "@router-solid-mono-solid-query/post-query": "workspace:*",
     "@router-solid-mono-solid-query/router": "workspace:*",
-    "solid-js": "2.0.0-beta.21",
-    "@solidjs/web": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25",
+    "@solidjs/web": "2.0.0-beta.25"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
     "vite-plugin-dts": "^4.5.4"

--- a/examples/solid/router-monorepo-solid-query/packages/post-feature/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/post-feature/package.json
@@ -15,7 +15,7 @@
     "@solidjs/web": "2.0.0-beta.25"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
     "vite-plugin-dts": "^4.5.4"

--- a/examples/solid/router-monorepo-solid-query/packages/post-query/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/post-query/package.json
@@ -13,7 +13,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "typescript": "^6.0.2",
     "vite": "^8.0.14"
   }

--- a/examples/solid/router-monorepo-solid-query/packages/post-query/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/post-query/package.json
@@ -13,7 +13,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "typescript": "^6.0.2",
     "vite": "^8.0.14"
   }

--- a/examples/solid/router-monorepo-solid-query/packages/router/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/router/package.json
@@ -19,7 +19,7 @@
     "@solidjs/web": "2.0.0-beta.25"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
     "vite-plugin-dts": "^4.5.4"

--- a/examples/solid/router-monorepo-solid-query/packages/router/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/router/package.json
@@ -15,11 +15,11 @@
     "@router-solid-mono-solid-query/post-query": "workspace:*",
     "redaxios": "^0.5.1",
     "zod": "^4.4.3",
-    "solid-js": "2.0.0-beta.21",
-    "@solidjs/web": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25",
+    "@solidjs/web": "2.0.0-beta.25"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
     "vite-plugin-dts": "^4.5.4"

--- a/examples/solid/scroll-restoration/package.json
+++ b/examples/solid/scroll-restoration/package.json
@@ -9,17 +9,17 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "@tanstack/solid-virtual": "^3.13.0",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/scroll-restoration/package.json
+++ b/examples/solid/scroll-restoration/package.json
@@ -20,6 +20,6 @@
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/search-validator-adapters/package.json
+++ b/examples/solid/search-validator-adapters/package.json
@@ -10,7 +10,7 @@
     "test:unit": "vitest"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/arktype-adapter": "^1.167.0",
     "@tanstack/router-plugin": "^1.168.19",
@@ -20,7 +20,7 @@
     "@tanstack/valibot-adapter": "^1.167.0",
     "@tanstack/zod-adapter": "^1.167.0",
     "arktype": "^2.1.7",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "valibot": "1.0.0-beta.15",
     "zod": "^3.24.2"
@@ -30,6 +30,6 @@
     "@testing-library/jest-dom": "^6.6.3",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/search-validator-adapters/package.json
+++ b/examples/solid/search-validator-adapters/package.json
@@ -30,6 +30,6 @@
     "@testing-library/jest-dom": "^6.6.3",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/start-basic-auth/package.json
+++ b/examples/solid/start-basic-auth/package.json
@@ -30,7 +30,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-basic-auth/package.json
+++ b/examples/solid/start-basic-auth/package.json
@@ -14,12 +14,12 @@
     "@libsql/client": "^0.15.15",
     "@prisma/adapter-libsql": "^7.0.0",
     "@prisma/client": "^7.0.0",
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "@tanstack/solid-start": "^2.0.0-beta.27",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
@@ -30,7 +30,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-basic-authjs/package.json
+++ b/examples/solid/start-basic-authjs/package.json
@@ -11,11 +11,11 @@
   },
   "dependencies": {
     "@auth/core": "^0.41.1",
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "@tanstack/solid-start": "^2.0.0-beta.27",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "start-authjs": "^1.0.0",
     "tailwind-merge": "^3.6.0"
   },
@@ -25,7 +25,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-basic-authjs/package.json
+++ b/examples/solid/start-basic-authjs/package.json
@@ -25,7 +25,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-basic-cloudflare/package.json
+++ b/examples/solid/start-basic-cloudflare/package.json
@@ -25,7 +25,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite-tsconfig-paths": "^5.1.4",
     "wrangler": "^4.74.0"
   }

--- a/examples/solid/start-basic-cloudflare/package.json
+++ b/examples/solid/start-basic-cloudflare/package.json
@@ -12,11 +12,11 @@
     "postinstall": "npm run cf-typegen"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "@tanstack/solid-start": "^2.0.0-beta.27",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.29.0",
@@ -25,7 +25,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite-tsconfig-paths": "^5.1.4",
     "wrangler": "^4.74.0"
   }

--- a/examples/solid/start-basic-netlify/package.json
+++ b/examples/solid/start-basic-netlify/package.json
@@ -22,7 +22,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-basic-netlify/package.json
+++ b/examples/solid/start-basic-netlify/package.json
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "@tanstack/solid-start": "^2.0.0-beta.27",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25"
   },
   "devDependencies": {
     "@netlify/vite-plugin-tanstack-start": "^1.1.4",
@@ -22,7 +22,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-basic-nitro/package.json
+++ b/examples/solid/start-basic-nitro/package.json
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "@tanstack/solid-start": "^2.0.0-beta.27",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.2",
@@ -22,7 +22,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-basic-nitro/package.json
+++ b/examples/solid/start-basic-nitro/package.json
@@ -22,7 +22,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-basic-solid-query/package.json
+++ b/examples/solid/start-basic-solid-query/package.json
@@ -10,7 +10,7 @@
     "start": "pnpx srvx --prod -s ../client dist/server/server.js"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-query": "^6.0.0-beta.5",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.5",
     "@tanstack/solid-router": "^2.0.0-beta.26",
@@ -18,7 +18,7 @@
     "@tanstack/solid-router-ssr-query": "^2.0.0-beta.27",
     "@tanstack/solid-start": "^2.0.0-beta.27",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
@@ -27,7 +27,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-basic-solid-query/package.json
+++ b/examples/solid/start-basic-solid-query/package.json
@@ -27,7 +27,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-basic-static/package.json
+++ b/examples/solid/start-basic-static/package.json
@@ -10,13 +10,13 @@
     "start": "pnpx srvx --prod -s ../client dist/server/server.js"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "@tanstack/solid-start": "^2.0.0-beta.27",
     "@tanstack/start-static-server-functions": "^1.167.18",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
@@ -25,7 +25,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite-tsconfig-paths": "^5.1.3"
   }
 }

--- a/examples/solid/start-basic-static/package.json
+++ b/examples/solid/start-basic-static/package.json
@@ -25,7 +25,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite-tsconfig-paths": "^5.1.3"
   }
 }

--- a/examples/solid/start-basic/package.json
+++ b/examples/solid/start-basic/package.json
@@ -10,12 +10,12 @@
     "start": "node .output/server/index.mjs"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "@tanstack/solid-start": "^2.0.0-beta.27",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
@@ -25,7 +25,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-basic/package.json
+++ b/examples/solid/start-basic/package.json
@@ -25,7 +25,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-bun/package.json
+++ b/examples/solid/start-bun/package.json
@@ -34,7 +34,7 @@
     "prettier": "^3.6.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vitest": "^4.1.4",
     "web-vitals": "^5.1.0"
   }

--- a/examples/solid/start-bun/package.json
+++ b/examples/solid/start-bun/package.json
@@ -13,7 +13,7 @@
     "check": "prettier --write . && eslint --fix"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.168.19",
     "@tanstack/solid-devtools": "^0.7.0",
@@ -21,7 +21,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "@tanstack/solid-router-ssr-query": "^2.0.0-beta.27",
     "@tanstack/solid-start": "^2.0.0-beta.27",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
@@ -34,7 +34,7 @@
     "prettier": "^3.6.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vitest": "^4.1.4",
     "web-vitals": "^5.1.0"
   }

--- a/examples/solid/start-convex-better-auth/package.json
+++ b/examples/solid/start-convex-better-auth/package.json
@@ -32,7 +32,7 @@
     "combinate": "^1.1.11",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-convex-better-auth/package.json
+++ b/examples/solid/start-convex-better-auth/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@convex-dev/better-auth": "^0.9.7",
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
@@ -22,7 +22,7 @@
     "convex": "^1.28.2",
     "convex-solidjs": "^0.0.3",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
@@ -32,7 +32,7 @@
     "combinate": "^1.1.11",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-counter/package.json
+++ b/examples/solid/start-counter/package.json
@@ -10,12 +10,12 @@
     "start": "pnpx srvx --prod -s ../client dist/server/server.js"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "@tanstack/solid-start": "^2.0.0-beta.27",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },
@@ -24,6 +24,6 @@
     "combinate": "^1.1.11",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/start-counter/package.json
+++ b/examples/solid/start-counter/package.json
@@ -24,6 +24,6 @@
     "combinate": "^1.1.11",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/start-i18n-paraglide/package.json
+++ b/examples/solid/start-i18n-paraglide/package.json
@@ -9,12 +9,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-devtools": "^0.7.0",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "@tanstack/solid-start": "^2.0.0-beta.27",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25"
   },
   "devDependencies": {
     "@inlang/paraglide-js": "^2.4.0",
@@ -23,6 +23,6 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/start-i18n-paraglide/package.json
+++ b/examples/solid/start-i18n-paraglide/package.json
@@ -23,6 +23,6 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/start-large/package.json
+++ b/examples/solid/start-large/package.json
@@ -12,13 +12,13 @@
     "test:types": "tsc --extendedDiagnostics"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-query": "^6.0.0-beta.5",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "@tanstack/solid-start": "^2.0.0-beta.27",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwind-merge": "^3.6.0",
     "valibot": "^1.0.0-beta.15"
   },
@@ -28,7 +28,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   },
   "keywords": [],
   "author": "",

--- a/examples/solid/start-large/package.json
+++ b/examples/solid/start-large/package.json
@@ -28,7 +28,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   },
   "keywords": [],
   "author": "",

--- a/examples/solid/start-streaming-data-from-server-functions/package.json
+++ b/examples/solid/start-streaming-data-from-server-functions/package.json
@@ -21,6 +21,6 @@
     "@types/node": "^22.5.4",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/start-streaming-data-from-server-functions/package.json
+++ b/examples/solid/start-streaming-data-from-server-functions/package.json
@@ -10,17 +10,17 @@
     "start": "pnpx srvx --prod -s ../client dist/server/server.js"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "@tanstack/solid-start": "^2.0.0-beta.27",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.5.4",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/start-supabase-basic/package.json
+++ b/examples/solid/start-supabase-basic/package.json
@@ -12,14 +12,14 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.48.1",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "@tanstack/solid-start": "^2.0.0-beta.27",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.2",
@@ -27,7 +27,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-supabase-basic/package.json
+++ b/examples/solid/start-supabase-basic/package.json
@@ -27,7 +27,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-tailwind-v4/package.json
+++ b/examples/solid/start-tailwind-v4/package.json
@@ -24,7 +24,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-tailwind-v4/package.json
+++ b/examples/solid/start-tailwind-v4/package.json
@@ -10,11 +10,11 @@
     "start": "node .output/server/index.mjs"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "@tanstack/solid-start": "^2.0.0-beta.27",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },
@@ -24,7 +24,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/view-transitions/package.json
+++ b/examples/solid/view-transitions/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/view-transitions/package.json
+++ b/examples/solid/view-transitions/package.json
@@ -9,19 +9,19 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.168.19",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/with-framer-motion/package.json
+++ b/examples/solid/with-framer-motion/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/with-framer-motion/package.json
+++ b/examples/solid/with-framer-motion/package.json
@@ -9,12 +9,12 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.26",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.21",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "solid-motionone": "^1.0.4",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
@@ -22,6 +22,6 @@
   "devDependencies": {
     "typescript": "^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/examples/solid/with-trpc/package.json
+++ b/examples/solid/with-trpc/package.json
@@ -27,6 +27,6 @@
     "@types/express": "^5.0.6",
     "tsx": "^4.20.3",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   }
 }

--- a/examples/solid/with-trpc/package.json
+++ b/examples/solid/with-trpc/package.json
@@ -10,7 +10,7 @@
     "start": "NODE_ENV=production node dist/server/server.js"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.168.19",
     "@tanstack/solid-router": "^2.0.0-beta.26",
@@ -19,7 +19,7 @@
     "@trpc/server": "^11.4.3",
     "express": "^5.2.1",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -27,6 +27,6 @@
     "@types/express": "^5.0.6",
     "tsx": "^4.20.3",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   }
 }

--- a/packages/solid-router-devtools/package.json
+++ b/packages/solid-router-devtools/package.json
@@ -74,7 +74,7 @@
     "@types/node": ">=20",
     "solid-js": "2.0.0-beta.25",
     "vite": "*",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   },
   "peerDependencies": {
     "@solidjs/web": "2.0.0-beta.25",

--- a/packages/solid-router-devtools/package.json
+++ b/packages/solid-router-devtools/package.json
@@ -66,21 +66,21 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/router-devtools-core": "workspace:*"
   },
   "devDependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@types/node": ">=20",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "vite": "*",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   },
   "peerDependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/router-core": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
-    "solid-js": "2.0.0-beta.21"
+    "solid-js": "2.0.0-beta.25"
   },
   "peerDependenciesMeta": {
     "@tanstack/router-core": {

--- a/packages/solid-router-ssr-query/package.json
+++ b/packages/solid-router-ssr-query/package.json
@@ -67,13 +67,13 @@
     "@tanstack/router-ssr-query-core": "workspace:*"
   },
   "devDependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/solid-query": "^6.0.0-beta.5",
     "@tanstack/solid-router": "workspace:*",
     "eslint-plugin-solid": "^0.14.5",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "vite": "*",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   },
   "peerDependencies": {
     "@solidjs/web": ">=2.0.0-beta.17",

--- a/packages/solid-router-ssr-query/package.json
+++ b/packages/solid-router-ssr-query/package.json
@@ -73,7 +73,7 @@
     "eslint-plugin-solid": "^0.14.5",
     "solid-js": "2.0.0-beta.25",
     "vite": "*",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   },
   "peerDependencies": {
     "@solidjs/web": ">=2.0.0-beta.17",

--- a/packages/solid-router/package.json
+++ b/packages/solid-router/package.json
@@ -106,7 +106,7 @@
   "dependencies": {
     "@solid-devtools/logger": "^0.9.4",
     "@solidjs/meta": "^0.29.4",
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/history": "workspace:*",
     "@tanstack/router-core": "workspace:*",
     "isbot": "^5.1.22",
@@ -114,14 +114,14 @@
   },
   "devDependencies": {
     "@solidjs/testing-library": "^0.8.10",
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@testing-library/jest-dom": "^6.6.3",
     "@types/node": ">=20",
     "combinate": "^1.1.11",
     "eslint-plugin-solid": "^0.14.5",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "vite": "*",
-    "vite-plugin-solid": "^3.0.0-next.14",
+    "vite-plugin-solid": "^3.0.0-next.15",
     "zod": "^4.4.3"
   },
   "peerDependencies": {

--- a/packages/solid-router/package.json
+++ b/packages/solid-router/package.json
@@ -121,7 +121,7 @@
     "eslint-plugin-solid": "^0.14.5",
     "solid-js": "2.0.0-beta.25",
     "vite": "*",
-    "vite-plugin-solid": "^3.0.0-next.15",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "zod": "^4.4.3"
   },
   "peerDependencies": {

--- a/packages/solid-start-client/package.json
+++ b/packages/solid-start-client/package.json
@@ -77,11 +77,11 @@
   },
   "devDependencies": {
     "@solidjs/testing-library": "^0.8.10",
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@testing-library/jest-dom": "^6.6.3",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "vite": "*",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   },
   "peerDependencies": {
     "@solidjs/web": ">=2.0.0-0 <3.0.0",

--- a/packages/solid-start-client/package.json
+++ b/packages/solid-start-client/package.json
@@ -81,7 +81,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "solid-js": "2.0.0-beta.25",
     "vite": "*",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   },
   "peerDependencies": {
     "@solidjs/web": ">=2.0.0-0 <3.0.0",

--- a/packages/solid-start-server/package.json
+++ b/packages/solid-start-server/package.json
@@ -67,7 +67,7 @@
     "solid-js": "2.0.0-beta.25",
     "typescript": "^6.0.2",
     "vite": "*",
-    "vite-plugin-solid": "^3.0.0-next.15"
+    "vite-plugin-solid": "^3.0.0-next.16"
   },
   "peerDependencies": {
     "@solidjs/web": ">=2.0.0-0 <3.0.0",

--- a/packages/solid-start-server/package.json
+++ b/packages/solid-start-server/package.json
@@ -63,11 +63,11 @@
     "@tanstack/start-server-core": "workspace:*"
   },
   "devDependencies": {
-    "@solidjs/web": "2.0.0-beta.21",
-    "solid-js": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
+    "solid-js": "2.0.0-beta.25",
     "typescript": "^6.0.2",
     "vite": "*",
-    "vite-plugin-solid": "^3.0.0-next.14"
+    "vite-plugin-solid": "^3.0.0-next.15"
   },
   "peerDependencies": {
     "@solidjs/web": ">=2.0.0-0 <3.0.0",

--- a/packages/solid-start/package.json
+++ b/packages/solid-start/package.json
@@ -128,10 +128,10 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^2.0.11",
-    "@solidjs/web": "2.0.0-beta.21",
+    "@solidjs/web": "2.0.0-beta.25",
     "@tanstack/router-utils": "workspace:*",
     "@types/node": ">=20",
-    "solid-js": "2.0.0-beta.21",
+    "solid-js": "2.0.0-beta.25",
     "vite": "*"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,7 +98,7 @@ importers:
         version: 5.99.0(react@19.2.3)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(solid-js@2.0.0-beta.25)
       '@tanstack/vite-config':
         specifier: 0.5.2
         version: 0.5.2(@types/node@25.0.9)(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -187,8 +187,8 @@ importers:
   benchmarks/bundle-size:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../packages/react-router
@@ -214,8 +214,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       vue:
         specifier: ^3.5.16
         version: 3.5.25(typescript@6.0.2)
@@ -251,14 +251,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   benchmarks/client-nav:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../packages/react-router
@@ -278,8 +278,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       vue:
         specifier: ^3.5.16
         version: 3.5.25(typescript@6.0.2)
@@ -315,8 +315,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@25.0.9)(@vitest/ui@4.1.4)(jsdom@29.1.1(@noble/hashes@2.0.1))(msw@2.7.0(@types/node@25.0.9)(typescript@6.0.2))(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -324,8 +324,8 @@ importers:
   benchmarks/memory/client:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -345,8 +345,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       vue:
         specifier: ^3.5.16
         version: 3.5.25(typescript@6.0.2)
@@ -385,8 +385,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@25.0.9)(@vitest/ui@4.1.4)(jsdom@29.1.1(@noble/hashes@2.0.1))(msw@2.7.0(@types/node@25.0.9)(typescript@6.0.2))(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -394,8 +394,8 @@ importers:
   benchmarks/memory/server:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -421,8 +421,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       vue:
         specifier: ^3.5.16
         version: 3.5.25(typescript@6.0.2)
@@ -449,8 +449,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@25.0.9)(@vitest/ui@4.1.4)(jsdom@29.1.1(@noble/hashes@2.0.1))(msw@2.7.0(@types/node@25.0.9)(typescript@6.0.2))(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -458,8 +458,8 @@ importers:
   benchmarks/ssr:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../packages/react-router
@@ -485,8 +485,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       vue:
         specifier: ^3.5.16
         version: 3.5.25(typescript@6.0.2)
@@ -510,8 +510,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@25.0.9)(@vitest/ui@4.1.4)(jsdom@29.1.1(@noble/hashes@2.0.1))(msw@2.7.0(@types/node@25.0.9)(typescript@6.0.2))(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -3644,8 +3644,8 @@ importers:
   e2e/solid-router/basepath-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/router-plugin':
         specifier: workspace:*
         version: link:../../../packages/router-plugin
@@ -3656,8 +3656,8 @@ importers:
         specifier: workspace:^
         version: link:../../../packages/solid-router-devtools
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
     devDependencies:
       '@playwright/test':
         specifier: ^1.57.0
@@ -3669,14 +3669,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/basic:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -3690,8 +3690,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -3706,14 +3706,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/basic-esbuild-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/router-plugin':
         specifier: workspace:*
         version: link:../../../packages/router-plugin
@@ -3727,8 +3727,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -3744,13 +3744,13 @@ importers:
         version: 0.27.4
       esbuild-plugin-solid:
         specifier: ^0.6.0
-        version: 0.6.0(esbuild@0.27.4)(solid-js@2.0.0-beta.21)
+        version: 0.6.0(esbuild@0.27.4)(solid-js@2.0.0-beta.25)
 
   e2e/solid-router/basic-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -3767,8 +3767,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -3789,14 +3789,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/basic-file-based-code-splitting:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -3810,8 +3810,8 @@ importers:
         specifier: workspace:^
         version: link:../../../packages/solid-router-devtools
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -3829,14 +3829,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/basic-scroll-restoration:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -3848,13 +3848,13 @@ importers:
         version: link:../../../packages/solid-router-devtools
       '@tanstack/solid-virtual':
         specifier: ^3.13.0
-        version: 3.13.12(solid-js@2.0.0-beta.21)
+        version: 3.13.12(solid-js@2.0.0-beta.25)
       redaxios:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -3872,23 +3872,23 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/basic-solid-query:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(solid-js@2.0.0-beta.25)
       '@tanstack/solid-query-devtools':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.25))(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -3899,8 +3899,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -3915,14 +3915,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/basic-solid-query-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -3931,10 +3931,10 @@ importers:
         version: link:../../../packages/router-plugin
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(solid-js@2.0.0-beta.25)
       '@tanstack/solid-query-devtools':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.25))(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -3945,8 +3945,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -3964,14 +3964,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/basic-virtual-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -3991,8 +3991,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -4010,14 +4010,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/basic-virtual-named-export-config-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4037,8 +4037,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -4056,14 +4056,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/generator-cli-only:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4080,8 +4080,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -4096,14 +4096,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/js-only-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4117,8 +4117,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -4136,14 +4136,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/rspack-basic-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4154,8 +4154,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
     devDependencies:
       '@playwright/test':
         specifier: ^1.57.0
@@ -4168,7 +4168,7 @@ importers:
         version: 1.1.2(@rsbuild/core@2.0.14)
       '@rsbuild/plugin-solid':
         specifier: ^2.0.0-beta.0
-        version: 2.0.0-beta.0(@babel/core@7.29.0)(@rsbuild/core@2.0.14)(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)
+        version: 2.0.0-beta.0(@babel/core@7.29.0)(@rsbuild/core@2.0.14)(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(solid-js@2.0.0-beta.25)
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -4191,8 +4191,8 @@ importers:
   e2e/solid-router/rspack-basic-virtual-named-export-config-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4203,8 +4203,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
     devDependencies:
       '@playwright/test':
         specifier: ^1.57.0
@@ -4217,7 +4217,7 @@ importers:
         version: 1.1.2(@rsbuild/core@2.0.14)
       '@rsbuild/plugin-solid':
         specifier: ^2.0.0-beta.0
-        version: 2.0.0-beta.0(@babel/core@7.29.0)(@rsbuild/core@2.0.14)(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)
+        version: 2.0.0-beta.0(@babel/core@7.29.0)(@rsbuild/core@2.0.14)(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(solid-js@2.0.0-beta.25)
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -4243,8 +4243,8 @@ importers:
   e2e/solid-router/scroll-restoration-sandbox-vite:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4261,8 +4261,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -4280,14 +4280,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/sentry-integration:
     dependencies:
       '@sentry/solid':
         specifier: ^10.32.0
-        version: 10.32.0(@tanstack/solid-router@packages+solid-router)(solid-js@2.0.0-beta.21)
+        version: 10.32.0(@tanstack/solid-router@packages+solid-router)(solid-js@2.0.0-beta.25)
       '@sentry/tracing':
         specifier: ^7.120.4
         version: 7.120.4
@@ -4295,8 +4295,8 @@ importers:
         specifier: ^4.6.1
         version: 4.6.1
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4310,8 +4310,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -4326,14 +4326,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/view-transitions:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4350,8 +4350,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -4372,14 +4372,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/basic:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4402,8 +4402,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -4422,7 +4422,7 @@ importers:
         version: 1.1.2(@rsbuild/core@2.0.14)
       '@rsbuild/plugin-solid':
         specifier: ^2.0.0-beta.0
-        version: 2.0.0-beta.0(@babel/core@7.29.0)(@rsbuild/core@2.0.14)(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)
+        version: 2.0.0-beta.0(@babel/core@7.29.0)(@rsbuild/core@2.0.14)(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(solid-js@2.0.0-beta.25)
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -4454,8 +4454,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/basic-auth:
     dependencies:
@@ -4469,8 +4469,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(prisma@7.0.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2))(typescript@6.0.2)
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4484,8 +4484,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -4521,14 +4521,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/basic-cloudflare:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4539,8 +4539,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.29.0
@@ -4567,8 +4567,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       wrangler:
         specifier: ^4.74.0
         version: 4.75.0
@@ -4576,14 +4576,14 @@ importers:
   e2e/solid-start/basic-solid-query:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(solid-js@2.0.0-beta.25)
       '@tanstack/solid-query-devtools':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.25))(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4600,8 +4600,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -4634,14 +4634,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/basic-tsr-config:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4652,8 +4652,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
     devDependencies:
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
@@ -4671,14 +4671,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/csp:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4686,8 +4686,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
     devDependencies:
       '@playwright/test':
         specifier: ^1.57.0
@@ -4708,14 +4708,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/css-modules:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:*
         version: link:../../../packages/solid-router
@@ -4723,8 +4723,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
     devDependencies:
       '@playwright/test':
         specifier: ^1.57.0
@@ -4748,8 +4748,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4757,8 +4757,8 @@ importers:
   e2e/solid-start/custom-basepath:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4775,8 +4775,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
     devDependencies:
       '@playwright/test':
         specifier: ^1.57.0
@@ -4812,8 +4812,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4821,8 +4821,8 @@ importers:
   e2e/solid-start/deferred-hydration:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4830,8 +4830,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
     devDependencies:
       '@rsbuild/core':
         specifier: ^2.0.11
@@ -4841,7 +4841,7 @@ importers:
         version: 1.1.2(@rsbuild/core@2.0.14)
       '@rsbuild/plugin-solid':
         specifier: ^2.0.0-beta.0
-        version: 2.0.0-beta.0(@babel/core@7.29.0)(@rsbuild/core@2.0.14)(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)
+        version: 2.0.0-beta.0(@babel/core@7.29.0)(@rsbuild/core@2.0.14)(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(solid-js@2.0.0-beta.25)
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -4858,20 +4858,20 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/query-integration:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(solid-js@2.0.0-beta.25)
       '@tanstack/solid-query-devtools':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.25))(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4885,8 +4885,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -4916,14 +4916,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/scroll-restoration:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4937,8 +4937,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -4974,14 +4974,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/selective-ssr:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4989,8 +4989,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -5014,8 +5014,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -5023,8 +5023,8 @@ importers:
   e2e/solid-start/serialization-adapters:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5035,8 +5035,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -5066,20 +5066,20 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/server-functions:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(solid-js@2.0.0-beta.25)
       '@tanstack/solid-query-devtools':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.25))(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5099,8 +5099,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -5139,17 +5139,17 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/server-routes:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5169,8 +5169,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -5209,17 +5209,17 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/solid-query-layout-suspense:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5227,8 +5227,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
     devDependencies:
       '@playwright/test':
         specifier: ^1.57.0
@@ -5246,14 +5246,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/spa-mode:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5264,8 +5264,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -5286,8 +5286,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -5295,8 +5295,8 @@ importers:
   e2e/solid-start/start-manifest:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5304,8 +5304,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
     devDependencies:
       '@playwright/test':
         specifier: ^1.57.0
@@ -5326,14 +5326,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/virtual-routes:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5350,8 +5350,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -5387,14 +5387,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/website:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5408,8 +5408,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -5442,8 +5442,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/vue-router/basepath-file-based:
     dependencies:
@@ -9504,7 +9504,7 @@ importers:
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/react-devtools':
         specifier: ^0.7.0
-        version: 0.7.0(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(csstype@3.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.21)
+        version: 0.7.0(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(csstype@3.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.25)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -9748,7 +9748,7 @@ importers:
     dependencies:
       '@tanstack/react-devtools':
         specifier: ^0.7.0
-        version: 0.7.0(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(csstype@3.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.21)
+        version: 0.7.0(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(csstype@3.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.25)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -10432,8 +10432,8 @@ importers:
   examples/solid/authenticated-routes:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -10450,8 +10450,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -10466,14 +10466,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/authenticated-routes-firebase:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -10496,8 +10496,8 @@ importers:
         specifier: ^14.9.0
         version: 14.9.0
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -10512,14 +10512,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -10533,8 +10533,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -10552,20 +10552,20 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-default-search-params:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -10576,8 +10576,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -10592,14 +10592,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-devtools-panel:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -10613,8 +10613,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -10626,14 +10626,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -10647,8 +10647,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -10666,14 +10666,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-non-nested-devtools:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -10687,8 +10687,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -10706,23 +10706,23 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-solid-query:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(solid-js@2.0.0-beta.25)
       '@tanstack/solid-query-devtools':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.25))(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -10733,8 +10733,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -10749,23 +10749,23 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-solid-query-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(solid-js@2.0.0-beta.25)
       '@tanstack/solid-query-devtools':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.25))(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -10776,8 +10776,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -10795,14 +10795,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-ssr-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/router-plugin':
         specifier: workspace:*
         version: link:../../../packages/router-plugin
@@ -10822,8 +10822,8 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
     devDependencies:
       '@tanstack/solid-router-devtools':
         specifier: workspace:^
@@ -10838,14 +10838,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-ssr-streaming-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -10871,8 +10871,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -10893,14 +10893,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-virtual-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -10920,8 +10920,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -10936,14 +10936,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-virtual-inside-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -10963,8 +10963,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -10979,14 +10979,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/deferred-data:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11000,8 +11000,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11016,14 +11016,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/i18n-paraglide:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11034,8 +11034,8 @@ importers:
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11053,14 +11053,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/kitchen-sink:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11077,8 +11077,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11093,14 +11093,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/kitchen-sink-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11117,8 +11117,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11136,23 +11136,23 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/kitchen-sink-solid-query:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(solid-js@2.0.0-beta.25)
       '@tanstack/solid-query-devtools':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.25))(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -11166,8 +11166,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11182,14 +11182,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/kitchen-sink-solid-query-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11198,10 +11198,10 @@ importers:
         version: link:../../../packages/router-plugin
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(solid-js@2.0.0-beta.25)
       '@tanstack/solid-query-devtools':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.25))(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -11215,8 +11215,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11231,14 +11231,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/large-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11247,7 +11247,7 @@ importers:
         version: link:../../../packages/router-plugin
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -11258,8 +11258,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11274,20 +11274,20 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/location-masking:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -11298,8 +11298,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11311,20 +11311,20 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/navigation-blocking:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -11335,8 +11335,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11348,14 +11348,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/quickstart:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11366,8 +11366,8 @@ importers:
         specifier: workspace:^
         version: link:../../../packages/solid-router-devtools
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11379,14 +11379,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/quickstart-esbuild-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/router-plugin':
         specifier: workspace:*
         version: link:../../../packages/router-plugin
@@ -11400,8 +11400,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11414,13 +11414,13 @@ importers:
         version: 0.27.4
       esbuild-plugin-solid:
         specifier: ^0.6.0
-        version: 0.6.0(esbuild@0.27.4)(solid-js@2.0.0-beta.21)
+        version: 0.6.0(esbuild@0.27.4)(solid-js@2.0.0-beta.25)
 
   examples/solid/quickstart-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11434,8 +11434,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11453,14 +11453,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/quickstart-rspack-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -11474,8 +11474,8 @@ importers:
         specifier: ^8.5.1
         version: 8.5.6
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11488,7 +11488,7 @@ importers:
         version: 1.1.2(@rsbuild/core@2.0.14)
       '@rsbuild/plugin-solid':
         specifier: ^2.0.0-beta.0
-        version: 2.0.0-beta.0(@babel/core@7.29.0)(@rsbuild/core@2.0.14)(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)
+        version: 2.0.0-beta.0(@babel/core@7.29.0)(@rsbuild/core@2.0.14)(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(solid-js@2.0.0-beta.25)
       '@tanstack/router-plugin':
         specifier: workspace:*
         version: link:../../../packages/router-plugin
@@ -11499,8 +11499,8 @@ importers:
   examples/solid/quickstart-webpack-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -11508,8 +11508,8 @@ importers:
         specifier: workspace:^
         version: link:../../../packages/solid-router-devtools
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11527,8 +11527,8 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0(@babel/core@7.28.5)(webpack@5.97.1)
       babel-preset-solid:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(@babel/core@7.28.5)(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(@babel/core@7.28.5)(solid-js@2.0.0-beta.25)
       css-loader:
         specifier: ^7.1.2
         version: 7.1.2(webpack@5.97.1)
@@ -11560,8 +11560,8 @@ importers:
   examples/solid/router-monorepo-simple:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/router-plugin':
         specifier: workspace:*
         version: link:../../../packages/router-plugin
@@ -11575,8 +11575,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
     devDependencies:
       '@types/node':
         specifier: 25.0.9
@@ -11591,14 +11591,14 @@ importers:
         specifier: 4.2.3
         version: 4.2.3(@types/node@25.0.9)(rollup@4.56.0)(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/router-monorepo-simple-lazy:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/router-plugin':
         specifier: workspace:*
         version: link:../../../packages/router-plugin
@@ -11612,8 +11612,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
     devDependencies:
       '@types/node':
         specifier: 25.0.9
@@ -11628,23 +11628,23 @@ importers:
         specifier: 4.2.3
         version: 4.2.3(@types/node@25.0.9)(rollup@4.56.0)(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/router-monorepo-solid-query:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/router-plugin':
         specifier: workspace:*
         version: link:../../../packages/router-plugin
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(solid-js@2.0.0-beta.25)
       '@tanstack/solid-query-devtools':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.25))(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -11655,8 +11655,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
     devDependencies:
       '@types/node':
         specifier: 25.0.9
@@ -11671,14 +11671,14 @@ importers:
         specifier: 4.2.3
         version: 4.2.3(@types/node@25.0.9)(rollup@4.56.0)(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/scroll-restoration:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11690,10 +11690,10 @@ importers:
         version: link:../../../packages/solid-router-devtools
       '@tanstack/solid-virtual':
         specifier: ^3.13.0
-        version: 3.13.12(solid-js@2.0.0-beta.21)
+        version: 3.13.12(solid-js@2.0.0-beta.25)
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11705,14 +11705,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/search-validator-adapters:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11724,7 +11724,7 @@ importers:
         version: link:../../../packages/router-plugin
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -11741,8 +11741,8 @@ importers:
         specifier: ^2.1.7
         version: 2.1.7
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11755,7 +11755,7 @@ importers:
     devDependencies:
       '@solidjs/testing-library':
         specifier: ^0.8.10
-        version: 0.8.10(solid-js@2.0.0-beta.21)
+        version: 0.8.10(solid-js@2.0.0-beta.25)
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.6.3
@@ -11766,14 +11766,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/start-basic:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -11787,8 +11787,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -11812,8 +11812,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11830,8 +11830,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(prisma@7.0.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2))(typescript@6.0.2)
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -11845,8 +11845,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -11873,8 +11873,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11885,8 +11885,8 @@ importers:
         specifier: ^0.41.1
         version: 0.41.1
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -11897,8 +11897,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       start-authjs:
         specifier: ^1.0.0
         version: 1.0.0(@auth/core@0.41.1)
@@ -11922,8 +11922,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11931,8 +11931,8 @@ importers:
   examples/solid/start-basic-cloudflare:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -11943,8 +11943,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.29.0
@@ -11965,8 +11965,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11977,8 +11977,8 @@ importers:
   examples/solid/start-basic-netlify:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -11989,8 +11989,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
     devDependencies:
       '@netlify/vite-plugin-tanstack-start':
         specifier: ^1.1.4
@@ -12011,8 +12011,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12020,8 +12020,8 @@ importers:
   examples/solid/start-basic-nitro:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -12032,8 +12032,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -12054,8 +12054,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12063,14 +12063,14 @@ importers:
   examples/solid/start-basic-solid-query:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(solid-js@2.0.0-beta.25)
       '@tanstack/solid-query-devtools':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.25))(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -12087,8 +12087,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -12109,8 +12109,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12118,8 +12118,8 @@ importers:
   examples/solid/start-basic-static:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -12136,8 +12136,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -12158,8 +12158,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.3
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12167,8 +12167,8 @@ importers:
   examples/solid/start-bun:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12177,7 +12177,7 @@ importers:
         version: link:../../../packages/router-plugin
       '@tanstack/solid-devtools':
         specifier: ^0.7.0
-        version: 0.7.14(csstype@3.2.3)(solid-js@2.0.0-beta.21)
+        version: 0.7.14(csstype@3.2.3)(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -12191,15 +12191,15 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
     devDependencies:
       '@solidjs/testing-library':
         specifier: ^0.8.10
-        version: 0.8.10(solid-js@2.0.0-beta.21)
+        version: 0.8.10(solid-js@2.0.0-beta.25)
       '@tanstack/eslint-config':
         specifier: ^0.3.2
         version: 0.3.2(@typescript-eslint/utils@8.57.1(eslint@9.22.0(jiti@2.7.0))(typescript@6.0.2))(eslint@9.22.0(jiti@2.7.0))(typescript@6.0.2)
@@ -12225,8 +12225,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@25.0.9)(@vitest/ui@4.1.4)(jsdom@27.0.0(postcss@8.5.15))(msw@2.7.0(@types/node@25.0.9)(typescript@6.0.2))(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12238,10 +12238,10 @@ importers:
     dependencies:
       '@convex-dev/better-auth':
         specifier: ^0.9.7
-        version: 0.9.7(@standard-schema/spec@1.1.0)(better-auth@1.6.19(@prisma/client@7.0.0(prisma@7.0.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2))(typescript@6.0.2))(@tanstack/solid-start@packages+solid-start)(mysql2@3.15.3)(prisma@7.0.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.21)(vitest@4.1.4)(vue@3.5.25(typescript@6.0.2)))(convex@1.28.2(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(hono@4.7.10)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2)
+        version: 0.9.7(@standard-schema/spec@1.1.0)(better-auth@1.6.19(@prisma/client@7.0.0(prisma@7.0.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2))(typescript@6.0.2))(@tanstack/solid-start@packages+solid-start)(mysql2@3.15.3)(prisma@7.0.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.25)(vitest@4.1.4)(vue@3.5.25(typescript@6.0.2)))(convex@1.28.2(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(hono@4.7.10)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2)
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12256,7 +12256,7 @@ importers:
         version: link:../../../packages/solid-start
       better-auth:
         specifier: ^1.3.27
-        version: 1.6.19(@prisma/client@7.0.0(prisma@7.0.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2))(typescript@6.0.2))(@tanstack/solid-start@packages+solid-start)(mysql2@3.15.3)(prisma@7.0.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.21)(vitest@4.1.4)(vue@3.5.25(typescript@6.0.2))
+        version: 1.6.19(@prisma/client@7.0.0(prisma@7.0.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2))(typescript@6.0.2))(@tanstack/solid-start@packages+solid-start)(mysql2@3.15.3)(prisma@7.0.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.25)(vitest@4.1.4)(vue@3.5.25(typescript@6.0.2))
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -12265,13 +12265,13 @@ importers:
         version: 1.28.2(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       convex-solidjs:
         specifier: ^0.0.3
-        version: 0.0.3(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.21)
+        version: 0.0.3(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.25)
       redaxios:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -12295,8 +12295,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12304,8 +12304,8 @@ importers:
   examples/solid/start-counter:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -12319,8 +12319,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -12341,17 +12341,17 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/start-i18n-paraglide:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-devtools':
         specifier: ^0.7.0
-        version: 0.7.14(csstype@3.2.3)(solid-js@2.0.0-beta.21)
+        version: 0.7.14(csstype@3.2.3)(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -12362,8 +12362,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
     devDependencies:
       '@inlang/paraglide-js':
         specifier: ^2.4.0
@@ -12384,17 +12384,17 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/start-large:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -12408,8 +12408,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -12433,14 +12433,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/start-streaming-data-from-server-functions:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -12451,8 +12451,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -12467,14 +12467,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/start-supabase-basic:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@supabase/ssr':
         specifier: ^0.5.2
         version: 0.5.2(@supabase/supabase-js@2.48.1)
@@ -12494,8 +12494,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -12513,8 +12513,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12522,8 +12522,8 @@ importers:
   examples/solid/start-tailwind-v4:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.26
         version: link:../../../packages/solid-router
@@ -12534,8 +12534,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -12559,8 +12559,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12568,8 +12568,8 @@ importers:
   examples/solid/view-transitions:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12586,8 +12586,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -12602,14 +12602,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/with-framer-motion:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12623,11 +12623,11 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       solid-motionone:
         specifier: ^1.0.4
-        version: 1.0.4(solid-js@2.0.0-beta.21)
+        version: 1.0.4(solid-js@2.0.0-beta.25)
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -12642,14 +12642,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/with-trpc:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12675,8 +12675,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -12694,8 +12694,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/vue/basic:
     dependencies:
@@ -13345,7 +13345,7 @@ importers:
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
         specifier: ^2.11.10 || ^3.0.0-0
-        version: 2.11.11(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        version: 2.11.11(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       webpack:
         specifier: '>=5.92.0'
         version: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)
@@ -13426,16 +13426,16 @@ importers:
     dependencies:
       '@solid-devtools/logger':
         specifier: ^0.9.4
-        version: 0.9.7(solid-js@2.0.0-beta.21)
+        version: 0.9.7(solid-js@2.0.0-beta.25)
       '@solid-primitives/refs':
         specifier: ^1.0.8
-        version: 1.1.0(solid-js@2.0.0-beta.21)
+        version: 1.1.0(solid-js@2.0.0-beta.25)
       '@solidjs/meta':
         specifier: ^0.29.4
-        version: 0.29.4(solid-js@2.0.0-beta.21)
+        version: 0.29.4(solid-js@2.0.0-beta.25)
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/history':
         specifier: workspace:*
         version: link:../history
@@ -13448,7 +13448,7 @@ importers:
     devDependencies:
       '@solidjs/testing-library':
         specifier: ^0.8.10
-        version: 0.8.10(solid-js@2.0.0-beta.21)
+        version: 0.8.10(solid-js@2.0.0-beta.25)
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.6.3
@@ -13462,14 +13462,14 @@ importers:
         specifier: ^0.14.5
         version: 0.14.5(eslint@9.22.0(jiti@2.7.0))(typescript@6.0.2)
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       vite:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -13477,8 +13477,8 @@ importers:
   packages/solid-router-devtools:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/router-core':
         specifier: workspace:*
         version: link:../router-core
@@ -13493,14 +13493,14 @@ importers:
         specifier: 25.0.9
         version: 25.0.9
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       vite:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   packages/solid-router-ssr-query:
     dependencies:
@@ -13512,11 +13512,11 @@ importers:
         version: link:../router-ssr-query-core
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.5(solid-js@2.0.0-beta.21)
+        version: 6.0.0-beta.5(solid-js@2.0.0-beta.25)
       '@tanstack/solid-router':
         specifier: workspace:*
         version: link:../solid-router
@@ -13524,14 +13524,14 @@ importers:
         specifier: ^0.14.5
         version: 0.14.5(eslint@9.22.0(jiti@2.7.0))(typescript@6.0.2)
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       vite:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   packages/solid-start:
     dependencies:
@@ -13561,8 +13561,8 @@ importers:
         specifier: ^2.0.11
         version: 2.0.14
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@tanstack/router-utils':
         specifier: workspace:*
         version: link:../router-utils
@@ -13570,8 +13570,8 @@ importers:
         specifier: 25.0.9
         version: 25.0.9
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       vite:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
@@ -13590,22 +13590,22 @@ importers:
     devDependencies:
       '@solidjs/testing-library':
         specifier: ^0.8.10
-        version: 0.8.10(solid-js@2.0.0-beta.21)
+        version: 0.8.10(solid-js@2.0.0-beta.25)
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.6.3
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       vite:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   packages/solid-start-server:
     dependencies:
@@ -13620,11 +13620,11 @@ importers:
         version: link:../start-server-core
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       solid-js:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -13632,8 +13632,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.14
-        version: 3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.15
+        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   packages/start-client-core:
     dependencies:
@@ -14873,44 +14873,44 @@ packages:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.24':
-    resolution: {integrity: sha512-IqPQQdgINMg6ev95xd/qfCH4stdooGRvNHiFzYitvKkv3fnqfc8+d72CuMX7eLJ9X2pVsyPzmrbEzwfrK1JoTA==}
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.25':
+    resolution: {integrity: sha512-ofFtSBj+cTHahndMNZrIXrNPxrrKk95U/2pY8zllAtPdHZRwOTYf86KCMcQ/i+muIpAIKsCcvI4p8A0B6ENzzw==}
     peerDependencies:
       '@babel/core': ^7.20.12
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.24':
-    resolution: {integrity: sha512-lT+WW7ehe7vZrWv9ZTkX9UXRa+73v84C2r9MdsNzj1EeGuHH29yYCh0idKAEtH9hS0+YS7LTAaGDO5x+0deRoQ==}
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.25':
+    resolution: {integrity: sha512-gStUMKI85sIslhEX+tEnvYSZL1s6EkW+6NsrUXEBUwL980BUejbHPe0B5ePE23SNJEQrVhRKtrXrAlKD68N+Bw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.24':
-    resolution: {integrity: sha512-Y2SaEwGRZxTPjSVsrmYcvsb9jblxfY1IfXwAGGMPYFgZmYUrL9QyTEF9nnqwsHEdg7pdQk5YRINQmQ302hCF8g==}
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.25':
+    resolution: {integrity: sha512-9Jy2lpkTOUP2vn6S8shH54ngdvyMXMbgTV7OZ3KjPHrk/YRk4+niOROksoiM6nyDxNeto1iyFij4gcfijNbxKg==}
     cpu: [x64]
     os: [darwin]
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.24':
-    resolution: {integrity: sha512-rx44q0WNxcB3TYrCJt07J0ZBdGFrieWAmg2ZDpjXcxCT1V2VgCoOARyLGv4FAM1dDlmJ2nymZ5XG3/H3CD8Tvg==}
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.25':
+    resolution: {integrity: sha512-iQ5rVmbu5MAfjmqlRdb7GTH1QtphVT7JALJIizQmUIPAJBFJJTNcfoSFeLpKnEnqCSY8uo8Etkjgsz3Nzip0/g==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.24':
-    resolution: {integrity: sha512-bmNfa4eMECDo39L35SvXgycIpIha591O5Vs2DmUNc3Ryo9I1uxvWJ+uH/EKRZOe4XATzAR8hSXxbWtXczUhksg==}
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.25':
+    resolution: {integrity: sha512-LYEHrCqhSat1QuATsRruqaaXW42BxlDFhHIHsTkQ6vhw7JYWA/kxZt1ujNvSPRanaEkaro+9/zyBLjebthjKEg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.24':
-    resolution: {integrity: sha512-IAdMBNx+T2Eb7ea5L3ak1WPQBo4FI1uwZm/xorenmJ4heYbGsptMwRC1Fi/aW+HoQGH9LqFA+wnoYeZx7dcEWQ==}
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.25':
+    resolution: {integrity: sha512-Vh5/ZKjzjeIeFIYvuxc5915qzfEcVw0y36r92zUojFuOQ1d1TYjeYwJ7KnYYQqYGtv8aV0DF3s3Glb2F2MAcgg==}
     engines: {node: '>=14.0.0'}
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.24':
-    resolution: {integrity: sha512-FQ2yrh3DUcfQ6hgwQNs0ghc1DYbx5kSh+Kq0buIGWxsDujOQF8LkXln0T2rwn6FVluu1UFx0cFoJOCEZ4keTuw==}
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.25':
+    resolution: {integrity: sha512-wNQdYFaKZ4mnuui5de0RmEfRwUXHBZ+DbvPdv3Qm+dsbNdrTAZMu7lFecQX/T7MrqElnKWBTzsgnhFwQj89Tfg==}
     cpu: [x64]
     os: [win32]
 
-  '@dom-expressions/compiler@0.50.0-next.24':
-    resolution: {integrity: sha512-L5+bnXh+6ODiGTVTNGilBgqxtgsZyKypJI77Fi4XjiIMwVD6P3WdV0HY4gOcJGpk0doPSpOp6bTWMA+Z311loA==}
+  '@dom-expressions/compiler@0.50.0-next.25':
+    resolution: {integrity: sha512-Uq3/BgCg3UGDyddKpjsQ1xQl9+q0hyUiOzCSxjYTIZdAOSegkIhMHxhVMDTC46mvRFTfmciGQ6DWSrqDad6Vng==}
 
   '@electric-sql/pglite-socket@0.0.6':
     resolution: {integrity: sha512-6RjmgzphIHIBA4NrMGJsjNWK4pu+bCWJlEWlwcxFTVY3WT86dFpKwbZaGWZV6C5Rd7sCk1Z0CI76QEfukLAUXw==}
@@ -19416,8 +19416,8 @@ packages:
     peerDependencies:
       solid-js: '>=1.8.4'
 
-  '@solidjs/signals@2.0.0-beta.21':
-    resolution: {integrity: sha512-dVBzBxWVvO3SubC1f8KZLeVqkiIp5TNNosCEbamggsOyLkfaWTWgOkRi7J/q6G9u4o1+dZ8LhqK70TJmimiZ9g==}
+  '@solidjs/signals@2.0.0-beta.25':
+    resolution: {integrity: sha512-Y4oSSCwt1rouvgz9LZxb3Wx2yLFMCjNhad/M2YZxOL4x7+sW6ST2BwI8ZP5vzEtyHUQX+5Pn5ltqkalaHjvlVA==}
 
   '@solidjs/testing-library@0.8.10':
     resolution: {integrity: sha512-qdeuIerwyq7oQTIrrKvV0aL9aFeuwTd86VYD3afdq5HYEwoox1OBTJy4y8A3TFZr8oAR0nujYgCzY/8wgHGfeQ==}
@@ -19429,10 +19429,10 @@ packages:
       '@solidjs/router':
         optional: true
 
-  '@solidjs/web@2.0.0-beta.21':
-    resolution: {integrity: sha512-QlpU6eAjcdsuggjy5groIfyAfU2S+YwAmka8eG+5kzSRSluxDYc9St8Xc+632KNpyOJS9kFjps2jjK4t20j6xg==}
+  '@solidjs/web@2.0.0-beta.25':
+    resolution: {integrity: sha512-ZuEhEpTXyUU6ERDGuZkShM1VdDoL6ib02pClRNjJmWR3MC5nvPDVXVJxsiUq/xBBQGX5XkzuWIQbE0i51ZsfGA==}
     peerDependencies:
-      solid-js: ^2.0.0-beta.21
+      solid-js: ^2.0.0-beta.25
 
   '@speed-highlight/core@1.2.14':
     resolution: {integrity: sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==}
@@ -21079,11 +21079,11 @@ packages:
       solid-js:
         optional: true
 
-  babel-preset-solid@2.0.0-beta.21:
-    resolution: {integrity: sha512-CbqiWmV+zXjfZM4HL+aT4JYkM41Kuaujch6sICkIbQLt5bmDoost+whFKUJa6/0e3iio4S5jWIr7iRV7InVerA==}
+  babel-preset-solid@2.0.0-beta.25:
+    resolution: {integrity: sha512-84U7dFD/zCS9SfSBNuy2GY4GhMYx5TynTAl133aVngnI3Au26NhCm3lJ7qpjTY7W+jcgCpBJ5ZfCm/KKB8k0og==}
     peerDependencies:
       '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-beta.21
+      solid-js: ^2.0.0-beta.25
     peerDependenciesMeta:
       solid-js:
         optional: true
@@ -25774,8 +25774,8 @@ packages:
   solid-js@1.9.12:
     resolution: {integrity: sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw==}
 
-  solid-js@2.0.0-beta.21:
-    resolution: {integrity: sha512-Z8YwRMXxnkseNrmWYE2l25orrAN2cRnIFanAPl3YbQyer8BIFOSaDQrmy7zQWZKiDn8Cp9JHPC143u44wVHAxQ==}
+  solid-js@2.0.0-beta.25:
+    resolution: {integrity: sha512-jWyMo3Z+Gv2IX6UvUvwBYSPM8/l9fm3sKM2dORTtC5xFrD4UTyJQBx9YdcawBalGQRXGX2xf+axkyBUUIVsw9Q==}
 
   solid-motionone@1.0.4:
     resolution: {integrity: sha512-aqEjgecoO9raDFznu/dEci7ORSmA26Kjj9J4Cn1Gyr0GZuOVdvsNxdxClTL9J40Aq/uYFx4GLwC8n70fMLHiuA==}
@@ -26876,12 +26876,12 @@ packages:
       '@testing-library/jest-dom':
         optional: true
 
-  vite-plugin-solid@3.0.0-next.14:
-    resolution: {integrity: sha512-WDy9TDa5Ekg/L94297+FKOOHOmrOyUlONRRkbGGOct/EB7SWyaobA3KRTy1pgeluy0pFrcquULhEeUg+4qKK2g==}
+  vite-plugin-solid@3.0.0-next.15:
+    resolution: {integrity: sha512-8Qa2KMqoX/MhD+vj5jLTb9tjrDZhLpe9VwxwyuI3IQYa/uIOhHEHfKepJmV4/nHnc78rCEs1K7R7E+AIPtuing==}
     peerDependencies:
-      '@solidjs/web': '>=2.0.0-beta.21 <2.0.0-experimental.0'
+      '@solidjs/web': '>=2.0.0-beta.22 <2.0.0-experimental.0'
       '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
-      solid-js: '>=2.0.0-beta.21 <2.0.0-experimental.0'
+      solid-js: '>=2.0.0-beta.22 <2.0.0-experimental.0'
       vite: ^8.0.14
     peerDependenciesMeta:
       '@testing-library/jest-dom':
@@ -28447,9 +28447,9 @@ snapshots:
 
   '@colors/colors@1.6.0': {}
 
-  '@convex-dev/better-auth@0.9.7(@standard-schema/spec@1.1.0)(better-auth@1.6.19(@prisma/client@7.0.0(prisma@7.0.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2))(typescript@6.0.2))(@tanstack/solid-start@packages+solid-start)(mysql2@3.15.3)(prisma@7.0.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.21)(vitest@4.1.4)(vue@3.5.25(typescript@6.0.2)))(convex@1.28.2(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(hono@4.7.10)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2)':
+  '@convex-dev/better-auth@0.9.7(@standard-schema/spec@1.1.0)(better-auth@1.6.19(@prisma/client@7.0.0(prisma@7.0.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2))(typescript@6.0.2))(@tanstack/solid-start@packages+solid-start)(mysql2@3.15.3)(prisma@7.0.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.25)(vitest@4.1.4)(vue@3.5.25(typescript@6.0.2)))(convex@1.28.2(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(hono@4.7.10)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2)':
     dependencies:
-      better-auth: 1.6.19(@prisma/client@7.0.0(prisma@7.0.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2))(typescript@6.0.2))(@tanstack/solid-start@packages+solid-start)(mysql2@3.15.3)(prisma@7.0.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.21)(vitest@4.1.4)(vue@3.5.25(typescript@6.0.2))
+      better-auth: 1.6.19(@prisma/client@7.0.0(prisma@7.0.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2))(typescript@6.0.2))(@tanstack/solid-start@packages+solid-start)(mysql2@3.15.3)(prisma@7.0.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.25)(vitest@4.1.4)(vue@3.5.25(typescript@6.0.2))
       common-tags: 1.8.2
       convex: 1.28.2(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       convex-helpers: 0.1.104(@standard-schema/spec@1.1.0)(convex@1.28.2(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(hono@4.7.10)(react@19.2.3)(typescript@6.0.2)(zod@3.25.76)
@@ -28563,7 +28563,7 @@ snapshots:
 
   '@discoveryjs/json-ext@0.5.7': {}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.24(@babel/core@7.28.5)':
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.25(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.18.6
@@ -28573,7 +28573,7 @@ snapshots:
       parse5: 7.3.0
       validate-html-nesting: 1.2.4
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.24(@babel/core@7.29.0)':
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.25(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.18.6
@@ -28583,36 +28583,36 @@ snapshots:
       parse5: 7.3.0
       validate-html-nesting: 1.2.4
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.24':
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.25':
     optional: true
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.24':
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.25':
     optional: true
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.24':
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.25':
     optional: true
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.24':
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.25':
     optional: true
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.24':
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.25':
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.24':
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.25':
     optional: true
 
-  '@dom-expressions/compiler@0.50.0-next.24':
+  '@dom-expressions/compiler@0.50.0-next.25':
     optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.24
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.24
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.24
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.24
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.24
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.24
+      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.25
+      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.25
+      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.25
+      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.25
+      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.25
+      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.25
 
   '@electric-sql/pglite-socket@0.0.6(@electric-sql/pglite@0.3.2)':
     dependencies:
@@ -32333,13 +32333,13 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-solid@2.0.0-beta.0(@babel/core@7.29.0)(@rsbuild/core@2.0.14)(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)':
+  '@rsbuild/plugin-solid@2.0.0-beta.0(@babel/core@7.29.0)(@rsbuild/core@2.0.14)(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(solid-js@2.0.0-beta.25)':
     dependencies:
       '@rsbuild/plugin-babel': 1.1.2(@rsbuild/core@2.0.14)
-      '@solidjs/web': 2.0.0-beta.21(solid-js@2.0.0-beta.21)
-      babel-preset-solid: 2.0.0-beta.21(@babel/core@7.29.0)(solid-js@2.0.0-beta.21)
-      solid-js: 2.0.0-beta.21
-      solid-refresh: 0.8.0-next.7(solid-js@2.0.0-beta.21)
+      '@solidjs/web': 2.0.0-beta.25(solid-js@2.0.0-beta.25)
+      babel-preset-solid: 2.0.0-beta.25(@babel/core@7.29.0)(solid-js@2.0.0-beta.25)
+      solid-js: 2.0.0-beta.25
+      solid-refresh: 0.8.0-next.7(solid-js@2.0.0-beta.25)
     optionalDependencies:
       '@rsbuild/core': 2.0.14
     transitivePeerDependencies:
@@ -32704,11 +32704,11 @@ snapshots:
       hoist-non-react-statics: 3.3.2
       react: 19.2.3
 
-  '@sentry/solid@10.32.0(@tanstack/solid-router@packages+solid-router)(solid-js@2.0.0-beta.21)':
+  '@sentry/solid@10.32.0(@tanstack/solid-router@packages+solid-router)(solid-js@2.0.0-beta.25)':
     dependencies:
       '@sentry/browser': 10.32.0
       '@sentry/core': 10.32.0
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
     optionalDependencies:
       '@tanstack/solid-router': link:packages/solid-router
 
@@ -32751,184 +32751,184 @@ snapshots:
       color: 5.0.2
       text-hex: 1.0.0
 
-  '@solid-devtools/debugger@0.26.0(solid-js@2.0.0-beta.21)':
+  '@solid-devtools/debugger@0.26.0(solid-js@2.0.0-beta.25)':
     dependencies:
       '@nothing-but/utils': 0.17.0
-      '@solid-devtools/shared': 0.19.0(solid-js@2.0.0-beta.21)
-      '@solid-primitives/bounds': 0.0.122(solid-js@2.0.0-beta.21)
-      '@solid-primitives/cursor': 0.0.115(solid-js@2.0.0-beta.21)
-      '@solid-primitives/event-listener': 2.4.0(solid-js@2.0.0-beta.21)
-      '@solid-primitives/keyboard': 1.3.0(solid-js@2.0.0-beta.21)
-      '@solid-primitives/platform': 0.1.2(solid-js@2.0.0-beta.21)
-      '@solid-primitives/rootless': 1.5.0(solid-js@2.0.0-beta.21)
-      '@solid-primitives/scheduled': 1.5.0(solid-js@2.0.0-beta.21)
-      '@solid-primitives/static-store': 0.0.8(solid-js@2.0.0-beta.21)
-      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.21)
-      solid-js: 2.0.0-beta.21
+      '@solid-devtools/shared': 0.19.0(solid-js@2.0.0-beta.25)
+      '@solid-primitives/bounds': 0.0.122(solid-js@2.0.0-beta.25)
+      '@solid-primitives/cursor': 0.0.115(solid-js@2.0.0-beta.25)
+      '@solid-primitives/event-listener': 2.4.0(solid-js@2.0.0-beta.25)
+      '@solid-primitives/keyboard': 1.3.0(solid-js@2.0.0-beta.25)
+      '@solid-primitives/platform': 0.1.2(solid-js@2.0.0-beta.25)
+      '@solid-primitives/rootless': 1.5.0(solid-js@2.0.0-beta.25)
+      '@solid-primitives/scheduled': 1.5.0(solid-js@2.0.0-beta.25)
+      '@solid-primitives/static-store': 0.0.8(solid-js@2.0.0-beta.25)
+      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.25)
+      solid-js: 2.0.0-beta.25
 
-  '@solid-devtools/logger@0.9.7(solid-js@2.0.0-beta.21)':
+  '@solid-devtools/logger@0.9.7(solid-js@2.0.0-beta.25)':
     dependencies:
       '@nothing-but/utils': 0.17.0
-      '@solid-devtools/debugger': 0.26.0(solid-js@2.0.0-beta.21)
-      '@solid-devtools/shared': 0.19.0(solid-js@2.0.0-beta.21)
-      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.21)
-      solid-js: 2.0.0-beta.21
+      '@solid-devtools/debugger': 0.26.0(solid-js@2.0.0-beta.25)
+      '@solid-devtools/shared': 0.19.0(solid-js@2.0.0-beta.25)
+      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.25)
+      solid-js: 2.0.0-beta.25
 
-  '@solid-devtools/shared@0.19.0(solid-js@2.0.0-beta.21)':
+  '@solid-devtools/shared@0.19.0(solid-js@2.0.0-beta.25)':
     dependencies:
       '@nothing-but/utils': 0.17.0
-      '@solid-primitives/event-listener': 2.4.0(solid-js@2.0.0-beta.21)
-      '@solid-primitives/media': 2.3.0(solid-js@2.0.0-beta.21)
-      '@solid-primitives/refs': 1.1.0(solid-js@2.0.0-beta.21)
-      '@solid-primitives/rootless': 1.5.0(solid-js@2.0.0-beta.21)
-      '@solid-primitives/scheduled': 1.5.0(solid-js@2.0.0-beta.21)
-      '@solid-primitives/static-store': 0.0.8(solid-js@2.0.0-beta.21)
-      '@solid-primitives/styles': 0.0.114(solid-js@2.0.0-beta.21)
-      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.21)
-      solid-js: 2.0.0-beta.21
+      '@solid-primitives/event-listener': 2.4.0(solid-js@2.0.0-beta.25)
+      '@solid-primitives/media': 2.3.0(solid-js@2.0.0-beta.25)
+      '@solid-primitives/refs': 1.1.0(solid-js@2.0.0-beta.25)
+      '@solid-primitives/rootless': 1.5.0(solid-js@2.0.0-beta.25)
+      '@solid-primitives/scheduled': 1.5.0(solid-js@2.0.0-beta.25)
+      '@solid-primitives/static-store': 0.0.8(solid-js@2.0.0-beta.25)
+      '@solid-primitives/styles': 0.0.114(solid-js@2.0.0-beta.25)
+      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.25)
+      solid-js: 2.0.0-beta.25
 
-  '@solid-primitives/bounds@0.0.122(solid-js@2.0.0-beta.21)':
+  '@solid-primitives/bounds@0.0.122(solid-js@2.0.0-beta.25)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.0(solid-js@2.0.0-beta.21)
-      '@solid-primitives/resize-observer': 2.1.0(solid-js@2.0.0-beta.21)
-      '@solid-primitives/static-store': 0.0.8(solid-js@2.0.0-beta.21)
-      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.21)
-      solid-js: 2.0.0-beta.21
+      '@solid-primitives/event-listener': 2.4.0(solid-js@2.0.0-beta.25)
+      '@solid-primitives/resize-observer': 2.1.0(solid-js@2.0.0-beta.25)
+      '@solid-primitives/static-store': 0.0.8(solid-js@2.0.0-beta.25)
+      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.25)
+      solid-js: 2.0.0-beta.25
 
-  '@solid-primitives/context@0.3.2(solid-js@2.0.0-beta.21)':
+  '@solid-primitives/context@0.3.2(solid-js@2.0.0-beta.25)':
     dependencies:
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
 
-  '@solid-primitives/cursor@0.0.115(solid-js@2.0.0-beta.21)':
+  '@solid-primitives/cursor@0.0.115(solid-js@2.0.0-beta.25)':
     dependencies:
-      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.21)
-      solid-js: 2.0.0-beta.21
+      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.25)
+      solid-js: 2.0.0-beta.25
 
-  '@solid-primitives/event-listener@2.4.0(solid-js@2.0.0-beta.21)':
+  '@solid-primitives/event-listener@2.4.0(solid-js@2.0.0-beta.25)':
     dependencies:
-      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.21)
-      solid-js: 2.0.0-beta.21
+      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.25)
+      solid-js: 2.0.0-beta.25
 
-  '@solid-primitives/event-listener@2.4.3(solid-js@2.0.0-beta.21)':
+  '@solid-primitives/event-listener@2.4.3(solid-js@2.0.0-beta.25)':
     dependencies:
-      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.21)
-      solid-js: 2.0.0-beta.21
+      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.25)
+      solid-js: 2.0.0-beta.25
 
-  '@solid-primitives/keyboard@1.3.0(solid-js@2.0.0-beta.21)':
+  '@solid-primitives/keyboard@1.3.0(solid-js@2.0.0-beta.25)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.0(solid-js@2.0.0-beta.21)
-      '@solid-primitives/rootless': 1.5.0(solid-js@2.0.0-beta.21)
-      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.21)
-      solid-js: 2.0.0-beta.21
+      '@solid-primitives/event-listener': 2.4.0(solid-js@2.0.0-beta.25)
+      '@solid-primitives/rootless': 1.5.0(solid-js@2.0.0-beta.25)
+      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.25)
+      solid-js: 2.0.0-beta.25
 
-  '@solid-primitives/keyboard@1.3.3(solid-js@2.0.0-beta.21)':
+  '@solid-primitives/keyboard@1.3.3(solid-js@2.0.0-beta.25)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.3(solid-js@2.0.0-beta.21)
-      '@solid-primitives/rootless': 1.5.2(solid-js@2.0.0-beta.21)
-      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.21)
-      solid-js: 2.0.0-beta.21
+      '@solid-primitives/event-listener': 2.4.3(solid-js@2.0.0-beta.25)
+      '@solid-primitives/rootless': 1.5.2(solid-js@2.0.0-beta.25)
+      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.25)
+      solid-js: 2.0.0-beta.25
 
-  '@solid-primitives/media@2.3.0(solid-js@2.0.0-beta.21)':
+  '@solid-primitives/media@2.3.0(solid-js@2.0.0-beta.25)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.0(solid-js@2.0.0-beta.21)
-      '@solid-primitives/rootless': 1.5.0(solid-js@2.0.0-beta.21)
-      '@solid-primitives/static-store': 0.1.0(solid-js@2.0.0-beta.21)
-      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.21)
-      solid-js: 2.0.0-beta.21
+      '@solid-primitives/event-listener': 2.4.0(solid-js@2.0.0-beta.25)
+      '@solid-primitives/rootless': 1.5.0(solid-js@2.0.0-beta.25)
+      '@solid-primitives/static-store': 0.1.0(solid-js@2.0.0-beta.25)
+      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.25)
+      solid-js: 2.0.0-beta.25
 
-  '@solid-primitives/platform@0.1.2(solid-js@2.0.0-beta.21)':
+  '@solid-primitives/platform@0.1.2(solid-js@2.0.0-beta.25)':
     dependencies:
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
 
-  '@solid-primitives/props@3.2.2(solid-js@2.0.0-beta.21)':
+  '@solid-primitives/props@3.2.2(solid-js@2.0.0-beta.25)':
     dependencies:
-      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.21)
-      solid-js: 2.0.0-beta.21
+      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.25)
+      solid-js: 2.0.0-beta.25
 
-  '@solid-primitives/refs@1.1.0(solid-js@2.0.0-beta.21)':
+  '@solid-primitives/refs@1.1.0(solid-js@2.0.0-beta.25)':
     dependencies:
-      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.21)
-      solid-js: 2.0.0-beta.21
+      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.25)
+      solid-js: 2.0.0-beta.25
 
-  '@solid-primitives/resize-observer@2.1.0(solid-js@2.0.0-beta.21)':
+  '@solid-primitives/resize-observer@2.1.0(solid-js@2.0.0-beta.25)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.0(solid-js@2.0.0-beta.21)
-      '@solid-primitives/rootless': 1.5.0(solid-js@2.0.0-beta.21)
-      '@solid-primitives/static-store': 0.1.0(solid-js@2.0.0-beta.21)
-      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.21)
-      solid-js: 2.0.0-beta.21
+      '@solid-primitives/event-listener': 2.4.0(solid-js@2.0.0-beta.25)
+      '@solid-primitives/rootless': 1.5.0(solid-js@2.0.0-beta.25)
+      '@solid-primitives/static-store': 0.1.0(solid-js@2.0.0-beta.25)
+      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.25)
+      solid-js: 2.0.0-beta.25
 
-  '@solid-primitives/resize-observer@2.1.3(solid-js@2.0.0-beta.21)':
+  '@solid-primitives/resize-observer@2.1.3(solid-js@2.0.0-beta.25)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.3(solid-js@2.0.0-beta.21)
-      '@solid-primitives/rootless': 1.5.2(solid-js@2.0.0-beta.21)
-      '@solid-primitives/static-store': 0.1.2(solid-js@2.0.0-beta.21)
-      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.21)
-      solid-js: 2.0.0-beta.21
+      '@solid-primitives/event-listener': 2.4.3(solid-js@2.0.0-beta.25)
+      '@solid-primitives/rootless': 1.5.2(solid-js@2.0.0-beta.25)
+      '@solid-primitives/static-store': 0.1.2(solid-js@2.0.0-beta.25)
+      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.25)
+      solid-js: 2.0.0-beta.25
 
-  '@solid-primitives/rootless@1.5.0(solid-js@2.0.0-beta.21)':
+  '@solid-primitives/rootless@1.5.0(solid-js@2.0.0-beta.25)':
     dependencies:
-      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.21)
-      solid-js: 2.0.0-beta.21
+      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.25)
+      solid-js: 2.0.0-beta.25
 
-  '@solid-primitives/rootless@1.5.2(solid-js@2.0.0-beta.21)':
+  '@solid-primitives/rootless@1.5.2(solid-js@2.0.0-beta.25)':
     dependencies:
-      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.21)
-      solid-js: 2.0.0-beta.21
+      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.25)
+      solid-js: 2.0.0-beta.25
 
-  '@solid-primitives/scheduled@1.5.0(solid-js@2.0.0-beta.21)':
+  '@solid-primitives/scheduled@1.5.0(solid-js@2.0.0-beta.25)':
     dependencies:
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
 
-  '@solid-primitives/static-store@0.0.8(solid-js@2.0.0-beta.21)':
+  '@solid-primitives/static-store@0.0.8(solid-js@2.0.0-beta.25)':
     dependencies:
-      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.21)
-      solid-js: 2.0.0-beta.21
+      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.25)
+      solid-js: 2.0.0-beta.25
 
-  '@solid-primitives/static-store@0.1.0(solid-js@2.0.0-beta.21)':
+  '@solid-primitives/static-store@0.1.0(solid-js@2.0.0-beta.25)':
     dependencies:
-      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.21)
-      solid-js: 2.0.0-beta.21
+      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.25)
+      solid-js: 2.0.0-beta.25
 
-  '@solid-primitives/static-store@0.1.2(solid-js@2.0.0-beta.21)':
+  '@solid-primitives/static-store@0.1.2(solid-js@2.0.0-beta.25)':
     dependencies:
-      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.21)
-      solid-js: 2.0.0-beta.21
+      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.25)
+      solid-js: 2.0.0-beta.25
 
-  '@solid-primitives/styles@0.0.114(solid-js@2.0.0-beta.21)':
+  '@solid-primitives/styles@0.0.114(solid-js@2.0.0-beta.25)':
     dependencies:
-      '@solid-primitives/rootless': 1.5.0(solid-js@2.0.0-beta.21)
-      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.21)
-      solid-js: 2.0.0-beta.21
+      '@solid-primitives/rootless': 1.5.0(solid-js@2.0.0-beta.25)
+      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.25)
+      solid-js: 2.0.0-beta.25
 
-  '@solid-primitives/transition-group@1.1.2(solid-js@2.0.0-beta.21)':
+  '@solid-primitives/transition-group@1.1.2(solid-js@2.0.0-beta.25)':
     dependencies:
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
 
-  '@solid-primitives/utils@6.3.0(solid-js@2.0.0-beta.21)':
+  '@solid-primitives/utils@6.3.0(solid-js@2.0.0-beta.25)':
     dependencies:
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
 
-  '@solid-primitives/utils@6.3.2(solid-js@2.0.0-beta.21)':
+  '@solid-primitives/utils@6.3.2(solid-js@2.0.0-beta.25)':
     dependencies:
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
 
-  '@solidjs/meta@0.29.4(solid-js@2.0.0-beta.21)':
+  '@solidjs/meta@0.29.4(solid-js@2.0.0-beta.25)':
     dependencies:
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
 
-  '@solidjs/signals@2.0.0-beta.21': {}
+  '@solidjs/signals@2.0.0-beta.25': {}
 
-  '@solidjs/testing-library@0.8.10(solid-js@2.0.0-beta.21)':
+  '@solidjs/testing-library@0.8.10(solid-js@2.0.0-beta.25)':
     dependencies:
       '@testing-library/dom': 10.4.1
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
 
-  '@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21)':
+  '@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25)':
     dependencies:
       seroval: 1.5.4
       seroval-plugins: 1.5.4(seroval@1.5.4)
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
 
   '@speed-highlight/core@1.2.14': {}
 
@@ -33204,46 +33204,46 @@ snapshots:
 
   '@tanstack/devtools-event-client@0.3.4': {}
 
-  '@tanstack/devtools-ui@0.3.5(csstype@3.2.3)(solid-js@2.0.0-beta.21)':
+  '@tanstack/devtools-ui@0.3.5(csstype@3.2.3)(solid-js@2.0.0-beta.25)':
     dependencies:
       clsx: 2.1.1
       goober: 2.1.16(csstype@3.2.3)
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
     transitivePeerDependencies:
       - csstype
 
-  '@tanstack/devtools-ui@0.4.4(csstype@3.2.3)(solid-js@2.0.0-beta.21)':
+  '@tanstack/devtools-ui@0.4.4(csstype@3.2.3)(solid-js@2.0.0-beta.25)':
     dependencies:
       clsx: 2.1.1
       goober: 2.1.16(csstype@3.2.3)
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
     transitivePeerDependencies:
       - csstype
 
-  '@tanstack/devtools@0.6.14(csstype@3.2.3)(solid-js@2.0.0-beta.21)':
+  '@tanstack/devtools@0.6.14(csstype@3.2.3)(solid-js@2.0.0-beta.25)':
     dependencies:
-      '@solid-primitives/keyboard': 1.3.0(solid-js@2.0.0-beta.21)
+      '@solid-primitives/keyboard': 1.3.0(solid-js@2.0.0-beta.25)
       '@tanstack/devtools-event-bus': 0.3.2
-      '@tanstack/devtools-ui': 0.3.5(csstype@3.2.3)(solid-js@2.0.0-beta.21)
+      '@tanstack/devtools-ui': 0.3.5(csstype@3.2.3)(solid-js@2.0.0-beta.25)
       clsx: 2.1.1
       goober: 2.1.16(csstype@3.2.3)
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
     transitivePeerDependencies:
       - bufferutil
       - csstype
       - utf-8-validate
 
-  '@tanstack/devtools@0.8.1(csstype@3.2.3)(solid-js@2.0.0-beta.21)':
+  '@tanstack/devtools@0.8.1(csstype@3.2.3)(solid-js@2.0.0-beta.25)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.3(solid-js@2.0.0-beta.21)
-      '@solid-primitives/keyboard': 1.3.3(solid-js@2.0.0-beta.21)
-      '@solid-primitives/resize-observer': 2.1.3(solid-js@2.0.0-beta.21)
+      '@solid-primitives/event-listener': 2.4.3(solid-js@2.0.0-beta.25)
+      '@solid-primitives/keyboard': 1.3.3(solid-js@2.0.0-beta.25)
+      '@solid-primitives/resize-observer': 2.1.3(solid-js@2.0.0-beta.25)
       '@tanstack/devtools-client': 0.0.4
       '@tanstack/devtools-event-bus': 0.3.3
-      '@tanstack/devtools-ui': 0.4.4(csstype@3.2.3)(solid-js@2.0.0-beta.21)
+      '@tanstack/devtools-ui': 0.4.4(csstype@3.2.3)(solid-js@2.0.0-beta.25)
       clsx: 2.1.1
       goober: 2.1.16(csstype@3.2.3)
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
     transitivePeerDependencies:
       - bufferutil
       - csstype
@@ -33295,9 +33295,9 @@ snapshots:
 
   '@tanstack/query-devtools@5.91.1': {}
 
-  '@tanstack/react-devtools@0.7.0(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(csstype@3.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.21)':
+  '@tanstack/react-devtools@0.7.0(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(csstype@3.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.25)':
     dependencies:
-      '@tanstack/devtools': 0.6.14(csstype@3.2.3)(solid-js@2.0.0-beta.21)
+      '@tanstack/devtools': 0.6.14(csstype@3.2.3)(solid-js@2.0.0-beta.25)
       '@types/react': 19.2.9
       '@types/react-dom': 19.2.3(@types/react@19.2.9)
       react: 19.2.3
@@ -33338,30 +33338,30 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@tanstack/solid-devtools@0.7.14(csstype@3.2.3)(solid-js@2.0.0-beta.21)':
+  '@tanstack/solid-devtools@0.7.14(csstype@3.2.3)(solid-js@2.0.0-beta.25)':
     dependencies:
-      '@tanstack/devtools': 0.8.1(csstype@3.2.3)(solid-js@2.0.0-beta.21)
-      solid-js: 2.0.0-beta.21
+      '@tanstack/devtools': 0.8.1(csstype@3.2.3)(solid-js@2.0.0-beta.25)
+      solid-js: 2.0.0-beta.25
     transitivePeerDependencies:
       - bufferutil
       - csstype
       - utf-8-validate
 
-  '@tanstack/solid-query-devtools@6.0.0-beta.5(@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.21))(solid-js@2.0.0-beta.21)':
+  '@tanstack/solid-query-devtools@6.0.0-beta.5(@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.25))(solid-js@2.0.0-beta.25)':
     dependencies:
       '@tanstack/query-devtools': 5.101.0
-      '@tanstack/solid-query': 6.0.0-beta.5(solid-js@2.0.0-beta.21)
-      solid-js: 2.0.0-beta.21
+      '@tanstack/solid-query': 6.0.0-beta.5(solid-js@2.0.0-beta.25)
+      solid-js: 2.0.0-beta.25
 
-  '@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.21)':
+  '@tanstack/solid-query@6.0.0-beta.5(solid-js@2.0.0-beta.25)':
     dependencies:
       '@tanstack/query-core': 5.99.0
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
 
-  '@tanstack/solid-virtual@3.13.12(solid-js@2.0.0-beta.21)':
+  '@tanstack/solid-virtual@3.13.12(solid-js@2.0.0-beta.25)':
     dependencies:
       '@tanstack/virtual-core': 3.13.12
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
 
   '@tanstack/store@0.9.3': {}
 
@@ -35267,33 +35267,33 @@ snapshots:
     optionalDependencies:
       solid-js: 1.9.12
 
-  babel-preset-solid@1.9.10(@babel/core@7.28.5)(solid-js@2.0.0-beta.21):
+  babel-preset-solid@1.9.10(@babel/core@7.28.5)(solid-js@2.0.0-beta.25):
     dependencies:
       '@babel/core': 7.28.5
       babel-plugin-jsx-dom-expressions: 0.40.3(@babel/core@7.28.5)
     optionalDependencies:
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
 
-  babel-preset-solid@1.9.10(@babel/core@7.29.0)(solid-js@2.0.0-beta.21):
+  babel-preset-solid@1.9.10(@babel/core@7.29.0)(solid-js@2.0.0-beta.25):
     dependencies:
       '@babel/core': 7.29.0
       babel-plugin-jsx-dom-expressions: 0.40.3(@babel/core@7.29.0)
     optionalDependencies:
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
 
-  babel-preset-solid@2.0.0-beta.21(@babel/core@7.28.5)(solid-js@2.0.0-beta.21):
+  babel-preset-solid@2.0.0-beta.25(@babel/core@7.28.5)(solid-js@2.0.0-beta.25):
     dependencies:
       '@babel/core': 7.28.5
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.24(@babel/core@7.28.5)
+      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.25(@babel/core@7.28.5)
     optionalDependencies:
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
 
-  babel-preset-solid@2.0.0-beta.21(@babel/core@7.29.0)(solid-js@2.0.0-beta.21):
+  babel-preset-solid@2.0.0-beta.25(@babel/core@7.29.0)(solid-js@2.0.0-beta.25):
     dependencies:
       '@babel/core': 7.29.0
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.24(@babel/core@7.29.0)
+      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.25(@babel/core@7.29.0)
     optionalDependencies:
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
 
   balanced-match@1.0.2: {}
 
@@ -35346,7 +35346,7 @@ snapshots:
       jsonpointer: 5.0.1
       leven: 3.1.0
 
-  better-auth@1.6.19(@prisma/client@7.0.0(prisma@7.0.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2))(typescript@6.0.2))(@tanstack/solid-start@packages+solid-start)(mysql2@3.15.3)(prisma@7.0.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.21)(vitest@4.1.4)(vue@3.5.25(typescript@6.0.2)):
+  better-auth@1.6.19(@prisma/client@7.0.0(prisma@7.0.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2))(typescript@6.0.2))(@tanstack/solid-start@packages+solid-start)(mysql2@3.15.3)(prisma@7.0.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.25)(vitest@4.1.4)(vue@3.5.25(typescript@6.0.2)):
     dependencies:
       '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.1.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.1.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
@@ -35372,7 +35372,7 @@ snapshots:
       prisma: 7.0.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.2)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
       vitest: 4.1.4(@types/node@25.0.9)(@vitest/ui@4.1.4)(jsdom@29.1.1(@noble/hashes@2.0.1))(msw@2.7.0(@types/node@25.0.9)(typescript@6.0.2))(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vue: 3.5.25(typescript@6.0.2)
     transitivePeerDependencies:
@@ -35877,11 +35877,11 @@ snapshots:
       typescript: 6.0.2
       zod: 3.25.76
 
-  convex-solidjs@0.0.3(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.21):
+  convex-solidjs@0.0.3(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.25):
     dependencies:
-      '@solid-primitives/context': 0.3.2(solid-js@2.0.0-beta.21)
+      '@solid-primitives/context': 0.3.2(solid-js@2.0.0-beta.25)
       convex: 1.28.2(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
     transitivePeerDependencies:
       - '@auth0/auth0-react'
       - '@clerk/clerk-react'
@@ -36496,13 +36496,13 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
-  esbuild-plugin-solid@0.6.0(esbuild@0.27.4)(solid-js@2.0.0-beta.21):
+  esbuild-plugin-solid@0.6.0(esbuild@0.27.4)(solid-js@2.0.0-beta.25):
     dependencies:
       '@babel/core': 7.28.5
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.5)
-      babel-preset-solid: 1.9.10(@babel/core@7.28.5)(solid-js@2.0.0-beta.21)
+      babel-preset-solid: 1.9.10(@babel/core@7.28.5)(solid-js@2.0.0-beta.25)
       esbuild: 0.27.4
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
     transitivePeerDependencies:
       - supports-color
 
@@ -40775,22 +40775,22 @@ snapshots:
       seroval: 1.5.4
       seroval-plugins: 1.5.4(seroval@1.5.4)
 
-  solid-js@2.0.0-beta.21:
+  solid-js@2.0.0-beta.25:
     dependencies:
-      '@solidjs/signals': 2.0.0-beta.21
+      '@solidjs/signals': 2.0.0-beta.25
       csstype: 3.2.3
       seroval: 1.5.4
       seroval-plugins: 1.5.4(seroval@1.5.4)
 
-  solid-motionone@1.0.4(solid-js@2.0.0-beta.21):
+  solid-motionone@1.0.4(solid-js@2.0.0-beta.25):
     dependencies:
       '@motionone/dom': 10.18.0
       '@motionone/utils': 10.18.0
-      '@solid-primitives/props': 3.2.2(solid-js@2.0.0-beta.21)
-      '@solid-primitives/refs': 1.1.0(solid-js@2.0.0-beta.21)
-      '@solid-primitives/transition-group': 1.1.2(solid-js@2.0.0-beta.21)
+      '@solid-primitives/props': 3.2.2(solid-js@2.0.0-beta.25)
+      '@solid-primitives/refs': 1.1.0(solid-js@2.0.0-beta.25)
+      '@solid-primitives/transition-group': 1.1.2(solid-js@2.0.0-beta.25)
       csstype: 3.1.3
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
 
   solid-refresh@0.6.3(solid-js@1.9.12):
     dependencies:
@@ -40801,20 +40801,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  solid-refresh@0.6.3(solid-js@2.0.0-beta.21):
+  solid-refresh@0.6.3(solid-js@2.0.0-beta.25):
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/helper-module-imports': 7.28.6
       '@babel/types': 7.29.0
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
     transitivePeerDependencies:
       - supports-color
 
-  solid-refresh@0.8.0-next.7(solid-js@2.0.0-beta.21):
+  solid-refresh@0.8.0-next.7(solid-js@2.0.0-beta.25):
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/types': 7.29.0
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
 
   sonic-boom@4.2.0:
     dependencies:
@@ -41678,14 +41678,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@2.11.11(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)):
+  vite-plugin-solid@2.11.11(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)):
     dependencies:
       '@babel/core': 7.29.0
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 1.9.10(@babel/core@7.29.0)(solid-js@2.0.0-beta.21)
+      babel-preset-solid: 1.9.10(@babel/core@7.29.0)(solid-js@2.0.0-beta.25)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.21
-      solid-refresh: 0.6.3(solid-js@2.0.0-beta.21)
+      solid-js: 2.0.0-beta.25
+      solid-refresh: 0.6.3(solid-js@2.0.0-beta.25)
       vite: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vitefu: 1.1.1(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
     optionalDependencies:
@@ -41693,16 +41693,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@3.0.0-next.14(@solidjs/web@2.0.0-beta.21(solid-js@2.0.0-beta.21))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.21)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)):
+  vite-plugin-solid@3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)):
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.29.0
-      '@dom-expressions/compiler': 0.50.0-next.24
-      '@solidjs/web': 2.0.0-beta.21(solid-js@2.0.0-beta.21)
+      '@dom-expressions/compiler': 0.50.0-next.25
+      '@solidjs/web': 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-beta.21(@babel/core@7.29.0)(solid-js@2.0.0-beta.21)
+      babel-preset-solid: 2.0.0-beta.25(@babel/core@7.29.0)(solid-js@2.0.0-beta.25)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.21
+      solid-js: 2.0.0-beta.25
       vite: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vitefu: 1.1.1(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,8 +251,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   benchmarks/client-nav:
     dependencies:
@@ -315,8 +315,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@25.0.9)(@vitest/ui@4.1.4)(jsdom@29.1.1(@noble/hashes@2.0.1))(msw@2.7.0(@types/node@25.0.9)(typescript@6.0.2))(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -385,8 +385,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@25.0.9)(@vitest/ui@4.1.4)(jsdom@29.1.1(@noble/hashes@2.0.1))(msw@2.7.0(@types/node@25.0.9)(typescript@6.0.2))(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -449,8 +449,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@25.0.9)(@vitest/ui@4.1.4)(jsdom@29.1.1(@noble/hashes@2.0.1))(msw@2.7.0(@types/node@25.0.9)(typescript@6.0.2))(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -510,8 +510,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@25.0.9)(@vitest/ui@4.1.4)(jsdom@29.1.1(@noble/hashes@2.0.1))(msw@2.7.0(@types/node@25.0.9)(typescript@6.0.2))(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -3669,8 +3669,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/basic:
     dependencies:
@@ -3706,8 +3706,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/basic-esbuild-file-based:
     dependencies:
@@ -3789,8 +3789,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/basic-file-based-code-splitting:
     dependencies:
@@ -3829,8 +3829,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/basic-scroll-restoration:
     dependencies:
@@ -3872,8 +3872,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/basic-solid-query:
     dependencies:
@@ -3915,8 +3915,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/basic-solid-query-file-based:
     dependencies:
@@ -3964,8 +3964,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/basic-virtual-file-based:
     dependencies:
@@ -4010,8 +4010,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/basic-virtual-named-export-config-file-based:
     dependencies:
@@ -4056,8 +4056,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/generator-cli-only:
     dependencies:
@@ -4096,8 +4096,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/js-only-file-based:
     dependencies:
@@ -4136,8 +4136,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/rspack-basic-file-based:
     dependencies:
@@ -4280,8 +4280,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/sentry-integration:
     dependencies:
@@ -4326,8 +4326,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/view-transitions:
     dependencies:
@@ -4372,8 +4372,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/basic:
     dependencies:
@@ -4454,8 +4454,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/basic-auth:
     dependencies:
@@ -4521,8 +4521,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/basic-cloudflare:
     dependencies:
@@ -4567,8 +4567,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       wrangler:
         specifier: ^4.74.0
         version: 4.75.0
@@ -4634,8 +4634,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/basic-tsr-config:
     dependencies:
@@ -4671,8 +4671,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/csp:
     dependencies:
@@ -4708,8 +4708,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/css-modules:
     dependencies:
@@ -4748,8 +4748,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4812,8 +4812,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4858,8 +4858,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/query-integration:
     dependencies:
@@ -4916,8 +4916,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/scroll-restoration:
     dependencies:
@@ -4974,8 +4974,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/selective-ssr:
     dependencies:
@@ -5014,8 +5014,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -5066,8 +5066,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/server-functions:
     dependencies:
@@ -5139,8 +5139,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/server-routes:
     dependencies:
@@ -5209,8 +5209,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/solid-query-layout-suspense:
     dependencies:
@@ -5246,8 +5246,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/spa-mode:
     dependencies:
@@ -5286,8 +5286,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -5326,8 +5326,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/virtual-routes:
     dependencies:
@@ -5387,8 +5387,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/website:
     dependencies:
@@ -5442,8 +5442,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/vue-router/basepath-file-based:
     dependencies:
@@ -10466,8 +10466,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/authenticated-routes-firebase:
     dependencies:
@@ -10512,8 +10512,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic:
     dependencies:
@@ -10552,8 +10552,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-default-search-params:
     dependencies:
@@ -10592,8 +10592,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-devtools-panel:
     dependencies:
@@ -10626,8 +10626,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-file-based:
     dependencies:
@@ -10666,8 +10666,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-non-nested-devtools:
     dependencies:
@@ -10706,8 +10706,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-solid-query:
     dependencies:
@@ -10749,8 +10749,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-solid-query-file-based:
     dependencies:
@@ -10795,8 +10795,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-ssr-file-based:
     dependencies:
@@ -10838,8 +10838,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-ssr-streaming-file-based:
     dependencies:
@@ -10893,8 +10893,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-virtual-file-based:
     dependencies:
@@ -10936,8 +10936,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-virtual-inside-file-based:
     dependencies:
@@ -10979,8 +10979,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/deferred-data:
     dependencies:
@@ -11016,8 +11016,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/i18n-paraglide:
     dependencies:
@@ -11053,8 +11053,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/kitchen-sink:
     dependencies:
@@ -11093,8 +11093,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/kitchen-sink-file-based:
     dependencies:
@@ -11136,8 +11136,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/kitchen-sink-solid-query:
     dependencies:
@@ -11182,8 +11182,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/kitchen-sink-solid-query-file-based:
     dependencies:
@@ -11231,8 +11231,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/large-file-based:
     dependencies:
@@ -11274,8 +11274,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/location-masking:
     dependencies:
@@ -11311,8 +11311,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/navigation-blocking:
     dependencies:
@@ -11348,8 +11348,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/quickstart:
     dependencies:
@@ -11379,8 +11379,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/quickstart-esbuild-file-based:
     dependencies:
@@ -11453,8 +11453,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/quickstart-rspack-file-based:
     dependencies:
@@ -11591,8 +11591,8 @@ importers:
         specifier: 4.2.3
         version: 4.2.3(@types/node@25.0.9)(rollup@4.56.0)(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/router-monorepo-simple-lazy:
     dependencies:
@@ -11628,8 +11628,8 @@ importers:
         specifier: 4.2.3
         version: 4.2.3(@types/node@25.0.9)(rollup@4.56.0)(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/router-monorepo-solid-query:
     dependencies:
@@ -11671,8 +11671,8 @@ importers:
         specifier: 4.2.3
         version: 4.2.3(@types/node@25.0.9)(rollup@4.56.0)(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/scroll-restoration:
     dependencies:
@@ -11705,8 +11705,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/search-validator-adapters:
     dependencies:
@@ -11766,8 +11766,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/start-basic:
     dependencies:
@@ -11812,8 +11812,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11873,8 +11873,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11922,8 +11922,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11965,8 +11965,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12011,8 +12011,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12054,8 +12054,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12109,8 +12109,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12158,8 +12158,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.3
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12225,8 +12225,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@25.0.9)(@vitest/ui@4.1.4)(jsdom@27.0.0(postcss@8.5.15))(msw@2.7.0(@types/node@25.0.9)(typescript@6.0.2))(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12295,8 +12295,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12341,8 +12341,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/start-i18n-paraglide:
     dependencies:
@@ -12384,8 +12384,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/start-large:
     dependencies:
@@ -12433,8 +12433,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/start-streaming-data-from-server-functions:
     dependencies:
@@ -12467,8 +12467,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/start-supabase-basic:
     dependencies:
@@ -12513,8 +12513,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12559,8 +12559,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12602,8 +12602,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/with-framer-motion:
     dependencies:
@@ -12642,8 +12642,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/with-trpc:
     dependencies:
@@ -12694,8 +12694,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/vue/basic:
     dependencies:
@@ -13468,8 +13468,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -13499,8 +13499,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   packages/solid-router-ssr-query:
     dependencies:
@@ -13530,8 +13530,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   packages/solid-start:
     dependencies:
@@ -13604,8 +13604,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   packages/solid-start-server:
     dependencies:
@@ -13632,8 +13632,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.15
-        version: 3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   packages/start-client-core:
     dependencies:
@@ -14878,39 +14878,39 @@ packages:
     peerDependencies:
       '@babel/core': ^7.20.12
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.25':
-    resolution: {integrity: sha512-gStUMKI85sIslhEX+tEnvYSZL1s6EkW+6NsrUXEBUwL980BUejbHPe0B5ePE23SNJEQrVhRKtrXrAlKD68N+Bw==}
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.29':
+    resolution: {integrity: sha512-QJ76cj13gbomntQpCUCvKVSkou8rvXZ+isdwTwNcyZyZQRyCcbke/NzoAQyiO94zuUfRemyDddqsUH/sZDC9gQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.25':
-    resolution: {integrity: sha512-9Jy2lpkTOUP2vn6S8shH54ngdvyMXMbgTV7OZ3KjPHrk/YRk4+niOROksoiM6nyDxNeto1iyFij4gcfijNbxKg==}
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.29':
+    resolution: {integrity: sha512-JNscWFkW+8scxRr4443GYDflUEYLlDtqysfflqeE35rMDYymmL0LDlqKeRl2eCOxMYCLTMJqYmNxvq6RamwOLA==}
     cpu: [x64]
     os: [darwin]
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.25':
-    resolution: {integrity: sha512-iQ5rVmbu5MAfjmqlRdb7GTH1QtphVT7JALJIizQmUIPAJBFJJTNcfoSFeLpKnEnqCSY8uo8Etkjgsz3Nzip0/g==}
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.29':
+    resolution: {integrity: sha512-KNEeatpePLIehshIyJmSh8DDetVQ3X1N5MDDfPdqNyxUXZw2AeH33+RgChHBtMhOnVCFFkkRClLKIojF6tcKcg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.25':
-    resolution: {integrity: sha512-LYEHrCqhSat1QuATsRruqaaXW42BxlDFhHIHsTkQ6vhw7JYWA/kxZt1ujNvSPRanaEkaro+9/zyBLjebthjKEg==}
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.29':
+    resolution: {integrity: sha512-lYe0kcLFQM3bWBjUxQsxtDdCndA9eFHaY0YyhQO5stfcfc4y4JX9H6O4oDCmdOvCgaskVpHMCKuFV+u0yBqiow==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.25':
-    resolution: {integrity: sha512-Vh5/ZKjzjeIeFIYvuxc5915qzfEcVw0y36r92zUojFuOQ1d1TYjeYwJ7KnYYQqYGtv8aV0DF3s3Glb2F2MAcgg==}
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.29':
+    resolution: {integrity: sha512-2kctxXRlfWjZd0PSgbHtaxtZoeR0h1lGKQpzf/PcBA5ZEydj8ZXxnYLYH0F/LOKY1HfgMJcYt0h1mEo/DNmjaQ==}
     engines: {node: '>=14.0.0'}
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.25':
-    resolution: {integrity: sha512-wNQdYFaKZ4mnuui5de0RmEfRwUXHBZ+DbvPdv3Qm+dsbNdrTAZMu7lFecQX/T7MrqElnKWBTzsgnhFwQj89Tfg==}
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.29':
+    resolution: {integrity: sha512-iCG1u15skcWFB+c19OwFZKNCsdGry4zeVPsrBLtpp3JgFkPyU4ADpiEMRyEKLFhAEptfneelUQxGB//Y6XRAUw==}
     cpu: [x64]
     os: [win32]
 
-  '@dom-expressions/compiler@0.50.0-next.25':
-    resolution: {integrity: sha512-Uq3/BgCg3UGDyddKpjsQ1xQl9+q0hyUiOzCSxjYTIZdAOSegkIhMHxhVMDTC46mvRFTfmciGQ6DWSrqDad6Vng==}
+  '@dom-expressions/compiler@0.50.0-next.29':
+    resolution: {integrity: sha512-jq2BzvPYWp15DilDcvg8O8xhzsHsc/YKGzpaLfcGlDRq2yonMbhrEcUjj7SBkk0kSUP/UAsqaxfyu2zEOC31lQ==}
 
   '@electric-sql/pglite-socket@0.0.6':
     resolution: {integrity: sha512-6RjmgzphIHIBA4NrMGJsjNWK4pu+bCWJlEWlwcxFTVY3WT86dFpKwbZaGWZV6C5Rd7sCk1Z0CI76QEfukLAUXw==}
@@ -26876,12 +26876,12 @@ packages:
       '@testing-library/jest-dom':
         optional: true
 
-  vite-plugin-solid@3.0.0-next.15:
-    resolution: {integrity: sha512-8Qa2KMqoX/MhD+vj5jLTb9tjrDZhLpe9VwxwyuI3IQYa/uIOhHEHfKepJmV4/nHnc78rCEs1K7R7E+AIPtuing==}
+  vite-plugin-solid@3.0.0-next.16:
+    resolution: {integrity: sha512-0x3vsnaobiwT9q1Dq67oFDdwJxOgLCXY1tbhwud33ZaKU7rGcPvbiRZzCPDcPVj6Ghya27dlq8rOLdasUvRGcg==}
     peerDependencies:
-      '@solidjs/web': '>=2.0.0-beta.22 <2.0.0-experimental.0'
+      '@solidjs/web': '>=2.0.0-beta.25 <2.0.0-experimental.0'
       '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
-      solid-js: '>=2.0.0-beta.22 <2.0.0-experimental.0'
+      solid-js: '>=2.0.0-beta.25 <2.0.0-experimental.0'
       vite: ^8.0.14
     peerDependenciesMeta:
       '@testing-library/jest-dom':
@@ -28583,36 +28583,36 @@ snapshots:
       parse5: 7.3.0
       validate-html-nesting: 1.2.4
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.25':
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.29':
     optional: true
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.25':
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.29':
     optional: true
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.25':
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.29':
     optional: true
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.25':
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.29':
     optional: true
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.25':
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.29':
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.25':
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.29':
     optional: true
 
-  '@dom-expressions/compiler@0.50.0-next.25':
+  '@dom-expressions/compiler@0.50.0-next.29':
     optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.25
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.25
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.25
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.25
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.25
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.25
+      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.29
+      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.29
+      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.29
+      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.29
+      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.29
+      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.29
 
   '@electric-sql/pglite-socket@0.0.6(@electric-sql/pglite@0.3.2)':
     dependencies:
@@ -41693,11 +41693,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@3.0.0-next.15(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)):
+  vite-plugin-solid@3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)):
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.29.0
-      '@dom-expressions/compiler': 0.50.0-next.25
+      '@dom-expressions/compiler': 0.50.0-next.29
       '@solidjs/web': 2.0.0-beta.25(solid-js@2.0.0-beta.25)
       '@types/babel__core': 7.20.5
       babel-preset-solid: 2.0.0-beta.25(@babel/core@7.29.0)(solid-js@2.0.0-beta.25)


### PR DESCRIPTION
Upgrades `solid-js`, `@solidjs/web`, and `babel-preset-solid` to `2.0.0-beta.25` across all packages, examples, and e2e apps, and `vite-plugin-solid` to `^3.0.0-next.16` (peer-requires solid-js >= beta.25, ships `@dom-expressions/compiler` 0.50.0-next.29).

Verified locally on the combined state:
- `@tanstack/solid-router` `test:unit`: 814 client + 2 server tests pass, no type errors
- `e2e/solid-start/basic`: build + 80 e2e tests pass
- `e2e/solid-router/basic-file-based`: build + 120 e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)