### PR TITLE
perf(router-core): skip impossible JSON parse attempts

### DIFF
--- a/.changeset/dirty-bushes-sink.md
+++ b/.changeset/dirty-bushes-sink.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+skip impossible JSON parse attempts

--- a/packages/router-core/src/searchParams.ts
+++ b/packages/router-core/src/searchParams.ts
@@ -1,6 +1,10 @@
 import { decode, encode } from './qss'
 import type { AnySchema } from './validators'
 
+// JSON can start with whitespace, ", [, {, -, a digit, or fa/nu/tr.
+// False positives safely fall through to JSON.parse.
+const jsonStart = /^(?:\s|["[{\d-]|fa|nu|tr)/
+
 /** Default `parseSearch` that strips leading '?' and JSON-parses values. */
 export const defaultParseSearch = parseSearchWith(JSON.parse)
 /** Default `stringifySearch` using JSON.stringify for complex values. */
@@ -59,25 +63,17 @@ export function stringifySearchWith(
   stringify: (search: any) => string,
   parser?: (str: string) => any,
 ) {
+  const isJsonParser = parser === JSON.parse
   function stringifyValue(val: any) {
-    if (typeof val === 'object' && val !== null) {
+    if (val && typeof val === 'object') {
       try {
         return stringify(val)
       } catch (_err) {
         // silent
       }
     } else if (parser && typeof val === 'string') {
-      // Skip JSON.parse when the first character cannot begin valid JSON.
-      const first = val.charCodeAt(0)
-      if (
-        parser === JSON.parse &&
-        first > 57 &&
-        first !== 91 &&
-        first !== 102 &&
-        first !== 110 &&
-        first !== 116 &&
-        first !== 123
-      ) {
+      // Skip JSON.parse when the value cannot begin valid JSON.
+      if (isJsonParser && !jsonStart.test(val)) {
         return val
       }
       try {

--- a/packages/router-core/src/searchParams.ts
+++ b/packages/router-core/src/searchParams.ts
@@ -59,7 +59,6 @@ export function stringifySearchWith(
   stringify: (search: any) => string,
   parser?: (str: string) => any,
 ) {
-  const hasParser = typeof parser === 'function'
   function stringifyValue(val: any) {
     if (typeof val === 'object' && val !== null) {
       try {
@@ -67,7 +66,20 @@ export function stringifySearchWith(
       } catch (_err) {
         // silent
       }
-    } else if (hasParser && typeof val === 'string') {
+    } else if (parser && typeof val === 'string') {
+      // Skip JSON.parse when the first character cannot begin valid JSON.
+      const first = val.charCodeAt(0)
+      if (
+        parser === JSON.parse &&
+        first > 57 &&
+        first !== 91 &&
+        first !== 102 &&
+        first !== 110 &&
+        first !== 116 &&
+        first !== 123
+      ) {
+        return val
+      }
       try {
         // Check if it's a valid parseable string.
         // If it is, then stringify it again.

--- a/packages/router-core/tests/searchParams.bench.ts
+++ b/packages/router-core/tests/searchParams.bench.ts
@@ -9,11 +9,51 @@ const ordinaryStrings = {
   category: 'hardware',
   sort: 'newest',
 }
-const jsonPrefixStrings = {
+const nonLiteralInitialStrings = {
+  tab: 'specs',
+  filter: 'available',
+  category: 'hardware',
+  sort: 'descending',
+}
+const jsonInitialStrings = {
   filter: 'foo',
   notification: 'new',
   tab: 'tabular',
   empty: '',
+}
+const emptyStrings = {
+  first: '',
+  second: '',
+  third: '',
+  fourth: '',
+}
+const punctuationStrings = {
+  file: '.env',
+  path: '/products',
+  positive: '+1',
+  priority: '!important',
+}
+const nonLiteralPrefixStrings = {
+  first: 'future',
+  second: 'framework',
+  third: 'name',
+  fourth: 'table',
+}
+const jsonLiteralPrefixStrings = {
+  first: 'favorite',
+  second: 'number',
+  third: 'travel',
+  fourth: 'nullish',
+}
+const jsonLiteralWordStrings = {
+  truthy: 'true_value',
+  falsy: 'false_value',
+  nullable: 'null_value',
+}
+const jsonLiteralBoundaryStrings = {
+  truthy: 'true-value',
+  falsy: 'false/value',
+  nullable: 'null.value',
 }
 const jsonStrings = {
   number: '123',
@@ -32,8 +72,29 @@ let benchmarkSink = 0
 expect(defaultStringifySearch(ordinaryStrings)).toBe(
   '?tab=specs&filter=available&category=hardware&sort=newest',
 )
-expect(defaultStringifySearch(jsonPrefixStrings)).toBe(
+expect(defaultStringifySearch(nonLiteralInitialStrings)).toBe(
+  '?tab=specs&filter=available&category=hardware&sort=descending',
+)
+expect(defaultStringifySearch(jsonInitialStrings)).toBe(
   '?filter=foo&notification=new&tab=tabular&empty=',
+)
+expect(defaultStringifySearch(emptyStrings)).toBe(
+  '?first=&second=&third=&fourth=',
+)
+expect(defaultStringifySearch(punctuationStrings)).toBe(
+  '?file=.env&path=%2Fproducts&positive=%2B1&priority=%21important',
+)
+expect(defaultStringifySearch(nonLiteralPrefixStrings)).toBe(
+  '?first=future&second=framework&third=name&fourth=table',
+)
+expect(defaultStringifySearch(jsonLiteralPrefixStrings)).toBe(
+  '?first=favorite&second=number&third=travel&fourth=nullish',
+)
+expect(defaultStringifySearch(jsonLiteralWordStrings)).toBe(
+  '?truthy=true_value&falsy=false_value&nullable=null_value',
+)
+expect(defaultStringifySearch(jsonLiteralBoundaryStrings)).toBe(
+  '?truthy=true-value&falsy=false%2Fvalue&nullable=null.value',
 )
 expect(defaultStringifySearch(jsonStrings)).toBe(
   '?number=%22123%22&boolean=%22true%22&object=%22%7B%5C%22nested%5C%22%3Atrue%7D%22&array=%22%5B1%2C2%2C3%5D%22',
@@ -55,8 +116,36 @@ describe('default search serialization', () => {
     stringifyBatch(ordinaryStrings)
   })
 
-  bench('ordinary strings with JSON-prefix characters', () => {
-    stringifyBatch(jsonPrefixStrings)
+  bench('ordinary strings outside JSON-literal initials', () => {
+    stringifyBatch(nonLiteralInitialStrings)
+  })
+
+  bench('ordinary strings with JSON-literal initials', () => {
+    stringifyBatch(jsonInitialStrings)
+  })
+
+  bench('empty string values', () => {
+    stringifyBatch(emptyStrings)
+  })
+
+  bench('ordinary strings with non-JSON punctuation starts', () => {
+    stringifyBatch(punctuationStrings)
+  })
+
+  bench('ordinary f/n/t words outside JSON-literal prefixes', () => {
+    stringifyBatch(nonLiteralPrefixStrings)
+  })
+
+  bench('application words with JSON-literal prefixes', () => {
+    stringifyBatch(jsonLiteralPrefixStrings)
+  })
+
+  bench('application words with complete JSON-literal prefixes', () => {
+    stringifyBatch(jsonLiteralWordStrings)
+  })
+
+  bench('JSON-literal prefixes followed by punctuation', () => {
+    stringifyBatch(jsonLiteralBoundaryStrings)
   })
 
   bench('JSON-compatible string values', () => {

--- a/packages/router-core/tests/searchParams.bench.ts
+++ b/packages/router-core/tests/searchParams.bench.ts
@@ -1,0 +1,71 @@
+import { bench, describe, expect } from 'vitest'
+import { defaultStringifySearch } from '../src'
+
+const iterations = 1_000
+
+const ordinaryStrings = {
+  tab: 'specs',
+  filter: 'available',
+  category: 'hardware',
+  sort: 'newest',
+}
+const jsonPrefixStrings = {
+  filter: 'foo',
+  notification: 'new',
+  tab: 'tabular',
+  empty: '',
+}
+const jsonStrings = {
+  number: '123',
+  boolean: 'true',
+  object: '{"nested":true}',
+  array: '[1,2,3]',
+}
+const mixedValues = {
+  tab: 'specs',
+  page: 2,
+  filters: ['available', 'featured'],
+  exactPage: '2',
+}
+let benchmarkSink = 0
+
+expect(defaultStringifySearch(ordinaryStrings)).toBe(
+  '?tab=specs&filter=available&category=hardware&sort=newest',
+)
+expect(defaultStringifySearch(jsonPrefixStrings)).toBe(
+  '?filter=foo&notification=new&tab=tabular&empty=',
+)
+expect(defaultStringifySearch(jsonStrings)).toBe(
+  '?number=%22123%22&boolean=%22true%22&object=%22%7B%5C%22nested%5C%22%3Atrue%7D%22&array=%22%5B1%2C2%2C3%5D%22',
+)
+expect(defaultStringifySearch(mixedValues)).toBe(
+  '?tab=specs&page=2&filters=%5B%22available%22%2C%22featured%22%5D&exactPage=%222%22',
+)
+
+function stringifyBatch(search: Record<string, unknown>) {
+  let size = 0
+  for (let index = 0; index < iterations; index++) {
+    size += defaultStringifySearch(search).length
+  }
+  benchmarkSink = size
+}
+
+describe('default search serialization', () => {
+  bench('ordinary string values', () => {
+    stringifyBatch(ordinaryStrings)
+  })
+
+  bench('ordinary strings with JSON-prefix characters', () => {
+    stringifyBatch(jsonPrefixStrings)
+  })
+
+  bench('JSON-compatible string values', () => {
+    stringifyBatch(jsonStrings)
+  })
+
+  bench('mixed application values', () => {
+    stringifyBatch(mixedValues)
+  })
+})
+
+void benchmarkSink

--- a/packages/router-core/tests/searchParams.test.ts
+++ b/packages/router-core/tests/searchParams.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'vitest'
-import { defaultParseSearch, defaultStringifySearch } from '../src'
+import {
+  defaultParseSearch,
+  defaultStringifySearch,
+  stringifySearchWith,
+} from '../src'
 
 describe('Search Params serialization and deserialization', () => {
   /*
@@ -45,6 +49,33 @@ describe('Search Params serialization and deserialization', () => {
     const str = defaultStringifySearch({ foo: 'bar', bar: undefined })
     expect(str).toEqual('?foo=bar')
     expect(defaultParseSearch(str)).toEqual({ foo: 'bar' })
+  })
+
+  test.each([
+    'false',
+    '-1',
+    '"quoted"',
+    ' true ',
+    '\tfalse',
+    '\nnull',
+    '\r1',
+    '   ',
+    '雪',
+    '"雪"',
+  ])('preserves JSON-compatible string %j as a string', (value) => {
+    const str = defaultStringifySearch({ value })
+    expect(defaultParseSearch(str)).toEqual({ value })
+  })
+
+  test('uses custom parsers for ordinary strings', () => {
+    const stringify = stringifySearchWith(JSON.stringify, (value) => {
+      if (value === 'word') {
+        return value
+      }
+      throw new Error('not parseable')
+    })
+
+    expect(stringify({ value: 'word' })).toEqual('?value=%22word%22')
   })
 
   test('[edge case] self-reference serializes to "object Object"', () => {

--- a/packages/router-core/tests/searchParams.test.ts
+++ b/packages/router-core/tests/searchParams.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import {
   defaultParseSearch,
   defaultStringifySearch,
@@ -56,6 +56,9 @@ describe('Search Params serialization and deserialization', () => {
     '-1',
     '"quoted"',
     ' true ',
+    'true ',
+    'false\t',
+    'null\r\n',
     '\tfalse',
     '\nnull',
     '\r1',
@@ -76,6 +79,34 @@ describe('Search Params serialization and deserialization', () => {
     })
 
     expect(stringify({ value: 'word' })).toEqual('?value=%22word%22')
+  })
+
+  test('skips JSON.parse for strings that cannot be JSON', () => {
+    const parseSpy = vi.spyOn(JSON, 'parse')
+    try {
+      const stringify = stringifySearchWith(JSON.stringify, JSON.parse)
+
+      expect(
+        stringify({
+          empty: '',
+          filter: 'foo',
+          future: 'future',
+          name: 'name',
+          notification: 'new',
+          tab: 'tabular',
+          topic: 'topic',
+          unicode: '雪',
+        }),
+      ).toEqual(
+        '?empty=&filter=foo&future=future&name=name&notification=new&tab=tabular&topic=topic&unicode=%E9%9B%AA',
+      )
+      expect(
+        stringify({ file: '.env', path: '/products', positive: '+1' }),
+      ).toEqual('?file=.env&path=%2Fproducts&positive=%2B1')
+      expect(parseSpy).not.toHaveBeenCalled()
+    } finally {
+      parseSpy.mockRestore()
+    }
   })
 
   test('[edge case] self-reference serializes to "object Object"', () => {


### PR DESCRIPTION
## What changed

- avoid calling `JSON.parse` when a string's first character cannot begin valid JSON
- apply the shortcut only when the configured parser is exactly `JSON.parse`
- preserve custom parser behavior and all valid JSON prefixes, including whitespace, quotes, numbers, literals, arrays, and objects
- add correctness cases and a focused benchmark covering expected and unfavorable distributions

## Why

The default search serializer probes every string with `JSON.parse` so JSON-looking strings remain strings after a round trip. Ordinary application strings usually fail that probe, making exception creation and handling the dominant cost. The grammar check avoids only parses that are guaranteed to fail.

## Impact

Focused local benchmarks, each serializing 1,000 objects:

- ordinary strings: 15.694 ms to 4.571 ms (about 70.9% faster)
- mixed application values: 4.669 ms to 0.482 ms (about 89.7% faster)
- JSON-compatible strings remain on the parse path (0.863 ms in the latest control run)
- strings beginning with JSON literal prefixes remain an intentionally unfavorable control (17.122 ms)

`react-router.minimal` changes from 85,919 to 85,956 bytes gzip (+37 bytes).

## Validation

- `@tanstack/router-core:test:unit`: 105 files / 1,547 tests passed, plus 3 expected failures
- `@tanstack/router-core:test:types`: TypeScript 5.6 through 7.0 passed
- `@tanstack/router-core:test:eslint`: zero errors (existing warnings remain)
- focused `tests/searchParams.bench.ts` run
- `react-router.minimal` bundle-size scenario on `main` and this branch
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved search-parameter serialization by skipping unnecessary JSON parsing for strings that cannot contain valid JSON.
  - Preserved correct handling of JSON-compatible values, empty strings, punctuation, and custom parsers.

- **Performance**
  - Reduced avoidable parsing work during query-string serialization.

- **Tests**
  - Expanded coverage for serialization edge cases.
  - Added benchmarks for representative search-parameter scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->