### PR TITLE
fix(eslint-plugin-start): support ESLint 10 peer dependency

### DIFF
--- a/packages/eslint-plugin-start/package.json
+++ b/packages/eslint-plugin-start/package.json
@@ -61,7 +61,7 @@
     "typescript": "^5.8.2"
   },
   "peerDependencies": {
-    "eslint": "^8.57.0 || ^9.0.0",
+    "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
     "typescript": ">=4.7.0"
   }
 }


### PR DESCRIPTION
## Summary

Updates the peer dependency for `@tanstack/eslint-plugin-start` to include ESLint 10, bringing it in line with `@tanstack/eslint-plugin-router`.

## Changes

- Added `^10.0.0` to the `eslint` peer dependency range.

## Testing

I attempted to run the package tests on Windows, but the repository installation fails during the `e2e/solid-start/basic-cloudflare` postinstall step due to the `WRANGLER_LOG=warn` environment variable syntax not being recognized on Windows. This appears to be unrelated to this metadata-only change.

## Related

Closes #7920

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added compatibility for ESLint 10.
  * Continued support for existing ESLint 8 and 9 versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->