### PR TITLE
perf(solid-router): avoid republishing unchanged link state

### DIFF
--- a/packages/solid-router/src/link.tsx
+++ b/packages/solid-router/src/link.tsx
@@ -133,61 +133,111 @@ export function useLinkProps<
 
   const next = Solid.createMemo(() => {
     // Rebuild when inherited search/hash or the current route context changes.
-    const _fromLocation = currentLocation()
-    const nextOptions = { _fromLocation, ...options } as any
+    const nextOptions = { _fromLocation: currentLocation(), ...options } as any
     // untrack because router-core will also access stores, which are signals in solid
     return Solid.untrack(() => router.buildLocation(nextOptions))
   })
 
-  const hrefOption = Solid.createMemo(() => {
-    if (options.disabled) return undefined
-    // Use publicHref - it contains the correct href for display
-    // When a rewrite changes the origin, publicHref is the full URL
-    // Otherwise it's the origin-stripped path
-    // This avoids constructing URL objects in the hot path
-    const location = next().maskedLocation ?? next()
-    const publicHref = location.publicHref
-    const external = location.external
+  type LinkState = readonly [
+    href: string | undefined,
+    external: string | undefined,
+    active: boolean,
+  ]
 
-    if (external) {
-      return { href: publicHref, external: true }
-    }
+  const linkState = Solid.createMemo(
+    (previous: LinkState | undefined): LinkState => {
+      const current = currentLocation()
+      const nextLocation = next()
+      const location = nextLocation.maskedLocation ?? nextLocation
+      const publicHref = location.publicHref
+      const href = options.disabled
+        ? undefined
+        : location.external
+          ? publicHref
+          : router.history.createHref(publicHref) || '/'
 
-    return {
-      href: router.history.createHref(publicHref) || '/',
-      external: false,
-    }
-  })
-
-  const externalLink = Solid.createMemo(() => {
-    const _href = hrefOption()
-    if (_href?.external) {
-      // Block dangerous protocols for external links
-      if (isDangerousProtocol(_href.href, router.protocolAllowlist)) {
-        if (process.env.NODE_ENV !== 'production') {
-          console.warn(`Blocked Link with dangerous protocol: ${_href.href}`)
+      let external: string | undefined
+      if (href !== undefined && location.external) {
+        // Block dangerous protocols for external links
+        if (isDangerousProtocol(href, router.protocolAllowlist)) {
+          if (process.env.NODE_ENV !== 'production') {
+            console.warn(`Blocked Link with dangerous protocol: ${href}`)
+          }
+        } else {
+          external = href
         }
-        return undefined
-      }
-      return _href.href
-    }
-    const to = options.to
-    const safeInternal = isSafeInternal(to)
-    if (safeInternal) return undefined
-    if (typeof to !== 'string' || to.indexOf(':') === -1) return undefined
-    try {
-      new URL(to as any)
-      // Block dangerous protocols like javascript:, blob:, data:
-      if (isDangerousProtocol(to, router.protocolAllowlist)) {
-        if (process.env.NODE_ENV !== 'production') {
-          console.warn(`Blocked Link with dangerous protocol: ${to}`)
+      } else {
+        const to = options.to
+        if (
+          !isSafeInternal(to) &&
+          typeof to === 'string' &&
+          to.indexOf(':') !== -1
+        ) {
+          try {
+            new URL(to)
+            // Block dangerous protocols like javascript:, blob:, data:
+            if (isDangerousProtocol(to, router.protocolAllowlist)) {
+              if (process.env.NODE_ENV !== 'production') {
+                console.warn(`Blocked Link with dangerous protocol: ${to}`)
+              }
+            } else {
+              external = to
+            }
+          } catch {}
         }
-        return undefined
       }
-      return to
-    } catch {}
-    return undefined
-  })
+
+      let active = false
+      if (external === undefined) {
+        const activeOptions = local.activeOptions
+        if (activeOptions?.exact) {
+          active = exactPathTest(
+            current.pathname,
+            nextLocation.pathname,
+            router.basepath,
+          )
+        } else {
+          const currentPath = removeTrailingSlash(
+            current.pathname,
+            router.basepath,
+          )
+          const nextPath = removeTrailingSlash(
+            nextLocation.pathname,
+            router.basepath,
+          )
+          active =
+            currentPath.startsWith(nextPath) &&
+            (currentPath.length === nextPath.length ||
+              currentPath[nextPath.length] === '/')
+        }
+
+        if (active && (activeOptions?.includeSearch ?? true)) {
+          active = deepEqual(current.search, nextLocation.search, {
+            partial: !activeOptions?.exact,
+            ignoreUndefined: !activeOptions?.explicitUndefined,
+          })
+        }
+
+        if (active && activeOptions?.includeHash) {
+          const currentHash =
+            shouldHydrateHash && !hasHydrated() ? '' : current.hash
+          active = currentHash === nextLocation.hash
+        }
+      }
+
+      if (
+        previous &&
+        previous[0] === href &&
+        previous[1] === external &&
+        previous[2] === active
+      ) {
+        return previous
+      }
+      return [href, external, active]
+    },
+  )
+
+  const externalLink = () => linkState()[1]
 
   const preload = Solid.createMemo(() => {
     if (options.reloadDocument || externalLink()) {
@@ -197,55 +247,6 @@ export function useLinkProps<
   })
   const preloadDelay = () =>
     local.preloadDelay ?? router.options.defaultPreloadDelay ?? 0
-
-  const isActive = Solid.createMemo(() => {
-    if (externalLink()) return false
-    const activeOptions = local.activeOptions
-    const current = currentLocation()
-    const nextLocation = next()
-
-    if (activeOptions?.exact) {
-      const testExact = exactPathTest(
-        current.pathname,
-        nextLocation.pathname,
-        router.basepath,
-      )
-      if (!testExact) {
-        return false
-      }
-    } else {
-      const currentPath = removeTrailingSlash(current.pathname, router.basepath)
-      const nextPath = removeTrailingSlash(
-        nextLocation.pathname,
-        router.basepath,
-      )
-
-      const pathIsFuzzyEqual =
-        currentPath.startsWith(nextPath) &&
-        (currentPath.length === nextPath.length ||
-          currentPath[nextPath.length] === '/')
-      if (!pathIsFuzzyEqual) {
-        return false
-      }
-    }
-
-    if (activeOptions?.includeSearch ?? true) {
-      const searchTest = deepEqual(current.search, nextLocation.search, {
-        partial: !activeOptions?.exact,
-        ignoreUndefined: !activeOptions?.explicitUndefined,
-      })
-      if (!searchTest) {
-        return false
-      }
-    }
-
-    if (activeOptions?.includeHash) {
-      const currentHash =
-        shouldHydrateHash && !hasHydrated() ? '' : current.hash
-      return currentHash === nextLocation.hash
-    }
-    return true
-  })
 
   const doPreload = () =>
     router
@@ -419,10 +420,11 @@ export function useLinkProps<
   }
 
   const resolvedProps = Solid.createMemo(() => {
-    const active = isActive()
+    const state = linkState()
+    const active = state[2]
 
     const base = {
-      href: hrefOption()?.href,
+      href: state[0],
       ref: mergeRefs(setRef, options.ref),
       onClick,
       onBlur,

--- a/packages/solid-router/src/link.tsx
+++ b/packages/solid-router/src/link.tsx
@@ -131,23 +131,21 @@ export function useLinkProps<
     { equals: (prev, next) => prev.href === next.href },
   )
 
-  const next = Solid.createMemo(() => {
-    // Rebuild when inherited search/hash or the current route context changes.
-    const nextOptions = { _fromLocation: currentLocation(), ...options } as any
-    // untrack because router-core will also access stores, which are signals in solid
-    return Solid.untrack(() => router.buildLocation(nextOptions))
-  })
-
   type LinkState = readonly [
     href: string | undefined,
     external: string | undefined,
     active: boolean,
   ]
 
+  let nextLocation: ReturnType<typeof router.buildLocation>
+
   const linkState = Solid.createMemo(
     (previous: LinkState | undefined): LinkState => {
       const current = currentLocation()
-      const nextLocation = next()
+      // Rebuild when inherited search/hash or the current route context changes.
+      const nextOptions = { _fromLocation: current, ...options } as any
+      // untrack because router-core will also access stores, which are signals in solid
+      nextLocation = Solid.untrack(() => router.buildLocation(nextOptions))
       const location = nextLocation.maskedLocation ?? nextLocation
       const publicHref = location.publicHref
       const href = options.disabled
@@ -248,13 +246,16 @@ export function useLinkProps<
   const preloadDelay = () =>
     local.preloadDelay ?? router.options.defaultPreloadDelay ?? 0
 
-  const doPreload = () =>
-    router
-      .preloadRoute({ ...options, _builtLocation: next() } as any)
+  const doPreload = () => {
+    // Refresh the privately held location even when published link state is stable.
+    linkState()
+    return router
+      .preloadRoute({ ...options, _builtLocation: nextLocation } as any)
       .catch((err: any) => {
         console.warn(err)
         console.warn(preloadWarning)
       })
+  }
 
   const preloadViewportIoCallback = (
     entry: IntersectionObserverEntry | undefined,

--- a/packages/solid-router/tests/link.test.tsx
+++ b/packages/solid-router/tests/link.test.tsx
@@ -613,6 +613,164 @@ describe('Link', () => {
       })
     })
 
+    test('does not republish link props when destination state is unchanged', async () => {
+      const activeProps = vi.fn(() => ({ class: 'active' }))
+      const inactiveProps = vi.fn(() => ({ class: 'inactive' }))
+      const rootRoute = createRootRoute({
+        component: () => (
+          <>
+            <Link
+              data-testid="stable-link"
+              to="/target"
+              activeProps={activeProps}
+              inactiveProps={inactiveProps}
+            >
+              Target
+            </Link>
+            <Outlet />
+          </>
+        ),
+      })
+      const indexRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/',
+        component: () => <p>Index</p>,
+      })
+      const otherRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/other',
+        component: () => <p>Other</p>,
+      })
+      const targetRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/target',
+        component: () => <p>Target route</p>,
+      })
+      const router = createRouter({
+        routeTree: rootRoute.addChildren([indexRoute, otherRoute, targetRoute]),
+        history: createMemoryHistory({ initialEntries: ['/'] }),
+      })
+
+      render(() => <RouterProvider router={router} />)
+
+      const link = await screen.findByTestId('stable-link')
+      const initialInactiveCalls = inactiveProps.mock.calls.length
+      expect(initialInactiveCalls).toBeGreaterThan(0)
+
+      await router.navigate({ to: '/other' })
+      expect(await screen.findByText('Other')).toBeInTheDocument()
+      expect(inactiveProps).toHaveBeenCalledTimes(initialInactiveCalls)
+
+      await router.navigate({ to: '/target' })
+      expect(await screen.findByText('Target route')).toBeInTheDocument()
+      expect(link).toHaveClass('active')
+      expect(activeProps).toHaveBeenCalledTimes(1)
+
+      await router.navigate({ to: '/other' })
+      expect(await screen.findByText('Other')).toBeInTheDocument()
+      expect(inactiveProps).toHaveBeenCalledTimes(initialInactiveCalls + 1)
+    })
+
+    test('does not republish props for an active fuzzy link between descendants', async () => {
+      const activeProps = vi.fn(() => ({ class: 'active' }))
+      const rootRoute = createRootRoute({
+        component: () => (
+          <>
+            <Link
+              data-testid="stable-active-link"
+              to="/posts"
+              activeProps={activeProps}
+            >
+              Posts
+            </Link>
+            <Outlet />
+          </>
+        ),
+      })
+      const postRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/posts/$postId',
+        component: () => <p>Post</p>,
+      })
+      const router = createRouter({
+        routeTree: rootRoute.addChildren([postRoute]),
+        history: createMemoryHistory({ initialEntries: ['/posts/one'] }),
+      })
+
+      render(() => <RouterProvider router={router} />)
+
+      const link = await screen.findByTestId('stable-active-link')
+      const initialActiveCalls = activeProps.mock.calls.length
+      expect(link).toHaveClass('active')
+      expect(initialActiveCalls).toBeGreaterThan(0)
+
+      await router.navigate({ to: '/posts/$postId', params: { postId: 'two' } })
+      expect(router.state.location.pathname).toBe('/posts/two')
+      expect(link).toHaveClass('active')
+      expect(activeProps).toHaveBeenCalledTimes(initialActiveCalls)
+    })
+
+    test('preloads the latest built location when published link state is unchanged', async () => {
+      const rootRoute = createRootRoute({
+        component: () => (
+          <>
+            <Link
+              data-testid="stable-preload-link"
+              to="/target"
+              preload="intent"
+              preloadDelay={0}
+            >
+              Target
+            </Link>
+            <Outlet />
+          </>
+        ),
+      })
+      const firstRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/first',
+        component: () => <p>First</p>,
+      })
+      const secondRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/second',
+        component: () => <p>Second</p>,
+      })
+      const targetRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/target',
+        component: () => <p>Target</p>,
+      })
+      const router = createRouter({
+        routeTree: rootRoute.addChildren([
+          firstRoute,
+          secondRoute,
+          targetRoute,
+        ]),
+        history: createMemoryHistory({ initialEntries: ['/first'] }),
+      })
+      const preloadRouteSpy = vi.spyOn(router, 'preloadRoute')
+
+      render(() => <RouterProvider router={router} />)
+
+      const link = await screen.findByTestId('stable-preload-link')
+      fireEvent.focus(link)
+      await waitFor(() => expect(preloadRouteSpy).toHaveBeenCalledTimes(1))
+      const firstBuiltLocation = (preloadRouteSpy.mock.calls[0]![0] as any)
+        ._builtLocation
+
+      await router.navigate({ to: '/second' })
+      expect(await screen.findByText('Second')).toBeInTheDocument()
+
+      fireEvent.mouseOver(link)
+      await waitFor(() => expect(preloadRouteSpy).toHaveBeenCalledTimes(2))
+      const secondBuiltLocation = (preloadRouteSpy.mock.calls[1]![0] as any)
+        ._builtLocation
+
+      expect(secondBuiltLocation).not.toBe(firstBuiltLocation)
+      expect(secondBuiltLocation.href).toBe(firstBuiltLocation.href)
+    })
+
     test('updates exact and fuzzy active state before the next route renders', async () => {
       const postLoader = createControlledPromise()
 


### PR DESCRIPTION
## What changed

- derive a Solid link's href, external destination, and active state in one memoized tuple
- preserve the tuple identity when those observable values do not change
- keep the built destination memo independent so preloading always receives the latest location
- add regressions for stable inactive links, fuzzy-active descendant navigation, and preload freshness

## Why

Persistent links rebuild their destination as router state changes. Even when the resulting href and active state remain identical, publishing fresh adapter state causes downstream prop work. Keeping this projection inside the existing link memo architecture lets Solid suppress that work without adding caches or side tables.

## Impact

The isolated local `client-nav` links benchmark improved from the captured 41.681 ms baseline to 17.949 ms mean on this branch (about 56.9% faster). The `solid-router.minimal` bundle remained at 34,015 bytes gzip.

## Validation

- `@tanstack/solid-router:test:unit`: 56 client files / 852 tests passed; 3 server files / 3 tests passed
- `@tanstack/solid-router:test:types`: TypeScript 5.6 through 7.0 passed
- `@tanstack/solid-router:test:eslint`: zero errors (existing warnings remain)
- `@benchmarks/client-nav-links-solid:build:client`
- focused `vitest bench` links run
- `solid-router.minimal` bundle-size scenario
- `git diff --check`
