### PR TITLE
Create file routes directly

### DIFF
--- a/.changeset/easy-zoos-greet.md
+++ b/.changeset/easy-zoos-greet.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/react-router': patch
+'@tanstack/solid-router': patch
+'@tanstack/vue-router': patch
+---
+
+createFileRoute does not rely on FileRoute class

--- a/packages/react-router/src/fileRoute.ts
+++ b/packages/react-router/src/fileRoute.ts
@@ -42,7 +42,7 @@ import type { UseRouteContextRoute } from './useRouteContext'
  * route. The returned function accepts standard route options. In normal usage
  * the `path` string is inserted and maintained by the `tsr` generator.
  *
- * @param _path File path literal for the route (usually auto-generated).
+ * @param path File path literal for the route (usually auto-generated).
  * @returns A function that accepts Route options and returns a Route instance.
  * @link https://tanstack.com/router/latest/docs/framework/react/api/router/createFileRouteFunction
  */
@@ -54,7 +54,8 @@ export function createFileRoute<
   TFullPath extends RouteConstraints['TFullPath'] =
     FileRoutesByPath[TFilePath]['fullPath'],
 >(
-  _path?: TFilePath,
+  // eslint-disable-next-line unused-imports/no-unused-vars
+  path?: TFilePath,
 ): FileRoute<TFilePath, TParentRoute, TId, TPath, TFullPath>['createRoute'] {
   const createRoute = (options?: any) => {
     const route = createRouteImpl(options)

--- a/packages/react-router/src/fileRoute.ts
+++ b/packages/react-router/src/fileRoute.ts
@@ -1,4 +1,4 @@
-import { createRoute as createRouteImpl } from './route'
+import { createRoute } from './route'
 
 import { useMatch } from './useMatch'
 import { useLoaderDeps } from './useLoaderDeps'
@@ -57,12 +57,11 @@ export function createFileRoute<
   // eslint-disable-next-line unused-imports/no-unused-vars
   path?: TFilePath,
 ): FileRoute<TFilePath, TParentRoute, TId, TPath, TFullPath>['createRoute'] {
-  const createRoute = (options?: any) => {
-    const route = createRouteImpl(options)
+  return (options) => {
+    const route = createRoute(options as any)
     ;(route as any).isRoot = false
-    return route
+    return route as any
   }
-  return createRoute as any
 }
 
 /** 
@@ -155,7 +154,7 @@ export class FileRoute<
         )
       }
     }
-    const route = createRouteImpl(options as any)
+    const route = createRoute(options as any)
     ;(route as any).isRoot = false
     return route as any
   }

--- a/packages/react-router/src/fileRoute.ts
+++ b/packages/react-router/src/fileRoute.ts
@@ -1,4 +1,4 @@
-import { createRoute } from './route'
+import { createRoute as createRouteImpl } from './route'
 
 import { useMatch } from './useMatch'
 import { useLoaderDeps } from './useLoaderDeps'
@@ -42,7 +42,7 @@ import type { UseRouteContextRoute } from './useRouteContext'
  * route. The returned function accepts standard route options. In normal usage
  * the `path` string is inserted and maintained by the `tsr` generator.
  *
- * @param path File path literal for the route (usually auto-generated).
+ * @param _path File path literal for the route (usually auto-generated).
  * @returns A function that accepts Route options and returns a Route instance.
  * @link https://tanstack.com/router/latest/docs/framework/react/api/router/createFileRouteFunction
  */
@@ -54,11 +54,14 @@ export function createFileRoute<
   TFullPath extends RouteConstraints['TFullPath'] =
     FileRoutesByPath[TFilePath]['fullPath'],
 >(
-  path?: TFilePath,
+  _path?: TFilePath,
 ): FileRoute<TFilePath, TParentRoute, TId, TPath, TFullPath>['createRoute'] {
-  return new FileRoute<TFilePath, TParentRoute, TId, TPath, TFullPath>(path, {
-    silent: true,
-  }).createRoute
+  const createRoute = (options?: any) => {
+    const route = createRouteImpl(options)
+    ;(route as any).isRoot = false
+    return route
+  }
+  return createRoute as any
 }
 
 /** 
@@ -151,7 +154,7 @@ export class FileRoute<
         )
       }
     }
-    const route = createRoute(options as any)
+    const route = createRouteImpl(options as any)
     ;(route as any).isRoot = false
     return route as any
   }

--- a/packages/react-router/tests/fileRoute.test.ts
+++ b/packages/react-router/tests/fileRoute.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { describe, it, expect } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 import {
   getRouteApi,
   createFileRoute,
@@ -7,7 +7,32 @@ import {
   createLazyFileRoute,
   LazyRoute,
   AnyRoute,
+  FileRoute,
 } from '../src'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('createFileRoute', () => {
+  it('creates a non-root route without a deprecation warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    // @ts-expect-error
+    const route = createFileRoute('')({})
+
+    expect(route.isRoot).toBe(false)
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('keeps the deprecation warning for direct FileRoute usage', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    // @ts-expect-error
+    const route = new FileRoute('').createRoute({})
+
+    expect(route.isRoot).toBe(false)
+    expect(warn).toHaveBeenCalledOnce()
+  })
+})
 
 describe('createFileRoute has the same hooks as getRouteApi', () => {
   const routeApi = getRouteApi('foo')

--- a/packages/solid-router/src/fileRoute.ts
+++ b/packages/solid-router/src/fileRoute.ts
@@ -1,4 +1,4 @@
-import { createRoute } from './route'
+import { createRoute as createRouteImpl } from './route'
 
 import { useMatch } from './useMatch'
 import { useLoaderDeps } from './useLoaderDeps'
@@ -43,11 +43,14 @@ export function createFileRoute<
   TFullPath extends RouteConstraints['TFullPath'] =
     FileRoutesByPath[TFilePath]['fullPath'],
 >(
-  path?: TFilePath,
+  _path?: TFilePath,
 ): FileRoute<TFilePath, TParentRoute, TId, TPath, TFullPath>['createRoute'] {
-  return new FileRoute<TFilePath, TParentRoute, TId, TPath, TFullPath>(path, {
-    silent: true,
-  }).createRoute
+  const createRoute = (options?: any) => {
+    const route = createRouteImpl(options)
+    ;(route as any).isRoot = false
+    return route
+  }
+  return createRoute as any
 }
 
 /** 
@@ -140,7 +143,7 @@ export class FileRoute<
         )
       }
     }
-    const route = createRoute(options as any)
+    const route = createRouteImpl(options as any)
     ;(route as any).isRoot = false
     return route as any
   }

--- a/packages/solid-router/src/fileRoute.ts
+++ b/packages/solid-router/src/fileRoute.ts
@@ -1,4 +1,4 @@
-import { createRoute as createRouteImpl } from './route'
+import { createRoute } from './route'
 
 import { useMatch } from './useMatch'
 import { useLoaderDeps } from './useLoaderDeps'
@@ -46,12 +46,11 @@ export function createFileRoute<
   // eslint-disable-next-line unused-imports/no-unused-vars
   path?: TFilePath,
 ): FileRoute<TFilePath, TParentRoute, TId, TPath, TFullPath>['createRoute'] {
-  const createRoute = (options?: any) => {
-    const route = createRouteImpl(options)
+  return (options) => {
+    const route = createRoute(options as any)
     ;(route as any).isRoot = false
-    return route
+    return route as any
   }
-  return createRoute as any
 }
 
 /** 
@@ -144,7 +143,7 @@ export class FileRoute<
         )
       }
     }
-    const route = createRouteImpl(options as any)
+    const route = createRoute(options as any)
     ;(route as any).isRoot = false
     return route as any
   }

--- a/packages/solid-router/src/fileRoute.ts
+++ b/packages/solid-router/src/fileRoute.ts
@@ -43,7 +43,8 @@ export function createFileRoute<
   TFullPath extends RouteConstraints['TFullPath'] =
     FileRoutesByPath[TFilePath]['fullPath'],
 >(
-  _path?: TFilePath,
+  // eslint-disable-next-line unused-imports/no-unused-vars
+  path?: TFilePath,
 ): FileRoute<TFilePath, TParentRoute, TId, TPath, TFullPath>['createRoute'] {
   const createRoute = (options?: any) => {
     const route = createRouteImpl(options)

--- a/packages/solid-router/tests/fileRoute.test.ts
+++ b/packages/solid-router/tests/fileRoute.test.ts
@@ -1,12 +1,37 @@
 /* eslint-disable */
-import { describe, it, expect } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 import {
   getRouteApi,
   createFileRoute,
   createLazyRoute,
   createLazyFileRoute,
   LazyRoute,
+  FileRoute,
 } from '../src'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('createFileRoute', () => {
+  it('creates a non-root route without a deprecation warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    // @ts-expect-error
+    const route = createFileRoute('')({})
+
+    expect(route.isRoot).toBe(false)
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('keeps the deprecation warning for direct FileRoute usage', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    // @ts-expect-error
+    const route = new FileRoute('').createRoute({})
+
+    expect(route.isRoot).toBe(false)
+    expect(warn).toHaveBeenCalledOnce()
+  })
+})
 
 describe('createFileRoute has the same hooks as getRouteApi', () => {
   const routeApi = getRouteApi('foo')

--- a/packages/vue-router/src/fileRoute.ts
+++ b/packages/vue-router/src/fileRoute.ts
@@ -43,7 +43,8 @@ export function createFileRoute<
   TFullPath extends RouteConstraints['TFullPath'] =
     FileRoutesByPath[TFilePath]['fullPath'],
 >(
-  _path?: TFilePath,
+  // eslint-disable-next-line unused-imports/no-unused-vars
+  path?: TFilePath,
 ): FileRoute<TFilePath, TParentRoute, TId, TPath, TFullPath>['createRoute'] {
   const createRoute = (options?: any) => {
     const route = createRouteImpl(options)

--- a/packages/vue-router/src/fileRoute.ts
+++ b/packages/vue-router/src/fileRoute.ts
@@ -1,4 +1,4 @@
-import { createRoute as createRouteImpl } from './route'
+import { createRoute } from './route'
 
 import { useMatch } from './useMatch'
 import { useLoaderDeps } from './useLoaderDeps'
@@ -46,12 +46,11 @@ export function createFileRoute<
   // eslint-disable-next-line unused-imports/no-unused-vars
   path?: TFilePath,
 ): FileRoute<TFilePath, TParentRoute, TId, TPath, TFullPath>['createRoute'] {
-  const createRoute = (options?: any) => {
-    const route = createRouteImpl(options)
+  return (options) => {
+    const route = createRoute(options as any)
     ;(route as any).isRoot = false
-    return route
+    return route as any
   }
-  return createRoute as any
 }
 
 /**
@@ -144,7 +143,7 @@ export class FileRoute<
         )
       }
     }
-    const route = createRouteImpl(options as any)
+    const route = createRoute(options as any)
     ;(route as any).isRoot = false
     return route as any
   }

--- a/packages/vue-router/src/fileRoute.ts
+++ b/packages/vue-router/src/fileRoute.ts
@@ -1,4 +1,4 @@
-import { createRoute } from './route'
+import { createRoute as createRouteImpl } from './route'
 
 import { useMatch } from './useMatch'
 import { useLoaderDeps } from './useLoaderDeps'
@@ -43,11 +43,14 @@ export function createFileRoute<
   TFullPath extends RouteConstraints['TFullPath'] =
     FileRoutesByPath[TFilePath]['fullPath'],
 >(
-  path?: TFilePath,
+  _path?: TFilePath,
 ): FileRoute<TFilePath, TParentRoute, TId, TPath, TFullPath>['createRoute'] {
-  return new FileRoute<TFilePath, TParentRoute, TId, TPath, TFullPath>(path, {
-    silent: true,
-  }).createRoute
+  const createRoute = (options?: any) => {
+    const route = createRouteImpl(options)
+    ;(route as any).isRoot = false
+    return route
+  }
+  return createRoute as any
 }
 
 /**
@@ -140,7 +143,7 @@ export class FileRoute<
         )
       }
     }
-    const route = createRoute(options as any)
+    const route = createRouteImpl(options as any)
     ;(route as any).isRoot = false
     return route as any
   }

--- a/packages/vue-router/tests/fileRoute.test.ts
+++ b/packages/vue-router/tests/fileRoute.test.ts
@@ -1,12 +1,37 @@
 /* eslint-disable */
-import { describe, it, expect } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 import {
   getRouteApi,
   createFileRoute,
   createLazyRoute,
   createLazyFileRoute,
   LazyRoute,
+  FileRoute,
 } from '../src'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('createFileRoute', () => {
+  it('creates a non-root route without a deprecation warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    // @ts-expect-error
+    const route = createFileRoute('')({})
+
+    expect(route.isRoot).toBe(false)
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('keeps the deprecation warning for direct FileRoute usage', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    // @ts-expect-error
+    const route = new FileRoute('').createRoute({})
+
+    expect(route.isRoot).toBe(false)
+    expect(warn).toHaveBeenCalledOnce()
+  })
+})
 
 describe('createFileRoute has the same hooks as getRouteApi', () => {
   const routeApi = getRouteApi('foo')


### PR DESCRIPTION
## What

- have `createFileRoute` create the route directly in React, Solid, and Vue
- keep the deprecated `FileRoute` class and its warning behavior intact
- preserve `isRoot = false` for file routes
- add mirrored factory/class behavior tests for all three frameworks

## Why

The public factory only instantiated `FileRoute` to reuse its `createRoute` field while suppressing the class's deprecation warning. Creating the route directly removes that unnecessary class path from normal file-route bundles without changing the deprecated API.

## Bundle impact

Prior isolated prototype measurements from the same `main` base:

- `react-router.minimal`: -117 B raw, -40 B gzip, -20 B Brotli
- `solid-router.minimal`: -117 B raw, -38 B gzip, +4 B Brotli

Measured for this PR head against the same base:

- `vue-router.minimal`: -113 B raw, -49 B gzip, -42 B Brotli

## Validation

- React and Vue focused file-route unit tests
- Solid full client/server unit suite (840 passed, 1 skipped; server suite 3 passed)
- React, Solid, and Vue type tests
- React, Solid, and Vue ESLint (0 errors; existing warnings only)
- React, Solid, and Vue production builds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File-based route creation no longer produces an unexpected deprecation warning.
  * Routes created through the standard file-route API are correctly treated as non-root routes.
  * Direct use of the deprecated route API continues to display its warning.

* **Tests**
  * Added coverage confirming route behavior and warning differences across React, Solid, and Vue integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->