### PR TITLE
Use scoped Vitest cleanup in lane regression tests

### DIFF
--- a/packages/react-router/tests/issue-4467-lazy-route-pending.test.tsx
+++ b/packages/react-router/tests/issue-4467-lazy-route-pending.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { act, cleanup, render, screen } from '@testing-library/react'
-import { afterEach, expect, test, vi } from 'vitest'
+import { afterEach, expect, onTestFinished, test, vi } from 'vitest'
 
 import {
   Outlet,
@@ -43,40 +43,40 @@ test('default pending component renders while lazy route options load', async ()
   })
   let navigationPromise: Promise<void> | undefined
 
-  try {
-    render(<RouterProvider router={router} />)
-
-    expect(
-      await screen.findByRole('heading', { name: 'Index page' }),
-    ).toBeInTheDocument()
-
-    act(() => {
-      navigationPromise = router.navigate({ to: '/page' })
-    })
-
-    expect(await screen.findByRole('status')).toHaveTextContent('Loading page')
-    expect(
-      screen.queryByRole('heading', { name: 'Page' }),
-    ).not.toBeInTheDocument()
-    expect(lazyOptions.status).toBe('pending')
-    expect(loadLazyOptions).toHaveBeenCalledTimes(1)
-
-    await act(async () => {
-      lazyOptions.resolve(lazyPageOptions)
-      await navigationPromise
-    })
-
-    expect(screen.getByRole('heading', { name: 'Page' })).toBeInTheDocument()
-    expect(screen.queryByRole('status')).not.toBeInTheDocument()
-    expect(loadLazyOptions).toHaveBeenCalledTimes(1)
-  } finally {
+  onTestFinished(async () => {
     await act(async () => {
       if (lazyOptions.status === 'pending') {
         lazyOptions.resolve(lazyPageOptions)
       }
       await navigationPromise
     })
-  }
+  })
+
+  render(<RouterProvider router={router} />)
+
+  expect(
+    await screen.findByRole('heading', { name: 'Index page' }),
+  ).toBeInTheDocument()
+
+  act(() => {
+    navigationPromise = router.navigate({ to: '/page' })
+  })
+
+  expect(await screen.findByRole('status')).toHaveTextContent('Loading page')
+  expect(
+    screen.queryByRole('heading', { name: 'Page' }),
+  ).not.toBeInTheDocument()
+  expect(lazyOptions.status).toBe('pending')
+  expect(loadLazyOptions).toHaveBeenCalledTimes(1)
+
+  await act(async () => {
+    lazyOptions.resolve(lazyPageOptions)
+    await navigationPromise
+  })
+
+  expect(screen.getByRole('heading', { name: 'Page' })).toBeInTheDocument()
+  expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  expect(loadLazyOptions).toHaveBeenCalledTimes(1)
 })
 
 test('a lazy pending component is offered while the eager loader is still pending', async () => {
@@ -106,41 +106,39 @@ test('a lazy pending component is offered while the eager loader is still pendin
   })
   let navigation: Promise<void> | undefined
 
-  try {
-    render(<RouterProvider router={router} />)
-    expect(
-      await screen.findByRole('heading', { name: 'Index page' }),
-    ).toBeInTheDocument()
-
-    act(() => {
-      navigation = router.navigate({ to: '/page' })
-    })
-    expect(await screen.findByRole('status')).toHaveTextContent(
-      'Loading default',
-    )
-
-    await act(async () => {
-      lazyOptions.resolve(lazyPageOptions)
-    })
-
-    expect(await screen.findByRole('status')).toHaveTextContent(
-      'Loading lazy page',
-    )
-    expect(
-      screen.queryByRole('heading', { name: 'Page' }),
-    ).not.toBeInTheDocument()
-
-    await act(async () => {
-      loader.resolve()
-      await navigation
-    })
-
-    expect(screen.getByRole('heading', { name: 'Page' })).toBeInTheDocument()
-  } finally {
+  onTestFinished(async () => {
     await act(async () => {
       lazyOptions.resolve(lazyPageOptions)
       loader.resolve()
       await navigation
     })
-  }
+  })
+
+  render(<RouterProvider router={router} />)
+  expect(
+    await screen.findByRole('heading', { name: 'Index page' }),
+  ).toBeInTheDocument()
+
+  act(() => {
+    navigation = router.navigate({ to: '/page' })
+  })
+  expect(await screen.findByRole('status')).toHaveTextContent('Loading default')
+
+  await act(async () => {
+    lazyOptions.resolve(lazyPageOptions)
+  })
+
+  expect(await screen.findByRole('status')).toHaveTextContent(
+    'Loading lazy page',
+  )
+  expect(
+    screen.queryByRole('heading', { name: 'Page' }),
+  ).not.toBeInTheDocument()
+
+  await act(async () => {
+    loader.resolve()
+    await navigation
+  })
+
+  expect(screen.getByRole('heading', { name: 'Page' })).toBeInTheDocument()
 })

--- a/packages/react-router/tests/issue-4476-react-query-cancellation.test.tsx
+++ b/packages/react-router/tests/issue-4476-react-query-cancellation.test.tsx
@@ -10,7 +10,7 @@ import {
   QueryClientProvider,
   useQuery,
 } from '@tanstack/react-query'
-import { afterEach, expect, test, vi } from 'vitest'
+import { afterEach, expect, onTestFinished, test, vi } from 'vitest'
 import {
   Link,
   Outlet,
@@ -97,33 +97,33 @@ test('#4476: pending navigation keeps the query observer mounted and its fetchQu
     },
   })
 
-  try {
-    render(
-      <QueryClientProvider client={queryClient}>
-        <RouterProvider router={router} />
-      </QueryClientProvider>,
-    )
-    expect(await screen.findByText('Page one: 3')).toBeInTheDocument()
-
-    const link = screen.getByRole('link', { name: 'Page two' })
-    fireEvent.mouseOver(link)
-    await waitFor(() => expect(pageTwoBeforeLoad).toHaveBeenCalledWith(true))
-    fireEvent.click(link)
-
-    await waitFor(() => expect(querySignal).toBeDefined())
-    expect(screen.getByTestId('page-one')).toBeInTheDocument()
-    expect(screen.getByTestId('page-two-pending')).toBeInTheDocument()
-    expect(querySignal?.aborted).toBe(false)
-    queryGate.resolve(10)
-
-    expect(await screen.findByText('Page two: 10')).toBeInTheDocument()
-    expect(routeError).not.toHaveBeenCalled()
-    expect(screen.queryByTestId('page-one')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('page-two-pending')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('page-two-error')).not.toBeInTheDocument()
-    expect(router.state.location.pathname).toBe('/page-two')
-  } finally {
+  onTestFinished(() => {
     queryGate.resolve(10)
     queryClient.clear()
-  }
+  })
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+  expect(await screen.findByText('Page one: 3')).toBeInTheDocument()
+
+  const link = screen.getByRole('link', { name: 'Page two' })
+  fireEvent.mouseOver(link)
+  await waitFor(() => expect(pageTwoBeforeLoad).toHaveBeenCalledWith(true))
+  fireEvent.click(link)
+
+  await waitFor(() => expect(querySignal).toBeDefined())
+  expect(screen.getByTestId('page-one')).toBeInTheDocument()
+  expect(screen.getByTestId('page-two-pending')).toBeInTheDocument()
+  expect(querySignal?.aborted).toBe(false)
+  queryGate.resolve(10)
+
+  expect(await screen.findByText('Page two: 10')).toBeInTheDocument()
+  expect(routeError).not.toHaveBeenCalled()
+  expect(screen.queryByTestId('page-one')).not.toBeInTheDocument()
+  expect(screen.queryByTestId('page-two-pending')).not.toBeInTheDocument()
+  expect(screen.queryByTestId('page-two-error')).not.toBeInTheDocument()
+  expect(router.state.location.pathname).toBe('/page-two')
 })

--- a/packages/react-router/tests/issue-4759-pending-frame.test.tsx
+++ b/packages/react-router/tests/issue-4759-pending-frame.test.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  onTestFinished,
+  test,
+  vi,
+} from 'vitest'
 import { act, cleanup, render, screen } from '@testing-library/react'
 import {
   RouterProvider,
@@ -59,34 +67,34 @@ describe('issue #4759: pendingMs 0 publishes pending DOM before a macrotask', ()
       }
     })
 
-    try {
-      render(
-        <main>
-          <RouterProvider
-            router={router}
-            defaultPendingMs={0}
-            defaultPendingMinMs={0}
-            defaultPendingComponent={() => (
-              <div data-testid="pending">pending...</div>
-            )}
-          />
-        </main>,
-      )
-
-      // Fake timers keep the first macrotask frozen. An implementation that
-      // publishes pending state with setTimeout cannot satisfy this assertion.
-      await act(async () => {})
-      expect(screen.getByTestId('pending')).toBeInTheDocument()
-
-      // Sanity: the load still completes normally afterwards.
-      resolveLoader('done')
-      await act(() => rendered)
-      expect(screen.getByTestId('loaded')).toBeInTheDocument()
-      expect(screen.queryByTestId('pending')).not.toBeInTheDocument()
-    } finally {
+    onTestFinished(() => {
       unsubscribe()
       resolveLoader('done')
       vi.useRealTimers()
-    }
+    })
+
+    render(
+      <main>
+        <RouterProvider
+          router={router}
+          defaultPendingMs={0}
+          defaultPendingMinMs={0}
+          defaultPendingComponent={() => (
+            <div data-testid="pending">pending...</div>
+          )}
+        />
+      </main>,
+    )
+
+    // Fake timers keep the first macrotask frozen. An implementation that
+    // publishes pending state with setTimeout cannot satisfy this assertion.
+    await act(async () => {})
+    expect(screen.getByTestId('pending')).toBeInTheDocument()
+
+    // Sanity: the load still completes normally afterwards.
+    resolveLoader('done')
+    await act(() => rendered)
+    expect(screen.getByTestId('loaded')).toBeInTheDocument()
+    expect(screen.queryByTestId('pending')).not.toBeInTheDocument()
   })
 })

--- a/packages/react-router/tests/issue-6371-search-default-normalization-abort.test.tsx
+++ b/packages/react-router/tests/issue-6371-search-default-normalization-abort.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, expect, test, vi } from 'vitest'
+import { afterEach, expect, onTestFinished, test, vi } from 'vitest'
 import { act, cleanup, render, screen } from '@testing-library/react'
 import {
   Outlet,
@@ -90,42 +90,42 @@ test('#6371: initial search defaults produce one live canonical loader', async (
     defaultPendingComponent: PendingLocation,
   })
 
-  try {
-    render(<RouterProvider router={router} />)
-
-    await act(async () => {
-      await canonicalLocation
-    })
-
-    expect(loader).toHaveBeenCalledTimes(1)
-    expect(loaderLocations).toEqual(['/about?page=1'])
-    expect(loaderSignals).toHaveLength(1)
-    expect(loaderSignals[0]?.aborted).toBe(false)
-
-    expect(
-      await screen.findByText('/about?page=1', {
-        selector: '[data-testid="pending-location"]',
-      }),
-    ).toBeInTheDocument()
-
-    await act(() => {
-      loaderGate.resolve('about data')
-    })
-
-    expect(await screen.findByTestId('about-data')).toHaveTextContent(
-      'about data',
-    )
-    expect(loader).toHaveBeenCalledTimes(1)
-    expect(loaderSignals[0]?.aborted).toBe(false)
-    expect(errorComponentRendered).not.toHaveBeenCalled()
-    expect(screen.queryByTestId('about-error')).not.toBeInTheDocument()
-  } finally {
+  onTestFinished(async () => {
     unsubscribeHistory()
     await act(() => {
       canonicalLocation.resolve()
       loaderGate.resolve('about data')
     })
-  }
+  })
+
+  render(<RouterProvider router={router} />)
+
+  await act(async () => {
+    await canonicalLocation
+  })
+
+  expect(loader).toHaveBeenCalledTimes(1)
+  expect(loaderLocations).toEqual(['/about?page=1'])
+  expect(loaderSignals).toHaveLength(1)
+  expect(loaderSignals[0]?.aborted).toBe(false)
+
+  expect(
+    await screen.findByText('/about?page=1', {
+      selector: '[data-testid="pending-location"]',
+    }),
+  ).toBeInTheDocument()
+
+  await act(() => {
+    loaderGate.resolve('about data')
+  })
+
+  expect(await screen.findByTestId('about-data')).toHaveTextContent(
+    'about data',
+  )
+  expect(loader).toHaveBeenCalledTimes(1)
+  expect(loaderSignals[0]?.aborted).toBe(false)
+  expect(errorComponentRendered).not.toHaveBeenCalled()
+  expect(screen.queryByTestId('about-error')).not.toBeInTheDocument()
 })
 
 test('initial canonicalization bypasses existing navigation blockers', async () => {
@@ -155,17 +155,15 @@ test('initial canonicalization bypasses existing navigation blockers', async () 
     history,
   })
 
-  try {
-    render(<RouterProvider router={router} />)
+  onTestFinished(unblock)
 
-    expect(await screen.findByText('/about?page=1')).toBeInTheDocument()
-    expect(loader).toHaveBeenCalledTimes(1)
-    expect(history.location.href).toBe('/about?page=1')
-    expect(router.latestLocation.href).toBe('/about?page=1')
-    expect(router.state.location.href).toBe('/about?page=1')
-    expect(router.state.resolvedLocation?.href).toBe('/about?page=1')
-    expect(blockerFn).not.toHaveBeenCalled()
-  } finally {
-    unblock()
-  }
+  render(<RouterProvider router={router} />)
+
+  expect(await screen.findByText('/about?page=1')).toBeInTheDocument()
+  expect(loader).toHaveBeenCalledTimes(1)
+  expect(history.location.href).toBe('/about?page=1')
+  expect(router.latestLocation.href).toBe('/about?page=1')
+  expect(router.state.location.href).toBe('/about?page=1')
+  expect(router.state.resolvedLocation?.href).toBe('/about?page=1')
+  expect(blockerFn).not.toHaveBeenCalled()
 })

--- a/packages/react-router/tests/preloaded-mount-resolution.test.tsx
+++ b/packages/react-router/tests/preloaded-mount-resolution.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, expect, onTestFinished, test, vi } from 'vitest'
 import * as React from 'react'
 import { createRoot } from 'react-dom/client'
 import { createMemoryHistory } from '@tanstack/history'
@@ -81,37 +81,37 @@ test('mounting after a settled load still resolves status and fires onRendered',
   const reactRoot = createRoot(container)
   let renderedTimeout: ReturnType<typeof setTimeout> | undefined
 
-  try {
-    // Load fully settles before the provider mounts — the exact shape of the
-    // memory benchmark's mount/unmount cycle.
-    await router.load()
-    expect(router.state.status).toBe('idle')
-    expect(router.state.resolvedLocation?.pathname).toBe('/')
-    expect(onLoad).toHaveBeenCalledTimes(1)
-    expect(onResolved).toHaveBeenCalledTimes(1)
-    expect(onRendered).not.toHaveBeenCalled()
-
-    reactRoot.render(<RouterProvider router={router} />)
-    await Promise.race([
-      rendered,
-      new Promise<never>((_, reject) => {
-        renderedTimeout = setTimeout(() => {
-          reject(new Error('Timed out waiting for onRendered'))
-        }, 2000)
-      }),
-    ])
-
-    expect(container.querySelector('[data-testid="home"]')).not.toBeNull()
-    expect(onRendered).toHaveBeenCalledTimes(1)
-    expect(lifecycle).toEqual(['layout', 'rendered'])
-    expect(router.state.status).toBe('idle')
-    expect(router.state.resolvedLocation?.pathname).toBe('/')
-  } finally {
+  onTestFinished(() => {
     clearTimeout(renderedTimeout)
     unsubscribe()
     reactRoot.unmount()
     container.remove()
-  }
+  })
+
+  // Load fully settles before the provider mounts — the exact shape of the
+  // memory benchmark's mount/unmount cycle.
+  await router.load()
+  expect(router.state.status).toBe('idle')
+  expect(router.state.resolvedLocation?.pathname).toBe('/')
+  expect(onLoad).toHaveBeenCalledTimes(1)
+  expect(onResolved).toHaveBeenCalledTimes(1)
+  expect(onRendered).not.toHaveBeenCalled()
+
+  reactRoot.render(<RouterProvider router={router} />)
+  await Promise.race([
+    rendered,
+    new Promise<never>((_, reject) => {
+      renderedTimeout = setTimeout(() => {
+        reject(new Error('Timed out waiting for onRendered'))
+      }, 2000)
+    }),
+  ])
+
+  expect(container.querySelector('[data-testid="home"]')).not.toBeNull()
+  expect(onRendered).toHaveBeenCalledTimes(1)
+  expect(lifecycle).toEqual(['layout', 'rendered'])
+  expect(router.state.status).toBe('idle')
+  expect(router.state.resolvedLocation?.pathname).toBe('/')
 })
 
 test('mounting during a load keeps the existing generation', async () => {
@@ -136,19 +136,20 @@ test('mounting during a load keeps the existing generation', async () => {
   const container = document.createElement('div')
   document.body.appendChild(container)
   const reactRoot = createRoot(container)
-  try {
-    reactRoot.render(<RouterProvider router={router} />)
-    await vi.waitFor(() => expect(beforeLoad).toHaveBeenCalledOnce())
-    gate.resolve()
-    await load
-    await vi.waitFor(() => {
-      expect(container.querySelector('[data-testid="home"]')).not.toBeNull()
-    })
 
-    expect(beforeLoad).toHaveBeenCalledOnce()
-    expect(loader).toHaveBeenCalledOnce()
-  } finally {
+  onTestFinished(() => {
     reactRoot.unmount()
     container.remove()
-  }
+  })
+
+  reactRoot.render(<RouterProvider router={router} />)
+  await vi.waitFor(() => expect(beforeLoad).toHaveBeenCalledOnce())
+  gate.resolve()
+  await load
+  await vi.waitFor(() => {
+    expect(container.querySelector('[data-testid="home"]')).not.toBeNull()
+  })
+
+  expect(beforeLoad).toHaveBeenCalledOnce()
+  expect(loader).toHaveBeenCalledOnce()
 })

--- a/packages/react-router/tests/renderRouterToStream.test.tsx
+++ b/packages/react-router/tests/renderRouterToStream.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, describe, expect, onTestFinished, test, vi } from 'vitest'
 import { attachRouterServerSsrUtils } from '@tanstack/router-core/ssr/server'
 import { createMemoryHistory, createRootRoute, createRouter } from '../src'
 
@@ -61,24 +61,24 @@ describe('renderRouterToStream - pipeable sync errors', () => {
 
     const router = await buildRouter()
     const controller = new AbortController()
-    try {
-      const response = unwrapResponse(
-        await renderRouterToStream({
-          request: new Request('http://localhost/', {
-            signal: controller.signal,
-          }),
-          router,
-          responseHeaders: new Headers(),
-          children: null,
-        }),
-      )
-
-      expect(response.body).not.toBeNull()
-      controller.abort(new Error('request-gone'))
-      await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce())
-    } finally {
+    onTestFinished(() => {
       router.serverSsr?.cleanup()
-    }
+    })
+
+    const response = unwrapResponse(
+      await renderRouterToStream({
+        request: new Request('http://localhost/', {
+          signal: controller.signal,
+        }),
+        router,
+        responseHeaders: new Headers(),
+        children: null,
+      }),
+    )
+
+    expect(response.body).not.toBeNull()
+    controller.abort(new Error('request-gone'))
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce())
   })
 
   test('sync onError before pipeable is assigned still aborts pipeable', async () => {

--- a/packages/router-core/tests/hmr-refresh-lifecycle.test.ts
+++ b/packages/router-core/tests/hmr-refresh-lifecycle.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  onTestFinished,
+  test,
+  vi,
+} from 'vitest'
 import { createMemoryHistory } from '@tanstack/history'
 import {
   BaseRootRoute,
@@ -106,12 +114,10 @@ describe('HMR route refresh', () => {
         reentrantLoad = router.load({ sync: true })
       }
     })
-    try {
-      await router._refreshRoute!()
-      await reentrantLoad
-    } finally {
-      unsubscribe()
-    }
+    onTestFinished(unsubscribe)
+
+    await router._refreshRoute!()
+    await reentrantLoad
 
     expect(loader).toHaveBeenCalledTimes(2)
     expect(router.state.matches.at(-1)?.loaderData).toBe(2)
@@ -451,11 +457,9 @@ describe('HMR route refresh', () => {
     const unsubscribe = router.subscribe('onBeforeLoad', () => {
       void router.preloadRoute({ to: '/page' })
     })
-    try {
-      await router._refreshRoute!()
-    } finally {
-      unsubscribe()
-    }
+    onTestFinished(unsubscribe)
+
+    await router._refreshRoute!()
 
     expect(router.state.matches.at(-1)?.loaderData).toBe(2)
   })

--- a/packages/router-core/tests/hydration-currentness.test.ts
+++ b/packages/router-core/tests/hydration-currentness.test.ts
@@ -1,5 +1,13 @@
 import { runInNewContext } from 'node:vm'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  onTestFinished,
+  test,
+  vi,
+} from 'vitest'
 import { createMemoryHistory } from '@tanstack/history'
 import {
   BaseRootRoute,
@@ -305,17 +313,17 @@ describe('hydration asset currentness', () => {
     )
 
     const hydration = hydrate(router)
-    try {
-      await hydrateStarted
-      await router.navigate({ to: '/new' })
-      await expect(hydration).resolves.toBeUndefined()
-
-      expect(router.state.resolvedLocation?.pathname).toBe('/new')
-      expect(router.state.matches.at(-1)?.routeId).toBe(newRoute.id)
-    } finally {
+    onTestFinished(async () => {
       hydrateGate.resolve()
       await hydration
-    }
+    })
+
+    await hydrateStarted
+    await router.navigate({ to: '/new' })
+    await expect(hydration).resolves.toBeUndefined()
+
+    expect(router.state.resolvedLocation?.pathname).toBe('/new')
+    expect(router.state.matches.at(-1)?.routeId).toBe(newRoute.id)
   })
 
   test('does not publish an old hydration lane after a newer navigation commits', async () => {
@@ -354,22 +362,22 @@ describe('hydration asset currentness', () => {
     )
 
     const hydration = hydrate(router)
-    try {
-      await oldChunkStarted
-      await router.navigate({ to: '/new' })
-
-      expect(router.state.resolvedLocation?.pathname).toBe('/new')
-      expect(router.state.matches.at(-1)?.routeId).toBe(newRoute.id)
-
-      await hydration
-
-      expect(router.state.location.pathname).toBe('/new')
-      expect(router.state.resolvedLocation?.pathname).toBe('/new')
-      expect(router.state.matches.at(-1)?.routeId).toBe(newRoute.id)
-    } finally {
+    onTestFinished(async () => {
       oldChunkGate.resolve()
       await hydration
-    }
+    })
+
+    await oldChunkStarted
+    await router.navigate({ to: '/new' })
+
+    expect(router.state.resolvedLocation?.pathname).toBe('/new')
+    expect(router.state.matches.at(-1)?.routeId).toBe(newRoute.id)
+
+    await hydration
+
+    expect(router.state.location.pathname).toBe('/new')
+    expect(router.state.resolvedLocation?.pathname).toBe('/new')
+    expect(router.state.matches.at(-1)?.routeId).toBe(newRoute.id)
   })
 
   test('an aborted hydration handoff falls back to a fresh client continuation', async () => {
@@ -413,11 +421,9 @@ describe('hydration asset currentness', () => {
     const unsubscribe = router.subscribe('onBeforeLoad', () => {
       hydrationController!.abort()
     })
-    try {
-      await router.load()
-    } finally {
-      unsubscribe()
-    }
+    onTestFinished(unsubscribe)
+
+    await router.load()
 
     expect(router.state.resolvedLocation?.pathname).toBe('/child')
     expect(router.state.matches.at(-1)).toMatchObject({

--- a/packages/router-core/tests/issue-4078-loader-notfound-root-boundary.test.ts
+++ b/packages/router-core/tests/issue-4078-loader-notfound-root-boundary.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, onTestFinished } from 'vitest'
 import { createMemoryHistory } from '@tanstack/history'
 import {
   BaseRootRoute,
@@ -72,12 +72,12 @@ describe('#4078 / #2255 existing Core root-boundary attribution', () => {
     await router.load()
 
     const navigation = router.navigate({ to: '/about' })
-    await loaderStarted
-    try {
-      expect(loaderResponse.status).toBe('pending')
-    } finally {
+    onTestFinished(() => {
       loaderResponse.resolve()
-    }
+    })
+    await loaderStarted
+    expect(loaderResponse.status).toBe('pending')
+    loaderResponse.resolve()
 
     await navigation
 

--- a/packages/router-core/tests/issue-5427-hydration-root-global-not-found.test.ts
+++ b/packages/router-core/tests/issue-5427-hydration-root-global-not-found.test.ts
@@ -1,5 +1,5 @@
 import { createMemoryHistory } from '@tanstack/history'
-import { describe, expect, test, vi } from 'vitest'
+import { describe, expect, onTestFinished, test, vi } from 'vitest'
 import { BaseRootRoute, BaseRoute } from '../src'
 import { hydrate } from '../src/ssr/client'
 import { dehydrateMatch } from '../src/ssr/ssr-server'
@@ -81,23 +81,22 @@ describe('issue #5427: root-only global not-found hydration', () => {
     }
     const previousBootstrap = window.$_TSR
     window.$_TSR = bootstrap
-
-    try {
-      const { rootRoute, router } = createRouter('/missing', false)
-
-      await hydrate(router)
-      await vi.waitFor(() => {
-        expect(router.state.resolvedLocation?.pathname).toBe('/missing')
-      })
-
-      expect(router.state.matches).toHaveLength(1)
-      expect(router.state.matches[0]).toMatchObject({
-        routeId: rootRoute.id,
-        _notFound: true,
-      })
-    } finally {
+    onTestFinished(() => {
       window.$_TSR = previousBootstrap
-    }
+    })
+
+    const { rootRoute, router } = createRouter('/missing', false)
+
+    await hydrate(router)
+    await vi.waitFor(() => {
+      expect(router.state.resolvedLocation?.pathname).toBe('/missing')
+    })
+
+    expect(router.state.matches).toHaveLength(1)
+    expect(router.state.matches[0]).toMatchObject({
+      routeId: rootRoute.id,
+      _notFound: true,
+    })
   })
 
   test('resolves a fuzzy client URL capped by an ancestor layout boundary', async () => {
@@ -119,23 +118,19 @@ describe('issue #5427: root-only global not-found hydration', () => {
     }
     const previousBootstrap = window.$_TSR
     window.$_TSR = bootstrap
-
-    try {
-      const { layoutRoute, router } = createLayoutRouter(
-        '/agents/missing',
-        false,
-      )
-
-      await hydrate(router)
-
-      expect(router.state.resolvedLocation?.pathname).toBe('/agents/missing')
-      expect(router.state.matches).toHaveLength(3)
-      expect(router.state.matches[1]).toMatchObject({
-        routeId: layoutRoute.id,
-        _notFound: true,
-      })
-    } finally {
+    onTestFinished(() => {
       window.$_TSR = previousBootstrap
-    }
+    })
+
+    const { layoutRoute, router } = createLayoutRouter('/agents/missing', false)
+
+    await hydrate(router)
+
+    expect(router.state.resolvedLocation?.pathname).toBe('/agents/missing')
+    expect(router.state.matches).toHaveLength(3)
+    expect(router.state.matches[1]).toMatchObject({
+      routeId: layoutRoute.id,
+      _notFound: true,
+    })
   })
 })

--- a/packages/router-core/tests/issue-6221-head-waits-for-loader.test.ts
+++ b/packages/router-core/tests/issue-6221-head-waits-for-loader.test.ts
@@ -1,5 +1,5 @@
 import { createMemoryHistory } from '@tanstack/history'
-import { describe, expect, test, vi } from 'vitest'
+import { describe, expect, onTestFinished, test, vi } from 'vitest'
 import {
   BaseRootRoute,
   BaseRoute,
@@ -132,31 +132,31 @@ describe('issue #6221: head does not run before loader data is ready', () => {
 
     const getQuoteMatch = () =>
       router.state.matches.find((match) => match.routeId === quoteRoute.id)
-    try {
-      await router.load()
-
-      await router.navigate({ to: '/quote' })
-      expect(getQuoteMatch()?.loaderData).toEqual({ author: 'author-1' })
-      expect(getQuoteMatch()?.meta).toEqual([{ title: 'Quote by author-1' }])
-
-      await router.navigate({ to: '/' })
-      const revisit = router.navigate({ to: '/quote' })
-      await secondLoaderStarted
-      await revisit
-
-      // The cached generation remains internally consistent while its stale
-      // loader is pending in the background.
-      expect(secondLoaderResponse.status).toBe('pending')
-      expect(getQuoteMatch()?.loaderData).toEqual({ author: 'author-1' })
-      expect(getQuoteMatch()?.meta).toEqual([{ title: 'Quote by author-1' }])
-
+    onTestFinished(() => {
       secondLoaderResponse.resolve({ author: 'author-2' })
-      await vi.waitFor(() => {
-        expect(getQuoteMatch()?.loaderData).toEqual({ author: 'author-2' })
-        expect(getQuoteMatch()?.meta).toEqual([{ title: 'Quote by author-2' }])
-      })
-    } finally {
-      secondLoaderResponse.resolve({ author: 'author-2' })
-    }
+    })
+
+    await router.load()
+
+    await router.navigate({ to: '/quote' })
+    expect(getQuoteMatch()?.loaderData).toEqual({ author: 'author-1' })
+    expect(getQuoteMatch()?.meta).toEqual([{ title: 'Quote by author-1' }])
+
+    await router.navigate({ to: '/' })
+    const revisit = router.navigate({ to: '/quote' })
+    await secondLoaderStarted
+    await revisit
+
+    // The cached generation remains internally consistent while its stale
+    // loader is pending in the background.
+    expect(secondLoaderResponse.status).toBe('pending')
+    expect(getQuoteMatch()?.loaderData).toEqual({ author: 'author-1' })
+    expect(getQuoteMatch()?.meta).toEqual([{ title: 'Quote by author-1' }])
+
+    secondLoaderResponse.resolve({ author: 'author-2' })
+    await vi.waitFor(() => {
+      expect(getQuoteMatch()?.loaderData).toEqual({ author: 'author-2' })
+      expect(getQuoteMatch()?.meta).toEqual([{ title: 'Quote by author-2' }])
+    })
   })
 })

--- a/packages/router-core/tests/issue-7602-parent-beforeload-context-child-loader.test.ts
+++ b/packages/router-core/tests/issue-7602-parent-beforeload-context-child-loader.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, vi } from 'vitest'
+import { expect, onTestFinished, test, vi } from 'vitest'
 import { createMemoryHistory } from '@tanstack/history'
 import { BaseRootRoute, BaseRoute, createControlledPromise } from '../src'
 import { createTestRouter } from './routerTestUtils'
@@ -57,53 +57,52 @@ test('#7602: browser Back republishes a cached child with fresh parent beforeLoa
   // RouterProvider's Transitioner installs this subscription in applications.
   // It is what turns a browser Back history event into a router load.
   const unsubscribe = router.history.subscribe(router.load)
-
-  try {
-    await router.load()
-    expect(router.state.location.pathname).toBe('/repro')
-    expect(getChildMatch()).toMatchObject({
-      routeId: reproIndexRoute.id,
-      status: 'success',
-      loaderData: { visit: 1 },
-      context: { number: 42, generation: 1 },
-    })
-    expect(loaderContexts).toEqual([{ number: 42, generation: 1 }])
-
-    await router.navigate({ to: '/' })
-    expect(router.state.location.pathname).toBe('/')
-    expect(router.state.isLoading).toBe(false)
-    expect(getChildMatch()).toBeUndefined()
-
-    router.history.back()
-    await vi.waitFor(() => expect(loaderContexts).toHaveLength(2))
-
-    // The cached success is visible while its stale loader reloads. It must
-    // never be published with the parent's context contribution missing.
-    expect(router.state.location.pathname).toBe('/repro')
-    expect(getChildMatch()).toMatchObject({
-      status: 'success',
-      loaderData: { visit: 1 },
-      context: { number: 42, generation: 2 },
-    })
-    expect(loaderContexts).toEqual([
-      { number: 42, generation: 1 },
-      { number: 42, generation: 2 },
-    ])
-
-    reloadGate.resolve()
-    await vi.waitFor(() =>
-      expect(getChildMatch()?.loaderData).toEqual({ visit: 2 }),
-    )
-    expect(router.state.location.pathname).toBe('/repro')
-    expect(router.state.isLoading).toBe(false)
-    expect(getChildMatch()?.context).toMatchObject({
-      number: 42,
-      generation: 2,
-    })
-    expect(beforeLoadRuns).toBe(2)
-    expect(loaderRuns).toBe(2)
-  } finally {
+  onTestFinished(() => {
     reloadGate.resolve()
     unsubscribe()
-  }
+  })
+
+  await router.load()
+  expect(router.state.location.pathname).toBe('/repro')
+  expect(getChildMatch()).toMatchObject({
+    routeId: reproIndexRoute.id,
+    status: 'success',
+    loaderData: { visit: 1 },
+    context: { number: 42, generation: 1 },
+  })
+  expect(loaderContexts).toEqual([{ number: 42, generation: 1 }])
+
+  await router.navigate({ to: '/' })
+  expect(router.state.location.pathname).toBe('/')
+  expect(router.state.isLoading).toBe(false)
+  expect(getChildMatch()).toBeUndefined()
+
+  router.history.back()
+  await vi.waitFor(() => expect(loaderContexts).toHaveLength(2))
+
+  // The cached success is visible while its stale loader reloads. It must
+  // never be published with the parent's context contribution missing.
+  expect(router.state.location.pathname).toBe('/repro')
+  expect(getChildMatch()).toMatchObject({
+    status: 'success',
+    loaderData: { visit: 1 },
+    context: { number: 42, generation: 2 },
+  })
+  expect(loaderContexts).toEqual([
+    { number: 42, generation: 1 },
+    { number: 42, generation: 2 },
+  ])
+
+  reloadGate.resolve()
+  await vi.waitFor(() =>
+    expect(getChildMatch()?.loaderData).toEqual({ visit: 2 }),
+  )
+  expect(router.state.location.pathname).toBe('/repro')
+  expect(router.state.isLoading).toBe(false)
+  expect(getChildMatch()?.context).toMatchObject({
+    number: 42,
+    generation: 2,
+  })
+  expect(beforeLoadRuns).toBe(2)
+  expect(loaderRuns).toBe(2)
 })

--- a/packages/router-core/tests/issue-7759-in-flight-preload-eviction.test.ts
+++ b/packages/router-core/tests/issue-7759-in-flight-preload-eviction.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, vi } from 'vitest'
+import { expect, onTestFinished, test, vi } from 'vitest'
 import { createMemoryHistory } from '@tanstack/history'
 import { BaseRootRoute, BaseRoute } from '../src'
 import { createTestRouter } from './routerTestUtils'
@@ -28,17 +28,16 @@ test('issue #7759: evicting an in-flight preload finishes without an internal er
     history: createMemoryHistory(),
   })
   const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
-
-  try {
-    const preload = router.preloadRoute({ to: '/target' })
-    await loaderStarted
-
-    router.clearCache()
-    resolveLoader('loaded')
-
-    await preload
-    expect(consoleError).not.toHaveBeenCalled()
-  } finally {
+  onTestFinished(() => {
     consoleError.mockRestore()
-  }
+  })
+
+  const preload = router.preloadRoute({ to: '/target' })
+  await loaderStarted
+
+  router.clearCache()
+  resolveLoader('loaded')
+
+  await preload
+  expect(consoleError).not.toHaveBeenCalled()
 })

--- a/packages/router-core/tests/public-hydration-contract.test.ts
+++ b/packages/router-core/tests/public-hydration-contract.test.ts
@@ -1,5 +1,13 @@
 import { runInNewContext } from 'node:vm'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  onTestFinished,
+  test,
+  vi,
+} from 'vitest'
 import { createBrowserHistory, createMemoryHistory } from '@tanstack/history'
 import {
   BaseRootRoute,
@@ -1036,26 +1044,25 @@ describe('public hydration contracts', () => {
         u: Date.now(),
       },
     ])
-
-    try {
-      await hydrate(router)
-      browserWindow.history.replaceState(
-        browserWindow.history.state,
-        '',
-        '/public-b',
-      )
-
-      await router.load()
-
-      expect(
-        beforeLoad.mock.calls.map(([options]) => options.location.publicHref),
-      ).toEqual(['/public-b'])
-      expect(loader).toHaveBeenCalledTimes(1)
-      expect(router.state.matches.at(-1)?.loaderData).toBe('/public-b')
-    } finally {
+    onTestFinished(() => {
       history.destroy()
       browserWindow.history.replaceState({}, '', '/')
-    }
+    })
+
+    await hydrate(router)
+    browserWindow.history.replaceState(
+      browserWindow.history.state,
+      '',
+      '/public-b',
+    )
+
+    await router.load()
+
+    expect(
+      beforeLoad.mock.calls.map(([options]) => options.location.publicHref),
+    ).toEqual(['/public-b'])
+    expect(loader).toHaveBeenCalledTimes(1)
+    expect(router.state.matches.at(-1)?.loaderData).toBe('/public-b')
   })
 
   test('keeps a hydration handoff when a provider initializes an empty context', async () => {

--- a/packages/router-core/tests/public-preload-lane-contract.test.ts
+++ b/packages/router-core/tests/public-preload-lane-contract.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, describe, expect, onTestFinished, test, vi } from 'vitest'
 import { createMemoryHistory } from '@tanstack/history'
 import {
   BaseRootRoute,
@@ -202,33 +202,7 @@ describe('public preload lane contracts', () => {
 
     let preload: Promise<unknown> | undefined
     let navigation: Promise<unknown> | undefined
-    try {
-      await router.load()
-      preload = router.preloadRoute({ to: '/shared' })
-      await vi.waitFor(() => expect(sharedBeforeLoad).toHaveBeenCalledOnce())
-
-      navigation = router.navigate({
-        to: '/hop/$hop',
-        params: { hop: '0' },
-      } as any)
-      await vi.waitFor(() => expect(sharedBeforeLoad).toHaveBeenCalledTimes(2))
-
-      redirectGate.resolve()
-      await Promise.all([preload, navigation])
-
-      expect(
-        sharedBeforeLoad.mock.calls.map(([context]) => context.preload),
-      ).toEqual([true, false])
-      expect(router.state.location.pathname).toBe('/shared')
-      expect(
-        router.state.matches.find((match) => match.status !== 'success'),
-      ).toMatchObject({
-        routeId: rootRoute.id,
-        status: 'error',
-        error: expect.objectContaining({ message: 'Too many redirects' }),
-      })
-      expect(router.state.status).toBe('idle')
-    } finally {
+    onTestFinished(async () => {
       redirectGate.resolve()
       const activeWork: Array<Promise<unknown>> = []
       if (preload) {
@@ -238,7 +212,33 @@ describe('public preload lane contracts', () => {
         activeWork.push(navigation)
       }
       await Promise.allSettled(activeWork)
-    }
+    })
+
+    await router.load()
+    preload = router.preloadRoute({ to: '/shared' })
+    await vi.waitFor(() => expect(sharedBeforeLoad).toHaveBeenCalledOnce())
+
+    navigation = router.navigate({
+      to: '/hop/$hop',
+      params: { hop: '0' },
+    } as any)
+    await vi.waitFor(() => expect(sharedBeforeLoad).toHaveBeenCalledTimes(2))
+
+    redirectGate.resolve()
+    await Promise.all([preload, navigation])
+
+    expect(
+      sharedBeforeLoad.mock.calls.map(([context]) => context.preload),
+    ).toEqual([true, false])
+    expect(router.state.location.pathname).toBe('/shared')
+    expect(
+      router.state.matches.find((match) => match.status !== 'success'),
+    ).toMatchObject({
+      routeId: rootRoute.id,
+      status: 'error',
+      error: expect.objectContaining({ message: 'Too many redirects' }),
+    })
+    expect(router.state.status).toBe('idle')
   })
 
   test.each([

--- a/packages/router-core/tests/server-chunk-failure-lifecycle.test.ts
+++ b/packages/router-core/tests/server-chunk-failure-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, onTestFinished, test } from 'vitest'
 import { createMemoryHistory } from '@tanstack/history'
 import {
   BaseRootRoute,
@@ -183,26 +183,25 @@ describe('server route chunk failure lifecycle', () => {
       unhandled.push(error)
     }
     process.on('unhandledRejection', onUnhandled)
-
-    try {
-      const responsePromise = loadServerResponse(
-        router,
-        '/child',
-        controller.signal,
-      )
-      await Promise.all([rootChunkStarted, childChunkStarted])
-
-      rootChunkGate.reject(rootError)
-      await expect(responsePromise).resolves.toMatchObject({ status: 500 })
-
-      controller.abort(abortError)
-      childChunkGate.resolve()
-      await new Promise<void>((resolve) => setTimeout(resolve, 0))
-
-      expect(unhandled).not.toContain(abortError)
-    } finally {
+    onTestFinished(() => {
       process.off('unhandledRejection', onUnhandled)
-    }
+    })
+
+    const responsePromise = loadServerResponse(
+      router,
+      '/child',
+      controller.signal,
+    )
+    await Promise.all([rootChunkStarted, childChunkStarted])
+
+    rootChunkGate.reject(rootError)
+    await expect(responsePromise).resolves.toMatchObject({ status: 500 })
+
+    controller.abort(abortError)
+    childChunkGate.resolve()
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+    expect(unhandled).not.toContain(abortError)
   })
 
   test('a required ancestor lazy chunk failure wins over a deeper loader notFound', async () => {

--- a/packages/router-core/tests/ssr-server-cleanup.test.ts
+++ b/packages/router-core/tests/ssr-server-cleanup.test.ts
@@ -1,5 +1,5 @@
 import { createMemoryHistory } from '@tanstack/history'
-import { afterEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, describe, expect, onTestFinished, test, vi } from 'vitest'
 import { BaseRootRoute, BaseRoute } from '../src'
 import { createRequestHandler } from '../src/ssr/createRequestHandler'
 import {
@@ -451,31 +451,32 @@ describe('serverSsr.cleanup', () => {
           signal: requestController.signal,
         }),
       })
-
-      try {
-        const response = handler(() => {
-          renderStarted.resolve()
-          return renderResult.promise
-        })
-
-        await renderStarted.promise
-        const cancellation = new Error('request disconnected')
-        requestController.abort(cancellation)
-        await expect(response).rejects.toBe(cancellation)
-
-        renderResult.resolve({
-          response: new Response('stream'),
-          serverSsrCleanup: 'stream',
-          dispose,
-        })
-        await vi.waitFor(() => {
-          expect(consoleError).toHaveBeenCalledWith(cleanupError)
-        })
-        expect(dispose).toHaveBeenCalledOnce()
-      } finally {
-        router.serverSsr?.cleanup()
+      onTestFinished(() => {
         consoleError.mockRestore()
-      }
+      })
+      onTestFinished(() => {
+        router.serverSsr?.cleanup()
+      })
+
+      const response = handler(() => {
+        renderStarted.resolve()
+        return renderResult.promise
+      })
+
+      await renderStarted.promise
+      const cancellation = new Error('request disconnected')
+      requestController.abort(cancellation)
+      await expect(response).rejects.toBe(cancellation)
+
+      renderResult.resolve({
+        response: new Response('stream'),
+        serverSsrCleanup: 'stream',
+        dispose,
+      })
+      await vi.waitFor(() => {
+        expect(consoleError).toHaveBeenCalledWith(cleanupError)
+      })
+      expect(dispose).toHaveBeenCalledOnce()
     },
   )
 

--- a/packages/router-plugin/tests/handle-route-update.test.ts
+++ b/packages/router-plugin/tests/handle-route-update.test.ts
@@ -8,7 +8,7 @@ import {
   createNonReactiveReadonlyStore,
   trimPathRight,
 } from '@tanstack/router-core'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, onTestFinished, vi } from 'vitest'
 import { Fragment, act, createElement } from 'react'
 import { createPortal } from 'react-dom'
 import { createRoot } from 'react-dom/client'
@@ -599,62 +599,56 @@ describe('handleRouteUpdate', () => {
     const reactRoot = createRoot(container)
     const previousActEnvironment = (globalThis as any).IS_REACT_ACT_ENVIRONMENT
     ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
-
-    try {
-      await act(async () => {
-        reactRoot.render(
-          createElement(RouterContextProvider, {
-            router,
-            children: createElement(
-              Fragment,
-              null,
-              createPortal(createElement(HeadContent), document.head),
-              createElement(Scripts),
-            ),
-          }),
-        )
-      })
-
-      expect(document.head.querySelector('title')?.textContent).toBe(
-        'hot title',
-      )
-      expect(
-        document.head.querySelector('script[src="/hot-head.js"]'),
-      ).not.toBeNull()
-      expect(
-        document.head.querySelector('script[src="/hot-body.js"]'),
-      ).not.toBeNull()
-
-      await act(async () => {
-        runHandleRouteUpdate(router, hotRoute.id, new BaseRoute({} as any))
-        await vi.waitFor(() => {
-          expect(router.state.matches[1]!.routeId).toBe(hotRoute.id)
-          expect(router.state.matches[1]!.meta).toBeUndefined()
-          expect(router.state.matches[1]!.headScripts).toBeUndefined()
-          expect(router.state.matches[1]!.scripts).toBeUndefined()
-        })
-      })
-
-      expect(document.head.querySelector('title')).toBeNull()
-      expect(
-        document.head.querySelector('script[src="/hot-head.js"]'),
-      ).toBeNull()
-      expect(
-        document.head.querySelector('script[src="/hot-body.js"]'),
-      ).toBeNull()
-    } finally {
-      try {
-        await act(async () => {
-          reactRoot.unmount()
-        })
-      } finally {
-        container.remove()
-        if (previousActEnvironment === undefined) {
-          delete (globalThis as any).IS_REACT_ACT_ENVIRONMENT
-        } else {
-          ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment
-        }
+    onTestFinished(() => {
+      if (previousActEnvironment === undefined) {
+        delete (globalThis as any).IS_REACT_ACT_ENVIRONMENT
+      } else {
+        ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment
       }
-    }
+    })
+    onTestFinished(() => {
+      container.remove()
+    })
+    onTestFinished(async () => {
+      await act(async () => {
+        reactRoot.unmount()
+      })
+    })
+
+    await act(async () => {
+      reactRoot.render(
+        createElement(RouterContextProvider, {
+          router,
+          children: createElement(
+            Fragment,
+            null,
+            createPortal(createElement(HeadContent), document.head),
+            createElement(Scripts),
+          ),
+        }),
+      )
+    })
+
+    expect(document.head.querySelector('title')?.textContent).toBe('hot title')
+    expect(
+      document.head.querySelector('script[src="/hot-head.js"]'),
+    ).not.toBeNull()
+    expect(
+      document.head.querySelector('script[src="/hot-body.js"]'),
+    ).not.toBeNull()
+
+    await act(async () => {
+      runHandleRouteUpdate(router, hotRoute.id, new BaseRoute({} as any))
+      await vi.waitFor(() => {
+        expect(router.state.matches[1]!.routeId).toBe(hotRoute.id)
+        expect(router.state.matches[1]!.meta).toBeUndefined()
+        expect(router.state.matches[1]!.headScripts).toBeUndefined()
+        expect(router.state.matches[1]!.scripts).toBeUndefined()
+      })
+    })
+
+    expect(document.head.querySelector('title')).toBeNull()
+    expect(document.head.querySelector('script[src="/hot-head.js"]')).toBeNull()
+    expect(document.head.querySelector('script[src="/hot-body.js"]')).toBeNull()
   })
 })

--- a/packages/solid-router/tests/createLazyRoute.test.tsx
+++ b/packages/solid-router/tests/createLazyRoute.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, onTestFinished, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library'
 import {
   Link,
@@ -128,38 +128,32 @@ it('replaces default pending UI when delayed lazy options provide pending UI', a
     defaultPendingMinMs: 0,
     defaultPendingComponent: () => <p role="status">Loading default</p>,
   })
-  let navigation: Promise<void> | undefined
+  render(() => <RouterProvider router={router} />)
+  expect(await screen.findByText('Index page')).toBeInTheDocument()
 
-  try {
-    render(() => <RouterProvider router={router} />)
-    expect(await screen.findByText('Index page')).toBeInTheDocument()
-
-    navigation = router.navigate({ to: '/page' })
-    expect(await screen.findByRole('status')).toHaveTextContent(
-      'Loading default',
-    )
-
-    lazyOptions.resolve(lazyPageOptions)
-    await vi.waitFor(() =>
-      expect(screen.getByRole('status')).toHaveTextContent('Loading lazy page'),
-    )
-    expect(preloadComponent).toHaveBeenCalledOnce()
-    expect(componentPreload.status).toBe('pending')
-    expect(screen.queryByText('Page')).not.toBeInTheDocument()
-
-    componentPreload.resolve()
-    loader.resolve()
-    await navigation
-
-    expect(await screen.findByText('Page')).toBeInTheDocument()
-  } finally {
+  const navigation = router.navigate({ to: '/page' })
+  onTestFinished(async () => {
     lazyOptions.resolve(lazyPageOptions)
     componentPreload.resolve()
     loader.resolve()
-    if (navigation) {
-      await Promise.allSettled([navigation])
-    }
-  }
+    await Promise.allSettled([navigation])
+  })
+
+  expect(await screen.findByRole('status')).toHaveTextContent('Loading default')
+
+  lazyOptions.resolve(lazyPageOptions)
+  await vi.waitFor(() =>
+    expect(screen.getByRole('status')).toHaveTextContent('Loading lazy page'),
+  )
+  expect(preloadComponent).toHaveBeenCalledOnce()
+  expect(componentPreload.status).toBe('pending')
+  expect(screen.queryByText('Page')).not.toBeInTheDocument()
+
+  componentPreload.resolve()
+  loader.resolve()
+  await navigation
+
+  expect(await screen.findByText('Page')).toBeInTheDocument()
 })
 
 it('renders an eager loader error with a delayed lazy errorComponent', async () => {

--- a/packages/solid-router/tests/errorComponent.test.tsx
+++ b/packages/solid-router/tests/errorComponent.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, describe, expect, onTestFinished, test, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library'
 import { createControlledPromise } from '@tanstack/router-core'
 
@@ -236,30 +236,27 @@ test('ancestor route errorComponent resets when a background child generation re
   vi.spyOn(console, 'warn').mockImplementation(() => {})
   vi.spyOn(console, 'error').mockImplementation(() => {})
 
-  let invalidation: Promise<void> | undefined
-  try {
-    render(() => <RouterProvider router={router} />)
-    expect(
-      await screen.findByText('Ancestor error: stale child render failed'),
-    ).toBeInTheDocument()
+  render(() => <RouterProvider router={router} />)
+  expect(
+    await screen.findByText('Ancestor error: stale child render failed'),
+  ).toBeInTheDocument()
 
-    invalidation = router.invalidate({
-      filter: (match) => match.routeId === childRoute.id,
-    })
-    await vi.waitFor(() => expect(loaderCalls).toBe(2))
-    expect(
-      screen.getByText('Ancestor error: stale child render failed'),
-    ).toBeInTheDocument()
+  const invalidation = router.invalidate({
+    filter: (match) => match.routeId === childRoute.id,
+  })
+  onTestFinished(async () => {
     refresh.resolve(2)
-    await invalidation
+    await Promise.allSettled([invalidation])
+  })
 
-    expect(
-      await screen.findByText('Recovered child revision 2'),
-    ).toBeInTheDocument()
-  } finally {
-    refresh.resolve(2)
-    if (invalidation) {
-      await Promise.allSettled([invalidation])
-    }
-  }
+  await vi.waitFor(() => expect(loaderCalls).toBe(2))
+  expect(
+    screen.getByText('Ancestor error: stale child render failed'),
+  ).toBeInTheDocument()
+  refresh.resolve(2)
+  await invalidation
+
+  expect(
+    await screen.findByText('Recovered child revision 2'),
+  ).toBeInTheDocument()
 })

--- a/packages/solid-router/tests/transitioner-listener-errors.test.tsx
+++ b/packages/solid-router/tests/transitioner-listener-errors.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen } from '@solidjs/testing-library'
-import { afterEach, expect, test } from 'vitest'
+import { afterEach, expect, onTestFinished, test } from 'vitest'
 import {
   Outlet,
   RouterProvider,
@@ -56,26 +56,25 @@ test('a throwing load-event listener cannot interrupt route hooks or later navig
       }
     }),
   ]
-
-  try {
-    await router.navigate({ to: '/first' })
-    expect(await screen.findByText('First route')).toBeInTheDocument()
-    expect(screen.queryByText('Index route')).not.toBeInTheDocument()
-    expect(lifecycle).toEqual(['enter:/first', 'throw:/first', 'load:/first'])
-
-    await router.navigate({ to: '/second' })
-    expect(await screen.findByText('Second route')).toBeInTheDocument()
-    expect(screen.queryByText('First route')).not.toBeInTheDocument()
-    expect(lifecycle).toEqual([
-      'enter:/first',
-      'throw:/first',
-      'load:/first',
-      'enter:/second',
-      'load:/second',
-    ])
-  } finally {
+  onTestFinished(() => {
     for (const unsubscribe of unsubscribers) {
       unsubscribe()
     }
-  }
+  })
+
+  await router.navigate({ to: '/first' })
+  expect(await screen.findByText('First route')).toBeInTheDocument()
+  expect(screen.queryByText('Index route')).not.toBeInTheDocument()
+  expect(lifecycle).toEqual(['enter:/first', 'throw:/first', 'load:/first'])
+
+  await router.navigate({ to: '/second' })
+  expect(await screen.findByText('Second route')).toBeInTheDocument()
+  expect(screen.queryByText('First route')).not.toBeInTheDocument()
+  expect(lifecycle).toEqual([
+    'enter:/first',
+    'throw:/first',
+    'load:/first',
+    'enter:/second',
+    'load:/second',
+  ])
 })

--- a/packages/solid-router/tests/transitioner-render-ack.test.tsx
+++ b/packages/solid-router/tests/transitioner-render-ack.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen, waitFor } from '@solidjs/testing-library'
-import { afterEach, expect, test } from 'vitest'
+import { afterEach, expect, onTestFinished, test } from 'vitest'
 import {
   Outlet,
   RouterProvider,
@@ -62,38 +62,37 @@ test('onResolved precedes onRendered and both observe the committed destination 
       })
     }),
   ]
-
-  try {
-    const navigation = router.navigate({ to: '/next' })
-
-    expect(screen.queryByText('Next')).toBeNull()
-    expect(screen.getByText('First')).toBeInTheDocument()
-    expect(lifecycle).toEqual([])
-
-    nextLoader.resolve()
-    await navigation
-    await waitFor(() =>
-      expect(lifecycle).toEqual([
-        {
-          event: 'onResolved',
-          pathname: '/next',
-          destination: true,
-          outgoing: false,
-        },
-        {
-          event: 'onRendered',
-          pathname: '/next',
-          destination: true,
-          outgoing: false,
-        },
-      ]),
-    )
-  } finally {
+  onTestFinished(() => {
     nextLoader.resolve()
     for (const unsubscribe of unsubscribers) {
       unsubscribe()
     }
-  }
+  })
+
+  const navigation = router.navigate({ to: '/next' })
+
+  expect(screen.queryByText('Next')).toBeNull()
+  expect(screen.getByText('First')).toBeInTheDocument()
+  expect(lifecycle).toEqual([])
+
+  nextLoader.resolve()
+  await navigation
+  await waitFor(() =>
+    expect(lifecycle).toEqual([
+      {
+        event: 'onResolved',
+        pathname: '/next',
+        destination: true,
+        outgoing: false,
+      },
+      {
+        event: 'onRendered',
+        pathname: '/next',
+        destination: true,
+        outgoing: false,
+      },
+    ]),
+  )
 })
 
 test('onRendered describes each committed navigation from the previously rendered location', async () => {
@@ -153,60 +152,57 @@ test('onRendered describes each committed navigation from the previously rendere
           : undefined,
     })
   })
+  onTestFinished(unsubscribe)
 
-  try {
-    await router.navigate({ to: '/next' })
-    expect(await screen.findByText('Next')).toBeInTheDocument()
-    await waitFor(() =>
-      expect(renderedChanges).toEqual([
-        {
-          fromPathname: '/',
-          toPathname: '/next',
-          fromHref: '/',
-          toHref: '/next',
-          pathChanged: true,
-          hrefChanged: true,
-          fromSameHrefState: false,
-          toSameHrefState: false,
-          renderedRoute: 'Next',
-        },
-      ]),
-    )
+  await router.navigate({ to: '/next' })
+  expect(await screen.findByText('Next')).toBeInTheDocument()
+  await waitFor(() =>
+    expect(renderedChanges).toEqual([
+      {
+        fromPathname: '/',
+        toPathname: '/next',
+        fromHref: '/',
+        toHref: '/next',
+        pathChanged: true,
+        hrefChanged: true,
+        fromSameHrefState: false,
+        toSameHrefState: false,
+        renderedRoute: 'Next',
+      },
+    ]),
+  )
 
-    const sameHrefState: SameHrefTestState = { sameHrefState: true }
-    await router.navigate({
-      to: '/next',
-      state: sameHrefState,
-    })
-    await waitFor(() =>
-      expect(renderedChanges).toEqual([
-        {
-          fromPathname: '/',
-          toPathname: '/next',
-          fromHref: '/',
-          toHref: '/next',
-          pathChanged: true,
-          hrefChanged: true,
-          fromSameHrefState: false,
-          toSameHrefState: false,
-          renderedRoute: 'Next',
-        },
-        {
-          fromPathname: '/next',
-          toPathname: '/next',
-          fromHref: '/next',
-          toHref: '/next',
-          pathChanged: false,
-          hrefChanged: false,
-          fromSameHrefState: false,
-          toSameHrefState: true,
-          renderedRoute: 'Next',
-        },
-      ]),
-    )
-  } finally {
-    unsubscribe()
-  }
+  const sameHrefState: SameHrefTestState = { sameHrefState: true }
+  await router.navigate({
+    to: '/next',
+    state: sameHrefState,
+  })
+  await waitFor(() =>
+    expect(renderedChanges).toEqual([
+      {
+        fromPathname: '/',
+        toPathname: '/next',
+        fromHref: '/',
+        toHref: '/next',
+        pathChanged: true,
+        hrefChanged: true,
+        fromSameHrefState: false,
+        toSameHrefState: false,
+        renderedRoute: 'Next',
+      },
+      {
+        fromPathname: '/next',
+        toPathname: '/next',
+        fromHref: '/next',
+        toHref: '/next',
+        pathChanged: false,
+        hrefChanged: false,
+        fromSameHrefState: false,
+        toSameHrefState: true,
+        renderedRoute: 'Next',
+      },
+    ]),
+  )
 })
 
 test('an older rendered destination cannot resolve a superseding navigation', async () => {
@@ -267,43 +263,42 @@ test('an older rendered destination cannot resolve a superseding navigation', as
       })
     }),
   ]
-
-  try {
-    const firstNavigation = router.navigate({ to: '/first' })
-
-    await waitFor(() => {
-      expect(nextNavigation).toBeDefined()
-    })
-    expect(screen.getByText('First')).toBeInTheDocument()
-    expect(screen.queryByText('Next')).not.toBeInTheDocument()
-    expect(lifecycle).toEqual([])
-
-    nextLoader.resolve()
-    await Promise.all([firstNavigation, nextNavigation!])
-
-    await waitFor(() => {
-      expect(screen.getByText('Next')).toBeInTheDocument()
-    })
-    expect(lifecycle).toEqual([
-      {
-        event: 'onResolved',
-        pathname: '/next',
-        destination: true,
-        superseded: false,
-      },
-      {
-        event: 'onRendered',
-        pathname: '/next',
-        destination: true,
-        superseded: false,
-      },
-    ])
-  } finally {
+  onTestFinished(() => {
     nextLoader.resolve()
     for (const unsubscribe of unsubscribers) {
       unsubscribe()
     }
-  }
+  })
+
+  const firstNavigation = router.navigate({ to: '/first' })
+
+  await waitFor(() => {
+    expect(nextNavigation).toBeDefined()
+  })
+  expect(screen.getByText('First')).toBeInTheDocument()
+  expect(screen.queryByText('Next')).not.toBeInTheDocument()
+  expect(lifecycle).toEqual([])
+
+  nextLoader.resolve()
+  await Promise.all([firstNavigation, nextNavigation!])
+
+  await waitFor(() => {
+    expect(screen.getByText('Next')).toBeInTheDocument()
+  })
+  expect(lifecycle).toEqual([
+    {
+      event: 'onResolved',
+      pathname: '/next',
+      destination: true,
+      superseded: false,
+    },
+    {
+      event: 'onRendered',
+      pathname: '/next',
+      destination: true,
+      superseded: false,
+    },
+  ])
 })
 
 test('same-location invalidation resolves after its refreshed DOM commits', async () => {
@@ -330,12 +325,9 @@ test('same-location invalidation resolves after its refreshed DOM commits', asyn
   const unsubscribe = router.subscribe('onResolved', () => {
     refreshedDomWasVisible.push(screen.queryByText('Generation 2') !== null)
   })
+  onTestFinished(unsubscribe)
 
-  try {
-    await router.invalidate()
-    expect(await screen.findByText('Generation 2')).toBeInTheDocument()
-    expect(refreshedDomWasVisible).toEqual([true])
-  } finally {
-    unsubscribe()
-  }
+  await router.invalidate()
+  expect(await screen.findByText('Generation 2')).toBeInTheDocument()
+  expect(refreshedDomWasVisible).toEqual([true])
 })

--- a/packages/start-server-core/tests/createStartHandler.test.ts
+++ b/packages/start-server-core/tests/createStartHandler.test.ts
@@ -1,6 +1,14 @@
 // @vitest-environment node
 
-import { afterAll, afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  afterAll,
+  afterEach,
+  describe,
+  expect,
+  it,
+  onTestFinished,
+  vi,
+} from 'vitest'
 import { createMemoryHistory } from '@tanstack/history'
 import { createMiddleware } from '@tanstack/start-client-core'
 import {
@@ -566,36 +574,37 @@ describe('createStartHandler request cancellation', () => {
       const renderResult = new Promise<any>((resolve) => {
         resolveRender = resolve
       })
-
-      try {
-        const handler = createStartHandler(() => {
-          notifyRenderStarted()
-          return renderResult
-        })
-        const response = handler(
-          new Request('http://localhost/', {
-            signal: requestController.signal,
-          }),
-          {},
-        )
-
-        await renderStarted
-        requestController.abort(new Error('request disconnected'))
-        expect((await response).status).toBe(500)
-
-        resolveRender({
-          response: new Response('stream'),
-          serverSsrCleanup: 'stream',
-          dispose,
-        })
-        await vi.waitFor(() => {
-          expect(consoleError).toHaveBeenCalledWith(cleanupError)
-        })
-        expect(dispose).toHaveBeenCalledOnce()
-      } finally {
-        router.serverSsr?.cleanup()
+      onTestFinished(() => {
         consoleError.mockRestore()
-      }
+      })
+      onTestFinished(() => {
+        router.serverSsr?.cleanup()
+      })
+
+      const handler = createStartHandler(() => {
+        notifyRenderStarted()
+        return renderResult
+      })
+      const response = handler(
+        new Request('http://localhost/', {
+          signal: requestController.signal,
+        }),
+        {},
+      )
+
+      await renderStarted
+      requestController.abort(new Error('request disconnected'))
+      expect((await response).status).toBe(500)
+
+      resolveRender({
+        response: new Response('stream'),
+        serverSsrCleanup: 'stream',
+        dispose,
+      })
+      await vi.waitFor(() => {
+        expect(consoleError).toHaveBeenCalledWith(cleanupError)
+      })
+      expect(dispose).toHaveBeenCalledOnce()
     },
   )
 
@@ -629,29 +638,30 @@ describe('createStartHandler request cancellation', () => {
           return new Promise<Response>(() => {})
         }),
       ]
-
-      try {
-        const handler = createStartHandler(() => new Response('unused'))
-        const response = handler(
-          new Request('http://localhost/_serverFn/test', {
-            headers: { 'x-tsr-serverFn': 'true' },
-            signal: requestController.signal,
-          }),
-          {},
-        )
-
-        await middlewareStarted
-        requestController.abort(new Error('request disconnected'))
-
-        expect((await response).status).toBe(500)
-        await vi.waitFor(() => {
-          expect(consoleError).toHaveBeenCalledWith(cleanupError)
-        })
-        expect(dispose).toHaveBeenCalledOnce()
-      } finally {
-        router.serverSsr?.cleanup()
+      onTestFinished(() => {
         consoleError.mockRestore()
-      }
+      })
+      onTestFinished(() => {
+        router.serverSsr?.cleanup()
+      })
+
+      const handler = createStartHandler(() => new Response('unused'))
+      const response = handler(
+        new Request('http://localhost/_serverFn/test', {
+          headers: { 'x-tsr-serverFn': 'true' },
+          signal: requestController.signal,
+        }),
+        {},
+      )
+
+      await middlewareStarted
+      requestController.abort(new Error('request disconnected'))
+
+      expect((await response).status).toBe(500)
+      await vi.waitFor(() => {
+        expect(consoleError).toHaveBeenCalledWith(cleanupError)
+      })
+      expect(dispose).toHaveBeenCalledOnce()
     },
   )
 

--- a/packages/vue-router/tests/Transitioner.test.tsx
+++ b/packages/vue-router/tests/Transitioner.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, onTestFinished, vi } from 'vitest'
 import { cleanup, render, waitFor } from '@testing-library/vue'
 import {
   RouterProvider,
@@ -58,19 +58,19 @@ describe('Transitioner', () => {
     })
 
     const load = router.load()
-    try {
-      await waitFor(() => expect(loader).toHaveBeenCalledTimes(1))
-
-      const view = render(<RouterProvider router={router} />)
-      loaderGate.resolve()
-      await load
-
-      expect(await view.findByText('Index')).toBeInTheDocument()
-      expect(beforeLoad).toHaveBeenCalledTimes(1)
-      expect(loader).toHaveBeenCalledTimes(1)
-    } finally {
+    onTestFinished(async () => {
       loaderGate.resolve()
       await Promise.allSettled([load])
-    }
+    })
+
+    await waitFor(() => expect(loader).toHaveBeenCalledTimes(1))
+
+    const view = render(<RouterProvider router={router} />)
+    loaderGate.resolve()
+    await load
+
+    expect(await view.findByText('Index')).toBeInTheDocument()
+    expect(beforeLoad).toHaveBeenCalledTimes(1)
+    expect(loader).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/vue-router/tests/transitioner-listener-errors.test.tsx
+++ b/packages/vue-router/tests/transitioner-listener-errors.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen } from '@testing-library/vue'
-import { afterEach, expect, test, vi } from 'vitest'
+import { afterEach, expect, onTestFinished, test, vi } from 'vitest'
 import { createMemoryHistory } from '@tanstack/history'
 import {
   Outlet,
@@ -55,22 +55,21 @@ test('a throwing load-event listener cannot interrupt later listeners, route hoo
   const unsubscribeLater = router.subscribe('onLoad', (event) => {
     laterOnLoad(event.toLocation.pathname)
   })
-
-  try {
-    await router.navigate({ to: '/first' })
-    expect(await screen.findByText('First route')).toBeTruthy()
-    expect(firstOnEnter).toHaveBeenCalledTimes(1)
-    expect(throwingOnLoad.mock.calls).toEqual([['/first']])
-    expect(laterOnLoad.mock.calls).toEqual([['/first']])
-
-    await router.navigate({ to: '/second' })
-    expect(await screen.findByText('Second route')).toBeTruthy()
-    expect(firstOnEnter).toHaveBeenCalledTimes(1)
-    expect(secondOnEnter).toHaveBeenCalledTimes(1)
-    expect(throwingOnLoad.mock.calls).toEqual([['/first'], ['/second']])
-    expect(laterOnLoad.mock.calls).toEqual([['/first'], ['/second']])
-  } finally {
+  onTestFinished(() => {
     unsubscribeThrowing()
     unsubscribeLater()
-  }
+  })
+
+  await router.navigate({ to: '/first' })
+  expect(await screen.findByText('First route')).toBeTruthy()
+  expect(firstOnEnter).toHaveBeenCalledTimes(1)
+  expect(throwingOnLoad.mock.calls).toEqual([['/first']])
+  expect(laterOnLoad.mock.calls).toEqual([['/first']])
+
+  await router.navigate({ to: '/second' })
+  expect(await screen.findByText('Second route')).toBeTruthy()
+  expect(firstOnEnter).toHaveBeenCalledTimes(1)
+  expect(secondOnEnter).toHaveBeenCalledTimes(1)
+  expect(throwingOnLoad.mock.calls).toEqual([['/first'], ['/second']])
+  expect(laterOnLoad.mock.calls).toEqual([['/first'], ['/second']])
 })


### PR DESCRIPTION
## Summary

- replace 37 broad end-of-test `try/finally` cleanup wrappers in tests added or modified by `fix-router-core-lane-match-loader` with test-local `onTestFinished` callbacks
- keep teardown registration next to the resource or operation it owns
- preserve four `try/finally` blocks where `finally` must run before later assertions or is itself behavior under test
- leave global test setup and central Vitest configuration unchanged

## Why

The broad wrappers add substantial nesting around each test's assertion path. Test-local cleanup keeps teardown scoped to the individual test and still runs when the test fails, while making the behavior being asserted easier to read.

## Validation

- targeted React Router, Router Core, Router Plugin, Start Server Core, and Vue Router unit tests
- full Solid Router unit target in client and server modes
- `test:types` for all six affected packages
- `test:eslint` for all six affected packages
- Prettier and `git diff --check`
