### PR TITLE
ci: run bundle size workflow for benchmark scripts

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -8,11 +8,13 @@ on:
     paths:
       - 'packages/**'
       - 'benchmarks/**'
+      - 'scripts/benchmarks/bundle-size/**'
   push:
     branches: [main]
     paths:
       - 'packages/**'
       - 'benchmarks/**'
+      - 'scripts/benchmarks/bundle-size/**'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bundle size checks now run when relevant benchmark scripts are updated.
  * These checks are triggered for both pull requests and pushes to the main branch.
  * Existing triggers for package and benchmark changes remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->