### PR TITLE
Upgrade solidjs beta 32

### DIFF
--- a/.changeset/solid-js-beta-32.md
+++ b/.changeset/solid-js-beta-32.md
@@ -1,0 +1,10 @@
+---
+'@tanstack/solid-router-devtools': patch
+'@tanstack/solid-router-ssr-query': patch
+'@tanstack/solid-router': patch
+'@tanstack/solid-start-client': patch
+'@tanstack/solid-start-server': patch
+'@tanstack/solid-start': patch
+---
+
+Upgrade `solid-js` and `@solidjs/web` to `2.0.0-beta.32`

--- a/benchmarks/bundle-size/package.json
+++ b/benchmarks/bundle-size/package.json
@@ -36,7 +36,7 @@
     }
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/react-router": "workspace:^",
     "@tanstack/react-start": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
@@ -45,7 +45,7 @@
     "@tanstack/vue-start": "workspace:^",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "vue": "^3.5.16"
   },
   "devDependencies": {
@@ -60,6 +60,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/benchmarks/client-nav/package.json
+++ b/benchmarks/client-nav/package.json
@@ -19,14 +19,14 @@
     "test:types:vue": "tsc -p ./vue/tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/react-router": "workspace:^",
     "@tanstack/router-core": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/vue-router": "workspace:^",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "vue": "^3.5.16"
   },
   "devDependencies": {
@@ -41,7 +41,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "vitest": "^4.1.4"
   },
   "nx": {

--- a/benchmarks/memory/client/package.json
+++ b/benchmarks/memory/client/package.json
@@ -12,14 +12,14 @@
     "#memory-client/lifecycle": "./lifecycle.ts"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/react-router": "workspace:*",
     "@tanstack/router-core": "workspace:*",
     "@tanstack/solid-router": "workspace:*",
     "@tanstack/vue-router": "workspace:*",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "vue": "^3.5.16"
   },
   "devDependencies": {
@@ -35,7 +35,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "vitest": "^4.1.4"
   },
   "nx": {

--- a/benchmarks/memory/server/package.json
+++ b/benchmarks/memory/server/package.json
@@ -11,7 +11,7 @@
     "#memory-server/flame-runner": "./flame-runner.ts"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/react-router": "workspace:*",
     "@tanstack/react-start": "workspace:*",
     "@tanstack/solid-router": "workspace:*",
@@ -20,7 +20,7 @@
     "@tanstack/vue-start": "workspace:*",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "vue": "^3.5.16"
   },
   "devDependencies": {
@@ -32,7 +32,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "vitest": "^4.1.4"
   },
   "nx": {

--- a/benchmarks/ssr/package.json
+++ b/benchmarks/ssr/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/react-router": "workspace:^",
     "@tanstack/react-start": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
@@ -12,7 +12,7 @@
     "@tanstack/vue-start": "workspace:^",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "vue": "^3.5.16"
   },
   "devDependencies": {
@@ -23,7 +23,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "vitest": "^4.1.4"
   },
   "nx": {

--- a/e2e/solid-router/basepath-file-based/package.json
+++ b/e2e/solid-router/basepath-file-based/package.json
@@ -11,16 +11,16 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/router-plugin": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
-    "solid-js": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "vite": "^8.0.14"
   }
 }

--- a/e2e/solid-router/basic-esbuild-file-based/package.json
+++ b/e2e/solid-router/basic-esbuild-file-based/package.json
@@ -10,12 +10,12 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/router-plugin": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/e2e/solid-router/basic-file-based-code-splitting/package.json
+++ b/e2e/solid-router/basic-file-based-code-splitting/package.json
@@ -11,12 +11,12 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -24,6 +24,6 @@
     "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/e2e/solid-router/basic-file-based/package.json
+++ b/e2e/solid-router/basic-file-based/package.json
@@ -12,13 +12,13 @@
     "test:e2e:default": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -27,6 +27,6 @@
     "@tanstack/router-e2e-utils": "workspace:^",
     "combinate": "^1.1.11",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/e2e/solid-router/basic-scroll-restoration/package.json
+++ b/e2e/solid-router/basic-scroll-restoration/package.json
@@ -11,20 +11,20 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-virtual": "^3.13.0",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "typescript": "~5.9.0"
   }
 }

--- a/e2e/solid-router/basic-solid-query-file-based/package.json
+++ b/e2e/solid-router/basic-solid-query-file-based/package.json
@@ -11,7 +11,7 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "workspace:^",
     "@tanstack/solid-query": "^6.0.0-beta.7",
@@ -19,7 +19,7 @@
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -27,6 +27,6 @@
     "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/e2e/solid-router/basic-solid-query/package.json
+++ b/e2e/solid-router/basic-solid-query/package.json
@@ -11,20 +11,20 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-query": "^6.0.0-beta.7",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.7",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/e2e/solid-router/basic-virtual-file-based/package.json
+++ b/e2e/solid-router/basic-virtual-file-based/package.json
@@ -11,14 +11,14 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/virtual-file-routes": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -26,6 +26,6 @@
     "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/e2e/solid-router/basic-virtual-named-export-config-file-based/package.json
+++ b/e2e/solid-router/basic-virtual-named-export-config-file-based/package.json
@@ -11,14 +11,14 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/virtual-file-routes": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -26,6 +26,6 @@
     "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/e2e/solid-router/basic/package.json
+++ b/e2e/solid-router/basic/package.json
@@ -11,18 +11,18 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/e2e/solid-router/generator-cli-only/package.json
+++ b/e2e/solid-router/generator-cli-only/package.json
@@ -11,19 +11,19 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-cli": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/e2e/solid-router/js-only-file-based/package.json
+++ b/e2e/solid-router/js-only-file-based/package.json
@@ -11,12 +11,12 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
@@ -24,6 +24,6 @@
     "@tanstack/router-e2e-utils": "workspace:^",
     "@tanstack/router-plugin": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/e2e/solid-router/rspack-basic-file-based/package.json
+++ b/e2e/solid-router/rspack-basic-file-based/package.json
@@ -10,11 +10,11 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.0",

--- a/e2e/solid-router/rspack-basic-virtual-named-export-config-file-based/package.json
+++ b/e2e/solid-router/rspack-basic-virtual-named-export-config-file-based/package.json
@@ -10,11 +10,11 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.0",

--- a/e2e/solid-router/scroll-restoration-sandbox-vite/package.json
+++ b/e2e/solid-router/scroll-restoration-sandbox-vite/package.json
@@ -14,13 +14,13 @@
     "test:e2e": "rm -rf port*.txt; pnpm run test:e2e:browser && pnpm run test:e2e:hash"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -28,6 +28,6 @@
     "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/e2e/solid-router/sentry-integration/package.json
+++ b/e2e/solid-router/sentry-integration/package.json
@@ -14,18 +14,18 @@
     "@sentry/solid": "^10.32.0",
     "@sentry/tracing": "^7.120.4",
     "@sentry/vite-plugin": "^4.6.1",
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.0",
     "@tanstack/router-e2e-utils": "workspace:^",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/e2e/solid-router/view-transitions/package.json
+++ b/e2e/solid-router/view-transitions/package.json
@@ -11,13 +11,13 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -27,6 +27,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/e2e/solid-start/basic-auth/package.json
+++ b/e2e/solid-start/basic-auth/package.json
@@ -16,12 +16,12 @@
     "@libsql/client": "^0.15.15",
     "@prisma/adapter-libsql": "^7.0.0",
     "@prisma/client": "^7.0.0",
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
@@ -36,6 +36,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/e2e/solid-start/basic-cloudflare/package.json
+++ b/e2e/solid-start/basic-cloudflare/package.json
@@ -13,11 +13,11 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.29.0",
@@ -29,7 +29,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "wrangler": "^4.74.0"
   }
 }

--- a/e2e/solid-start/basic-solid-query/package.json
+++ b/e2e/solid-start/basic-solid-query/package.json
@@ -12,7 +12,7 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-query": "^6.0.0-beta.7",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.7",
     "@tanstack/solid-router": "workspace:^",
@@ -20,7 +20,7 @@
     "@tanstack/solid-router-ssr-query": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },
@@ -34,6 +34,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/e2e/solid-start/basic-tsr-config/package.json
+++ b/e2e/solid-start/basic-tsr-config/package.json
@@ -11,11 +11,11 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32"
   },
   "devDependencies": {
     "@tanstack/router-e2e-utils": "workspace:^",
@@ -24,6 +24,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/e2e/solid-start/basic/package.json
+++ b/e2e/solid-start/basic/package.json
@@ -14,7 +14,7 @@
     "test:e2e:local": "playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
@@ -22,7 +22,7 @@
     "http-proxy-middleware": "^3.0.5",
     "js-cookie": "^3.0.5",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },
@@ -42,7 +42,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   },
   "nx": {
     "metadata": {

--- a/e2e/solid-start/csp/package.json
+++ b/e2e/solid-start/csp/package.json
@@ -11,10 +11,10 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.0",
@@ -24,6 +24,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/e2e/solid-start/css-modules/package.json
+++ b/e2e/solid-start/css-modules/package.json
@@ -14,10 +14,10 @@
     "test:e2e": "rm -rf port*.txt; pnpm run test:e2e:dev"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "workspace:*",
     "@tanstack/solid-start": "workspace:*",
-    "solid-js": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.0",
@@ -28,7 +28,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/e2e/solid-start/custom-basepath/package.json
+++ b/e2e/solid-start/custom-basepath/package.json
@@ -11,13 +11,13 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "express": "^5.2.1",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.0",
@@ -32,7 +32,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/e2e/solid-start/deferred-hydration/package.json
+++ b/e2e/solid-start/deferred-hydration/package.json
@@ -18,10 +18,10 @@
     "test:e2e": "playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32"
   },
   "devDependencies": {
     "@rsbuild/core": "^2.1.0",
@@ -33,7 +33,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   },
   "nx": {
     "targets": {

--- a/e2e/solid-start/query-integration/package.json
+++ b/e2e/solid-start/query-integration/package.json
@@ -12,14 +12,14 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-query": "^6.0.0-beta.7",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.7",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-router-ssr-query": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },
@@ -32,6 +32,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/e2e/solid-start/scroll-restoration/package.json
+++ b/e2e/solid-start/scroll-restoration/package.json
@@ -12,12 +12,12 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },
@@ -32,6 +32,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/e2e/solid-start/selective-ssr/package.json
+++ b/e2e/solid-start/selective-ssr/package.json
@@ -12,10 +12,10 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -26,7 +26,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/e2e/solid-start/serialization-adapters/package.json
+++ b/e2e/solid-start/serialization-adapters/package.json
@@ -12,11 +12,11 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "vite-tsconfig-paths": "^5.1.4",
     "zod": "^4.4.3"
   },
@@ -29,6 +29,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/e2e/solid-start/server-functions/package.json
+++ b/e2e/solid-start/server-functions/package.json
@@ -12,7 +12,7 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-query": "^6.0.0-beta.7",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.7",
     "@tanstack/solid-router": "workspace:^",
@@ -21,7 +21,7 @@
     "@tanstack/solid-start": "workspace:^",
     "js-cookie": "^3.0.5",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },
@@ -37,6 +37,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/e2e/solid-start/server-routes/package.json
+++ b/e2e/solid-start/server-routes/package.json
@@ -12,7 +12,7 @@
     "test:e2e": "playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-query": "^6.0.0-beta.7",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
@@ -20,7 +20,7 @@
     "@tanstack/solid-start": "workspace:^",
     "js-cookie": "^3.0.5",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },
@@ -36,6 +36,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/e2e/solid-start/solid-query-layout-suspense/package.json
+++ b/e2e/solid-start/solid-query-layout-suspense/package.json
@@ -10,11 +10,11 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-query": "^6.0.0-beta.7",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.0",
@@ -23,6 +23,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/e2e/solid-start/spa-mode/package.json
+++ b/e2e/solid-start/spa-mode/package.json
@@ -12,11 +12,11 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -26,7 +26,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/e2e/solid-start/start-manifest/package.json
+++ b/e2e/solid-start/start-manifest/package.json
@@ -10,10 +10,10 @@
     "test:e2e": "playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
-    "solid-js": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.0",
@@ -23,7 +23,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   },
   "nx": {
     "targets": {

--- a/e2e/solid-start/virtual-routes/package.json
+++ b/e2e/solid-start/virtual-routes/package.json
@@ -12,13 +12,13 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "@tanstack/virtual-file-routes": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },
@@ -33,6 +33,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/e2e/solid-start/website/package.json
+++ b/e2e/solid-start/website/package.json
@@ -12,12 +12,12 @@
     "test:e2e": "rm -rf port*.txt; playwright test --project=chromium"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },
@@ -31,6 +31,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/authenticated-routes-firebase/package.json
+++ b/examples/solid/authenticated-routes-firebase/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.168.24",
     "@tanstack/solid-router": "^2.0.0-beta.29",
@@ -17,7 +17,7 @@
     "firebase": "^11.4.0",
     "redaxios": "^0.5.1",
     "simple-icons": "^14.9.0",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -25,6 +25,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/authenticated-routes/package.json
+++ b/examples/solid/authenticated-routes/package.json
@@ -9,13 +9,13 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.168.24",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -23,6 +23,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/basic-default-search-params/package.json
+++ b/examples/solid/basic-default-search-params/package.json
@@ -9,13 +9,13 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-query": "^6.0.0-beta.7",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -23,6 +23,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/basic-devtools-panel/package.json
+++ b/examples/solid/basic-devtools-panel/package.json
@@ -9,18 +9,18 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/basic-file-based/package.json
+++ b/examples/solid/basic-file-based/package.json
@@ -9,12 +9,12 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -23,6 +23,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/basic-non-nested-devtools/package.json
+++ b/examples/solid/basic-non-nested-devtools/package.json
@@ -9,12 +9,12 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
@@ -23,6 +23,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/basic-solid-query-file-based/package.json
+++ b/examples/solid/basic-solid-query-file-based/package.json
@@ -10,14 +10,14 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-query": "^6.0.0-beta.7",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.7",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -26,6 +26,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/basic-solid-query/package.json
+++ b/examples/solid/basic-solid-query/package.json
@@ -9,14 +9,14 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-query": "^6.0.0-beta.7",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.7",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
@@ -24,6 +24,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/basic-ssr-file-based/package.json
+++ b/examples/solid/basic-ssr-file-based/package.json
@@ -11,14 +11,14 @@
     "debug": "node --inspect-brk server"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/router-plugin": "^1.168.24",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "compression": "^1.8.0",
     "express": "^5.2.1",
     "get-port": "^7.1.0",
     "node-fetch": "^3.3.2",
-    "solid-js": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32"
   },
   "devDependencies": {
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
@@ -26,6 +26,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/basic-ssr-streaming-file-based/package.json
+++ b/examples/solid/basic-ssr-streaming-file-based/package.json
@@ -11,7 +11,7 @@
     "debug": "node --inspect-brk server"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
@@ -20,7 +20,7 @@
     "get-port": "^7.1.0",
     "node-fetch": "^3.3.2",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -30,6 +30,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/basic-virtual-file-based/package.json
+++ b/examples/solid/basic-virtual-file-based/package.json
@@ -9,14 +9,14 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.168.24",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "@tanstack/virtual-file-routes": "^1.162.0",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -24,6 +24,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/basic-virtual-inside-file-based/package.json
+++ b/examples/solid/basic-virtual-inside-file-based/package.json
@@ -9,14 +9,14 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.168.24",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "@tanstack/virtual-file-routes": "^1.162.0",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -24,6 +24,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/basic/package.json
+++ b/examples/solid/basic/package.json
@@ -9,12 +9,12 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
@@ -23,6 +23,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/deferred-data/package.json
+++ b/examples/solid/deferred-data/package.json
@@ -9,12 +9,12 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -22,6 +22,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/i18n-paraglide/package.json
+++ b/examples/solid/i18n-paraglide/package.json
@@ -10,11 +10,11 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.168.24",
     "@tanstack/solid-router": "^2.0.0-beta.29",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
@@ -23,6 +23,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/kitchen-sink-file-based/package.json
+++ b/examples/solid/kitchen-sink-file-based/package.json
@@ -9,13 +9,13 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "immer": "^10.1.1",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -24,6 +24,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/kitchen-sink-solid-query-file-based/package.json
+++ b/examples/solid/kitchen-sink-solid-query-file-based/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.168.24",
     "@tanstack/solid-query": "^6.0.0-beta.7",
@@ -18,7 +18,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "immer": "^10.1.1",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -26,6 +26,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/kitchen-sink-solid-query/package.json
+++ b/examples/solid/kitchen-sink-solid-query/package.json
@@ -9,7 +9,7 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-query": "^6.0.0-beta.7",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.7",
@@ -17,7 +17,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "immer": "^10.1.1",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -25,6 +25,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/kitchen-sink/package.json
+++ b/examples/solid/kitchen-sink/package.json
@@ -9,13 +9,13 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "immer": "^10.1.1",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -23,6 +23,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/large-file-based/package.json
+++ b/examples/solid/large-file-based/package.json
@@ -11,14 +11,14 @@
     "test:types": "tsc --extendedDiagnostics"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.168.24",
     "@tanstack/solid-query": "^6.0.0-beta.7",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -26,6 +26,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/location-masking/package.json
+++ b/examples/solid/location-masking/package.json
@@ -9,19 +9,19 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-query": "^6.0.0-beta.7",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/navigation-blocking/package.json
+++ b/examples/solid/navigation-blocking/package.json
@@ -9,19 +9,19 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-query": "^6.0.0-beta.7",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/quickstart-esbuild-file-based/package.json
+++ b/examples/solid/quickstart-esbuild-file-based/package.json
@@ -9,12 +9,12 @@
     "start": "dev"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/router-plugin": "^1.168.24",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },

--- a/examples/solid/quickstart-file-based/package.json
+++ b/examples/solid/quickstart-file-based/package.json
@@ -9,12 +9,12 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -23,6 +23,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/quickstart-rspack-file-based/package.json
+++ b/examples/solid/quickstart-rspack-file-based/package.json
@@ -8,12 +8,12 @@
     "preview": "rsbuild preview"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/postcss": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "postcss": "^8.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {

--- a/examples/solid/quickstart-webpack-file-based/package.json
+++ b/examples/solid/quickstart-webpack-file-based/package.json
@@ -7,10 +7,10 @@
     "build": "webpack build && tsc --noEmit"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
@@ -18,7 +18,7 @@
     "@babel/preset-typescript": "^7.27.1",
     "@tanstack/router-plugin": "^1.168.24",
     "babel-loader": "^10.0.0",
-    "babel-preset-solid": "2.0.0-beta.29",
+    "babel-preset-solid": "2.0.0-beta.32",
     "css-loader": "^7.1.2",
     "html-webpack-plugin": "^5.6.3",
     "postcss": "^8.5.6",

--- a/examples/solid/quickstart/package.json
+++ b/examples/solid/quickstart/package.json
@@ -9,17 +9,17 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/router-monorepo-simple-lazy/package.json
+++ b/examples/solid/router-monorepo-simple-lazy/package.json
@@ -8,12 +8,12 @@
     "dev": "pnpm router build && pnpm post-feature build && pnpm app dev"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/router-plugin": "^1.168.24",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32"
   },
   "devDependencies": {
     "@types/node": "^22.7.4",
@@ -21,7 +21,7 @@
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
     "vite-plugin-dts": "^4.5.4",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   },
   "keywords": [],
   "author": "",

--- a/examples/solid/router-monorepo-simple-lazy/packages/post-feature/package.json
+++ b/examples/solid/router-monorepo-simple-lazy/packages/post-feature/package.json
@@ -18,11 +18,11 @@
   "dependencies": {
     "@tanstack/solid-query": "^6.0.0-beta.7",
     "@router-solid-mono-simple-lazy/router": "workspace:*",
-    "solid-js": "2.0.0-beta.29",
-    "@solidjs/web": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32",
+    "@solidjs/web": "2.0.0-beta.32"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",

--- a/examples/solid/router-monorepo-simple-lazy/packages/router/package.json
+++ b/examples/solid/router-monorepo-simple-lazy/packages/router/package.json
@@ -13,11 +13,11 @@
     "@tanstack/router-plugin": "^1.168.24",
     "redaxios": "^0.5.1",
     "zod": "^4.4.3",
-    "solid-js": "2.0.0-beta.29",
-    "@solidjs/web": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32",
+    "@solidjs/web": "2.0.0-beta.32"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",

--- a/examples/solid/router-monorepo-simple/package.json
+++ b/examples/solid/router-monorepo-simple/package.json
@@ -8,12 +8,12 @@
     "dev": "pnpm router build && pnpm post-feature build && pnpm app dev"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/router-plugin": "^1.168.24",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32"
   },
   "devDependencies": {
     "@types/node": "^22.7.4",
@@ -21,7 +21,7 @@
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
     "vite-plugin-dts": "^4.5.4",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   },
   "keywords": [],
   "author": "",

--- a/examples/solid/router-monorepo-simple/packages/app/package.json
+++ b/examples/solid/router-monorepo-simple/packages/app/package.json
@@ -11,11 +11,11 @@
   "dependencies": {
     "@router-solid-mono-simple/post-feature": "workspace:*",
     "@router-solid-mono-simple/router": "workspace:*",
-    "solid-js": "2.0.0-beta.29",
-    "@solidjs/web": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32",
+    "@solidjs/web": "2.0.0-beta.32"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",

--- a/examples/solid/router-monorepo-simple/packages/post-feature/package.json
+++ b/examples/solid/router-monorepo-simple/packages/post-feature/package.json
@@ -9,11 +9,11 @@
   "types": "./dist/index.d.ts",
   "dependencies": {
     "@router-solid-mono-simple/router": "workspace:*",
-    "solid-js": "2.0.0-beta.29",
-    "@solidjs/web": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32",
+    "@solidjs/web": "2.0.0-beta.32"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",

--- a/examples/solid/router-monorepo-simple/packages/router/package.json
+++ b/examples/solid/router-monorepo-simple/packages/router/package.json
@@ -13,11 +13,11 @@
     "@tanstack/router-plugin": "^1.168.24",
     "redaxios": "^0.5.1",
     "zod": "^4.4.3",
-    "solid-js": "2.0.0-beta.29",
-    "@solidjs/web": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32",
+    "@solidjs/web": "2.0.0-beta.32"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",

--- a/examples/solid/router-monorepo-solid-query/package.json
+++ b/examples/solid/router-monorepo-solid-query/package.json
@@ -10,14 +10,14 @@
     "dev": "pnpm post-query build && pnpm router build && pnpm post-feature build && pnpm app dev"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/router-plugin": "^1.168.24",
     "@tanstack/solid-query": "^6.0.0-beta.7",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.7",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",
@@ -25,7 +25,7 @@
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
     "vite-plugin-dts": "^4.5.4",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   },
   "keywords": [],
   "author": "",

--- a/examples/solid/router-monorepo-solid-query/packages/app/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/app/package.json
@@ -12,11 +12,11 @@
     "@tanstack/solid-query": "^6.0.0-beta.7",
     "@router-solid-mono-solid-query/post-feature": "workspace:*",
     "@router-solid-mono-solid-query/router": "workspace:*",
-    "solid-js": "2.0.0-beta.29",
-    "@solidjs/web": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32",
+    "@solidjs/web": "2.0.0-beta.32"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",

--- a/examples/solid/router-monorepo-solid-query/packages/post-feature/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/post-feature/package.json
@@ -11,11 +11,11 @@
     "@tanstack/solid-query": "^6.0.0-beta.7",
     "@router-solid-mono-solid-query/post-query": "workspace:*",
     "@router-solid-mono-solid-query/router": "workspace:*",
-    "solid-js": "2.0.0-beta.29",
-    "@solidjs/web": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32",
+    "@solidjs/web": "2.0.0-beta.32"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",

--- a/examples/solid/router-monorepo-solid-query/packages/post-query/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/post-query/package.json
@@ -13,7 +13,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14"

--- a/examples/solid/router-monorepo-solid-query/packages/router/package.json
+++ b/examples/solid/router-monorepo-solid-query/packages/router/package.json
@@ -15,11 +15,11 @@
     "@router-solid-mono-solid-query/post-query": "workspace:*",
     "redaxios": "^0.5.1",
     "zod": "^4.4.3",
-    "solid-js": "2.0.0-beta.29",
-    "@solidjs/web": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32",
+    "@solidjs/web": "2.0.0-beta.32"
   },
   "devDependencies": {
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",

--- a/examples/solid/scroll-restoration/package.json
+++ b/examples/solid/scroll-restoration/package.json
@@ -9,18 +9,18 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "@tanstack/solid-virtual": "^3.13.0",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/search-validator-adapters/package.json
+++ b/examples/solid/search-validator-adapters/package.json
@@ -10,7 +10,7 @@
     "test:unit": "vitest"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/arktype-adapter": "^1.167.0",
     "@tanstack/router-plugin": "^1.168.24",
@@ -20,7 +20,7 @@
     "@tanstack/valibot-adapter": "^1.167.0",
     "@tanstack/zod-adapter": "^1.167.0",
     "arktype": "^2.1.7",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "valibot": "1.0.0-beta.15",
     "zod": "^3.24.2"
@@ -31,6 +31,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/start-basic-auth/package.json
+++ b/examples/solid/start-basic-auth/package.json
@@ -14,12 +14,12 @@
     "@libsql/client": "^0.15.15",
     "@prisma/adapter-libsql": "^7.0.0",
     "@prisma/client": "^7.0.0",
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "@tanstack/solid-start": "^2.0.0-beta.30",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
@@ -31,7 +31,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-basic-authjs/package.json
+++ b/examples/solid/start-basic-authjs/package.json
@@ -11,11 +11,11 @@
   },
   "dependencies": {
     "@auth/core": "^0.41.1",
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "@tanstack/solid-start": "^2.0.0-beta.30",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "start-authjs": "^1.0.0",
     "tailwind-merge": "^3.6.0"
   },
@@ -26,7 +26,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-basic-cloudflare/package.json
+++ b/examples/solid/start-basic-cloudflare/package.json
@@ -12,11 +12,11 @@
     "postinstall": "npm run cf-typegen"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "@tanstack/solid-start": "^2.0.0-beta.30",
-    "solid-js": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.29.0",
@@ -26,7 +26,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "vite-tsconfig-paths": "^5.1.4",
     "wrangler": "^4.74.0"
   }

--- a/examples/solid/start-basic-netlify/package.json
+++ b/examples/solid/start-basic-netlify/package.json
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "@tanstack/solid-start": "^2.0.0-beta.30",
-    "solid-js": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32"
   },
   "devDependencies": {
     "@netlify/vite-plugin-tanstack-start": "^1.1.4",
@@ -23,7 +23,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-basic-nitro/package.json
+++ b/examples/solid/start-basic-nitro/package.json
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "@tanstack/solid-start": "^2.0.0-beta.30",
-    "solid-js": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.2",
@@ -23,7 +23,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-basic-solid-query/package.json
+++ b/examples/solid/start-basic-solid-query/package.json
@@ -10,7 +10,7 @@
     "start": "pnpx srvx --prod -s ../client dist/server/server.js"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-query": "^6.0.0-beta.7",
     "@tanstack/solid-query-devtools": "^6.0.0-beta.7",
     "@tanstack/solid-router": "^2.0.0-beta.29",
@@ -18,7 +18,7 @@
     "@tanstack/solid-router-ssr-query": "^2.0.0-beta.30",
     "@tanstack/solid-start": "^2.0.0-beta.30",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
@@ -28,7 +28,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-basic-static/package.json
+++ b/examples/solid/start-basic-static/package.json
@@ -10,13 +10,13 @@
     "start": "pnpx srvx --prod -s ../client dist/server/server.js"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "@tanstack/solid-start": "^2.0.0-beta.30",
     "@tanstack/start-static-server-functions": "^1.167.20",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
@@ -26,7 +26,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "vite-tsconfig-paths": "^5.1.3"
   }
 }

--- a/examples/solid/start-basic/package.json
+++ b/examples/solid/start-basic/package.json
@@ -10,12 +10,12 @@
     "start": "node .output/server/index.mjs"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "@tanstack/solid-start": "^2.0.0-beta.30",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
@@ -26,7 +26,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-bun/package.json
+++ b/examples/solid/start-bun/package.json
@@ -13,7 +13,7 @@
     "check": "prettier --write . && eslint --fix"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.168.24",
     "@tanstack/solid-devtools": "^0.7.0",
@@ -21,7 +21,7 @@
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "@tanstack/solid-router-ssr-query": "^2.0.0-beta.30",
     "@tanstack/solid-start": "^2.0.0-beta.30",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
@@ -35,7 +35,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "vitest": "^4.1.4",
     "web-vitals": "^5.1.0"
   }

--- a/examples/solid/start-convex-better-auth/package.json
+++ b/examples/solid/start-convex-better-auth/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@convex-dev/better-auth": "^0.9.7",
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
@@ -22,7 +22,7 @@
     "convex": "^1.28.2",
     "convex-solidjs": "^0.0.3",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
@@ -33,7 +33,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-counter/package.json
+++ b/examples/solid/start-counter/package.json
@@ -10,12 +10,12 @@
     "start": "pnpx srvx --prod -s ../client dist/server/server.js"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "@tanstack/solid-start": "^2.0.0-beta.30",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },
@@ -25,6 +25,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/start-i18n-paraglide/package.json
+++ b/examples/solid/start-i18n-paraglide/package.json
@@ -9,12 +9,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-devtools": "^0.7.0",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "@tanstack/solid-start": "^2.0.0-beta.30",
-    "solid-js": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32"
   },
   "devDependencies": {
     "@inlang/paraglide-js": "^2.4.0",
@@ -24,6 +24,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/start-large/package.json
+++ b/examples/solid/start-large/package.json
@@ -12,13 +12,13 @@
     "test:types": "tsc --extendedDiagnostics"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-query": "^6.0.0-beta.7",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "@tanstack/solid-start": "^2.0.0-beta.30",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwind-merge": "^3.6.0",
     "valibot": "^1.0.0-beta.15"
   },
@@ -29,7 +29,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   },
   "keywords": [],
   "author": "",

--- a/examples/solid/start-streaming-data-from-server-functions/package.json
+++ b/examples/solid/start-streaming-data-from-server-functions/package.json
@@ -10,11 +10,11 @@
     "start": "pnpx srvx --prod -s ../client dist/server/server.js"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "@tanstack/solid-start": "^2.0.0-beta.30",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -22,6 +22,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/start-supabase-basic/package.json
+++ b/examples/solid/start-supabase-basic/package.json
@@ -12,14 +12,14 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.48.1",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "@tanstack/solid-start": "^2.0.0-beta.30",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.2",
@@ -28,7 +28,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/start-tailwind-v4/package.json
+++ b/examples/solid/start-tailwind-v4/package.json
@@ -10,11 +10,11 @@
     "start": "node .output/server/index.mjs"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "@tanstack/solid-start": "^2.0.0-beta.30",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },
@@ -25,7 +25,7 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/examples/solid/view-transitions/package.json
+++ b/examples/solid/view-transitions/package.json
@@ -9,13 +9,13 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.168.24",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -23,6 +23,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/with-framer-motion/package.json
+++ b/examples/solid/with-framer-motion/package.json
@@ -9,12 +9,12 @@
     "start": "vite"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/solid-router": "^2.0.0-beta.29",
     "@tanstack/solid-router-devtools": "^2.0.0-beta.24",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "solid-motionone": "^1.0.4",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
@@ -23,6 +23,6 @@
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/examples/solid/with-trpc/package.json
+++ b/examples/solid/with-trpc/package.json
@@ -10,7 +10,7 @@
     "start": "NODE_ENV=production node dist/server/server.js"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.168.24",
     "@tanstack/solid-router": "^2.0.0-beta.29",
@@ -19,7 +19,7 @@
     "@trpc/server": "^11.4.3",
     "express": "^5.2.1",
     "redaxios": "^0.5.1",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "tailwindcss": "^4.2.2",
     "zod": "^4.4.3"
   },
@@ -27,6 +27,6 @@
     "@types/express": "^5.0.6",
     "tsx": "^4.20.3",
     "vite": "^8.0.14",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   }
 }

--- a/packages/solid-router-devtools/package.json
+++ b/packages/solid-router-devtools/package.json
@@ -66,21 +66,21 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/router-devtools-core": "workspace:*"
   },
   "devDependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@types/node": ">=20",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "vite": "*",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   },
   "peerDependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/router-core": "workspace:^",
     "@tanstack/solid-router": "workspace:^",
-    "solid-js": "2.0.0-beta.29"
+    "solid-js": "2.0.0-beta.32"
   },
   "peerDependenciesMeta": {
     "@tanstack/router-core": {

--- a/packages/solid-router-ssr-query/package.json
+++ b/packages/solid-router-ssr-query/package.json
@@ -67,13 +67,13 @@
     "@tanstack/router-ssr-query-core": "workspace:*"
   },
   "devDependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/solid-query": "^6.0.0-beta.7",
     "@tanstack/solid-router": "workspace:*",
     "eslint-plugin-solid": "^0.14.5",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "vite": "*",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   },
   "peerDependencies": {
     "@solidjs/web": ">=2.0.0-beta.17",

--- a/packages/solid-router/package.json
+++ b/packages/solid-router/package.json
@@ -106,7 +106,7 @@
   "dependencies": {
     "@solid-devtools/logger": "^0.9.4",
     "@solidjs/meta": "^0.29.4",
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/history": "workspace:*",
     "@tanstack/router-core": "workspace:*",
     "isbot": "^5.1.22",
@@ -114,14 +114,14 @@
   },
   "devDependencies": {
     "@solidjs/testing-library": "^0.8.10",
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@testing-library/jest-dom": "^6.6.3",
     "@types/node": ">=20",
     "combinate": "^1.1.11",
     "eslint-plugin-solid": "^0.14.5",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "vite": "*",
-    "vite-plugin-solid": "^3.0.0-next.21",
+    "vite-plugin-solid": "^3.0.0-next.23",
     "zod": "^4.4.3"
   },
   "peerDependencies": {

--- a/packages/solid-router/tests/server/ClientOnly.test.tsx
+++ b/packages/solid-router/tests/server/ClientOnly.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { renderToStringAsync } from '@solidjs/web'
+import { renderToStream } from '@solidjs/web'
 import {
   RouterProvider,
   createMemoryHistory,
@@ -44,7 +44,7 @@ describe('ClientOnly (server)', () => {
     await router.load()
 
     // Initial render (SSR)
-    const html = await renderToStringAsync(() => (
+    const html = await renderToStream(() => (
       <RouterProvider router={router} />
     ))
 

--- a/packages/solid-router/tests/server/ClientOnly.test.tsx
+++ b/packages/solid-router/tests/server/ClientOnly.test.tsx
@@ -44,9 +44,7 @@ describe('ClientOnly (server)', () => {
     await router.load()
 
     // Initial render (SSR)
-    const html = await renderToStream(() => (
-      <RouterProvider router={router} />
-    ))
+    const html = await renderToStream(() => <RouterProvider router={router} />)
 
     expect(html).include('Loading...')
     expect(html).not.include('Client Only Content')

--- a/packages/solid-router/tests/server/Transitioner.test.tsx
+++ b/packages/solid-router/tests/server/Transitioner.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { renderToStringAsync } from '@solidjs/web'
+import { renderToStream } from '@solidjs/web'
 import {
   createMemoryHistory,
   createRootRoute,
@@ -33,7 +33,7 @@ describe('Transitioner (server)', () => {
 
     await router.load()
 
-    await renderToStringAsync(() => <RouterProvider router={router} />)
+    await renderToStream(() => <RouterProvider router={router} />)
 
     expect(loadSpy).toHaveBeenCalledTimes(1)
     expect(loader).toHaveBeenCalledTimes(1)

--- a/packages/solid-start-client/package.json
+++ b/packages/solid-start-client/package.json
@@ -77,11 +77,11 @@
   },
   "devDependencies": {
     "@solidjs/testing-library": "^0.8.10",
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@testing-library/jest-dom": "^6.6.3",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "vite": "*",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   },
   "peerDependencies": {
     "@solidjs/web": ">=2.0.0-0 <3.0.0",

--- a/packages/solid-start-server/package.json
+++ b/packages/solid-start-server/package.json
@@ -63,12 +63,12 @@
     "@tanstack/start-server-core": "workspace:*"
   },
   "devDependencies": {
-    "@solidjs/web": "2.0.0-beta.29",
-    "solid-js": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
+    "solid-js": "2.0.0-beta.32",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "*",
-    "vite-plugin-solid": "^3.0.0-next.21"
+    "vite-plugin-solid": "^3.0.0-next.23"
   },
   "peerDependencies": {
     "@solidjs/web": ">=2.0.0-0 <3.0.0",

--- a/packages/solid-start/package.json
+++ b/packages/solid-start/package.json
@@ -128,10 +128,10 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^2.1.0",
-    "@solidjs/web": "2.0.0-beta.29",
+    "@solidjs/web": "2.0.0-beta.32",
     "@tanstack/router-utils": "workspace:*",
     "@types/node": ">=20",
-    "solid-js": "2.0.0-beta.29",
+    "solid-js": "2.0.0-beta.32",
     "vite": "*"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,7 +98,7 @@ importers:
         version: 5.99.0(react@19.2.3)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(solid-js@2.0.0-beta.32)
       '@tanstack/vite-config':
         specifier: 0.5.2
         version: 0.5.2(@types/node@25.0.9)(@typescript/typescript6@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -187,8 +187,8 @@ importers:
   benchmarks/bundle-size:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../packages/react-router
@@ -214,8 +214,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       vue:
         specifier: ^3.5.16
         version: 3.5.25(@typescript/typescript6@6.0.2)
@@ -254,14 +254,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   benchmarks/client-nav:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../packages/react-router
@@ -281,8 +281,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       vue:
         specifier: ^3.5.16
         version: 3.5.25(@typescript/typescript6@6.0.2)
@@ -321,8 +321,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@25.0.9)(@vitest/ui@4.1.4)(jsdom@29.1.1(@noble/hashes@2.0.1))(msw@2.7.0(@types/node@25.0.9)(@typescript/typescript6@6.0.2))(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -330,8 +330,8 @@ importers:
   benchmarks/memory/client:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -351,8 +351,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       vue:
         specifier: ^3.5.16
         version: 3.5.25(@typescript/typescript6@6.0.2)
@@ -394,8 +394,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@25.0.9)(@vitest/ui@4.1.4)(jsdom@29.1.1(@noble/hashes@2.0.1))(msw@2.7.0(@types/node@25.0.9)(@typescript/typescript6@6.0.2))(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -403,8 +403,8 @@ importers:
   benchmarks/memory/server:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -430,8 +430,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       vue:
         specifier: ^3.5.16
         version: 3.5.25(@typescript/typescript6@6.0.2)
@@ -461,8 +461,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@25.0.9)(@vitest/ui@4.1.4)(jsdom@29.1.1(@noble/hashes@2.0.1))(msw@2.7.0(@types/node@25.0.9)(@typescript/typescript6@6.0.2))(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -470,8 +470,8 @@ importers:
   benchmarks/ssr:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../packages/react-router
@@ -497,8 +497,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       vue:
         specifier: ^3.5.16
         version: 3.5.25(@typescript/typescript6@6.0.2)
@@ -525,8 +525,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@25.0.9)(@vitest/ui@4.1.4)(jsdom@29.1.1(@noble/hashes@2.0.1))(msw@2.7.0(@types/node@25.0.9)(@typescript/typescript6@6.0.2))(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -3893,8 +3893,8 @@ importers:
   e2e/solid-router/basepath-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/router-plugin':
         specifier: workspace:*
         version: link:../../../packages/router-plugin
@@ -3905,8 +3905,8 @@ importers:
         specifier: workspace:^
         version: link:../../../packages/solid-router-devtools
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
     devDependencies:
       '@playwright/test':
         specifier: ^1.61.0
@@ -3918,14 +3918,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/basic:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -3939,8 +3939,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -3955,14 +3955,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/basic-esbuild-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/router-plugin':
         specifier: workspace:*
         version: link:../../../packages/router-plugin
@@ -3976,8 +3976,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -3993,13 +3993,13 @@ importers:
         version: 0.27.4
       esbuild-plugin-solid:
         specifier: ^0.6.0
-        version: 0.6.0(esbuild@0.27.4)(solid-js@2.0.0-beta.29)
+        version: 0.6.0(esbuild@0.27.4)(solid-js@2.0.0-beta.32)
 
   e2e/solid-router/basic-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4016,8 +4016,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -4038,14 +4038,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/basic-file-based-code-splitting:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4059,8 +4059,8 @@ importers:
         specifier: workspace:^
         version: link:../../../packages/solid-router-devtools
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -4078,14 +4078,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/basic-scroll-restoration:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4097,13 +4097,13 @@ importers:
         version: link:../../../packages/solid-router-devtools
       '@tanstack/solid-virtual':
         specifier: ^3.13.0
-        version: 3.13.12(solid-js@2.0.0-beta.29)
+        version: 3.13.12(solid-js@2.0.0-beta.32)
       redaxios:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -4121,23 +4121,23 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/basic-solid-query:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(solid-js@2.0.0-beta.32)
       '@tanstack/solid-query-devtools':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.29))(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.32))(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4148,8 +4148,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -4164,14 +4164,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/basic-solid-query-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4180,10 +4180,10 @@ importers:
         version: link:../../../packages/router-plugin
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(solid-js@2.0.0-beta.32)
       '@tanstack/solid-query-devtools':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.29))(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.32))(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4194,8 +4194,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -4213,14 +4213,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/basic-virtual-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4240,8 +4240,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -4259,14 +4259,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/basic-virtual-named-export-config-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4286,8 +4286,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -4305,14 +4305,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/generator-cli-only:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4329,8 +4329,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -4345,14 +4345,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/js-only-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4366,8 +4366,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -4385,14 +4385,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/rspack-basic-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4403,8 +4403,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
     devDependencies:
       '@playwright/test':
         specifier: ^1.61.0
@@ -4417,7 +4417,7 @@ importers:
         version: 1.1.2(@rsbuild/core@2.1.1)
       '@rsbuild/plugin-solid':
         specifier: ^2.0.0-beta.0
-        version: 2.0.0-beta.0(@babel/core@7.29.0)(@rsbuild/core@2.1.1)(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(solid-js@2.0.0-beta.29)
+        version: 2.0.0-beta.0(@babel/core@7.29.0)(@rsbuild/core@2.1.1)(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(solid-js@2.0.0-beta.32)
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -4443,8 +4443,8 @@ importers:
   e2e/solid-router/rspack-basic-virtual-named-export-config-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4455,8 +4455,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
     devDependencies:
       '@playwright/test':
         specifier: ^1.61.0
@@ -4469,7 +4469,7 @@ importers:
         version: 1.1.2(@rsbuild/core@2.1.1)
       '@rsbuild/plugin-solid':
         specifier: ^2.0.0-beta.0
-        version: 2.0.0-beta.0(@babel/core@7.29.0)(@rsbuild/core@2.1.1)(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(solid-js@2.0.0-beta.29)
+        version: 2.0.0-beta.0(@babel/core@7.29.0)(@rsbuild/core@2.1.1)(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(solid-js@2.0.0-beta.32)
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -4498,8 +4498,8 @@ importers:
   e2e/solid-router/scroll-restoration-sandbox-vite:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4516,8 +4516,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -4535,14 +4535,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/sentry-integration:
     dependencies:
       '@sentry/solid':
         specifier: ^10.32.0
-        version: 10.32.0(@tanstack/solid-router@packages+solid-router)(solid-js@2.0.0-beta.29)
+        version: 10.32.0(@tanstack/solid-router@packages+solid-router)(solid-js@2.0.0-beta.32)
       '@sentry/tracing':
         specifier: ^7.120.4
         version: 7.120.4
@@ -4550,8 +4550,8 @@ importers:
         specifier: ^4.6.1
         version: 4.6.1
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4565,8 +4565,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -4581,14 +4581,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-router/view-transitions:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -4605,8 +4605,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -4630,14 +4630,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/basic:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4660,8 +4660,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -4680,7 +4680,7 @@ importers:
         version: 1.1.2(@rsbuild/core@2.1.1)
       '@rsbuild/plugin-solid':
         specifier: ^2.0.0-beta.0
-        version: 2.0.0-beta.0(@babel/core@7.29.0)(@rsbuild/core@2.1.1)(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(solid-js@2.0.0-beta.29)
+        version: 2.0.0-beta.0(@babel/core@7.29.0)(@rsbuild/core@2.1.1)(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(solid-js@2.0.0-beta.32)
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -4715,8 +4715,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/basic-auth:
     dependencies:
@@ -4730,8 +4730,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(@typescript/typescript6@6.0.2)(prisma@7.0.0(@types/react@19.2.9)(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4745,8 +4745,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -4785,14 +4785,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/basic-cloudflare:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4803,8 +4803,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.29.0
@@ -4834,8 +4834,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       wrangler:
         specifier: ^4.74.0
         version: 4.75.0
@@ -4843,14 +4843,14 @@ importers:
   e2e/solid-start/basic-solid-query:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(solid-js@2.0.0-beta.32)
       '@tanstack/solid-query-devtools':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.29))(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.32))(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4867,8 +4867,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -4904,14 +4904,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/basic-tsr-config:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4922,8 +4922,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
     devDependencies:
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
@@ -4944,14 +4944,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/csp:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -4959,8 +4959,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
     devDependencies:
       '@playwright/test':
         specifier: ^1.61.0
@@ -4984,14 +4984,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/css-modules:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:*
         version: link:../../../packages/solid-router
@@ -4999,8 +4999,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
     devDependencies:
       '@playwright/test':
         specifier: ^1.61.0
@@ -5027,8 +5027,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(@typescript/typescript6@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -5036,8 +5036,8 @@ importers:
   e2e/solid-start/custom-basepath:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5054,8 +5054,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
     devDependencies:
       '@playwright/test':
         specifier: ^1.61.0
@@ -5094,8 +5094,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(@typescript/typescript6@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -5103,8 +5103,8 @@ importers:
   e2e/solid-start/deferred-hydration:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5112,8 +5112,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
     devDependencies:
       '@rsbuild/core':
         specifier: ^2.1.0
@@ -5123,7 +5123,7 @@ importers:
         version: 1.1.2(@rsbuild/core@2.1.1)
       '@rsbuild/plugin-solid':
         specifier: ^2.0.0-beta.0
-        version: 2.0.0-beta.0(@babel/core@7.29.0)(@rsbuild/core@2.1.1)(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(solid-js@2.0.0-beta.29)
+        version: 2.0.0-beta.0(@babel/core@7.29.0)(@rsbuild/core@2.1.1)(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(solid-js@2.0.0-beta.32)
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -5143,20 +5143,20 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/query-integration:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(solid-js@2.0.0-beta.32)
       '@tanstack/solid-query-devtools':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.29))(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.32))(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5170,8 +5170,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -5204,14 +5204,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/scroll-restoration:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5225,8 +5225,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -5265,14 +5265,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/selective-ssr:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5280,8 +5280,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -5308,8 +5308,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(@typescript/typescript6@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -5317,8 +5317,8 @@ importers:
   e2e/solid-start/serialization-adapters:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5329,8 +5329,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(@typescript/typescript6@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -5363,20 +5363,20 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/server-functions:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(solid-js@2.0.0-beta.32)
       '@tanstack/solid-query-devtools':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.29))(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.32))(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5396,8 +5396,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -5439,17 +5439,17 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/server-routes:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5469,8 +5469,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -5512,17 +5512,17 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/solid-query-layout-suspense:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5530,8 +5530,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
     devDependencies:
       '@playwright/test':
         specifier: ^1.61.0
@@ -5552,14 +5552,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/spa-mode:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5570,8 +5570,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -5595,8 +5595,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(@typescript/typescript6@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -5604,8 +5604,8 @@ importers:
   e2e/solid-start/start-manifest:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5613,8 +5613,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
     devDependencies:
       '@playwright/test':
         specifier: ^1.61.0
@@ -5638,14 +5638,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/virtual-routes:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5662,8 +5662,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -5702,14 +5702,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/solid-start/website:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:^
         version: link:../../../packages/solid-router
@@ -5723,8 +5723,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -5760,8 +5760,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   e2e/vue-router/basepath-file-based:
     dependencies:
@@ -10081,7 +10081,7 @@ importers:
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/react-devtools':
         specifier: ^0.7.0
-        version: 0.7.0(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(csstype@3.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.29)
+        version: 0.7.0(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(csstype@3.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.32)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -10337,7 +10337,7 @@ importers:
     dependencies:
       '@tanstack/react-devtools':
         specifier: ^0.7.0
-        version: 0.7.0(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(csstype@3.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.29)
+        version: 0.7.0(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(csstype@3.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.32)
       '@tanstack/react-router':
         specifier: workspace:*
         version: link:../../../packages/react-router
@@ -11051,8 +11051,8 @@ importers:
   examples/solid/authenticated-routes:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11069,8 +11069,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11088,14 +11088,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/authenticated-routes-firebase:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11118,8 +11118,8 @@ importers:
         specifier: ^14.9.0
         version: 14.9.0
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11137,14 +11137,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11158,8 +11158,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11180,20 +11180,20 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-default-search-params:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -11204,8 +11204,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11223,14 +11223,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-devtools-panel:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11244,8 +11244,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11260,14 +11260,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11281,8 +11281,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11303,14 +11303,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-non-nested-devtools:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11324,8 +11324,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11346,23 +11346,23 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-solid-query:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(solid-js@2.0.0-beta.32)
       '@tanstack/solid-query-devtools':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.29))(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.32))(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -11373,8 +11373,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11392,23 +11392,23 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-solid-query-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(solid-js@2.0.0-beta.32)
       '@tanstack/solid-query-devtools':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.29))(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.32))(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -11419,8 +11419,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11441,14 +11441,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-ssr-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/router-plugin':
         specifier: workspace:*
         version: link:../../../packages/router-plugin
@@ -11468,8 +11468,8 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
     devDependencies:
       '@tanstack/solid-router-devtools':
         specifier: workspace:^
@@ -11487,14 +11487,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-ssr-streaming-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11520,8 +11520,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11545,14 +11545,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-virtual-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11572,8 +11572,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11591,14 +11591,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/basic-virtual-inside-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11618,8 +11618,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11637,14 +11637,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/deferred-data:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11658,8 +11658,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11677,14 +11677,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/i18n-paraglide:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11695,8 +11695,8 @@ importers:
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11717,14 +11717,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/kitchen-sink:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11741,8 +11741,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11760,14 +11760,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/kitchen-sink-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11784,8 +11784,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11806,23 +11806,23 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/kitchen-sink-solid-query:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(solid-js@2.0.0-beta.32)
       '@tanstack/solid-query-devtools':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.29))(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.32))(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -11836,8 +11836,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11855,14 +11855,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/kitchen-sink-solid-query-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11871,10 +11871,10 @@ importers:
         version: link:../../../packages/router-plugin
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(solid-js@2.0.0-beta.32)
       '@tanstack/solid-query-devtools':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.29))(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.32))(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -11888,8 +11888,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11907,14 +11907,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/large-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -11923,7 +11923,7 @@ importers:
         version: link:../../../packages/router-plugin
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -11934,8 +11934,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11953,20 +11953,20 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/location-masking:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -11977,8 +11977,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -11993,20 +11993,20 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/navigation-blocking:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -12017,8 +12017,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -12033,14 +12033,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/quickstart:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12051,8 +12051,8 @@ importers:
         specifier: workspace:^
         version: link:../../../packages/solid-router-devtools
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -12067,14 +12067,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/quickstart-esbuild-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/router-plugin':
         specifier: workspace:*
         version: link:../../../packages/router-plugin
@@ -12088,8 +12088,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -12102,13 +12102,13 @@ importers:
         version: 0.27.4
       esbuild-plugin-solid:
         specifier: ^0.6.0
-        version: 0.6.0(esbuild@0.27.4)(solid-js@2.0.0-beta.29)
+        version: 0.6.0(esbuild@0.27.4)(solid-js@2.0.0-beta.32)
 
   examples/solid/quickstart-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12122,8 +12122,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -12144,14 +12144,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/quickstart-rspack-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -12165,8 +12165,8 @@ importers:
         specifier: ^8.5.1
         version: 8.5.6
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -12179,7 +12179,7 @@ importers:
         version: 1.1.2(@rsbuild/core@2.1.1)
       '@rsbuild/plugin-solid':
         specifier: ^2.0.0-beta.0
-        version: 2.0.0-beta.0(@babel/core@7.29.0)(@rsbuild/core@2.1.1)(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(solid-js@2.0.0-beta.29)
+        version: 2.0.0-beta.0(@babel/core@7.29.0)(@rsbuild/core@2.1.1)(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(solid-js@2.0.0-beta.32)
       '@tanstack/router-plugin':
         specifier: workspace:*
         version: link:../../../packages/router-plugin
@@ -12193,8 +12193,8 @@ importers:
   examples/solid/quickstart-webpack-file-based:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -12202,8 +12202,8 @@ importers:
         specifier: workspace:^
         version: link:../../../packages/solid-router-devtools
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -12224,8 +12224,8 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0(@babel/core@7.28.5)(webpack@5.97.1)
       babel-preset-solid:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(@babel/core@7.28.5)(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(@babel/core@7.28.5)(solid-js@2.0.0-beta.32)
       css-loader:
         specifier: ^7.1.2
         version: 7.1.2(webpack@5.97.1)
@@ -12257,8 +12257,8 @@ importers:
   examples/solid/router-monorepo-simple:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/router-plugin':
         specifier: workspace:*
         version: link:../../../packages/router-plugin
@@ -12272,8 +12272,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
     devDependencies:
       '@types/node':
         specifier: 25.0.9
@@ -12291,14 +12291,14 @@ importers:
         specifier: 4.2.3
         version: 4.2.3(@types/node@25.0.9)(@typescript/typescript6@6.0.2)(rollup@4.56.0)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/router-monorepo-simple-lazy:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/router-plugin':
         specifier: workspace:*
         version: link:../../../packages/router-plugin
@@ -12312,8 +12312,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
     devDependencies:
       '@types/node':
         specifier: 25.0.9
@@ -12331,23 +12331,23 @@ importers:
         specifier: 4.2.3
         version: 4.2.3(@types/node@25.0.9)(@typescript/typescript6@6.0.2)(rollup@4.56.0)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/router-monorepo-solid-query:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/router-plugin':
         specifier: workspace:*
         version: link:../../../packages/router-plugin
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(solid-js@2.0.0-beta.32)
       '@tanstack/solid-query-devtools':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.29))(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.32))(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -12358,8 +12358,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
     devDependencies:
       '@types/node':
         specifier: 25.0.9
@@ -12377,14 +12377,14 @@ importers:
         specifier: 4.2.3
         version: 4.2.3(@types/node@25.0.9)(@typescript/typescript6@6.0.2)(rollup@4.56.0)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/scroll-restoration:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12396,10 +12396,10 @@ importers:
         version: link:../../../packages/solid-router-devtools
       '@tanstack/solid-virtual':
         specifier: ^3.13.0
-        version: 3.13.12(solid-js@2.0.0-beta.29)
+        version: 3.13.12(solid-js@2.0.0-beta.32)
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -12414,14 +12414,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/search-validator-adapters:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12433,7 +12433,7 @@ importers:
         version: link:../../../packages/router-plugin
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -12450,8 +12450,8 @@ importers:
         specifier: ^2.1.7
         version: 2.1.7
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -12464,7 +12464,7 @@ importers:
     devDependencies:
       '@solidjs/testing-library':
         specifier: ^0.8.10
-        version: 0.8.10(solid-js@2.0.0-beta.29)
+        version: 0.8.10(solid-js@2.0.0-beta.32)
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.6.3
@@ -12478,14 +12478,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/start-basic:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -12499,8 +12499,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -12527,8 +12527,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(@typescript/typescript6@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12545,8 +12545,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(@typescript/typescript6@6.0.2)(prisma@7.0.0(@types/react@19.2.9)(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -12560,8 +12560,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -12591,8 +12591,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(@typescript/typescript6@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12603,8 +12603,8 @@ importers:
         specifier: ^0.41.1
         version: 0.41.1
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -12615,8 +12615,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       start-authjs:
         specifier: ^1.0.0
         version: 1.0.0(@auth/core@0.41.1)
@@ -12643,8 +12643,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(@typescript/typescript6@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12652,8 +12652,8 @@ importers:
   examples/solid/start-basic-cloudflare:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -12664,8 +12664,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.29.0
@@ -12689,8 +12689,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(@typescript/typescript6@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12701,8 +12701,8 @@ importers:
   examples/solid/start-basic-netlify:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -12713,8 +12713,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
     devDependencies:
       '@netlify/vite-plugin-tanstack-start':
         specifier: ^1.1.4
@@ -12738,8 +12738,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(@typescript/typescript6@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12747,8 +12747,8 @@ importers:
   examples/solid/start-basic-nitro:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -12759,8 +12759,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -12784,8 +12784,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(@typescript/typescript6@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12793,14 +12793,14 @@ importers:
   examples/solid/start-basic-solid-query:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(solid-js@2.0.0-beta.32)
       '@tanstack/solid-query-devtools':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.29))(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.32))(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -12817,8 +12817,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -12842,8 +12842,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(@typescript/typescript6@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12851,8 +12851,8 @@ importers:
   examples/solid/start-basic-static:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -12869,8 +12869,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -12894,8 +12894,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.3
         version: 5.1.4(@typescript/typescript6@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12903,8 +12903,8 @@ importers:
   examples/solid/start-bun:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12913,7 +12913,7 @@ importers:
         version: link:../../../packages/router-plugin
       '@tanstack/solid-devtools':
         specifier: ^0.7.0
-        version: 0.7.14(csstype@3.2.3)(solid-js@2.0.0-beta.29)
+        version: 0.7.14(csstype@3.2.3)(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -12927,15 +12927,15 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
     devDependencies:
       '@solidjs/testing-library':
         specifier: ^0.8.10
-        version: 0.8.10(solid-js@2.0.0-beta.29)
+        version: 0.8.10(solid-js@2.0.0-beta.32)
       '@tanstack/eslint-config':
         specifier: ^0.3.2
         version: 0.3.2(@typescript-eslint/utils@8.57.1(@typescript/typescript6@6.0.2)(eslint@9.22.0(jiti@2.7.0)))(@typescript/typescript6@6.0.2)(eslint@9.22.0(jiti@2.7.0))
@@ -12964,8 +12964,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@25.0.9)(@vitest/ui@4.1.4)(jsdom@27.0.0(postcss@8.5.15))(msw@2.7.0(@types/node@25.0.9)(@typescript/typescript6@6.0.2))(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12977,10 +12977,10 @@ importers:
     dependencies:
       '@convex-dev/better-auth':
         specifier: ^0.9.7
-        version: 0.9.7(@standard-schema/spec@1.1.0)(@typescript/typescript6@6.0.2)(better-auth@1.6.19(@prisma/client@7.0.0(@typescript/typescript6@6.0.2)(prisma@7.0.0(@types/react@19.2.9)(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(@tanstack/solid-start@packages+solid-start)(mysql2@3.15.3)(prisma@7.0.0(@types/react@19.2.9)(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.29)(vitest@4.1.4)(vue@3.5.25(@typescript/typescript6@6.0.2)))(convex@1.28.2(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(hono@4.7.10)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.9.7(@standard-schema/spec@1.1.0)(@typescript/typescript6@6.0.2)(better-auth@1.6.19(@prisma/client@7.0.0(@typescript/typescript6@6.0.2)(prisma@7.0.0(@types/react@19.2.9)(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(@tanstack/solid-start@packages+solid-start)(mysql2@3.15.3)(prisma@7.0.0(@types/react@19.2.9)(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.32)(vitest@4.1.4)(vue@3.5.25(@typescript/typescript6@6.0.2)))(convex@1.28.2(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(hono@4.7.10)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -12995,7 +12995,7 @@ importers:
         version: link:../../../packages/solid-start
       better-auth:
         specifier: ^1.6.19
-        version: 1.6.19(@prisma/client@7.0.0(@typescript/typescript6@6.0.2)(prisma@7.0.0(@types/react@19.2.9)(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(@tanstack/solid-start@packages+solid-start)(mysql2@3.15.3)(prisma@7.0.0(@types/react@19.2.9)(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.29)(vitest@4.1.4)(vue@3.5.25(@typescript/typescript6@6.0.2))
+        version: 1.6.19(@prisma/client@7.0.0(@typescript/typescript6@6.0.2)(prisma@7.0.0(@types/react@19.2.9)(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(@tanstack/solid-start@packages+solid-start)(mysql2@3.15.3)(prisma@7.0.0(@types/react@19.2.9)(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.32)(vitest@4.1.4)(vue@3.5.25(@typescript/typescript6@6.0.2))
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -13004,13 +13004,13 @@ importers:
         version: 1.28.2(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       convex-solidjs:
         specifier: ^0.0.3
-        version: 0.0.3(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.29)
+        version: 0.0.3(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.32)
       redaxios:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -13037,8 +13037,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(@typescript/typescript6@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -13046,8 +13046,8 @@ importers:
   examples/solid/start-counter:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -13061,8 +13061,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -13086,17 +13086,17 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/start-i18n-paraglide:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-devtools':
         specifier: ^0.7.0
-        version: 0.7.14(csstype@3.2.3)(solid-js@2.0.0-beta.29)
+        version: 0.7.14(csstype@3.2.3)(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -13107,8 +13107,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
     devDependencies:
       '@inlang/paraglide-js':
         specifier: ^2.4.0
@@ -13132,17 +13132,17 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/start-large:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -13156,8 +13156,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -13184,14 +13184,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/start-streaming-data-from-server-functions:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -13202,8 +13202,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -13221,14 +13221,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/start-supabase-basic:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@supabase/ssr':
         specifier: ^0.5.2
         version: 0.5.2(@supabase/supabase-js@2.48.1)
@@ -13248,8 +13248,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -13270,8 +13270,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(@typescript/typescript6@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -13279,8 +13279,8 @@ importers:
   examples/solid/start-tailwind-v4:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.29
         version: link:../../../packages/solid-router
@@ -13291,8 +13291,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/solid-start
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -13319,8 +13319,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(@typescript/typescript6@6.0.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -13328,8 +13328,8 @@ importers:
   examples/solid/view-transitions:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -13346,8 +13346,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -13365,14 +13365,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/with-framer-motion:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -13386,11 +13386,11 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       solid-motionone:
         specifier: ^1.0.4
-        version: 1.0.4(solid-js@2.0.0-beta.29)
+        version: 1.0.4(solid-js@2.0.0-beta.32)
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -13408,14 +13408,14 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/solid/with-trpc:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -13441,8 +13441,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -13460,8 +13460,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   examples/vue/basic:
     dependencies:
@@ -14117,7 +14117,7 @@ importers:
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
         specifier: ^2.11.10 || ^3.0.0-0
-        version: 2.11.11(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        version: 2.11.11(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       webpack:
         specifier: '>=5.92.0'
         version: 5.97.1(@swc/core@1.15.33(@swc/helpers@0.5.23))(esbuild@0.27.4)
@@ -14201,16 +14201,16 @@ importers:
     dependencies:
       '@solid-devtools/logger':
         specifier: ^0.9.4
-        version: 0.9.7(solid-js@2.0.0-beta.29)
+        version: 0.9.7(solid-js@2.0.0-beta.32)
       '@solid-primitives/refs':
         specifier: ^1.0.8
-        version: 1.1.0(solid-js@2.0.0-beta.29)
+        version: 1.1.0(solid-js@2.0.0-beta.32)
       '@solidjs/meta':
         specifier: ^0.29.4
-        version: 0.29.4(solid-js@2.0.0-beta.29)
+        version: 0.29.4(solid-js@2.0.0-beta.32)
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/history':
         specifier: workspace:*
         version: link:../history
@@ -14223,7 +14223,7 @@ importers:
     devDependencies:
       '@solidjs/testing-library':
         specifier: ^0.8.10
-        version: 0.8.10(solid-js@2.0.0-beta.29)
+        version: 0.8.10(solid-js@2.0.0-beta.32)
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.6.3
@@ -14237,14 +14237,14 @@ importers:
         specifier: ^0.14.5
         version: 0.14.5(@typescript/typescript6@6.0.2)(eslint@9.22.0(jiti@2.7.0))
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       vite:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -14252,8 +14252,8 @@ importers:
   packages/solid-router-devtools:
     dependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/router-core':
         specifier: workspace:*
         version: link:../router-core
@@ -14268,14 +14268,14 @@ importers:
         specifier: 25.0.9
         version: 25.0.9
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       vite:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   packages/solid-router-ssr-query:
     dependencies:
@@ -14287,11 +14287,11 @@ importers:
         version: link:../router-ssr-query-core
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/solid-query':
         specifier: ^6.0.0-beta.7
-        version: 6.0.0-beta.7(solid-js@2.0.0-beta.29)
+        version: 6.0.0-beta.7(solid-js@2.0.0-beta.32)
       '@tanstack/solid-router':
         specifier: workspace:*
         version: link:../solid-router
@@ -14299,14 +14299,14 @@ importers:
         specifier: ^0.14.5
         version: 0.14.5(@typescript/typescript6@6.0.2)(eslint@9.22.0(jiti@2.7.0))
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       vite:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   packages/solid-start:
     dependencies:
@@ -14336,8 +14336,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.1
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@tanstack/router-utils':
         specifier: workspace:*
         version: link:../router-utils
@@ -14345,8 +14345,8 @@ importers:
         specifier: 25.0.9
         version: 25.0.9
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       vite:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
@@ -14365,22 +14365,22 @@ importers:
     devDependencies:
       '@solidjs/testing-library':
         specifier: ^0.8.10
-        version: 0.8.10(solid-js@2.0.0-beta.29)
+        version: 0.8.10(solid-js@2.0.0-beta.32)
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.6.3
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       vite:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   packages/solid-start-server:
     dependencies:
@@ -14395,14 +14395,14 @@ importers:
         version: link:../start-server-core
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@typescript/native':
         specifier: npm:typescript@^7.0.2
         version: typescript@7.0.2
       solid-js:
-        specifier: 2.0.0-beta.29
-        version: 2.0.0-beta.29
+        specifier: 2.0.0-beta.32
+        version: 2.0.0-beta.32
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -14410,8 +14410,8 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vite-plugin-solid:
-        specifier: ^3.0.0-next.21
-        version: 3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+        specifier: ^3.0.0-next.23
+        version: 3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
 
   packages/start-client-core:
     dependencies:
@@ -15636,44 +15636,44 @@ packages:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.34':
-    resolution: {integrity: sha512-mcH1h/FgNkf9jatVCuU/tE9PUGRxQfT3862GXh+IbCcH9PKEbxQKoA3GsKpixsOmLVkbcW2auJxKIV8u8WacOw==}
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.40':
+    resolution: {integrity: sha512-elH34kK5V3fm5+AztmzpyDmlgYXkboVRPtHJhDVOfk7WPXR16dvssQjrnCjo/ulkTSP9IGTsKCOjG/zRCU74yQ==}
     peerDependencies:
       '@babel/core': ^7.20.12
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.34':
-    resolution: {integrity: sha512-MkIi1jWuVPaFoyM6qXlx3EPYXgUyySCDUJ/2zxpqzITW6/fkVvCQ++o2MrumgNFjQ/wxXdg8j0WMLcarnJ2H2Q==}
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.40':
+    resolution: {integrity: sha512-+3aXdhw4SVt08fvgAsEM56ky/wdCVPXT0Wtxo164Cchgg7sapPsRqo8Gwwn0UU5AhVcEp3CIhdB5+pMoUicKFg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.34':
-    resolution: {integrity: sha512-T7epwdLa+0WZBWvme3vHvYPz3Zc8APFsDAZh0N+OPlQywRjsIKymqP9Z5DAOScSIkZP3FERgThHk++vbv6pMhQ==}
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.40':
+    resolution: {integrity: sha512-Tbjg6ZQEIhKLKGd/Ep6MKqD76arPdV6SE2d3fkrP4qooIv2gYvAkvUw90qNdZxVHcuyjutrbJE0WpXYY9nSIIQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.34':
-    resolution: {integrity: sha512-5Q9D+qPS/djpfRrMPxCkYKkSzIweFk72hpZcKdQnXNnttmj6pi7L4rp5ZzupX3XVGTsZGXIjjuirViysfjiIoQ==}
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.40':
+    resolution: {integrity: sha512-tIJMY8dPyjiYNSL5uc4JA5l88Sw0WoMwoAilqTTHpGYdCL5GwzGq6ZOV1bndw8XKEYFYfnTr276FDHyYpLtRYQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.34':
-    resolution: {integrity: sha512-aPXMQM3KoZPOWv7AYBKz7oT9mUdPkLjJZoiYftua7AM59A4VJ+I6RvvXYnRNK28uk1zzt+IkZxrEKIQFOptDBg==}
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.40':
+    resolution: {integrity: sha512-H/K/3Ykk8aCSNuKDlv/sgbPdSks+zqFxZ4mzqaGJmlDqEfeaWYXan5fsvwQbACdNDJeKoKLO4GhnlnKlKWjiJg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.34':
-    resolution: {integrity: sha512-XpghiRyhrY5/Zxg5q1dcUCCNCSOqnNZQ1IX87MfwrDWdIZ3ZDaGrcCFUcT37veeZgzgbb3bpt5fSKwyN9VAq3w==}
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.40':
+    resolution: {integrity: sha512-2SAfc35FEvvxkUz2yeh/4aNx0s9waZnce4KS64oUMlVpYEFtNBdfnZKCB/bgzJFvTxXjMs+HcU6OInGltH5jHA==}
     engines: {node: '>=14.0.0'}
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.34':
-    resolution: {integrity: sha512-4+RLrBo//1Ruok1GG1qIDv2wn0vRWIMi5lhphp6i6H0zwUTPgOLPY6ksMz8ZyEiAIh86jBTNiLj5rKCAU4pepQ==}
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.40':
+    resolution: {integrity: sha512-bBdHMxdfUHtIrS5xrt9udqdGRnGKdYQgKxJNIts+Il3Fs8QGyNwaZpi0tjnlRjYa0+GdWEC3Gw1Pmq/HFXzFeQ==}
     cpu: [x64]
     os: [win32]
 
-  '@dom-expressions/compiler@0.50.0-next.34':
-    resolution: {integrity: sha512-XGlXicYgEKB2hesd37GT+HuctvbLRShd/G3ij2sxAIEEo6clza2jB64ZezyuuZY6iZn/QJwxAIyUVEChZ+Tl9g==}
+  '@dom-expressions/compiler@0.50.0-next.40':
+    resolution: {integrity: sha512-RI/kHU+QkLOHo4CQyqLTn9c7sAfl/GEULMsOpS1YqkPJgy7R8MCPWXFN4sI0QDBbM6ePtEyuW+2bsdsXqyxkzQ==}
 
   '@electric-sql/pglite-socket@0.0.6':
     resolution: {integrity: sha512-6RjmgzphIHIBA4NrMGJsjNWK4pu+bCWJlEWlwcxFTVY3WT86dFpKwbZaGWZV6C5Rd7sCk1Z0CI76QEfukLAUXw==}
@@ -20180,8 +20180,8 @@ packages:
     peerDependencies:
       solid-js: '>=1.8.4'
 
-  '@solidjs/signals@2.0.0-beta.29':
-    resolution: {integrity: sha512-/W4goRwA/t9SqA0acIcD008pBJr2p5BMxVpzcdvWMYNswyE88se1ecJKQO/QTa6DjVRZvplOOtKEtDRHpEo3rQ==}
+  '@solidjs/signals@2.0.0-beta.32':
+    resolution: {integrity: sha512-ZRdZksswcPRyPnye6AR3LMacc0Dn/sV/cW1jPsMgJHO5pg2iNvg+8UWojLXClIO2K3oD2ftVWeQIwyVbvM971A==}
 
   '@solidjs/testing-library@0.8.10':
     resolution: {integrity: sha512-qdeuIerwyq7oQTIrrKvV0aL9aFeuwTd86VYD3afdq5HYEwoox1OBTJy4y8A3TFZr8oAR0nujYgCzY/8wgHGfeQ==}
@@ -20193,10 +20193,10 @@ packages:
       '@solidjs/router':
         optional: true
 
-  '@solidjs/web@2.0.0-beta.29':
-    resolution: {integrity: sha512-Bsb1JP1n6OIuiCQiYlE1B3+cNY0UlDPyA1UUYC3trFudUMs0aDCxGmY/B5KXnmw4NNcRIUA2bW46h3FC9qhWXA==}
+  '@solidjs/web@2.0.0-beta.32':
+    resolution: {integrity: sha512-7HBUbGNoNnQIKTtgJRpmqZkQ5GzBt4K6d1BiHAaHksWbdYAsXkzRU7b72WtTwklN4Z2iA5MY8b5jiITlvY1noA==}
     peerDependencies:
-      solid-js: ^2.0.0-beta.29
+      solid-js: ^2.0.0-beta.32
 
   '@speed-highlight/core@1.2.14':
     resolution: {integrity: sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==}
@@ -22051,11 +22051,11 @@ packages:
       solid-js:
         optional: true
 
-  babel-preset-solid@2.0.0-beta.29:
-    resolution: {integrity: sha512-k3kDFDYdThcPZo5/PEIdZa+tYw/f4TVJomRjL7U2par3OWZxu49O3I9fHyezwEIfYjtyIyLygIKVfQ8Apu5wEg==}
+  babel-preset-solid@2.0.0-beta.32:
+    resolution: {integrity: sha512-D+ziCSJ+oznNOUHaUu6nrhSjf9sHOOdIoGhdpIFpR1yV/JqWE4kGh3wtcSzei5Hf7AdYHMv1qAr9Lz/gTxadjA==}
     peerDependencies:
       '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-beta.29
+      solid-js: ^2.0.0-beta.32
     peerDependenciesMeta:
       solid-js:
         optional: true
@@ -26736,8 +26736,8 @@ packages:
   solid-js@1.9.12:
     resolution: {integrity: sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw==}
 
-  solid-js@2.0.0-beta.29:
-    resolution: {integrity: sha512-Jv0jRw7joECw63cRfeqo5lnEVNVhAcH1hWt1nSvyp5npTgk6eyCmP5UDLTNWm6ox5G5LmBJzFkBulm+hp9+vmA==}
+  solid-js@2.0.0-beta.32:
+    resolution: {integrity: sha512-Ka7SHt7wn8JYn61sXf9neBhxIdVGes8qVIdTNgrOu7LN0SveQ6k1tGa7BCvhqvDgrciy8a9lh4oW6cZdaU3s3w==}
 
   solid-motionone@1.0.4:
     resolution: {integrity: sha512-aqEjgecoO9raDFznu/dEci7ORSmA26Kjj9J4Cn1Gyr0GZuOVdvsNxdxClTL9J40Aq/uYFx4GLwC8n70fMLHiuA==}
@@ -27846,12 +27846,12 @@ packages:
       '@testing-library/jest-dom':
         optional: true
 
-  vite-plugin-solid@3.0.0-next.21:
-    resolution: {integrity: sha512-N9NJtw87jbdcQHSmwK//bvTJpDdrcZJ8zWMko4y9dq+XPoip7kmgUZSK8hwG+d9qz8Z+WyC1fUcu78hpesbPzQ==}
+  vite-plugin-solid@3.0.0-next.23:
+    resolution: {integrity: sha512-3I5U5y5eU0wqRhFRbhpTtPpmr7yrLNowGuEM4j868vXDuzzjdc2uNhWKbIk59tUSjfIVXUYe5zDSjOXKWjRm8A==}
     peerDependencies:
-      '@solidjs/web': '>=2.0.0-beta.29 <2.0.0-experimental.0'
+      '@solidjs/web': '>=2.0.0-beta.32 <2.0.0-experimental.0'
       '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
-      solid-js: '>=2.0.0-beta.29 <2.0.0-experimental.0'
+      solid-js: '>=2.0.0-beta.32 <2.0.0-experimental.0'
       vite: ^8.0.14
     peerDependenciesMeta:
       '@testing-library/jest-dom':
@@ -29383,9 +29383,9 @@ snapshots:
 
   '@colors/colors@1.6.0': {}
 
-  '@convex-dev/better-auth@0.9.7(@standard-schema/spec@1.1.0)(@typescript/typescript6@6.0.2)(better-auth@1.6.19(@prisma/client@7.0.0(@typescript/typescript6@6.0.2)(prisma@7.0.0(@types/react@19.2.9)(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(@tanstack/solid-start@packages+solid-start)(mysql2@3.15.3)(prisma@7.0.0(@types/react@19.2.9)(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.29)(vitest@4.1.4)(vue@3.5.25(@typescript/typescript6@6.0.2)))(convex@1.28.2(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(hono@4.7.10)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@convex-dev/better-auth@0.9.7(@standard-schema/spec@1.1.0)(@typescript/typescript6@6.0.2)(better-auth@1.6.19(@prisma/client@7.0.0(@typescript/typescript6@6.0.2)(prisma@7.0.0(@types/react@19.2.9)(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(@tanstack/solid-start@packages+solid-start)(mysql2@3.15.3)(prisma@7.0.0(@types/react@19.2.9)(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.32)(vitest@4.1.4)(vue@3.5.25(@typescript/typescript6@6.0.2)))(convex@1.28.2(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(hono@4.7.10)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      better-auth: 1.6.19(@prisma/client@7.0.0(@typescript/typescript6@6.0.2)(prisma@7.0.0(@types/react@19.2.9)(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(@tanstack/solid-start@packages+solid-start)(mysql2@3.15.3)(prisma@7.0.0(@types/react@19.2.9)(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.29)(vitest@4.1.4)(vue@3.5.25(@typescript/typescript6@6.0.2))
+      better-auth: 1.6.19(@prisma/client@7.0.0(@typescript/typescript6@6.0.2)(prisma@7.0.0(@types/react@19.2.9)(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(@tanstack/solid-start@packages+solid-start)(mysql2@3.15.3)(prisma@7.0.0(@types/react@19.2.9)(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.32)(vitest@4.1.4)(vue@3.5.25(@typescript/typescript6@6.0.2))
       common-tags: 1.8.2
       convex: 1.28.2(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       convex-helpers: 0.1.104(@standard-schema/spec@1.1.0)(@typescript/typescript6@6.0.2)(convex@1.28.2(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(hono@4.7.10)(react@19.2.3)(zod@3.25.76)
@@ -29499,7 +29499,7 @@ snapshots:
 
   '@discoveryjs/json-ext@0.5.7': {}
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.34(@babel/core@7.28.5)':
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.40(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.18.6
@@ -29509,7 +29509,7 @@ snapshots:
       parse5: 7.3.0
       validate-html-nesting: 1.2.4
 
-  '@dom-expressions/babel-plugin-jsx@0.50.0-next.34(@babel/core@7.29.0)':
+  '@dom-expressions/babel-plugin-jsx@0.50.0-next.40(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.18.6
@@ -29519,36 +29519,36 @@ snapshots:
       parse5: 7.3.0
       validate-html-nesting: 1.2.4
 
-  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.34':
+  '@dom-expressions/compiler-darwin-arm64@0.50.0-next.40':
     optional: true
 
-  '@dom-expressions/compiler-darwin-x64@0.50.0-next.34':
+  '@dom-expressions/compiler-darwin-x64@0.50.0-next.40':
     optional: true
 
-  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.34':
+  '@dom-expressions/compiler-linux-arm64-gnu@0.50.0-next.40':
     optional: true
 
-  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.34':
+  '@dom-expressions/compiler-linux-x64-gnu@0.50.0-next.40':
     optional: true
 
-  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.34':
+  '@dom-expressions/compiler-wasm32-wasi@0.50.0-next.40':
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
-  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.34':
+  '@dom-expressions/compiler-win32-x64-msvc@0.50.0-next.40':
     optional: true
 
-  '@dom-expressions/compiler@0.50.0-next.34':
+  '@dom-expressions/compiler@0.50.0-next.40':
     optionalDependencies:
-      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.34
-      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.34
-      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.34
-      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.34
-      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.34
-      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.34
+      '@dom-expressions/compiler-darwin-arm64': 0.50.0-next.40
+      '@dom-expressions/compiler-darwin-x64': 0.50.0-next.40
+      '@dom-expressions/compiler-linux-arm64-gnu': 0.50.0-next.40
+      '@dom-expressions/compiler-linux-x64-gnu': 0.50.0-next.40
+      '@dom-expressions/compiler-wasm32-wasi': 0.50.0-next.40
+      '@dom-expressions/compiler-win32-x64-msvc': 0.50.0-next.40
 
   '@electric-sql/pglite-socket@0.0.6(@electric-sql/pglite@0.3.2)':
     dependencies:
@@ -33264,13 +33264,13 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-solid@2.0.0-beta.0(@babel/core@7.29.0)(@rsbuild/core@2.1.1)(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(solid-js@2.0.0-beta.29)':
+  '@rsbuild/plugin-solid@2.0.0-beta.0(@babel/core@7.29.0)(@rsbuild/core@2.1.1)(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(solid-js@2.0.0-beta.32)':
     dependencies:
       '@rsbuild/plugin-babel': 1.1.2(@rsbuild/core@2.1.1)
-      '@solidjs/web': 2.0.0-beta.29(solid-js@2.0.0-beta.29)
-      babel-preset-solid: 2.0.0-beta.29(@babel/core@7.29.0)(solid-js@2.0.0-beta.29)
-      solid-js: 2.0.0-beta.29
-      solid-refresh: 0.8.0-next.7(solid-js@2.0.0-beta.29)
+      '@solidjs/web': 2.0.0-beta.32(solid-js@2.0.0-beta.32)
+      babel-preset-solid: 2.0.0-beta.32(@babel/core@7.29.0)(solid-js@2.0.0-beta.32)
+      solid-js: 2.0.0-beta.32
+      solid-refresh: 0.8.0-next.7(solid-js@2.0.0-beta.32)
     optionalDependencies:
       '@rsbuild/core': 2.1.1
     transitivePeerDependencies:
@@ -33622,11 +33622,11 @@ snapshots:
       hoist-non-react-statics: 3.3.2
       react: 19.2.3
 
-  '@sentry/solid@10.32.0(@tanstack/solid-router@packages+solid-router)(solid-js@2.0.0-beta.29)':
+  '@sentry/solid@10.32.0(@tanstack/solid-router@packages+solid-router)(solid-js@2.0.0-beta.32)':
     dependencies:
       '@sentry/browser': 10.32.0
       '@sentry/core': 10.32.0
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
     optionalDependencies:
       '@tanstack/solid-router': link:packages/solid-router
 
@@ -33669,184 +33669,184 @@ snapshots:
       color: 5.0.2
       text-hex: 1.0.0
 
-  '@solid-devtools/debugger@0.26.0(solid-js@2.0.0-beta.29)':
+  '@solid-devtools/debugger@0.26.0(solid-js@2.0.0-beta.32)':
     dependencies:
       '@nothing-but/utils': 0.17.0
-      '@solid-devtools/shared': 0.19.0(solid-js@2.0.0-beta.29)
-      '@solid-primitives/bounds': 0.0.122(solid-js@2.0.0-beta.29)
-      '@solid-primitives/cursor': 0.0.115(solid-js@2.0.0-beta.29)
-      '@solid-primitives/event-listener': 2.4.0(solid-js@2.0.0-beta.29)
-      '@solid-primitives/keyboard': 1.3.0(solid-js@2.0.0-beta.29)
-      '@solid-primitives/platform': 0.1.2(solid-js@2.0.0-beta.29)
-      '@solid-primitives/rootless': 1.5.0(solid-js@2.0.0-beta.29)
-      '@solid-primitives/scheduled': 1.5.0(solid-js@2.0.0-beta.29)
-      '@solid-primitives/static-store': 0.0.8(solid-js@2.0.0-beta.29)
-      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.29)
-      solid-js: 2.0.0-beta.29
+      '@solid-devtools/shared': 0.19.0(solid-js@2.0.0-beta.32)
+      '@solid-primitives/bounds': 0.0.122(solid-js@2.0.0-beta.32)
+      '@solid-primitives/cursor': 0.0.115(solid-js@2.0.0-beta.32)
+      '@solid-primitives/event-listener': 2.4.0(solid-js@2.0.0-beta.32)
+      '@solid-primitives/keyboard': 1.3.0(solid-js@2.0.0-beta.32)
+      '@solid-primitives/platform': 0.1.2(solid-js@2.0.0-beta.32)
+      '@solid-primitives/rootless': 1.5.0(solid-js@2.0.0-beta.32)
+      '@solid-primitives/scheduled': 1.5.0(solid-js@2.0.0-beta.32)
+      '@solid-primitives/static-store': 0.0.8(solid-js@2.0.0-beta.32)
+      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.32)
+      solid-js: 2.0.0-beta.32
 
-  '@solid-devtools/logger@0.9.7(solid-js@2.0.0-beta.29)':
+  '@solid-devtools/logger@0.9.7(solid-js@2.0.0-beta.32)':
     dependencies:
       '@nothing-but/utils': 0.17.0
-      '@solid-devtools/debugger': 0.26.0(solid-js@2.0.0-beta.29)
-      '@solid-devtools/shared': 0.19.0(solid-js@2.0.0-beta.29)
-      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.29)
-      solid-js: 2.0.0-beta.29
+      '@solid-devtools/debugger': 0.26.0(solid-js@2.0.0-beta.32)
+      '@solid-devtools/shared': 0.19.0(solid-js@2.0.0-beta.32)
+      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.32)
+      solid-js: 2.0.0-beta.32
 
-  '@solid-devtools/shared@0.19.0(solid-js@2.0.0-beta.29)':
+  '@solid-devtools/shared@0.19.0(solid-js@2.0.0-beta.32)':
     dependencies:
       '@nothing-but/utils': 0.17.0
-      '@solid-primitives/event-listener': 2.4.0(solid-js@2.0.0-beta.29)
-      '@solid-primitives/media': 2.3.0(solid-js@2.0.0-beta.29)
-      '@solid-primitives/refs': 1.1.0(solid-js@2.0.0-beta.29)
-      '@solid-primitives/rootless': 1.5.0(solid-js@2.0.0-beta.29)
-      '@solid-primitives/scheduled': 1.5.0(solid-js@2.0.0-beta.29)
-      '@solid-primitives/static-store': 0.0.8(solid-js@2.0.0-beta.29)
-      '@solid-primitives/styles': 0.0.114(solid-js@2.0.0-beta.29)
-      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.29)
-      solid-js: 2.0.0-beta.29
+      '@solid-primitives/event-listener': 2.4.0(solid-js@2.0.0-beta.32)
+      '@solid-primitives/media': 2.3.0(solid-js@2.0.0-beta.32)
+      '@solid-primitives/refs': 1.1.0(solid-js@2.0.0-beta.32)
+      '@solid-primitives/rootless': 1.5.0(solid-js@2.0.0-beta.32)
+      '@solid-primitives/scheduled': 1.5.0(solid-js@2.0.0-beta.32)
+      '@solid-primitives/static-store': 0.0.8(solid-js@2.0.0-beta.32)
+      '@solid-primitives/styles': 0.0.114(solid-js@2.0.0-beta.32)
+      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.32)
+      solid-js: 2.0.0-beta.32
 
-  '@solid-primitives/bounds@0.0.122(solid-js@2.0.0-beta.29)':
+  '@solid-primitives/bounds@0.0.122(solid-js@2.0.0-beta.32)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.0(solid-js@2.0.0-beta.29)
-      '@solid-primitives/resize-observer': 2.1.0(solid-js@2.0.0-beta.29)
-      '@solid-primitives/static-store': 0.0.8(solid-js@2.0.0-beta.29)
-      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.29)
-      solid-js: 2.0.0-beta.29
+      '@solid-primitives/event-listener': 2.4.0(solid-js@2.0.0-beta.32)
+      '@solid-primitives/resize-observer': 2.1.0(solid-js@2.0.0-beta.32)
+      '@solid-primitives/static-store': 0.0.8(solid-js@2.0.0-beta.32)
+      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.32)
+      solid-js: 2.0.0-beta.32
 
-  '@solid-primitives/context@0.3.2(solid-js@2.0.0-beta.29)':
+  '@solid-primitives/context@0.3.2(solid-js@2.0.0-beta.32)':
     dependencies:
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
 
-  '@solid-primitives/cursor@0.0.115(solid-js@2.0.0-beta.29)':
+  '@solid-primitives/cursor@0.0.115(solid-js@2.0.0-beta.32)':
     dependencies:
-      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.29)
-      solid-js: 2.0.0-beta.29
+      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.32)
+      solid-js: 2.0.0-beta.32
 
-  '@solid-primitives/event-listener@2.4.0(solid-js@2.0.0-beta.29)':
+  '@solid-primitives/event-listener@2.4.0(solid-js@2.0.0-beta.32)':
     dependencies:
-      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.29)
-      solid-js: 2.0.0-beta.29
+      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.32)
+      solid-js: 2.0.0-beta.32
 
-  '@solid-primitives/event-listener@2.4.3(solid-js@2.0.0-beta.29)':
+  '@solid-primitives/event-listener@2.4.3(solid-js@2.0.0-beta.32)':
     dependencies:
-      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.29)
-      solid-js: 2.0.0-beta.29
+      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.32)
+      solid-js: 2.0.0-beta.32
 
-  '@solid-primitives/keyboard@1.3.0(solid-js@2.0.0-beta.29)':
+  '@solid-primitives/keyboard@1.3.0(solid-js@2.0.0-beta.32)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.0(solid-js@2.0.0-beta.29)
-      '@solid-primitives/rootless': 1.5.0(solid-js@2.0.0-beta.29)
-      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.29)
-      solid-js: 2.0.0-beta.29
+      '@solid-primitives/event-listener': 2.4.0(solid-js@2.0.0-beta.32)
+      '@solid-primitives/rootless': 1.5.0(solid-js@2.0.0-beta.32)
+      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.32)
+      solid-js: 2.0.0-beta.32
 
-  '@solid-primitives/keyboard@1.3.3(solid-js@2.0.0-beta.29)':
+  '@solid-primitives/keyboard@1.3.3(solid-js@2.0.0-beta.32)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.3(solid-js@2.0.0-beta.29)
-      '@solid-primitives/rootless': 1.5.2(solid-js@2.0.0-beta.29)
-      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.29)
-      solid-js: 2.0.0-beta.29
+      '@solid-primitives/event-listener': 2.4.3(solid-js@2.0.0-beta.32)
+      '@solid-primitives/rootless': 1.5.2(solid-js@2.0.0-beta.32)
+      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.32)
+      solid-js: 2.0.0-beta.32
 
-  '@solid-primitives/media@2.3.0(solid-js@2.0.0-beta.29)':
+  '@solid-primitives/media@2.3.0(solid-js@2.0.0-beta.32)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.0(solid-js@2.0.0-beta.29)
-      '@solid-primitives/rootless': 1.5.0(solid-js@2.0.0-beta.29)
-      '@solid-primitives/static-store': 0.1.0(solid-js@2.0.0-beta.29)
-      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.29)
-      solid-js: 2.0.0-beta.29
+      '@solid-primitives/event-listener': 2.4.0(solid-js@2.0.0-beta.32)
+      '@solid-primitives/rootless': 1.5.0(solid-js@2.0.0-beta.32)
+      '@solid-primitives/static-store': 0.1.0(solid-js@2.0.0-beta.32)
+      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.32)
+      solid-js: 2.0.0-beta.32
 
-  '@solid-primitives/platform@0.1.2(solid-js@2.0.0-beta.29)':
+  '@solid-primitives/platform@0.1.2(solid-js@2.0.0-beta.32)':
     dependencies:
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
 
-  '@solid-primitives/props@3.2.2(solid-js@2.0.0-beta.29)':
+  '@solid-primitives/props@3.2.2(solid-js@2.0.0-beta.32)':
     dependencies:
-      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.29)
-      solid-js: 2.0.0-beta.29
+      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.32)
+      solid-js: 2.0.0-beta.32
 
-  '@solid-primitives/refs@1.1.0(solid-js@2.0.0-beta.29)':
+  '@solid-primitives/refs@1.1.0(solid-js@2.0.0-beta.32)':
     dependencies:
-      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.29)
-      solid-js: 2.0.0-beta.29
+      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.32)
+      solid-js: 2.0.0-beta.32
 
-  '@solid-primitives/resize-observer@2.1.0(solid-js@2.0.0-beta.29)':
+  '@solid-primitives/resize-observer@2.1.0(solid-js@2.0.0-beta.32)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.0(solid-js@2.0.0-beta.29)
-      '@solid-primitives/rootless': 1.5.0(solid-js@2.0.0-beta.29)
-      '@solid-primitives/static-store': 0.1.0(solid-js@2.0.0-beta.29)
-      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.29)
-      solid-js: 2.0.0-beta.29
+      '@solid-primitives/event-listener': 2.4.0(solid-js@2.0.0-beta.32)
+      '@solid-primitives/rootless': 1.5.0(solid-js@2.0.0-beta.32)
+      '@solid-primitives/static-store': 0.1.0(solid-js@2.0.0-beta.32)
+      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.32)
+      solid-js: 2.0.0-beta.32
 
-  '@solid-primitives/resize-observer@2.1.3(solid-js@2.0.0-beta.29)':
+  '@solid-primitives/resize-observer@2.1.3(solid-js@2.0.0-beta.32)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.3(solid-js@2.0.0-beta.29)
-      '@solid-primitives/rootless': 1.5.2(solid-js@2.0.0-beta.29)
-      '@solid-primitives/static-store': 0.1.2(solid-js@2.0.0-beta.29)
-      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.29)
-      solid-js: 2.0.0-beta.29
+      '@solid-primitives/event-listener': 2.4.3(solid-js@2.0.0-beta.32)
+      '@solid-primitives/rootless': 1.5.2(solid-js@2.0.0-beta.32)
+      '@solid-primitives/static-store': 0.1.2(solid-js@2.0.0-beta.32)
+      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.32)
+      solid-js: 2.0.0-beta.32
 
-  '@solid-primitives/rootless@1.5.0(solid-js@2.0.0-beta.29)':
+  '@solid-primitives/rootless@1.5.0(solid-js@2.0.0-beta.32)':
     dependencies:
-      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.29)
-      solid-js: 2.0.0-beta.29
+      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.32)
+      solid-js: 2.0.0-beta.32
 
-  '@solid-primitives/rootless@1.5.2(solid-js@2.0.0-beta.29)':
+  '@solid-primitives/rootless@1.5.2(solid-js@2.0.0-beta.32)':
     dependencies:
-      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.29)
-      solid-js: 2.0.0-beta.29
+      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.32)
+      solid-js: 2.0.0-beta.32
 
-  '@solid-primitives/scheduled@1.5.0(solid-js@2.0.0-beta.29)':
+  '@solid-primitives/scheduled@1.5.0(solid-js@2.0.0-beta.32)':
     dependencies:
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
 
-  '@solid-primitives/static-store@0.0.8(solid-js@2.0.0-beta.29)':
+  '@solid-primitives/static-store@0.0.8(solid-js@2.0.0-beta.32)':
     dependencies:
-      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.29)
-      solid-js: 2.0.0-beta.29
+      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.32)
+      solid-js: 2.0.0-beta.32
 
-  '@solid-primitives/static-store@0.1.0(solid-js@2.0.0-beta.29)':
+  '@solid-primitives/static-store@0.1.0(solid-js@2.0.0-beta.32)':
     dependencies:
-      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.29)
-      solid-js: 2.0.0-beta.29
+      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.32)
+      solid-js: 2.0.0-beta.32
 
-  '@solid-primitives/static-store@0.1.2(solid-js@2.0.0-beta.29)':
+  '@solid-primitives/static-store@0.1.2(solid-js@2.0.0-beta.32)':
     dependencies:
-      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.29)
-      solid-js: 2.0.0-beta.29
+      '@solid-primitives/utils': 6.3.2(solid-js@2.0.0-beta.32)
+      solid-js: 2.0.0-beta.32
 
-  '@solid-primitives/styles@0.0.114(solid-js@2.0.0-beta.29)':
+  '@solid-primitives/styles@0.0.114(solid-js@2.0.0-beta.32)':
     dependencies:
-      '@solid-primitives/rootless': 1.5.0(solid-js@2.0.0-beta.29)
-      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.29)
-      solid-js: 2.0.0-beta.29
+      '@solid-primitives/rootless': 1.5.0(solid-js@2.0.0-beta.32)
+      '@solid-primitives/utils': 6.3.0(solid-js@2.0.0-beta.32)
+      solid-js: 2.0.0-beta.32
 
-  '@solid-primitives/transition-group@1.1.2(solid-js@2.0.0-beta.29)':
+  '@solid-primitives/transition-group@1.1.2(solid-js@2.0.0-beta.32)':
     dependencies:
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
 
-  '@solid-primitives/utils@6.3.0(solid-js@2.0.0-beta.29)':
+  '@solid-primitives/utils@6.3.0(solid-js@2.0.0-beta.32)':
     dependencies:
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
 
-  '@solid-primitives/utils@6.3.2(solid-js@2.0.0-beta.29)':
+  '@solid-primitives/utils@6.3.2(solid-js@2.0.0-beta.32)':
     dependencies:
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
 
-  '@solidjs/meta@0.29.4(solid-js@2.0.0-beta.29)':
+  '@solidjs/meta@0.29.4(solid-js@2.0.0-beta.32)':
     dependencies:
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
 
-  '@solidjs/signals@2.0.0-beta.29': {}
+  '@solidjs/signals@2.0.0-beta.32': {}
 
-  '@solidjs/testing-library@0.8.10(solid-js@2.0.0-beta.29)':
+  '@solidjs/testing-library@0.8.10(solid-js@2.0.0-beta.32)':
     dependencies:
       '@testing-library/dom': 10.4.1
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
 
-  '@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29)':
+  '@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32)':
     dependencies:
       seroval: 1.5.4
       seroval-plugins: 1.5.4(seroval@1.5.4)
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
 
   '@speed-highlight/core@1.2.14': {}
 
@@ -34189,46 +34189,46 @@ snapshots:
 
   '@tanstack/devtools-event-client@0.3.4': {}
 
-  '@tanstack/devtools-ui@0.3.5(csstype@3.2.3)(solid-js@2.0.0-beta.29)':
+  '@tanstack/devtools-ui@0.3.5(csstype@3.2.3)(solid-js@2.0.0-beta.32)':
     dependencies:
       clsx: 2.1.1
       goober: 2.1.16(csstype@3.2.3)
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
     transitivePeerDependencies:
       - csstype
 
-  '@tanstack/devtools-ui@0.4.4(csstype@3.2.3)(solid-js@2.0.0-beta.29)':
+  '@tanstack/devtools-ui@0.4.4(csstype@3.2.3)(solid-js@2.0.0-beta.32)':
     dependencies:
       clsx: 2.1.1
       goober: 2.1.16(csstype@3.2.3)
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
     transitivePeerDependencies:
       - csstype
 
-  '@tanstack/devtools@0.6.14(csstype@3.2.3)(solid-js@2.0.0-beta.29)':
+  '@tanstack/devtools@0.6.14(csstype@3.2.3)(solid-js@2.0.0-beta.32)':
     dependencies:
-      '@solid-primitives/keyboard': 1.3.0(solid-js@2.0.0-beta.29)
+      '@solid-primitives/keyboard': 1.3.0(solid-js@2.0.0-beta.32)
       '@tanstack/devtools-event-bus': 0.3.2
-      '@tanstack/devtools-ui': 0.3.5(csstype@3.2.3)(solid-js@2.0.0-beta.29)
+      '@tanstack/devtools-ui': 0.3.5(csstype@3.2.3)(solid-js@2.0.0-beta.32)
       clsx: 2.1.1
       goober: 2.1.16(csstype@3.2.3)
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
     transitivePeerDependencies:
       - bufferutil
       - csstype
       - utf-8-validate
 
-  '@tanstack/devtools@0.8.1(csstype@3.2.3)(solid-js@2.0.0-beta.29)':
+  '@tanstack/devtools@0.8.1(csstype@3.2.3)(solid-js@2.0.0-beta.32)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.3(solid-js@2.0.0-beta.29)
-      '@solid-primitives/keyboard': 1.3.3(solid-js@2.0.0-beta.29)
-      '@solid-primitives/resize-observer': 2.1.3(solid-js@2.0.0-beta.29)
+      '@solid-primitives/event-listener': 2.4.3(solid-js@2.0.0-beta.32)
+      '@solid-primitives/keyboard': 1.3.3(solid-js@2.0.0-beta.32)
+      '@solid-primitives/resize-observer': 2.1.3(solid-js@2.0.0-beta.32)
       '@tanstack/devtools-client': 0.0.4
       '@tanstack/devtools-event-bus': 0.3.3
-      '@tanstack/devtools-ui': 0.4.4(csstype@3.2.3)(solid-js@2.0.0-beta.29)
+      '@tanstack/devtools-ui': 0.4.4(csstype@3.2.3)(solid-js@2.0.0-beta.32)
       clsx: 2.1.1
       goober: 2.1.16(csstype@3.2.3)
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
     transitivePeerDependencies:
       - bufferutil
       - csstype
@@ -34280,9 +34280,9 @@ snapshots:
 
   '@tanstack/query-devtools@5.91.1': {}
 
-  '@tanstack/react-devtools@0.7.0(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(csstype@3.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.29)':
+  '@tanstack/react-devtools@0.7.0(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(csstype@3.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.32)':
     dependencies:
-      '@tanstack/devtools': 0.6.14(csstype@3.2.3)(solid-js@2.0.0-beta.29)
+      '@tanstack/devtools': 0.6.14(csstype@3.2.3)(solid-js@2.0.0-beta.32)
       '@types/react': 19.2.9
       '@types/react-dom': 19.2.3(@types/react@19.2.9)
       react: 19.2.3
@@ -34323,30 +34323,30 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@tanstack/solid-devtools@0.7.14(csstype@3.2.3)(solid-js@2.0.0-beta.29)':
+  '@tanstack/solid-devtools@0.7.14(csstype@3.2.3)(solid-js@2.0.0-beta.32)':
     dependencies:
-      '@tanstack/devtools': 0.8.1(csstype@3.2.3)(solid-js@2.0.0-beta.29)
-      solid-js: 2.0.0-beta.29
+      '@tanstack/devtools': 0.8.1(csstype@3.2.3)(solid-js@2.0.0-beta.32)
+      solid-js: 2.0.0-beta.32
     transitivePeerDependencies:
       - bufferutil
       - csstype
       - utf-8-validate
 
-  '@tanstack/solid-query-devtools@6.0.0-beta.7(@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.29))(solid-js@2.0.0-beta.29)':
+  '@tanstack/solid-query-devtools@6.0.0-beta.7(@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.32))(solid-js@2.0.0-beta.32)':
     dependencies:
       '@tanstack/query-devtools': 5.101.0
-      '@tanstack/solid-query': 6.0.0-beta.7(solid-js@2.0.0-beta.29)
-      solid-js: 2.0.0-beta.29
+      '@tanstack/solid-query': 6.0.0-beta.7(solid-js@2.0.0-beta.32)
+      solid-js: 2.0.0-beta.32
 
-  '@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.29)':
+  '@tanstack/solid-query@6.0.0-beta.7(solid-js@2.0.0-beta.32)':
     dependencies:
       '@tanstack/query-core': 5.99.0
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
 
-  '@tanstack/solid-virtual@3.13.12(solid-js@2.0.0-beta.29)':
+  '@tanstack/solid-virtual@3.13.12(solid-js@2.0.0-beta.32)':
     dependencies:
       '@tanstack/virtual-core': 3.13.12
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
 
   '@tanstack/store@0.9.3': {}
 
@@ -36303,33 +36303,33 @@ snapshots:
     optionalDependencies:
       solid-js: 1.9.12
 
-  babel-preset-solid@1.9.10(@babel/core@7.28.5)(solid-js@2.0.0-beta.29):
+  babel-preset-solid@1.9.10(@babel/core@7.28.5)(solid-js@2.0.0-beta.32):
     dependencies:
       '@babel/core': 7.28.5
       babel-plugin-jsx-dom-expressions: 0.40.3(@babel/core@7.28.5)
     optionalDependencies:
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
 
-  babel-preset-solid@1.9.10(@babel/core@7.29.0)(solid-js@2.0.0-beta.29):
+  babel-preset-solid@1.9.10(@babel/core@7.29.0)(solid-js@2.0.0-beta.32):
     dependencies:
       '@babel/core': 7.29.0
       babel-plugin-jsx-dom-expressions: 0.40.3(@babel/core@7.29.0)
     optionalDependencies:
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
 
-  babel-preset-solid@2.0.0-beta.29(@babel/core@7.28.5)(solid-js@2.0.0-beta.29):
+  babel-preset-solid@2.0.0-beta.32(@babel/core@7.28.5)(solid-js@2.0.0-beta.32):
     dependencies:
       '@babel/core': 7.28.5
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.34(@babel/core@7.28.5)
+      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.40(@babel/core@7.28.5)
     optionalDependencies:
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
 
-  babel-preset-solid@2.0.0-beta.29(@babel/core@7.29.0)(solid-js@2.0.0-beta.29):
+  babel-preset-solid@2.0.0-beta.32(@babel/core@7.29.0)(solid-js@2.0.0-beta.32):
     dependencies:
       '@babel/core': 7.29.0
-      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.34(@babel/core@7.29.0)
+      '@dom-expressions/babel-plugin-jsx': 0.50.0-next.40(@babel/core@7.29.0)
     optionalDependencies:
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
 
   balanced-match@1.0.2: {}
 
@@ -36382,7 +36382,7 @@ snapshots:
       jsonpointer: 5.0.1
       leven: 3.1.0
 
-  better-auth@1.6.19(@prisma/client@7.0.0(@typescript/typescript6@6.0.2)(prisma@7.0.0(@types/react@19.2.9)(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(@tanstack/solid-start@packages+solid-start)(mysql2@3.15.3)(prisma@7.0.0(@types/react@19.2.9)(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.29)(vitest@4.1.4)(vue@3.5.25(@typescript/typescript6@6.0.2)):
+  better-auth@1.6.19(@prisma/client@7.0.0(@typescript/typescript6@6.0.2)(prisma@7.0.0(@types/react@19.2.9)(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(@tanstack/solid-start@packages+solid-start)(mysql2@3.15.3)(prisma@7.0.0(@types/react@19.2.9)(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.32)(vitest@4.1.4)(vue@3.5.25(@typescript/typescript6@6.0.2)):
     dependencies:
       '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.1.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.1.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
@@ -36408,7 +36408,7 @@ snapshots:
       prisma: 7.0.0(@types/react@19.2.9)(@typescript/typescript6@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
       vitest: 4.1.4(@types/node@25.0.9)(@vitest/ui@4.1.4)(jsdom@29.1.1(@noble/hashes@2.0.1))(msw@2.7.0(@types/node@25.0.9)(@typescript/typescript6@6.0.2))(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
       vue: 3.5.25(@typescript/typescript6@6.0.2)
     transitivePeerDependencies:
@@ -36913,11 +36913,11 @@ snapshots:
       typescript: '@typescript/typescript6@6.0.2'
       zod: 3.25.76
 
-  convex-solidjs@0.0.3(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.29):
+  convex-solidjs@0.0.3(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(solid-js@2.0.0-beta.32):
     dependencies:
-      '@solid-primitives/context': 0.3.2(solid-js@2.0.0-beta.29)
+      '@solid-primitives/context': 0.3.2(solid-js@2.0.0-beta.32)
       convex: 1.28.2(@clerk/clerk-react@5.59.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
     transitivePeerDependencies:
       - '@auth0/auth0-react'
       - '@clerk/clerk-react'
@@ -37539,13 +37539,13 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
-  esbuild-plugin-solid@0.6.0(esbuild@0.27.4)(solid-js@2.0.0-beta.29):
+  esbuild-plugin-solid@0.6.0(esbuild@0.27.4)(solid-js@2.0.0-beta.32):
     dependencies:
       '@babel/core': 7.28.5
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.5)
-      babel-preset-solid: 1.9.10(@babel/core@7.28.5)(solid-js@2.0.0-beta.29)
+      babel-preset-solid: 1.9.10(@babel/core@7.28.5)(solid-js@2.0.0-beta.32)
       esbuild: 0.27.4
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
     transitivePeerDependencies:
       - supports-color
 
@@ -41801,22 +41801,22 @@ snapshots:
       seroval: 1.5.4
       seroval-plugins: 1.5.4(seroval@1.5.4)
 
-  solid-js@2.0.0-beta.29:
+  solid-js@2.0.0-beta.32:
     dependencies:
-      '@solidjs/signals': 2.0.0-beta.29
+      '@solidjs/signals': 2.0.0-beta.32
       csstype: 3.2.3
       seroval: 1.5.4
       seroval-plugins: 1.5.4(seroval@1.5.4)
 
-  solid-motionone@1.0.4(solid-js@2.0.0-beta.29):
+  solid-motionone@1.0.4(solid-js@2.0.0-beta.32):
     dependencies:
       '@motionone/dom': 10.18.0
       '@motionone/utils': 10.18.0
-      '@solid-primitives/props': 3.2.2(solid-js@2.0.0-beta.29)
-      '@solid-primitives/refs': 1.1.0(solid-js@2.0.0-beta.29)
-      '@solid-primitives/transition-group': 1.1.2(solid-js@2.0.0-beta.29)
+      '@solid-primitives/props': 3.2.2(solid-js@2.0.0-beta.32)
+      '@solid-primitives/refs': 1.1.0(solid-js@2.0.0-beta.32)
+      '@solid-primitives/transition-group': 1.1.2(solid-js@2.0.0-beta.32)
       csstype: 3.1.3
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
 
   solid-refresh@0.6.3(solid-js@1.9.12):
     dependencies:
@@ -41827,20 +41827,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  solid-refresh@0.6.3(solid-js@2.0.0-beta.29):
+  solid-refresh@0.6.3(solid-js@2.0.0-beta.32):
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/helper-module-imports': 7.28.6
       '@babel/types': 7.29.0
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
     transitivePeerDependencies:
       - supports-color
 
-  solid-refresh@0.8.0-next.7(solid-js@2.0.0-beta.29):
+  solid-refresh@0.8.0-next.7(solid-js@2.0.0-beta.32):
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/types': 7.29.0
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
 
   sonic-boom@4.2.0:
     dependencies:
@@ -42733,14 +42733,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@2.11.11(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)):
+  vite-plugin-solid@2.11.11(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)):
     dependencies:
       '@babel/core': 7.29.0
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 1.9.10(@babel/core@7.29.0)(solid-js@2.0.0-beta.29)
+      babel-preset-solid: 1.9.10(@babel/core@7.29.0)(solid-js@2.0.0-beta.32)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.29
-      solid-refresh: 0.6.3(solid-js@2.0.0-beta.29)
+      solid-js: 2.0.0-beta.32
+      solid-refresh: 0.6.3(solid-js@2.0.0-beta.32)
       vite: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
       vitefu: 1.1.1(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
     optionalDependencies:
@@ -42748,18 +42748,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@3.0.0-next.21(@solidjs/web@2.0.0-beta.29(solid-js@2.0.0-beta.29))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.29)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)):
+  vite-plugin-solid@3.0.0-next.23(@solidjs/web@2.0.0-beta.32(solid-js@2.0.0-beta.32))(@testing-library/jest-dom@6.6.3)(solid-js@2.0.0-beta.32)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)):
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.29.0
-      '@dom-expressions/compiler': 0.50.0-next.34
-      '@solidjs/web': 2.0.0-beta.29(solid-js@2.0.0-beta.29)
+      '@dom-expressions/compiler': 0.50.0-next.40
+      '@solidjs/web': 2.0.0-beta.32(solid-js@2.0.0-beta.32)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-beta.29(@babel/core@7.29.0)(solid-js@2.0.0-beta.29)
+      babel-preset-solid: 2.0.0-beta.32(@babel/core@7.29.0)(solid-js@2.0.0-beta.32)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.29
+      solid-js: 2.0.0-beta.32
       vite: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
-      vitefu: 1.1.1(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
+      vitefu: 1.1.3(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
     optionalDependencies:
       '@testing-library/jest-dom': 6.6.3
     transitivePeerDependencies:


### PR DESCRIPTION
Upgrades to the latest Solid 2.0 beta (skips over beta.30/31) and the latest plugin.

- `solid-js`, `@solidjs/web`, `babel-preset-solid` → `2.0.0-beta.32`
- `vite-plugin-solid` → `3.0.0-next.23` (peer-requires `>=2.0.0-beta.32`, ships `@dom-expressions/compiler@0.50.0-next.40`)

### Breaking change handled: `renderToStringAsync` removed

beta.32's `@solidjs/web` exports only `render`, `renderToString` (now synchronous-only), and `renderToStream`. The replacement for the old async-settled string render is built into the stream object: `await renderToStream(...)` resolves with the complete HTML once every boundary settles. The two server test files in `packages/solid-router` were migrated accordingly; no runtime source used the removed API.

## Verification

| Suite | Result |
| --- | --- |
| `packages/solid-router` `test:unit` (client) | 838 passed, 2 skipped, no type errors |
| `packages/solid-router` `test:unit` (server) | 2 passed |
| `e2e/solid-start/basic` build + e2e | 80 passed, 4 skipped |

Counts match the beta.29 baseline (client suite grew 814 → 838 from tests added on the base branch since). Lockfile audited: zero stale beta.29/next.21 resolutions, transitive `babel-preset-solid` moved to beta.32 on a plain install (no lockfile surgery needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)