### PR TITLE
docs: version optional param to only capture version not capturing "e…

### DIFF
--- a/docs/router/guide/path-params.md
+++ b/docs/router/guide/path-params.md
@@ -582,10 +582,10 @@ Optional parameters can be combined with wildcards for complex routing patterns:
 
 # React
 
-```tsx title="src/routes/docs/{-$version}/$.tsx"
-// Route: /docs/{-$version}/$
+```tsx title="src/routes/docs/v{-$version}/$.tsx"
+// Route: /docs/v{-$version}/$
 // Matches: /docs/extra/path, /docs/v2/extra/path
-export const Route = createFileRoute('/docs/{-$version}/$')({
+export const Route = createFileRoute('/docs/v{-$version}/$')({
   component: DocsComponent,
 })
 
@@ -595,7 +595,7 @@ function DocsComponent() {
 
   return (
     <div>
-      Version: {version || 'latest'}
+      Version: {version ? `v${version}` : 'latest'}
       Path: {_splat}
     </div>
   )
@@ -604,10 +604,10 @@ function DocsComponent() {
 
 # Solid
 
-```tsx title="src/routes/docs/{-$version}/$.tsx"
-// Route: /docs/{-$version}/$
+```tsx title="src/routes/docs/v{-$version}/$.tsx"
+// Route: /docs/v{-$version}/$
 // Matches: /docs/extra/path, /docs/v2/extra/path
-export const Route = createFileRoute('/docs/{-$version}/$')({
+export const Route = createFileRoute('/docs/v{-$version}/$')({
   component: DocsComponent,
 })
 
@@ -616,7 +616,7 @@ function DocsComponent() {
 
   return (
     <div>
-      Version: {params().version || 'latest'}
+      Version: {params().version ? `v${params().version} : 'latest'}
       Path: {params()._splat}
     </div>
   )

--- a/docs/router/guide/path-params.md
+++ b/docs/router/guide/path-params.md
@@ -616,7 +616,7 @@ function DocsComponent() {
 
   return (
     <div>
-      Version: {params().version ? `v${params().version} : 'latest'}
+      Version: {params().version ? `v${params().version}` : 'latest'}
       Path: {params()._splat}
     </div>
   )


### PR DESCRIPTION
old doc would capture "extra" as version, fixed by adding "v" as prefix to only capture the versions.
i don't know if it is the best solution for it, would like to know if you got better idea

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated optional wildcard routing examples to support versioned paths with a `v` prefix.
  * Clarified displayed version formatting for React and Solid examples, including `latest` when no version is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->