### PR TITLE
Always execute beforeLoad for client lanes

### DIFF
--- a/docs/router/api/router/RouterType.md
+++ b/docs/router/api/router/RouterType.md
@@ -168,10 +168,9 @@ An active preload is speculative and is not published as the current match
 presentation. Successful loader data can enter the normal in-memory route cache
 and remain reusable according to `preloadStaleTime` and `preloadGcTime`.
 
-Completed preload `beforeLoad` context is not cached. A later navigation reruns
-`beforeLoad` unless it adopts an identical whole-route preload that is still
-active. Adoption also requires unchanged router context, additional context,
-and user-supplied location state.
+Every preload and navigation runs its own `beforeLoad` chain. Preloads can
+donate cached or in-flight loader work, but never `beforeLoad` context or
+control flow.
 
 - Type: `(opts: NavigateOptions) => Promise<RouteMatch[] | undefined>`
 - Properties

--- a/docs/router/guide/preloading.md
+++ b/docs/router/guide/preloading.md
@@ -26,9 +26,8 @@ two independent lifetimes:
 - **Unused retention defaults to 5 minutes.** Configure it with
   `defaultPreloadGcTime` or a route's `preloadGcTime`.
 - **The speculative lane is never promoted into router state.** Navigation
-  creates its own presentation and can reuse cached loader data. It reruns
-  `beforeLoad` unless it adopts the same whole lane while that preload is still
-  active.
+  creates its own presentation and runs its own `beforeLoad` chain. It can reuse
+  cached loader data or join a loader that is still in flight.
 
 If you need more control over preloading, caching and/or garbage collection of preloaded data, you should use an external caching library like [TanStack Query](https://tanstack.com/query).
 
@@ -143,11 +142,16 @@ export const Route = createFileRoute('/posts/$postId')({
 })
 ```
 
-Client-side preloading also runs each new route's `beforeLoad` with `preload: true`. A completed preload never caches the context returned by `beforeLoad`; a later navigation calls `beforeLoad` again with `preload: false`, even when it reuses the preload's cached loader data.
+Client-side preloading runs each route's `beforeLoad` with `preload: true`.
+Every later preload or navigation runs its own `beforeLoad` chain, so a
+navigation observes `preload: false` even when an identical preload is still
+active. Preloads can donate cached or in-flight loader work, but not
+`beforeLoad` context, redirects, errors, or not-found results. The
+`shouldReload` option remains loader-only.
 
-There is one exception: if navigation starts while an identical whole-route preload is still running, it can adopt that active work. Compatibility includes the complete ordered route lane, params, search, router context, additional context, user-supplied location state, redirect depth, and any explicit mask's href, search, state, and `unmaskOnReload` value. Router-managed history and temporary-mask keys are ignored. In that case navigation can use the active preload's `beforeLoad` result, or follow its redirect, without calling `beforeLoad` again. A completed, failed, not-found, or canceled preload does not donate `beforeLoad` context to a later navigation. The `shouldReload` option remains loader-only.
-
-If any route in the lane has `preload: false`, navigation does not adopt the active preload. It reruns the `beforeLoad` chain and performs the loader work that speculation skipped.
+If a route has `preload: false`, its speculative lane still runs `beforeLoad`,
+but skips that route's loader. Navigation runs `beforeLoad` again and performs
+the skipped loader work.
 
 ## Preloading with External Libraries
 

--- a/packages/react-router/src/Transitioner.tsx
+++ b/packages/react-router/src/Transitioner.tsx
@@ -35,18 +35,14 @@ export function Transitioner() {
     }
   }
   if (process.env.NODE_ENV === 'production') {
-    router.startTransition = (fn, expected, urgent) =>
+    router.startTransition = (fn, expected) =>
       new Promise((resolve) => {
         acknowledgement.current?.[1](false)
         acknowledgement.current = [expected, resolve]
-        if (urgent) {
-          fn()
-        } else {
-          React.startTransition(fn)
-        }
+        React.startTransition(fn)
       })
   } else {
-    router.startTransition = (fn, expected, urgent) =>
+    router.startTransition = (fn, expected) =>
       new Promise((resolve, reject) => {
         acknowledgement.current?.[1](false)
         const next: NonNullable<typeof acknowledgement.current> = [
@@ -55,11 +51,7 @@ export function Transitioner() {
         ]
         acknowledgement.current = next
         try {
-          if (urgent) {
-            fn()
-          } else {
-            React.startTransition(fn)
-          }
+          React.startTransition(fn)
         } catch (cause) {
           if (acknowledgement.current === next) {
             acknowledgement.current = undefined

--- a/packages/router-core/INTERNALS.md
+++ b/packages/router-core/INTERNALS.md
@@ -322,13 +322,14 @@ rules.
 Hydration is not a general `beforeLoad` cache. Its temporary handoff is valid
 only for the initial client load of the same document entry and exact committed
 owner; rejection, invalidation, or any later load returns to normal serial
-execution. The claim also requires the same route tree, root/additional context,
-search, user history state, and exact browser history generation. That initial
-load may transfer the accepted hydration prefix and
-keep its transported context while it completes a selective-SSR suffix. A
-preload never claims this prefix. Frameworks must start the initial client load
-before descendant route code can preload; invoking a preload in the gap after
-raw `hydrate()` and before that load is outside the supported handoff protocol.
+execution. The claim also requires the same raw browser href and history-state
+object. Finish-time match-ID validation proves that rematching still produced
+the accepted prefix; opaque router context and route-tree objects are not
+compared. That initial load may transfer the accepted hydration prefix and keep
+its transported context while it completes a selective-SSR suffix. A preload
+never claims this prefix. Frameworks must start the initial client load before
+descendant route code can preload; invoking a preload in the gap after raw
+`hydrate()` and before that load is outside the supported handoff protocol.
 
 ## Loader data, cache entries, and flights
 
@@ -823,8 +824,9 @@ matches and collects the selected match IDs. Every committed and cached
 generation with one of those IDs is then replaced as invalid, and its loader
 discovery entry is detached. This ID-wide rule prevents a cache-first or
 in-flight same-ID generation from escaping invalidation merely because a
-different generation was the one passed to the filter. Route context needs no
-invalidation marker; every new lane rebuilds it regardless.
+different generation was the one passed to the filter. Route context retains
+same-ID cacheability across this replacement and needs no separate invalidation
+marker.
 
 Invalidated successful data may remain visible until pending or terminal
 publication, depending on reload mode. Error/not-found generations reset through
@@ -1084,14 +1086,14 @@ reconstruction fails, only the accepted prefix is committed as described above;
 the complete branch remains presentation, not semantic reuse authority.
 
 Only the subsequent ordinary client load may transfer the whole hydration
-prefix, and only while the exact committed-prefix owner, structurally shared
-parsed history-state generation, and live hydration controller remain current
-with no active transaction. The payload does not serialize a second URL
-authority: Core captures the reconstructed browser generation only to prevent a
-supported reentrant lifecycle event from handing document work to a successor
-location. The transported prefix must also pass finish-time match-ID validation.
-Core does not coordinate speculative work started between raw `hydrate()` and
-that load; framework adapters own the supported ordering.
+prefix, and only while the exact committed-prefix owner, raw history-state
+object, browser href, and live hydration controller remain current with no
+active transaction. The payload does not serialize a second URL authority: Core
+captures the raw browser generation only to prevent a supported reentrant
+lifecycle event from handing document work to a successor location. The
+transported prefix must also pass finish-time match-ID validation. Core does not
+coordinate speculative work started between raw `hydrate()` and that load;
+framework adapters own the supported ordering.
 
 The two-phase transfer proceeds as follows:
 

--- a/packages/router-core/INTERNALS.md
+++ b/packages/router-core/INTERNALS.md
@@ -34,7 +34,7 @@ The main authorities are:
 | `_committed`                 | The accepted current lane and lifecycle/background CAS base         |
 | `stores.matches`             | The current match presentation exposed to renderers and users       |
 | `router._cache`              | Off-screen loader generations and first same-ID planning seeds      |
-| Active preload entry         | One still-running speculative whole lane                            |
+| Active preload entry         | Cancellation and cache-clearing ownership for one speculative lane  |
 | Loader flight registry entry | The latest same-ID loader generation available to new consumers     |
 | Match flight lease           | Ownership keeping that loader work alive                            |
 | Pending session              | One reveal/minimum-visible deadline and its current owner           |
@@ -186,7 +186,7 @@ Contextualization walks parent to child. For each route it:
 
 1. computes route context from the completed parent context,
 2. handles params/search validation,
-3. runs `beforeLoad` when required, and
+3. runs the route's `beforeLoad`, when defined, and
 4. merges the result before moving to the child.
 
 This serial order guarantees that child route context, child `beforeLoad`, and
@@ -202,8 +202,9 @@ reuse an older merged context or `beforeLoad` contribution.
 
 Server requests have fresh matches and execute route context normally.
 Hydration executes each accepted route context locally, stores its `_ctx`, and
-then merges transported `beforeLoad` output. An active identical preload donates
-the whole lane it is still contextualizing.
+then merges transported `beforeLoad` output. Every ordinary client lane,
+including every preload, performs its own contextualization and `beforeLoad`
+chain.
 
 ### Reduced
 
@@ -282,7 +283,7 @@ Every asynchronous client publication checks `_tx` immediately before the
 write. Background publication additionally checks the exact committed base
 array from which it was derived.
 
-## `beforeLoad`: execution, active adoption, and hydration
+## `beforeLoad`: execution and hydration
 
 `beforeLoad` context is not a cache.
 
@@ -292,59 +293,23 @@ same-ID route-local `_ctx` may remain reusable. A later navigation rebuilds the
 merged context from the current parent and `_ctx`, then reruns `beforeLoad`, even
 when it reuses completed loader data.
 
-There are two deliberate exceptions.
+There is one deliberate exception: hydration.
 
-### Identical active whole-lane adoption
+### Ordinary client lanes
 
-A navigation may latch onto an entry in `router._preloads` that is still running
-only when the whole lane is identical. Admission is decided before rematching
-from the preload's href and redirect depth, route-tree identity, semantic owner,
-parsed search, router root context, additional context, user-supplied location
-state, and any explicit mask's href, search, user state, and
-`unmaskOnReload`. Router-managed history and temporary-mask keys do not
-participate. With deterministic route planning, those inputs imply the same
-ordered routes, params, validated search, and global-path-miss meaning. They may
-be observed by `beforeLoad` even when the route lane is unchanged.
-Adoption inputs are treated as immutable values: replace a context/state object
-to express a generation change; in-place mutation is not detected.
-Adoption is all-or-nothing. There is no prefix donation and no
-completed-preload freshness window for `beforeLoad`. Matching derives
-global-path-miss semantics for every lane, including preloads, so an otherwise
-identical candidate cannot erase that terminal meaning during adoption.
+Every navigation and every preload rematches and runs its own serial
+`beforeLoad` chain. This remains true for identical concurrent preloads and for
+a navigation that targets a still-running preload. A call made with
+`preload: true` is never accepted as the navigation's call with
+`preload: false`; its context, redirect, error, and not-found result stay private
+to that speculative lane.
 
-The active preload also captures the identity of `_committed` from which
-it was planned. Whole-lane adoption requires that semantic owner to remain
-current. Invalidation replaces the committed generation, so an older preload
-may still donate an identical loader flight but cannot donate its pre-invalidation
-`beforeLoad` context.
-
-The adopting navigation takes ownership of the active lane and its controller.
-The original public preload call must then stop releasing that lane. Individual
-successful loader tasks may still publish cache entries through their original
-per-match compare-and-swap; that publication belongs to the transferred lane,
-not to a second whole-lane owner.
-
-If the adopted speculative lane succeeds, the navigation may use the
-`beforeLoad` calls that ran with `preload: true`. A redirect from that same
-active lane is also accepted as navigation control flow. An ordinary failure,
-not-found, or cancellation is not authoritative for navigation: the real
-navigation replans and reruns `beforeLoad` with `preload: false`. Successful
-loader work anywhere in the settled lane remains eligible for reuse, including
-a descendant that completed after an ancestor loader failed. Each successful
-loader generation has already attempted its own cache publication at settlement,
-so retry does not scan the terminal lane or create another cache handoff. It
-discards the failed speculative semantic lane and replans cache-first. The retry
-rebuilds the serial context chain and reruns `beforeLoad`; only independently
-successful loader generations cross that boundary through the normal
-cache/flight rules.
-
-Routes with `preload: false` do not permit active whole-lane adoption. Their
-speculative `beforeLoad` may run with `preload: true`, but navigation reruns the
-serial chain and performs the skipped loader work.
-
-Rejecting whole-lane adoption does not require discarding loader work before
-the real lane reaches its reload decisions. The rejected preload may remain a
-resource-only donor until that lane settles.
+`router._preloads` therefore has no semantic adoption role. It tracks active
+speculative match owners only so cache clearing can cancel selected work and
+release their resources safely. Loader results remain independently reusable:
+a completed preload may seed the match cache, and a still-running preload may
+donate its same-ID loader flight after the receiving lane has run its own
+`beforeLoad` and made its reload decision.
 
 ### Hydration
 
@@ -391,7 +356,7 @@ generations when its error or not-found came from `beforeLoad`, validation, or
 another route. Each preload loader success attempts cache admission immediately,
 before whole-lane reduction. The cache receives a non-terminal copy and an
 additional flight lease; the speculative lane keeps its own lease and terminal
-meaning until it is adopted or discarded. This works even below the eventual
+meaning until it is discarded. This works even below the eventual
 render boundary and does not preserve the speculative parent chain: merged
 context and `beforeLoad` output are cleared. Same-ID `_ctx`, loader identity,
 and successful loader data remain reusable by design.
@@ -431,22 +396,35 @@ Two facts must remain separate:
 - registry membership means new consumers may join the flight;
 - a match lease means an existing consumer keeps the flight alive.
 
-Registry membership itself owns no lease. A settled generation remains
+Registry membership normally owns no lease. A settled generation remains
 discoverable while at least one semantic or cached match owns it. Releasing the
 last lease removes that generation only if it is still the current registry
 entry, then aborts its controller. Every copied semantic match that retains a
 flight must acquire a lease, and every discarded match must release one exactly
-once. Consequently, a flight referenced by a match or discoverable in the
-registry always has a positive lease count. Acquisition code must not recover
-from a referenced zero-lease flight; that would hide an ownership bug.
+once.
+
+There is one short reservation phase. The navigation-supersession handoff may
+leave a predecessor's same-ID registry flight at zero leases while the successor
+contextualizes. An independently owned same-ID flight that loses its last lease
+while that lane visibly runs `beforeLoad` joins the same window. Generic releases
+after contextualization never infer a reservation merely from `_tx` membership.
+After the navigation's loader tasks are planned, they either acquire the flight
+or a single sweep removes and aborts it. Preloads neither create nor sweep this
+navigation handoff state. No match flag, extra counter, or second completion
+promise represents the phase. An explicit `shouldReload` result does not consume
+a zero-owner reservation: it removes and aborts that generation before
+registering fresh work. Active positive-lease work may still be shared by
+another lane that requests a reload. Invalidation removes discovery entries for
+every selected ID before its superseding load, so it always starts the requested
+generation.
 
 Releasing a set of matches is deliberately two-phase. First every outgoing
-match drops its `_flight` lease and every zero-owner generation is removed from
-the discovery registry. Only after the entire outgoing set is detached are the
-collected flight controllers aborted. Do not interleave one flight abort with
-detaching later matches in the same replacement: an abort listener can
-synchronously reenter, and that load must observe every logically removed lease
-and registry entry as already gone.
+match drops its `_flight` lease and every zero-owner generation not reserved by
+the current transaction is removed from the discovery registry. Only after the
+entire outgoing set is detached are the collected flight controllers aborted.
+Do not interleave one flight abort with detaching later matches in the same
+replacement: an abort listener can synchronously reenter, and that load must
+observe every logically removed lease and registry entry as already gone.
 
 A successful accepted match may keep its lease after the loader promise has
 settled. This keeps the loader's public `AbortSignal` alive for that semantic
@@ -469,12 +447,9 @@ the donor; a background reload keeps accepted data visible and gives the donor
 lease to its private candidate. This one lookup covers work started by active
 preloads, navigation, and background refresh without scanning those owners.
 
-When a different lane supersedes an active preload at the same href, the old
-lane stops being adoptable but retains its resources until the successor lane
-settles. Its leased flights therefore remain discoverable for the successor's
-late reload decisions without giving every planned match a second reservation
-lease. The successor then releases the old lane; any borrowed flight remains
-alive through the successor match's ordinary `_flight` lease.
+Active preload flights need no special handoff. Their speculative matches keep
+ordinary positive leases until the preload settles or is canceled, so another
+lane can discover and acquire the flight without adopting the preload lane.
 
 A joining navigation accepts successful shared loader work. A failure,
 not-found, or cancellation produced under another speculative generation is not
@@ -843,25 +818,27 @@ redirects. A losing background lane cannot redirect.
 Invalidation creates a new semantic generation and reloads through the ordinary
 transaction path. It does not turn `stores.matches` into a planning lane.
 
-Filtered invalidation evaluates committed and cached matches and collects the
-selected match IDs. Every committed and cached generation with one of those IDs
-is then replaced as invalid. This ID-wide rule prevents a cache-first same-ID
-generation from escaping invalidation merely because a different generation
-was the one passed to the filter. Route context needs no invalidation marker;
-every new lane rebuilds it regardless.
+Filtered invalidation evaluates committed, cached, and active-transaction
+matches and collects the selected match IDs. Every committed and cached
+generation with one of those IDs is then replaced as invalid, and its loader
+discovery entry is detached. This ID-wide rule prevents a cache-first or
+in-flight same-ID generation from escaping invalidation merely because a
+different generation was the one passed to the filter. Route context needs no
+invalidation marker; every new lane rebuilds it regardless.
 
 Invalidated successful data may remain visible until pending or terminal
 publication, depending on reload mode. Error/not-found generations reset through
 the same loading protocol rather than becoming cache successes.
 
 Cache clearing derives the retained active-preload and cache maps, installs both
-replacement authorities, bulk-detaches removed leases, lets that operation
-abort zero-owner flight controllers, and only then aborts selected preload lane
-controllers. A public loader signal can synchronously reenter from its abort
-listener; that reentrant load must observe the cleared authorities and every
-removed lease as already detached. Unselected concurrent preloads remain
-independent, and every later cache publication must still pass the per-match
-cache-entry identity check captured during planning.
+replacement authorities, and removes a discovery entry only when every positive
+lease belongs to discarded matches. It then bulk-detaches removed leases and
+only afterward aborts selected preload lane controllers. A public loader signal
+can synchronously reenter from its abort listener; that reentrant load must
+observe the cleared authorities and every removed lease as already detached.
+Unselected concurrent preloads keep shared flights discoverable, and every later
+cache publication must still pass the per-match cache-entry identity check
+captured during planning.
 
 Development refresh is deliberately aggressive: it aborts flights, discards
 active preloads and caches, drops the committed semantic lane, and rematches
@@ -877,8 +854,6 @@ navigation, but it never becomes `_tx` and never publishes match presentation.
 
 Its match/cache ownership effects are limited to:
 
-- an active identical whole lane that a navigation may adopt while it is still
-  running;
 - joinable same-id loader flights; and
 - individual successful preload loader generations entering the loader cache as
   they settle.
@@ -887,10 +862,9 @@ A preload can also install durable lazy route options through the separate
 route-chunk owner described above. That is route definition readiness, not
 authority over a completed match lane or `beforeLoad` result.
 
-A completed preload's failure, not-found, redirect, cancellation, and route
-context do not become authority for a later navigation. An adopted still-active
-identical lane is the exception described above, including its redirect control
-flow. Standalone preload redirects may be followed only while the preload
+A preload's failure, not-found, redirect, cancellation, route context, and
+`beforeLoad` result do not become authority for another preload or a later
+navigation. Standalone preload redirects may be followed only while the preload
 remains current and within its bounded redirect policy. A preload never performs
 a document reload.
 
@@ -1176,13 +1150,10 @@ When changing this architecture, verify all of the following:
 6. Each successful preload loader generation may enter the cache as it settles,
    even if its whole lane later becomes terminal or is canceled. It may retain
    same-ID route-local `_ctx`, but never merged context or `beforeLoad` output.
-7. Active preload adoption is identical-whole-lane only, including router
-   context, additional context, and user-supplied location state. It also
-   requires the semantic committed owner captured during planning to remain
-   current; rejected lanes may donate loader flights, never `beforeLoad`
-   context. Retrying a terminal adopted lane may retain every independently
-   successful loader generation, but rebuilds merged context and reruns the
-   serial `beforeLoad` chain.
+7. Every ordinary client lane runs its own serial `beforeLoad` chain. Active
+   preloads may donate same-ID loader flights and completed preloads may donate
+   cache entries, but neither can donate merged context, control flow, or a
+   `beforeLoad` result.
 8. Hydration is the only completed-work exception for `beforeLoad` reuse. It
    verifies each transported match identity, reconstructs the accepted ordered
    prefix, reruns route context locally, preserves terminal/selective-SSR
@@ -1203,7 +1174,10 @@ When changing this architecture, verify all of the following:
     started by navigation, preload, or background work. Registry joinability
     and lease ownership remain separate; donor selection happens synchronously
     after the reload decision, and accepted signal lifetime may outlive promise
-    settlement.
+    settlement. A zero-lease reservation exists only while the current `_tx`
+    contextualizes a distinct same-ID successor; the explicit supersession
+    handoff creates it, contextualizing lanes may retain it, and navigation task
+    planning consumes or sweeps it.
 12. Child `parentMatchPromise` follows the fresh semantic parent generation.
 13. The first parallel ordinary failure is chronological unless a required
     ancestor failure has no accepted loader data or its required chunk fails;

--- a/packages/router-core/src/load-client.ts
+++ b/packages/router-core/src/load-client.ts
@@ -206,15 +206,6 @@ export type LaneInputs = [
     | undefined,
 ]
 
-export type ActivePreload = [
-  matches: Array<AnyRouteMatch>,
-  controller: AbortController,
-  result: Promise<LaneResult>,
-  semanticOwner: Array<AnyRouteMatch>,
-  inputs: LaneInputs,
-  redirects: number,
-]
-
 export type LoadTransaction = [
   controller: AbortController,
   redirects: number,
@@ -244,8 +235,8 @@ export type PendingSession = [
 ]
 
 type CoordinatorRouter = AnyRouter & {
-  /** Whole speculative lanes that a matching navigation may adopt. */
-  _preloads?: Map<string, ActivePreload>
+  /** Active speculative lanes retained for cancellation and cache clearing. */
+  _preloads?: Map<AbortController, Array<AnyRouteMatch>>
   _refreshNextLoad?: boolean
   _rollbackRefresh?: () => void
   _cancelTransition?: () => void
@@ -485,14 +476,27 @@ async function contextualize(
 
 function releaseOwnedFlight(
   router: AnyRouter,
-  id: string,
+  match: WorkMatch,
   flight?: LoaderFlight,
 ): AbortController | undefined {
   if (!flight || --flight[2]) {
     return
   }
-  if (router._flights?.get(id) === flight) {
-    router._flights.delete(id)
+  if (router._flights?.get(match.id) === flight) {
+    const current = router._tx
+    if (
+      current &&
+      !current[0].signal.aborted &&
+      !(process.env.NODE_ENV !== 'production' && current[6]) &&
+      !current[3].includes(match) &&
+      current[3].some((candidate) => candidate.id === match.id) &&
+      current[3].some((candidate) => candidate.isFetching === 'beforeLoad')
+    ) {
+      // Keep work discoverable only while the current lane is still running
+      // beforeLoad. Loader planning performs the matching zero-owner sweep.
+      return
+    }
+    router._flights.delete(match.id)
   }
   return flight[1]
 }
@@ -500,7 +504,7 @@ function releaseOwnedFlight(
 function releaseFlight(router: AnyRouter, match: WorkMatch): void {
   const flight = match._flight
   match._flight = undefined
-  releaseOwnedFlight(router, match.id, flight)?.abort()
+  releaseOwnedFlight(router, match, flight)?.abort()
 }
 export function laneInputs(
   router: AnyRouter,
@@ -522,22 +526,6 @@ export function laneInputs(
   ]
 }
 
-function samePreloadLane(
-  preload: ActivePreload,
-  router: AnyRouter,
-  location: ParsedLocation,
-  redirects: number,
-): boolean {
-  return (
-    preload[3] === router._committed &&
-    preload[5] === redirects &&
-    deepEqual(preload[4], laneInputs(router, location)) &&
-    !preload[0].some(
-      (match) => getRoute(router, match as WorkMatch).options.preload === false,
-    )
-  )
-}
-
 /**
  * Not passing in a `next` ownership recipient
  * is equivalent to discarding the match resources
@@ -552,7 +540,7 @@ export function transferMatchResources(
     if (!next?.includes(match)) {
       const flight = match._flight
       match._flight = undefined
-      const controller = releaseOwnedFlight(router, match.id, flight)
+      const controller = releaseOwnedFlight(router, match, flight)
       if (controller) {
         abort.push(controller)
       }
@@ -563,9 +551,48 @@ export function transferMatchResources(
   }
 }
 
-function discardPreload(router: AnyRouter, preload: ActivePreload): void {
-  preload[1].abort()
-  transferMatchResources(router, preload[0])
+function transferPredecessorResources(
+  router: AnyRouter,
+  previous: Array<AnyRouteMatch>,
+  next: Array<AnyRouteMatch>,
+): void {
+  const abort: Array<AbortController> = []
+  for (const match of previous as Array<WorkMatch>) {
+    if (!next.includes(match)) {
+      const flight = match._flight
+      match._flight = undefined
+      if (
+        flight?.[2] === 1 &&
+        router._flights?.get(match.id) === flight &&
+        !(process.env.NODE_ENV !== 'production' && router._tx?.[6]) &&
+        next.some((candidate) => candidate.id === match.id)
+      ) {
+        // The successor has not made its same-ID reload decision yet.
+        flight[2] = 0
+      } else {
+        const controller = releaseOwnedFlight(router, match, flight)
+        if (controller) {
+          abort.push(controller)
+        }
+      }
+    }
+  }
+  for (const controller of abort) {
+    controller.abort()
+  }
+}
+
+function releaseUnownedFlights(router: AnyRouter): void {
+  const abort: Array<AbortController> = []
+  for (const [id, flight] of router._flights ?? []) {
+    if (!flight[2]) {
+      router._flights!.delete(id)
+      abort.push(flight[1])
+    }
+  }
+  for (const controller of abort) {
+    controller.abort()
+  }
 }
 
 function acquireMatchResources(matches: Array<AnyRouteMatch>): void {
@@ -774,10 +801,10 @@ function createLoaderTask(
   const route = getRoute(router, match)
   const preload = !!options[4]
   const plannedCacheMatch = preload ? router._cache.get(match.id) : undefined
+  let configured
   let reload = false
   let reloadFailure: LoaderOutcome | undefined
   try {
-    let configured
     if (match.status === 'success') {
       configured = route.options.shouldReload
       if (typeof configured === 'function') {
@@ -831,6 +858,28 @@ function createLoaderTask(
   const routeLoader = route.options.loader
   const loader =
     typeof routeLoader === 'function' ? routeLoader : routeLoader?.handler
+  let donor =
+    (!preload || route.options.preload !== false) &&
+    routeLoader &&
+    !(process.env.NODE_ENV !== 'production' && router._tx?.[6])
+      ? router._flights?.get(match.id)
+      : undefined
+  if (donor === match._flight || reloadFailure) {
+    donor = undefined
+  } else if (donor && !donor[2] && configured !== undefined) {
+    // A transaction may temporarily reserve its predecessor's generation
+    // while beforeLoad settles. An explicit reload decision starts fresh, so
+    // retire the unowned generation before its registry entry is replaced.
+    router._flights!.delete(match.id)
+    donor[1].abort()
+    donor = undefined
+  } else if (donor && !reload && !preload && configured === undefined) {
+    // Normal cache policy accepts an already-running generation even when this
+    // lane itself would not have started another loader.
+    reload = true
+  } else if (!reload) {
+    donor = undefined
+  }
   const background = !!(
     routeLoader &&
     reload &&
@@ -849,16 +898,13 @@ function createLoaderTask(
     match.invalid = false
     match.updatedAt = Date.now()
   }
-  let donor = loaded && routeLoader ? router._flights?.get(match.id) : undefined
-  if (donor === match._flight) {
-    donor = undefined
-  } else if (donor) {
+  if (donor) {
     donor[2]++
   }
   if (blocking) {
     const acceptedFlight = match._flight
     match._flight = donor
-    releaseOwnedFlight(router, match.id, acceptedFlight)?.abort()
+    releaseOwnedFlight(router, match, acceptedFlight)?.abort()
     // A successful route without a loader has no blocking work to present. It
     // still gets a task so its chunk and derived assets participate in the
     // lane, but putting it back into pending would hide an already-rendered
@@ -1288,6 +1334,9 @@ async function executeClientLane(
       options,
     )
   }
+  if (options[2]() && !options[4]) {
+    releaseUnownedFlights(router)
+  }
   let reduced: ReducedLane | ControlOutcome
   try {
     const reduction = reduceLane(
@@ -1436,7 +1485,7 @@ function offerPending(router: CoordinatorRouter, tx: LoadTransaction): void {
   }))
   offered[boundary]!.status = 'pending'
   const ack = router
-    .startTransition(() => router.stores.setMatches(offered), offered, true)
+    .startTransition(() => router.stores.setMatches(offered), offered)
     .then((rendered) => {
       if (
         rendered &&
@@ -1797,8 +1846,6 @@ async function runClientTransaction(
   onReady?: () => void,
   sync?: boolean,
   resolvedPrefix?: number,
-  adopted?: ActivePreload,
-  retained?: ActivePreload,
 ): Promise<void> {
   const options: ExecuteLaneOptions = [
     tx[0],
@@ -1811,41 +1858,7 @@ async function runClientTransaction(
     resolvedPrefix,
     onReady,
   ]
-  let result: LaneResult
-  try {
-    result = adopted
-      ? await adopted[2]
-      : await executeClientLane(router, tx[2], tx[3], options)
-  } finally {
-    if (retained) {
-      discardPreload(router, retained)
-    }
-  }
-  if (
-    adopted &&
-    router._tx === tx &&
-    ((isControl(result) && result[0] === CANCELED) ||
-      (!isControl(result) &&
-        result[1].some(
-          (match) => match.status !== 'success' || match._notFound,
-        )))
-  ) {
-    // Successful loaders already seeded the cache; retry only the guard lane.
-    const donors = tx[3] as Array<WorkMatch>
-    tx[3] = []
-    transferMatchResources(router, donors)
-    tx[0].abort()
-    if (router._tx !== tx) {
-      return
-    }
-    const controller = new AbortController()
-    tx[0] = options[0] = controller
-    tx[3] = router.matchRoutes(tx[2], {
-      _controller: controller,
-    })
-    acquireMatchResources(tx[3])
-    result = await executeClientLane(router, tx[2], tx[3], options)
-  }
+  const result = await executeClientLane(router, tx[2], tx[3], options)
 
   if (isControl(result)) {
     if (result[0] === REDIRECTED && router._tx === tx) {
@@ -1968,7 +1981,7 @@ async function runClientTransaction(
 
 export async function loadClientRoute(
   router: CoordinatorRouter,
-  opts?: { sync?: boolean; _dedupe?: boolean },
+  opts?: { sync?: boolean },
 ): Promise<void> {
   let rematerialize = false
   if (process.env.NODE_ENV !== 'production') {
@@ -1989,20 +2002,6 @@ export async function loadClientRoute(
     pendingLocation?.href === location.href
       ? (pendingLocation._redirects ?? 0)
       : 0
-  // A same-location navigation joins the transaction already loading it
-  // instead of restarting its work. Reload requests never carry the flag,
-  // and same-location redirects must restart the lane they came from.
-  if (
-    opts?._dedupe &&
-    !redirects &&
-    previousOwner &&
-    !rematerialize &&
-    previousOwner[2].href === location.href &&
-    router.stores.status.get() === 'pending'
-  ) {
-    await awaitCurrent(router)
-    return
-  }
   const handoff = router._handoff
   const hydrationController = rematerialize ? undefined : handoff?.[0]()
   const preflight = new AbortController()
@@ -2028,79 +2027,41 @@ export async function loadClientRoute(
     return
   }
   const sameHref = previousLocation.href === location.href
-  let adopted = router._preloads?.get(location.href)
-  let retained: ActivePreload | undefined
-  if (rematerialize && adopted) {
-    router._preloads!.delete(location.href)
-    discardPreload(router, adopted)
-    adopted = undefined
-    if (preflight.signal.aborted || router._tx !== previousOwner) {
-      preflight.abort()
-      await awaitCurrent(router, previousOwner)
-      return
-    }
-  }
-  if (
-    adopted &&
-    (hydrationController ||
-      !samePreloadLane(
-        adopted,
-        router,
-        pendingLocation?.href === location.href ? pendingLocation : location,
-        redirects,
-      ))
-  ) {
-    router._preloads!.delete(location.href)
-    // Keep incompatible loader flights alive through the real lane's reload
-    // decisions so matching generations can still donate their work.
-    retained = adopted
-    adopted = undefined
-  }
   let matches: Array<AnyRouteMatch>
   let controller = preflight
-  let resolvedPrefix: number | undefined
-  if (adopted) {
-    controller = adopted[1]
-    matches = adopted[0]
-    router._preloads!.delete(location.href)
-  } else {
-    try {
-      matches =
-        process.env.NODE_ENV !== 'production' && rematerialize
-          ? router.matchRoutes(location, {
-              _controller: preflight,
-              _rematerialize: true,
-            })
-          : router.matchRoutes(location, { _controller: preflight })
-      acquireMatchResources(matches)
-    } catch (cause) {
-      preflight.abort()
-      if (retained) {
-        discardPreload(router, retained)
+  try {
+    matches =
+      process.env.NODE_ENV !== 'production' && rematerialize
+        ? router.matchRoutes(location, {
+            _controller: preflight,
+            _rematerialize: true,
+          })
+        : router.matchRoutes(location, { _controller: preflight })
+    acquireMatchResources(matches)
+  } catch (cause) {
+    preflight.abort()
+    if (!isRedirect(cause)) {
+      if (process.env.NODE_ENV !== 'production' && rematerialize) {
+        router._refreshNextLoad = undefined
       }
-      if (!isRedirect(cause)) {
-        if (process.env.NODE_ENV !== 'production' && rematerialize) {
-          router._refreshNextLoad = undefined
-        }
-        await awaitCurrent(router)
-        router._commitPromise?.resolve()
-        router._commitPromise = undefined
-        return
-      }
-      await router.navigate({
-        ...cause.options,
-        replace: true,
-        ignoreBlocker: true,
-      })
-      await awaitCurrent(router, previousOwner)
+      await awaitCurrent(router)
+      router._commitPromise?.resolve()
+      router._commitPromise = undefined
       return
     }
-    resolvedPrefix = hydrationController ? handoff![1](matches) : undefined
-    if (resolvedPrefix) {
-      controller = hydrationController!
-    } else {
-      hydrationController?.abort()
-    }
+    await router.navigate({
+      ...cause.options,
+      replace: true,
+      ignoreBlocker: true,
+    })
+    await awaitCurrent(router, previousOwner)
+    return
+  }
+  const resolvedPrefix = hydrationController ? handoff![1](matches) : undefined
+  if (resolvedPrefix) {
+    controller = hydrationController!
+  } else {
+    hydrationController?.abort()
   }
   if (router._preflight !== preflight || router._tx !== previousOwner) {
     preflight.abort()
@@ -2125,8 +2086,6 @@ export async function loadClientRoute(
           () => offerPending(router, tx),
           opts?.sync,
           resolvedPrefix,
-          adopted,
-          retained,
         ),
       )
       .catch(() => {
@@ -2154,7 +2113,7 @@ export async function loadClientRoute(
       }
     }
     previousOwner[0].abort()
-    transferMatchResources(router, previousOwner[3])
+    transferPredecessorResources(router, previousOwner[3], tx[3])
   }
   if (router._tx !== tx) {
     transferMatchResources(router, tx[3])
@@ -2162,7 +2121,6 @@ export async function loadClientRoute(
     await awaitCurrent(router, tx)
     return
   }
-
   router.batch(() => {
     router.stores.status.set('pending')
     router.stores.location.set(location)
@@ -2236,58 +2194,24 @@ export async function preloadClientRoute(
   const base = router._committed
   const controller = new AbortController()
   let matches: Array<AnyRouteMatch> | undefined
-  let preload: ActivePreload | undefined
-  let replaced: ActivePreload | undefined
   try {
-    const pending = router._preloads?.get(location.href)
-    if (pending) {
-      if (samePreloadLane(pending, router, location, redirects)) {
-        const result = await pending[2]
-        return isControl(result)
-          ? followPreloadRedirect(router, result, location, owner, redirects)
-          : result[1]
-      }
-      router._preloads!.delete(location.href)
-      // Keep the superseded lane alive until this lane has made its reload
-      // decisions. Its active flights are the synchronous donor authority.
-      replaced = pending
-    }
     matches = router.matchRoutes(location, {
       _controller: controller,
     })
     acquireMatchResources(matches)
-    const promise = Promise.resolve()
-      .then(() =>
-        executeClientLane(router, location, matches!, [
-          controller,
-          redirects,
-          // Preload lanes run to completion even when unrelated navigations
-          // commit: finished work seeds the cache, and adoption safety is
-          // enforced independently by samePreloadLane's base identity check.
-          () => true,
-          base,
-          true,
-        ]),
-      )
-      .finally(() => {
-        if (replaced) {
-          discardPreload(router, replaced)
-        }
-      })
-    preload = [
-      matches,
+    ;(router._preloads ??= new Map()).set(controller, matches)
+    const result = await executeClientLane(router, location, matches, [
       controller,
-      promise,
-      base,
-      laneInputs(router, location),
       redirects,
-    ]
-    ;(router._preloads ??= new Map()).set(location.href, preload)
-    const result = await promise
-    if (router._preloads?.get(location.href) !== preload) {
+      // Preload lanes run to completion even when unrelated navigations commit:
+      // finished work seeds the cache.
+      () => true,
+      base,
+      true,
+    ])
+    if (!router._preloads.delete(controller)) {
       return isControl(result) ? undefined : result[1]
     }
-    router._preloads.delete(location.href)
     if (isControl(result)) {
       controller.abort()
       transferMatchResources(router, matches)
@@ -2298,10 +2222,7 @@ export async function preloadClientRoute(
     controller.abort()
     return result[1]
   } catch (cause) {
-    if (!preload || router._preloads?.get(location.href) === preload) {
-      if (preload) {
-        router._preloads!.delete(location.href)
-      }
+    if (!matches || router._preloads?.delete(controller)) {
       controller.abort()
       if (matches) {
         transferMatchResources(router, matches)

--- a/packages/router-core/src/load-client.ts
+++ b/packages/router-core/src/load-client.ts
@@ -2,12 +2,7 @@
 // can rewrite relative imports for both ESM and CJS.
 import { isNotFound } from './not-found'
 import { isRedirect } from './redirect'
-import {
-  _getUserHistoryState,
-  getLocationChangeInfo,
-  runRouteLifecycle,
-} from './router'
-import { deepEqual } from './utils'
+import { getLocationChangeInfo, runRouteLifecycle } from './router'
 import { hydrateSsrMatchId } from './ssr/ssr-match-id'
 import type { GLOBAL_SEROVAL, GLOBAL_TSR } from './ssr/constants'
 import type { AnySerializationAdapter } from './ssr/serializer/transformer'
@@ -189,22 +184,6 @@ declare const matchPhase: unique symbol
  * already settled (dehydrated server data) must cast at a named boundary.
  */
 type SettledMatch = WorkMatch & { readonly [matchPhase]: 'settled' }
-
-export type LaneInputs = [
-  routeTree: AnyRoute,
-  context: unknown,
-  additionalContext: unknown,
-  state: object,
-  search: object,
-  maskedLocation:
-    | [
-        href: string,
-        state: object,
-        search: object,
-        unmaskOnReload: boolean | undefined,
-      ]
-    | undefined,
-]
 
 export type LoadTransaction = [
   controller: AbortController,
@@ -506,26 +485,6 @@ function releaseFlight(router: AnyRouter, match: WorkMatch): void {
   match._flight = undefined
   releaseOwnedFlight(router, match, flight)?.abort()
 }
-export function laneInputs(
-  router: AnyRouter,
-  location: ParsedLocation,
-): LaneInputs {
-  const masked = location.maskedLocation
-  return [
-    router.routeTree,
-    router.options.context ?? {},
-    router.options.additionalContext,
-    _getUserHistoryState(location.state),
-    location.search,
-    masked && [
-      masked.href,
-      _getUserHistoryState(masked.state),
-      masked.search,
-      masked.unmaskOnReload,
-    ],
-  ]
-}
-
 /**
  * Not passing in a `next` ownership recipient
  * is equivalent to discarding the match resources
@@ -2301,7 +2260,8 @@ export async function hydrate(router: AnyRouter): Promise<void> {
 
   let location!: AnyRouter['latestLocation']
   let candidates!: Array<AnyRouteMatch>
-  let handoffInputs!: ReturnType<typeof laneInputs>
+  let handoffHistoryHref!: string
+  let handoffHistoryState: unknown
   try {
     await waitFor(
       router.options.hydrate?.(dehydratedRouter!.dehydratedData),
@@ -2310,10 +2270,14 @@ export async function hydrate(router: AnyRouter): Promise<void> {
     if (!isCurrent()) {
       return
     }
+    // Hydration trusts transported context and beforeLoad. The raw history
+    // entry owns the handoff; route structure is verified after rematching.
+    const historyLocation = router.history.location
+    handoffHistoryHref = historyLocation.href
+    handoffHistoryState = historyLocation.state
     router.updateLatestLocation()
     location = router.latestLocation
     router.stores.location.set(location)
-    handoffInputs = laneInputs(router, location)
     candidates = router.matchRoutes(location, {
       _controller: controller,
     })
@@ -2557,16 +2521,18 @@ export async function hydrate(router: AnyRouter): Promise<void> {
     }
   }
 
-  const claim = () =>
-    needsClientLoad &&
-    !router._tx &&
-    router.latestLocation.state === location.state &&
-    deepEqual(handoffInputs, laneInputs(router, router.latestLocation)) &&
-    router._committed === committedMatches &&
-    committedMatches.length &&
-    !controller.signal.aborted
+  const claim = () => {
+    const historyLocation = router.history.location
+    return needsClientLoad &&
+      !router._tx &&
+      historyLocation.href === handoffHistoryHref &&
+      historyLocation.state === handoffHistoryState &&
+      router._committed === committedMatches &&
+      committedMatches.length &&
+      !controller.signal.aborted
       ? controller
       : undefined
+  }
   const handoff: NonNullable<AnyRouter['_handoff']> = [
     claim,
     (matches) => {

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -58,7 +58,6 @@ import type {
 import type { SearchParser, SearchSerializer } from './searchParams'
 import type { AnyRedirect, ResolvedRedirect } from './redirect'
 import type {
-  ActivePreload,
   LoadTransaction,
   LoaderFlight,
   PendingSession,
@@ -766,7 +765,6 @@ export type LoadFn = (opts?: {
   sync?: boolean
   action?: { type: HistoryAction }
   _signal?: AbortSignal
-  _dedupe?: boolean
 }) => Promise<void>
 
 export type CommitLocationFn = ({
@@ -778,7 +776,6 @@ export type CommitLocationFn = ({
 export type StartTransitionFn = (
   fn: () => void,
   expected: Array<AnyRouteMatch>,
-  urgent?: boolean,
 ) => Promise<boolean>
 
 export interface MatchRoutesFn {
@@ -1027,8 +1024,8 @@ export interface RouterCore<
   _tx?: LoadTransaction
   /** Joinable in-flight loader generations keyed by match ID. */
   _flights?: Map<string, LoaderFlight>
-  /** Whole speculative lanes that an identical navigation may adopt. */
-  _preloads?: Map<string, ActivePreload>
+  /** Active speculative lanes retained for cancellation and cache clearing. */
+  _preloads?: Map<AbortController, Array<AnyRouteMatch>>
   /** Owns cancellable work before a client transaction publishes. */
   _preflight?: AbortController
   /** Transfers one reconstructed SSR prefix into its initial client load. */
@@ -2169,7 +2166,7 @@ export class RouterCore<
 
     // Don't commit to history if nothing changed
     if (isSameLocation) {
-      this.load({ _dedupe: true })
+      this.load()
     } else {
       let {
         // eslint-disable-next-line prefer-const
@@ -2469,15 +2466,15 @@ export class RouterCore<
   > = (opts) => {
     const committedMatches = this._committed
     const filter = opts?.filter
-    const invalidIds = filter
-      ? new Set(
-          [...committedMatches, ...this._cache.values()]
-            .filter((match) => filter(match as MakeRouteMatchUnion<this>))
-            .map((match) => match.id),
+    const invalidIds = new Set(
+      [...committedMatches, ...this._cache.values(), ...(this._tx?.[3] ?? [])]
+        .filter(
+          (match) => !filter || filter(match as MakeRouteMatchUnion<this>),
         )
-      : undefined
+        .map((match) => match.id),
+    )
     const invalidate = (d: MakeRouteMatch<TRouteTree>) => {
-      if (!invalidIds || invalidIds.has(d.id)) {
+      if (invalidIds.has(d.id)) {
         const route = this.routesById[d.routeId] as AnyRoute
         const next = {
           ...d,
@@ -2503,6 +2500,11 @@ export class RouterCore<
       cache.set(id, invalidate(match))
     }
     this._cache = cache
+    // The superseding load must not discover any same-ID generation selected
+    // for replacement. Existing owners release it in their normal order.
+    for (const id of invalidIds) {
+      this._flights?.delete(id)
+    }
 
     this.shouldViewTransition = false
     return this.load({ sync: opts?.sync })
@@ -2563,14 +2565,14 @@ export class RouterCore<
         discarded.push(match)
       }
     }
-    const retainedPreloads = new Map<string, ActivePreload>()
-    const discardedPreloads: Array<ActivePreload> = []
-    for (const [href, preload] of preloads ?? []) {
-      if (!filter || preload[0].some(filter as any)) {
-        discardedPreloads.push(preload)
-        discarded.push(...preload[0])
+    const retainedPreloads = new Map<AbortController, Array<AnyRouteMatch>>()
+    const discardedPreloads: Array<AbortController> = []
+    for (const [controller, matches] of preloads ?? []) {
+      if (!filter || matches.some(filter as any)) {
+        discardedPreloads.push(controller)
+        discarded.push(...matches)
       } else {
-        retainedPreloads.set(href, preload)
+        retainedPreloads.set(controller, matches)
       }
     }
 
@@ -2578,9 +2580,28 @@ export class RouterCore<
     // signal, whose abort listeners can synchronously reenter the router.
     this._cache = retained
     this._preloads = retainedPreloads
+    const discardedFlights = new Map<LoaderFlight, [string, number]>()
+    for (const match of discarded as Array<
+      AnyRouteMatch & { _flight?: LoaderFlight }
+    >) {
+      const flight = match._flight
+      if (flight && this._flights?.get(match.id) === flight) {
+        const entry = discardedFlights.get(flight)
+        if (entry) {
+          entry[1]++
+        } else {
+          discardedFlights.set(flight, [match.id, 1])
+        }
+      }
+    }
+    for (const [flight, [id, owners]] of discardedFlights) {
+      if (flight[2] === owners && this._flights?.get(id) === flight) {
+        this._flights.delete(id)
+      }
+    }
     transferMatchResources(this, discarded)
-    for (const preload of discardedPreloads) {
-      preload[1].abort()
+    for (const controller of discardedPreloads) {
+      controller.abort()
     }
   }
 

--- a/packages/router-core/tests/issue-3928-rapid-reload-abort.test.ts
+++ b/packages/router-core/tests/issue-3928-rapid-reload-abort.test.ts
@@ -102,6 +102,7 @@ describe('issue #3928: rapid reloads of a reused parent', () => {
     await vi.waitFor(() => {
       expect(rootInvocations.has('ab')).toBe(true)
       expect(indexInvocations.has('ab')).toBe(true)
+      expect(rootInvocations.get('a')!.signal.aborted).toBe(true)
       expect(indexInvocations.get('a')!.signal.aborted).toBe(true)
     })
 
@@ -109,6 +110,7 @@ describe('issue #3928: rapid reloads of a reused parent', () => {
     await vi.waitFor(() => {
       expect(rootInvocations.has('abc')).toBe(true)
       expect(indexInvocations.has('abc')).toBe(true)
+      expect(rootInvocations.get('ab')!.signal.aborted).toBe(true)
       expect(indexInvocations.get('ab')!.signal.aborted).toBe(true)
     })
 

--- a/packages/router-core/tests/issue-6371-search-default-normalization-abort.test.ts
+++ b/packages/router-core/tests/issue-6371-search-default-normalization-abort.test.ts
@@ -9,17 +9,10 @@ import { createTestRouter } from './routerTestUtils'
  * Entering a route directly via URL without search params, while
  * validateSearch supplies defaults, makes the framework Transitioner commit a
  * canonical replace-navigation (URL with the defaulted search) right after
- * the mount load already started. That replace supersedes the first load
- * pass and aborts its match's abortController. A loader that forwarded that
- * signal to fetch() re-throws an AbortError ("signal is aborted without
- * reason"): it belongs to the abandoned pass and must not surface as a route
- * error; the follow-up canonical load must complete normally.
+ * the mount load already started. The canonical pass may reuse that loader
+ * generation, and the URL-only replacement must not abort it or surface an
+ * AbortError.
  */
-
-const waitForMacrotask = () =>
-  new Promise<void>((resolve) => {
-    setTimeout(resolve, 0)
-  })
 
 describe('issue #6371: search default normalization aborts the mount load silently', () => {
   test('canonical replace after validateSearch defaults does not surface AbortError', async () => {
@@ -74,26 +67,20 @@ describe('issue #6371: search default normalization aborts the mount load silent
     // In core (no history subscribers) commitLocation starts the second load.
     void router.commitLocation({ ...nextLocation, replace: true } as any)
 
-    await vi.waitFor(() => expect(invocations.length).toBe(2))
-
-    // The superseded mount-load generation was aborted (its fetch canceled).
-    expect(invocations[0]!.signal.aborted).toBe(true)
-
-    // Give the aborted rejection time to (incorrectly) commit as an error.
-    await waitForMacrotask()
-    await waitForMacrotask()
+    await Promise.resolve()
+    expect(invocations).toHaveLength(1)
+    expect(invocations[0]!.signal.aborted).toBe(false)
 
     for (const match of router.state.matches) {
       expect(match.status).not.toBe('error')
       expect((match.error as Error | undefined)?.name).not.toBe('AbortError')
     }
 
-    invocations[1]!.resolve()
+    invocations[0]!.resolve()
     // Awaiting the superseded mount load also awaits the superseding chain.
     await initialLoad
 
-    // No runaway normalization loop: exactly one aborted + one canonical run.
-    expect(invocations.length).toBe(2)
+    expect(invocations).toHaveLength(1)
 
     const aboutMatch = router.state.matches.find(
       (match) => match.routeId === aboutRoute.id,

--- a/packages/router-core/tests/load.test.ts
+++ b/packages/router-core/tests/load.test.ts
@@ -215,8 +215,7 @@ describe('beforeLoad skip or exec', () => {
     await router.navigate({ to: '/foo' })
 
     expect(router.state.location.pathname).toBe('/foo')
-    // An identical navigation may latch onto the still-active whole lane.
-    expect(beforeLoad).toHaveBeenCalledTimes(1)
+    expect(beforeLoad).toHaveBeenCalledTimes(2)
   })
 
   test('exec if rejected preload (notFound)', async () => {
@@ -278,9 +277,9 @@ describe('beforeLoad skip or exec', () => {
     await Promise.resolve()
     await router.navigate({ to: '/foo' })
 
-    expect(router.state.location.pathname).toBe('/bar')
+    expect(router.state.location.pathname).toBe('/foo')
     expect(router.state.matches.at(-1)?.status).toBe('success')
-    expect(beforeLoad).toHaveBeenCalledTimes(1)
+    expect(beforeLoad).toHaveBeenCalledTimes(2)
   })
 
   test('exec if rejected preload (error)', async () => {

--- a/packages/router-core/tests/loader-architecture-regressions.test.ts
+++ b/packages/router-core/tests/loader-architecture-regressions.test.ts
@@ -171,6 +171,59 @@ test('superseding a load clears fetching state from the still-presented lane', a
   await Promise.all([firstNavigation, secondNavigation])
 })
 
+test('an ignored preload flight is released after a navigation has planned its loaders', async () => {
+  const preloadFailure = createControlledPromise<string>()
+  const childGate = createControlledPromise<string>()
+  let preloadSignal: AbortSignal | undefined
+  const parentLoader = vi.fn(
+    ({ abortController }: { abortController: AbortController }) => {
+      const generation = parentLoader.mock.calls.length
+      if (generation === 1) {
+        return 'initial parent data'
+      }
+      preloadSignal = abortController.signal
+      return preloadFailure
+    },
+  )
+  const childLoader = vi.fn(() => childGate)
+  const rootRoute = new BaseRootRoute({})
+  const parentRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/parent',
+    shouldReload: ({ preload }) => preload,
+    loader: parentLoader,
+  })
+  const childRoute = new BaseRoute({
+    getParentRoute: () => parentRoute,
+    path: '/child',
+    loader: childLoader,
+  })
+  const siblingRoute = new BaseRoute({
+    getParentRoute: () => parentRoute,
+    path: '/sibling',
+  })
+  const router = createTestRouter({
+    routeTree: rootRoute.addChildren([
+      parentRoute.addChildren([childRoute, siblingRoute]),
+    ]),
+    history: createMemoryHistory({ initialEntries: ['/parent'] }),
+  })
+
+  await router.load()
+  const preload = router.preloadRoute({ to: '/parent/sibling' })
+  await vi.waitFor(() => expect(parentLoader).toHaveBeenCalledTimes(2))
+
+  const navigation = router.navigate({ to: '/parent/child' })
+  await vi.waitFor(() => expect(childLoader).toHaveBeenCalledOnce())
+
+  preloadFailure.reject(new Error('discarded preload generation'))
+  await preload
+  expect(preloadSignal?.aborted).toBe(true)
+
+  childGate.resolve('child data')
+  await navigation
+})
+
 test('an ordinary route-context failure still permits ancestor loaders', async () => {
   const failure = new Error('child context failed')
   const parentLoader = vi.fn(() => 'parent data')
@@ -279,9 +332,9 @@ test('invalidation reruns the loader with same-id route context', async () => {
   })
 })
 
-test('a preload cannot abort its controller after navigation adopts its lane', async () => {
+test("a settled preload cannot abort a navigation's beforeLoad controller", async () => {
   const suspended = createControlledPromise<void>()
-  let adoptedSignal: AbortSignal | undefined
+  let navigationSignal: AbortSignal | undefined
   const rootRoute = new BaseRootRoute({})
   const indexRoute = new BaseRoute({
     getParentRoute: () => rootRoute,
@@ -290,8 +343,10 @@ test('a preload cannot abort its controller after navigation adopts its lane', a
   const guardedRoute = new BaseRoute({
     getParentRoute: () => rootRoute,
     path: '/guarded',
-    beforeLoad: ({ abortController }) => {
-      adoptedSignal = abortController.signal
+    beforeLoad: ({ abortController, preload }) => {
+      if (!preload) {
+        navigationSignal = abortController.signal
+      }
       throw suspended
     },
   })
@@ -305,7 +360,7 @@ test('a preload cannot abort its controller after navigation adopts its lane', a
   const navigation = router.navigate({ to: '/guarded' })
 
   await preload
-  expect(adoptedSignal?.aborted).toBe(false)
+  expect(navigationSignal?.aborted).toBe(false)
 
   await navigation
 })
@@ -385,6 +440,138 @@ test('a fast background candidate remains private when a reentrant navigation wi
   expect(parentLoads).toBe(2)
   expect(activeSignal?.aborted).toBe(false)
   expect(replacementSignal?.aborted).toBe(true)
+})
+
+test('a superseding navigation reuses a pending background loader after async beforeLoad', async () => {
+  const backgroundResult = createControlledPromise<number>()
+  const beforeLoadStarted = createControlledPromise<void>()
+  const beforeLoadGate = createControlledPromise<void>()
+  const signals: Array<AbortSignal> = []
+  let generation = 0
+
+  const rootRoute = new BaseRootRoute({})
+  const route = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/page',
+    validateSearch: (search: Record<string, unknown>) => ({
+      reload: Number(search.reload ?? 0),
+    }),
+    shouldReload: ({ location }) =>
+      (location.search as { reload: number }).reload === 1 ? true : undefined,
+    beforeLoad: async ({ search }) => {
+      if (search.reload === 2) {
+        beforeLoadStarted.resolve()
+        await beforeLoadGate
+      }
+    },
+    loader: {
+      staleReloadMode: 'background',
+      handler: ({ abortController }) => {
+        signals.push(abortController.signal)
+        generation++
+        return generation === 2 ? backgroundResult : generation
+      },
+    },
+  })
+  const router = createTestRouter({
+    routeTree: rootRoute.addChildren([route]),
+    history: createMemoryHistory({
+      initialEntries: ['/page?reload=0'],
+    }),
+  })
+
+  await router.load()
+  await router.navigate({
+    to: '/page',
+    search: { reload: 1 },
+  })
+  await vi.waitFor(() => expect(generation).toBe(2))
+
+  const successor = router.navigate({
+    to: '/page',
+    search: { reload: 2 },
+  })
+  await beforeLoadStarted
+
+  backgroundResult.resolve(2)
+  beforeLoadGate.resolve()
+  await successor
+
+  await vi.waitFor(() => {
+    expect(router.state.matches.at(-1)?.loaderData).toBe(2)
+  })
+  expect(generation).toBe(2)
+  expect(signals[1]?.aborted).toBe(false)
+  expect(router.state.matches.at(-1)?.preload).toBe(false)
+})
+
+test('an ancestor beforeLoad failure releases an unconsumed background loader', async () => {
+  const backgroundResult = createControlledPromise<number>()
+  const signals: Array<AbortSignal> = []
+  let generation = 0
+
+  const rootRoute = new BaseRootRoute({})
+  const parentRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/parent',
+    validateSearch: (search: Record<string, unknown>) => ({
+      phase: String(search.phase ?? 'initial'),
+    }),
+    beforeLoad: ({ search }) => {
+      if (search.phase === 'fail') {
+        throw new Error('parent failed')
+      }
+    },
+  })
+  const childRoute = new BaseRoute({
+    getParentRoute: () => parentRoute,
+    path: '/child',
+    shouldReload: ({ location }) =>
+      (location.search as { phase: string }).phase === 'refresh'
+        ? true
+        : undefined,
+    staleTime: Infinity,
+    loader: {
+      staleReloadMode: 'background',
+      handler: ({ abortController }) => {
+        signals.push(abortController.signal)
+        generation++
+        return generation === 2 ? backgroundResult : generation
+      },
+    },
+  })
+  const router = createTestRouter({
+    routeTree: rootRoute.addChildren([parentRoute.addChildren([childRoute])]),
+    history: createMemoryHistory({
+      initialEntries: ['/parent/child?phase=initial'],
+    }),
+  })
+
+  await router.load()
+  await router.navigate({
+    to: '/parent/child',
+    search: { phase: 'refresh' },
+  })
+  await vi.waitFor(() => expect(generation).toBe(2))
+
+  await router.navigate({
+    to: '/parent/child',
+    search: { phase: 'fail' },
+  })
+
+  expect(
+    router.state.matches.find((match) => match.routeId === parentRoute.id),
+  ).toMatchObject({ status: 'error' })
+  expect(signals[1]?.aborted).toBe(true)
+
+  backgroundResult.resolve(2)
+  await router.navigate({
+    to: '/parent/child',
+    search: { phase: 'recovered' },
+  })
+
+  expect(generation).toBe(2)
+  expect(router.state.matches.at(-1)?.loaderData).toBe(1)
 })
 
 test('reentrant navigation from onError cancels stale serial work', async () => {
@@ -866,7 +1053,8 @@ test('a stale shouldReload cannot continue a superseded preload', async () => {
   expect(onError).toHaveBeenCalledOnce()
 })
 
-test('an onLeave navigation to the in-flight destination joins it and enters once', async () => {
+test('an onLeave navigation to the in-flight destination runs a fresh lane', async () => {
+  const beforeLoad = vi.fn()
   const firstEnter = vi.fn()
   const firstStay = vi.fn()
   let successor: Promise<void> | undefined
@@ -887,6 +1075,7 @@ test('an onLeave navigation to the in-flight destination joins it and enters onc
   const firstRoute = new BaseRoute({
     getParentRoute: () => rootRoute,
     path: '/first',
+    beforeLoad,
     onEnter: firstEnter,
     onStay: firstStay,
   })
@@ -901,8 +1090,6 @@ test('an onLeave navigation to the in-flight destination joins it and enters onc
 
   expect(router.state.location.pathname).toBe('/first')
   expect(router.state.matches.at(-1)?.routeId).toBe(firstRoute.id)
-  // The reentrant same-destination navigation joins the in-flight lane, so
-  // the route is entered exactly once rather than restarted into a stay.
-  expect(firstEnter).toHaveBeenCalledOnce()
-  expect(firstStay).not.toHaveBeenCalled()
+  expect(beforeLoad).toHaveBeenCalledTimes(2)
+  expect(firstEnter.mock.calls.length + firstStay.mock.calls.length).toBe(1)
 })

--- a/packages/router-core/tests/preload-adoption.test.ts
+++ b/packages/router-core/tests/preload-adoption.test.ts
@@ -96,7 +96,7 @@ describe('preload adoption', () => {
     ).toEqual({ notifications: ['fresh'] })
   })
 
-  test('navigation adopts an identical preload still in its serial phase', async () => {
+  test('navigation runs beforeLoad independently of a preload serial phase', async () => {
     const beforeLoadGate = createControlledPromise<void>()
     const preloadSerialStarted = createControlledPromise<void>()
     let beforeLoadCalls = 0
@@ -134,12 +134,12 @@ describe('preload adoption', () => {
     expect(beforeLoadCalls).toBe(1)
 
     const navigation = router.navigate({ to: '/foo' })
-    await Promise.resolve()
-    expect(loader).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect(beforeLoadCalls).toBe(2))
+    expect(loader).toHaveBeenCalledTimes(1)
 
     beforeLoadGate.resolve()
     await Promise.all([navigation, preload])
-    expect(beforeLoadCalls).toBe(1)
+    expect(beforeLoadCalls).toBe(2)
     expect(loader).toHaveBeenCalledTimes(1)
     expect(
       router.state.matches.find((match) => match.routeId === fooRoute.id)
@@ -147,7 +147,7 @@ describe('preload adoption', () => {
     ).toBe('success')
   })
 
-  test("a sibling preload adopts another preload lane's in-flight loader", async () => {
+  test("a sibling preload shares another preload lane's in-flight loader", async () => {
     const loaderGate = createControlledPromise<string>()
     const loaderStarted = createControlledPromise<void>()
     let preloadBeforeLoadCalls = 0
@@ -184,8 +184,7 @@ describe('preload adoption', () => {
     await loaderStarted
 
     const second = router.preloadRoute({ to: '/foo' } as any)
-    await Promise.resolve()
-    expect(preloadBeforeLoadCalls).toBe(1)
+    await vi.waitFor(() => expect(preloadBeforeLoadCalls).toBe(2))
     expect(loader).toHaveBeenCalledTimes(1)
 
     loaderGate.resolve('once')

--- a/packages/router-core/tests/preload-beforeload-reuse.test.ts
+++ b/packages/router-core/tests/preload-beforeload-reuse.test.ts
@@ -90,7 +90,7 @@ describe('preloaded loader reuse with fresh beforeLoad context', () => {
     })
   })
 
-  test('adopts beforeLoad and loader from an identical active preload', async () => {
+  test('reruns beforeLoad while sharing an identical active preload loader', async () => {
     const loaderGate = createControlledPromise<string>()
     const beforeLoad = vi.fn(({ preload }: { preload: boolean }) => ({
       guard: preload ? 'preloaded' : 'loaded',
@@ -118,9 +118,10 @@ describe('preloaded loader reuse with fresh beforeLoad context', () => {
     await vi.waitFor(() => expect(loader).toHaveBeenCalledTimes(1))
 
     const navigation = router.navigate({ to: '/guarded' })
-    await vi.waitFor(() => expect(beforeLoad).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(beforeLoad).toHaveBeenCalledTimes(2))
     expect(beforeLoad.mock.calls.map(([context]) => context.preload)).toEqual([
       true,
+      false,
     ])
     expect(loader).toHaveBeenCalledTimes(1)
 
@@ -128,7 +129,7 @@ describe('preloaded loader reuse with fresh beforeLoad context', () => {
     await Promise.all([preload, navigation])
 
     expect(loader).toHaveBeenCalledTimes(1)
-    expect(router.state.matches.at(-1)?.context).toEqual({ guard: 'preloaded' })
+    expect(router.state.matches.at(-1)?.context).toEqual({ guard: 'loaded' })
     expect(router.state.matches.at(-1)?.loaderData).toBe('shared loader data')
   })
 

--- a/packages/router-core/tests/preload-navigation-adoption.test.ts
+++ b/packages/router-core/tests/preload-navigation-adoption.test.ts
@@ -50,12 +50,12 @@ describe('navigation adopting an in-flight preload', () => {
     expect(preloadSignal).toBeDefined()
     expect(preloadSignal?.aborted).toBe(false)
 
-    // The identical navigation adopts the whole active lane, including its
-    // already-completed beforeLoad context.
+    // The navigation runs its own guard but shares the loader generation.
     const navigation = router.navigate({ to: '/foo' })
-    await Promise.resolve()
+    await vi.waitFor(() => expect(beforeLoad).toHaveBeenCalledTimes(2))
     expect(beforeLoad.mock.calls.map(([context]) => context.preload)).toEqual([
       true,
+      false,
     ])
     expect(loaderGate.status).toBe('pending')
     expect(loader).toHaveBeenCalledTimes(1)

--- a/packages/router-core/tests/preload-public-cache-behavior.test.ts
+++ b/packages/router-core/tests/preload-public-cache-behavior.test.ts
@@ -202,6 +202,62 @@ test('clearCache cancels a brand-new in-flight preload before it can populate th
   ).toBe('navigation data')
 })
 
+test('clearCache does not reserve a discarded preload for a navigation in beforeLoad', async () => {
+  const navigationBeforeLoad = createControlledPromise<void>()
+  let preloadSignal: AbortSignal | undefined
+  const beforeLoad = vi.fn(({ preload }: { preload: boolean }) =>
+    preload ? undefined : navigationBeforeLoad,
+  )
+  const loader = vi.fn(
+    ({ abortController }: { abortController: AbortController }) => {
+      const generation = loader.mock.calls.length
+      if (generation !== 1) {
+        return 'fresh navigation data'
+      }
+      preloadSignal = abortController.signal
+      return new Promise<string>((_resolve, reject) => {
+        abortController.signal.addEventListener(
+          'abort',
+          () => reject(abortController.signal.reason),
+          { once: true },
+        )
+      })
+    },
+  )
+  const rootRoute = new BaseRootRoute({})
+  const homeRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+  })
+  const targetRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/target',
+    beforeLoad,
+    loader,
+  })
+  const router = createTestRouter({
+    routeTree: rootRoute.addChildren([homeRoute, targetRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  await router.load()
+  const preload = router.preloadRoute({ to: '/target' })
+  await vi.waitFor(() => expect(loader).toHaveBeenCalledOnce())
+  const navigation = router.navigate({ to: '/target' })
+  await vi.waitFor(() => expect(beforeLoad).toHaveBeenCalledTimes(2))
+
+  router.clearCache({
+    filter: (match) => match.routeId === targetRoute.id,
+  })
+  await vi.waitFor(() => expect(preloadSignal?.aborted).toBe(true))
+  await preload
+
+  navigationBeforeLoad.resolve()
+  await navigation
+  expect(loader).toHaveBeenCalledTimes(2)
+  expect(router.state.matches.at(-1)?.loaderData).toBe('fresh navigation data')
+})
+
 test('clearCache installs replacement authorities before abort listeners reenter', async () => {
   let reentrantNavigation: Promise<void> | undefined
   let router: ReturnType<typeof createTestRouter>
@@ -319,6 +375,68 @@ test('clearCache detaches every discarded flight before abort listeners reenter'
   expect(secondLoader).toHaveBeenCalledTimes(2)
   expect(router.state.location.pathname).toBe('/second')
   expect(router.state.matches.at(-1)?.loaderData).toBe('generation 2')
+})
+
+test('filtered clearCache keeps shared loader work discoverable through a retained preload', async () => {
+  const layoutGate = createControlledPromise<string>()
+  const layoutLoader = vi.fn(() => layoutGate)
+  const rootRoute = new BaseRootRoute({})
+  const layoutRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/layout',
+    loader: layoutLoader,
+  })
+  const firstBeforeLoad = vi.fn()
+  const firstRoute = new BaseRoute({
+    getParentRoute: () => layoutRoute,
+    path: '/first',
+    beforeLoad: firstBeforeLoad,
+  })
+  const secondBeforeLoad = vi.fn()
+  const secondLoader = vi.fn(() => 'second data')
+  const secondRoute = new BaseRoute({
+    getParentRoute: () => layoutRoute,
+    path: '/second',
+    beforeLoad: secondBeforeLoad,
+    loader: secondLoader,
+  })
+  const thirdBeforeLoad = vi.fn()
+  const thirdLoader = vi.fn(() => 'third data')
+  const thirdRoute = new BaseRoute({
+    getParentRoute: () => layoutRoute,
+    path: '/third',
+    beforeLoad: thirdBeforeLoad,
+    loader: thirdLoader,
+  })
+  const router = createTestRouter({
+    routeTree: rootRoute.addChildren([
+      layoutRoute.addChildren([firstRoute, secondRoute, thirdRoute]),
+    ]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  await router.load()
+  const firstPreload = router.preloadRoute({ to: '/layout/first' })
+  const secondPreload = router.preloadRoute({ to: '/layout/second' })
+  await vi.waitFor(() => {
+    expect(firstBeforeLoad).toHaveBeenCalledOnce()
+    expect(secondBeforeLoad).toHaveBeenCalledOnce()
+    expect(layoutLoader).toHaveBeenCalledOnce()
+    expect(secondLoader).toHaveBeenCalledOnce()
+  })
+
+  router.clearCache({
+    filter: (match) => match.routeId === firstRoute.id,
+  })
+  const thirdPreload = router.preloadRoute({ to: '/layout/third' })
+  await vi.waitFor(() => {
+    expect(thirdBeforeLoad).toHaveBeenCalledOnce()
+    expect(thirdLoader).toHaveBeenCalledOnce()
+  })
+
+  expect(layoutLoader).toHaveBeenCalledOnce()
+  layoutGate.resolve('layout data')
+  await Promise.all([firstPreload, secondPreload, thirdPreload])
 })
 
 test('independent concurrent preloads both populate the cache', async () => {

--- a/packages/router-core/tests/public-hydration-contract.test.ts
+++ b/packages/router-core/tests/public-hydration-contract.test.ts
@@ -1,6 +1,6 @@
 import { runInNewContext } from 'node:vm'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { createMemoryHistory } from '@tanstack/history'
+import { createBrowserHistory, createMemoryHistory } from '@tanstack/history'
 import {
   BaseRootRoute,
   BaseRoute,
@@ -11,11 +11,12 @@ import { hydrate } from '../src/ssr/client'
 import { attachRouterServerSsrUtils } from '../src/ssr/ssr-server'
 import { dehydrateSsrMatchId } from '../src/ssr/ssr-match-id'
 import { createTestRouter } from './routerTestUtils'
-import type { AnyRouteMatch, AnyRouter } from '../src'
+import type { AnyRouteMatch, AnyRouter, LocationRewrite } from '../src'
 import type { DehydratedRouter, TsrSsrGlobal } from '../src/ssr/types'
 import type { ServerManifest } from '../src/manifest'
 
 const testManifest: ServerManifest = { routes: {} }
+const browserWindow = window
 
 async function dehydrateToBootstrap(router: AnyRouter): Promise<TsrSsrGlobal> {
   attachRouterServerSsrUtils({ router, manifest: testManifest })
@@ -986,6 +987,77 @@ describe('public hydration contracts', () => {
     expect(router.state.matches.at(-1)?.loaderData).toBe('client new')
   })
 
+  test('does not hand transported context to a replaced public URL generation', async () => {
+    vi.spyOn(browserWindow, 'scrollTo').mockImplementation(() => undefined)
+    browserWindow.history.replaceState({}, '', '/public-a')
+    const history = createBrowserHistory({ window: browserWindow })
+    const rewrite: LocationRewrite = {
+      input: ({ url }) => {
+        if (url.pathname === '/public-a' || url.pathname === '/public-b') {
+          url.pathname = '/internal'
+        }
+        return url
+      },
+      output: ({ url }) => url,
+    }
+    const beforeLoad = vi.fn(({ location }: { location: any }) => ({
+      publicHref: location.publicHref,
+    }))
+    const loader = vi.fn(
+      ({ context: routeContext }: { context: { publicHref: string } }) =>
+        routeContext.publicHref,
+    )
+    const rootRoute = new BaseRootRoute({ beforeLoad })
+    const internalRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/internal',
+      ssr: false,
+      loader,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([internalRoute]),
+      history,
+      rewrite,
+      isServer: false,
+    })
+    const matches = router.matchRoutes(router.stores.location.get())
+    installHydrationPayload(mockWindow, [
+      {
+        i: dehydrateSsrMatchId(matches[0]!.id),
+        s: 'success',
+        b: { publicHref: '/public-a' },
+        ssr: true,
+        u: Date.now(),
+      },
+      {
+        i: dehydrateSsrMatchId(matches[1]!.id),
+        s: 'pending',
+        ssr: false,
+        u: Date.now(),
+      },
+    ])
+
+    try {
+      await hydrate(router)
+      browserWindow.history.replaceState(
+        browserWindow.history.state,
+        '',
+        '/public-b',
+      )
+
+      await router.load()
+
+      expect(
+        beforeLoad.mock.calls.map(([options]) => options.location.publicHref),
+      ).toEqual(['/public-b'])
+      expect(loader).toHaveBeenCalledTimes(1)
+      expect(router.state.matches.at(-1)?.loaderData).toBe('/public-b')
+    } finally {
+      history.destroy()
+      browserWindow.history.replaceState({}, '', '/')
+    }
+  })
+
   test('keeps a hydration handoff when a provider initializes an empty context', async () => {
     const rootBeforeLoad = vi.fn(() => ({ source: 'client' }))
     const rootLoader = vi.fn(() => 'client root')
@@ -1042,7 +1114,73 @@ describe('public hydration contracts', () => {
     expect(router.state.matches[1]).toMatchObject({ loaderData: 'server' })
   })
 
-  test('does not hand transported context across a router-context generation change', async () => {
+  test('keeps transported hydration context across a cyclic router-context replacement', async () => {
+    const rootBeforeLoad = vi.fn(({ context }: { context: any }) => ({
+      value: context.value,
+    }))
+    const rootLoader = vi.fn(() => 'client root')
+    const pageContext = vi.fn(({ context }: { context: any }) => ({
+      value: context.value,
+    }))
+    const pageLoader = vi.fn(
+      ({ context }: { context: any }) => context.value,
+    )
+    const rootRoute = new BaseRootRoute({
+      beforeLoad: rootBeforeLoad,
+      loader: rootLoader,
+    })
+    const pageRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/page',
+      ssr: false,
+      context: pageContext,
+      loader: pageLoader,
+    })
+    const initialValue: Record<string, unknown> = {}
+    initialValue.self = initialValue
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([pageRoute]),
+      history: createMemoryHistory({ initialEntries: ['/page'] }),
+      isServer: false,
+      context: { value: initialValue },
+    })
+    const matches = router.matchRoutes(router.stores.location.get())
+    installHydrationPayload(mockWindow, [
+      {
+        i: dehydrateSsrMatchId(matches[0]!.id),
+        s: 'success',
+        b: { value: initialValue },
+        l: 'server root',
+        ssr: true,
+        u: Date.now(),
+      },
+      {
+        i: dehydrateSsrMatchId(matches[1]!.id),
+        s: 'pending',
+        ssr: false,
+        u: Date.now(),
+      },
+    ])
+
+    await hydrate(router)
+    const nextValue: Record<string, unknown> = {}
+    nextValue.self = nextValue
+    router.update({
+      ...router.options,
+      context: { value: nextValue },
+    })
+
+    await expect(router.load()).resolves.toBeUndefined()
+
+    expect(rootBeforeLoad).not.toHaveBeenCalled()
+    expect(pageContext).toHaveBeenCalledTimes(1)
+    expect(rootLoader).not.toHaveBeenCalled()
+    expect(pageLoader).toHaveBeenCalledTimes(1)
+    expect(router.state.matches[0]?.loaderData).toBe('server root')
+    expect(router.state.matches[1]?.loaderData).toBe(initialValue)
+  })
+
+  test('does not hand transported context across an invalidation', async () => {
     const rootBeforeLoad = vi.fn(({ context }: { context: any }) => ({
       auth: context.auth,
     }))
@@ -1084,7 +1222,7 @@ describe('public hydration contracts', () => {
       ...router.options,
       context: { auth: 'client new' },
     })
-    await router.load()
+    await router.invalidate()
 
     expect(rootBeforeLoad).toHaveBeenCalledTimes(1)
     expect(pageLoader).toHaveBeenCalledTimes(1)

--- a/packages/router-core/tests/public-hydration-contract.test.ts
+++ b/packages/router-core/tests/public-hydration-contract.test.ts
@@ -1122,9 +1122,7 @@ describe('public hydration contracts', () => {
     const pageContext = vi.fn(({ context }: { context: any }) => ({
       value: context.value,
     }))
-    const pageLoader = vi.fn(
-      ({ context }: { context: any }) => context.value,
-    )
+    const pageLoader = vi.fn(({ context }: { context: any }) => context.value)
     const rootRoute = new BaseRootRoute({
       beforeLoad: rootBeforeLoad,
       loader: rootLoader,

--- a/packages/router-core/tests/public-preload-lane-contract.test.ts
+++ b/packages/router-core/tests/public-preload-lane-contract.test.ts
@@ -51,14 +51,17 @@ describe('public preload lane contracts', () => {
     expect(loader).toHaveBeenCalledTimes(1)
   })
 
-  test('active preloads share only an identical full lane', async () => {
+  test('every active preload runs beforeLoad even for an identical location', async () => {
     const gates = new Map<
       number,
       ReturnType<typeof createControlledPromise<void>>
     >()
     const beforeLoad = vi.fn(({ search }: { search: { version: number } }) => {
-      const gate = createControlledPromise<void>()
-      gates.set(search.version, gate)
+      let gate = gates.get(search.version)
+      if (!gate) {
+        gate = createControlledPromise<void>()
+        gates.set(search.version, gate)
+      }
       return gate
     })
     const rootRoute = new BaseRootRoute({})
@@ -91,6 +94,7 @@ describe('public preload lane contracts', () => {
       search: { version: 2 },
     })
     await vi.waitFor(() => expect(beforeLoad).toHaveBeenCalledTimes(2))
+    gates.get(1)!.resolve(undefined)
     gates.get(2)!.resolve(undefined)
     await Promise.all([first, second])
 
@@ -103,13 +107,12 @@ describe('public preload lane contracts', () => {
       to: '/target',
       search: { version: 3 },
     })
-    await Promise.resolve()
-    expect(beforeLoad).toHaveBeenCalledTimes(3)
+    await vi.waitFor(() => expect(beforeLoad).toHaveBeenCalledTimes(4))
     gates.get(3)!.resolve(undefined)
     await Promise.all([third, identical])
   })
 
-  test('navigation adopts beforeLoad from an identical active preload lane', async () => {
+  test('navigation reruns beforeLoad while sharing an identical preload loader', async () => {
     const beforeLoadGate = createControlledPromise<void>()
     const beforeLoad = vi.fn(async ({ preload }: { preload: boolean }) => {
       await beforeLoadGate
@@ -137,18 +140,18 @@ describe('public preload lane contracts', () => {
     await vi.waitFor(() => expect(beforeLoad).toHaveBeenCalledTimes(1))
 
     const navigation = router.navigate({ to: '/target' })
-    await Promise.resolve()
-    expect(beforeLoad).toHaveBeenCalledTimes(1)
+    await vi.waitFor(() => expect(beforeLoad).toHaveBeenCalledTimes(2))
 
     beforeLoadGate.resolve()
     await Promise.all([preload, navigation])
 
     expect(beforeLoad.mock.calls.map(([context]) => context.preload)).toEqual([
       true,
+      false,
     ])
     expect(loader).toHaveBeenCalledTimes(1)
     expect(router.state.matches.at(-1)).toMatchObject({
-      context: { source: 'preload' },
+      context: { source: 'navigation' },
       loaderData: 'loader data',
     })
   })
@@ -850,7 +853,7 @@ describe('public preload lane contracts', () => {
     })
   })
 
-  test('navigation retries an adopted preload lane that failed', async () => {
+  test('navigation runs independently when an active preload fails', async () => {
     const preloadGate = createControlledPromise<void>()
     const beforeLoad = vi.fn(async ({ preload }: { preload: boolean }) => {
       if (preload) {

--- a/packages/router-core/tests/same-destination-navigation-join.test.ts
+++ b/packages/router-core/tests/same-destination-navigation-join.test.ts
@@ -10,6 +10,7 @@ afterEach(() => {
 describe('same-destination navigation while one is in flight', () => {
   function setup() {
     const gate = createControlledPromise<string>()
+    const beforeLoad = vi.fn()
     const loader = vi.fn(() => gate)
     const rootRoute = new BaseRootRoute({})
     const indexRoute = new BaseRoute({
@@ -19,17 +20,18 @@ describe('same-destination navigation while one is in flight', () => {
     const targetRoute = new BaseRoute({
       getParentRoute: () => rootRoute,
       path: '/target',
+      beforeLoad,
       loader,
     })
     const router = createTestRouter({
       routeTree: rootRoute.addChildren([indexRoute, targetRoute]),
       history: createMemoryHistory({ initialEntries: ['/'] }),
     })
-    return { router, loader, gate, targetRoute }
+    return { router, beforeLoad, loader, gate, targetRoute }
   }
 
   test('a second navigation to the same destination joins the in-flight load', async () => {
-    const { router, loader, gate, targetRoute } = setup()
+    const { router, beforeLoad, loader, gate, targetRoute } = setup()
     await router.load()
 
     const first = router.navigate({ to: '/target' })
@@ -39,6 +41,7 @@ describe('same-destination navigation while one is in flight', () => {
     gate.resolve('once')
     await Promise.all([first, second])
 
+    expect(beforeLoad).toHaveBeenCalledTimes(2)
     expect(loader).toHaveBeenCalledTimes(1)
     expect(router.state.matches.at(-1)).toMatchObject({
       routeId: targetRoute.id,
@@ -89,6 +92,58 @@ describe('same-destination navigation while one is in flight', () => {
     await Promise.all([first, second])
 
     expect(loader).toHaveBeenCalledTimes(2)
+  })
+
+  test('filtered invalidate does not adopt same-id work from an active preload', async () => {
+    const secondGate = createControlledPromise<string>()
+    const loader = vi.fn(
+      ({ abortController }: { abortController: AbortController }) => {
+        const generation = loader.mock.calls.length
+        return generation === 2
+          ? secondGate
+          : `generation ${generation}:${abortController.signal.aborted}`
+      },
+    )
+    const rootRoute = new BaseRootRoute({})
+    const targetRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/target',
+      validateSearch: (search: Record<string, unknown>) => ({
+        revision: Number(search.revision ?? 1),
+      }),
+      shouldReload: ({ preload }) => (preload ? true : undefined),
+      loader,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([targetRoute]),
+      history: createMemoryHistory({
+        initialEntries: ['/target?revision=1'],
+      }),
+    })
+
+    await router.load()
+    const preload = router.preloadRoute({
+      to: '/target',
+      search: { revision: 2 },
+    })
+    await vi.waitFor(() => expect(loader).toHaveBeenCalledTimes(2))
+
+    const invalidation = router.invalidate({
+      filter: (match) =>
+        match.routeId === targetRoute.id &&
+        (match.search as { revision: number }).revision === 1,
+    })
+    await vi.waitFor(() => expect(loader).toHaveBeenCalledTimes(3))
+    await invalidation
+
+    expect(router.state.location.search).toEqual({ revision: 1 })
+    expect(router.state.matches.at(-1)).toMatchObject({
+      routeId: targetRoute.id,
+      loaderData: 'generation 3:false',
+    })
+
+    secondGate.resolve('preload data')
+    await preload
   })
 
   test('a repeat navigation after settle reloads instead of joining', async () => {


### PR DESCRIPTION
## What changed

- run `beforeLoad` independently for every client navigation and preload lane, including identical and same-location requests
- keep loader reuse separate, allowing completed and in-flight loader generations to remain shareable by match ID
- remove whole-preload-lane adoption and same-location transaction deduplication
- narrow loader-flight reservation to navigation handoff and active `beforeLoad` planning
- make invalidation and filtered `clearCache` preserve correct loader ownership
- remove the `urgent` mode from `StartTransitionFn`
- update the orchestration documentation and add public-API regressions for supersession, invalidation, cache clearing, and signal lifetime

## Why

`beforeLoad` carries lane-specific guard and context semantics, so adopting it from cache or another in-flight lane can expose stale context and control flow. Loader data is the intended reusable boundary. Separating these rules simplifies the match-loading architecture while retaining loader deduplication.

The previous broad reservation and lane-adoption mechanisms also made it possible to leak zero-owner loader flights, replay stale work after invalidation, or make retained shared work undiscoverable during filtered cache clearing.

## Impact

Every client lane now evaluates its own `beforeLoad`. Loader work can still be reused from cache or an in-flight generation, even when lane arguments such as `preload` or context differ. The resulting orchestration has fewer semantic authorities and removes per-preload full-flight-registry sweeps.

## Validation

- router-core unit tests: 1,506 passed, 3 expected failures
- react-router unit tests: 986 passed, 1 skipped
- router-core and react-router TypeScript version matrices
- router-core and react-router ESLint targets (no errors; existing warnings only)
- full bundle-size suite: gzip decreased in all 17 scenarios; `react-router.minimal` decreased by 166 bytes
