### PR TITLE
chore: update seroval to 1.6.2

### DIFF
--- a/.changeset/wise-ducks-serialize.md
+++ b/.changeset/wise-ducks-serialize.md
@@ -1,0 +1,9 @@
+---
+'@tanstack/router-core': patch
+'@tanstack/start-client-core': patch
+'@tanstack/start-plugin-core': patch
+'@tanstack/start-server-core': patch
+'@tanstack/start-static-server-functions': patch
+---
+
+Update Seroval dependencies to version 1.6.2.

--- a/benchmarks/ssr/package.json
+++ b/benchmarks/ssr/package.json
@@ -18,7 +18,7 @@
     "@codspeed/vitest-plugin": "^5.5.0",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitejs/plugin-vue-jsx": "^5.1.5",
-    "seroval": "^1.5.4",
+    "seroval": "^1.6.2",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",

--- a/packages/router-core/package.json
+++ b/packages/router-core/package.json
@@ -184,8 +184,8 @@
   "dependencies": {
     "@tanstack/history": "workspace:*",
     "cookie-es": "^3.0.0",
-    "seroval": "^1.5.4",
-    "seroval-plugins": "^1.5.4"
+    "seroval": "^1.6.2",
+    "seroval-plugins": "^1.6.2"
   },
   "devDependencies": {
     "@tanstack/store": "^0.9.3",

--- a/packages/start-client-core/package.json
+++ b/packages/start-client-core/package.json
@@ -109,7 +109,7 @@
     "@tanstack/router-core": "workspace:*",
     "@tanstack/start-fn-stubs": "workspace:*",
     "@tanstack/start-storage-context": "workspace:*",
-    "seroval": "^1.5.4"
+    "seroval": "^1.6.2"
   },
   "devDependencies": {
     "vite": "*",

--- a/packages/start-plugin-core/package.json
+++ b/packages/start-plugin-core/package.json
@@ -97,7 +97,7 @@
     "lightningcss": "^1.32.0",
     "pathe": "^2.0.3",
     "picomatch": "^4.0.3",
-    "seroval": "^1.5.4",
+    "seroval": "^1.6.2",
     "source-map": "^0.7.6",
     "srvx": "^0.11.9",
     "tinyglobby": "^0.2.15",

--- a/packages/start-server-core/package.json
+++ b/packages/start-server-core/package.json
@@ -105,7 +105,7 @@
     "@tanstack/start-storage-context": "workspace:*",
     "fetchdts": "^0.1.6",
     "h3-v2": "npm:h3@2.0.1-rc.20",
-    "seroval": "^1.5.4"
+    "seroval": "^1.6.2"
   },
   "devDependencies": {
     "@standard-schema/spec": "^1.0.0",

--- a/packages/start-static-server-functions/package.json
+++ b/packages/start-static-server-functions/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@tanstack/start-client-core": "workspace:*",
-    "seroval": "^1.5.4"
+    "seroval": "^1.6.2"
   },
   "devDependencies": {
     "vite": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -502,8 +502,8 @@ importers:
         specifier: ^5.1.5
         version: 5.1.5(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))(vue@3.5.25(@typescript/typescript6@6.0.2))
       seroval:
-        specifier: ^1.5.4
-        version: 1.5.4
+        specifier: ^1.6.2
+        version: 1.6.2
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -13645,11 +13645,11 @@ importers:
         specifier: ^3.0.0
         version: 3.1.1
       seroval:
-        specifier: ^1.5.4
-        version: 1.5.4
+        specifier: ^1.6.2
+        version: 1.6.2
       seroval-plugins:
-        specifier: ^1.5.4
-        version: 1.5.4(seroval@1.5.4)
+        specifier: ^1.6.2
+        version: 1.6.2(seroval@1.6.2)
     devDependencies:
       '@tanstack/store':
         specifier: ^0.9.3
@@ -14069,8 +14069,8 @@ importers:
         specifier: workspace:*
         version: link:../start-storage-context
       seroval:
-        specifier: ^1.5.4
-        version: 1.5.4
+        specifier: ^1.6.2
+        version: 1.6.2
     devDependencies:
       '@types/node':
         specifier: 25.0.9
@@ -14124,8 +14124,8 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3
       seroval:
-        specifier: ^1.5.4
-        version: 1.5.4
+        specifier: ^1.6.2
+        version: 1.6.2
       source-map:
         specifier: ^0.7.6
         version: 0.7.6
@@ -14188,8 +14188,8 @@ importers:
         specifier: npm:h3@2.0.1-rc.20
         version: h3@2.0.1-rc.20(crossws@0.4.5(srvx@0.11.22))
       seroval:
-        specifier: ^1.5.4
-        version: 1.5.4
+        specifier: ^1.6.2
+        version: 1.6.2
     devDependencies:
       '@standard-schema/spec':
         specifier: ^1.0.0
@@ -14216,8 +14216,8 @@ importers:
         specifier: workspace:*
         version: link:../start-client-core
       seroval:
-        specifier: ^1.5.4
-        version: 1.5.4
+        specifier: ^1.6.2
+        version: 1.6.2
     devDependencies:
       '@types/node':
         specifier: 25.0.9
@@ -26122,8 +26122,18 @@ packages:
     peerDependencies:
       seroval: ^1.0
 
+  seroval-plugins@1.6.2:
+    resolution: {integrity: sha512-TfxuUjlbBESzUOWdTkTKqvSmav0ABym+itetDXLK6mDz8SmrpdI30aF8RTXE8Bvq+tH/1yIDkvy3W0lfQb1ipQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
   seroval@1.5.4:
     resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
+    engines: {node: '>=10'}
+
+  seroval@1.6.2:
+    resolution: {integrity: sha512-mPT+SD2TrlB6wvte1KkYOYUkubaTbd6pZ/6Kk3C9nxzrHmCZyhxOO7XGAeL7f+yLKZglzGtM9odUVvg/EhO+vQ==}
     engines: {node: '>=10'}
 
   serve-index@1.9.1:
@@ -40905,7 +40915,13 @@ snapshots:
     dependencies:
       seroval: 1.5.4
 
+  seroval-plugins@1.6.2(seroval@1.6.2):
+    dependencies:
+      seroval: 1.6.2
+
   seroval@1.5.4: {}
+
+  seroval@1.6.2: {}
 
   serve-index@1.9.1:
     dependencies:


### PR DESCRIPTION
## Summary

- update `seroval` and `seroval-plugins` to 1.6.2 across the affected Router and Start packages
- update the SSR benchmark dependency and refresh the pnpm lockfile
- add patch changesets for the five affected public packages

## Why

This adopts the latest Seroval serialization fixes, Temporal support, constructor serialization compatibility, restored CJS/ESM builds, and Promise-deserialization validation. The upstream changelog and published package diff did not show an API migration requirement.

## Validation

- `CI=1 NX_DAEMON=false pnpm nx run-many --target=test:unit --projects=@tanstack/router-core,@tanstack/start-client-core,@tanstack/start-server-core,@tanstack/start-static-server-functions,@tanstack/start-plugin-core --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run-many --target=test:types --projects=@tanstack/router-core,@tanstack/start-client-core,@tanstack/start-server-core,@tanstack/start-static-server-functions,@tanstack/start-plugin-core --outputStyle=stream --skipRemoteCache`
- `pnpm exec changeset status`
- CommonJS and ESM import smoke tests for `seroval` and `seroval-plugins/web`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated serialization dependencies to version 1.6.2 across supported packages and SSR benchmarks.

- **Release**
  - Prepared patch releases for six packages to incorporate the dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->