### PR TITLE
fix(router-core): don't drop invalidate() when a background stale reload is in flight

### DIFF
--- a/.changeset/fix-invalidate-dropped-inflight-stale-reload.md
+++ b/.changeset/fix-invalidate-dropped-inflight-stale-reload.md
@@ -1,0 +1,9 @@
+---
+'@tanstack/router-core': patch
+---
+
+fix(router-core): don't drop `invalidate()` when a background stale reload is in flight
+
+`router.invalidate()` was silently ignored if a background stale reload was already running for the same match: no request was made, no error raised, and the match kept serving data fetched before the invalidation. Since the default `staleTime` of `0` starts such a reload on re-entering a route, any mutation shortly after arriving on a page could land in that window and appear to do nothing until a full reload.
+
+`loadRouteMatch` now treats an explicitly invalidated match as a reason not to reuse an in-flight load, both in the early return and in the follow-up re-run check. Behaviour is unchanged for matches that are merely stale.

--- a/packages/router-core/src/load-matches.ts
+++ b/packages/router-core/src/load-matches.ts
@@ -893,9 +893,13 @@ const loadRouteMatch = async (
     if (prevMatch._nonReactive.loaderPromise) {
       // do not block if we already have stale data we can show
       // but only if the ongoing load is not a preload since error handling is different for preloads
-      // and we don't want to swallow errors
+      // and we don't want to swallow errors.
+      // an explicitly invalidated match is excluded: the in-flight load started
+      // before the invalidation, so its result is known-stale and returning here
+      // would drop the invalidation entirely.
       if (
         prevMatch.status === 'success' &&
+        !prevMatch.invalid &&
         !inner.sync &&
         !prevMatch.preload &&
         shouldReloadInBackground
@@ -909,7 +913,10 @@ const loadRouteMatch = async (
         handleRedirectAndNotFound(inner, match, error)
       }
 
-      if (match.status === 'pending') {
+      // `invalid` matters as much as `pending`: the load we just awaited was
+      // started before the invalidation, so it left the match `success` with
+      // pre-invalidation data.
+      if (match.status === 'pending' || match.invalid) {
         await handleLoader(
           preload,
           prevMatch,

--- a/packages/router-core/tests/load.test.ts
+++ b/packages/router-core/tests/load.test.ts
@@ -1119,6 +1119,61 @@ describe('stale loader reload triggers', () => {
       resolveStaleReload,
     )
   })
+
+  test('invalidate() is not dropped by an in-flight background stale reload', async () => {
+    // A background stale reload starts on re-entering a route (staleTime: 0).
+    // If something invalidates the router while that reload is still in flight
+    // -- the shape of every "mutate, then refresh" flow -- the loader must
+    // still re-run: the in-flight load was started *before* the invalidation,
+    // so its result is known-stale by the time it lands.
+    let resolveStaleReload: (() => void) | undefined
+    let callCount = 0
+
+    const loader = vi.fn(() => {
+      callCount += 1
+      if (callCount === 1) return { value: 'first' }
+      if (callCount === 2) {
+        // The background reload, started before the invalidation.
+        return new Promise<{ value: string }>((resolve) => {
+          resolveStaleReload = () => resolve({ value: 'stale' })
+        })
+      }
+      // Anything the invalidation triggers sees post-mutation data.
+      return { value: 'fresh' }
+    })
+
+    const router = setup({ loader, staleTime: 0 })
+
+    await router.navigate({ to: '/foo' })
+    expect(loader).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1)
+    await router.navigate({ to: '/bar' })
+    await vi.advanceTimersByTimeAsync(1)
+
+    const revisit = router.navigate({ to: '/foo' })
+    expect(loader).toHaveBeenCalledTimes(2)
+    await revisit
+
+    // Precondition: rendering stale data with a reload still in flight.
+    const backgroundReloadPromise = getMatchById(router, '/foo/foo')
+      ?._nonReactive.loaderPromise
+    expect(backgroundReloadPromise).toBeDefined()
+    expect(getMatchById(router, '/foo/foo')?.loaderData).toEqual({
+      value: 'first',
+    })
+
+    // Invalidate mid-flight, then let the stale reload land.
+    const invalidated = router.invalidate()
+    resolveStaleReload?.()
+    await invalidated
+
+    expect(loader).toHaveBeenCalledTimes(3)
+    expect(getMatchById(router, '/foo/foo')?.loaderData).toEqual({
+      value: 'fresh',
+    })
+  })
+
 })
 
 test('cancelMatches after pending timeout', async () => {


### PR DESCRIPTION
## Problem

`router.invalidate()` is silently dropped if a background stale reload is already in flight for the same match. No request is made, no error is raised, and the loader never re-runs — the match keeps serving data fetched *before* the invalidation.

In an app the symptom is a mutation that appears to do nothing: the write commits, `await router.invalidate()` resolves, and the UI still shows the pre-mutation state until a full page reload.

This is easier to hit than it sounds. With the default `staleTime: 0`, re-entering a route starts a background revalidation on mount, so any mutation fired shortly after arriving on a page lands inside the window. In the app where I found it, it reproduced roughly 1 run in 6 of an end-to-end suite.

## Cause

In `loadRouteMatch` (`packages/router-core/src/load-matches.ts`):

```ts
if (prevMatch._nonReactive.loaderPromise) {
  // do not block if we already have stale data we can show
  if (
    prevMatch.status === 'success' &&
    !inner.sync &&
    !prevMatch.preload &&
    shouldReloadInBackground
  ) {
    return prevMatch          // <- invalidation dropped here
  }
  await prevMatch._nonReactive.loaderPromise
  ...
  if (match.status === 'pending') {   // <- and again here
    await handleLoader(...)
  }
}
```

The early return is deliberate and correct for a *stale* match — there's no reason to block navigation when displayable data exists. But it doesn't distinguish "stale" from "explicitly invalidated". An invalidation means the caller knows the current data is wrong, and the in-flight load was started before it, so returning that load's result discards the invalidation.

The fallback path has the same gap: after awaiting the in-flight load the match is `success` (not `pending`), so the guard skips re-running the loader even though `invalid` is still set.

This is also why neither documented escape hatch helps:

- `invalidate({ sync: true })` skips the early return, then loses to the `status === 'pending'` check.
- `defaultStaleReloadMode: 'blocking'` makes the reload blocking, but the awaited load still leaves the match `success`, so the same check skips it.

Raising `defaultStaleTime` only narrows the window, and trades this for stale reads on re-entry.

## Fix

Treat `invalid` as a reason not to reuse an in-flight load, in both places. Behaviour is unchanged for matches that are merely stale — only explicitly invalidated ones take the new path.

## Test

Adds `invalidate() is not dropped by an in-flight background stale reload` to the existing `stale loader reload triggers` block in `packages/router-core/tests/load.test.ts`, reusing that block's `setup` helper and controlled-loader idiom.

It navigates away and back to start a background reload, asserts the precondition (match rendering stale data with `_nonReactive.loaderPromise` defined), then invalidates mid-flight and resolves the stale reload. The loader must be called a third time and the match must end up with the post-invalidation value.

On `main` without the fix it fails with:

```
AssertionError: expected "vi.fn()" to be called 3 times, but got 2 times
```

## Verification

| Suite | This branch | `main` |
|---|---|---|
| `router-core` | 67 files, 1263 passed, 3 expected-fail, no type errors | same, minus the new test |
| `react-router` | 56 files, 943 passed, 1 skipped, no type errors | identical |

`nx run @tanstack/router-core:test:eslint` — 0 errors (20 pre-existing warnings).

No regressions across ~2,200 tests, including the preload, redirect and notFound paths that share this code path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where invalidating a route during an in-progress background reload could be ignored.
  * Invalidated routes now complete a fresh reload and correctly update displayed data.

* **Tests**
  * Added coverage to verify that invalidation refreshes route data after an in-flight reload completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->