### PR TITLE
fix: Change import statement to use type keyword

### DIFF
--- a/docs/start/framework/react/tutorial/reading-writing-file.md
+++ b/docs/start/framework/react/tutorial/reading-writing-file.md
@@ -178,7 +178,7 @@ Now let's create a new component `JokesList` to render the jokes on the page wit
 
 ```tsx
 // src/components/JokesList.tsx
-import { Joke } from '../types'
+import type { Joke } from '../types'
 
 interface JokesListProps {
   jokes: Joke[]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the React tutorial example to use a type-only import, ensuring cleaner generated output without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->