### PR TITLE
fix(start): throw on aborted bot SSR render instead of silently returning 200

### DIFF
--- a/packages/react-router/src/ssr/renderRouterToStream.tsx
+++ b/packages/react-router/src/ssr/renderRouterToStream.tsx
@@ -66,6 +66,11 @@ export const renderRouterToStream = async ({
 
     if (isbot(request.headers.get('User-Agent'))) {
       await waitForReadyOrAbort(stream.allReady, request.signal)
+
+      if (request.signal.aborted) {
+        stream.cancel().catch(() => {})
+        throw request.signal.reason ?? new Error('Request aborted')
+      }
     }
 
     const responseStream = transformReadableStreamWithRouter(

--- a/packages/solid-router/src/ssr/renderRouterToStream.tsx
+++ b/packages/solid-router/src/ssr/renderRouterToStream.tsx
@@ -126,6 +126,10 @@ export const renderRouterToStream = async ({
       Promise.resolve(stream as unknown),
       request.signal,
     )
+
+    if (request.signal.aborted) {
+      throw request.signal.reason ?? new Error('Request aborted')
+    }
   }
 
   const solidWritable = new WritableStream({

--- a/packages/solid-router/tests/renderRouterToStream.test.tsx
+++ b/packages/solid-router/tests/renderRouterToStream.test.tsx
@@ -91,22 +91,8 @@ describe('renderRouterToStream - bot abort', () => {
       await Promise.resolve()
       abortController.abort(new Error('client-gone'))
 
-      const result = await Promise.race([
-        responsePromise,
-        new Promise<false>((resolve) => setTimeout(() => resolve(false), 2000)),
-      ])
-
-      expect(result).not.toBe(false)
+      await expect(responsePromise).rejects.toThrow('client-gone')
       expect(solidMocks.pipeTo).not.toHaveBeenCalled()
-      const response = unwrapResponse(result as Exclude<typeof result, false>)
-      expect(response.body).not.toBeNull()
-
-      const terminated = await Promise.race([
-        drainBody(response),
-        new Promise<false>((resolve) => setTimeout(() => resolve(false), 2000)),
-      ])
-
-      expect(terminated).toBe(true)
     } finally {
       errorSpy.mockRestore()
       router.serverSsr?.cleanup()


### PR DESCRIPTION
After `waitForReadyOrAbort` resolves due to request signal abort, the render path continued to create a Response with status 200. This throws when `request.signal.aborted` is true, so the abort propagates as an error instead.

Fixes #7929

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side rendering for bot requests by handling aborted requests after content is ready.
  * Aborted rendering now cancels streaming and reports the appropriate error instead of continuing unexpectedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->