### PR TITLE
fix(router-core): preserve encoded slashes in splat params

### DIFF
--- a/packages/router-core/src/new-process-route-tree.ts
+++ b/packages/router-core/src/new-process-route-tree.ts
@@ -860,6 +860,19 @@ type ParamExtractionState = {
   segment: number
 }
 
+function decodeSplatParam(value: string) {
+  return value
+    .split('/')
+    .map((part) =>
+      decodeURIComponent(
+        // Decode each path segment, but keep encoded slashes inside a segment
+        // distinct from the real slashes that separate splat segments.
+        part.replace(/%2F/gi, (match) => `%25${match.slice(1)}`),
+      ),
+    )
+    .join('/')
+}
+
 /**
  * This function is "resumable":
  * - the `leaf` input can contain `extract` and `rawParams` properties from a previous `extractParams` call
@@ -950,7 +963,7 @@ function extractParams<T extends RouteLike>(
         currentPathIndex + (n.prefix?.length ?? 0),
         path.length - (n.suffix?.length ?? 0),
       )
-      const splat = decodeURIComponent(value)
+      const splat = decodeSplatParam(value)
       // TODO: Deprecate *
       rawParams['*'] = splat
       rawParams._splat = splat
@@ -1313,7 +1326,7 @@ function getNodeMatch<T extends RouteLike>(
     }
     const splat = sliceIndex === path.length ? '/' : path.slice(sliceIndex)
     bestFuzzy.rawParams ??= Object.create(null)
-    bestFuzzy.rawParams!['**'] = decodeURIComponent(splat)
+    bestFuzzy.rawParams!['**'] = decodeSplatParam(splat)
     return bestFuzzy
   }
 

--- a/packages/router-core/src/new-process-route-tree.ts
+++ b/packages/router-core/src/new-process-route-tree.ts
@@ -860,6 +860,13 @@ type ParamExtractionState = {
   segment: number
 }
 
+/**
+ * Decodes a splat match while preserving encoded slashes within each segment.
+ *
+ * Splat values can span multiple URL segments. Decoding the whole value at once
+ * would make `%2F` indistinguishable from the literal `/` separators already in
+ * the matched path, so each segment is decoded independently.
+ */
 function decodeSplatParam(value: string) {
   return value
     .split('/')

--- a/packages/router-core/tests/path.test.ts
+++ b/packages/router-core/tests/path.test.ts
@@ -758,6 +758,39 @@ describe('matchPathname', () => {
           _splat: 'tanner/sean/manuel',
         },
       },
+      {
+        name: 'should preserve encoded slashes inside splat path segments',
+        input: '/parts/make/Ford%2FNew%20Holland',
+        matchingOptions: {
+          to: '/parts/$',
+        },
+        expectedMatchedParams: {
+          '*': 'make/Ford%2FNew Holland',
+          _splat: 'make/Ford%2FNew Holland',
+        },
+      },
+      {
+        name: 'should keep real splat separators distinct from encoded slashes',
+        input: '/parts/make/Ford/New%20Holland',
+        matchingOptions: {
+          to: '/parts/$',
+        },
+        expectedMatchedParams: {
+          '*': 'make/Ford/New Holland',
+          _splat: 'make/Ford/New Holland',
+        },
+      },
+      {
+        name: 'should still decode other reserved characters inside splat path segments',
+        input: '/docs/page%23section/query%3Dvalue',
+        matchingOptions: {
+          to: '/docs/$',
+        },
+        expectedMatchedParams: {
+          '*': 'page#section/query=value',
+          _splat: 'page#section/query=value',
+        },
+      },
     ])('$name', ({ input, matchingOptions, expectedMatchedParams }) => {
       expect(matchPathname(input, matchingOptions)).toStrictEqual(
         toNullObj(expectedMatchedParams),
@@ -825,6 +858,21 @@ describe('matchPathname', () => {
     ])('$name', ({ input, matchingOptions, expectedMatchedParams }) => {
       expect(matchPathname(input, matchingOptions)).toStrictEqual(
         toNullObj(expectedMatchedParams),
+      )
+    })
+  })
+
+  describe('fuzzy matching', () => {
+    it('should preserve encoded slashes inside fuzzy catch-all params', () => {
+      expect(
+        matchPathname('/docs/make/Ford%2FNew%20Holland', {
+          to: '/docs',
+          fuzzy: true,
+        }),
+      ).toStrictEqual(
+        toNullObj({
+          '**': 'make/Ford%2FNew Holland',
+        }),
       )
     })
   })


### PR DESCRIPTION
Fixes #7871.

Splat params span multiple path segments, so decoding the whole splat with `decodeURIComponent` makes an encoded slash inside a segment indistinguishable from a real path separator.

This decodes splat params segment-by-segment and keeps `%2F` encoded inside each segment. Other encoded characters in the segment, like `%20`, `%23`, and `%3D`, are still decoded as before. The same helper is used for fuzzy `**` params.

Tests:
- `pnpm --dir packages/router-core test:unit --run tests/path.test.ts`
- `pnpm --dir packages/router-core test:eslint`
- `pnpm --dir packages/history build && pnpm --dir packages/router-core test:types:ts70`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed wildcard (`*`) and fuzzy catch-all (`**`) route parameter decoding so encoded slashes (`%2F`) stay within the same matched segment.
  * Improved handling of reserved characters inside wildcard and fuzzy catch-all matches.
  * Ensured encoded slashes are not treated the same as real path separators (`/`).
* **Tests**
  * Extended route matching tests to cover encoded-slash preservation and fuzzy catch-all behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->