### PR TITLE
perf(router-core): classify simple segments before slicing

### DIFF
--- a/packages/router-core/src/new-process-route-tree.ts
+++ b/packages/router-core/src/new-process-route-tree.ts
@@ -80,9 +80,33 @@ export function parseSegment(
 ): ParsedSegment {
   const next = path.indexOf('/', start)
   const end = next === -1 ? path.length : next
-  const part = path.substring(start, end)
+  const firstChar = path.charCodeAt(start)
 
-  if (!part || !part.includes('$')) {
+  if (firstChar === 36) {
+    // $ (wildcard)
+    if (end === start + 1) {
+      const total = path.length
+      output[0] = SEGMENT_TYPE_WILDCARD
+      output[1] = start
+      output[2] = start
+      output[3] = total
+      output[4] = total
+      output[5] = total
+      return output as ParsedSegment
+    }
+
+    // $paramName
+    output[0] = SEGMENT_TYPE_PARAM
+    output[1] = start
+    output[2] = start + 1 // skip '$'
+    output[3] = end
+    output[4] = end
+    output[5] = end
+    return output as ParsedSegment
+  }
+
+  const dollar = path.indexOf('$', start)
+  if (start === end || dollar === -1 || dollar >= end) {
     // early escape for static pathname
     output[0] = SEGMENT_TYPE_PATHNAME
     output[1] = start
@@ -93,29 +117,7 @@ export function parseSegment(
     return output as ParsedSegment
   }
 
-  // $ (wildcard)
-  if (part === '$') {
-    const total = path.length
-    output[0] = SEGMENT_TYPE_WILDCARD
-    output[1] = start
-    output[2] = start
-    output[3] = total
-    output[4] = total
-    output[5] = total
-    return output as ParsedSegment
-  }
-
-  // $paramName
-  if (part.charCodeAt(0) === 36) {
-    output[0] = SEGMENT_TYPE_PARAM
-    output[1] = start
-    output[2] = start + 1 // skip '$'
-    output[3] = end
-    output[4] = end
-    output[5] = end
-    return output as ParsedSegment
-  }
-
+  const part = path.substring(start, end)
   const braces = getOpenAndCloseBraces(part)
   if (braces) {
     const [openBrace, closeBrace] = braces

--- a/packages/router-core/tests/parseSegment.bench.ts
+++ b/packages/router-core/tests/parseSegment.bench.ts
@@ -1,0 +1,94 @@
+import { bench, describe, expect } from 'vitest'
+import {
+  SEGMENT_TYPE_OPTIONAL_PARAM,
+  SEGMENT_TYPE_PARAM,
+  SEGMENT_TYPE_PATHNAME,
+  parseSegment,
+} from '../src/new-process-route-tree'
+
+const iterations = 10_000
+const mixedPath =
+  '/organizations/$organizationId/projects/$projectId/settings'
+const staticPath = '/organizations/projects/settings/members/activity'
+const deepStaticPath = `/${Array.from(
+  { length: 32 },
+  (_, index) => `segment-${index}`,
+).join('/')}`
+const bracedPath =
+  '/organizations/prefix{$organizationId}/projects/{-$projectId}/settings'
+let benchmarkSink = 0
+
+function segmentTypes(path: string) {
+  const types: Array<number> = []
+  const output = new Uint16Array(6)
+  let cursor = 0
+  while (cursor < path.length) {
+    const segment = parseSegment(path, cursor, output)
+    types.push(segment[0])
+    cursor = segment[5] + 1
+  }
+  return types
+}
+
+expect(segmentTypes(mixedPath)).toEqual([
+  SEGMENT_TYPE_PATHNAME,
+  SEGMENT_TYPE_PATHNAME,
+  SEGMENT_TYPE_PARAM,
+  SEGMENT_TYPE_PATHNAME,
+  SEGMENT_TYPE_PARAM,
+  SEGMENT_TYPE_PATHNAME,
+])
+expect(segmentTypes(staticPath)).toEqual([
+  SEGMENT_TYPE_PATHNAME,
+  SEGMENT_TYPE_PATHNAME,
+  SEGMENT_TYPE_PATHNAME,
+  SEGMENT_TYPE_PATHNAME,
+  SEGMENT_TYPE_PATHNAME,
+  SEGMENT_TYPE_PATHNAME,
+])
+expect(segmentTypes(deepStaticPath)).toHaveLength(33)
+expect(segmentTypes(deepStaticPath)).toEqual(
+  Array<number>(33).fill(SEGMENT_TYPE_PATHNAME),
+)
+expect(segmentTypes(bracedPath)).toEqual([
+  SEGMENT_TYPE_PATHNAME,
+  SEGMENT_TYPE_PATHNAME,
+  SEGMENT_TYPE_PARAM,
+  SEGMENT_TYPE_PATHNAME,
+  SEGMENT_TYPE_OPTIONAL_PARAM,
+  SEGMENT_TYPE_PATHNAME,
+])
+
+function parsePathBatch(path: string) {
+  const output = new Uint16Array(6)
+  let checksum = 0
+  for (let index = 0; index < iterations; index++) {
+    let cursor = 0
+    while (cursor < path.length) {
+      const segment = parseSegment(path, cursor, output)
+      checksum += segment[0] + segment[2] + segment[3]
+      cursor = segment[5] + 1
+    }
+  }
+  benchmarkSink = checksum
+}
+
+describe('parseSegment', () => {
+  bench('mixed static and parameter segments', () => {
+    parsePathBatch(mixedPath)
+  })
+
+  bench('all-static segments', () => {
+    parsePathBatch(staticPath)
+  })
+
+  bench('deep all-static segments', () => {
+    parsePathBatch(deepStaticPath)
+  })
+
+  bench('braced parameter segments', () => {
+    parsePathBatch(bracedPath)
+  })
+})
+
+void benchmarkSink


### PR DESCRIPTION
## What changed

- classify `$param` and `$` segments from their boundaries before creating a substring
- recognize static segments without allocating their segment substring
- defer substring creation to braced or otherwise complex segment syntax
- add a direct parser benchmark covering mixed, static, deep-static, and braced paths

## Why

`parseSegment` previously allocated a substring before it knew whether the segment needed complex parsing. Simple params, wildcards, and static segments make up the common route grammar, so classifying them from the original path removes avoidable allocation while keeping one canonical parser.

This PR does not require the separate interpolation cleanup. `parseSegment` is already used by route-tree processing and other core path operations, so the change is independently useful and mergeable in either order.

## Impact

Focused local parser benchmarks, each parsing 10,000 complete paths:

- mixed static/parameter path: 1.599 ms to 1.180 ms (about 26.2% faster)
- all-static path: 1.506 ms to 1.338 ms (about 11.2% faster)
- 32-segment all-static path: 9.508 ms to 9.101 ms (about 4.3% faster)
- braced-parameter path: 1.994 ms to 1.781 ms (about 10.7% faster)

`react-router.minimal` changes from 85,919 to 85,938 bytes gzip (+19 bytes; raw +23 bytes).

## Validation

- `@tanstack/router-core:test:unit`: 105 files / 1,536 tests passed, plus 3 expected failures
- `@tanstack/router-core:test:types`: TypeScript 5.6 through 7.0 passed
- `@tanstack/router-core:test:eslint`: zero errors (existing warnings remain)
- focused before/after `tests/parseSegment.bench.ts` runs
- `react-router.minimal` bundle-size scenario on `main` and this branch
- `git diff --check`
