### PR TITLE
fix(router): preserve raw params for match identity

### DIFF
--- a/packages/react-router/src/useBlocker.tsx
+++ b/packages/react-router/src/useBlocker.tsx
@@ -179,22 +179,24 @@ export function useBlocker(
         location: HistoryLocation,
       ): AnyShouldBlockFnLocation {
         const parsedLocation = router.parseLocation(location)
-        const matchedRoutes = router.getMatchedRoutes(parsedLocation.pathname)
-        if (matchedRoutes.foundRoute === undefined) {
+        const [, rawParams, foundRoute] = router.getMatchedRoutes(
+          parsedLocation.pathname,
+        )
+        if (foundRoute === undefined) {
           return {
             routeId: '__notFound__',
             fullPath: parsedLocation.pathname,
             pathname: parsedLocation.pathname,
-            params: matchedRoutes.routeParams,
+            params: rawParams,
             search: router.options.parseSearch(location.search),
           }
         }
 
         return {
-          routeId: matchedRoutes.foundRoute.id,
-          fullPath: matchedRoutes.foundRoute.fullPath,
+          routeId: foundRoute.id,
+          fullPath: foundRoute.fullPath,
           pathname: parsedLocation.pathname,
-          params: matchedRoutes.routeParams,
+          params: rawParams,
           search: router.options.parseSearch(location.search),
         }
       }

--- a/packages/react-router/tests/issue-7964-param-parsing-loader.test.tsx
+++ b/packages/react-router/tests/issue-7964-param-parsing-loader.test.tsx
@@ -1,0 +1,107 @@
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, expect, test } from 'vitest'
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+
+afterEach(() => {
+  cleanup()
+})
+
+// https://github.com/TanStack/router/issues/7964
+test('#7964: a child loader receives fresh structured params after revisiting its route', async () => {
+  const rootRoute = createRootRoute({
+    component: Outlet,
+  })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <div>Home page</div>,
+  })
+  const parsedParamRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/$parsedParam',
+    params: {
+      parse: ({ parsedParam }) => {
+        const [recordName, revisionNumber] = parsedParam.split('-')
+        return {
+          parsedParam: {
+            recordName: recordName!,
+            revisionNumber: Number(revisionNumber),
+          },
+        }
+      },
+      stringify: ({ parsedParam }) => ({
+        parsedParam: `${parsedParam.recordName}-${parsedParam.revisionNumber}`,
+      }),
+    },
+    component: Outlet,
+  })
+  const parsedParamIndexRoute = createRoute({
+    getParentRoute: () => parsedParamRoute,
+    path: '/',
+    loader: ({ params }) => params.parsedParam.revisionNumber * 100,
+    component: () => {
+      const params = parsedParamIndexRoute.useParams()
+      const loaderData = parsedParamIndexRoute.useLoaderData()
+
+      return (
+        <>
+          <div data-testid="params">
+            Params have {params.parsedParam.recordName} with revision{' '}
+            {params.parsedParam.revisionNumber}
+          </div>
+          <div data-testid="loader-data">Loader data is {loaderData}</div>
+        </>
+      )
+    },
+  })
+  const routeTree = rootRoute.addChildren([
+    indexRoute,
+    parsedParamRoute.addChildren([parsedParamIndexRoute]),
+  ])
+  const router = createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  render(<RouterProvider router={router} />)
+  expect(await screen.findByText('Home page')).toBeInTheDocument()
+
+  await act(() =>
+    router.navigate({
+      to: '/$parsedParam',
+      params: { parsedParam: { recordName: 'blue', revisionNumber: 1 } },
+    }),
+  )
+  expect(
+    await screen.findByText('Params have blue with revision 1'),
+  ).toBeInTheDocument()
+  expect(await screen.findByText('Loader data is 100')).toBeInTheDocument()
+
+  await act(() => router.navigate({ to: '/' }))
+  expect(await screen.findByText('Home page')).toBeInTheDocument()
+
+  await act(() =>
+    router.navigate({
+      to: '/$parsedParam',
+      params: { parsedParam: { recordName: 'red', revisionNumber: 2 } },
+    }),
+  )
+  expect(router.state.location.pathname).toBe('/red-2')
+
+  await waitFor(() => {
+    expect({
+      params: screen.getByTestId('params').textContent,
+      loaderData: screen.getByTestId('loader-data').textContent,
+    }).toEqual({
+      params: 'Params have red with revision 2',
+      loaderData: 'Loader data is 200',
+    })
+  })
+})

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1511,8 +1511,9 @@ export class RouterCore<
     next: ParsedLocation,
     opts?: MatchRoutesOpts,
   ): Array<AnyRouteMatch> {
-    const [initialMatchedRoutes, rawParams, foundRoute] =
-      this.getMatchedRoutes(next.pathname)
+    const [initialMatchedRoutes, rawParams, foundRoute] = this.getMatchedRoutes(
+      next.pathname,
+    )
     let matchedRoutes = initialMatchedRoutes
     let isGlobalNotFound = false
 
@@ -1642,8 +1643,7 @@ export class RouterCore<
 
       // Carry parsed ancestors forward without mutating the raw route params.
       strictParams =
-        existingMatch?._strictParams ??
-        Object.assign(usedParams, strictParams)
+        existingMatch?._strictParams ?? Object.assign(usedParams, strictParams)
 
       let paramsError: unknown
 
@@ -1772,9 +1772,7 @@ export class RouterCore<
       return cached[1 /* result */]
     }
 
-    const [matchedRoutes, rawParams] = this.getMatchedRoutes(
-      location.pathname,
-    )
+    const [matchedRoutes, rawParams] = this.getMatchedRoutes(location.pathname)
     const lastRoute = last(matchedRoutes)!
 
     // I don't know if we should run the full search middleware chain, or just validateSearch

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1512,9 +1512,12 @@ export class RouterCore<
     next: ParsedLocation,
     opts?: MatchRoutesOpts,
   ): Array<AnyRouteMatch> {
-    const matchedRoutesResult = this.getMatchedRoutes(next.pathname)
-    const { foundRoute, routeParams } = matchedRoutesResult
-    let { matchedRoutes } = matchedRoutesResult
+    const {
+      foundRoute,
+      routeParams,
+      matchedRoutes: initialMatchedRoutes,
+    } = this.getMatchedRoutes(next.pathname)
+    let matchedRoutes = initialMatchedRoutes
     let isGlobalNotFound = false
 
     // Check to see if the route needs a 404 entry
@@ -1549,6 +1552,7 @@ export class RouterCore<
           : undefined
     }
 
+    let strictParams: AnyRouteMatch['_strictParams'] | undefined
     for (let index = 0; index < matchedRoutes.length; index++) {
       const route = matchedRoutes[index]!
       // Take each matched route and resolve + validate its search params
@@ -1614,6 +1618,7 @@ export class RouterCore<
         }
         searchError ??= cause
       }
+      // Match identity must only use the raw params captured from the URL.
       const { interpolatedPath, usedParams } = interpolatePath({
         path: route.fullPath,
         params: routeParams,
@@ -1639,7 +1644,10 @@ export class RouterCore<
           : (this._cache.get(matchId) ??
             (previousMatch?.id === matchId ? previousMatch : undefined))
 
-      const strictParams = existingMatch?._strictParams ?? usedParams
+      // Carry parsed ancestors forward without mutating the raw route params.
+      strictParams =
+        existingMatch?._strictParams ??
+        Object.assign(usedParams, strictParams)
 
       let paramsError: unknown
 
@@ -1661,8 +1669,6 @@ export class RouterCore<
         }
       }
 
-      Object.assign(routeParams, strictParams)
-
       const cause = previousMatch ? 'stay' : 'enter'
 
       let match: AnyRouteMatch
@@ -1671,8 +1677,6 @@ export class RouterCore<
         match = {
           ...existingMatch,
           cause,
-          params: previousMatch?.params ?? routeParams,
-          _strictParams: strictParams,
           search: previousMatch
             ? nullReplaceEqualDeep(previousMatch.search, preMatchSearch)
             : nullReplaceEqualDeep(existingMatch.search, preMatchSearch),
@@ -1687,7 +1691,7 @@ export class RouterCore<
           ssr: (isServer ?? this.isServer) ? undefined : route.options.ssr,
           index,
           routeId: route.id,
-          params: previousMatch?.params ?? routeParams,
+          params: previousMatch?.params ?? strictParams,
           _strictParams: strictParams,
           pathname: interpolatedPath,
           updatedAt: Date.now(),
@@ -1727,8 +1731,8 @@ export class RouterCore<
       const match = matches[index]!
       match.params =
         match.cause === 'stay'
-          ? nullReplaceEqualDeep(match.params, routeParams)
-          : routeParams
+          ? nullReplaceEqualDeep(match.params, strictParams)
+          : strictParams!
       if (opts?._controller) {
         match.context = {}
       }

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -750,13 +750,12 @@ export type ParseLocationFn<TRouteTree extends AnyRoute> = (
   previousLocation?: ParsedLocation<FullSearchSchema<TRouteTree>>,
 ) => ParsedLocation<FullSearchSchema<TRouteTree>>
 
-export type GetMatchRoutesFn = (pathname: string) => {
-  matchedRoutes: ReadonlyArray<AnyRoute>
+export type GetMatchRoutesFn = (pathname: string) => [
+  matchedRoutes: ReadonlyArray<AnyRoute>,
   /** exhaustive params, still in their string form */
-  routeParams: Record<string, string>
-  foundRoute: AnyRoute | undefined
-  parseError?: unknown
-}
+  rawParams: Record<string, string>,
+  foundRoute: AnyRoute | undefined,
+]
 
 export type EmitFn = (routerEvent: RouterEvent) => void
 
@@ -1512,11 +1511,8 @@ export class RouterCore<
     next: ParsedLocation,
     opts?: MatchRoutesOpts,
   ): Array<AnyRouteMatch> {
-    const {
-      foundRoute,
-      routeParams,
-      matchedRoutes: initialMatchedRoutes,
-    } = this.getMatchedRoutes(next.pathname)
+    const [initialMatchedRoutes, rawParams, foundRoute] =
+      this.getMatchedRoutes(next.pathname)
     let matchedRoutes = initialMatchedRoutes
     let isGlobalNotFound = false
 
@@ -1524,7 +1520,7 @@ export class RouterCore<
     if (
       // If we found a route, and it's not an index route and we have left over path
       foundRoute
-        ? foundRoute.path !== '/' && routeParams['**']
+        ? foundRoute.path !== '/' && rawParams['**']
         : // Or if we didn't find a route and we have left over path
           trimPathRight(next.pathname)
     ) {
@@ -1621,7 +1617,7 @@ export class RouterCore<
       // Match identity must only use the raw params captured from the URL.
       const { interpolatedPath, usedParams } = interpolatePath({
         path: route.fullPath,
-        params: routeParams,
+        params: rawParams,
         decoder: this.pathParamsDecoder,
         server: this.isServer,
       })
@@ -1742,20 +1738,20 @@ export class RouterCore<
   }
 
   getMatchedRoutes: GetMatchRoutesFn = (pathname) => {
-    const routeParams: Record<string, string> = Object.create(null)
+    const rawParams: Record<string, string> = Object.create(null)
     const match = findRouteMatch(
       trimPathRight(pathname),
       this.processedTree,
       true,
     )
     if (match) {
-      Object.assign(routeParams, match.rawParams)
+      Object.assign(rawParams, match.rawParams)
     }
-    return {
-      matchedRoutes: match?.branch || [this.routesById[rootRouteId]!],
-      routeParams,
-      foundRoute: match?.route,
-    }
+    return [
+      match?.branch || [this.routesById[rootRouteId]!],
+      rawParams,
+      match?.route,
+    ]
   }
 
   /**
@@ -1776,7 +1772,7 @@ export class RouterCore<
       return cached[1 /* result */]
     }
 
-    const { matchedRoutes, routeParams } = this.getMatchedRoutes(
+    const [matchedRoutes, rawParams] = this.getMatchedRoutes(
       location.pathname,
     )
     const lastRoute = last(matchedRoutes)!
@@ -1816,7 +1812,7 @@ export class RouterCore<
       // Parse params through the route chain
       const strictParams: Record<string, unknown> = Object.assign(
         Object.create(null),
-        routeParams,
+        rawParams,
       )
       for (const route of matchedRoutes) {
         try {
@@ -1866,7 +1862,7 @@ export class RouterCore<
         process.env.NODE_ENV !== 'production' &&
         dest._isNavigate
       ) {
-        const allFromMatches = this.getMatchedRoutes(dest.from).matchedRoutes
+        const [allFromMatches] = this.getMatchedRoutes(dest.from)
 
         const matchedFrom = findLast(lightweightResult.matchedRoutes, (d) => {
           return comparePaths(d.fullPath, dest.from!)
@@ -1922,14 +1918,13 @@ export class RouterCore<
         // typed destination mismatch, not a concrete URL to route-match.
         destRoutes = []
       } else {
-        const destMatchResult = this.getMatchedRoutes(nextTo)
-        destRoutes = destMatchResult.matchedRoutes
+        const [matchedRoutes, rawParams, foundRoute] =
+          this.getMatchedRoutes(nextTo)
+        destRoutes = matchedRoutes
 
         if (
           this.options.notFoundRoute &&
-          (!destMatchResult.foundRoute ||
-            (destMatchResult.foundRoute.path !== '/' &&
-              destMatchResult.routeParams['**']))
+          (!foundRoute || (foundRoute.path !== '/' && rawParams['**']))
         ) {
           destRoutes = [...destRoutes, this.options.notFoundRoute]
         }
@@ -1972,10 +1967,10 @@ export class RouterCore<
         !opts.leaveParams
       ) {
         try {
-          const roundTrip = this.getMatchedRoutes(nextPathname)
-          if (roundTrip.foundRoute?.id !== destRoute.id) {
+          const foundRoute = this.getMatchedRoutes(nextPathname)[2]
+          if (foundRoute?.id !== destRoute.id) {
             console.warn(
-              `Generated path "${nextPathname}" for route "${destRoute.id}" matched route "${roundTrip.foundRoute?.id}" instead. This can happen when multiple route templates resolve to the same URL. Use the route template that matches the intended route, or adjust params.stringify if it changed the target path.`,
+              `Generated path "${nextPathname}" for route "${destRoute.id}" matched route "${foundRoute?.id}" instead. This can happen when multiple route templates resolve to the same URL. Use the route template that matches the intended route, or adjust params.stringify if it changed the target path.`,
             )
           }
         } catch {

--- a/packages/router-plugin/tests/handle-route-update.test.ts
+++ b/packages/router-plugin/tests/handle-route-update.test.ts
@@ -240,7 +240,7 @@ describe('handleRouteUpdate', () => {
     const routeTree = rootRoute.addChildren([asAnyRoute(itemRoute)])
     const router = createTestRouter(routeTree)
 
-    expect(router.getMatchedRoutes('/items/abc').foundRoute?.id).toBeUndefined()
+    expect(router.getMatchedRoutes('/items/abc')[2]?.id).toBeUndefined()
 
     const restoreWindow = withWindowRouter(router)
     try {
@@ -258,9 +258,7 @@ describe('handleRouteUpdate', () => {
       restoreWindow()
     }
 
-    expect(router.getMatchedRoutes('/items/abc').foundRoute?.id).toBe(
-      itemRoute.id,
-    )
+    expect(router.getMatchedRoutes('/items/abc')[2]?.id).toBe(itemRoute.id)
   })
 
   it('hydrates the hot module route export with generated route tree state', () => {

--- a/packages/solid-router/src/useBlocker.tsx
+++ b/packages/solid-router/src/useBlocker.tsx
@@ -186,21 +186,23 @@ export function useBlocker(
         location: HistoryLocation,
       ): AnyShouldBlockFnLocation {
         const parsedLocation = router.parseLocation(location)
-        const matchedRoutes = router.getMatchedRoutes(parsedLocation.pathname)
-        if (matchedRoutes.foundRoute === undefined) {
+        const [, rawParams, foundRoute] = router.getMatchedRoutes(
+          parsedLocation.pathname,
+        )
+        if (foundRoute === undefined) {
           return {
             routeId: '__notFound__',
             fullPath: parsedLocation.pathname,
             pathname: parsedLocation.pathname,
-            params: matchedRoutes.routeParams,
+            params: rawParams,
             search: parsedLocation.search,
           }
         }
         return {
-          routeId: matchedRoutes.foundRoute.id,
-          fullPath: matchedRoutes.foundRoute.fullPath,
+          routeId: foundRoute.id,
+          fullPath: foundRoute.fullPath,
           pathname: parsedLocation.pathname,
-          params: matchedRoutes.routeParams,
+          params: rawParams,
           search: parsedLocation.search,
         }
       }

--- a/packages/solid-router/tests/issue-7964-param-parsing-loader.test.tsx
+++ b/packages/solid-router/tests/issue-7964-param-parsing-loader.test.tsx
@@ -1,0 +1,102 @@
+import { cleanup, render, screen, waitFor } from '@solidjs/testing-library'
+import { afterEach, expect, test } from 'vitest'
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+
+afterEach(() => {
+  cleanup()
+})
+
+// https://github.com/TanStack/router/issues/7964
+test('#7964: a child loader receives fresh structured params after revisiting its route', async () => {
+  const rootRoute = createRootRoute({
+    component: Outlet,
+  })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <div>Home page</div>,
+  })
+  const parsedParamRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/$parsedParam',
+    params: {
+      parse: ({ parsedParam }) => {
+        const [recordName, revisionNumber] = parsedParam.split('-')
+        return {
+          parsedParam: {
+            recordName: recordName!,
+            revisionNumber: Number(revisionNumber),
+          },
+        }
+      },
+      stringify: ({ parsedParam }) => ({
+        parsedParam: `${parsedParam.recordName}-${parsedParam.revisionNumber}`,
+      }),
+    },
+    component: Outlet,
+  })
+  const parsedParamIndexRoute = createRoute({
+    getParentRoute: () => parsedParamRoute,
+    path: '/',
+    loader: ({ params }) => params.parsedParam.revisionNumber * 100,
+    component: () => {
+      const params = parsedParamIndexRoute.useParams()
+      const loaderData = parsedParamIndexRoute.useLoaderData()
+
+      return (
+        <>
+          <div data-testid="params">
+            Params have {params().parsedParam.recordName} with revision{' '}
+            {params().parsedParam.revisionNumber}
+          </div>
+          <div data-testid="loader-data">Loader data is {loaderData()}</div>
+        </>
+      )
+    },
+  })
+  const routeTree = rootRoute.addChildren([
+    indexRoute,
+    parsedParamRoute.addChildren([parsedParamIndexRoute]),
+  ])
+  const router = createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  render(() => <RouterProvider router={router} />)
+
+  await router.navigate({
+    to: '/$parsedParam',
+    params: { parsedParam: { recordName: 'blue', revisionNumber: 1 } },
+  })
+  expect(
+    await screen.findByText('Params have blue with revision 1'),
+  ).toBeInTheDocument()
+  expect(await screen.findByText('Loader data is 100')).toBeInTheDocument()
+
+  await router.navigate({ to: '/' })
+  expect(await screen.findByText('Home page')).toBeInTheDocument()
+
+  await router.navigate({
+    to: '/$parsedParam',
+    params: { parsedParam: { recordName: 'red', revisionNumber: 2 } },
+  })
+  expect(router.state.location.pathname).toBe('/red-2')
+
+  await waitFor(() => {
+    expect({
+      params: screen.getByTestId('params').textContent,
+      loaderData: screen.getByTestId('loader-data').textContent,
+    }).toEqual({
+      params: 'Params have red with revision 2',
+      loaderData: 'Loader data is 200',
+    })
+  })
+})

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -893,10 +893,10 @@ async function handleServerRoutes({
   // this will perform a fuzzy match, however for server routes we need an exact match
   // if the route is not an exact match, executeRouter will handle rendering the app router
   // the match will be cached internally, so no extra work is done during the app router render
-  const { matchedRoutes, foundRoute, routeParams } =
+  const [matchedRoutes, rawParams, foundRoute] =
     router.getMatchedRoutes(pathname)
 
-  const isExactMatch = foundRoute && routeParams['**'] === undefined
+  const isExactMatch = foundRoute && rawParams['**'] === undefined
 
   // Collect and dedupe route middlewares
   const routeMiddlewares: Array<AnyMiddlewareServerFn> = []
@@ -964,7 +964,7 @@ async function handleServerRoutes({
     {
       request,
       context,
-      params: routeParams,
+      params: rawParams,
       pathname,
       handlerType: 'router',
     },

--- a/packages/vue-router/src/useBlocker.tsx
+++ b/packages/vue-router/src/useBlocker.tsx
@@ -179,21 +179,23 @@ export function useBlocker(
         location: HistoryLocation,
       ): AnyShouldBlockFnLocation {
         const parsedLocation = router.parseLocation(location)
-        const matchedRoutes = router.getMatchedRoutes(parsedLocation.pathname)
-        if (matchedRoutes.foundRoute === undefined) {
+        const [, rawParams, foundRoute] = router.getMatchedRoutes(
+          parsedLocation.pathname,
+        )
+        if (foundRoute === undefined) {
           return {
             routeId: '__notFound__',
             fullPath: parsedLocation.pathname,
             pathname: parsedLocation.pathname,
-            params: matchedRoutes.routeParams,
+            params: rawParams,
             search: parsedLocation.search,
           }
         }
         return {
-          routeId: matchedRoutes.foundRoute.id,
-          fullPath: matchedRoutes.foundRoute.fullPath,
+          routeId: foundRoute.id,
+          fullPath: foundRoute.fullPath,
           pathname: parsedLocation.pathname,
-          params: matchedRoutes.routeParams,
+          params: rawParams,
           search: parsedLocation.search,
         }
       }
@@ -373,21 +375,23 @@ const BlockImpl = Vue.defineComponent({
           location: HistoryLocation,
         ): AnyShouldBlockFnLocation {
           const parsedLocation = router.parseLocation(location)
-          const matchedRoutes = router.getMatchedRoutes(parsedLocation.pathname)
-          if (matchedRoutes.foundRoute === undefined) {
+          const [, rawParams, foundRoute] = router.getMatchedRoutes(
+            parsedLocation.pathname,
+          )
+          if (foundRoute === undefined) {
             return {
               routeId: '__notFound__',
               fullPath: parsedLocation.pathname,
               pathname: parsedLocation.pathname,
-              params: matchedRoutes.routeParams,
+              params: rawParams,
               search: parsedLocation.search,
             }
           }
           return {
-            routeId: matchedRoutes.foundRoute.id,
-            fullPath: matchedRoutes.foundRoute.fullPath,
+            routeId: foundRoute.id,
+            fullPath: foundRoute.fullPath,
             pathname: parsedLocation.pathname,
-            params: matchedRoutes.routeParams,
+            params: rawParams,
             search: parsedLocation.search,
           }
         }


### PR DESCRIPTION
## What changed

- Keep URL-derived route params in their raw string form throughout route matching and interpolation.
- Carry parsed ancestor params separately when constructing or reusing matches.
- Return `getMatchedRoutes` as a labeled tuple and name the unparsed value `rawParams` throughout its consumers.
- Add public-API regression coverage for React Router and Solid Router that verifies the URL, rendered params, and loader data across cached navigation.

## Root cause

`matchRoutesInternal` reused the same object for raw URL params and parsed params. A structured `params.parse` result could therefore replace a path-param string with an object before a descendant route was interpolated. That produced an incorrect match ID (for example, `[object Object]`), allowing a cached match to restore stale parsed params and loader data.

The fix preserves raw params for match identity while maintaining a separate parsed-param snapshot. It still calls `interpolatePath` once per route and does not require stringifying params without route context. The tuple contract removes repeated object keys and the `rawParams` label documents the invariant at each internal consumer.

## Validation

- Affected `test:unit`: 30 projects passed
- Affected `test:types`: 40 projects passed across supported TypeScript versions
- Affected `test:eslint`: 32 projects passed
- SSR adjacent A/B benchmark: effectively flat (+0.16%)
- Loader-heavy client benchmark: effectively flat
- Structured-param fix nested-client benchmark: low-single-digit variance (~3%)
- Tuple-only nested-client A/B: 74.92 -> 77.46 ops/s (+3.4%, within low-single-digit error margins)
- Structured-param fix bundle delta: aggregate gzip **-108 B**, raw **-627 B**, Brotli **-26 B**
- Tuple-only bundle delta: all 17 scenarios improved; aggregate gzip **-623 B**, initial gzip **-619 B**, raw **-2,886 B**, Brotli **-664 B**

Fixes #7964, Fixes #7731

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where revisiting routes with structured parameters could retain stale parsed parameters or loader data.
  * Ensured route URLs, parsed parameters, and loader results refresh correctly when navigating between different parameter values.
  * Improved route matching and navigation state handling across supported router integrations.

* **Tests**
  * Added regression coverage for structured parameter parsing, navigation, and loader data refreshes across React and Solid Router.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->