### PR TITLE
perf(router-core): faster enumerable-key collection in structural sharing

### DIFF
--- a/.changeset/perf-structural-sharing-enumerable-keys.md
+++ b/.changeset/perf-structural-sharing-enumerable-keys.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+perf: speed up structural sharing (`replaceEqualDeep`) by computing enumerable own keys with `Object.keys` + a length compare instead of `getOwnPropertyNames` followed by a `propertyIsEnumerable` call per key. This runs on every selector result on every state update when `defaultStructuralSharing` is enabled, and is ~1.3–1.5x faster on typical router state objects with identical behavior.

--- a/.changeset/perf-structural-sharing-enumerable-keys.md
+++ b/.changeset/perf-structural-sharing-enumerable-keys.md
@@ -2,4 +2,4 @@
 '@tanstack/router-core': patch
 ---
 
-perf: speed up structural sharing (`replaceEqualDeep`) by computing enumerable own keys with `Object.keys` + a length compare instead of `getOwnPropertyNames` followed by a `propertyIsEnumerable` call per key. This runs on every selector result on every state update when `defaultStructuralSharing` is enabled, and is ~1.3–1.5x faster on typical router state objects with identical behavior.
+perf: speed up structural sharing (`replaceEqualDeep`) by computing enumerable own keys with `Object.keys` + a length compare instead of `getOwnPropertyNames` followed by a `propertyIsEnumerable` call per key. This runs on every selector result on every state update when `defaultStructuralSharing` is enabled, and is ~1.3-1.5x faster on typical router state objects with identical behavior.

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -299,24 +299,25 @@ export function replaceEqualDeep<T>(
  * Optimized for the common case where objects have no symbol properties.
  */
 function getEnumerableOwnKeys(o: object) {
-  const names = Object.getOwnPropertyNames(o)
-
-  // Fast path: check all string property names are enumerable
-  for (const name of names) {
-    if (!isEnumerable.call(o, name)) return false
-  }
+  // `Object.keys` returns only enumerable own string keys natively (no per-key
+  // JS callback). If it has fewer entries than `getOwnPropertyNames` (all own
+  // string keys), the object has a non-enumerable own string prop and is not
+  // "clone-friendly" -> bail. This replaces an O(n) loop of
+  // `propertyIsEnumerable` calls with two native calls.
+  const keys = Object.keys(o)
+  if (keys.length !== Object.getOwnPropertyNames(o).length) return false
 
   // Only check symbols if the object has any (most plain objects don't)
   const symbols = Object.getOwnPropertySymbols(o)
 
-  // Fast path: no symbols, return names directly (avoids array allocation/concat)
-  if (symbols.length === 0) return names
+  // Fast path: no symbols, return enumerable string keys directly
+  if (symbols.length === 0) return keys
 
-  // Slow path: has symbols, need to check and merge
-  const keys: Array<string | symbol> = names
+  // Slow path: has symbols, include only enumerable ones, bail on any
+  // non-enumerable symbol so it round-trips like the string-key check above.
   for (const symbol of symbols) {
     if (!isEnumerable.call(o, symbol)) return false
-    keys.push(symbol)
+    ;(keys as Array<string | symbol>).push(symbol)
   }
   return keys
 }

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -305,18 +305,24 @@ function getEnumerableOwnKeys(o: object) {
   // "clone-friendly" -> bail. This replaces an O(n) loop of
   // `propertyIsEnumerable` calls with two native calls.
   const keys = Object.keys(o)
-  if (keys.length !== Object.getOwnPropertyNames(o).length) return false
+  if (keys.length !== Object.getOwnPropertyNames(o).length) {
+    return false
+  }
 
   // Only check symbols if the object has any (most plain objects don't)
   const symbols = Object.getOwnPropertySymbols(o)
 
   // Fast path: no symbols, return enumerable string keys directly
-  if (symbols.length === 0) return keys
+  if (symbols.length === 0) {
+    return keys
+  }
 
   // Slow path: has symbols, include only enumerable ones, bail on any
   // non-enumerable symbol so it round-trips like the string-key check above.
   for (const symbol of symbols) {
-    if (!isEnumerable.call(o, symbol)) return false
+    if (!isEnumerable.call(o, symbol)) {
+      return false
+    }
     ;(keys as Array<string | symbol>).push(symbol)
   }
   return keys

--- a/packages/router-core/tests/utils.test.ts
+++ b/packages/router-core/tests/utils.test.ts
@@ -950,6 +950,53 @@ describe('getEnumerableOwnKeys behavior (via replaceEqualDeep)', () => {
       ]
       expect(replaceEqualDeep(prev, next)).toBe(prev)
     })
+
+    it('preserves identity of unchanged nested subtrees when one leaf changes', () => {
+      const prev = {
+        search: { q: 'hello', f: 'live' },
+        params: { username: 'elonmusk', tweetId: '123' },
+        loaderData: {
+          user: { id: '44196397', name: 'Elon' },
+          tabs: ['a', 'b'],
+        },
+      }
+      const next = {
+        search: { q: 'hello', f: 'live' },
+        params: { username: 'elonmusk', tweetId: '123' },
+        loaderData: {
+          user: { id: '44196397', name: 'Musk' },
+          tabs: ['a', 'b'],
+        },
+      }
+      const result = replaceEqualDeep(prev, next)
+      // user.name changed -> top object is new, but every unchanged subtree
+      // (including the array) keeps its previous reference for cheap memo checks.
+      expect(result).not.toBe(prev)
+      expect(result.search).toBe(prev.search)
+      expect(result.params).toBe(prev.params)
+      expect(result.loaderData.tabs).toBe(prev.loaderData.tabs)
+      expect(result.loaderData.user).not.toBe(prev.loaderData.user)
+      expect(result.loaderData.user.name).toBe('Musk')
+    })
+
+    it('bails to next for a nested object carrying a non-enumerable prop', () => {
+      const prevInner: Record<string, number> = { a: 1 }
+      Object.defineProperty(prevInner, 'hidden', {
+        value: 2,
+        enumerable: false,
+      })
+      const nextInner: Record<string, number> = { a: 1 }
+      Object.defineProperty(nextInner, 'hidden', {
+        value: 2,
+        enumerable: false,
+      })
+      const prev = { shared: { x: 1 }, inner: prevInner }
+      const next = { shared: { x: 1 }, inner: nextInner }
+      const result = replaceEqualDeep(prev, next)
+      // inner is not clone-friendly -> returns nextInner; sibling subtree shared.
+      expect(result.inner).toBe(nextInner)
+      expect(result.shared).toBe(prev.shared)
+    })
   })
 })
 


### PR DESCRIPTION
Supersedes #7664. The original PR is closed, comes from a private fork, and does not allow maintainer edits, so it could not be brought up to date in place.

The original commit was cherry-picked onto current `main`, preserving Yagiz Nizipli as author. A separate follow-up addresses the outstanding review request to use block bodies for the changed `if` statements.

## What

- Replaces the per-key `propertyIsEnumerable` loop with `Object.keys` plus one `getOwnPropertyNames` length comparison.
- Preserves the existing symbol handling and non-enumerable-property bailout behavior.
- Retains the original structural-sharing regression tests and patch changeset.

## Tests

- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/router-core:test:unit --outputStyle=stream --skipRemoteCache -- tests/utils.test.ts` (117 passed, 3 expected failures)
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/router-core:test:types --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/router-core:test:eslint --outputStyle=stream --skipRemoteCache` (no errors; existing unrelated warnings)
- `pnpm prettier --check .changeset/perf-structural-sharing-enumerable-keys.md packages/router-core/src/utils.ts packages/router-core/tests/utils.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved deep comparison performance for complex objects.
  * Preserved structural sharing of unchanged nested data during updates.

* **Bug Fixes**
  * Improved handling of objects with non-enumerable properties.
  * Ensured unchanged sibling data remains stable when nested values change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->