### PR TITLE
perf(react-router): stop persisted matches re-rendering on every navigation

### DIFF
--- a/.changeset/mean-pugs-play.md
+++ b/.changeset/mean-pugs-play.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-router': patch
+---
+
+Stop persisted route matches from re-rendering on every navigation. `Match` subscribed to its match store by identity, and `buildMatches` re-mints every staying match on every navigation, so each mounted route re-rendered its `MatchView`/`Suspense`/`CatchBoundary`/`CatchNotFound`/`MatchInner` chain even when nothing it renders had changed. `Match` now selects only the fields its subtree renders, and the per-navigation identity that resets `CatchBoundary` is observed in a wrapper that is only mounted for routes that actually have an `errorComponent`.

--- a/packages/react-router/src/Match.tsx
+++ b/packages/react-router/src/Match.tsx
@@ -12,6 +12,7 @@ import { SafeFragment } from './SafeFragment'
 import { renderRouteNotFound } from './renderRouteNotFound'
 import { ScrollRestoration } from './scroll-restoration'
 import { ClientOnly } from './ClientOnly'
+import type { ErrorRouteComponent } from './route'
 import type {
   AnyRoute,
   AnyRouteMatch,
@@ -37,6 +38,72 @@ const outletMatchSelectionEqual = (
   b: OutletMatchSelection,
 ) => a[0] === b[0] && a[1] === b[1]
 
+type MatchSelection = [
+  matchId: string | undefined,
+  ssr: boolean | 'data-only' | undefined,
+  status: AnyRouteMatch['status'] | undefined,
+  error: unknown,
+  remountKey: string | undefined,
+  lazy: LazyRouteState,
+]
+
+// `_lazy` is marked `@internal`, so it is stripped from the published
+// declarations router-core's consumers compile against.
+type LazyRouteState = Promise<void> | true | undefined
+
+const matchSelectionEqual = (a: MatchSelection, b: MatchSelection) =>
+  a[0] === b[0] &&
+  a[1] === b[1] &&
+  a[2] === b[2] &&
+  a[3] === b[3] &&
+  a[4] === b[4] &&
+  a[5] === b[5]
+
+const emptyMatchSelection: MatchSelection = [
+  undefined,
+  undefined,
+  undefined,
+  undefined,
+  undefined,
+  undefined,
+]
+
+// `buildMatches` re-mints every staying match on every navigation (a fresh
+// object with a fresh `_strictSearch`, `context` and `abortController`, and an
+// updated `cause`), so a match store always republishes with a new identity.
+// Selecting only the fields this subtree renders lets a staying route bail out.
+// `loaderDeps`/`_strictParams`/`_strictSearch` reach the output solely through
+// the remount key, so the key is computed here and compared as a string.
+// `route._lazy` is selected too: a lazy route's options are assigned onto the
+// route in place, and a re-offered pending match is the only signal that the
+// components this subtree renders have just been replaced.
+function selectMatchFields(
+  router: ReturnType<typeof useRouter>,
+  routeId: string,
+  match: AnyRouteMatch | undefined,
+): MatchSelection {
+  if (!match) return emptyMatchSelection
+
+  const route = router.routesById[routeId] as AnyRoute
+  const remountFn =
+    route.options.remountDeps ?? router.options.defaultRemountDeps
+  const remountDeps = remountFn?.({
+    routeId,
+    loaderDeps: match.loaderDeps,
+    params: match._strictParams,
+    search: match._strictSearch,
+  })
+
+  return [
+    match.id,
+    match.ssr,
+    match.status,
+    match.error,
+    remountDeps ? JSON.stringify(remountDeps) : undefined,
+    (route as { _lazy?: LazyRouteState })._lazy,
+  ]
+}
+
 export const Match = React.memo(function MatchImpl({
   routeId,
 }: {
@@ -46,23 +113,61 @@ export const Match = React.memo(function MatchImpl({
 
   if (isServer ?? router.isServer) {
     const match = router.stores.byRoute.get(routeId)!.get()!
-    return <MatchView router={router} match={match} />
+    return (
+      <MatchView
+        router={router}
+        routeId={routeId}
+        selection={selectMatchFields(router, routeId, match)}
+      />
+    )
   }
 
   const matchStore = router.stores.getMatchStore(routeId)
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  const match = useStore(matchStore, (value) => value)
-  return <MatchView router={router} match={match!} />
+  const selection = useStore(
+    matchStore,
+    (match) => selectMatchFields(router, routeId, match),
+    matchSelectionEqual,
+  )
+  return <MatchView router={router} routeId={routeId} selection={selection} />
 })
+
+// `CatchBoundary` resets its error whenever `getResetKey()` changes, and the
+// match identity is what changes per navigation. Observing it here rather than
+// in `Match` keeps that per-navigation update off every mounted route: only
+// routes that actually have an `errorComponent` pay for it, and because
+// `props.children` is the element `MatchView` already created, the subtree
+// below bails out.
+function ResettableCatchBoundary({
+  routeId,
+  ...props
+}: {
+  routeId: string
+  children: React.ReactNode
+  errorComponent?: ErrorRouteComponent
+  onCatch?: (error: Error, errorInfo: React.ErrorInfo) => void
+}) {
+  const router = useRouter()
+  const resetKey =
+    (isServer ?? router.isServer)
+      ? router.stores.byRoute.get(routeId)!.get()
+      : // eslint-disable-next-line react-hooks/rules-of-hooks -- condition is static
+        useStore(router.stores.getMatchStore(routeId), (match) => match)
+
+  return <CatchBoundary getResetKey={() => resetKey} {...props} />
+}
 
 function MatchView({
   router,
-  match,
+  routeId,
+  selection,
 }: {
   router: ReturnType<typeof useRouter>
-  match: AnyRouteMatch
+  routeId: string
+  selection: MatchSelection
 }) {
-  const route: AnyRoute = router.routesById[match.routeId]
+  const [matchId, ssr, status, error, remountKey] = selection
+  const route: AnyRoute = router.routesById[routeId]
 
   const pendingElement = renderPending(router, route)
 
@@ -77,7 +182,7 @@ function MatchView({
       router.options.notFoundRoute?.options.component)
     : route.options.notFoundComponent
 
-  const resolvedNoSsr = match.ssr === false || match.ssr === 'data-only'
+  const resolvedNoSsr = ssr === false || ssr === 'data-only'
   const ResolvedSuspenseBoundary =
     (route.options.wrapInSuspense ??
     pendingElement ??
@@ -86,7 +191,7 @@ function MatchView({
       : SafeFragment
 
   const ResolvedCatchBoundary = routeErrorComponent
-    ? CatchBoundary
+    ? ResettableCatchBoundary
     : SafeFragment
 
   const ResolvedNotFoundBoundary = routeNotFoundComponent
@@ -98,28 +203,28 @@ function MatchView({
     : SafeFragment
   return (
     <ShellComponent>
-      <matchContext.Provider value={match.routeId}>
+      <matchContext.Provider value={routeId}>
         <ResolvedSuspenseBoundary fallback={pendingElement}>
           <ResolvedCatchBoundary
-            getResetKey={() => match}
+            routeId={routeId}
             errorComponent={routeErrorComponent as any}
             onCatch={(error, errorInfo) => {
               // Forward not found errors (we don't want to show the error component for these)
               if (isNotFound(error)) {
-                error.routeId ??= match.routeId
+                error.routeId ??= routeId
                 throw error
               }
               if (process.env.NODE_ENV !== 'production') {
-                console.warn(`Warning: Error in route match: ${match.id}`)
+                console.warn(`Warning: Error in route match: ${matchId}`)
               }
               routeOnCatch?.(error, errorInfo)
             }}
           >
             <ResolvedNotFoundBoundary
               fallback={(error) => {
-                error.routeId ??= match.routeId
+                error.routeId ??= routeId
 
-                if (error.routeId !== match.routeId) {
+                if (error.routeId !== routeId) {
                   throw error
                 }
 
@@ -131,10 +236,20 @@ function MatchView({
             >
               {resolvedNoSsr ? (
                 <ClientOnly fallback={pendingElement}>
-                  <MatchInner match={match} />
+                  <MatchInner
+                    routeId={routeId}
+                    status={status}
+                    error={error}
+                    remountKey={remountKey}
+                  />
                 </ClientOnly>
               ) : (
-                <MatchInner match={match} />
+                <MatchInner
+                  routeId={routeId}
+                  status={status}
+                  error={error}
+                  remountKey={remountKey}
+                />
               )}
             </ResolvedNotFoundBoundary>
           </ResolvedCatchBoundary>
@@ -150,48 +265,35 @@ function MatchView({
 }
 
 export const MatchInner = React.memo(function MatchInnerImpl({
-  match,
+  routeId,
+  status,
+  error,
+  remountKey,
 }: {
-  match: AnyRouteMatch
+  routeId: string
+  status: AnyRouteMatch['status'] | undefined
+  error: unknown
+  remountKey: string | undefined
 }): any {
   const router = useRouter()
-  const routeId = match.routeId
   const route = router.routesById[routeId] as AnyRoute
-  const key = React.useMemo(() => {
-    const remountFn =
-      route.options.remountDeps ?? router.options.defaultRemountDeps
-    const remountDeps = remountFn?.({
-      routeId,
-      loaderDeps: match.loaderDeps,
-      params: match._strictParams,
-      search: match._strictSearch,
-    })
-    return remountDeps ? JSON.stringify(remountDeps) : undefined
-  }, [
-    routeId,
-    match.loaderDeps,
-    match._strictParams,
-    match._strictSearch,
-    route.options.remountDeps,
-    router.options.defaultRemountDeps,
-  ])
   const out = React.useMemo(() => {
     const Comp = route.options.component ?? router.options.defaultComponent
-    return Comp ? <Comp key={key} /> : <Outlet />
-  }, [key, route.options.component, router.options.defaultComponent])
+    return Comp ? <Comp key={remountKey} /> : <Outlet />
+  }, [remountKey, route.options.component, router.options.defaultComponent])
 
-  if (match.status === 'pending') {
+  if (status === 'pending') {
     if (router._tx) {
       throw router._tx[5]
     }
     return renderPending(router, route)
   }
 
-  if (match.status === 'notFound') {
-    return renderRouteNotFound(router, route, match.error)
+  if (status === 'notFound') {
+    return renderRouteNotFound(router, route, error)
   }
 
-  if (match.status === 'error') {
+  if (status === 'error') {
     if (isServer ?? router.isServer) {
       const RouteErrorComponent =
         (route.options.errorComponent ??
@@ -199,7 +301,7 @@ export const MatchInner = React.memo(function MatchInnerImpl({
         ErrorComponent
       return (
         <RouteErrorComponent
-          error={match.error as any}
+          error={error as any}
           reset={undefined as any}
           info={{
             componentStack: '',
@@ -207,7 +309,7 @@ export const MatchInner = React.memo(function MatchInnerImpl({
         />
       )
     }
-    throw match.error
+    throw error
   }
 
   return out

--- a/packages/react-router/tests/match-rerender-probe.test.tsx
+++ b/packages/react-router/tests/match-rerender-probe.test.tsx
@@ -1,0 +1,396 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { act, cleanup, render, screen } from '@testing-library/react'
+import * as React from 'react'
+import type * as ReactNS from 'react'
+
+// ---------------------------------------------------------------------------
+// Render counter: patch React.memo so every `React.memo(function XImpl(){})`
+// component in the router source is wrapped with a counter keyed on the inner
+// function name. This is applied identically to the baseline and the patched
+// build, so the counts are directly comparable.
+// ---------------------------------------------------------------------------
+const renderCounts: Record<string, number> = {}
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactNS>()
+  const origMemo = actual.memo
+  const memo = ((fn: any, cmp: any) => {
+    if (typeof fn !== 'function' || !fn.name) return origMemo(fn, cmp)
+    const name = fn.name
+    const wrapper = (props: any, ref: any) => {
+      renderCounts[name] = (renderCounts[name] ?? 0) + 1
+      return fn(props, ref)
+    }
+    Object.defineProperty(wrapper, 'name', { value: name })
+    return origMemo(wrapper as any, cmp)
+  }) as typeof actual.memo
+  return { ...actual, memo, default: { ...(actual as any), memo } }
+})
+
+const {
+  Link,
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  useRouterState,
+} = await import('../src')
+
+function resetCounts() {
+  for (const k of Object.keys(renderCounts)) delete renderCounts[k]
+}
+
+// naive structural equality used only for reporting (does NOT ignore undefined)
+function sameDeep(a: any, b: any, seen = new Set<any>()): boolean {
+  if (Object.is(a, b)) return true
+  if (typeof a !== 'object' || typeof b !== 'object' || !a || !b) return false
+  if (seen.has(a)) return true
+  seen.add(a)
+  const ka = Object.keys(a)
+  const kb = Object.keys(b)
+  if (ka.length !== kb.length) return false
+  return ka.every((k) => sameDeep(a[k], b[k], seen))
+}
+
+function createTestRouter() {
+  const rootRoute = createRootRoute({
+    component: function RootComp() {
+      // A root that genuinely re-renders on every navigation.
+      const href = useRouterState({ select: (s) => s.location.href })
+      return (
+        <div>
+          <span data-testid="href">{href}</span>
+          <Outlet />
+        </div>
+      )
+    },
+  })
+
+  const sectionRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: 'section',
+    validateSearch: (search: Record<string, unknown>) => ({
+      tab: (search.tab as string) ?? 'all',
+    }),
+    loader: () => ({ section: true }),
+    component: () => <Outlet />,
+  })
+
+  const listRoute = createRoute({
+    getParentRoute: () => sectionRoute,
+    path: 'list',
+    loader: () => ({ list: [1, 2, 3] }),
+    component: () => (
+      <div>
+        {/* inline literals on purpose: fresh object identity every render */}
+        <Link to="/section/list/a" search={{ tab: 'all' }}>
+          go a
+        </Link>
+        <Link to="/section/list/b" search={{ tab: 'all' }}>
+          go b
+        </Link>
+        <Outlet />
+      </div>
+    ),
+  })
+
+  const leafA = createRoute({
+    getParentRoute: () => listRoute,
+    path: 'a',
+    component: () => <div data-testid="leaf">leaf-a</div>,
+  })
+  const leafB = createRoute({
+    getParentRoute: () => listRoute,
+    path: 'b',
+    component: () => <div data-testid="leaf">leaf-b</div>,
+  })
+
+  const routeTree = rootRoute.addChildren([
+    sectionRoute.addChildren([listRoute.addChildren([leafA, leafB])]),
+  ])
+
+  return createRouter({
+    routeTree,
+    basepath: '/app',
+    history: createMemoryHistory({
+      initialEntries: ['/app/section/list/a?tab=all'],
+    }),
+  })
+}
+
+type Probe = {
+  publishes: Array<{
+    routeId: string
+    deepEqual: boolean
+    changedKeys: Array<string>
+  }>
+}
+
+function instrument(router: any): Probe {
+  const probe: Probe = { publishes: [] }
+  for (const [routeId, store] of router.stores.byRoute as Map<string, any>) {
+    let prev = store.get()
+    store.subscribe(() => {
+      const next = store.get()
+      if (!prev || !next) {
+        prev = next
+        return
+      }
+      const changedKeys = [
+        ...new Set([...Object.keys(prev), ...Object.keys(next)]),
+      ]
+        .filter((k) => !Object.is(prev[k], next[k]))
+        .map((k) =>
+          sameDeep(prev[k], next[k]) ? `${k}(identity-only)` : `${k}(value)`,
+        )
+      probe.publishes.push({
+        routeId,
+        deepEqual: sameDeep(prev, next),
+        changedKeys,
+      })
+      prev = next
+    })
+  }
+  return probe
+}
+
+describe('Match re-render churn probe', () => {
+  afterEach(() => {
+    cleanup()
+    resetCounts()
+  })
+
+  test('sibling navigation /section/list/a -> /section/list/b', async () => {
+    const router = createTestRouter()
+    await act(() => router.load())
+    render(<RouterProvider router={router} />)
+    await act(() => new Promise((r) => setTimeout(r, 0)))
+    expect(screen.getByTestId('leaf')).toHaveTextContent('leaf-a')
+
+    const stayingIds = [
+      ...(router.stores.byRoute as Map<string, any>).keys(),
+    ].filter((id) => id !== '/section/list/a')
+    const probe = instrument(router)
+    resetCounts()
+
+    await act(async () => {
+      await router.navigate({ to: '/section/list/b', search: { tab: 'all' } })
+    })
+    await act(() => new Promise((r) => setTimeout(r, 0)))
+    expect(screen.getByTestId('leaf')).toHaveTextContent('leaf-b')
+
+    const report = {
+      MatchImpl: renderCounts.MatchImpl ?? 0,
+      MatchInnerImpl: renderCounts.MatchInnerImpl ?? 0,
+      OutletImpl: renderCounts.OutletImpl ?? 0,
+      LinkImpl: renderCounts.LinkComponentImpl ?? renderCounts.LinkImpl ?? 0,
+      stayingMatchPublishes: probe.publishes.filter((p) =>
+        stayingIds.includes(p.routeId),
+      ).length,
+      stayingMatchPublishesDeepEqual: probe.publishes.filter(
+        (p) => stayingIds.includes(p.routeId) && p.deepEqual,
+      ).length,
+      publishDetail: probe.publishes.map((p) => ({
+        routeId: p.routeId,
+        changedKeys: p.changedKeys,
+      })),
+      allRenderCounts: { ...renderCounts },
+    }
+
+    console.log('PROBE_SIBLING_NAV ' + JSON.stringify(report, null, 2))
+
+    expect(report).toBeTruthy()
+  })
+
+  test('search-only navigation ?tab=all -> ?tab=mine', async () => {
+    const router = createTestRouter()
+    await act(() => router.load())
+    render(<RouterProvider router={router} />)
+    await act(() => new Promise((r) => setTimeout(r, 0)))
+
+    const probe = instrument(router)
+    resetCounts()
+
+    await act(async () => {
+      await router.navigate({ to: '/section/list/a', search: { tab: 'mine' } })
+    })
+    await act(() => new Promise((r) => setTimeout(r, 0)))
+
+    const report = {
+      MatchImpl: renderCounts.MatchImpl ?? 0,
+      MatchInnerImpl: renderCounts.MatchInnerImpl ?? 0,
+      OutletImpl: renderCounts.OutletImpl ?? 0,
+      publishes: probe.publishes.length,
+      publishDetail: probe.publishes.map((p) => ({
+        routeId: p.routeId,
+        changedKeys: p.changedKeys,
+      })),
+    }
+
+    console.log('PROBE_SEARCH_NAV ' + JSON.stringify(report, null, 2))
+
+    expect(report).toBeTruthy()
+  })
+
+  test('same-route re-navigation (no-op href change)', async () => {
+    const router = createTestRouter()
+    await act(() => router.load())
+    render(<RouterProvider router={router} />)
+    await act(() => new Promise((r) => setTimeout(r, 0)))
+
+    const probe = instrument(router)
+    resetCounts()
+
+    await act(async () => {
+      await router.navigate({ to: '/section/list/b', search: { tab: 'all' } })
+    })
+    await act(async () => {
+      await router.navigate({ to: '/section/list/a', search: { tab: 'all' } })
+    })
+    await act(() => new Promise((r) => setTimeout(r, 0)))
+
+    const report = {
+      MatchImpl: renderCounts.MatchImpl ?? 0,
+      MatchInnerImpl: renderCounts.MatchInnerImpl ?? 0,
+      OutletImpl: renderCounts.OutletImpl ?? 0,
+      publishes: probe.publishes.length,
+      publishDetail: probe.publishes.map((p) => ({
+        routeId: p.routeId,
+        changedKeys: p.changedKeys,
+      })),
+    }
+
+    console.log('PROBE_TWO_NAVS ' + JSON.stringify(report, null, 2))
+
+    expect(report).toBeTruthy()
+  })
+})
+
+describe('error boundary reset semantics', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    cleanup()
+    resetCounts()
+    vi.restoreAllMocks()
+  })
+
+  test('a layout that throws during render resets its boundary on the next navigation', async () => {
+    // The layout route stays mounted across the sibling navigation, so the
+    // ONLY thing that can clear its CatchBoundary is a resetKey change.
+    let shouldThrow = true
+
+    const rootRoute = createRootRoute({ component: () => <Outlet /> })
+    const layoutRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: 'layout',
+      errorComponent: () => <div data-testid="boundary">boundary</div>,
+      component: function LayoutComp() {
+        if (shouldThrow) throw new Error('boom')
+        return (
+          <div>
+            <span data-testid="layout">layout-ok</span>
+            <Outlet />
+          </div>
+        )
+      },
+    })
+    const a = createRoute({
+      getParentRoute: () => layoutRoute,
+      path: 'a',
+      component: () => <div data-testid="leaf">a</div>,
+    })
+    const b = createRoute({
+      getParentRoute: () => layoutRoute,
+      path: 'b',
+      component: () => <div data-testid="leaf">b</div>,
+    })
+
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([layoutRoute.addChildren([a, b])]),
+      history: createMemoryHistory({ initialEntries: ['/layout/a'] }),
+    })
+
+    await act(() => router.load())
+    render(<RouterProvider router={router} />)
+    await act(() => new Promise((r) => setTimeout(r, 0)))
+
+    expect(screen.getByTestId('boundary')).toBeInTheDocument()
+
+    shouldThrow = false
+    await act(async () => {
+      await router.navigate({ to: '/layout/b' })
+    })
+    await act(() => new Promise((r) => setTimeout(r, 0)))
+
+    expect(screen.queryByTestId('boundary')).not.toBeInTheDocument()
+    expect(screen.getByTestId('layout')).toHaveTextContent('layout-ok')
+    expect(screen.getByTestId('leaf')).toHaveTextContent('b')
+  })
+
+  test('error thrown by a staying layout after the last commit still resets on the next navigation', async () => {
+    // Timing edge: the component renders fine on the first commit, then a
+    // later state change makes it throw *after* the match store last changed.
+    // The next navigation must still reset the boundary.
+    let shouldThrow = false
+    let forceRerender: (() => void) | undefined
+
+    const rootRoute = createRootRoute({ component: () => <Outlet /> })
+    const layoutRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: 'layout',
+      errorComponent: () => <div data-testid="boundary">boundary</div>,
+      component: function LayoutComp() {
+        const [, setTick] = React.useState(0)
+        forceRerender = () => setTick((t) => t + 1)
+        if (shouldThrow) throw new Error('late boom')
+        return (
+          <div>
+            <span data-testid="layout">layout-ok</span>
+            <Outlet />
+          </div>
+        )
+      },
+    })
+    const a = createRoute({
+      getParentRoute: () => layoutRoute,
+      path: 'a',
+      component: () => <div data-testid="leaf">a</div>,
+    })
+    const b = createRoute({
+      getParentRoute: () => layoutRoute,
+      path: 'b',
+      component: () => <div data-testid="leaf">b</div>,
+    })
+
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([layoutRoute.addChildren([a, b])]),
+      history: createMemoryHistory({ initialEntries: ['/layout/a'] }),
+    })
+
+    await act(() => router.load())
+    render(<RouterProvider router={router} />)
+    await act(() => new Promise((r) => setTimeout(r, 0)))
+    expect(screen.getByTestId('layout')).toBeInTheDocument()
+
+    // trip the error well after the last match-store change
+    shouldThrow = true
+    act(() => {
+      forceRerender!()
+    })
+    expect(screen.getByTestId('boundary')).toBeInTheDocument()
+
+    shouldThrow = false
+    await act(async () => {
+      await router.navigate({ to: '/layout/b' })
+    })
+    await act(() => new Promise((r) => setTimeout(r, 0)))
+
+    expect(screen.queryByTestId('boundary')).not.toBeInTheDocument()
+    expect(screen.getByTestId('leaf')).toHaveTextContent('b')
+  })
+})

--- a/packages/react-router/tests/match-rerender-probe.test.tsx
+++ b/packages/react-router/tests/match-rerender-probe.test.tsx
@@ -201,7 +201,13 @@ describe('Match re-render churn probe', () => {
 
     console.log('PROBE_SIBLING_NAV ' + JSON.stringify(report, null, 2))
 
-    expect(report).toBeTruthy()
+    // Three routes (root, /section, /section/list) persist across this
+    // navigation and render nothing that changed. `Match` is keyed by routeId
+    // on main, so the leaf route's `Match` swaps its store contents in place
+    // rather than mounting a new one -- one render for the leaf, none for the
+    // three that stayed.
+    expect(report.MatchImpl).toBe(1)
+    expect(report.MatchInnerImpl).toBe(1)
   })
 
   test('search-only navigation ?tab=all -> ?tab=mine', async () => {
@@ -231,7 +237,10 @@ describe('Match re-render churn probe', () => {
 
     console.log('PROBE_SEARCH_NAV ' + JSON.stringify(report, null, 2))
 
-    expect(report).toBeTruthy()
+    // No route enters or leaves, and nothing Match/MatchInner render depends
+    // on changes -- search reaches route components through useSearch.
+    expect(report.MatchImpl).toBe(0)
+    expect(report.MatchInnerImpl).toBe(0)
   })
 
   test('same-route re-navigation (no-op href change)', async () => {
@@ -264,7 +273,9 @@ describe('Match re-render churn probe', () => {
 
     console.log('PROBE_TWO_NAVS ' + JSON.stringify(report, null, 2))
 
-    expect(report).toBeTruthy()
+    // One leaf swap per navigation, nothing else.
+    expect(report.MatchImpl).toBe(2)
+    expect(report.MatchInnerImpl).toBe(2)
   })
 })
 

--- a/packages/react-router/tests/match-rerender-probe.test.tsx
+++ b/packages/react-router/tests/match-rerender-probe.test.tsx
@@ -224,6 +224,11 @@ describe('Match re-render churn probe', () => {
     })
     await act(() => new Promise((r) => setTimeout(r, 0)))
 
+    // Confirm the search navigation actually landed before asserting that it
+    // caused no re-renders -- otherwise the zero-render assertions would pass
+    // even if the navigation had silently done nothing.
+    expect(screen.getByTestId('href')).toHaveTextContent('tab=mine')
+
     const report = {
       MatchImpl: renderCounts.MatchImpl ?? 0,
       MatchInnerImpl: renderCounts.MatchInnerImpl ?? 0,


### PR DESCRIPTION
# perf(react-router): stop persisted matches re-rendering on every navigation

Fixes the churn described in the accompanying issue (#7989): every mounted
`Match` and `MatchInner` re-rendered on every navigation, including matches that
stayed and rendered identical output.

Closes #7989.

Branch: `match-rerender-main` (3 commits, off `abf9b81b1f`).

## What changed

`packages/react-router/src/Match.tsx` only.

**1. `Match` selects the fields its subtree renders, instead of the whole match
by identity.**

```diff
-const match = useStore(matchStore, (value) => value)
-return <MatchView router={router} match={match!} />
+const selection = useStore(
+  matchStore,
+  (match) => selectMatchFields(router, routeId, match),
+  matchSelectionEqual,
+)
+return <MatchView router={router} routeId={routeId} selection={selection} />
```

The selection is a labelled tuple of `[matchId, ssr, status, error, remountKey,
lazy]`. `loaderDeps`, `_strictParams` and `_strictSearch` only reach the output
through `remountDeps`, so the remount key is computed inside the selector and
compared as a string — which also retires the `MatchInner` `key` `useMemo`,
which never held anyway (a fresh `_strictSearch` object invalidated it every
navigation). `MatchInner` now receives primitives, so its `React.memo` can
actually bail out.

**2. The per-navigation identity that resets `CatchBoundary` is observed in a
wrapper that only mounts for routes that have an `errorComponent`.**

```tsx
function ResettableCatchBoundary({ routeId, ...props }) {
  const router = useRouter()
  const resetKey = (isServer ?? router.isServer)
    ? router.stores.byRoute.get(routeId)!.get()
    : useStore(router.stores.getMatchStore(routeId), (match) => match)

  return <CatchBoundary getResetKey={() => resetKey} {...props} />
}
```

`getResetKey={() => match}` was the whole reason `Match` needed the match
identity. Moving that read down means only routes that can actually show an
error pay for it, and because `props.children` is the element `MatchView`
already created, the subtree below the wrapper bails out even when the wrapper
itself re-renders.

**3. `route._lazy` is part of the selection.** A lazy route's options are
`Object.assign`ed onto the route object in place, and a re-offered pending match
is the only signal that the components this subtree renders have just been
replaced. Without it,
`tests/issue-4467-lazy-route-pending.test.tsx › a lazy pending component is
offered while the eager loader is still pending` fails (it keeps showing
`Loading default` instead of `Loading lazy page`). `_lazy` is `@internal`, so it
is stripped from the published declarations and is read through a narrow local
structural type.

## Red / green counts

Counted by patching `React.memo` to wrap every `*Impl` component with a counter
(`packages/react-router/tests/match-rerender-probe.test.tsx`, added in the first
commit as reporting-only and asserted in the third). Four matches mounted, three
of them staying across a sibling navigation.

### `main` (this PR)

| Scenario | `MatchImpl` before | after | `MatchInnerImpl` before | after |
| --- | --- | --- | --- | --- |
| sibling `/section/list/a → /b` | 4 | **1** | 4 | **1** |
| search-only `?tab=all → ?tab=mine` | 4 | **0** | 4 | **0** |
| two navigations back and forth | 8 | **2** | 8 | **2** |

`OutletImpl` is unchanged (1 / 0 / 2) — the fix does not suppress renders that
are genuinely required.

Store-side counts, unchanged by the fix because `router-core` is untouched:
3 staying-match publishes per sibling navigation, 0 of which are structurally
equal to the previous value.

### Released `1.170.17` line, for reference

The same shape of fix applies there, and it splits into two independently
measurable hunks. `Match` on 1.170.x also subscribes to `router.stores.loadedAt`
purely for `getResetKey`.

| Scenario | baseline | + `loadedAt` hunk only | + both hunks |
| --- | --- | --- | --- |
| sibling — `MatchImpl` / `MatchInnerImpl` | 4 / 4 | **1** / 4 | **1** / **1** |
| search-only — `MatchImpl` / `MatchInnerImpl` | 4 / 4 | **0** / 4 | **0** / **0** |
| two navs — `MatchImpl` / `MatchInnerImpl` | 8 / 8 | **2** / 8 | **2** / **2** |

## Unit suites

`packages/react-router`, `vitest run` (typecheck enabled), full suite:

| Branch | Baseline | Patched |
| --- | --- | --- |
| `main` | 74 files, 993 passed / 3 failed / 1 skipped (997) | 74 files, **996 passed** / 1 skipped (997) |
| `1.170.17` | 45 files, 914 passed / 3 failed / 1 skipped (918) | 45 files, **917 passed** / 1 skipped (918) |

The 3 baseline failures are the probe's own count assertions, i.e. the red side
of this change. No other test changes state, and `Type Errors  no errors` on
both sides of both branches.

## Error-boundary reset semantics

This is the behaviour the change most risks, since it moves what feeds
`getResetKey`. Two tests cover it, and both pass **before and after** on both
branches (so they are guards, not new behaviour being introduced):

1. *a layout that throws during render resets its boundary on the next
   navigation* — the throwing layout **stays mounted** across the navigation, so
   a resetKey change is the only thing that can clear the boundary.
2. *error thrown by a staying layout after the last commit still resets on the
   next navigation* — the timing edge: the component renders fine, then a later
   `setState` makes it throw **after** the last store/`loadedAt` tick. The next
   navigation must still reset.

The repo's existing `errorComponent.test.tsx`,
`disableGlobalCatchBoundary.test.tsx` and `not-found.test.tsx` also pass
unchanged.

### One sizing note

An app that sets a router-level `defaultErrorComponent` resolves an
`errorComponent` for *every* route, so `ResettableCatchBoundary` mounts once per
match rather than only for routes that declare their own error component. That is
bounded: the residual cost is the wrapper + `CatchBoundary` pair, and the subtree
below still bails on element identity (`props.children` is the element
`MatchView` already created), so the per-match render savings this PR delivers are
unaffected. If you want the residual per-match subscription gone even in the
default-error-component case, the direction would be `CatchBoundary` reading its
reset signal only while it is actually errored — that is deliberately out of scope
here and would be a follow-up rather than something to fold into this change.

## Benchmarks

Strictly **interleaved A/B**, never A×n then B×n — sequential batching on this
box invents 10–15% swings. Each round: swap the built `@tanstack/react-router`
`dist` for the other side, rebuild the benchmark app, run the bench. Medians
across rounds; `vitest bench` `time: 10_000`, `warmupIterations: 100`.

### `benchmarks/client-nav` (react), 8 interleaved rounds per side

| Metric | baseline median | patched median | Δ | baseline range | patched range | paired wins |
| --- | --- | --- | --- | --- | --- | --- |
| throughput (hz, higher better) | 57.26 | 58.94 | **+2.9%** | 53.73–59.54 | 57.50–60.20 | 6/8 |
| mean (ms, lower better) | 17.47 | 16.97 | **−2.9%** | 16.80–18.61 | 16.61–17.39 | 6/8 |
| min (ms, lower better) | 14.17 | 14.06 | −0.8% | 13.98–14.57 | 13.95–14.18 | 5/8 |

**Honest reading:** the median moves the right way and the patched side is
visibly tighter, but the harness cannot cleanly resolve an effect this size. The
round-to-round spread of the *baseline against itself* is ~10%, wider than the
~3% median delta, and 2 of 8 paired rounds went the other way (sign test on 6/8
is not significant). Machine: 4 vCPU, load average 0.7–0.9 from unrelated
background work, per-run `rme` 0.8–1.2%. Treat CodSpeed on CI as the deciding
measurement; this is not a claim of a 3% win.

### `benchmarks/ssr` (react), 4 interleaved rounds per side

| Metric | baseline median | patched median | Δ |
| --- | --- | --- | --- |
| throughput (hz) | 43.20 | 43.44 | +0.6% |
| mean (ms) | 23.15 | 23.02 | −0.6% |
| min (ms) | 20.02 | 19.93 | −0.5% |

**No measurable change**, which is expected: the fix targets re-render churn
across *client* navigations, and SSR renders each match once. Reported to show
there is no regression, not a win. (`benchmarks/memory` was not run.)

Never traded runtime for bytes: nothing in this change adds work to a render
path in order to shrink output.

## Bundle size

Bundle size is a review gate here, so: gzip first (`gzip -9`), then raw, then
brotli (quality 11), per emitted file. Measured on `packages/react-router/dist`
from `vite build`. The build of the unmodified tag is **byte-identical to the
published 1.170.17 tarball across all 299 dist files**, so these deltas are
attributable to the source change and nothing else.

Attribution is per hunk, on the `1.170.17` line where the change splits cleanly
into the `loadedAt` hunk and the field-selection hunk (the selector-only column
is `full − loadedAt`):

| File | Metric | baseline | `loadedAt` hunk | selector hunk | **both** |
| --- | --- | --- | --- | --- | --- |
| `esm/Match.js` | **gzip** | 2878 | +24 | +71 | **+95** |
| `esm/Match.js` | raw | 12912 | +138 | −141 | **−3** |
| `esm/Match.js` | brotli | 2554 | +25 | +75 | **+100** |
| `cjs/Match.cjs` | **gzip** | 3011 | +25 | +69 | **+94** |
| `cjs/Match.cjs` | raw | 14909 | +210 | −246 | **−36** |
| `cjs/Match.cjs` | brotli | 2662 | +36 | +66 | **+102** |
| whole `dist/esm` JS | **gzip** | 41020 | +24 | +71 | **+95** |
| whole `dist/cjs` JS | **gzip** | 46177 | +25 | +69 | **+94** |

`esm/index.js`, `esm/index.dev.js` and `cjs/index.cjs` are byte-identical in
every variant — the change is contained to the `Match` chunk.

So: **+95 B gzip** on the esm payload (+0.23% of 41.0 kB), and raw output
actually *shrinks*, because retiring the `key` `useMemo` and the two dead
`isServer` branches removes more code than the wrapper adds.

### Tuples over objects

The `MatchInner`/`Match` selection publishes a **labelled tuple**, not an
object. Measured both, same logic:

| File | Metric | object selection | labelled tuple | tuple saves |
| --- | --- | --- | --- | --- |
| `esm/Match.js` | gzip | 3001 | 2973 | **28 B** |
| `esm/Match.js` | raw | 13073 | 12909 | 164 B |
| `cjs/Match.cjs` | gzip | 3130 | 3105 | **25 B** |
| `cjs/Match.cjs` | raw | 15037 | 14873 | 164 B |

### One build-output note worth knowing

The production build **keeps `/** … *\/` JSDoc blocks** in `dist` and drops `//`
line comments. Writing the `ResettableCatchBoundary` rationale as a JSDoc block
cost **+335 B gzip** instead of +95 B — the comment was 70% of the change's
gzip footprint. Internal, non-exported helpers here therefore document
themselves with `//`.

## Dead code removed

- `MatchView`'s `resetKey` prop and its type (1.170.x) — the boundary owns it now.
- `MatchInner`'s `key` `useMemo` and its six-entry dependency array (both
  branches) — the key is computed in the store selector.
- 1.170.x only, two unreachable server branches inside `MatchInner`'s
  **client** path: the `if (isServer ?? router.isServer)` guard around
  `minPendingPromise`, and the whole server `status === 'error'` branch.
  `MatchInner` has its own `if (isServer ?? router.isServer) { … return }`
  block far above that returns before either is reachable. (On `main` the
  server error branch *is* live — `MatchInner` has no separate server block
  there — so it is kept.)

No other parameter or local became unused; `eslint` is clean on the changed
files.

## Solid

**The same pattern does not apply, and no fix is needed.** Not implemented.

`packages/solid-router/src/Match.tsx` has no component-level re-render to
suppress. `currentMatch` is a `createMemo` over the same per-route store, and
every consumer — `Show`, `Switch`, `Dynamic`, the `getResetKey` passed to
`CatchBoundary` — is its own fine-grained reactive computation. A fresh match
identity re-runs only the computations that read it, and only patches DOM where
the derived value actually changed. There is no `MatchView`/`MatchInner`
subtree that gets invalidated wholesale, so there is nothing for a field
selection to save.

Two details worth noting for reviewers:

- Solid's `getResetKey={currentMatch}` is the direct analogue of this PR's
  `ResettableCatchBoundary`, and it already costs nothing extra: it is a signal
  read inside the boundary, not a re-render of every match.
- Solid deliberately depends on the whole match identity in exactly one place,
  and its comment names the reason: *"Lazy route option mutations become
  observable with the next client match publication."* That is precisely the
  dependency the React port had to re-add as the `route._lazy` selection slot —
  independent confirmation that it is a real render input rather than a
  workaround.

## How to review

1. Read `selectMatchFields` and ask whether anything `MatchView`/`MatchInner`
   renders is missing from the tuple. That is the whole correctness argument.
2. Read `ResettableCatchBoundary` and confirm the two error-reset tests in the
   probe file are the ones you would have asked for — especially the second, the
   "error tripped after the last store tick" edge.
3. Everything else is mechanical: props threaded as primitives instead of a
   match object.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary component re-renders during navigation, improving routing performance.
  * Preserved correct behavior for pending, not-found, error, and server-rendered routes.
  * Improved error-boundary reset behavior so it occurs only when appropriate.
  * Maintained correct component remounting during route transitions.

* **Tests**
  * Added coverage for navigation rendering, route updates, repeated navigations, route-store changes, and error-boundary resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->