### PR TITLE
fix(history): restore blocked pop navigation by delta

### DIFF
--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -439,7 +439,7 @@ export function createBrowserHistory(opts?: {
           })
           if (isBlocked) {
             ignoreNextPop = true
-            win.history.go(1)
+            win.history.go(-delta)
             history.notify(notify)
             return
           }

--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -438,6 +438,14 @@ export function createBrowserHistory(opts?: {
             action,
           })
           if (isBlocked) {
+            // The browser has already traversed. Without a usable delta, the
+            // previous entry cannot be restored without guessing a direction.
+            // Accept the traversal instead of calling go(0), which reloads.
+            if (!Number.isSafeInteger(delta) || delta === 0) {
+              currentLocation = nextLocation
+              history.notify(notify)
+              return
+            }
             ignoreNextPop = true
             win.history.go(-delta)
             history.notify(notify)

--- a/packages/history/tests/createBrowserHistory.test.ts
+++ b/packages/history/tests/createBrowserHistory.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { createBrowserHistory } from '../src'
+import type { RouterHistory } from '../src'
+
+describe('createBrowserHistory', () => {
+  let history: RouterHistory | undefined
+
+  afterEach(() => {
+    history?.destroy()
+    history = undefined
+  })
+
+  function setupEntries(
+    firstPath: string,
+    ...remainingPaths: Array<string>
+  ): RouterHistory {
+    window.history.replaceState(
+      { __TSR_index: 0, __TSR_key: 'entry-0' },
+      '',
+      firstPath,
+    )
+    remainingPaths.forEach((path, index) => {
+      const historyIndex = index + 1
+      window.history.pushState(
+        {
+          __TSR_index: historyIndex,
+          __TSR_key: `entry-${historyIndex}`,
+        },
+        '',
+        path,
+      )
+    })
+
+    history = createBrowserHistory()
+    return history
+  }
+
+  async function expectLocation(pathname: string) {
+    await vi.waitFor(() => {
+      expect(window.location.pathname).toBe(pathname)
+      expect(history?.location.pathname).toBe(pathname)
+    })
+  }
+
+  test('restores the current entry when a forward navigation is blocked', async () => {
+    const history = setupEntries('/one', '/two')
+    history.back()
+    await expectLocation('/one')
+    const blockerFn = vi.fn(() => true)
+    history.block({ blockerFn })
+
+    history.forward()
+
+    await vi.waitFor(() => expect(blockerFn).toHaveBeenCalledOnce())
+    await expectLocation('/one')
+  })
+
+  test('restores the exact current entry when a multi-entry navigation is blocked', async () => {
+    const history = setupEntries('/one', '/two', '/three')
+    const blockerFn = vi.fn(() => true)
+    history.block({ blockerFn })
+
+    history.go(-2)
+
+    await vi.waitFor(() => expect(blockerFn).toHaveBeenCalledOnce())
+    await expectLocation('/three')
+  })
+})

--- a/packages/history/tests/createBrowserHistory.test.ts
+++ b/packages/history/tests/createBrowserHistory.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
 
 import { createBrowserHistory } from '../src'
-import type { RouterHistory } from '../src'
+import type { BlockerFn, RouterHistory } from '../src'
 
 describe('createBrowserHistory', () => {
   let history: RouterHistory | undefined
@@ -94,6 +94,49 @@ describe('createBrowserHistory', () => {
     expect(subscriber).toHaveBeenLastCalledWith({
       location: expect.objectContaining({ pathname: '/one' }),
       action: { type: 'GO', index: 0 },
+    })
+  })
+
+  test('accepts a blocked pop into a legacy history entry without reloading', async () => {
+    // A hard reload after switching routers preserves older pushState entries.
+    // The active entry is already TanStack history, while the previous entry
+    // still has the history@4 `{ key, state }` shape and no `__TSR_index`.
+    const legacyState = {
+      key: 'history-v4-entry',
+      state: { source: 'history@4' },
+    }
+    window.history.replaceState(legacyState, '', '/legacy')
+    window.history.pushState(
+      { __TSR_index: 1, __TSR_key: 'tanstack-entry' },
+      '',
+      '/current',
+    )
+    history = createBrowserHistory()
+    let observedDelta: number | undefined
+    const blockerFn = vi.fn<BlockerFn>(({ currentLocation, nextLocation }) => {
+      observedDelta =
+        Reflect.get(nextLocation.state, '__TSR_index') -
+        currentLocation.state.__TSR_index
+      return true
+    })
+    history.block({ blockerFn })
+    const goSpy = vi.spyOn(window.history, 'go')
+    const subscriber = vi.fn()
+    history.subscribe(subscriber)
+
+    history.back()
+
+    await vi.waitFor(() => expect(blockerFn).toHaveBeenCalledOnce())
+    expect(observedDelta).toBeNaN()
+    await expectLocation('/legacy')
+    expect(history.location.state).toEqual(legacyState)
+    expect(goSpy).not.toHaveBeenCalled()
+    expect(subscriber).toHaveBeenLastCalledWith({
+      location: expect.objectContaining({
+        pathname: '/legacy',
+        state: legacyState,
+      }),
+      action: expect.objectContaining({ type: 'GO' }),
     })
   })
 })

--- a/packages/history/tests/createBrowserHistory.test.ts
+++ b/packages/history/tests/createBrowserHistory.test.ts
@@ -9,6 +9,7 @@ describe('createBrowserHistory', () => {
   afterEach(() => {
     history?.destroy()
     history = undefined
+    vi.restoreAllMocks()
   })
 
   function setupEntries(
@@ -65,5 +66,34 @@ describe('createBrowserHistory', () => {
 
     await vi.waitFor(() => expect(blockerFn).toHaveBeenCalledOnce())
     await expectLocation('/three')
+  })
+
+  test('accepts a blocked pop with zero delta instead of reloading', async () => {
+    window.history.replaceState(
+      { __TSR_index: 0, __TSR_key: 'entry-0' },
+      '',
+      '/one',
+    )
+    window.history.pushState(
+      { __TSR_index: 0, __TSR_key: 'entry-1' },
+      '',
+      '/two',
+    )
+    history = createBrowserHistory()
+    const blockerFn = vi.fn(() => true)
+    history.block({ blockerFn })
+    const goSpy = vi.spyOn(window.history, 'go')
+    const subscriber = vi.fn()
+    history.subscribe(subscriber)
+
+    history.back()
+
+    await vi.waitFor(() => expect(blockerFn).toHaveBeenCalledOnce())
+    await expectLocation('/one')
+    expect(goSpy).not.toHaveBeenCalled()
+    expect(subscriber).toHaveBeenLastCalledWith({
+      location: expect.objectContaining({ pathname: '/one' }),
+      action: { type: 'GO', index: 0 },
+    })
   })
 })


### PR DESCRIPTION
## Problem

When a browser POP is blocked, `createBrowserHistory` always calls
`window.history.go(1)` to undo it. That only reverses a single-entry Back:

- blocking Forward attempts to move farther forward instead of returning;
- blocking `go(-2)` returns only one entry, leaving the browser URL and the
  router's current location on different history entries.

There are also cases where the POP has already happened, but its computed delta
is unusable:

- restored or legacy entries can expose the same navigation index, producing
  `delta === 0`;
- after a hard reload during a router migration, the active entry can already
  use TanStack metadata while an older `history@4` `{ key, state }` entry has no
  `__TSR_index`, producing `delta === NaN`.

Passing either value back to `window.history.go(-delta)` can reload the current
page instead of restoring the entry that was active before the POP.

## Fix

Undo an observed POP with its inverse delta: `window.history.go(-delta)`.
For Back this remains `go(1)`, while Forward and multi-entry GO operations now
return to the exact entry from which navigation started.

When the delta is zero or otherwise not a safe integer, the original entry
cannot be recovered without guessing a direction. In that case, accept the
already-completed browser traversal, synchronize `currentLocation`, and notify
subscribers instead of passing an unusable delta to `history.go`.

This means a blocker cannot restore a POP whose displacement is unknowable; the
browser traversal stands. That is intentional and avoids both a destructive
reload and an arbitrary move to the wrong history entry.

## Tests

Added browser-history regressions for:

- a blocked Forward;
- a blocked multi-entry `go(-2)`;
- a blocked POP with `delta === 0`, asserting that no `history.go` call occurs
  and subscribers observe the accepted location with action index `0`;
- a hybrid post-reload stack whose active entry has TanStack metadata and whose
  previous entry still has the `history@4` `{ key, state }` shape. The test
  explicitly observes `delta === NaN`, verifies that `history.go` is not called,
  and verifies that browser history, `currentLocation`, state, and subscribers
  all adopt the already-opened legacy entry.

Validated with:

```text
CI=1 NX_DAEMON=false pnpm nx run @tanstack/history:test:unit --outputStyle=stream --skipRemoteCache
CI=1 NX_DAEMON=false pnpm nx run @tanstack/history:test:types --outputStyle=stream --skipRemoteCache
CI=1 NX_DAEMON=false pnpm nx run @tanstack/history:test:eslint --outputStyle=stream --skipRemoteCache
pnpm exec prettier --check packages/history/src/index.ts packages/history/tests/createBrowserHistory.test.ts
```

The Forward and multi-entry tests fail on `main` by restoring the wrong entry.
The zero-delta regression fails on the previous implementation by attempting
`history.go(0)`. The hybrid-history regression independently pins the
non-safe-integer branch: removing only that guard leaves the zero-delta test
green while the legacy traversal fails.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser history rollback handling for blocked back/forward and multi-step navigations by rolling back the correct movement distance.
  * Avoids unsafe rollback when movement is zero or not a valid number, instead accepting the traversed state and still notifying subscribers with the correct location update.
  * Adds coverage for blocked pops into legacy-style history entries.

* **Tests**
  * Expanded browser history tests with seeded multi-entry state and async location assertions.
  * Added scenarios for blocked navigations with zero movement and legacy entries, including verification of expected subscriber notifications and navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
