### PR TITLE
chore: add changeset for #7966

### DIFF
--- a/.changeset/raw-params-match.md
+++ b/.changeset/raw-params-match.md
@@ -1,0 +1,11 @@
+---
+'@tanstack/router-core': patch
+'@tanstack/react-router': patch
+'@tanstack/solid-router': patch
+'@tanstack/vue-router': patch
+'@tanstack/start-server-core': patch
+---
+
+Preserve path params in their raw string form while matching routes so structured values returned by `params.parse` produce stable match IDs and do not reuse stale loader data.
+
+`RouterCore.getMatchedRoutes()` now returns `[matchedRoutes, rawParams, foundRoute]` instead of an object.


### PR DESCRIPTION
## What changed

- add the missing patch changeset for #7966
- release @tanstack/router-core, the React/Solid/Vue router bindings, and @tanstack/start-server-core
- document both the raw-param match identity fix and the getMatchedRoutes() tuple contract

## Why

#7966 was merged without a changeset, so its fix and developer-visible API change would otherwise be absent from release versioning and notes.

## Validation

- pnpm changeset status --since=origin/main
- pnpm exec prettier --check .changeset/raw-params-match.md
- git diff --check origin/main...HEAD

Follow-up to #7966.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved raw path parameters during route matching.
  * Improved matched-route results to include the original parameter values and the matched route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->