### PR TITLE
perf(router-core): skip impossible JSON parses during search parsing

### DIFF
--- a/.changeset/fast-search-parsing.md
+++ b/.changeset/fast-search-parsing.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+skip impossible JSON parse attempts when parsing search params

--- a/packages/router-core/src/searchParams.ts
+++ b/packages/router-core/src/searchParams.ts
@@ -24,6 +24,7 @@ export const defaultStringifySearch = stringifySearchWith(
  * @link https://tanstack.com/router/latest/docs/framework/react/guide/custom-search-param-serialization
  */
 export function parseSearchWith(parser: (str: string) => any) {
+  const isJsonParser = parser === JSON.parse
   return (searchStr: string): AnySchema => {
     if (searchStr[0] === '?') {
       searchStr = searchStr.substring(1)
@@ -35,6 +36,10 @@ export function parseSearchWith(parser: (str: string) => any) {
     for (const key in query) {
       const value = query[key]
       if (typeof value === 'string') {
+        // Skip JSON.parse when the value cannot begin valid JSON.
+        if (isJsonParser && !jsonStart.test(value)) {
+          continue
+        }
         try {
           query[key] = parser(value)
         } catch (_err) {

--- a/packages/router-core/tests/searchParams.bench.ts
+++ b/packages/router-core/tests/searchParams.bench.ts
@@ -1,5 +1,5 @@
 import { bench, describe, expect } from 'vitest'
-import { defaultStringifySearch } from '../src'
+import { defaultParseSearch, defaultStringifySearch } from '../src'
 
 const iterations = 1_000
 
@@ -103,10 +103,28 @@ expect(defaultStringifySearch(mixedValues)).toBe(
   '?tab=specs&page=2&filters=%5B%22available%22%2C%22featured%22%5D&exactPage=%222%22',
 )
 
+const ordinarySearch = defaultStringifySearch(ordinaryStrings)
+const jsonInitialSearch = defaultStringifySearch(jsonInitialStrings)
+const jsonSearch = defaultStringifySearch(jsonStrings)
+const mixedSearch = defaultStringifySearch(mixedValues)
+
+expect(defaultParseSearch(ordinarySearch)).toEqual(ordinaryStrings)
+expect(defaultParseSearch(jsonInitialSearch)).toEqual(jsonInitialStrings)
+expect(defaultParseSearch(jsonSearch)).toEqual(jsonStrings)
+expect(defaultParseSearch(mixedSearch)).toEqual(mixedValues)
+
 function stringifyBatch(search: Record<string, unknown>) {
   let size = 0
   for (let index = 0; index < iterations; index++) {
     size += defaultStringifySearch(search).length
+  }
+  benchmarkSink = size
+}
+
+function parseBatch(search: string) {
+  let size = 0
+  for (let index = 0; index < iterations; index++) {
+    size += Object.keys(defaultParseSearch(search)).length
   }
   benchmarkSink = size
 }
@@ -154,6 +172,24 @@ describe('default search serialization', () => {
 
   bench('mixed application values', () => {
     stringifyBatch(mixedValues)
+  })
+})
+
+describe('default search parsing', () => {
+  bench('ordinary string values', () => {
+    parseBatch(ordinarySearch)
+  })
+
+  bench('ordinary strings with JSON-literal initials', () => {
+    parseBatch(jsonInitialSearch)
+  })
+
+  bench('JSON-compatible string values', () => {
+    parseBatch(jsonSearch)
+  })
+
+  bench('mixed application values', () => {
+    parseBatch(mixedSearch)
   })
 })
 

--- a/packages/router-core/tests/searchParams.test.ts
+++ b/packages/router-core/tests/searchParams.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, test, vi } from 'vitest'
+import { describe, expect, onTestFinished, test, vi } from 'vitest'
 import {
   defaultParseSearch,
   defaultStringifySearch,
+  parseSearchWith,
   stringifySearchWith,
 } from '../src'
 
@@ -79,6 +80,41 @@ describe('Search Params serialization and deserialization', () => {
     })
 
     expect(stringify({ value: 'word' })).toEqual('?value=%22word%22')
+  })
+
+  test('uses custom parsers for ordinary strings during parsing', () => {
+    const parser = vi.fn((value: string) => value.toUpperCase())
+    const parse = parseSearchWith(parser)
+
+    expect(parse('?value=word')).toEqual({ value: 'WORD' })
+    expect(parser).toHaveBeenCalledWith('word')
+  })
+
+  test('skips JSON.parse during parsing for strings that cannot be JSON', () => {
+    const parseSpy = vi.spyOn(JSON, 'parse')
+    onTestFinished(() => parseSpy.mockRestore())
+    const parse = parseSearchWith(JSON.parse)
+
+    expect(
+      parse(
+        '?empty=&filter=foo&future=future&name=name&notification=new&tab=tabular&topic=topic&unicode=%E9%9B%AA',
+      ),
+    ).toEqual({
+      empty: '',
+      filter: 'foo',
+      future: 'future',
+      name: 'name',
+      notification: 'new',
+      tab: 'tabular',
+      topic: 'topic',
+      unicode: '雪',
+    })
+    expect(parse('?file=.env&path=%2Fproducts&positive=%2B1')).toEqual({
+      file: '.env',
+      path: '/products',
+      positive: '+1',
+    })
+    expect(parseSpy).not.toHaveBeenCalled()
   })
 
   test('skips JSON.parse for strings that cannot be JSON', () => {


### PR DESCRIPTION
## Summary

- apply the existing `jsonStart` fast path to `parseSearchWith` when using `JSON.parse`
- preserve custom parser behavior and cover both paths with unit tests
- add default search parsing benchmark scenarios and a patch changeset

## Testing

- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/router-core:test:unit --outputStyle=stream --skipRemoteCache -- tests/searchParams.test.ts`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/router-core:test:types --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/router-core:test:eslint --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @tanstack/router-core:test:unit --outputStyle=stream --skipRemoteCache -- bench tests/searchParams.bench.ts --run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search-parameter parsing by skipping values that cannot be valid JSON.
  * Preserved existing parsing behavior and silent error handling for eligible values.

* **Performance**
  * Reduced unnecessary JSON parsing during search-parameter processing.

* **Tests**
  * Added coverage for custom parsing, decoded parameters, invalid JSON values, and parsing performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->