### PR TITLE
fix(router-plugin): escape single quotes in split route file paths

### DIFF
--- a/packages/router-plugin/src/core/code-splitter/compilers.ts
+++ b/packages/router-plugin/src/core/code-splitter/compilers.ts
@@ -623,7 +623,7 @@ export function compileCodeSplitReferenceRoute(
                         ) {
                           programPath.unshiftContainer('body', [
                             template.statement(
-                              `const ${splitNodeMeta.localImporterIdent} = () => import('${splitUrl}')`,
+                              `const ${splitNodeMeta.localImporterIdent} = () => import('${splitUrl.replace(/'/g, "\\'")}')`,
                             )(),
                           ])
                         }
@@ -719,7 +719,7 @@ export function compileCodeSplitReferenceRoute(
                         ) {
                           programPath.unshiftContainer('body', [
                             template.statement(
-                              `const ${splitNodeMeta.localImporterIdent} = () => import('${splitUrl}')`,
+                              `const ${splitNodeMeta.localImporterIdent} = () => import('${splitUrl.replace(/'/g, "\\'")}')`,
                             )(),
                           ])
                         }


### PR DESCRIPTION
When a project directory contains a single quote (e.g. `/Users/dev/it's here/app`), the code-splitter generates syntactically invalid JavaScript:

```js
// Generated — broken
const $$splitComponentImporter = () => import('/Users/dev/it's here/app/routes/index.tsx')
//                                                              ^ unmatched quote
```

Babel then throws on every route, surfacing as a 500 on the entire app. Setting `autoCodeSplitting: false` doesn't help because the plugin registers unconditionally.

**Fix:** escape single quotes in `splitUrl` before interpolation at both sites in `compilers.ts` (lines 626 and 722):

```ts
splitUrl.replace(/'/g, "\\'")
```

This is the minimal change to make path-with-apostrophe projects work without touching the broader `autoCodeSplitting` config gate.

Fixes #7754