### PR TITLE
test(start): cover ssr false hydration redirect

### DIFF
--- a/e2e/react-start/selective-ssr/src/routeTree.gen.ts
+++ b/e2e/react-start/selective-ssr/src/routeTree.gen.ts
@@ -11,6 +11,8 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as Issue4614RouteImport } from './routes/issue-4614'
+import { Route as Issue7947RouteImport } from './routes/issue-7947'
+import { Route as Issue7947TargetRouteImport } from './routes/issue-7947-target'
 import { Route as PostsRouteImport } from './routes/posts'
 import { Route as PostsPostIdRouteImport } from './routes/posts.$postId'
 
@@ -22,6 +24,16 @@ const IndexRoute = IndexRouteImport.update({
 const Issue4614Route = Issue4614RouteImport.update({
   id: '/issue-4614',
   path: '/issue-4614',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const Issue7947Route = Issue7947RouteImport.update({
+  id: '/issue-7947',
+  path: '/issue-7947',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const Issue7947TargetRoute = Issue7947TargetRouteImport.update({
+  id: '/issue-7947-target',
+  path: '/issue-7947-target',
   getParentRoute: () => rootRouteImport,
 } as any)
 const PostsRoute = PostsRouteImport.update({
@@ -38,12 +50,16 @@ const PostsPostIdRoute = PostsPostIdRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/issue-4614': typeof Issue4614Route
+  '/issue-7947': typeof Issue7947Route
+  '/issue-7947-target': typeof Issue7947TargetRoute
   '/posts': typeof PostsRouteWithChildren
   '/posts/$postId': typeof PostsPostIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/issue-4614': typeof Issue4614Route
+  '/issue-7947': typeof Issue7947Route
+  '/issue-7947-target': typeof Issue7947TargetRoute
   '/posts': typeof PostsRouteWithChildren
   '/posts/$postId': typeof PostsPostIdRoute
 }
@@ -51,20 +67,43 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/issue-4614': typeof Issue4614Route
+  '/issue-7947': typeof Issue7947Route
+  '/issue-7947-target': typeof Issue7947TargetRoute
   '/posts': typeof PostsRouteWithChildren
   '/posts/$postId': typeof PostsPostIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/issue-4614' | '/posts' | '/posts/$postId'
+  fullPaths:
+    | '/'
+    | '/issue-4614'
+    | '/issue-7947'
+    | '/issue-7947-target'
+    | '/posts'
+    | '/posts/$postId'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/issue-4614' | '/posts' | '/posts/$postId'
-  id: '__root__' | '/' | '/issue-4614' | '/posts' | '/posts/$postId'
+  to:
+    | '/'
+    | '/issue-4614'
+    | '/issue-7947'
+    | '/issue-7947-target'
+    | '/posts'
+    | '/posts/$postId'
+  id:
+    | '__root__'
+    | '/'
+    | '/issue-4614'
+    | '/issue-7947'
+    | '/issue-7947-target'
+    | '/posts'
+    | '/posts/$postId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   Issue4614Route: typeof Issue4614Route
+  Issue7947Route: typeof Issue7947Route
+  Issue7947TargetRoute: typeof Issue7947TargetRoute
   PostsRoute: typeof PostsRouteWithChildren
 }
 
@@ -82,6 +121,20 @@ declare module '@tanstack/react-router' {
       path: '/issue-4614'
       fullPath: '/issue-4614'
       preLoaderRoute: typeof Issue4614RouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/issue-7947': {
+      id: '/issue-7947'
+      path: '/issue-7947'
+      fullPath: '/issue-7947'
+      preLoaderRoute: typeof Issue7947RouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/issue-7947-target': {
+      id: '/issue-7947-target'
+      path: '/issue-7947-target'
+      fullPath: '/issue-7947-target'
+      preLoaderRoute: typeof Issue7947TargetRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/posts': {
@@ -114,6 +167,8 @@ const PostsRouteWithChildren = PostsRoute._addFileChildren(PostsRouteChildren)
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   Issue4614Route: Issue4614Route,
+  Issue7947Route: Issue7947Route,
+  Issue7947TargetRoute: Issue7947TargetRoute,
   PostsRoute: PostsRouteWithChildren,
 }
 export const routeTree = rootRouteImport

--- a/e2e/react-start/selective-ssr/src/routes/issue-7947-target.tsx
+++ b/e2e/react-start/selective-ssr/src/routes/issue-7947-target.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/issue-7947-target')({
+  ssr: false,
+  // A different head shape exposes redirects that land before hydration as
+  // React's structural hydration error #418.
+  head: () => ({
+    meta: [
+      { title: 'Issue 7947 target' },
+      { name: 'robots', content: 'noindex, nofollow' },
+      { name: 'description', content: 'beforeLoad redirect target' },
+    ],
+  }),
+  component: () => <div data-testid="issue-7947-target">Target</div>,
+})

--- a/e2e/react-start/selective-ssr/src/routes/issue-7947.tsx
+++ b/e2e/react-start/selective-ssr/src/routes/issue-7947.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/issue-7947')({
+  ssr: false,
+  head: () => ({ meta: [{ title: 'Issue 7947 origin' }] }),
+  beforeLoad: () => {
+    throw redirect({ to: '/issue-7947-target' })
+  },
+  component: () => <div data-testid="issue-7947-origin">Origin</div>,
+})

--- a/e2e/react-start/selective-ssr/tests/app.spec.ts
+++ b/e2e/react-start/selective-ssr/tests/app.spec.ts
@@ -4,6 +4,34 @@ import { test } from '@tanstack/router-e2e-utils'
 const testCount = 7
 
 test.describe('selective ssr', () => {
+  test('#7947: beforeLoad redirect on an ssr: false route does not cause a hydration error', async ({
+    page,
+  }) => {
+    const browserErrors: Array<string> = []
+    // React's default onRecoverableError reports through both channels,
+    // depending on whether the development or production build is running.
+    page.on('console', (message) => {
+      if (message.type() === 'error') {
+        browserErrors.push(message.text())
+      }
+    })
+    page.on('pageerror', (error) => {
+      browserErrors.push(error.message)
+    })
+
+    await page.goto('/issue-7947')
+
+    await expect(page).toHaveURL(/\/issue-7947-target$/)
+    await expect(page.getByTestId('issue-7947-target')).toBeVisible()
+
+    const hydrationErrors = browserErrors.filter((error) =>
+      /hydrat|did not match|server rendered HTML|Minified React error #(418|423|425)\b/i.test(
+        error,
+      ),
+    )
+    expect(hydrationErrors).toEqual([])
+  })
+
   test('#4614: cached parent loader data does not cache its beforeLoad context', async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary

- add a React Start selective-SSR fixture for an `ssr: false` route whose `beforeLoad` redirects
- give the redirect target a structurally different document head to reproduce the hydration race from #7947
- assert through Playwright-visible URL, DOM, console, and page-error behavior without modifying router internals

## Why

Issue #7947 could redirect from the initial route before React committed hydration. React would then hydrate the destination tree against the origin route's HTML and report hydration error #418.

The recent lane-loader rewrite prevents the race, but it did not include focused regression coverage. This test protects that user-visible behavior using only public router APIs.

## Test plan

- `CI=1 NX_DAEMON=false pnpm nx run tanstack-react-start-e2e-selective-ssr:test:e2e --outputStyle=stream --skipRemoteCache` — 11 passed
- repeated the issue-7947 test five times on current `main` — 5 passed
- applied the same test to commit `b5e540d74a` from August 3 — fails with React error #418 as expected
- `pnpm test:eslint`, `pnpm test:types`, and `pnpm test:unit` — no affected non-e2e targets


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/issue-7947` and `/issue-7947-target` routes with custom page metadata.
  * Added redirect handling from the issue route to its target page.

* **Bug Fixes**
  * Improved behavior for routes rendered without server-side rendering, preventing hydration-related browser errors during redirects.

* **Tests**
  * Added end-to-end coverage verifying the redirect and target page load successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->