### PR TITLE
fix(react-start-rsc): avoid pulling the router entry into the RSC bundle via start-server-core barrel import

### DIFF
--- a/.changeset/fix-rsc-barrel-import-leak.md
+++ b/.changeset/fix-rsc-barrel-import-leak.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-start-rsc': patch
+---
+
+Import `getRequest` from the `@tanstack/start-server-core/request-response` subpath instead of the root barrel. The barrel re-exports `createStartHandler`, whose dynamic `#tanstack-router-entry` import survived into the RSC build whenever `renderServerComponent` or `createCompositeComponent` entered the `rsc` environment graph, emitting a chunk that duplicated every server-route dependency into the RSC bundle.

--- a/packages/react-start-rsc/src/createCompositeComponent.ts
+++ b/packages/react-start-rsc/src/createCompositeComponent.ts
@@ -1,6 +1,6 @@
 import { createElement } from 'react'
 import { renderToReadableStream } from 'virtual:tanstack-rsc-runtime'
-import { getRequest } from '@tanstack/start-server-core'
+import { getRequest } from '@tanstack/start-server-core/request-response'
 import { getStartContext } from '@tanstack/start-storage-context'
 import { sanitizeSlotArgs } from './slotUsageSanitizer'
 import { ReplayableStream } from './ReplayableStream'

--- a/packages/react-start-rsc/src/renderServerComponent.ts
+++ b/packages/react-start-rsc/src/renderServerComponent.ts
@@ -1,5 +1,5 @@
 import { renderToReadableStream } from 'virtual:tanstack-rsc-runtime'
-import { getRequest } from '@tanstack/start-server-core'
+import { getRequest } from '@tanstack/start-server-core/request-response'
 import { getStartContext } from '@tanstack/start-storage-context'
 import { ReplayableStream } from './ReplayableStream'
 import { RENDERABLE_RSC, SERVER_COMPONENT_STREAM } from './ServerComponentTypes'


### PR DESCRIPTION
Closes #7934

`renderServerComponent` and `createCompositeComponent` imported `getRequest` from the `@tanstack/start-server-core` root barrel. That barrel re-exports `createStartHandler`, which contains `import('#tanstack-router-entry')` / `import('#tanstack-start-entry')`. When either RSC helper enters the `rsc` environment graph (e.g. a server-fn file importing it — even unused, since `@tanstack/react-start-rsc` has no `sideEffects: false`), the dynamic router-entry import survives into the RSC build. Because the `rsc` environment gets the unpruned route tree, this emits a `router-*.js` chunk containing every route file — including server-only API routes and their heavy imports — duplicated from the SSR bundle (79 MB in the linked reproduction; exceeds Cloudflare Workers size limits).

Fix: import `getRequest` from the self-contained `@tanstack/start-server-core/request-response` subpath (the same subpath `react-start/src/server.rsc.ts` already re-exports for the RSC context), so `createStartHandler` and its router-entry dynamic import never enter the RSC module graph.

## Verification

Verified against the issue reproduction (https://github.com/jeremy-code/tanstack-rsc-api-routes): a baseline build emits `dist/server/rsc/assets/router-*.js` at 76 MB (153 MB total dist). Applying this same two-import change to the installed `@tanstack/react-start-rsc` dist and rebuilding, the router chunk is no longer emitted and total dist drops to 78 MB. Unit tests (61) and the package build pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved React Server Component bundle generation by preventing unnecessary server-route dependencies from being included.
  * Reduced the risk of duplicated dependencies in generated RSC bundles.

* **Chores**
  * Updated internal request handling imports without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->