### PR TITLE
[WIP][experimental] solid-start: back createServerFn with vite-plugin-solid native server functions

### DIFF
--- a/e2e/solid-start/server-functions/tests/server-functions.spec.ts
+++ b/e2e/solid-start/server-functions/tests/server-functions.spec.ts
@@ -14,7 +14,8 @@ test('Server function URLs correctly include constant ids', async ({
     const form = page.locator('form')
     const actionUrl = await form.getAttribute('action')
 
-    expect(actionUrl).toMatch(/^\/_serverFn\/constant_id/)
+    // Directive transport: the function id travels as a query parameter
+    expect(actionUrl).toMatch(/^\/_serverFn\/\?id=constant_id/)
   }
 })
 
@@ -29,7 +30,11 @@ test('invoking a server function with custom response status code', async ({
     page.on('response', (response) => {
       expect(response.status()).toBe(225)
       expect(response.statusText()).toBe('hello')
-      expect(response.headers()['content-type']).toContain('application/json')
+      // Directive transport wire format is a framed codec stream (text/plain
+      // + X-Server-Function-Format), not application/json
+      expect(
+        response.headers()['x-server-function-format'],
+      ).toBeDefined()
       resolve()
     })
   })

--- a/packages/solid-start/package.json
+++ b/packages/solid-start/package.json
@@ -68,6 +68,12 @@
         "default": "./dist/esm/ssr-rpc.js"
       }
     },
+    "./server-fn-dispatch": {
+      "import": {
+        "types": "./dist/esm/server-fn-dispatch.d.ts",
+        "default": "./dist/esm/server-fn-dispatch.js"
+      }
+    },
     "./server": {
       "import": {
         "types": "./dist/esm/server.d.ts",
@@ -118,13 +124,16 @@
     "node": ">=22.12.0"
   },
   "dependencies": {
+    "@tanstack/router-core": "workspace:*",
     "@tanstack/solid-router": "workspace:*",
     "@tanstack/solid-start-client": "workspace:*",
     "@tanstack/solid-start-server": "workspace:*",
     "@tanstack/start-client-core": "workspace:*",
     "@tanstack/start-plugin-core": "workspace:*",
     "@tanstack/start-server-core": "workspace:*",
-    "pathe": "^2.0.3"
+    "pathe": "^2.0.3",
+    "seroval": "^1.5.4",
+    "seroval-plugins": "^1.5.4"
   },
   "devDependencies": {
     "@rsbuild/core": "^2.0.11",
@@ -132,12 +141,14 @@
     "@tanstack/router-utils": "workspace:*",
     "@types/node": ">=20",
     "solid-js": "2.0.0-beta.25",
-    "vite": "*"
+    "vite": "*",
+    "vite-plugin-solid": "^3.0.0-next.16"
   },
   "peerDependencies": {
     "@solidjs/web": ">=2.0.0-0 <3.0.0",
     "solid-js": ">=2.0.0-0 <3.0.0",
     "vite": ">=7.0.0",
+    "vite-plugin-solid": "^3.0.0-next.16",
     "@rsbuild/core": "^2.0.0"
   },
   "peerDependenciesMeta": {
@@ -145,6 +156,9 @@
       "optional": true
     },
     "vite": {
+      "optional": true
+    },
+    "vite-plugin-solid": {
       "optional": true
     }
   }

--- a/packages/solid-start/src/client-rpc.ts
+++ b/packages/solid-start/src/client-rpc.ts
@@ -1,1 +1,190 @@
+import { isNotFound, parseRedirect } from '@tanstack/router-core'
+import {
+  TSS_FORMDATA_CONTEXT,
+  TSS_SERVER_FUNCTION,
+  X_TSS_RAW_RESPONSE,
+  getStartOptions,
+} from '@tanstack/start-client-core'
+import { ERROR_HEADER, decodeResponse } from '@solidjs/web/server-functions'
+import {
+  BODY_FORMAT_FORMDATA,
+  BODY_FORMAT_HEADER,
+  BODY_FORMAT_SERIALIZED,
+  FUNCTION_ID_HEADER,
+  INSTANCE_HEADER,
+  X_CONTENT_RAW,
+  getWireCodecOptions,
+  serializeWireBody,
+  serializeWireJson,
+} from './directive-wire'
+import type { ClientFnMeta } from '@tanstack/start-client-core'
+
+// Kept for the split transport (serverFnTransport: 'split').
 export * from '@tanstack/start-client-core/client-rpc'
+
+interface DirectiveFetcherOptions {
+  method: 'GET' | 'POST'
+  data?: unknown
+  context?: Record<string, unknown>
+  headers?: HeadersInit
+  signal?: AbortSignal
+  fetch?: typeof fetch
+}
+
+let instanceCounter = 0
+
+/**
+ * Client transport for the directive server-fn pipeline: wraps the fetch stub
+ * vite-plugin-solid compiled out of the "use server" trampoline. The stub is
+ * only compile mechanics (its module-ordinal id is not split-safe) — calls go
+ * out under the TanStack function id from `meta`, and the fetch is owned here
+ * so per-call headers, abort signals and TanStack's custom `fetch` option
+ * keep working.
+ */
+export function createDirectiveClientRpc(
+  _stub: unknown,
+  meta: ClientFnMeta,
+) {
+  const functionId = meta.id
+  const url = `${process.env.TSS_SERVER_FN_BASE}?id=${encodeURIComponent(functionId)}`
+  const serverFnMeta: ClientFnMeta = { id: functionId }
+
+  const clientFn = (...args: Array<any>) => {
+    const first = (args[0] ?? {}) as DirectiveFetcherOptions
+    return directiveFetcher(functionId, url, first)
+  }
+
+  return Object.assign(clientFn, {
+    url,
+    serverFnMeta,
+    [TSS_SERVER_FUNCTION]: true,
+  })
+}
+
+async function directiveFetcher(
+  functionId: string,
+  baseUrl: string,
+  first: DirectiveFetcherOptions,
+) {
+  const startFetch = getStartOptions()?.serverFns?.fetch
+  const fetchImpl = first.fetch ?? startFetch ?? fetch
+
+  const headers = new Headers(first.headers)
+  headers.set('x-tsr-serverFn', 'true')
+  headers.set(FUNCTION_ID_HEADER, functionId)
+  // The instance header marks this as a scripted (client-runtime) call so the
+  // server responds with the codec wire format instead of no-JS semantics.
+  headers.set(INSTANCE_HEADER, `tss-${instanceCounter++}`)
+
+  // The single argument the registered server trampoline receives; it is
+  // passed straight to __executeServer. `context` here is the middleware
+  // chain's sendContext.
+  const wirePayload: Record<string, unknown> = { method: first.method }
+  if (first.data !== undefined) {
+    wirePayload.data = first.data
+  }
+  if (first.context && hasOwnProperties(first.context)) {
+    wirePayload.context = first.context
+  }
+
+  let url = baseUrl
+  let body: BodyInit | undefined
+
+  if (first.method === 'GET') {
+    if (first.data instanceof FormData) {
+      throw new Error('FormData is not supported with GET requests')
+    }
+    const serialized = await serializeWireBody([wirePayload])
+    url += `&args=${encodeURIComponent(serialized)}`
+  } else if (first.data instanceof FormData) {
+    // Native multipart body; sendContext rides in a reserved form field the
+    // server trampoline extracts before invoking __executeServer.
+    if (wirePayload.context) {
+      first.data.set(
+        TSS_FORMDATA_CONTEXT,
+        await serializeWireJson(wirePayload.context),
+      )
+    }
+    body = first.data
+    headers.set(BODY_FORMAT_HEADER, BODY_FORMAT_FORMDATA)
+  } else {
+    body = await serializeWireBody([wirePayload])
+    headers.set(BODY_FORMAT_HEADER, BODY_FORMAT_SERIALIZED)
+    headers.set('content-type', 'text/plain')
+  }
+
+  return getDirectiveResponse(() =>
+    fetchImpl(url, {
+      method: first.method,
+      headers,
+      signal: first.signal,
+      body,
+    }),
+  )
+}
+
+async function getDirectiveResponse(fn: () => Promise<Response>) {
+  let response: Response
+  try {
+    response = await fn()
+  } catch (error) {
+    if (error instanceof Response) {
+      response = error
+    } else {
+      throw error
+    }
+  }
+
+  // Raw Response results pass through the transport untouched.
+  if (
+    response.headers.get(X_TSS_RAW_RESPONSE) === 'true' ||
+    response.headers.has(X_CONTENT_RAW)
+  ) {
+    return response
+  }
+
+  // decodeResponse understands the runtime's body-format tags and reads from
+  // a clone, so the body stays available for the fallbacks below.
+  const result = await decodeResponse(response, getWireCodecOptions())
+
+  if (response.headers.has(ERROR_HEADER)) {
+    // A value thrown outside the __executeServer envelope (which itself
+    // catches into { error }).
+    throw result ?? new Error(`Server function ${response.status} error`)
+  }
+
+  if (result !== undefined) {
+    return result
+  }
+
+  // Plain JSON responses (no wire format tag): redirects converted by
+  // handleRedirectResponse, not-found payloads, and user JSON responses.
+  const contentType = response.headers.get('content-type')
+  if (contentType?.includes('application/json')) {
+    const jsonPayload = await response.json()
+    const redirect = parseRedirect(jsonPayload)
+    if (redirect) {
+      throw redirect
+    }
+    if (isNotFound(jsonPayload)) {
+      throw jsonPayload
+    }
+    return jsonPayload
+  }
+
+  if (!response.ok) {
+    throw new Error(await response.text())
+  }
+
+  return response
+}
+
+const hop = Object.prototype.hasOwnProperty
+function hasOwnProperties(obj: object): boolean {
+  for (const key in obj) {
+    if (hop.call(obj, key)) {
+      return true
+    }
+  }
+  return false
+}

--- a/packages/solid-start/src/directive-wire.ts
+++ b/packages/solid-start/src/directive-wire.ts
@@ -1,0 +1,103 @@
+import { Feature, fromCrossJSON, toCrossJSONAsync } from 'seroval'
+import {
+  AbortSignalPlugin,
+  CustomEventPlugin,
+  DOMExceptionPlugin,
+  EventPlugin,
+  FormDataPlugin,
+  HeadersPlugin,
+  ReadableStreamPlugin,
+  RequestPlugin,
+  ResponsePlugin,
+  URLPlugin,
+  URLSearchParamsPlugin,
+} from 'seroval-plugins/web'
+import { getDefaultSerovalPlugins } from '@tanstack/start-client-core'
+import type { Plugin as SerovalPlugin } from 'seroval'
+
+// ---------------------------------------------------------------------------
+// Wire constants of the @solidjs/web/server-functions transport. The shared
+// layer types them but the client entry does not export them at runtime, so
+// they are mirrored here. Values verified against @solidjs/web
+// 2.0.0-beta.25 — keep the peer range tight when bumping.
+// ---------------------------------------------------------------------------
+export const FUNCTION_ID_HEADER = 'X-Server-Function-Id'
+export const INSTANCE_HEADER = 'X-Server-Function-Instance'
+export const BODY_FORMAT_HEADER = 'X-Server-Function-Format'
+export const BODY_FORMAT_SERIALIZED = '0'
+export const BODY_FORMAT_FORMDATA = '2'
+/** Set on a Response to make handleServerFunctionRequest return it verbatim. */
+export const X_CONTENT_RAW = 'X-Content-Raw'
+
+// Mirrors DEFAULT_WEB_PLUGINS in @solidjs/web's serializer. The runtime's
+// resolveSerializerPlugins appends these AFTER any custom codec plugins, so
+// appending them after the TanStack plugins here yields the identical
+// resolution order on both wire legs.
+const SOLID_WEB_PLUGINS: Array<SerovalPlugin<any, any>> = [
+  AbortSignalPlugin,
+  CustomEventPlugin,
+  DOMExceptionPlugin,
+  EventPlugin,
+  FormDataPlugin,
+  HeadersPlugin,
+  ReadableStreamPlugin,
+  RequestPlugin,
+  ResponsePlugin,
+  URLSearchParamsPlugin,
+  URLPlugin,
+] as Array<SerovalPlugin<any, any>>
+
+// Matches JSON_CODEC_DISABLED_FEATURES in @solidjs/web's serializer.
+const DISABLED_FEATURES = Feature.RegExp
+
+function getWirePlugins(): Array<SerovalPlugin<any, any>> {
+  return [...getDefaultSerovalPlugins(), ...SOLID_WEB_PLUGINS]
+}
+
+/**
+ * Codec options understood by @solidjs/web's server-function runtime
+ * (decodeResponse / handleServerFunctionRequest). The runtime appends its own
+ * web plugins, so only the TanStack plugins are passed.
+ */
+export function getWireCodecOptions(): { plugins: Array<any> } {
+  return { plugins: getDefaultSerovalPlugins() }
+}
+
+/** Serializes a value to a seroval cross-JSON node string (no framing). */
+export async function serializeWireJson(value: unknown): Promise<string> {
+  const node = await toCrossJSONAsync(value, {
+    refs: new Map(),
+    plugins: getWirePlugins(),
+    disabledFeatures: DISABLED_FEATURES,
+  })
+  return JSON.stringify(node)
+}
+
+/** Inverse of serializeWireJson. */
+export function deserializeWireJson(serialized: string): unknown {
+  return fromCrossJSON(JSON.parse(serialized), {
+    refs: new Map(),
+    plugins: getWirePlugins(),
+    disabledFeatures: DISABLED_FEATURES,
+  })
+}
+
+/**
+ * Frames a payload for the @solidjs/web chunk-stream wire format:
+ * `;0x<len32>;` (byte length, 8 hex digits) followed by the data. A single
+ * frame is a valid stream — the server's ChunkReader reads it as the source
+ * value and finds the stream done.
+ */
+export function frameWireChunk(data: string): string {
+  const byteLength = new TextEncoder().encode(data).length
+  const hex = byteLength.toString(16)
+  return `;0x${'00000000'.substring(0, 8 - hex.length)}${hex};${data}`
+}
+
+/**
+ * Serializes a wire value as a single framed chunk, suitable as a POST body
+ * (BODY_FORMAT_SERIALIZED) or a GET `args` query parameter.
+ */
+export async function serializeWireBody(value: unknown): Promise<string> {
+  return frameWireChunk(await serializeWireJson(value))
+}

--- a/packages/solid-start/src/plugin/vite.ts
+++ b/packages/solid-start/src/plugin/vite.ts
@@ -1,7 +1,9 @@
+import { joinPaths } from '@tanstack/router-core'
 import {
   START_ENVIRONMENT_NAMES,
   tanStackStartVite,
 } from '@tanstack/start-plugin-core/vite'
+import { serverFunctions as solidServerFunctions } from 'vite-plugin-solid'
 import type {
   TanStackStartViteInputConfig,
   TanStackStartVitePluginCoreOptions,
@@ -20,7 +22,24 @@ export function tanstackStart(
     ssrResolverStrategy: {
       type: 'default',
     },
+    // Server functions compile to "use server" directive trampolines and run
+    // through vite-plugin-solid's serverFunctions pipeline + the
+    // @solidjs/web/server-functions runtime (see the serverFunctions plugins
+    // appended below).
+    serverFnTransport: 'directive',
   }
+
+  // Must produce the same path as TSS_SERVER_FN_BASE (createServerFnBasePath):
+  // vite-plugin-solid applies the Vite `base` itself, and the router basepath
+  // defaults to that base — so only an explicitly configured basepath is
+  // included here. Misaligned setups (vite base and router basepath both set,
+  // to different values) are not supported with the directive transport.
+  const serverFnEndpoint = joinPaths([
+    '/',
+    options?.router?.basepath ?? '',
+    options?.serverFns?.base ?? '/_serverFn',
+    '/',
+  ])
 
   return [
     {
@@ -64,7 +83,28 @@ export function tanstackStart(
               : undefined,
         }
       },
+      configResolved(config) {
+        // Our serverFunctions plugins are appended below; if the user ALSO
+        // enabled `serverFunctions` on their own vite-plugin-solid instance,
+        // every "use server" module would be compiled twice.
+        const compilerInstances = config.plugins.filter(
+          (p) => p.name === 'solid:server-functions/compiler',
+        ).length
+        if (compilerInstances > 1) {
+          config.logger.warn(
+            '[tanstack-solid-start] Multiple vite-plugin-solid serverFunctions ' +
+              'compilers detected. TanStack Start already configures server ' +
+              'functions — remove the `serverFunctions` option from your ' +
+              'viteSolid() plugin config.',
+          )
+        }
+      },
     },
     tanStackStartVite(corePluginOpts, options),
+    // The standalone serverFunctions() export (meta-framework mode): performs
+    // the "use server" directive split + manifest, but installs no dev
+    // middleware — TanStack Start dispatches the endpoint itself through
+    // createStartHandler (see #tanstack-start-server-fn-dispatch).
+    ...solidServerFunctions({ endpoint: serverFnEndpoint }),
   ]
 }

--- a/packages/solid-start/src/server-fn-dispatch.ts
+++ b/packages/solid-start/src/server-fn-dispatch.ts
@@ -1,0 +1,122 @@
+import { isRedirect } from '@tanstack/router-core'
+import { X_TSS_RAW_RESPONSE } from '@tanstack/start-client-core'
+import { getResponse } from '@tanstack/start-server-core'
+import {
+  BODY_FORMAT_HEADER,
+  X_CONTENT_RAW,
+  getWireCodecOptions,
+} from './directive-wire'
+
+/**
+ * Options for @solidjs/web's handleServerFunctionRequest that wire TanStack
+ * Start semantics into the directive server-fn transport. Called per request
+ * from the #tanstack-start-server-fn-dispatch virtual module, inside
+ * runWithStartContext (start options / serialization adapters are live).
+ */
+export function createTanStackDispatchOptions() {
+  return {
+    codec: getWireCodecOptions(),
+    transformResult: (
+      _event: unknown,
+      result: any,
+      ctx: { thrown?: boolean },
+    ) => {
+      if (ctx.thrown) {
+        return result
+      }
+
+      // `result` is the { result, error, context } envelope produced by
+      // __executeServer (middleware errors, redirects and notFound land in
+      // `error` — the client middleware chain handles those after decoding).
+      if (result && typeof result === 'object') {
+        const unwrapped =
+          result.result !== undefined ? result.result : result.error
+
+        if (unwrapped instanceof Response) {
+          if (isRedirect(unwrapped)) {
+            // Return the redirect Response itself so the SERVER_FN_BASE
+            // branch's handleRedirectResponse resolves it and converts it to
+            // serialized-redirect JSON for scripted calls. X-Content-Raw only
+            // forces verbatim passthrough out of handleServerFunctionRequest;
+            // postprocessDirectiveResponse strips it again.
+            unwrapped.headers.set(X_CONTENT_RAW, 'true')
+            return unwrapped
+          }
+
+          // Raw Response result: hand it to the client untouched.
+          unwrapped.headers.set(X_TSS_RAW_RESPONSE, 'true')
+          unwrapped.headers.set(X_CONTENT_RAW, 'true')
+          return unwrapped
+        }
+      }
+
+      return result
+    },
+    // Calls without the client runtime (no instance header): native no-JS
+    // form posts and direct HTTP requests. Mirror the split transport, which
+    // returned the unwrapped result as a plain response.
+    handleNoJS: (result: any, _request: Request, _args: Array<unknown>) => {
+      const unwrapped =
+        result && typeof result === 'object'
+          ? (result.result ?? result.error ?? result)
+          : result
+
+      if (unwrapped instanceof Response) {
+        return unwrapped
+      }
+
+      if (typeof unwrapped === 'string') {
+        return new Response(unwrapped, {
+          headers: { 'content-type': 'text/plain;charset=UTF-8' },
+        })
+      }
+
+      return Response.json(unwrapped ?? null)
+    },
+  }
+}
+
+/**
+ * Post-processing for responses returned by handleServerFunctionRequest with
+ * the TanStack dispatch options:
+ *
+ * - Redirect Responses passed through verbatim must not keep the
+ *   X-Content-Raw marker, or handleRedirectResponse's JSON replacement
+ *   (which copies the redirect's headers) would make the client treat the
+ *   serialized redirect as a raw response.
+ * - setResponseStatus()/statusText from the request-scoped h3 event are
+ *   applied to codec-encoded responses (the handler itself only knows about
+ *   ResponseEnvelope statuses). Headers set on the event are merged by the
+ *   outer requestHandler (h3 toResponse), so only status needs mapping.
+ */
+export function postprocessDirectiveResponse(response: Response): Response {
+  if (isRedirect(response)) {
+    response.headers.delete(X_CONTENT_RAW)
+    return response
+  }
+
+  if (
+    response.headers.has(X_CONTENT_RAW) ||
+    response.headers.get(X_TSS_RAW_RESPONSE) === 'true'
+  ) {
+    return response
+  }
+
+  if (response.headers.has(BODY_FORMAT_HEADER)) {
+    const alsResponse = getResponse()
+    const status = alsResponse.status ?? response.status
+    const statusText = alsResponse.statusText ?? ''
+    if (
+      status !== response.status ||
+      (statusText && statusText !== response.statusText)
+    ) {
+      return new Response(response.body, {
+        status,
+        statusText,
+        headers: response.headers,
+      })
+    }
+  }
+
+  return response
+}

--- a/packages/solid-start/src/server-rpc.ts
+++ b/packages/solid-start/src/server-rpc.ts
@@ -1,1 +1,108 @@
+import {
+  GET,
+  getServerFunction,
+  registerServerFunction,
+} from '@solidjs/web/server-functions/server'
+import {
+  TSS_FORMDATA_CONTEXT,
+  TSS_SERVER_FUNCTION,
+} from '@tanstack/start-client-core'
+import { deserializeWireJson } from './directive-wire'
+import type { ServerFnMeta } from '@tanstack/start-client-core'
+
+// Kept for the split transport (serverFnTransport: 'split').
 export { createServerRpc } from '@tanstack/start-server-core/createServerRpc'
+
+// Registered symbol brand the runtime uses to detect server function
+// references (see @solidjs/web/server-functions).
+const SERVER_FUNCTION_METADATA = Symbol.for('solid.ServerFunctionMetadata')
+
+/**
+ * Server-side wrapper for the directive server-fn pipeline. Receives the
+ * in-process reference vite-plugin-solid's server transform leaves behind
+ * (`createServerReference(registerServerReference(ordinalId, trampoline))`)
+ * plus TanStack's own function meta, and exposes the extractedFn contract
+ * createServerFn().handler() expects.
+ *
+ * The directive compiler's ordinal id is only used to fish the raw
+ * trampoline back out of the runtime registry; the function is re-registered
+ * under TanStack's split-safe id, which is what the client transport dials
+ * (the ordinal ids collide across router code-split modules of one file).
+ * Calls go through the raw trampoline rather than the reference proxy so
+ * in-process SSR invocations don't require a solid request event —
+ * TanStack's own start context provides request state.
+ */
+export function createDirectiveServerRpc(
+  ref: { id: string },
+  meta: ServerFnMeta,
+) {
+  const rawFn = getServerFunction(ref.id)
+  registerServerFunction(meta.id, rawFn)
+
+  const rpcFn = (...args: Array<any>) => rawFn(...args)
+
+  // createServerFn().handler() assigns the declared HTTP method onto the
+  // extracted fn at module-eval time. Intercept it to register GET functions
+  // in the runtime's method map — without that declaration
+  // handleServerFunctionRequest answers GET requests with 405.
+  let method: 'GET' | 'POST' | undefined
+  Object.defineProperty(rpcFn, 'method', {
+    get: () => method,
+    set: (value: 'GET' | 'POST' | undefined) => {
+      method = value
+      if (value === 'GET') {
+        // GET() only accepts branded server function references; brand a
+        // stand-in carrying the TanStack id so the method map keys on it.
+        const brand: any = () => {}
+        brand[SERVER_FUNCTION_METADATA] = {}
+        brand.id = meta.id
+        GET(brand)
+      }
+    },
+    enumerable: true,
+    configurable: true,
+  })
+
+  return Object.assign(rpcFn, {
+    url: `${process.env.TSS_SERVER_FN_BASE}?id=${encodeURIComponent(meta.id)}`,
+    serverFnMeta: meta,
+    [TSS_SERVER_FUNCTION]: true,
+  })
+}
+
+/**
+ * Normalizes the single wire argument the registered trampoline receives into
+ * the options object __executeServer expects. Codec-serialized calls already
+ * carry the options object; native FormData bodies arrive as the bare
+ * FormData with sendContext smuggled in a reserved field.
+ */
+export function normalizeDirectiveServerOpts(opts: any) {
+  // Native no-JS form posts default to urlencoded bodies; the split
+  // transport parsed those as FormData (request.formData() accepts both),
+  // so keep handing FormData to validators/handlers.
+  if (opts instanceof URLSearchParams) {
+    const formData = new FormData()
+    opts.forEach((value, key) => formData.append(key, value))
+    opts = formData
+  }
+
+  if (typeof FormData !== 'undefined' && opts instanceof FormData) {
+    const serializedContext = opts.get(TSS_FORMDATA_CONTEXT)
+    opts.delete(TSS_FORMDATA_CONTEXT)
+
+    let context: unknown
+    if (typeof serializedContext === 'string') {
+      try {
+        context = deserializeWireJson(serializedContext)
+      } catch (error) {
+        if (process.env.NODE_ENV === 'development') {
+          console.warn('Failed to parse FormData context:', error)
+        }
+      }
+    }
+
+    return { data: opts, context, method: 'POST' }
+  }
+
+  return opts ?? {}
+}

--- a/packages/solid-start/vite.config.ts
+++ b/packages/solid-start/vite.config.ts
@@ -31,6 +31,7 @@ export default mergeConfig(
       './src/client-rpc.ts',
       './src/ssr-rpc.ts',
       './src/server-rpc.ts',
+      './src/server-fn-dispatch.ts',
       './src/server.tsx',
       './src/plugin/rsbuild.ts',
       './src/plugin/vite.ts',

--- a/packages/start-client-core/src/index.tsx
+++ b/packages/start-client-core/src/index.tsx
@@ -129,6 +129,7 @@ export type {
 export type { Register } from '@tanstack/router-core'
 
 export { getRouterInstance } from './getRouterInstance'
+export { getStartOptions } from './getStartOptions'
 export { getDefaultSerovalPlugins } from './getDefaultSerovalPlugins'
 export { getGlobalStartContext } from './getGlobalStartContext'
 export { safeObjectMerge, createNullProtoObject } from './safeObjectMerge'

--- a/packages/start-plugin-core/src/start-compiler/compiler.ts
+++ b/packages/start-plugin-core/src/start-compiler/compiler.ts
@@ -546,6 +546,11 @@ export class StartCompiler {
        */
       providerEnvName: string
       /**
+       * Server function compilation/transport strategy.
+       * Defaults to 'split' (TanStack module splitting + RPC).
+       */
+      serverFnTransport?: 'split' | 'directive'
+      /**
        * Custom function ID generator (optional, defaults to hash-based).
        */
       generateFunctionId?: (opts: {
@@ -1360,6 +1365,7 @@ export class StartCompiler {
         root: this.options.root,
         framework: this.options.framework,
         providerEnvName: this.options.providerEnvName,
+        serverFnTransport: this.options.serverFnTransport ?? 'split',
         types: t,
         parseExpression: (expressionCode) =>
           babel.template.expression(expressionCode, {

--- a/packages/start-plugin-core/src/start-compiler/handleCreateServerFn.ts
+++ b/packages/start-plugin-core/src/start-compiler/handleCreateServerFn.ts
@@ -47,6 +47,45 @@ const ssrRpcManifestTemplate = babel.template.expression(
   `createSsrRpc(%%functionId%%)`,
 )
 
+// ============================================================================
+// Directive transport templates (serverFnTransport: 'directive')
+//
+// The trampoline arrow carries a "use server" directive so a framework-native
+// directive compiler (e.g. vite-plugin-solid's serverFunctions plugins,
+// running after the start compiler in the same enforce:'pre' bucket) performs
+// the client-stub/server-registration split. Function IDs are derived by that
+// compiler from the module path + per-module ordinal, so emitting the
+// trampolines in identical order in the client and server outputs keeps the
+// IDs aligned across environments with no coordination.
+// ============================================================================
+
+// Function identity note: the directive compiler derives its own ids from
+// (module path, per-module ordinal). Those are NOT usable as wire ids here —
+// the router code-splitter fans one route file out into several virtual
+// modules that share the same path, so ordinals collide across split modules
+// and differ between the client and server environments. Instead the start
+// compiler passes its own split-safe function id (same generator as the
+// split transport, honoring serverFns.generateFunctionId) as meta, and the
+// runtime wrappers register/dispatch under that id via the runtime's public
+// registry (registerServerFunction); the directive compiler's internal id is
+// only used to fish the registered trampoline back out at module-eval time.
+
+// Client env: handler body is dropped entirely; the directive arrow's body is
+// erased by the directive compiler's client transform and replaced with a
+// fetch stub, which createDirectiveClientRpc wraps with the TanStack wire
+// protocol.
+const directiveClientTemplate = babel.template.expression(
+  `createDirectiveClientRpc((opts) => { 'use server'; return %%fnVar%%.__executeServer(opts) }, %%meta%%)`,
+)
+
+// Server env: the directive compiler hoists + registers the arrow and leaves
+// an in-process reference behind, which createDirectiveServerRpc wraps.
+// normalizeDirectiveServerOpts converts raw HTTP payload shapes (FormData)
+// into the options object __executeServer expects.
+const directiveServerTemplate = babel.template.expression(
+  `createDirectiveServerRpc((opts) => { 'use server'; return %%fnVar%%.__executeServer(normalizeDirectiveServerOpts(opts)) }, %%meta%%)`,
+)
+
 // TODO remove upon stable
 function warnInputValidatorDeprecation(
   context: CompilationContext,
@@ -66,7 +105,12 @@ function warnInputValidatorDeprecation(
 // Runtime code cache (cached per framework to avoid repeated AST generation)
 // ============================================================================
 
-type RuntimeCodeType = 'provider' | 'client' | 'ssr'
+type RuntimeCodeType =
+  | 'provider'
+  | 'client'
+  | 'ssr'
+  | 'directiveClient'
+  | 'directiveServer'
 type FrameworkRuntimeCache = Record<RuntimeCodeType, t.Statement>
 const RuntimeCodeCache = new Map<
   CompileStartFrameworkOptions,
@@ -90,6 +134,14 @@ function getCachedRuntimeCode(
       ) as t.Statement,
       ssr: babel.template.ast(
         `import { createSsrRpc } from '@tanstack/${framework}-start/ssr-rpc'`,
+        { placeholderPattern: false },
+      ) as t.Statement,
+      directiveClient: babel.template.ast(
+        `import { createDirectiveClientRpc } from '@tanstack/${framework}-start/client-rpc'`,
+        { placeholderPattern: false },
+      ) as t.Statement,
+      directiveServer: babel.template.ast(
+        `import { createDirectiveServerRpc, normalizeDirectiveServerOpts } from '@tanstack/${framework}-start/server-rpc'`,
         { placeholderPattern: false },
       ) as t.Statement,
     }
@@ -213,6 +265,11 @@ export function handleCreateServerFn(
   context: CompilationContext,
 ) {
   if (candidates.length === 0) {
+    return
+  }
+
+  if (context.serverFnTransport === 'directive') {
+    handleCreateServerFnDirective(candidates, context)
     return
   }
 
@@ -480,6 +537,198 @@ export function handleCreateServerFn(
   const runtimeCode = getCachedRuntimeCode(
     context.framework,
     envConfig.runtimeCodeType,
+  )
+  context.ast.program.body.unshift(t.cloneNode(runtimeCode))
+}
+
+/**
+ * Directive-transport variant of handleCreateServerFn.
+ *
+ * No module splitting, no TanStack manifest, no RPC stub injection: each
+ * createServerFn handler is rewritten to a "use server" trampoline that a
+ * framework-native directive compiler (running after this one) splits into a
+ * client fetch stub / server registration. The original handler stays in
+ * place on the server (passed as the second .handler() argument, same shape
+ * the split provider files use today) and is dropped on the client.
+ */
+function handleCreateServerFnDirective(
+  candidates: Array<RewriteCandidate>,
+  context: CompilationContext,
+) {
+  const isClientEnv = context.env === 'client'
+  const isProviderFile = context.id.includes(TSS_SERVERFN_SPLIT_PARAM)
+
+  // Track function names to ensure uniqueness within this module
+  const functionNameSet = new Set<string>()
+  const serverFnVariableNames = new Set<string>()
+  const serverFnsById: Record<string, ServerFn> = {}
+
+  const [baseFilename] = context.id.split('?') as [string]
+  // Function ids are generated against the provider-style module id
+  // (base file + tss-serverfn-split query, ignored by the router code
+  // splitter). One route file fans out into several code-split virtual
+  // modules that each compile a subset of its server functions, in both
+  // environments — keying ids to the base file keeps them identical across
+  // all variants, and importing the provider module evaluates (and thereby
+  // registers) every server function of the file, including ones living in
+  // lazy code-split chunks the SSR render never loads.
+  const extractedFilename = `${baseFilename}?${TSS_SERVERFN_SPLIT_PARAM}`
+  const relativeFilename = path.relative(context.root, baseFilename)
+  const cleanedContextId = cleanId(context.id)
+
+  for (const candidate of candidates) {
+    const { path: candidatePath, methodChain } = candidate
+    const { validator, inputValidator, handler } = methodChain
+
+    const candidateVariableDeclarator = getVariableDeclaratorForExpressionPath(
+      candidatePath as babel.NodePath<t.Expression>,
+    )
+
+    if (!candidateVariableDeclarator) {
+      throw new Error('createServerFn must be assigned to a variable!')
+    }
+
+    const variableDeclarator = candidateVariableDeclarator.node
+    if (!t.isIdentifier(variableDeclarator.id)) {
+      throw codeFrameError(
+        context.code,
+        variableDeclarator.id.loc!,
+        'createServerFn must be assigned to a simple identifier, not a destructuring pattern',
+      )
+    }
+    const existingVariableName = variableDeclarator.id.name
+    serverFnVariableNames.add(existingVariableName)
+
+    // TODO remove upon stable
+    if (inputValidator) {
+      warnInputValidatorDeprecation(context, inputValidator)
+    }
+
+    // Handle validators - remove on client
+    for (const [methodName, methodCall] of [
+      ['validator', validator],
+      // TODO remove upon stable
+      ['inputValidator', inputValidator],
+    ] as const) {
+      if (!methodCall) {
+        continue
+      }
+
+      if (!methodCall.callPath.node.arguments[0]) {
+        throw new Error(
+          `createServerFn().${methodName}() must be called with a validator!`,
+        )
+      }
+
+      if (isClientEnv) {
+        stripMethodCall(methodCall.callPath)
+      }
+    }
+
+    const handlerFnPath = handler?.firstArgPath
+
+    if (!handler || !handlerFnPath?.node) {
+      throw codeFrameError(
+        context.code,
+        candidatePath.node.callee.loc!,
+        `createServerFn must be called with a "handler" property!`,
+      )
+    }
+
+    if (!t.isExpression(handlerFnPath.node)) {
+      throw codeFrameError(
+        context.code,
+        handlerFnPath.node.loc!,
+        `handler() must be called with an expression, not a ${handlerFnPath.node.type}`,
+      )
+    }
+
+    // Generate the split-safe function id: dev ids encode the provider
+    // module specifier (so the dispatcher can lazily import it), build ids
+    // derive from (relative base filename, function name) — identical in
+    // the client and server environments regardless of how the code
+    // splitter laid out the modules.
+    let functionName = `${existingVariableName}_createServerFn_handler`
+    while (functionNameSet.has(functionName)) {
+      functionName = incrementFunctionNameVersion(functionName)
+    }
+    functionNameSet.add(functionName)
+
+    const functionId = context.generateFunctionId({
+      filename: relativeFilename,
+      functionName,
+      extractedFilename,
+    })
+
+    serverFnsById[functionId] = {
+      functionName,
+      functionId,
+      filename: cleanedContextId,
+      extractedFilename,
+      isClientReferenced: true,
+    }
+
+    const fnVar = t.identifier(existingVariableName)
+
+    if (isClientEnv) {
+      // Drop the original handler body entirely; only the directive
+      // trampoline (whose body the directive compiler erases) remains.
+      // Client meta only carries the id (name/filename may expose server
+      // internals).
+      const meta = t.objectExpression([
+        t.objectProperty(t.identifier('id'), t.stringLiteral(functionId)),
+      ])
+      handler.callPath.node.arguments = [
+        directiveClientTemplate({ fnVar, meta }),
+      ]
+    } else {
+      // Keep the original handler as the second argument, mirroring the
+      // (extractedFn, serverFn) signature the runtime expects.
+      const meta = buildServerFnMetaObject(
+        functionId,
+        existingVariableName,
+        relativeFilename,
+      )
+      const serverFnNode = t.cloneNode(handlerFnPath.node, true)
+      handler.callPath.node.arguments = [
+        directiveServerTemplate({ fnVar, meta }),
+        serverFnNode,
+      ]
+    }
+  }
+
+  if (hasKeys(serverFnsById) && context.onServerFnsById) {
+    context.onServerFnsById(serverFnsById)
+  }
+
+  // Provider modules (base file + tss-serverfn-split, imported by the
+  // dispatcher purely for their registration side effects) are pruned like
+  // the split transport's provider files: drop all original exports and
+  // export only the server function variables, so dead code elimination
+  // strips components and other top-level code that may not be safe to
+  // evaluate on the server (e.g. `window` access in ssr:false routes).
+  if (!isClientEnv && isProviderFile) {
+    safeRemoveExports(context.ast)
+
+    if (serverFnVariableNames.size > 0) {
+      context.ast.program.body.push(
+        t.exportNamedDeclaration(
+          undefined,
+          Array.from(serverFnVariableNames).map((name) =>
+            t.exportSpecifier(t.identifier(name), t.identifier(name)),
+          ),
+        ),
+      )
+    }
+
+    if (context.mode === 'dev') {
+      context.ast.program.body.push(...providerHmrAcceptTemplate())
+    }
+  }
+
+  const runtimeCode = getCachedRuntimeCode(
+    context.framework,
+    isClientEnv ? 'directiveClient' : 'directiveServer',
   )
   context.ast.program.body.unshift(t.cloneNode(runtimeCode))
 }

--- a/packages/start-plugin-core/src/start-compiler/host.ts
+++ b/packages/start-plugin-core/src/start-compiler/host.ts
@@ -19,6 +19,7 @@ export interface CreateStartCompilerOptions {
   root: string
   framework: CompileStartFrameworkOptions
   providerEnvName: string
+  serverFnTransport?: 'split' | 'directive'
   mode: 'dev' | 'build'
   generateFunctionId?: GenerateFunctionIdFnOptional
   compilerTransforms?: Array<StartCompilerImportTransform> | undefined
@@ -50,6 +51,7 @@ export function createStartCompiler(
     mode: options.mode,
     framework: options.framework,
     providerEnvName: options.providerEnvName,
+    serverFnTransport: options.serverFnTransport,
     generateFunctionId: options.generateFunctionId,
     onServerFnsById: options.onServerFnsById,
     compilerTransforms: options.compilerTransforms,

--- a/packages/start-plugin-core/src/start-compiler/types.ts
+++ b/packages/start-plugin-core/src/start-compiler/types.ts
@@ -13,6 +13,13 @@ export interface CompilationContext extends StartCompilerTransformContext {
   getKnownServerFns: () => Record<string, ServerFn>
   /** Module-level directives to add to extracted server function provider files. */
   serverFnProviderModuleDirectives: ReadonlyArray<string> | undefined
+  /**
+   * When 'directive', createServerFn handlers are compiled to "use server"
+   * directive trampolines instead of being split into provider modules.
+   * A framework-native directive compiler (e.g. vite-plugin-solid's
+   * serverFunctions plugins) is expected to run after the start compiler.
+   */
+  serverFnTransport: 'split' | 'directive'
 
   /**
    * Callback when server functions are discovered.

--- a/packages/start-plugin-core/src/vite/plugin.ts
+++ b/packages/start-plugin-core/src/vite/plugin.ts
@@ -224,6 +224,7 @@ export function tanStackStartVite(
       serverFnProviderModuleDirectives:
         corePluginOpts.serverFnProviderModuleDirectives,
       providerEnvName: serverFnProviderEnv,
+      serverFnTransport: corePluginOpts.serverFnTransport,
     }),
     importProtectionPlugin({
       getConfig,

--- a/packages/start-plugin-core/src/vite/start-compiler-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/vite/start-compiler-plugin/plugin.ts
@@ -228,6 +228,11 @@ export interface StartCompilerPluginOptions {
    * The Vite environment name for the server function provider.
    */
   providerEnvName: string
+  /**
+   * Server function compilation/transport strategy.
+   * Defaults to 'split' (TanStack module splitting + RPC).
+   */
+  serverFnTransport?: 'split' | 'directive'
 }
 
 export function startCompilerPlugin(
@@ -334,6 +339,7 @@ export function startCompilerPlugin(
               mode,
               framework: opts.framework,
               providerEnvName: opts.providerEnvName,
+              serverFnTransport: opts.serverFnTransport,
               generateFunctionId: opts.generateFunctionId,
               compilerTransforms,
               compilerPlugins,
@@ -567,6 +573,25 @@ export function startCompilerPlugin(
                 typeof decoded.file === 'string' &&
                 typeof decoded.export === 'string'
               ) {
+                if (this.environment.mode !== 'dev') {
+                  this.error(
+                    `could not validate server function ID ${fnId}: unknown environment mode ${this.environment.mode}`,
+                  )
+                }
+
+                // Directive transport ids encode the provider module
+                // specifier (base file + tss-serverfn-split query).
+                // Transform it directly — the compile registers the file's
+                // function ids in serverFnsById as a side effect (nothing is
+                // evaluated; the dispatcher only imports validated modules).
+                if (opts.serverFnTransport === 'directive') {
+                  await this.environment.transformRequest(decoded.file)
+
+                  if (serverFnsById[fnId]) {
+                    return `export {}`
+                  }
+                }
+
                 // Use the Vite when to decode the module specifier
                 // back to the original source file path.
                 const sourceFile = decodeViteDevServerModuleSpecifier(
@@ -580,12 +605,6 @@ export function startCompilerPlugin(
                   // Trigger transform of the source file in this environment,
                   // which will compile createServerFn calls and populate
                   // serverFnsById as a side effect.
-                  if (this.environment.mode !== 'dev') {
-                    this.error(
-                      `could not validate server function ID ${fnId}: unknown environment mode ${this.environment.mode}`,
-                    )
-                  }
-
                   await this.environment.transformRequest(
                     `${absPath}?${SERVER_FN_LOOKUP}`,
                   )
@@ -614,6 +633,14 @@ export function startCompilerPlugin(
         return appliedResolverEnvironments.has(env.name)
       },
       load() {
+        // With the directive transport there is no TanStack server-fn
+        // manifest — resolution happens inside the framework's native
+        // server-function registry. Satisfy the static import with a
+        // throwing stub.
+        if (opts.serverFnTransport === 'directive') {
+          return `export function getServerFnById(id) { throw new Error('getServerFnById is not available with the directive server function transport (requested id: ' + id + ')') }`
+        }
+
         if (this.environment.name !== opts.providerEnvName) {
           const mod = opts.environments.find(
             (e) => e.name === this.environment.name,
@@ -642,5 +669,95 @@ export function startCompilerPlugin(
         })
       },
     }),
+    // Dispatch module for the server-fn HTTP endpoint. createStartHandler
+    // routes requests under TSS_SERVER_FN_BASE through
+    // `#tanstack-start-server-fn-dispatch`; with the default (split)
+    // transport that specifier resolves through start-server-core's package
+    // imports map to the split dispatch, so the virtual override is only
+    // installed for alternative transports.
+    ...(opts.serverFnTransport === 'directive'
+      ? [
+          createVirtualModule({
+            name: 'tanstack-start-core:server-fn-dispatch',
+            moduleId: VIRTUAL_MODULES.serverFnDispatch,
+            enforce: 'pre',
+            applyToEnvironment: (env) => {
+              return appliedResolverEnvironments.has(env.name)
+            },
+            load() {
+              // Directive transport (currently vite-plugin-solid only): the
+              // request is dispatched through @solidjs/web's server-function
+              // handler, wired with TanStack codec/result semantics.
+              // Functions register (under their TanStack ids) as a
+              // module-eval side effect of their provider modules, so those
+              // must be evaluated before dispatch:
+              // - Build: dynamic imports of every provider module the client
+              //   build discovered server functions in (the server
+              //   environment builds after the client, so serverFnsById is
+              //   populated). This covers functions whose module the SSR
+              //   render never evaluates (lazy code-split chunks, data-only
+              //   routes).
+              // - Dev: TanStack function ids encode the provider module
+              //   specifier; validate the id, then import it on demand.
+              const dispatchBody = [
+                `export async function dispatchServerFnRequest({ request }) {`,
+                `  await ensureServerFnModule(request)`,
+                `  const response = await handleServerFunctionRequest(request, createTanStackDispatchOptions())`,
+                `  return postprocessDirectiveResponse(response)`,
+                `}`,
+              ]
+
+              const runtimeImports = [
+                `import { handleServerFunctionRequest } from 'virtual:solid-server-function-handler'`,
+                `import { createTanStackDispatchOptions, postprocessDirectiveResponse } from '@tanstack/${opts.framework}-start/server-fn-dispatch'`,
+              ]
+
+              if (this.environment.mode !== 'build') {
+                return [
+                  ...runtimeImports,
+                  `const FUNCTION_HEADER = 'X-Server-Function-Id'`,
+                  `async function ensureServerFnModule(request) {`,
+                  `  const url = new URL(request.url)`,
+                  `  const headerId = request.headers.get(FUNCTION_HEADER)`,
+                  `  const id = (headerId ? headerId.split('#')[0] : undefined) || url.searchParams.get('id')`,
+                  `  if (!id) return`,
+                  `  try {`,
+                  `    const validateIdImport = ${JSON.stringify(validateServerFnIdVirtualModule)} + '?id=' + id`,
+                  `    await import(/* @vite-ignore */ '/@id/__x00__' + validateIdImport)`,
+                  `    const decoded = JSON.parse(Buffer.from(id, 'base64url').toString('utf8'))`,
+                  `    await import(/* @vite-ignore */ decoded.file)`,
+                  `  } catch {`,
+                  `    // Unknown/invalid ids fall through; the handler responds 404.`,
+                  `  }`,
+                  `}`,
+                  ...dispatchBody,
+                ].join('\n')
+              }
+
+              const registrationModules = new Set(
+                Object.values(serverFnsById).map((fn) => fn.extractedFilename),
+              )
+
+              // Dynamic imports on first dispatch (not static side-effect
+              // imports): apps commonly declare `"sideEffects": false`,
+              // which would let the bundler tree-shake bare provider-module
+              // imports — dynamic imports always keep their target chunks.
+              return [
+                ...runtimeImports,
+                `let registrationPromise`,
+                `function ensureServerFnModule() {`,
+                `  registrationPromise ??= Promise.all([`,
+                ...Array.from(registrationModules, (id) => {
+                  return `    import(${JSON.stringify(id)}),`
+                }),
+                `  ])`,
+                `  return registrationPromise`,
+                `}`,
+                ...dispatchBody,
+              ].join('\n')
+            },
+          }),
+        ]
+      : []),
   ]
 }

--- a/packages/start-plugin-core/src/vite/types.ts
+++ b/packages/start-plugin-core/src/vite/types.ts
@@ -11,8 +11,19 @@ export type SsrResolverStrategy =
   | { type: 'default' }
   | ViteRscForwardSsrResolverStrategy
 
+/**
+ * How server functions are compiled and transported.
+ * - 'split' (default): TanStack's own module splitting + RPC transport.
+ * - 'directive': emit "use server" directive trampolines and delegate
+ *   splitting, registration and HTTP transport to the framework's native
+ *   server-function pipeline (currently only vite-plugin-solid +
+ *   `@solidjs/web/server-functions`).
+ */
+export type ServerFnTransport = 'split' | 'directive'
+
 export type TanStackStartVitePluginCoreOptions = TanStackStartCoreOptions & {
   providerEnvironmentName: string
   ssrIsProvider: boolean
   ssrResolverStrategy: SsrResolverStrategy
+  serverFnTransport?: ServerFnTransport
 }

--- a/packages/start-plugin-core/tests/createServerFn/directiveTransport.test.ts
+++ b/packages/start-plugin-core/tests/createServerFn/directiveTransport.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from 'vitest'
+import { StartCompiler } from '../../src/start-compiler/compiler'
+import type { LookupConfig, LookupKind } from '../../src/start-compiler/compiler'
+
+function createDirectiveCompiler(env: 'client' | 'server') {
+  const lookupKinds: Set<LookupKind> = new Set(['ServerFn'])
+
+  const lookupConfigurations: Array<LookupConfig> = [
+    {
+      libName: '@tanstack/solid-start',
+      rootExport: 'createServerFn',
+      kind: 'Root',
+    },
+  ]
+
+  return new StartCompiler({
+    env,
+    envName: env === 'client' ? 'client' : 'ssr',
+    root: '/test',
+    framework: 'solid',
+    providerEnvName: 'ssr',
+    serverFnTransport: 'directive',
+    lookupKinds,
+    lookupConfigurations,
+    getKnownServerFns: () => ({}),
+    loadModule: async () => {},
+    resolveId: async (id) => id,
+    mode: 'build',
+  })
+}
+
+const code = `
+import { createServerFn } from '@tanstack/solid-start'
+import { z } from 'zod'
+
+export const myPostFn = createServerFn({ method: 'POST' })
+  .validator(z.object({ name: z.string() }))
+  .handler(async ({ data }) => {
+    return { greeting: 'hello ' + data.name }
+  })
+
+export const myGetFn = createServerFn({ method: 'GET' }).handler(async () => {
+  return secretServerValue
+})
+
+const secretServerValue = 'secret'
+`
+
+describe('serverFnTransport: directive', () => {
+  test('client env emits directive trampolines, strips validator and handler bodies', async () => {
+    const compiler = createDirectiveCompiler('client')
+    const result = await compiler.compile({ code, id: '/test/src/posts.tsx' })
+
+    expect(result?.code).toMatchInlineSnapshot(`
+      "import { createDirectiveClientRpc } from '@tanstack/solid-start/client-rpc';
+      import { createServerFn } from '@tanstack/solid-start';
+      export const myPostFn = createServerFn({
+        method: 'POST'
+      }).handler(createDirectiveClientRpc(opts => {
+        'use server';
+
+        return myPostFn.__executeServer(opts);
+      }, {
+        id: "076f92307bf3754bbe037e56349363766566fc371126b25b72eac02fbaa10ce8"
+      }));
+      export const myGetFn = createServerFn({
+        method: 'GET'
+      }).handler(createDirectiveClientRpc(opts => {
+        'use server';
+
+        return myGetFn.__executeServer(opts);
+      }, {
+        id: "889d7c24abc6d5a359e5f26892f82ee1de44543e3b6bc4cd9dd6d32ae01aa5a6"
+      }));"
+    `)
+
+    // No server code may leak into the client bundle
+    expect(result?.code).not.toContain('secretServerValue')
+    expect(result?.code).not.toContain('zod')
+  })
+
+  test('server env keeps validator + original handler and emits normalizing trampolines', async () => {
+    const compiler = createDirectiveCompiler('server')
+    const result = await compiler.compile({ code, id: '/test/src/posts.tsx' })
+
+    expect(result?.code).toMatchInlineSnapshot(`
+      "import { createDirectiveServerRpc, normalizeDirectiveServerOpts } from '@tanstack/solid-start/server-rpc';
+      import { createServerFn } from '@tanstack/solid-start';
+      import { z } from 'zod';
+      export const myPostFn = createServerFn({
+        method: 'POST'
+      }).validator(z.object({
+        name: z.string()
+      })).handler(createDirectiveServerRpc(opts => {
+        'use server';
+
+        return myPostFn.__executeServer(normalizeDirectiveServerOpts(opts));
+      }, {
+        id: "076f92307bf3754bbe037e56349363766566fc371126b25b72eac02fbaa10ce8",
+        name: "myPostFn",
+        filename: "src/posts.tsx"
+      }), async ({
+        data
+      }) => {
+        return {
+          greeting: 'hello ' + data.name
+        };
+      });
+      export const myGetFn = createServerFn({
+        method: 'GET'
+      }).handler(createDirectiveServerRpc(opts => {
+        'use server';
+
+        return myGetFn.__executeServer(normalizeDirectiveServerOpts(opts));
+      }, {
+        id: "889d7c24abc6d5a359e5f26892f82ee1de44543e3b6bc4cd9dd6d32ae01aa5a6",
+        name: "myGetFn",
+        filename: "src/posts.tsx"
+      }), async () => {
+        return secretServerValue;
+      });
+      const secretServerValue = 'secret';"
+    `)
+  })
+})

--- a/packages/start-server-core/package.json
+++ b/packages/start-server-core/package.json
@@ -73,6 +73,9 @@
     },
     "#tanstack-start-plugin-adapters": {
       "default": "./dist/esm/empty-plugin-adapters.js"
+    },
+    "#tanstack-start-server-fn-dispatch": {
+      "default": "./dist/esm/default-server-fn-dispatch.js"
     }
   },
   "sideEffects": false,

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -27,7 +27,7 @@ import {
 } from '@tanstack/start-storage-context'
 import { requestHandler } from './request-response'
 import { getStartManifest } from './router-manifest'
-import { handleServerAction } from './server-functions-handler'
+import { dispatchServerFnRequest } from '#tanstack-start-server-fn-dispatch'
 import { createEarlyHintsCollector } from './early-hints'
 import {
   createCachedBaseManifestLoader,
@@ -491,14 +491,6 @@ export function createStartHandler<TRegister = Register>(
           warnMissingCsrfMiddlewareOnce()
         }
 
-        const serverFnId = url.pathname
-          .slice(SERVER_FN_BASE.length)
-          .split('/')[0]
-
-        if (!serverFnId) {
-          throw new Error('Invalid server action param for serverFnId')
-        }
-
         const serverFnHandler = async ({ context }: TODO) => {
           return runWithStartContext(
             {
@@ -510,10 +502,10 @@ export function createStartHandler<TRegister = Register>(
               handlerType: 'serverFn',
             },
             () =>
-              handleServerAction({
+              dispatchServerFnRequest({
                 request,
                 context: requestOpts?.context,
-                serverFnId,
+                serverFnBase: SERVER_FN_BASE,
               }),
           )
         }

--- a/packages/start-server-core/src/default-server-fn-dispatch.ts
+++ b/packages/start-server-core/src/default-server-fn-dispatch.ts
@@ -1,0 +1,5 @@
+// Default resolution target for `#tanstack-start-server-fn-dispatch` (see
+// the package.json `imports` map): the split-transport dispatch. Alternative
+// transports (e.g. the solid directive transport) override the specifier
+// with a virtual module at build time.
+export { defaultDispatchServerFnRequest as dispatchServerFnRequest } from './server-functions-handler'

--- a/packages/start-server-core/src/index.tsx
+++ b/packages/start-server-core/src/index.tsx
@@ -26,6 +26,8 @@ export * from './request-response'
 
 export * from './virtual-modules'
 
+export { defaultDispatchServerFnRequest } from './server-functions-handler'
+
 export { HEADERS } from './constants'
 
 export type { RequestHandler, RequestOptions } from './request-handler'

--- a/packages/start-server-core/src/server-functions-handler.ts
+++ b/packages/start-server-core/src/server-functions-handler.ts
@@ -33,6 +33,32 @@ const FORM_DATA_CONTENT_TYPES = [
 // Maximum payload size for GET requests (1MB)
 const MAX_PAYLOAD_SIZE = 1_000_000
 
+/**
+ * Default server function dispatch: extracts the function id from the URL
+ * path (as produced by TanStack's split RPC transport) and runs it through
+ * handleServerAction. The `#tanstack-start-server-fn-dispatch` virtual module
+ * re-exports this by default; alternative transports (e.g. the solid
+ * directive transport) substitute their own dispatch implementation.
+ */
+export const defaultDispatchServerFnRequest = async ({
+  request,
+  context,
+  serverFnBase,
+}: {
+  request: Request
+  context: any
+  serverFnBase: string
+}) => {
+  const url = new URL(request.url)
+  const serverFnId = url.pathname.slice(serverFnBase.length).split('/')[0]
+
+  if (!serverFnId) {
+    throw new Error('Invalid server action param for serverFnId')
+  }
+
+  return handleServerAction({ request, context, serverFnId })
+}
+
 export const handleServerAction = async ({
   request,
   context,

--- a/packages/start-server-core/src/tanstack-start.d.ts
+++ b/packages/start-server-core/src/tanstack-start.d.ts
@@ -21,3 +21,11 @@ declare module '#tanstack-start-server-fn-resolver' {
     access: ServerFnLookupAccess,
   ): Promise<ServerFn>
 }
+
+declare module '#tanstack-start-server-fn-dispatch' {
+  export function dispatchServerFnRequest(opts: {
+    request: Request
+    context: any
+    serverFnBase: string
+  }): Promise<Response>
+}

--- a/packages/start-server-core/src/virtual-modules.ts
+++ b/packages/start-server-core/src/virtual-modules.ts
@@ -1,5 +1,6 @@
 export const VIRTUAL_MODULES = {
   startManifest: 'tanstack-start-manifest:v',
   serverFnResolver: '#tanstack-start-server-fn-resolver',
+  serverFnDispatch: '#tanstack-start-server-fn-dispatch',
   pluginAdapters: '#tanstack-start-plugin-adapters',
 } as const

--- a/packages/start-server-core/tests/createStartHandler.test.ts
+++ b/packages/start-server-core/tests/createStartHandler.test.ts
@@ -40,8 +40,8 @@ vi.mock('#tanstack-router-entry', () => ({
   getRouter: () => startMocks.router,
 }))
 
-vi.mock('../src/server-functions-handler', () => ({
-  handleServerAction: () => startMocks.serverFnResult,
+vi.mock('#tanstack-start-server-fn-dispatch', () => ({
+  dispatchServerFnRequest: () => startMocks.serverFnResult,
 }))
 
 const getStoreConfig = () => ({

--- a/packages/start-server-core/vite.config.ts
+++ b/packages/start-server-core/vite.config.ts
@@ -37,6 +37,7 @@ export default mergeConfig(
         './src/createSsrRpc.ts',
         './src/request-response.ts',
         './src/fake-start-server-fn-resolver.ts',
+        './src/default-server-fn-dispatch.ts',
         './src/empty-plugin-adapters.ts',
       ],
       externalDeps: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13535,6 +13535,9 @@ importers:
 
   packages/solid-start:
     dependencies:
+      '@tanstack/router-core':
+        specifier: workspace:*
+        version: link:../router-core
       '@tanstack/solid-router':
         specifier: workspace:*
         version: link:../solid-router
@@ -13556,6 +13559,12 @@ importers:
       pathe:
         specifier: ^2.0.3
         version: 2.0.3
+      seroval:
+        specifier: ^1.5.4
+        version: 1.5.4
+      seroval-plugins:
+        specifier: ^1.5.4
+        version: 1.5.4(seroval@1.5.4)
     devDependencies:
       '@rsbuild/core':
         specifier: ^2.0.11
@@ -13575,6 +13584,9 @@ importers:
       vite:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
+      vite-plugin-solid:
+        specifier: ^3.0.0-next.16
+        version: 3.0.0-next.16(@solidjs/web@2.0.0-beta.25(solid-js@2.0.0-beta.25))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.25)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   packages/solid-start-client:
     dependencies:


### PR DESCRIPTION
> [!WARNING]
> **Highly experimental WIP** — exploring what it takes to run TanStack Solid Start's server functions on vite-plugin-solid's native `"use server"` pipeline. Not intended to merge as-is; opening for visibility/discussion. No changeset.

## What

For `framework: 'solid'` only, replaces the split server-fn transport (babel module splitting + `handleServerAction` RPC) with vite-plugin-solid `^3.0.0-next.16`'s directive compiler and the `@solidjs/web/server-functions` runtime (seroval chunk-stream wire, `handleServerFunctionRequest`). The public `createServerFn().validator().middleware().handler()` API is unchanged — validator, middleware + `sendContext`, redirects, `notFound`, raw `Response`s, FormData (scripted and no-JS), abort signals, streaming results and `setResponseStatus` all keep working. React and other frameworks stay on the split transport untouched.

## How

- **Compiler** (`start-plugin-core`, gated by new `serverFnTransport: 'directive'`): `createServerFn().handler(fn)` compiles to a `"use server"` trampoline (`(opts) => fn.__executeServer(opts)`) in place — no module splitting. vite-plugin-solid's standalone `serverFunctions()` plugins (appended by `tanstackStart()`, no dev middleware) turn it into a client fetch stub / hoisted server registration.
- **Ids**: vite-plugin-solid's `hash(path)-ordinal` ids collide across router code-split virtual modules (`?tsr-shared`/`?tsr-split` share the file path) and misalign between environments. TanStack therefore keeps generating its own split-safe ids (`serverFns.generateFunctionId` still honored) and re-registers the compiled trampolines under them via the runtime's public `registerServerFunction()`; the ordinal ids never reach the wire.
- **Dispatch**: `createStartHandler`'s `SERVER_FN_BASE` branch now routes through `#tanstack-start-server-fn-dispatch`. Default resolution (package `imports` map) is the existing split dispatch — byte-for-byte behavior for react/vue — while directive mode overrides it with a virtual that wires TanStack semantics (codec plugins from serialization adapters, raw-Response/redirect passthrough, ALS status/statusText, no-JS form-post handling) into `handleServerFunctionRequest`.
- **Registration coverage**: functions in lazy code-split chunks (`ssr: false`, data-only routes) never evaluate server-side, so dispatch evaluates pruned provider modules (`<file>?tss-serverfn-split`, full-file compile the router splitter ignores, `safeRemoveExports` + DCE so component-level `window` access can't crash the import) — dynamically imported because `"sideEffects": false` apps tree-shake static side-effect imports. Dev resolves lazily by decoding the id and validating through the existing `validate-server-fn-id` gate.

## Testing

- `e2e/solid-start/server-functions`: 28 passed, 1 (pre-existing) skip — two assertions adapted to the new wire (fn URLs are now `/_serverFn/?id=…`; responses are framed `text/plain` + `X-Server-Function-Format` instead of `application/json`)
- `e2e/solid-start/basic`: 80 passed
- `e2e/react-start/server-functions`: 53 passed (split-transport regression)
- Unit suites green across `start-plugin-core` (488, incl. new directive compiler snapshots), `start-server-core` (101), `start-client-core` (80)
- Manually verified `examples/solid/start-basic` in dev and nitro prod

## Known gaps / open questions

- Misaligned vite `base` + router `basepath` combos unsupported (endpoint must equal `TSS_SERVER_FN_BASE`)
- `@solidjs/web` doesn't runtime-export the wire constants its shared types declare (`BODY_FORMAT_HEADER`, `serializeString`, …) — mirrored in `directive-wire.ts`, peer range pinned; worth upstreaming exports
- Upstream candidates for Solid: custom-id hook on the directive compiler, `statusText` in `ResponseEnvelope`
- Raw `ReadableStream` framing uses seroval's stream support instead of TanStack's frame protocol (covered by e2e, but semantics differ at the margins)
- Unrelated: `/deferred` client-nav crashes with `PENDING_ASYNC_UNTRACKED_READ` in solid-router's `InnerAwait` on solid 2.0.0-beta.25 — reproduces on the base branch without these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)