### PR TITLE
fix(react-start-rsc): require @vitejs/plugin-rsc >=0.5.30 for route component HMR

### DIFF
--- a/.changeset/thick-jars-listen.md
+++ b/.changeset/thick-jars-listen.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-start-rsc': patch
+---
+
+Raise the `@vitejs/plugin-rsc` peer range to `>=0.5.30`. Versions in `0.5.20 - 0.5.29` suppress client HMR for a route component co-located with a `createServerFn`, fixed upstream in `@vitejs/plugin-rsc@0.5.30`.

--- a/e2e/react-start/rsc-deferred-hydration/package.json
+++ b/e2e/react-start/rsc-deferred-hydration/package.json
@@ -37,7 +37,7 @@
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "@vitejs/plugin-rsc": "^0.5.20",
+    "@vitejs/plugin-rsc": "^0.5.30",
     "srvx": "^0.11.9",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",

--- a/e2e/react-start/rsc-query/package.json
+++ b/e2e/react-start/rsc-query/package.json
@@ -28,7 +28,7 @@
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "@vitejs/plugin-rsc": "^0.5.20",
+    "@vitejs/plugin-rsc": "^0.5.30",
     "srvx": "^0.10.0",
     "typescript": "^5.7.2",
     "vite": "^8.0.14"

--- a/e2e/react-start/rsc/package.json
+++ b/e2e/react-start/rsc/package.json
@@ -49,7 +49,7 @@
     "@types/react-dom": "^19.0.3",
     "@typescript-eslint/parser": "^8.23.0",
     "@vitejs/plugin-react": "^6.0.1",
-    "@vitejs/plugin-rsc": "^0.5.20",
+    "@vitejs/plugin-rsc": "^0.5.30",
     "eslint": "^9.22.0",
     "srvx": "^0.10.0",
     "typescript": "^5.7.2",

--- a/examples/react/start-rscs/package.json
+++ b/examples/react/start-rscs/package.json
@@ -26,7 +26,7 @@
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
     "@vitejs/plugin-react": "^6.0.1",
-    "@vitejs/plugin-rsc": "^0.5.20",
+    "@vitejs/plugin-rsc": "^0.5.30",
     "nitro": "^3.0.260311-beta",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.7.2",

--- a/packages/react-start-rsc/package.json
+++ b/packages/react-start-rsc/package.json
@@ -111,12 +111,12 @@
     "@rspack/core": "2.0.0",
     "@testing-library/react": "^16.2.0",
     "@vitejs/plugin-react": "^4.3.4",
-    "@vitejs/plugin-rsc": "^0.5.20",
+    "@vitejs/plugin-rsc": "^0.5.30",
     "react-server-dom-rspack": "^0.0.2"
   },
   "peerDependencies": {
     "@rspack/core": ">=2.0.0-0",
-    "@vitejs/plugin-rsc": ">=0.5.20",
+    "@vitejs/plugin-rsc": ">=0.5.30",
     "react": ">=18.0.0 || >=19.0.0",
     "react-dom": ">=18.0.0 || >=19.0.0",
     "react-server-dom-rspack": ">=0.0.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2727,8 +2727,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@vitejs/plugin-rsc':
-        specifier: ^0.5.20
-        version: 0.5.20(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^0.5.30
+        version: 0.5.30(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       eslint:
         specifier: ^9.22.0
         version: 9.22.0(jiti@2.7.0)
@@ -2779,8 +2779,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@vitejs/plugin-rsc':
-        specifier: ^0.5.20
-        version: 0.5.20(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^0.5.30
+        version: 0.5.30(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       srvx:
         specifier: ^0.11.9
         version: 0.11.15
@@ -2837,8 +2837,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@vitejs/plugin-rsc':
-        specifier: ^0.5.20
-        version: 0.5.20(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^0.5.30
+        version: 0.5.30(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       srvx:
         specifier: ^0.10.0
         version: 0.10.0
@@ -10290,8 +10290,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@vitejs/plugin-rsc':
-        specifier: ^0.5.20
-        version: 0.5.20(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^0.5.30
+        version: 0.5.30(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       nitro:
         specifier: ^3.0.260311-beta
         version: 3.0.260311-beta(@electric-sql/pglite@0.3.2)(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@libsql/client@0.15.15)(@netlify/blobs@10.1.0)(chokidar@5.0.0)(dotenv@17.4.2)(giget@2.0.0)(jiti@2.7.0)(lru-cache@11.5.1)(miniflare@4.20260317.0)(mysql2@3.15.3)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -13463,8 +13463,8 @@ importers:
         specifier: ^4.3.4
         version: 4.7.0(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@vitejs/plugin-rsc':
-        specifier: ^0.5.20
-        version: 0.5.20(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^0.5.30
+        version: 0.5.30(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       react-server-dom-rspack:
         specifier: ^0.0.2
         version: 0.0.2(@rspack/core@2.0.0(@swc/helpers@0.5.23))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -14069,7 +14069,7 @@ importers:
         version: 0.1.7
       h3-v2:
         specifier: npm:h3@2.0.1-rc.20
-        version: h3@2.0.1-rc.20(crossws@0.4.5(srvx@0.11.18))
+        version: h3@2.0.1-rc.20(crossws@0.4.5(srvx@0.11.22))
       seroval:
         specifier: ^1.5.4
         version: 1.5.4
@@ -18829,9 +18829,6 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.2':
     resolution: {integrity: sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==}
 
-  '@rolldown/pluginutils@1.0.0-rc.4':
-    resolution: {integrity: sha512-1BrrmTu0TWfOP1riA8uakjFc9bpIUGzVKETsOtzY39pPga8zELGDl8eu1Dx7/gjM5CAz14UknsUMpBO8L+YntQ==}
-
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
 
@@ -20902,8 +20899,8 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
-  '@vitejs/plugin-rsc@0.5.20':
-    resolution: {integrity: sha512-JHPqfR8SSE2oNzCDRoyzEpbgxCxDks0PJAlo0KpK+OldYUxvozHroYpn0QtSdbZWq9YQ/ok1JUJ3GMc1xOmN0g==}
+  '@vitejs/plugin-rsc@0.5.30':
+    resolution: {integrity: sha512-q4fje/9heG/Mx3m5hEC9fpP1bUcpVtpq1sSZ7pWcVrYVxkMNBEEfcILwmUIo2EtMwbBp0/aPzVBsXcA8mG777A==}
     peerDependencies:
       react: ^19.2.3
       react-dom: ^19.2.3
@@ -22727,6 +22724,9 @@ packages:
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -23923,9 +23923,6 @@ packages:
 
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
-
-  is-reference@3.0.3:
-    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -25211,9 +25208,6 @@ packages:
   perfect-debounce@2.0.0:
     resolution: {integrity: sha512-fkEH/OBiKrqqI/yIgjR92lMfs2K8105zt/VT6+7eTjNwisrsh47CeIED9z58zI7DfKdH3uHAn25ziRZn3kgAow==}
 
-  periscopic@4.0.2:
-    resolution: {integrity: sha512-sqpQDUy8vgB7ycLkendSKS6HnVz1Rneoc3Rc+ZBUCe2pbqlVuCC5vF52l0NJ1aiMg/r1qfYF9/myz8CZeI2rjA==}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -26273,6 +26267,11 @@ packages:
     engines: {node: '>=20.16.0'}
     hasBin: true
 
+  srvx@0.11.22:
+    resolution: {integrity: sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
+
   stable-hash-x@0.2.0:
     resolution: {integrity: sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==}
     engines: {node: '>=12.0.0'}
@@ -26718,8 +26717,8 @@ packages:
     resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
     engines: {node: '>= 6.0.0'}
 
-  turbo-stream@3.1.0:
-    resolution: {integrity: sha512-tVI25WEXl4fckNEmrq70xU1XumxUwEx/FZD5AgEcV8ri7Wvrg2o7GEq8U7htrNx3CajciGm+kDyhRf5JB6t7/A==}
+  turbo-stream@3.2.0:
+    resolution: {integrity: sha512-EK+bZ9UVrVh7JLslVFOV0GEMsociOqVOvEMTAd4ixMyffN5YNIEdLZWXUx5PJqDbTxSIBWw04HS9gCY4frYQDQ==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -27329,6 +27328,14 @@ packages:
       vite:
         optional: true
 
+  vitefu@1.1.3:
+    resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
+    peerDependencies:
+      vite: ^8.0.14
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
   vitest@4.1.4:
     resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -27767,9 +27774,6 @@ packages:
 
   zeptomatch@2.0.2:
     resolution: {integrity: sha512-H33jtSKf8Ijtb5BW6wua3G5DhnFjbFML36eFu+VdOoVY4HD9e7ggjqdM6639B+L87rjnR6Y+XeRzBXZdy52B/g==}
-
-  zimmerframe@1.1.4:
-    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
@@ -32412,8 +32416,6 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.2': {}
 
-  '@rolldown/pluginutils@1.0.0-rc.4': {}
-
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
   '@rolldown/pluginutils@1.0.0-rc.9': {}
@@ -34721,20 +34723,19 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
 
-  '@vitejs/plugin-rsc@0.5.20(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))':
+  '@vitejs/plugin-rsc@0.5.30(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))':
     dependencies:
-      '@rolldown/pluginutils': 1.0.0-rc.4
-      es-module-lexer: 2.0.0
+      '@rolldown/pluginutils': 1.0.1
+      es-module-lexer: 2.3.1
       estree-walker: 3.0.3
       magic-string: 0.30.21
-      periscopic: 4.0.2
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      srvx: 0.11.15
+      srvx: 0.11.22
       strip-literal: 3.1.0
-      turbo-stream: 3.1.0
+      turbo-stream: 3.2.0
       vite: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
-      vitefu: 1.1.1(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+      vitefu: 1.1.3(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   '@vitejs/plugin-vue-jsx@4.2.0(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))(vue@3.5.25(@typescript/typescript6@6.0.2))':
     dependencies:
@@ -36301,9 +36302,13 @@ snapshots:
     optionalDependencies:
       srvx: 0.11.15
 
-  crossws@0.4.5(srvx@0.11.18):
+  crossws@0.4.4(srvx@0.11.18):
     optionalDependencies:
       srvx: 0.11.18
+
+  crossws@0.4.5(srvx@0.11.22):
+    optionalDependencies:
+      srvx: 0.11.22
     optional: true
 
   css-loader@7.1.2(webpack@5.97.1):
@@ -36764,9 +36769,9 @@ snapshots:
 
   env-runner@0.1.6(miniflare@4.20260317.0):
     dependencies:
-      crossws: 0.4.4(srvx@0.11.15)
+      crossws: 0.4.4(srvx@0.11.18)
       httpxy: 0.3.1
-      srvx: 0.11.15
+      srvx: 0.11.18
     optionalDependencies:
       miniflare: 4.20260317.0
 
@@ -36801,6 +36806,8 @@ snapshots:
   es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.0.0: {}
+
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -37879,16 +37886,16 @@ snapshots:
   h3@2.0.1-rc.16(crossws@0.4.4(srvx@0.11.15)):
     dependencies:
       rou3: 0.8.1
-      srvx: 0.11.15
+      srvx: 0.11.18
     optionalDependencies:
       crossws: 0.4.4(srvx@0.11.15)
 
-  h3@2.0.1-rc.20(crossws@0.4.5(srvx@0.11.18)):
+  h3@2.0.1-rc.20(crossws@0.4.5(srvx@0.11.22)):
     dependencies:
       rou3: 0.8.1
       srvx: 0.11.15
     optionalDependencies:
-      crossws: 0.4.5(srvx@0.11.18)
+      crossws: 0.4.5(srvx@0.11.22)
 
   handle-thing@2.0.1: {}
 
@@ -38342,10 +38349,6 @@ snapshots:
   is-property@1.0.2: {}
 
   is-reference@1.2.1:
-    dependencies:
-      '@types/estree': 1.0.8
-
-  is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
 
@@ -39941,12 +39944,6 @@ snapshots:
 
   perfect-debounce@2.0.0: {}
 
-  periscopic@4.0.2:
-    dependencies:
-      '@types/estree': 1.0.8
-      is-reference: 3.0.3
-      zimmerframe: 1.1.4
-
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -41203,6 +41200,8 @@ snapshots:
 
   srvx@0.11.18: {}
 
+  srvx@0.11.22: {}
+
   stable-hash-x@0.2.0: {}
 
   stack-trace@0.0.10: {}
@@ -41630,7 +41629,7 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  turbo-stream@3.1.0: {}
+  turbo-stream@3.2.0: {}
 
   type-check@0.4.0:
     dependencies:
@@ -42054,6 +42053,10 @@ snapshots:
       yaml: 2.9.0
 
   vitefu@1.1.1(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)):
+    optionalDependencies:
+      vite: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
+
+  vitefu@1.1.3(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)):
     optionalDependencies:
       vite: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
 
@@ -42738,8 +42741,6 @@ snapshots:
   zeptomatch@2.0.2:
     dependencies:
       grammex: 3.1.11
-
-  zimmerframe@1.1.4: {}
 
   zip-stream@6.0.1:
     dependencies:


### PR DESCRIPTION
### Description

Raises the `@vitejs/plugin-rsc` floor past the range that breaks dev-mode HMR for RSC routes, and updates the lockfile so the workspace actually installs a fixed version.

Closes #7618.

### Why

`@vitejs/plugin-rsc` `0.5.20 - 0.5.29` suppress client HMR for a route component co-located with a `createServerFn`. The route file is in the `rsc` module graph, and the plugin's client `hotUpdate` returned `[]` for any file in that graph without a `"use client"` boundary — a guard meant to stop server-only files watched as style deps (Tailwind, `addWatchFile`) from forcing full reloads. A genuine client route component co-located with a server fn got caught by it, so editing the component produced an `(rsc) hmr update …?tss-serverfn-split` and no client update at all: no DOM change, no reload.

Fixed upstream in vitejs/vite-plugin-react#1248, released in [`@vitejs/plugin-rsc@0.5.30`](https://www.npmjs.com/package/@vitejs/plugin-rsc/v/0.5.30). The guard now only bails when the changed module has no non-CSS client importer, so CSS/style-dep reloads behave as before.

Since co-locating a server function with its route component is an idiomatic Start pattern, the current `>=0.5.20` peer range lets users land on a version where that pattern silently breaks Fast Refresh.

### Changes

- `packages/react-start-rsc` — peer `@vitejs/plugin-rsc` `>=0.5.20` → `>=0.5.30`, dev `^0.5.20` → `^0.5.30`
- `e2e/react-start/rsc`, `e2e/react-start/rsc-query`, `e2e/react-start/rsc-deferred-hydration`, `examples/react/start-rscs` — dev `^0.5.20` → `^0.5.30`
- `pnpm-lock.yaml` regenerated — it pinned `0.5.20`, so the range bumps alone would not have changed what installs
- patch changeset for `@tanstack/react-start-rsc`

No source changes.

### Verification

Against the reproducer from #7618, with the browser HMR socket confirmed connected before each run:

| | `0.5.27` | `0.5.30` |
|---|---|---|
| terminal | `(rsc) hmr update …?tss-serverfn-split` only | `(client) hmr update /src/routes/index.tsx, …?tsr-split=component` **+** the rsc line |
| DOM | unchanged | updated |
| client state | — | preserved (Fast Refresh, not a reload) |

Also confirmed on a real Start RSC app, and that the guard's original purpose still holds: a co-located route importing a CSS module still Fast Refreshes, and a CSS-only edit still hot-swaps styles without a full reload.

### Notes

- There are no breaking changes in the `@vitejs/plugin-rsc` changelog between `0.5.20` and `0.5.30`, so the floor raise should be a cheap upgrade for consumers.
- `@vitejs/plugin-rsc` stays `optional: true` in `peerDependenciesMeta`, so the range is only validated when it is actually installed.
- Happy to drop the floor raise and keep just the lockfile/devDependency updates if you would rather not move the peer minimum — the issue is resolved either way by upgrading the plugin.
- Unrelated and left alone: `packages/react-start/package.json` lists `@vitejs/plugin-rsc` in `peerDependenciesMeta` with no matching `peerDependencies` entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored client hot module reloading for route components colocated with server functions.
  * Updated the supported RSC tooling version to ensure the fix is available.

* **Documentation**
  * Added release notes describing the hot reload fix and updated compatibility requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->