### PR TITLE
fix(start-plugin-core): fail fast when the Vite plugin runs on Vite older than v7

### DIFF
--- a/.changeset/fair-pugs-argue.md
+++ b/.changeset/fair-pugs-argue.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/start-plugin-core': patch
+---
+
+Fail fast with a clear error when the TanStack Start Vite plugin runs on Vite older than v7. Vite 6 and older never invoke the `buildApp` plugin hook, so builds appeared to succeed while post-build steps such as prerendering and SPA shell (`_shell.html`) generation were silently skipped.

--- a/packages/start-plugin-core/src/vite/plugin.ts
+++ b/packages/start-plugin-core/src/vite/plugin.ts
@@ -1,3 +1,4 @@
+import { version as viteVersion } from 'vite'
 import { crawlFrameworkPkgs } from 'vitefu'
 import {
   applyResolvedBaseAndOutput,
@@ -35,6 +36,7 @@ import {
 } from './output-directory'
 import { postServerBuild } from './post-server-build'
 import { serializationAdaptersPlugin } from './serialization-adapters-plugin'
+import { assertSupportedViteVersion } from './vite-version'
 import type {
   TanStackStartVitePluginCoreOptions,
   ViteRscForwardSsrResolverStrategy,
@@ -90,6 +92,8 @@ export function tanStackStartVite(
       name: 'tanstack-start-core:config',
       enforce: 'pre',
       async config(viteConfig, { command }) {
+        assertSupportedViteVersion(viteVersion)
+
         const publicBase = normalizePublicBase(viteConfig.base)
         applyResolvedBaseAndOutput({
           resolvedStartConfig,

--- a/packages/start-plugin-core/src/vite/vite-version.ts
+++ b/packages/start-plugin-core/src/vite/vite-version.ts
@@ -1,0 +1,23 @@
+const MINIMUM_SUPPORTED_VITE_MAJOR = 7
+
+/**
+ * TanStack Start relies on the `buildApp` plugin hook, which Vite only
+ * invokes since v7. On older Vite versions (e.g. v6) the build appears to
+ * succeed, but post-build steps such as prerendering and SPA shell
+ * generation are silently skipped.
+ * Fail fast with an actionable error instead.
+ * see https://github.com/TanStack/router/issues/7918
+ */
+export function assertSupportedViteVersion(viteVersion: string): void {
+  const major = Number.parseInt(viteVersion.split('.')[0]!, 10)
+
+  if (Number.isNaN(major) || major >= MINIMUM_SUPPORTED_VITE_MAJOR) {
+    return
+  }
+
+  throw new Error(
+    `TanStack Start requires Vite v${MINIMUM_SUPPORTED_VITE_MAJOR}.0.0 or newer, but Vite v${viteVersion} was detected. ` +
+      `Older Vite versions do not invoke the \`buildApp\` plugin hook, so post-build steps such as prerendering and SPA shell generation would be silently skipped. ` +
+      `Please upgrade the "vite" dependency to >=${MINIMUM_SUPPORTED_VITE_MAJOR}.0.0.`,
+  )
+}

--- a/packages/start-plugin-core/tests/vite/vite-version.test.ts
+++ b/packages/start-plugin-core/tests/vite/vite-version.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'vitest'
+import { version as viteVersion } from 'vite'
+import { assertSupportedViteVersion } from '../../src/vite/vite-version'
+
+describe('assertSupportedViteVersion', () => {
+  test.each(['6.4.3', '6.0.0', '5.4.11', '4.5.0'])(
+    'throws for unsupported Vite v%s',
+    (version) => {
+      expect(() => assertSupportedViteVersion(version)).toThrowError(
+        `TanStack Start requires Vite v7.0.0 or newer, but Vite v${version} was detected.`,
+      )
+    },
+  )
+
+  test('mentions the silently skipped buildApp hook and the upgrade path', () => {
+    expect(() => assertSupportedViteVersion('6.4.3')).toThrowError(
+      /`buildApp` plugin hook.*SPA shell generation.*upgrade the "vite" dependency to >=7\.0\.0/s,
+    )
+  })
+
+  test.each(['7.0.0', '7.2.4', '8.0.0', '8.0.0-beta.1'])(
+    'accepts supported Vite v%s',
+    (version) => {
+      expect(() => assertSupportedViteVersion(version)).not.toThrow()
+    },
+  )
+
+  test('does not throw for an unparseable version string', () => {
+    expect(() => assertSupportedViteVersion('unknown')).not.toThrow()
+  })
+
+  test('accepts the Vite version installed in this workspace', () => {
+    expect(() => assertSupportedViteVersion(viteVersion)).not.toThrow()
+  })
+})


### PR DESCRIPTION
Fixes #7918, reported by @apacholik-univio, implementing the issue's requested fail-fast behavior.

Root cause: `_shell.html` (and all Start post-build steps: prerender, sitemap) run via the plugin-level `buildApp` hook. Vite 7 iterates `getSortedPlugins('buildApp')`, but Vite 6 only calls the config-level `builder.buildApp` and silently ignores plugin hooks, so on Vite 6 both environments build and post-build never runs. Vite 6 is outside the declared peer range (`vite: ">=7.0.0"`), but that peer is optional (for rsbuild users), so package managers never enforce it, which is how a Vite 6 app gets a silent broken build.

Making Vite 6 actually work would contradict the declared support range, so this adds an `assertSupportedViteVersion` guard called from the Start core plugin's `config` hook that throws a clear error naming the detected version, the steps that would be silently skipped, and the upgrade path.

Verified end to end with published packages: unpatched on Vite 6.4.3 reproduces the silent success with no `_shell.html`; patched on 6.4.3 fails fast with the actionable error; patched on Vite 7.3.6 and the in-repo e2e on 8.0.14 generate shells normally. Unit suite: 517 passed (11 new; the new test file fails without the fix). Changeset (patch, `@tanstack/start-plugin-core`), eslint/types/build targets all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * TanStack Start now fails fast with a clear compatibility error when used with Vite versions older than 7.
  * Prevents builds from appearing successful when post-build tasks such as prerendering or SPA shell generation are skipped.
  * Supported Vite versions continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->