### PR TITLE
fix(router-core): properly handle serialization of readonly maps/sets at type level

### DIFF
--- a/.changeset/full-flowers-carry.md
+++ b/.changeset/full-flowers-carry.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+fix(router-core): properly handle serialization of readonly maps/sets at type level

--- a/packages/router-core/src/ssr/serializer/transformer.ts
+++ b/packages/router-core/src/ssr/serializer/transformer.ts
@@ -86,10 +86,10 @@ export type ValidateSerializable<T, TSerializable> = T extends TSerializable
           ? ValidateSerializablePromise<T, TSerializable>
           : T extends ReadableStream<any>
             ? ValidateReadableStream<T, TSerializable>
-            : T extends Set<any>
-              ? ValidateSerializableSet<T, TSerializable>
-              : T extends Map<any, any>
-                ? ValidateSerializableMap<T, TSerializable>
+            : T extends ReadonlyMap<any, any>
+              ? ValidateSerializableMap<T, TSerializable>
+              : T extends ReadonlySet<any>
+                ? ValidateSerializableSet<T, TSerializable>
                 : T extends AsyncGenerator<any, any>
                   ? ValidateSerializableAsyncGenerator<T, TSerializable>
                   : T extends object
@@ -118,7 +118,9 @@ export type ValidateReadableStream<T, TSerializable> =
 export type ValidateSerializableSet<T, TSerializable> =
   T extends Set<infer TItem>
     ? Set<ValidateSerializable<TItem, TSerializable>>
-    : never
+    : T extends ReadonlySet<infer TItem>
+      ? ReadonlySet<ValidateSerializable<TItem, TSerializable>>
+      : never
 
 export type ValidateSerializableMap<T, TSerializable> =
   T extends Map<infer TKey, infer TValue>
@@ -126,7 +128,12 @@ export type ValidateSerializableMap<T, TSerializable> =
         ValidateSerializable<TKey, TSerializable>,
         ValidateSerializable<TValue, TSerializable>
       >
-    : never
+    : T extends ReadonlyMap<infer TKey, infer TValue>
+      ? ReadonlyMap<
+          ValidateSerializable<TKey, TSerializable>,
+          ValidateSerializable<TValue, TSerializable>
+        >
+      : never
 
 export type ValidateSerializableArray<T, TSerializable> = T extends readonly [
   any,

--- a/packages/router-core/tests/serializer.test-d.ts
+++ b/packages/router-core/tests/serializer.test-d.ts
@@ -21,4 +21,39 @@ describe('Serializer', () => {
       ValidateSerializable<MyCustomType, Serializable>
     >().toEqualTypeOf<MyCustomType>()
   })
+
+  it('works for readonly sets containing serializable values', () => {
+    type Value = ReadonlySet<string>
+
+    expectTypeOf<
+      ValidateSerializable<Value, Serializable>
+    >().toEqualTypeOf<Value>()
+  })
+
+  it('fails for readonly sets containing unserializable values', () => {
+    type Value = ReadonlySet<() => void>
+
+    expectTypeOf<ValidateSerializable<Value, Serializable>>().toEqualTypeOf<
+      ReadonlySet<SerializationError<'Function may not be serializable'>>
+    >()
+  })
+
+  it('works for readonly maps containing serializable values', () => {
+    type Value = ReadonlyMap<string, number>
+
+    expectTypeOf<
+      ValidateSerializable<Value, Serializable>
+    >().toEqualTypeOf<Value>()
+  })
+
+  it('fails for readonly maps containing unserializable values', () => {
+    type Value = ReadonlyMap<string, () => void>
+
+    expectTypeOf<ValidateSerializable<Value, Serializable>>().toEqualTypeOf<
+      ReadonlyMap<
+        string,
+        SerializationError<'Function may not be serializable'>
+      >
+    >()
+  })
 })


### PR DESCRIPTION
Currently Set and Maps are properly serialized via Seroval. This is reflected on the type level so Set and Maps are properly validated for containing only serializable outputs for server functions. However, this doesn't properly work with ReadonlySet and ReadonlyMap variants:

<img width="1828" height="362" alt="image" src="https://github.com/user-attachments/assets/0b43415c-bc64-4522-babe-201f2d832af8" />

<img width="1830" height="428" alt="image" src="https://github.com/user-attachments/assets/e1a02994-b76b-4fc9-bc3a-d0aad3a43fd4" />

WIth the patch from this PR applied it works correctly:

<img width="1153" height="200" alt="image" src="https://github.com/user-attachments/assets/b7a6998a-fed0-4cea-b1bd-bb585d496406" />

Besides validating in my project I've also added tests to existing spec that tested type level serialization behavior to ensure all of these works properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved serialization type validation for readonly maps and sets.
  - Readonly collection contents are now checked recursively, including keys, values, and elements.
  - Invalid nested values produce clearer serialization errors.

- **Tests**
  - Added coverage for valid and invalid readonly maps and sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->