### PR TITLE
fix(router-core): handle excessive parent relative links

### DIFF
--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -953,6 +953,26 @@ describe('Link', () => {
         expect(relativeFoo).toHaveAttribute('href', '/invoices/foo')
       })
     })
+
+    test('relative links from root keep javascript-like segments rooted', async () => {
+      const rootRoute = createRootRoute()
+      const indexRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/',
+        component: () => <Link to="../javascript:alert(1)">Continue</Link>,
+      })
+
+      const router = createRouter({
+        routeTree: rootRoute.addChildren([indexRoute]),
+        history: createMemoryHistory({ initialEntries: ['/'] }),
+      })
+
+      render(<RouterProvider router={router} />)
+
+      expect(
+        await screen.findByRole('link', { name: 'Continue' }),
+      ).toHaveAttribute('href', '/javascript:alert(1)')
+    })
   })
 
   test('when the current route is the root with beforeLoad that throws', async () => {

--- a/packages/router-core/src/path.ts
+++ b/packages/router-core/src/path.ts
@@ -112,8 +112,8 @@ export function resolvePath({
   trailingSlash = 'never',
   cache,
 }: ResolvePathOptions) {
+  const isBase = to === '.'
   const isAbsolute = to.startsWith('/')
-  const isBase = !isAbsolute && to === '.'
 
   let key
   if (cache) {
@@ -148,7 +148,11 @@ export function resolvePath({
           // ignore inter-slashes
         }
       } else if (value === '..') {
-        baseSegments.pop()
+        if (baseSegments.length > 1) {
+          baseSegments.pop()
+        } else {
+          baseSegments = ['']
+        }
       } else if (value === '.') {
         // ignore
       } else {

--- a/packages/router-core/tests/build-location.test.ts
+++ b/packages/router-core/tests/build-location.test.ts
@@ -1300,6 +1300,31 @@ describe('buildLocation - relative paths', () => {
     expect(location.pathname).toBe('/a/d')
   })
 
+  test('over-root traversal stays rooted for javascript-like segments', async () => {
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+
+    const routeTree = rootRoute.addChildren([indexRoute])
+
+    const router = createTestRouter({
+      routeTree,
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+
+    const location = router.buildLocation({
+      to: '../javascript:alert(1)',
+    })
+
+    expect(location.pathname).toBe('/javascript:alert(1)')
+    expect(location.href).toBe('/javascript:alert(1)')
+    expect(location.publicHref).toBe('/javascript:alert(1)')
+  })
+
   test('. should stay on current route', async () => {
     const rootRoute = new BaseRootRoute({})
     const postsRoute = new BaseRoute({

--- a/packages/router-core/tests/path.test.ts
+++ b/packages/router-core/tests/path.test.ts
@@ -94,6 +94,9 @@ describe('resolvePath', () => {
     ['/', 'a/', '/a'],
     ['/', '/a/b', '/a/b'],
     ['/a', 'b', '/a/b'],
+    ['/a', '', '/'],
+    ['/a', '.well-known', '/a/.well-known'],
+    ['/a', '/absolute', '/absolute'],
     ['/', 'a/b', '/a/b'],
     ['/', './a/b', '/a/b'],
     ['/a/b/c', 'd', '/a/b/c/d'],
@@ -106,6 +109,8 @@ describe('resolvePath', () => {
     ['/a/b/c', '../..', '/a'],
     ['/a/b/c', '../../..', '/'],
     ['/a/b/c/', '../../..', '/'],
+    ['/', '../javascript:alert(1)', '/javascript:alert(1)'],
+    ['/posts', '../../data:text/html,test', '/data:text/html,test'],
   ])('resolves correctly', (a, b, eq) => {
     it(`${a} to ${b} === ${eq}`, () => {
       expect(resolvePath({ base: a, to: b })).toEqual(eq)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relative path handling to keep navigation safely within the application root.
  * Correctly normalized empty, dot-prefixed, absolute, and parent-directory paths.

* **Tests**
  * Added regression coverage for root traversal and potentially unsafe-looking URL segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->