### PR TITLE
don't use esbuild to minify in vite's bundlesize benchmarks

### DIFF
--- a/scripts/benchmarks/bundle-size/measure.mjs
+++ b/scripts/benchmarks/bundle-size/measure.mjs
@@ -548,8 +548,6 @@ async function buildViteScenario({ root, outDir, sourcemap }) {
     build: {
       outDir,
       emptyOutDir: true,
-      target: 'es2022',
-      minify: 'esbuild',
       sourcemap: sourcemap ? 'hidden' : false,
       reportCompressedSize: false,
       manifest: true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the Vite benchmark build configuration to use its default JavaScript target and minification settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->