### PR TITLE
fix(router-core): close instead of error stream on lifetime watchdog expiry

### DIFF
--- a/.changeset/calm-streams-close.md
+++ b/.changeset/calm-streams-close.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+Close SSR stream transforms gracefully when their lifetime watchdog expires

--- a/packages/router-core/src/ssr/transformStreamWithRouter.ts
+++ b/packages/router-core/src/ssr/transformStreamWithRouter.ts
@@ -311,7 +311,7 @@ function makeFastPathStream(
       console.warn(
         `SSR stream transform exceeded maximum lifetime (${lifetimeMs}ms), forcing cleanup`,
       )
-      safeError(err)
+      safeClose()
       cleanup(err)
     }
   }, lifetimeMs)
@@ -735,7 +735,7 @@ function makeMainStream(
       console.warn(
         `SSR stream transform exceeded maximum lifetime (${lifetimeMs}ms), forcing cleanup`,
       )
-      safeError(err)
+      safeClose()
       cleanup(err)
     }
   }, lifetimeMs)

--- a/packages/router-core/tests/transformStreamWithRouter.test.ts
+++ b/packages/router-core/tests/transformStreamWithRouter.test.ts
@@ -639,37 +639,80 @@ describe('transformStreamWithRouter — cleanup side-effects', () => {
     }
   })
 
-  test('lifetime timeout cancels upstream and runs cleanup once', async () => {
-    vi.useFakeTimers()
-    try {
-      const { router, cleanupCalls } = makeRouter({
-        isSerializationFinished: () => true,
-        takeBufferedHtml: () => undefined,
-      })
-      const upstream = makeManualUpstream()
+  const lifetimeTimeoutCases = [
+    {
+      name: 'fast path with an active reader',
+      reserveStreamFastPath: true,
+      activeReader: true,
+    },
+    {
+      name: 'fast path without an active reader',
+      reserveStreamFastPath: true,
+      activeReader: false,
+    },
+    {
+      name: 'main path with an active reader',
+      reserveStreamFastPath: false,
+      activeReader: true,
+    },
+    {
+      name: 'main path without an active reader',
+      reserveStreamFastPath: false,
+      activeReader: false,
+    },
+  ] as const
 
-      const out = transformStreamWithRouter(
-        router as any,
-        upstream.stream as any,
-        { lifetimeMs: 10 },
-      )
+  test.each(lifetimeTimeoutCases)(
+    'lifetime timeout closes $name and cleans up',
+    async ({ reserveStreamFastPath, activeReader }) => {
+      vi.useFakeTimers()
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        const { router, cleanupCalls } = makeRouter({
+          isSerializationFinished: () => true,
+          reserveStreamFastPath: () => reserveStreamFastPath,
+          takeBufferedHtml: () => undefined,
+        })
+        const upstream = makeManualUpstream()
 
-      // Do NOT consume. Advance fake time past lifetimeMs deterministically.
-      await vi.advanceTimersByTimeAsync(15)
+        const out = transformStreamWithRouter(
+          router as any,
+          upstream.stream as any,
+          { lifetimeMs: 10 },
+        )
+        if (activeReader) {
+          const reader = out.getReader()
+          const pendingRead = reader.read()
 
-      expect(upstream.cancelled.value).toBe(true)
-      expect(cleanupCalls.count).toBe(1)
+          await vi.advanceTimersByTimeAsync(15)
 
-      // Drain (read errors silently) so vitest doesn't see an unhandled error.
-      const reader = (
-        out as any
-      ).getReader() as ReadableStreamDefaultReader<Uint8Array>
-      reader.read().catch(() => {})
-      reader.releaseLock()
-    } finally {
-      vi.useRealTimers()
-    }
-  })
+          await expect(pendingRead).resolves.toEqual({
+            done: true,
+            value: undefined,
+          })
+          reader.releaseLock()
+        } else {
+          await vi.advanceTimersByTimeAsync(15)
+
+          const reader = out.getReader()
+          await expect(reader.read()).resolves.toEqual({
+            done: true,
+            value: undefined,
+          })
+          reader.releaseLock()
+        }
+        expect(upstream.cancelled.value).toBe(true)
+        expect(upstream.cancelled.reason).toEqual(
+          new Error('Stream lifetime exceeded'),
+        )
+        expect(cleanupCalls.count).toBe(1)
+        expect(warnSpy).toHaveBeenCalledOnce()
+      } finally {
+        warnSpy.mockRestore()
+        vi.useRealTimers()
+      }
+    },
+  )
 
   test('upstream cancel() that rejects does not produce an unhandled rejection', async () => {
     // Some upstream sources may reject when cancel() is called (e.g. their


### PR DESCRIPTION
Fixes #7748

[#7748 has a nice minimal repro and isolates this to two layers](https://github.com/TanStack/router/issues/7748): the Nitro V2 dev adapter misses a client abort, then router-core turns the abandoned stream into an unhandled error when the lifetime watchdog fires two minutes later. This PR fixes the router-core half, so a missed cancellation cannot take down the server runtime.

Basically: the watchdog is a leak-prevention fallback. By the time it fires, there is no useful consumer left to receive the error.

This changes both router-core stream paths to close cleanly when the lifetime watchdog fires. The existing warning and cleanup reason stay in place, so the upstream app render is still cancelled and the SSR resources are released. Real render and serialization failures still error the stream.

Added coverage for the fast and main paths, both with and without an active reader.

Tests:
- affected lint
- affected type tests
- affected unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SSR streams now close cleanly when their lifetime expires, preventing unnecessary stream errors.
  * Stream cleanup and upstream cancellation continue to run reliably across supported streaming modes.
  * Active readers now finish gracefully when a stream reaches its lifetime limit.

* **Tests**
  * Expanded coverage for stream timeout behavior, including fast-path and standard streaming scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->