### PR TITLE
fix(router-plugin): don't patch foreign routers on first route-module import

### DIFF
--- a/.changeset/fix-multi-router-first-import.md
+++ b/.changeset/fix-multi-router-first-import.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-plugin': patch
+---
+
+Only run the eager HMR route patch on hot re-evaluations of a route module. On a first import, a same-id route on `window.__TSR_ROUTER__` belongs to a different router in the same window (e.g. module federation host/remote), and patching it corrupted both route trees, causing "Invalid hook call" errors.

--- a/packages/router-plugin/src/core/hmr/vite-adapter.ts
+++ b/packages/router-plugin/src/core/hmr/vite-adapter.ts
@@ -22,6 +22,14 @@ export function createViteHmrStatement(
   const routeIdFallback =
     typeof opts.routeId === 'string' ? JSON.stringify(opts.routeId) : 'Route.id'
 
+  // `hot.data` persists across re-evaluations of this module but starts empty
+  // on the very first import. The eager patch below (which mirrors the live
+  // route's generated state onto this module's `Route` export, see #4303)
+  // must therefore only run on a hot re-evaluation: on a first import, a
+  // same-id route found on `window.__TSR_ROUTER__` belongs to a *different*
+  // router living in the same window (e.g. a module-federation host/remote
+  // pair), and patching it would graft foreign route options and components
+  // across the two apps (#7921).
   return [
     template.statement(
       `
@@ -33,8 +41,10 @@ if (import.meta.hot) {
   if (initialRouteId) {
     hotData['tsr-route-id'] = initialRouteId
   }
+  const isHotReevaluation = hotData['tsr-route-initialized'] === true
+  hotData['tsr-route-initialized'] = true
   const existingRoute =
-    typeof window !== 'undefined' && initialRouteId
+    isHotReevaluation && typeof window !== 'undefined' && initialRouteId
       ? window.__TSR_ROUTER__?.routesById?.[initialRouteId]
       : undefined
   if (initialRouteId && existingRoute && existingRoute !== Route) {

--- a/packages/router-plugin/tests/add-hmr.test.ts
+++ b/packages/router-plugin/tests/add-hmr.test.ts
@@ -147,6 +147,22 @@ describe('add-hmr works', () => {
     expect(output).toContain('"object":{"type":"Identifier","name":"hotData"}')
   })
 
+  it('gates the eager live-route patch behind a persisted hot-data flag', async () => {
+    const statement = createRouteHmrStatement([], {
+      hmrStyle: 'vite',
+      targetFramework: 'react',
+      routeId: '/posts',
+    })
+    const output = JSON.stringify(statement)
+
+    // On a first import the module must never patch a route owned by a
+    // different router in the same window (module federation / multiple
+    // routers, see #7921). The eager patch may only run on hot
+    // re-evaluations, detected via `hot.data`, which persists across updates.
+    expect(output).toContain('tsr-route-initialized')
+    expect(output).toContain('"name":"isHotReevaluation"')
+  })
+
   it('normalizes the generated root route id for Vite HMR', async () => {
     const statement = createRouteHmrStatement([], {
       hmrStyle: 'vite',

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/arrow-function@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/arrow-function@true.tsx
@@ -172,7 +172,9 @@ if (import.meta.hot) {
   if (initialRouteId) {
     hotData['tsr-route-id'] = initialRouteId;
   }
-  const existingRoute = typeof window !== 'undefined' && initialRouteId ? window.__TSR_ROUTER__?.routesById?.[initialRouteId] : undefined;
+  const isHotReevaluation = hotData['tsr-route-initialized'] === true;
+  hotData['tsr-route-initialized'] = true;
+  const existingRoute = isHotReevaluation && typeof window !== 'undefined' && initialRouteId ? window.__TSR_ROUTER__?.routesById?.[initialRouteId] : undefined;
   if (initialRouteId && existingRoute && existingRoute !== Route) {
     handleRouteUpdate(initialRouteId, Route);
     hotData['tsr-route-update-handled'] = Route;

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/createFileRoute-lowercase-components@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/createFileRoute-lowercase-components@true.tsx
@@ -183,7 +183,9 @@ if (import.meta.hot) {
   if (initialRouteId) {
     hotData['tsr-route-id'] = initialRouteId;
   }
-  const existingRoute = typeof window !== 'undefined' && initialRouteId ? window.__TSR_ROUTER__?.routesById?.[initialRouteId] : undefined;
+  const isHotReevaluation = hotData['tsr-route-initialized'] === true;
+  hotData['tsr-route-initialized'] = true;
+  const existingRoute = isHotReevaluation && typeof window !== 'undefined' && initialRouteId ? window.__TSR_ROUTER__?.routesById?.[initialRouteId] : undefined;
   if (initialRouteId && existingRoute && existingRoute !== Route) {
     handleRouteUpdate(initialRouteId, Route);
     hotData['tsr-route-update-handled'] = Route;

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/createRootRoute-inline-component@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/createRootRoute-inline-component@true.tsx
@@ -161,7 +161,9 @@ if (import.meta.hot) {
   if (initialRouteId) {
     hotData['tsr-route-id'] = initialRouteId;
   }
-  const existingRoute = typeof window !== 'undefined' && initialRouteId ? window.__TSR_ROUTER__?.routesById?.[initialRouteId] : undefined;
+  const isHotReevaluation = hotData['tsr-route-initialized'] === true;
+  hotData['tsr-route-initialized'] = true;
+  const existingRoute = isHotReevaluation && typeof window !== 'undefined' && initialRouteId ? window.__TSR_ROUTER__?.routesById?.[initialRouteId] : undefined;
   if (initialRouteId && existingRoute && existingRoute !== Route) {
     handleRouteUpdate(initialRouteId, Route);
     hotData['tsr-route-update-handled'] = Route;

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/createRootRoute-lowercase-components@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/createRootRoute-lowercase-components@true.tsx
@@ -179,7 +179,9 @@ if (import.meta.hot) {
   if (initialRouteId) {
     hotData['tsr-route-id'] = initialRouteId;
   }
-  const existingRoute = typeof window !== 'undefined' && initialRouteId ? window.__TSR_ROUTER__?.routesById?.[initialRouteId] : undefined;
+  const isHotReevaluation = hotData['tsr-route-initialized'] === true;
+  hotData['tsr-route-initialized'] = true;
+  const existingRoute = isHotReevaluation && typeof window !== 'undefined' && initialRouteId ? window.__TSR_ROUTER__?.routesById?.[initialRouteId] : undefined;
   if (initialRouteId && existingRoute && existingRoute !== Route) {
     handleRouteUpdate(initialRouteId, Route);
     hotData['tsr-route-update-handled'] = Route;

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/createRootRoute@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/createRootRoute@true.tsx
@@ -163,7 +163,9 @@ if (import.meta.hot) {
   if (initialRouteId) {
     hotData['tsr-route-id'] = initialRouteId;
   }
-  const existingRoute = typeof window !== 'undefined' && initialRouteId ? window.__TSR_ROUTER__?.routesById?.[initialRouteId] : undefined;
+  const isHotReevaluation = hotData['tsr-route-initialized'] === true;
+  hotData['tsr-route-initialized'] = true;
+  const existingRoute = isHotReevaluation && typeof window !== 'undefined' && initialRouteId ? window.__TSR_ROUTER__?.routesById?.[initialRouteId] : undefined;
   if (initialRouteId && existingRoute && existingRoute !== Route) {
     handleRouteUpdate(initialRouteId, Route);
     hotData['tsr-route-update-handled'] = Route;

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/createRootRouteWithContext-type-args@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/createRootRouteWithContext-type-args@true.tsx
@@ -166,7 +166,9 @@ if (import.meta.hot) {
   if (initialRouteId) {
     hotData['tsr-route-id'] = initialRouteId;
   }
-  const existingRoute = typeof window !== 'undefined' && initialRouteId ? window.__TSR_ROUTER__?.routesById?.[initialRouteId] : undefined;
+  const isHotReevaluation = hotData['tsr-route-initialized'] === true;
+  hotData['tsr-route-initialized'] = true;
+  const existingRoute = isHotReevaluation && typeof window !== 'undefined' && initialRouteId ? window.__TSR_ROUTER__?.routesById?.[initialRouteId] : undefined;
   if (initialRouteId && existingRoute && existingRoute !== Route) {
     handleRouteUpdate(initialRouteId, Route);
     hotData['tsr-route-update-handled'] = Route;

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/explicit-undefined-component@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/explicit-undefined-component@true.tsx
@@ -160,7 +160,9 @@ if (import.meta.hot) {
   if (initialRouteId) {
     hotData['tsr-route-id'] = initialRouteId;
   }
-  const existingRoute = typeof window !== 'undefined' && initialRouteId ? window.__TSR_ROUTER__?.routesById?.[initialRouteId] : undefined;
+  const isHotReevaluation = hotData['tsr-route-initialized'] === true;
+  hotData['tsr-route-initialized'] = true;
+  const existingRoute = isHotReevaluation && typeof window !== 'undefined' && initialRouteId ? window.__TSR_ROUTER__?.routesById?.[initialRouteId] : undefined;
   if (initialRouteId && existingRoute && existingRoute !== Route) {
     handleRouteUpdate(initialRouteId, Route);
     hotData['tsr-route-update-handled'] = Route;

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/function-declaration@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/function-declaration@true.tsx
@@ -172,7 +172,9 @@ if (import.meta.hot) {
   if (initialRouteId) {
     hotData['tsr-route-id'] = initialRouteId;
   }
-  const existingRoute = typeof window !== 'undefined' && initialRouteId ? window.__TSR_ROUTER__?.routesById?.[initialRouteId] : undefined;
+  const isHotReevaluation = hotData['tsr-route-initialized'] === true;
+  hotData['tsr-route-initialized'] = true;
+  const existingRoute = isHotReevaluation && typeof window !== 'undefined' && initialRouteId ? window.__TSR_ROUTER__?.routesById?.[initialRouteId] : undefined;
   if (initialRouteId && existingRoute && existingRoute !== Route) {
     handleRouteUpdate(initialRouteId, Route);
     hotData['tsr-route-update-handled'] = Route;

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/multi-component@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/multi-component@true.tsx
@@ -182,7 +182,9 @@ if (import.meta.hot) {
   if (initialRouteId) {
     hotData['tsr-route-id'] = initialRouteId;
   }
-  const existingRoute = typeof window !== 'undefined' && initialRouteId ? window.__TSR_ROUTER__?.routesById?.[initialRouteId] : undefined;
+  const isHotReevaluation = hotData['tsr-route-initialized'] === true;
+  hotData['tsr-route-initialized'] = true;
+  const existingRoute = isHotReevaluation && typeof window !== 'undefined' && initialRouteId ? window.__TSR_ROUTER__?.routesById?.[initialRouteId] : undefined;
   if (initialRouteId && existingRoute && existingRoute !== Route) {
     handleRouteUpdate(initialRouteId, Route);
     hotData['tsr-route-update-handled'] = Route;

--- a/packages/router-plugin/tests/add-hmr/snapshots/react/string-literal-keys@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/react/string-literal-keys@true.tsx
@@ -182,7 +182,9 @@ if (import.meta.hot) {
   if (initialRouteId) {
     hotData['tsr-route-id'] = initialRouteId;
   }
-  const existingRoute = typeof window !== 'undefined' && initialRouteId ? window.__TSR_ROUTER__?.routesById?.[initialRouteId] : undefined;
+  const isHotReevaluation = hotData['tsr-route-initialized'] === true;
+  hotData['tsr-route-initialized'] = true;
+  const existingRoute = isHotReevaluation && typeof window !== 'undefined' && initialRouteId ? window.__TSR_ROUTER__?.routesById?.[initialRouteId] : undefined;
   if (initialRouteId && existingRoute && existingRoute !== Route) {
     handleRouteUpdate(initialRouteId, Route);
     hotData['tsr-route-update-handled'] = Route;

--- a/packages/router-plugin/tests/add-hmr/snapshots/solid/arrow-function@true.tsx
+++ b/packages/router-plugin/tests/add-hmr/snapshots/solid/arrow-function@true.tsx
@@ -143,7 +143,9 @@ if (import.meta.hot) {
   if (initialRouteId) {
     hotData['tsr-route-id'] = initialRouteId;
   }
-  const existingRoute = typeof window !== 'undefined' && initialRouteId ? window.__TSR_ROUTER__?.routesById?.[initialRouteId] : undefined;
+  const isHotReevaluation = hotData['tsr-route-initialized'] === true;
+  hotData['tsr-route-initialized'] = true;
+  const existingRoute = isHotReevaluation && typeof window !== 'undefined' && initialRouteId ? window.__TSR_ROUTER__?.routesById?.[initialRouteId] : undefined;
   if (initialRouteId && existingRoute && existingRoute !== Route) {
     handleRouteUpdate(initialRouteId, Route);
     hotData['tsr-route-update-handled'] = Route;


### PR DESCRIPTION
Closes #7921

## Problem

Since `@tanstack/router-plugin@1.168.17` (837897f, #7560), the injected Vite HMR preamble eagerly calls `handleRouteUpdate` during the *initial* evaluation of every route module whenever `window.__TSR_ROUTER__` already owns a route with the same id but a different object identity.

That heuristic assumes "same id + different identity ⇒ re-imported copy of this file". With multiple routers in one window (module federation host/remote, microfrontends), route ids like `__root__` and `/` collide between apps, and `window.__TSR_ROUTER__` points at whichever router was created last. The remote's route modules then patch the host's router: the host's route options are overwritten, `preserveComponentIdentity` grafts the host's components onto the remote's route options, and `syncHotRouteExport` rewrites the remote's `Route` export (`parentRoute`, `_id`, `_path`, …) with the host's tree state. Since each app ships its own React copy in dev, rendering the remote's router executes components bound to the host's React → "Invalid hook call". Creating the host router is enough to trigger it — no rendering needed.

## Fix

Vite's `hot.data` persists across re-evaluations of a module but starts empty on first import — exactly the missing discriminator. The eager patch (only needed for the #4303 aliased-import re-evaluation case) is now gated behind a `tsr-route-initialized` flag in `hot.data`, restoring the pre-1.168.17 behavior for first imports while keeping the #4303 fix intact.

Note: the `hot.accept` path has always resolved `window.__TSR_ROUTER__` (pre-1.168.17), so editing a route file while a foreign router was created last can still target the wrong router. That's a pre-existing, edit-time-only limitation; properly scoping the global to a per-router registry is left as a follow-up if maintainers want it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Vite hot-module reloading to prevent route conflicts during initial application loads.
  - Prevented routes from separate router instances from being incorrectly merged or updated.
  - Ensured existing routes are only reused during genuine hot re-evaluations.

- **Tests**
  - Added coverage for route initialization and hot re-evaluation behavior across supported route patterns and frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->