### PR TITLE
Fix invalidation of active preloads

### DIFF
--- a/.changeset/lane-match-loader-rewrite.md
+++ b/.changeset/lane-match-loader-rewrite.md
@@ -7,6 +7,7 @@
 
 Rewrite match loading around a lane-based scheduler that tracks each navigation, preload, and background reload as an ordered unit of work. This fixes pending/redirect/retry state leaking between overlapping navigations, restores correct SSR status codes for redirects, errors, and not-found responses, and closes hydration gaps where the client re-ran work the server had already completed.
 
+- Invalidation now retires matching active preloads so older speculative loader results cannot become fresh cache data after invalidation.
 - Route `headers()` now only runs on the server, matching the documented behavior — it is no longer invoked during client-side asset projection.
 - Default `gcTime` and `preloadGcTime` are reduced from 30 minutes (`1_800_000`) to 5 minutes (`300_000`).
 

--- a/docs/router/api/router/RouterType.md
+++ b/docs/router/api/router/RouterType.md
@@ -134,8 +134,8 @@ protocol.
 
 - Type: `(opts?: {filter?: (d: MakeRouteMatchUnion<TRouter>) => boolean, sync?: boolean, forcePending?: boolean }) => Promise<void>`
 - This is useful any time your loader data might be out of date or stale. For example, if you have a route that displays a list of posts, and you have a loader function that fetches the list of posts from an API, you might want to invalidate the route matches for that route any time a new post is created so that the list of posts is always up-to-date.
-- If `filter` is not supplied, all committed and cached match generations are invalidated.
-- If `filter` is supplied, it is evaluated against committed and cached matches. Selecting one generation invalidates every committed or cached generation with the same match ID.
+- If `filter` is not supplied, all committed, cached, and in-flight match generations are invalidated.
+- If `filter` is supplied, it is evaluated against committed, cached, and in-flight matches. Selecting one generation invalidates every committed, cached, or in-flight generation with the same match ID.
 - Invalidation reruns `beforeLoad`; reusable loader data is marked stale and reloads through the normal loading protocol. Route-level `context` remains reusable while the match ID is unchanged.
 - If `sync` is `true`, stale loader work is blocking and the returned promise resolves after it finishes instead of leaving a background refresh detached.
 - If `forcePending` is `true`, selected routes that need loading enter the normal pending protocol even when successful data was already available.

--- a/packages/router-core/INTERNALS.md
+++ b/packages/router-core/INTERNALS.md
@@ -309,12 +309,14 @@ private to its speculative lane. This does not isolate the normalized outcome of
 a same-ID loader flight that multiple lanes deliberately share.
 
 `router._preloads` has no semantic adoption role. Its controller entry owns
-cancellation and cache clearing and proves that a standalone preload remained
-active through normal settlement; successful removal authorizes private redirect
-continuation. Loader results remain independently reusable: a completed preload
-may seed the match cache, and a still-running preload may donate its same-ID
-loader flight after the receiving lane has run its own `beforeLoad` and made its
-reload decision.
+cancellation, invalidation, and cache clearing and proves that a standalone
+preload remained active through normal settlement; successful removal authorizes
+private redirect continuation. Its live lane signal is also the final authority
+for cache publication, including the microtask window after a loader outcome has
+fulfilled. Loader results remain independently reusable: a completed preload may
+seed the match cache, and a still-running preload may donate its same-ID loader
+flight after the receiving lane has run its own `beforeLoad` and made its reload
+decision.
 
 ### Hydration
 
@@ -832,28 +834,36 @@ redirects. A losing background lane cannot redirect.
 Invalidation creates a new semantic generation and reloads through the ordinary
 transaction path. It does not turn `stores.matches` into a planning lane.
 
-Filtered invalidation evaluates committed, cached, and active-transaction
-matches and collects the selected match IDs. Every committed and cached
-generation with one of those IDs is then replaced as invalid, and its loader
-discovery entry is detached. This ID-wide rule prevents a cache-first or
-in-flight same-ID generation from escaping invalidation merely because a
-different generation was the one passed to the filter. Route context retains
-same-ID cacheability across this replacement and needs no separate invalidation
-marker.
+Filtered invalidation evaluates committed, cached, active-transaction, and
+active-preload matches and collects the selected match IDs. Every committed and
+cached generation with one of those IDs is made invalid. Cached matches are
+already settled successes, so their data owner is marked invalid in place.
+Matching active preload owners are retired first, which prevents older
+speculative work from clearing that stale mark or publishing fresh cache data;
+the lane signal remains the publication fence if its loader outcome already
+fulfilled. The loader discovery entry is also detached before the superseding
+load. Unselected preload lanes remain active. This ID-wide rule prevents a
+cache-first or in-flight same-ID generation from escaping invalidation merely
+because a different generation was the one passed to the filter. Route context
+retains same-ID cacheability across this replacement and needs no separate
+invalidation marker.
 
 Invalidated successful data may remain visible until pending or terminal
 publication, depending on reload mode. Error/not-found generations reset through
 the same loading protocol rather than becoming cache successes.
 
-Cache clearing derives the retained active-preload and cache maps, installs both
-replacement authorities, and removes a discovery entry only when every positive
-lease belongs to discarded matches. It then bulk-detaches removed leases and
-only afterward aborts selected preload lane controllers. A public loader signal
-can synchronously reenter from its abort listener; that reentrant load must
-observe the cleared authorities and every removed lease as already detached.
-Unselected concurrent preloads keep shared flights discoverable, and every later
-cache publication must still pass the per-match cache-entry identity check
-captured during planning.
+Cache clearing first snapshots every selected cache match and active preload so
+a throwing public filter changes no authority. It then prunes both authorities
+and directly releases every discarded match lease.
+When the last lease is discarded, cache clearing removes the discovery entry
+instead of preserving the normal zero-owner navigation handoff. Only after all
+leases and discovery entries are detached does it abort the collected flight and
+preload-lane controllers. A public loader signal can synchronously reenter from
+its abort listener; that reentrant load must observe the cleared authorities and
+every removed lease as already detached. Unselected concurrent preloads keep
+shared flights discoverable, and every later cache publication must still have a
+live preload signal and pass the per-match cache-entry identity check captured
+during planning.
 
 Development refresh is deliberately aggressive: it aborts flights, discards
 active preloads and caches, drops the committed semantic lane, and rematches
@@ -1194,8 +1204,9 @@ When changing this architecture, verify all of the following:
    create unsupported speculative work in the handoff gap.
 9. Match-id cache compatibility and route-id lifecycle identity are not mixed.
 10. Cache publication retains only the generation allowed by its planning CAS;
-    same-ID committed and cached generations invalidate together, and accepted
-    recipients are installed before replaced resources are released.
+    same-ID committed and cached generations invalidate together, affected
+    speculative owners are retired, and accepted recipients are installed before
+    replaced resources are released.
 11. The registry is the sole discovery authority for the latest same-ID flight
     started by navigation, preload, or background work. Registry joinability
     and lease ownership remain separate; donor selection happens synchronously

--- a/packages/router-core/src/load-client.ts
+++ b/packages/router-core/src/load-client.ts
@@ -225,7 +225,7 @@ export type PendingSession = [
 ]
 
 type CoordinatorRouter = AnyRouter & {
-  /** Active speculative lanes retained for cancellation and cache clearing. */
+  /** Active speculative lanes retained for cancellation, invalidation, and cache clearing. */
   _preloads?: Map<AbortController, Array<AnyRouteMatch>>
   _refreshNextLoad?: boolean
   _cancelTransition?: () => void
@@ -507,7 +507,7 @@ function releaseFlight(router: AnyRouter, match: WorkMatch): void {
  * Not passing in a `next` ownership recipient
  * is equivalent to discarding the match resources
  */
-export function transferMatchResources(
+function transferMatchResources(
   router: AnyRouter,
   previous: Array<AnyRouteMatch>,
   next?: Array<AnyRouteMatch>,
@@ -909,7 +909,11 @@ function createLoaderTask(
     if (blocking) {
       settleInto(match, result, preload)
       if (result[0 /* kind */] === SUCCESS) {
-        if (preload && routeLoader) {
+        if (
+          preload &&
+          routeLoader &&
+          !options[0 /* controller */].signal.aborted
+        ) {
           cacheLoaderMatch(router, match, plannedCacheMatch)
         }
         // A route is renderable only after both its data and normal component

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -2513,8 +2513,8 @@ export class RouterCore<
     this._committed = committedMatches.map(invalidate)
     // Cache entries are settled successes. Retiring matching active preload
     // owners makes an in-place stale mark sufficient while preserving data.
-    for (const match of this._cache.values()) {
-      if (invalidIds.has(match.id)) {
+    for (const [id, match] of this._cache) {
+      if (invalidIds.has(id)) {
         match.invalid = true
         if (opts?.forcePending) {
           match.status = 'pending'

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -41,7 +41,6 @@ import {
   preloadClientRoute,
   refreshClientRoute,
   replaceRouteChunk,
-  transferMatchResources,
 } from './load-client'
 import {
   composeRewrites,
@@ -1024,7 +1023,7 @@ export interface RouterCore<
   _tx?: LoadTransaction
   /** Joinable in-flight loader generations keyed by match ID. */
   _flights?: Map<string, LoaderFlight>
-  /** Active speculative lanes retained for cancellation and cache clearing. */
+  /** Active speculative lanes retained for cancellation, invalidation, and cache clearing. */
   _preloads?: Map<AbortController, Array<AnyRouteMatch>>
   /** Owns cancellable work before a client transaction publishes. */
   _preflight?: AbortController
@@ -2451,9 +2450,11 @@ export class RouterCore<
   }
 
   /**
-   * Invalidate the current matches and optionally force them back into a pending state.
+   * Invalidate selected match generations and optionally force current matches
+   * back into a pending state.
    *
-   * - Marks all matches that pass the optional `filter` as `invalid: true`.
+   * - Marks committed and cached matches whose IDs are selected as invalid.
+   * - Retires selected active preloads so older work cannot publish fresh data.
    *
    * The next load decides when to publish pending UI, so invalidation does not
    * mutate the currently rendered status.
@@ -2469,10 +2470,12 @@ export class RouterCore<
   > = (opts) => {
     const committedMatches = this._committed
     const filter = opts?.filter
+    const preloads = this._preloads
     const invalidIds = new Set(
       [
         ...committedMatches,
         ...this._cache.values(),
+        ...[...(preloads?.values() ?? [])].flat(),
         ...(this._tx?.[3 /* matches */] ?? []),
       ]
         .filter(
@@ -2480,6 +2483,13 @@ export class RouterCore<
         )
         .map((match) => match.id),
     )
+    const discardedPreloads: Array<AbortController> = []
+    for (const [controller, matches] of preloads ?? []) {
+      if (matches.some((match) => invalidIds.has(match.id))) {
+        preloads!.delete(controller)
+        discardedPreloads.push(controller)
+      }
+    }
     const invalidate = (d: MakeRouteMatch<TRouteTree>) => {
       if (invalidIds.has(d.id)) {
         const route = this.routesById[d.routeId] as AnyRoute
@@ -2500,17 +2510,24 @@ export class RouterCore<
       return d
     }
 
-    const committed = committedMatches.map(invalidate)
-    this._committed = committed
-    const cache = new Map<string, AnyRouteMatch>()
-    for (const [id, match] of this._cache) {
-      cache.set(id, invalidate(match))
+    this._committed = committedMatches.map(invalidate)
+    // Cache entries are settled successes. Retiring matching active preload
+    // owners makes an in-place stale mark sufficient while preserving data.
+    for (const match of this._cache.values()) {
+      if (invalidIds.has(match.id)) {
+        match.invalid = true
+        if (opts?.forcePending) {
+          match.status = 'pending'
+        }
+      }
     }
-    this._cache = cache
     // The superseding load must not discover any same-ID generation selected
     // for replacement. Existing owners release it in their normal order.
     for (const id of invalidIds) {
       this._flights?.delete(id)
+    }
+    for (const controller of discardedPreloads) {
+      controller.abort()
     }
 
     this.shouldViewTransition = false
@@ -2563,57 +2580,46 @@ export class RouterCore<
     const cached = this._cache
     const preloads = this._preloads
     const filter = opts?.filter
-    const retained = new Map<string, AnyRouteMatch>()
     const discarded: Array<AnyRouteMatch> = []
+    const discardedIds: Array<string> = []
     for (const [id, match] of cached) {
-      if (filter && !filter(match as MakeRouteMatchUnion<this>)) {
-        retained.set(id, match)
-      } else {
+      if (!filter || filter(match as MakeRouteMatchUnion<this>)) {
+        discardedIds.push(id)
         discarded.push(match)
       }
     }
-    const retainedPreloads = new Map<AbortController, Array<AnyRouteMatch>>()
-    const discardedPreloads: Array<AbortController> = []
+    const abort: Array<AbortController> = []
     for (const [controller, matches] of preloads ?? []) {
       if (!filter || matches.some(filter as any)) {
-        discardedPreloads.push(controller)
+        abort.push(controller)
         discarded.push(...matches)
-      } else {
-        retainedPreloads.set(controller, matches)
       }
     }
 
-    // Install both replacement authorities before releasing a public loader
+    // Run every public filter before changing authority, then prune both maps
+    // before releasing a public loader
     // signal, whose abort listeners can synchronously reenter the router.
-    this._cache = retained
-    this._preloads = retainedPreloads
-    const discardedFlights = new Map<
-      LoaderFlight,
-      [id: string, owners: number]
-    >()
+    for (const id of discardedIds) {
+      cached.delete(id)
+    }
+    for (const controller of abort) {
+      preloads!.delete(controller)
+    }
+    // clearCache is a force-retirement boundary, so a final discarded lease
+    // must not use the normal zero-owner handoff window.
     for (const match of discarded as Array<
       AnyRouteMatch & { _flight?: LoaderFlight }
     >) {
       const flight = match._flight
-      if (flight && this._flights?.get(match.id) === flight) {
-        const entry = discardedFlights.get(flight)
-        if (entry) {
-          entry[1 /* owners */]++
-        } else {
-          discardedFlights.set(flight, [match.id, 1])
+      match._flight = undefined
+      if (flight && !--flight[2 /* leases */]) {
+        if (this._flights?.get(match.id) === flight) {
+          this._flights.delete(match.id)
         }
+        abort.push(flight[1 /* controller */])
       }
     }
-    for (const [flight, [id, owners]] of discardedFlights) {
-      if (
-        flight[2 /* leases */] === owners &&
-        this._flights?.get(id) === flight
-      ) {
-        this._flights.delete(id)
-      }
-    }
-    transferMatchResources(this, discarded)
-    for (const controller of discardedPreloads) {
+    for (const controller of abort) {
       controller.abort()
     }
   }

--- a/packages/router-core/tests/preload-beforeload-reuse.test.ts
+++ b/packages/router-core/tests/preload-beforeload-reuse.test.ts
@@ -407,7 +407,9 @@ describe('preloaded loader reuse with fresh beforeLoad context', () => {
       generation,
       preload,
     }))
-    const loader = vi.fn(() => loaderGate)
+    const loader = vi.fn(() =>
+      loader.mock.calls.length === 1 ? loaderGate : 'new loader data',
+    )
     const rootRoute = new BaseRootRoute({})
     const indexRoute = new BaseRoute({
       getParentRoute: () => rootRoute,
@@ -441,12 +443,12 @@ describe('preloaded loader reuse with fresh beforeLoad context', () => {
       true,
       false,
     ])
-    expect(loader).toHaveBeenCalledOnce()
+    expect(loader).toHaveBeenCalledTimes(2)
     expect(router.state.matches.at(-1)?.context).toEqual({
       generation: 2,
       preload: false,
     })
-    expect(router.state.matches.at(-1)?.loaderData).toBe('shared loader data')
+    expect(router.state.matches.at(-1)?.loaderData).toBe('new loader data')
   })
 
   test('preload false does not cache beforeLoad context for navigation', async () => {

--- a/packages/router-core/tests/preload-public-cache-behavior.test.ts
+++ b/packages/router-core/tests/preload-public-cache-behavior.test.ts
@@ -258,6 +258,101 @@ test('clearCache does not reserve a discarded preload for a navigation in before
   expect(router.state.matches.at(-1)?.loaderData).toBe('fresh navigation data')
 })
 
+test('clearCache does not abort loader work still used by a navigation', async () => {
+  const loaderGate = createControlledPromise<string>()
+  let loaderSignal: AbortSignal | undefined
+  const beforeLoad = vi.fn()
+  const loader = vi.fn(
+    ({ abortController }: { abortController: AbortController }) => {
+      loaderSignal = abortController.signal
+      return loaderGate
+    },
+  )
+  const rootRoute = new BaseRootRoute({})
+  const homeRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+  })
+  const targetRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/target',
+    beforeLoad,
+    loader,
+  })
+  const router = createTestRouter({
+    routeTree: rootRoute.addChildren([homeRoute, targetRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  await router.load()
+  const preload = router.preloadRoute({ to: '/target' })
+  await vi.waitFor(() => expect(loader).toHaveBeenCalledOnce())
+  const navigation = router.navigate({ to: '/target' })
+  await vi.waitFor(() => expect(beforeLoad).toHaveBeenCalledTimes(2))
+
+  router.clearCache({
+    filter: (match) => match.routeId === targetRoute.id,
+  })
+  expect(loaderSignal?.aborted).toBe(false)
+
+  loaderGate.resolve('shared loader data')
+  await Promise.all([preload, navigation])
+
+  expect(loader).toHaveBeenCalledOnce()
+  expect(router.state.matches.at(-1)?.loaderData).toBe('shared loader data')
+})
+
+test('clearCache leaves cache authority intact when its filter throws', async () => {
+  let firstSignal: AbortSignal | undefined
+  let secondSignal: AbortSignal | undefined
+  const rootRoute = new BaseRootRoute({})
+  const firstRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/first',
+    loader: ({ abortController }) => {
+      firstSignal = abortController.signal
+      return 'first data'
+    },
+  })
+  const secondRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/second',
+    loader: ({ abortController }) => {
+      secondSignal = abortController.signal
+      return 'second data'
+    },
+  })
+  const router = createTestRouter({
+    routeTree: rootRoute.addChildren([firstRoute, secondRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  await router.load()
+  await router.preloadRoute({ to: '/first' })
+  await router.preloadRoute({ to: '/second' })
+  const filterError = new Error('filter failed')
+
+  expect(() =>
+    router.clearCache({
+      filter: (match) => {
+        if (match.routeId === firstRoute.id) {
+          return true
+        }
+        if (match.routeId === secondRoute.id) {
+          throw filterError
+        }
+        return false
+      },
+    }),
+  ).toThrow(filterError)
+  expect(firstSignal?.aborted).toBe(false)
+  expect(secondSignal?.aborted).toBe(false)
+
+  router.clearCache()
+  expect(firstSignal?.aborted).toBe(true)
+  expect(secondSignal?.aborted).toBe(true)
+})
+
 test('clearCache installs replacement authorities before abort listeners reenter', async () => {
   let reentrantNavigation: Promise<void> | undefined
   let router: ReturnType<typeof createTestRouter>
@@ -485,12 +580,128 @@ test('independent concurrent preloads both populate the cache', async () => {
   expect(secondLoader).toHaveBeenCalledOnce()
 })
 
-// Probe, not a required cancellation policy: invalidating the accepted route
-// need not cancel unrelated private preload work, but the public operations
-// must both settle and leave navigation usable.
-test('invalidate and an unrelated in-flight preload both settle cleanly', async () => {
-  const loaderGate = createControlledPromise<string>()
-  const loader = vi.fn(() => loaderGate)
+test.each([
+  ['unfiltered', undefined, true],
+  ['filtered affected', 'target', true],
+  ['filtered unaffected', 'home', false],
+] as const)(
+  '%s invalidation preserves the correct preload generation',
+  async (_mode, selected, shouldReload) => {
+    const oldLoaderGate = createControlledPromise<string>()
+    let generation = 1
+    const loader = vi.fn(() =>
+      loader.mock.calls.length === 1
+        ? oldLoaderGate
+        : `generation ${generation}`,
+    )
+    const rootRoute = new BaseRootRoute({})
+    const homeRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const targetRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/target',
+      preloadStaleTime: Infinity,
+      staleTime: Infinity,
+      loader,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([homeRoute, targetRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+    const preload = router.preloadRoute({ to: '/target' })
+    await vi.waitFor(() => expect(loader).toHaveBeenCalledOnce())
+
+    generation = 2
+    await (selected
+      ? router.invalidate({
+          filter: (match) =>
+            match.routeId ===
+            (selected === 'target' ? targetRoute.id : homeRoute.id),
+        })
+      : router.invalidate())
+
+    oldLoaderGate.resolve('generation 1')
+    await preload
+    await router.navigate({ to: '/target' })
+
+    expect(loader).toHaveBeenCalledTimes(shouldReload ? 2 : 1)
+    expect(router.state.matches.at(-1)?.loaderData).toBe(
+      `generation ${shouldReload ? 2 : 1}`,
+    )
+  },
+)
+
+test('filtering only an active preload invalidates seeded same-ID cache data', async () => {
+  const replacementGate = createControlledPromise<string>()
+  const loader = vi.fn(() => {
+    const generation = loader.mock.calls.length
+    return generation === 2 ? replacementGate : `generation ${generation}`
+  })
+  const rootRoute = new BaseRootRoute({})
+  const homeRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+  })
+  const targetRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/target',
+    validateSearch: (search: Record<string, unknown>) => ({
+      revision: Number(search.revision ?? 1),
+    }),
+    preloadStaleTime: 0,
+    staleTime: Infinity,
+    loader,
+  })
+  const router = createTestRouter({
+    routeTree: rootRoute.addChildren([homeRoute, targetRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  await router.load()
+  await router.navigate({ to: '/target', search: { revision: 1 } })
+  await router.navigate({ to: '/' })
+  const preload = router.preloadRoute({
+    to: '/target',
+    search: { revision: 2 },
+  })
+  await vi.waitFor(() => expect(loader).toHaveBeenCalledTimes(2))
+
+  await router.invalidate({
+    filter: (match) =>
+      match.routeId === targetRoute.id &&
+      (match.search as { revision?: number }).revision === 2,
+  })
+  replacementGate.resolve('obsolete generation 2')
+  await preload
+  await router.navigate({ to: '/target' })
+
+  await vi.waitFor(() => {
+    expect(loader).toHaveBeenCalledTimes(3)
+    expect(router.state.matches.at(-1)?.loaderData).toBe('generation 3')
+  })
+})
+
+test('invalidation wins after a preload loader settles but before it publishes', async () => {
+  let invalidation: Promise<void> | undefined
+  let generation = 0
+  let router: ReturnType<typeof createTestRouter>
+  const loader = vi.fn(() => {
+    const data = `generation ${++generation}`
+    if (generation === 1) {
+      // Schedule invalidation after the loader outcome has fulfilled while the
+      // preload lane's cache publication is still queued.
+      let turn = Promise.resolve()
+      for (let index = 0; index < 4; index++) {
+        turn = turn.then()
+      }
+      invalidation = turn.then(() => router.invalidate())
+    }
+    return data
+  })
   const rootRoute = new BaseRootRoute({})
   const homeRoute = new BaseRoute({
     getParentRoute: () => rootRoute,
@@ -503,27 +714,22 @@ test('invalidate and an unrelated in-flight preload both settle cleanly', async 
     staleTime: Infinity,
     loader,
   })
-  const router = createTestRouter({
+  router = createTestRouter({
     routeTree: rootRoute.addChildren([homeRoute, targetRoute]),
     history: createMemoryHistory({ initialEntries: ['/'] }),
   })
 
   await router.load()
   const preload = router.preloadRoute({ to: '/target' })
-  await vi.waitFor(() => expect(loader).toHaveBeenCalledTimes(1))
-  expect(loaderGate.status).toBe('pending')
-  await router.invalidate()
-  expect(loaderGate.status).toBe('pending')
-  loaderGate.resolve('target data')
+  await vi.waitFor(() => expect(invalidation).toBeDefined())
+  await invalidation
   await preload
-
   await router.navigate({ to: '/target' })
-  expect(router.state.location.pathname).toBe('/target')
-  expect(
-    router.state.matches.find((match) => match.routeId === targetRoute.id)
-      ?.loaderData,
-  ).toBe('target data')
-  expect(loader).toHaveBeenCalledTimes(1)
+
+  await vi.waitFor(() => {
+    expect(loader).toHaveBeenCalledTimes(2)
+    expect(router.state.matches.at(-1)?.loaderData).toBe('generation 2')
+  })
 })
 
 // Preload lanes are not cancelled by unrelated navigations: an in-flight


### PR DESCRIPTION
## What changed

- Include active preload matches in ID-wide invalidation selection.
- Retire matching preload lanes and fence late cache publication with the existing lane abort signal.
- Preserve unrelated preloads and navigation-owned shared loader work.
- Consolidate `clearCache` lease release while keeping throwing filters atomic.
- Add public-API regressions and update the invalidation documentation.

## Why

An in-flight preload could outlive `router.invalidate()`, settle afterward, and publish its old loader result as fresh cache data. A later navigation would then reuse that stale generation instead of loading again.

## User impact

Affected preloads can no longer repopulate the cache after invalidation. Unselected preloads continue normally, and loader work shared with an active navigation is retained for that navigation.

## Validation

- Router-core unit tests
- Router-core type tests
- Router-core ESLint
- Prettier and diff checks
- Full bundle-size matrix: all 17 gzip scenarios decreased; `react-router.minimal` changed by -9 bytes
