### PR TITLE
docs: Fix typo in path-params documentation

### DIFF
--- a/docs/router/guide/path-params.md
+++ b/docs/router/guide/path-params.md
@@ -226,7 +226,7 @@ function PostComponent() {
 
 <!-- ::end:framework -->
 
-You can even combines prefixes with wildcard routes to create more complex patterns:
+You can even combine prefixes with wildcard routes to create more complex patterns:
 
 <!-- ::start:framework -->
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the grammar in the routing guide’s explanation of prefix and wildcard combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->