### PR TITLE
fix(router): correct lane loader changeset

### DIFF
--- a/.changeset/lane-match-loader-rewrite.md
+++ b/.changeset/lane-match-loader-rewrite.md
@@ -19,14 +19,14 @@ Rewrite match loading around a lane-based scheduler that tracks each navigation,
 - `RouteMatch.status` no longer includes `'redirected'` (it remains `'pending' | 'success' | 'error' | 'notFound'`) — redirected matches are dropped from the match list instead of being rendered.
 - `RouteMatch.globalNotFound` has been renamed and privatized to the internal `_notFound` field. Use `match.status === 'notFound'` instead.
 - The exported React, Solid, and Vue `Match` components now accept `routeId` instead of `matchId`.
-- The exported `RouterStores` adapter contract now uses route-keyed presentation stores: `matchesId` is replaced by `ids`, `matchStores` by `byRoute`, and `getRouteMatchStore()` by `getMatchStore()`. The separate loaded/loading/transition, status/redirect, pending, and cache stores and setters have been removed, as has `StoreConfig.init`. Read application-facing state from `router.state`; preload and cache coordination are now internal.
+- The exported `RouterStores` adapter contract now uses route-keyed presentation stores: `matchesId` is replaced by `ids`, `matchStores` by `byRoute`, and `getRouteMatchStore()` by `getMatchStore()`. The separate `loadedAt`, `isLoading`, `isTransitioning`, `statusCode`, and `redirect` stores have been removed, along with the pending/cache stores and their setters. `StoreConfig.init` has also been removed. Read application-facing state from `router.state`; preload and cache coordination are now internal.
 - Removed `RouterCore` members `getMatch()`, `updateMatch()`, `cancelMatch()`, and `cancelMatches()` — read matches from `router.state.matches` (e.g. `router.state.matches.find((m) => m.id === id)`); there is no replacement for mutating or cancelling an individual in-flight match from outside the router.
-- Removed `hasNotFoundMatch()` — use `router.state.matches.some((m) => m.status === 'notFound')`.
-- Removed `looseRoutesById` — use `routesById`.
-- Removed `isPrerendering()`, `isViewTransitionTypesSupported`, and `viewTransitionPromise`, with no replacement.
-- Removed `getParsedLocationHref()` and `clearExpiredCache()`, with no replacement — expired cache entries are now reconciled automatically as part of match commit.
-- Removed `latestLoadPromise` and `beforeLoad()`, with no replacement.
-- `commitLocationPromise` and `pendingBuiltLocation` are now private (`_commitPromise`, `_pendingLocation`) and no longer part of the public `RouterCore` surface.
+- Removed `RouterCore.hasNotFoundMatch()` — use `router.state.matches.some((m) => m.status === 'notFound')`.
+- Removed `RouterCore.looseRoutesById` — use `routesById`.
+- Removed `RouterCore.isPrerendering()`, `RouterCore.isViewTransitionTypesSupported`, and `RouterCore.viewTransitionPromise`, with no replacement.
+- Removed `RouterCore.getParsedLocationHref()` and `RouterCore.clearExpiredCache()`, with no replacement — expired cache entries are now reconciled automatically as part of match commit.
+- Removed `RouterCore.latestLoadPromise` and `RouterCore.beforeLoad()`, with no replacement.
+- `RouterCore.commitLocationPromise` and `RouterCore.pendingBuiltLocation` have been replaced by the internal `_commitPromise` and `_pendingLocation` fields.
 - Removed the exported `GetMatchFn` and `UpdateMatchFn` types, along with the methods they typed.
 - Removed the standalone `getMatchedRoutes()` export from `@tanstack/router-core` — use the `router.getMatchedRoutes()` instance method instead.
 - `RouterCore.loadRouteChunk()` no longer accepts an array of component types as its second argument. One-argument usage is unchanged; the optional second argument is now `'errorComponent'`, `'notFoundComponent'`, or `false` for internal boundary loading.

--- a/.changeset/lane-match-loader-rewrite.md
+++ b/.changeset/lane-match-loader-rewrite.md
@@ -1,8 +1,8 @@
 ---
-'@tanstack/router-core': minor
-'@tanstack/react-router': minor
-'@tanstack/solid-router': minor
-'@tanstack/vue-router': minor
+'@tanstack/router-core': patch
+'@tanstack/react-router': patch
+'@tanstack/solid-router': patch
+'@tanstack/vue-router': patch
 '@tanstack/router-devtools-core': patch
 ---
 
@@ -12,7 +12,7 @@ Rewrite match loading around a lane-based scheduler that tracks each navigation,
 - Route `headers()` now only runs on the server, matching the documented behavior — it is no longer invoked during client-side asset projection.
 - The documented default `gcTime` and `preloadGcTime` now match the existing runtime default of 5 minutes (`300_000`).
 
-**Removed / changed public API**
+**Removed / changed exported internals**
 
 - `RouterState` no longer includes `loadedAt`, `isTransitioning`, `statusCode`, or `redirect`. Use `match.updatedAt` in place of `loadedAt`; subscribe to `router.state.status` / `router.state.isLoading` in place of `isTransitioning`; server response status and redirect handling are now internal to the server loader and are no longer exposed on `router.state`.
 - `RouteMatch.fetchCount` has been removed, with no replacement — it was purely informational.

--- a/.changeset/lane-match-loader-rewrite.md
+++ b/.changeset/lane-match-loader-rewrite.md
@@ -1,15 +1,16 @@
 ---
-'@tanstack/router-core': patch
-'@tanstack/react-router': patch
-'@tanstack/solid-router': patch
-'@tanstack/vue-router': patch
+'@tanstack/router-core': minor
+'@tanstack/react-router': minor
+'@tanstack/solid-router': minor
+'@tanstack/vue-router': minor
+'@tanstack/router-devtools-core': patch
 ---
 
 Rewrite match loading around a lane-based scheduler that tracks each navigation, preload, and background reload as an ordered unit of work. This fixes pending/redirect/retry state leaking between overlapping navigations, restores correct SSR status codes for redirects, errors, and not-found responses, and closes hydration gaps where the client re-ran work the server had already completed.
 
 - Invalidation now retires matching active preloads so older speculative loader results cannot become fresh cache data after invalidation.
 - Route `headers()` now only runs on the server, matching the documented behavior — it is no longer invoked during client-side asset projection.
-- Default `gcTime` and `preloadGcTime` are reduced from 30 minutes (`1_800_000`) to 5 minutes (`300_000`).
+- The documented default `gcTime` and `preloadGcTime` now match the existing runtime default of 5 minutes (`300_000`).
 
 **Removed / changed public API**
 
@@ -17,6 +18,8 @@ Rewrite match loading around a lane-based scheduler that tracks each navigation,
 - `RouteMatch.fetchCount` has been removed, with no replacement — it was purely informational.
 - `RouteMatch.status` no longer includes `'redirected'` (it remains `'pending' | 'success' | 'error' | 'notFound'`) — redirected matches are dropped from the match list instead of being rendered.
 - `RouteMatch.globalNotFound` has been renamed and privatized to the internal `_notFound` field. Use `match.status === 'notFound'` instead.
+- The exported React, Solid, and Vue `Match` components now accept `routeId` instead of `matchId`.
+- The exported `RouterStores` adapter contract now uses route-keyed presentation stores: `matchesId` is replaced by `ids`, `matchStores` by `byRoute`, and `getRouteMatchStore()` by `getMatchStore()`. The separate loaded/loading/transition, status/redirect, pending, and cache stores and setters have been removed, as has `StoreConfig.init`. Read application-facing state from `router.state`; preload and cache coordination are now internal.
 - Removed `RouterCore` members `getMatch()`, `updateMatch()`, `cancelMatch()`, and `cancelMatches()` — read matches from `router.state.matches` (e.g. `router.state.matches.find((m) => m.id === id)`); there is no replacement for mutating or cancelling an individual in-flight match from outside the router.
 - Removed `hasNotFoundMatch()` — use `router.state.matches.some((m) => m.status === 'notFound')`.
 - Removed `looseRoutesById` — use `routesById`.
@@ -26,5 +29,7 @@ Rewrite match loading around a lane-based scheduler that tracks each navigation,
 - `commitLocationPromise` and `pendingBuiltLocation` are now private (`_commitPromise`, `_pendingLocation`) and no longer part of the public `RouterCore` surface.
 - Removed the exported `GetMatchFn` and `UpdateMatchFn` types, along with the methods they typed.
 - Removed the standalone `getMatchedRoutes()` export from `@tanstack/router-core` — use the `router.getMatchedRoutes()` instance method instead.
+- `RouterCore.loadRouteChunk()` no longer accepts an array of component types as its second argument. One-argument usage is unchanged; the optional second argument is now `'errorComponent'`, `'notFoundComponent'`, or `false` for internal boundary loading.
+- Removed `Redirect.redirectHandled`, which was internal redirect bookkeeping.
 - `MatchRoutesOpts.preload` and `MatchRoutesOpts.dest` have been removed.
-- `StartTransitionFn` is now `(fn, expected, urgent?) => Promise<boolean>` (previously `(fn) => void`). This only affects custom framework adapters that implement `startTransition`.
+- `StartTransitionFn` is now `(fn, expected) => Promise<boolean>` (previously `(fn) => void`). This only affects custom framework adapters that implement `startTransition`.

--- a/packages/router-devtools-core/src/AgeTicker.tsx
+++ b/packages/router-devtools-core/src/AgeTicker.tsx
@@ -47,7 +47,7 @@ export function AgeTicker({
   const staleTime =
     route.options.staleTime ?? router().options.defaultStaleTime ?? 0
   const gcTime =
-    route.options.gcTime ?? router().options.defaultGcTime ?? 30 * 60 * 1000
+    route.options.gcTime ?? router().options.defaultGcTime ?? 300_000
 
   return (
     <div class={cx(styles().ageTicker(age > staleTime))}>

--- a/packages/router-devtools-core/tests/cache-replacement.test.ts
+++ b/packages/router-devtools-core/tests/cache-replacement.test.ts
@@ -35,7 +35,7 @@ describe('cached matches', () => {
     vi.useRealTimers()
   })
 
-  it('refreshes when an existing cache entry is replaced', async () => {
+  it('uses the default gc time and refreshes replaced cache entries', async () => {
     vi.useFakeTimers()
 
     const route = {
@@ -88,6 +88,7 @@ describe('cached matches', () => {
         ),
       ).not.toBeNull()
     })
+    expect(container.textContent).toContain('5min')
 
     const cachedMatch = container.querySelector(
       '[aria-label="Open match details for cached-match"]',


### PR DESCRIPTION
## Summary

- keep the lane-loader fixes as patch releases for the core and framework router packages
- add `@tanstack/router-devtools-core` so the compatible devtools implementation and wrapper packages are published
- correct and complete the changeset's behavior and exported-internals migration notes
- align the devtools GC fallback with the router's existing five-minute default and cover it with a regression assertion

## Why

This is a release-metadata follow-up to [TanStack/router#7805](https://github.com/TanStack/router/pull/7805). The merged changeset omitted the modified devtools core from the release graph, stated that the runtime GC default changed when it was already five minutes, contained a stale `StartTransitionFn` signature, and described unsupported exported internals as public API.

Those removed surfaces were not considered supported public contracts, so the affected router packages remain patch releases. Without a devtools-core release, previously published devtools can access router fields removed by #7805.

## Impact

The unreleased router rewrite will have accurate patch release notes, and the compatible devtools core plus its framework wrappers will be included in the release. The devtools age ticker now displays the same default GC duration used by router core.

## Validation

- `pnpm changeset status --since origin/main`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/router-devtools-core:test:unit --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/router-devtools-core:test:types --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/router-devtools-core:test:eslint --outputStyle=stream --skipRemoteCache`
- `pnpm exec prettier --check .changeset/lane-match-loader-rewrite.md packages/router-devtools-core/src/AgeTicker.tsx packages/router-devtools-core/tests/cache-replacement.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lane-based match loading across navigation, preloading, reloads, invalidation, server-rendered responses, and hydration.
  * Added support for server-only route headers.
  * Set the default router DevTools cache duration to 5 minutes.
  * Published a patch update for the router DevTools core package.

* **Improvements**
  * Streamlined routing APIs and component properties for match handling.
  * Updated transition and redirect interfaces.
  * Improved cached match replacement and refreshed displayed match information.
  * Corrected the cache-duration display to show the 5-minute default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->