### PR TITLE
docs: note layout routes require an Outlet element

### DIFF
--- a/docs/start/framework/react/guide/routing.md
+++ b/docs/start/framework/react/guide/routing.md
@@ -202,6 +202,9 @@ To create a route, create a new file that corresponds to the path of the route y
 | `/posts/:postId` | `posts/$postId.tsx` | Dynamic Route  |
 | `/rest/*`        | `rest/$.tsx`        | Wildcard Route |
 
+> [!NOTE]
+> When you create a layout route (like `posts.tsx`), the auto-generated component will not contain an `<Outlet />` by default. You must add an `<Outlet />` to the component to render its child routes (like `posts/$postId.tsx` and `posts/index.tsx`).
+
 ## Defining Routes
 
 To define a route, use the `createFileRoute` function to export the route as the `Route` variable.

--- a/docs/start/framework/solid/guide/routing.md
+++ b/docs/start/framework/solid/guide/routing.md
@@ -198,6 +198,9 @@ To create a route, create a new file that corresponds to the path of the route y
 | `/posts/:postId` | `posts/$postId.tsx` | Dynamic Route  |
 | `/rest/*`        | `rest/$.tsx`        | Wildcard Route |
 
+> [!NOTE]
+> When you create a layout route (like `posts.tsx`), the auto-generated component will not contain an `<Outlet />` by default. You must add an `<Outlet />` to the component to render its child routes (like `posts/$postId.tsx` and `posts/index.tsx`).
+
 ## Defining Routes
 
 To define a route, use the `createFileRoute` function to export the route as the `Route` variable.


### PR DESCRIPTION
Fixes a documentation issue where layout routes did not explicitly mention the requirement of an `<Outlet />` component to render child routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added routing guidance for React and Solid explaining that layout routes require an `<Outlet />` to render nested child routes.
  - Included examples of nested routes that depend on the outlet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->