### PR TITLE
fix(router-core): stream post-</body> render output instead of quarantining it

### DIFF
--- a/packages/router-core/src/ssr/transformStreamWithRouter.ts
+++ b/packages/router-core/src/ssr/transformStreamWithRouter.ts
@@ -45,18 +45,29 @@ const MIN_CLOSING_TAG_LENGTH = 4
 const DEFAULT_SERIALIZATION_TIMEOUT_MS = 60000
 const DEFAULT_LIFETIME_TIMEOUT_MS = DEFAULT_SERIALIZATION_TIMEOUT_MS * 2
 const MAX_LEFTOVER_CHARS = 2048
-const MAX_TAIL_CHARS = 64 * 1024
 const MAX_ROUTER_HTML_CHARS = 16 * 1024 * 1024
 const MAX_PENDING_WRITE_CHARS = 16 * 1024 * 1024
 
-// Merge lifecycle: body bytes can stream, router HTML must precede tail,
-// terminal states own close/error/cleanup exactly once.
+const BODY_CLOSE_LENGTH = '</body>'.length
+const HTML_CLOSE = '</html>'
+// Whitespace tolerated between </body> and </html> while capturing the
+// document terminator. Past this the shape is treated as unknown and bytes
+// stream through instead of buffering.
+const MAX_TERMINATOR_WHITESPACE = 256
+
+// Merge lifecycle: body bytes can stream, router HTML must precede the held
+// document terminator, terminal states own close/error/cleanup exactly once.
 const MergeState = {
   ReadingBody: 0,
+  // Saw </body>; capturing the document terminator (</body>[ws]</html>).
   HoldingTail: 1,
-  AppDone: 2,
-  Draining: 3,
-  Done: 4,
+  // Terminator captured (or shape unknown): app bytes stream through again
+  // (out-of-order fragments from renderers like Solid that emit a complete
+  // document up front), and the held terminator is emitted last.
+  PostBody: 2,
+  AppDone: 3,
+  Draining: 4,
+  Done: 5,
 } as const
 
 type MergeState = (typeof MergeState)[keyof typeof MergeState]
@@ -124,6 +135,40 @@ function findHtmlBoundary(str: string): number {
   }
 
   return lastClosingTagEnd
+}
+
+/**
+ * Incrementally match the document terminator `</body>[whitespace]</html>`
+ * (case-insensitive) at the start of `tail`, which is known to begin with
+ * `</body>`. Returns the end index of the terminator when fully matched,
+ * -1 while more bytes could still complete it, and -2 when the shape cannot
+ * match (unknown renderer shape — caller should stop buffering).
+ */
+function matchDocumentTerminator(tail: string): number {
+  let i = BODY_CLOSE_LENGTH
+  let whitespace = 0
+  while (i < tail.length) {
+    const code = tail.charCodeAt(i)
+    if (
+      code === 32 || // space
+      code === 9 || // \t
+      code === 10 || // \n
+      code === 13 || // \r
+      code === 12 // \f
+    ) {
+      if (++whitespace > MAX_TERMINATOR_WHITESPACE) return -2
+      i++
+      continue
+    }
+    break
+  }
+  for (let j = 0; j < HTML_CLOSE.length; j++) {
+    const at = i + j
+    if (at >= tail.length) return -1
+    // `| 32` lowercases ASCII letters and is a no-op for `<`, `/`, `>`.
+    if ((tail.charCodeAt(at) | 32) !== HTML_CLOSE.charCodeAt(j)) return -2
+  }
+  return i + HTML_CLOSE.length
 }
 
 /**
@@ -580,7 +625,8 @@ function makeMainStream(
   // between-chunk text buffer; keep bounded to avoid unbounded memory
   let leftover = ''
 
-  // captured bytes from </body> onward; must stay behind router scripts.
+  // Held document terminator (</body>[ws]</html>, bounded by construction);
+  // emitted last so injected router scripts always land inside <body>.
   let pendingTail = ''
 
   let streamBarrierLifted = false
@@ -639,7 +685,14 @@ function makeMainStream(
       cleanup(err)
       return
     }
-    if (state === MergeState.HoldingTail) {
+    // Past </body> the injected HTML is self-contained script/markup and can
+    // be written immediately — but only when the scanner sits at a safe
+    // boundary (no partial app tag pending in `leftover`), so an injection
+    // can never split an app tag mid-bytes.
+    if (
+      state === MergeState.HoldingTail ||
+      (state === MergeState.PostBody && !leftover)
+    ) {
       flushPendingRouterHtml()
       writeChunk(html)
     } else {
@@ -667,10 +720,84 @@ function makeMainStream(
     pendingRouterHtmlChars = 0
   }
 
-  function appendTail(chunk: string) {
+  /**
+   * Accumulate bytes into the held document terminator. Returns the excess
+   * that follows the terminator (to be streamed through), or '' while the
+   * terminator may still be completing. When the bytes after </body> don't
+   * form `[whitespace]</html>`, degrade gracefully: hold only </body> and
+   * stream everything else — never buffer unbounded app output.
+   */
+  function captureTail(chunk: string): string {
     pendingTail += chunk
-    if (pendingTail.length > MAX_TAIL_CHARS) {
-      throw new Error('SSR stream tail exceeded maximum buffer')
+    const end = matchDocumentTerminator(pendingTail)
+    if (end === -1) return ''
+    state = MergeState.PostBody
+    const keep = end === -2 ? BODY_CLOSE_LENGTH : end
+    const excess = pendingTail.slice(keep)
+    pendingTail = pendingTail.slice(0, keep)
+    return excess
+  }
+
+  /**
+   * Scan a chunk for safe injection boundaries and stream it. In ReadingBody
+   * a </body> match starts terminator capture (and any excess re-enters here
+   * in PostBody, so recursion depth is at most 2); in PostBody a literal
+   * </body> is treated as an ordinary closing-tag boundary.
+   */
+  function processScanChunk(chunkString: string): void {
+    const boundary = findHtmlBoundary(chunkString)
+
+    if (boundary < -1 && state === MergeState.ReadingBody) {
+      const bodyStart = -boundary - 2
+      state = MergeState.HoldingTail
+      const bodyChunk = chunkString.slice(0, bodyStart)
+      writeChunk(bodyChunk)
+      if (cleanedUp || isDone()) return
+      noteBarrierMarker(bodyChunk)
+      liftBarrierAfterBoundary()
+      if (cleanedUp || isDone()) return
+      flushPendingRouterHtml()
+      if (cleanedUp || isDone()) return
+      const excess = captureTail(chunkString.slice(bodyStart))
+      if (cleanedUp || isDone()) return
+      if (excess) processScanChunk(excess)
+      return
+    }
+
+    const lastClosingTagEnd =
+      boundary < -1 ? -boundary - 2 + BODY_CLOSE_LENGTH : boundary
+
+    if (lastClosingTagEnd > 0) {
+      const safeChunk = chunkString.slice(0, lastClosingTagEnd)
+      writeChunk(safeChunk)
+      if (cleanedUp || isDone()) return
+      noteBarrierMarker(safeChunk)
+      liftBarrierAfterBoundary()
+      if (cleanedUp || isDone()) return
+      flushPendingRouterHtml()
+
+      leftover = chunkString.slice(lastClosingTagEnd)
+      if (leftover.length > MAX_LEFTOVER_CHARS) {
+        // Ensure bounded memory even if a consumer streams long text sequences
+        // without any closing tags. This may reduce injection granularity but is correct.
+        noteBarrierMarker(leftover)
+        const flushed = leftover.slice(0, leftover.length - MAX_LEFTOVER_CHARS)
+        writeChunk(flushed)
+        leftover = leftover.slice(-MAX_LEFTOVER_CHARS)
+      }
+    } else {
+      // No closing tag found; keep small tail to handle split closing tags,
+      // but stream older bytes to prevent unbounded buffering.
+      const combined = chunkString
+      if (combined.length > MAX_LEFTOVER_CHARS) {
+        noteBarrierMarker(combined)
+        const flushUpto = combined.length - MAX_LEFTOVER_CHARS
+        const flushed = combined.slice(0, flushUpto)
+        writeChunk(flushed)
+        leftover = combined.slice(flushUpto)
+      } else {
+        leftover = combined
+      }
     }
   }
 
@@ -819,69 +946,22 @@ function makeMainStream(
             ? value
             : textDecoder.decode(value as ArrayBufferView, { stream: true })
 
-        const chunkString = leftover ? leftover + text : text
+        let chunkString = leftover ? leftover + text : text
+        leftover = ''
 
-        // If we already saw </body>, everything else is tail. Keep it bounded
-        // and held until router scripts are ready so injection remains before </body>.
-        if (state >= MergeState.HoldingTail) {
-          appendTail(chunkString)
-          leftover = ''
-          continue
+        // Saw </body>: we're capturing the document terminator so it can be
+        // emitted after all injected router HTML. Renderers that keep
+        // producing after the terminator (Solid's out-of-order boundary
+        // fragments) continue below in PostBody pass-through.
+        // (`state` is mutated inside processScanChunk/captureTail; widen to
+        // defeat stale control-flow narrowing.)
+        if ((state as MergeState) === MergeState.HoldingTail) {
+          chunkString = captureTail(chunkString)
+          if (!chunkString) continue
         }
 
-        const boundary = findHtmlBoundary(chunkString)
-        if (boundary < -1) {
-          const bodyEndIndex = -boundary - 2
-          state = MergeState.HoldingTail
-          appendTail(chunkString.slice(bodyEndIndex))
-          const bodyChunk = chunkString.slice(0, bodyEndIndex)
-          writeChunk(bodyChunk)
-          if (cleanedUp || isDone()) return
-          noteBarrierMarker(bodyChunk)
-          liftBarrierAfterBoundary()
-          if (cleanedUp || isDone()) return
-          flushPendingRouterHtml()
-          leftover = ''
-          continue
-        }
-
-        const lastClosingTagEnd = boundary
-
-        if (lastClosingTagEnd > 0) {
-          const safeChunk = chunkString.slice(0, lastClosingTagEnd)
-          writeChunk(safeChunk)
-          if (cleanedUp || isDone()) return
-          noteBarrierMarker(safeChunk)
-          liftBarrierAfterBoundary()
-          if (cleanedUp || isDone()) return
-          flushPendingRouterHtml()
-
-          leftover = chunkString.slice(lastClosingTagEnd)
-          if (leftover.length > MAX_LEFTOVER_CHARS) {
-            // Ensure bounded memory even if a consumer streams long text sequences
-            // without any closing tags. This may reduce injection granularity but is correct.
-            noteBarrierMarker(leftover)
-            const flushed = leftover.slice(
-              0,
-              leftover.length - MAX_LEFTOVER_CHARS,
-            )
-            writeChunk(flushed)
-            leftover = leftover.slice(-MAX_LEFTOVER_CHARS)
-          }
-        } else {
-          // No closing tag found; keep small tail to handle split closing tags,
-          // but stream older bytes to prevent unbounded buffering.
-          const combined = chunkString
-          if (combined.length > MAX_LEFTOVER_CHARS) {
-            noteBarrierMarker(combined)
-            const flushUpto = combined.length - MAX_LEFTOVER_CHARS
-            const flushed = combined.slice(0, flushUpto)
-            writeChunk(flushed)
-            leftover = combined.slice(flushUpto)
-          } else {
-            leftover = combined
-          }
-        }
+        processScanChunk(chunkString)
+        if (cleanedUp || isDone()) return
       }
 
       if (cleanedUp || isDone()) return

--- a/packages/router-core/tests/transformStreamWithRouter.test.ts
+++ b/packages/router-core/tests/transformStreamWithRouter.test.ts
@@ -158,6 +158,31 @@ async function flush(n = 5) {
   for (let i = 0; i < n; i++) await Promise.resolve()
 }
 
+// Continuously drain the transform output so mid-stream assertions can
+// observe exactly which bytes have been released before the stream ends.
+function collectOutput(s: ReadableStream<Uint8Array>) {
+  let done = false
+  let received = ''
+  const finished = (async () => {
+    const reader = s.getReader()
+    while (true) {
+      const { done: d, value } = await reader.read()
+      if (d) break
+      received += Buffer.from(
+        value.buffer,
+        value.byteOffset,
+        value.byteLength,
+      ).toString('utf8')
+    }
+    done = true
+  })()
+  return {
+    finished,
+    isDone: () => done,
+    text: () => received,
+  }
+}
+
 function createDeferred<T>() {
   let resolve!: (value: T) => void
   let reject!: (reason?: unknown) => void
@@ -801,27 +826,26 @@ describe('transformStreamWithRouter — cleanup side-effects', () => {
     }
   })
 
-  test('tail overflow errors and runs cleanup', async () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    try {
-      const { router, cleanupCalls, finishSerialization } = makeRouter()
-      const upstream = makeManualUpstream()
+  test('large post-</body> content streams through instead of erroring', async () => {
+    // Previously this input threw 'SSR stream tail exceeded maximum buffer'
+    // (64KB cap on the held tail) and killed the connection mid-response.
+    // Post-</body> bytes now stream through; only the document terminator
+    // is held, so the cap (and the hard failure) no longer exist.
+    const { router, cleanupCalls, finishSerialization } = makeRouter()
+    const upstream = makeManualUpstream()
 
-      const out = transformStreamWithRouter(
-        router as any,
-        upstream.stream as any,
-      )
-      upstream.push(`<html><body>done</body>${'x'.repeat(64 * 1024 + 1)}`)
-      upstream.close()
-      finishSerialization()
+    const out = transformStreamWithRouter(router as any, upstream.stream as any)
+    const big = 'x'.repeat(64 * 1024 + 1)
+    upstream.push(`<html><body>done</body>${big}`)
+    upstream.close()
+    finishSerialization()
 
-      await expect(readAll(out as any)).rejects.toThrow(
-        'SSR stream tail exceeded maximum buffer',
-      )
-      expect(cleanupCalls.count).toBe(1)
-    } finally {
-      errorSpy.mockRestore()
-    }
+    const full = await readAll(out as any)
+    expect(full).toContain('done')
+    expect(full).toContain(big)
+    // No </html> ever arrived, so only </body> was held and emitted last.
+    expect(full.endsWith('</body>')).toBe(true)
+    expect(cleanupCalls.count).toBe(1)
   })
 
   test('router HTML overflow errors and runs cleanup', async () => {
@@ -1130,6 +1154,37 @@ describe('transformStreamWithRouter — injected HTML ordering', () => {
     }
   })
 
+  test('post-body pass-through: injection during a partial fragment waits for a safe boundary', async () => {
+    // While the scanner holds an incomplete trailing tag (leftover), an
+    // injected script must queue rather than write immediately — otherwise
+    // it could interleave into partially-flushed app output.
+    const { router, injectHtml, finishSerialization } = makeRouter()
+    const upstream = makeManualUpstream()
+    const out = transformStreamWithRouter(router as any, upstream.stream as any)
+    const output = collectOutput(out as any)
+
+    upstream.push('<html><body>app</body></html>')
+    // Fragment split mid-tag: first half has no closing tag boundary.
+    upstream.push('<template id="pl-1">partial')
+    await flush()
+    injectHtml('<script>data()</script>')
+    await flush()
+    expect(output.text()).not.toContain('<script>data()</script>')
+
+    upstream.push('</template><script>$df("pl-1")</script>')
+    await flush()
+    // Boundary reached: fragment flushed first, then the queued script.
+    expect(output.text()).toContain('</template>')
+    expect(output.text()).toContain('<script>data()</script>')
+    expect(output.text().indexOf('<script>data()</script>')).toBeGreaterThan(
+      output.text().indexOf('</template>'),
+    )
+
+    upstream.close()
+    finishSerialization()
+    await output.finished
+  })
+
   test('upstream writable abort surfaces; readable does not hang', async () => {
     const { router, finishSerialization } = makeRouter()
     finishSerialization()
@@ -1163,5 +1218,158 @@ describe('transformStreamWithRouter — injected HTML ordering', () => {
     } finally {
       errorSpy.mockRestore()
     }
+  })
+})
+
+// Out-of-order streaming renderers (Solid's renderToStream, same protocol as
+// Solid 1.x) emit a COMPLETE document (`…</body></html>`) as the shell and
+// then keep streaming boundary fragments (`<template>` + swap `<script>`s)
+// after </body>; browsers reparent trailing content into <body>. The
+// transform previously treated everything after the first </body> as a held
+// tail flushed only when render + serialization finished. Measured on a
+// TanStack Start (Solid) fixture: every fragment — including one whose query
+// settled at 25ms — reached the browser only at stream end, so fallbacks
+// stayed visible ~1.5s while the data was in the client cache at ~92ms; and
+// a boundary rendering ~100KB overflowed the 64KB tail cap, threw, and
+// killed the connection mid-response (ERR_INCOMPLETE_CHUNKED_ENCODING) with
+// a permanently stuck fallback. Only the document terminator
+// (`</body>[ws]</html>`) is held now; later bytes stream through.
+describe('transformStreamWithRouter — out-of-order (post-</body>) streaming', () => {
+  test('fragments after </body> flush immediately, before the stream ends', async () => {
+    const { router, injectHtml, finishSerialization } = makeRouter()
+    const upstream = makeManualUpstream()
+    const out = transformStreamWithRouter(router as any, upstream.stream as any)
+    const output = collectOutput(out as any)
+
+    // Complete document shell, fallbacks included (Solid shape).
+    upstream.push(
+      '<html><body><main><span>fallback</span></main></body></html>',
+    )
+    await flush()
+    // Body content released; terminator held for last.
+    expect(output.text()).toContain('<span>fallback</span>')
+    expect(output.text()).not.toContain('</body>')
+
+    // First settled boundary streams its fragment after </body>.
+    const fragment1 =
+      '<template id="pl-1">shell content</template><script>$df("pl-1")</script>'
+    upstream.push(fragment1)
+    await flush()
+    expect(output.isDone()).toBe(false)
+    expect(output.text()).toContain(fragment1)
+
+    // Router-injected data script between fragments flushes immediately…
+    injectHtml('<script>resolveQuery(2)</script>')
+    await flush()
+    expect(output.text()).toContain('<script>resolveQuery(2)</script>')
+
+    // …and therefore precedes the next fragment's markup.
+    const fragment2 =
+      '<template id="pl-2">slow content</template><script>$df("pl-2")</script>'
+    upstream.push(fragment2)
+    await flush()
+    expect(output.text()).toContain(fragment2)
+    expect(output.text().indexOf('<script>resolveQuery(2)</script>')).toBeLessThan(
+      output.text().indexOf('<template id="pl-2">'),
+    )
+
+    upstream.close()
+    finishSerialization()
+    await output.finished
+
+    // The document still terminates properly, exactly once, at the very end.
+    const full = output.text()
+    expect(full.endsWith('</body></html>')).toBe(true)
+    expect(full.indexOf('</body>')).toBe(full.lastIndexOf('</body>'))
+    expect(full.indexOf('</body>')).toBeGreaterThan(full.indexOf(fragment2))
+  })
+
+  test('a fragment larger than the old 64KB tail cap streams through and the stream completes', async () => {
+    const { router, cleanupCalls, finishSerialization } = makeRouter()
+    const upstream = makeManualUpstream()
+    const out = transformStreamWithRouter(router as any, upstream.stream as any)
+    const output = collectOutput(out as any)
+
+    upstream.push('<html><body><p>fallback</p></body></html>')
+    // ~100KB boundary payload (the measured hard-failure case).
+    const bigFragment = `<template id="pl-big">${'<li>row</li>'.repeat(
+      9000,
+    )}</template><script>$df("pl-big")</script>`
+    expect(bigFragment.length).toBeGreaterThan(64 * 1024)
+    upstream.push(bigFragment)
+    await flush()
+    expect(output.isDone()).toBe(false)
+    expect(output.text()).toContain('$df("pl-big")')
+
+    upstream.close()
+    finishSerialization()
+    await expect(output.finished).resolves.toBeUndefined()
+
+    expect(output.text().endsWith('</body></html>')).toBe(true)
+    expect(cleanupCalls.count).toBe(1)
+  })
+
+  test('document terminator split across chunks is still captured and emitted last', async () => {
+    const { router, finishSerialization } = makeRouter()
+    const upstream = makeManualUpstream()
+    const out = transformStreamWithRouter(router as any, upstream.stream as any)
+
+    upstream.push('<html><body>app</body>')
+    upstream.push('</ht')
+    upstream.push('ml><template id="pl-1">late</template>')
+    upstream.close()
+    finishSerialization()
+
+    const full = await readAll(out as any)
+    expect(full).toBe(
+      '<html><body>app<template id="pl-1">late</template></body></html>',
+    )
+  })
+
+  test('uppercase terminator with interior whitespace, fragments after', async () => {
+    const { router, finishSerialization } = makeRouter()
+    const upstream = makeManualUpstream()
+    const out = transformStreamWithRouter(router as any, upstream.stream as any)
+
+    upstream.push('<html><body>app</BODY>\n</HTML><template id="pl-1">late</template>')
+    upstream.close()
+    finishSerialization()
+
+    const full = await readAll(out as any)
+    expect(full).toBe(
+      '<html><body>app<template id="pl-1">late</template></BODY>\n</HTML>',
+    )
+  })
+
+  test('React shape (body held open until the end) is byte-identical', async () => {
+    // React's renderToPipeableStream keeps <body> open until all boundaries
+    // settle: </body></html> arrives as the final render bytes. Nothing
+    // follows the terminator, so holding it produces today's exact output:
+    // late scripts before </body>, terminator last.
+    const { router, injectHtml, finishSerialization } = makeRouter()
+    const upstream = makeManualUpstream()
+    const out = transformStreamWithRouter(router as any, upstream.stream as any)
+
+    upstream.push('<html><body><div>a</div>')
+    await flush()
+    injectHtml('<script>S1</script>')
+    await flush()
+    upstream.push('<div id="B:0">boundary</div>')
+    await flush()
+    upstream.push('</body></html>')
+    upstream.close()
+    await flush()
+    // Serialization finishing after render close (typical): late script must
+    // still land before </body>.
+    injectHtml('<script>S2</script>')
+    finishSerialization()
+
+    const full = await readAll(out as any)
+    // Same bytes the pre-fix transform produced for this sequence: injected
+    // HTML flushes at the next safe boundary, late scripts precede </body>.
+    expect(full).toBe(
+      '<html><body><div>a</div><div id="B:0">boundary</div><script>S1</script>' +
+        '<script>S2</script></body></html>',
+    )
   })
 })

--- a/packages/router-core/tests/transformStreamWithRouter.test.ts
+++ b/packages/router-core/tests/transformStreamWithRouter.test.ts
@@ -1269,9 +1269,9 @@ describe('transformStreamWithRouter — out-of-order (post-</body>) streaming', 
     upstream.push(fragment2)
     await flush()
     expect(output.text()).toContain(fragment2)
-    expect(output.text().indexOf('<script>resolveQuery(2)</script>')).toBeLessThan(
-      output.text().indexOf('<template id="pl-2">'),
-    )
+    expect(
+      output.text().indexOf('<script>resolveQuery(2)</script>'),
+    ).toBeLessThan(output.text().indexOf('<template id="pl-2">'))
 
     upstream.close()
     finishSerialization()
@@ -1331,7 +1331,9 @@ describe('transformStreamWithRouter — out-of-order (post-</body>) streaming', 
     const upstream = makeManualUpstream()
     const out = transformStreamWithRouter(router as any, upstream.stream as any)
 
-    upstream.push('<html><body>app</BODY>\n</HTML><template id="pl-1">late</template>')
+    upstream.push(
+      '<html><body>app</BODY>\n</HTML><template id="pl-1">late</template>',
+    )
     upstream.close()
     finishSerialization()
 


### PR DESCRIPTION
# fix(router-core): stream post-`</body>` render output instead of quarantining it (out-of-order SSR renderers)

## Problem

`transformStreamWithRouter` assumes the renderer holds `<body>` open until the render
stream completes — true for React's `renderToPipeableStream`, where `</body></html>`
are the final bytes. Solid's `renderToStream` has the opposite shape (unchanged since
Solid 1.x): it flushes a **complete document** (`…</body></html>`) as the shell, then
keeps streaming out-of-order boundary fragments (`<template>` + `$df()` swap scripts)
*after* `</body>`. Browsers reparent trailing content into `<body>`; that is the
protocol.

The transform treats everything from the first `</body>` onward as "tail"
(`MergeState.HoldingTail` → `appendTail`) and holds it until render **and**
serialization finish, so its `$_TSR` script injections land before `</body>`. Under
Solid's shape that quarantines every boundary fragment until the end of the stream.
Two measured consequences (TanStack Start, Solid 2.0 line, production build; fixture:
three queries under separate boundaries settling at 25 ms / ~717 ms / ~1500 ms):

**1. No progressive paint — every boundary is gated on the slowest query on the page.**

Server byte stream, before the fix (real-Chrome UA):

| t (ms) | chunk | content |
|---|---|---|
| 46.5 | 0 | Shell with all three fallbacks, `$_TSR.router=` blob |
| 62.8 | 1 | `shell` query resolution script (data on the wire at ~63 ms) |
| 739.4 | 2 | `renderOnly` query script |
| 1536.8 | 3 | `slow` query script |
| 1538.0 | 5 | **Held tail: `</body></html>` + all three boundary `<template>`s + swap scripts** |

Client side, the `shell` boundary's data was in the query cache at ~92 ms, but its
markup arrived at ~1538 ms — a ~1.45 s window where the fallback stayed visible with
the data already hydrated. Each boundary's content is delayed to the end of the
*entire* stream.

**2. Hard failure above 64 KB.** The tail buffer is capped (`MAX_TAIL_CHARS`,
64 KB). A streamed boundary rendering ~100 KB of HTML throws
`SSR stream tail exceeded maximum buffer` server-side, the connection dies
mid-response (`net::ERR_INCOMPLETE_CHUNKED_ENCODING`), and the user is left with a
permanently stuck loading fallback — the corresponding query hydrated as a pending
promise that never resolves, so the client cannot recover. Any content-heavy streamed
route hits this.

## What the transform must guarantee (and why it buffered)

The tail-holding exists for exactly one reason: injected router HTML (the `$_TSR`
state blob and streamed seroval script chunks) must land **inside `<body>`**, i.e.
before the document terminator. With React's shape that is nearly free — the held
tail is just the final `</body></html>`. The bug is that the hold is keyed on *first
sight of `</body>`* rather than on *the terminator itself*, so a renderer that keeps
producing after the terminator gets its entire remaining output quarantined.

The transform's other invariant — injected HTML only enters the stream at safe
closing-tag boundaries, never splitting app bytes mid-tag — is independent of the
tail hold and is preserved (see below).

## Fix

Hold **only the document terminator**, and keep streaming everything after it:

- On seeing `</body>`, the transform captures `</body>[whitespace]</html>`
  (case-insensitive, incremental across chunk splits, whitespace bounded at 256
  chars) into `pendingTail` and emits it last, exactly as before.
- Everything after the captured terminator re-enters the normal scan-and-inject
  pipeline (new `MergeState.PostBody`): fragments flush immediately, and router
  script injections interleave with them. Scripts landing after `</body>` on the
  wire is precisely Solid's own protocol — the parser reparents them into `<body>`,
  and the relocated terminator means the *final document* is better-formed than the
  renderer's raw output, not worse.
- If the bytes after `</body>` don't look like `[whitespace]</html>` (unknown
  renderer shape), the transform degrades gracefully: it holds only `</body>` and
  streams the rest. No path buffers unbounded app output anymore.
- Injection safety in pass-through: injected HTML is written immediately only when
  the scanner is at a safe boundary (no partial trailing tag held in `leftover`);
  otherwise it queues and flushes at the next closing-tag boundary, same as before
  `</body>`. This matters because the bounded-`leftover` overflow path can flush
  output that ends mid-element (e.g. inside `<script>` text), where an immediate
  injection would corrupt the stream.

### Ordering guarantees, before vs. after

- `$_TSR` scripts still always precede the emitted terminator (held tail flushed
  last at `tryFinish`, after any remaining router HTML). Unchanged.
- Data-script-before-dependent-markup for streamed queries: previously an accident
  of the quarantine (scripts flushed immediately while all fragments were held).
  Now it holds by arrival order — the seroval chunk for a settled query is injected
  at the settle event, at or before the moment the renderer flushes that boundary's
  fragment, and the e2e capture confirms each data script precedes its fragment on
  the wire. Note the client is also order-tolerant here: fragments swap fallback
  DOM without needing the data, and hydrated pending promises resolve whenever the
  script executes.

### The 64 KB cap

`MAX_TAIL_CHARS` and the `SSR stream tail exceeded maximum buffer` failure are
removed, not raised: the held tail is now structurally bounded by the terminator
matcher (≤ `</body>` + 256 chars whitespace + `</html>`). Remaining buffers, audited:

| buffer | bound | on overflow |
|---|---|---|
| `pendingTail` | ~270 chars by construction | n/a (matcher gives up and streams through) |
| `leftover` (split-tag window) | 2 KB rolling | older bytes flushed (pre-existing) |
| `pendingRouterHtml` | 16 MB | hard error (pre-existing; router's own scripts, not app output) |
| `pendingWrites` (downstream backpressure) | 16 MB | hard error (pre-existing; consumer stalled) |

App render output can no longer terminate the response.

## Cross-framework safety

- **React shape is byte-identical.** When `</body></html>` are the final render
  bytes, nothing follows the terminator: the capture completes, pass-through never
  carries app bytes, late serialization scripts still flush before the held
  terminator. A new test asserts exact output equality for a React-shaped sequence,
  and it passes unchanged against the pre-fix transform (verified by stashing the
  fix and re-running: the 4 Solid-shape tests fail on the old code, the React
  byte-identity test passes).
- Suites: `@tanstack/router-core` unit suite fully green (105 files, 1575 passed,
  3 pre-existing expected-fails); `@tanstack/react-router` unit suite fully green;
  `@tanstack/solid-router` unit suite fully green.
- One existing test rewritten deliberately: `tail overflow errors and runs cleanup`
  asserted the old kill-the-connection behavior for >64 KB post-`</body>` content.
  It is now `large post-</body> content streams through instead of erroring`, which
  asserts the same input survives, with the rationale in a comment.

## Tests added (`packages/router-core/tests/transformStreamWithRouter.test.ts`)

New describe block `out-of-order (post-</body>) streaming`, with the measured
timeline as the repro description:

- Solid-shaped fixture: complete document, then fragments — asserts each fragment is
  released **before the stream ends** (mid-stream assertion via a continuous
  collector), that an injected data script between fragments flushes immediately and
  precedes the next fragment, and that the document still ends with exactly one
  `</body></html>`.
- A >64 KB fragment (the measured hard-failure case) streams through and the
  connection survives to a clean close.
- Terminator split across chunks (`</body>` … `</ht` … `ml>`) and uppercase
  `</BODY>\n</HTML>` variants — captured and emitted last, byte-exact output asserted.
- React-shaped fixture asserting byte-identical output (see above).
- Injection while a partial fragment tag is pending queues until the next safe
  boundary (the stream-corruption guard).

## End-to-end verification (instrumented Start app, Solid 2.0 line)

Same fixture and probes as the original investigation; the fix was applied to the
installed `router-core` dist as a minimal surgical patch (identical logic) so the
measured delta is exactly this change. Baseline re-measured on the same machine
immediately before.

**Server byte stream (fragment arrival):**

| boundary (query settle) | before | after |
|---|---|---|
| `shell` (25 ms) | 1588 ms (held tail) | **83 ms** |
| `renderOnly` (~717 ms) | 1588 ms (held tail) | **768 ms** |
| `slow` (~1500 ms) | 1588 ms (held tail) | **1561 ms** |
| `</body></html>` | start of held tail | final 14-byte chunk |

Each data script (chunks 1, 5, 9) precedes its boundary's fragment on the wire.

**Client timeline (headless Chrome, real-Chrome UA):**

| event | before | after |
|---|---|---|
| `shell` data in cache | ~80 ms | ~70 ms |
| `shell` boundary content rendered | 1511.8 ms | **77.5 ms** |
| `renderOnly` boundary content rendered | 1514.3 ms | **710.6 ms** |
| `slow` boundary content rendered | 1515.1 ms | 1508.8 ms |
| first counter click handled | 460 ms | 451 ms |

The ~1.45 s data-in-cache→content-visible window for the fast boundary is gone; each
boundary now paints at its own data-arrival time instead of the slowest query's.
Client `queryFn` executions remain **0** (all DOM tokens are the SSR tokens), console
clean apart from a favicon 404.

**64 KB case (`/big`, ~100 KB boundary):** before — server threw
`SSR stream tail exceeded maximum buffer`, connection died at ~98 KB read
(`ERR_INCOMPLETE_CHUNKED_ENCODING`), fallback stuck forever. After — response
completes cleanly: 394,564 bytes, all 1505 `<li>` rows, terminates with
`</body></html>`, zero server errors.

## Notes for reviewers

- `findHtmlBoundary`'s `</body>`-detection is unchanged; in `PostBody` a literal
  `</body>` in content is treated as an ordinary closing-tag boundary rather than a
  second terminator.
- The fast path (`reserveStreamFastPath`) is untouched.
- A widening cast was needed in the read loop (`state as MergeState`) because the
  state transitions moved into helper closures and TypeScript's control-flow
  narrowing otherwise pins `state` to its initial value.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved server-rendered page streaming for faster, more reliable delivery.
  * Supports large and split document terminators, including varied letter casing.
  * Preserves correct ordering for dynamically rendered page fragments.
  * Handles content that appears after the document body closes.

* **Bug Fixes**
  * Prevented streaming interruptions when output exceeds previous buffering limits.
  * Improved compatibility with React-generated output.
  * Prevented malformed or incomplete page endings from disrupting streamed content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->