### PR TITLE
test(router-core): add missing test cleanup in 3920

### DIFF
--- a/packages/router-core/tests/issue-3920-on-before-navigate-after-initial-redirect.test.ts
+++ b/packages/router-core/tests/issue-3920-on-before-navigate-after-initial-redirect.test.ts
@@ -1,5 +1,5 @@
 import { createMemoryHistory } from '@tanstack/history'
-import { expect, test } from 'vitest'
+import { expect, onTestFinished, test } from 'vitest'
 import { BaseRootRoute, BaseRoute, redirect } from '../src'
 import { createTestRouter } from './routerTestUtils'
 
@@ -30,9 +30,10 @@ test('onBeforeNavigate fires after the initial load redirects', async () => {
   expect(router.state.location.pathname).toBe('/target')
 
   const navigatedPaths: Array<string> = []
-  router.subscribe('onBeforeNavigate', (event) => {
+  const unsub = router.subscribe('onBeforeNavigate', (event) => {
     navigatedPaths.push(event.toLocation.pathname)
   })
+  onTestFinished(unsub)
 
   await router.navigate({ to: '/third' })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup for navigation event subscriptions.
  * Preserved existing assertions for navigation paths and initial redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->