### PR TITLE
[Documentation] Update Chicane url

### DIFF
--- a/docs/router/overview.md
+++ b/docs/router/overview.md
@@ -131,7 +131,7 @@ TanStack Router builds on concepts and patterns popularized by many other OSS pr
 
 - [TRPC](https://trpc.io/)
 - [Remix](https://remix.run)
-- [Chicane](https://swan-io.github.io/chicane/)
+- [Chicane](https://zoontek.github.io/chicane/)
 - [Next.js](https://nextjs.org)
 
 We acknowledge the investment, risk and research that went into their development, but are excited to push the bar they have set even higher.


### PR DESCRIPTION
Hello there!

This PR updates the link to `Chicane` website because the repository was migrated a few months ago and today it shows a 404 error.

cc @zoontek

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Chicane acknowledgement link to point to its new website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->