### PR TITLE
fix(solid-router): make the global loading boundary opt-in and server/client-symmetric

### DIFF
--- a/packages/solid-router/src/Matches.tsx
+++ b/packages/solid-router/src/Matches.tsx
@@ -1,6 +1,5 @@
 import * as Solid from 'solid-js'
 import { replaceEqualDeep, rootRouteId } from '@tanstack/router-core'
-import { isServer } from '@tanstack/router-core/isServer'
 import { CatchBoundary, ErrorComponent } from './CatchBoundary'
 import { useRouter } from './useRouter'
 import { Rendered, Transitioner } from './Transitioner'
@@ -38,18 +37,61 @@ declare module '@tanstack/router-core' {
   }
 }
 
+/**
+ * Select the global loading boundary for `Matches`.
+ *
+ * Loading UI belongs to the application, not the router. Solid 2's async
+ * model never injects fallbacks the app didn't write: pending state
+ * propagates through the graph to whatever boundary the app placed (or is
+ * held at the root when there is none), and an unresolved `lazy()` chunk is
+ * just a pending async value. The wrapper here is therefore strictly opt-in:
+ * it renders only when the app configured root pending UI
+ * (`pendingComponent` on the root route or `defaultPendingComponent`).
+ * Nothing configured means no wrapper — pending match/chunk states propagate
+ * as ordinary Solid async.
+ *
+ * The decision is deliberately SYMMETRIC between server and client, and
+ * consults no hydration or environment state. Solid's hydration claims
+ * server nodes positionally through the boundary structure, so the client
+ * must render a boundary exactly where the server rendered one — a
+ * client-only wrapper (even a settled one that renders its children
+ * directly) desyncs node claiming and detaches the app from the server DOM.
+ * The inputs below (`pendingComponent` configuration,
+ * `disableGlobalCatchBoundary`, `router.ssr`) all resolve identically on the
+ * server and on the hydrating client, so the trees always agree. This also
+ * keeps the decision stable across the app's lifetime: it is made once per
+ * `Matches` instance, so gating it on transient state (like "currently
+ * hydrating") would permanently freeze the configured pending UI off for
+ * every post-hydration navigation of a hydrated app.
+ *
+ * `router.ssr` (TanStack's `$_TSR` SSR utilities) is symmetric too:
+ * `attachRouterServerSsrUtils` sets it on the server before rendering, and
+ * router-core `hydrate()` (invoked by `RouterClient`, which TanStack Start
+ * builds on) sets it on the client before rendering. It short-circuits the
+ * wrapper exactly as before: that protocol legitimately hydrates matches in
+ * pending states (`ssr: 'data-only'`), where a settled boundary is not
+ * guaranteed.
+ *
+ * When disableGlobalCatchBoundary is true, we must NOT wrap with
+ * Solid.Loading because Solid.Loading transforms STATUS_ERROR into
+ * STATUS_PENDING, which prevents errors from propagating to an external
+ * Errored boundary.
+ */
+export function _resolveMatchesLoadingBoundary(router: AnyRouter) {
+  const pendingComponent =
+    (router.routesById[rootRouteId] as AnyRoute | undefined)?.options
+      .pendingComponent ?? router.options.defaultPendingComponent
+  return !pendingComponent ||
+    router.options.disableGlobalCatchBoundary ||
+    router.ssr
+    ? SafeFragment
+    : Solid.Loading
+}
+
 export function Matches() {
   const router = useRouter()
 
-  // When disableGlobalCatchBoundary is true, we must NOT wrap with Solid.Loading
-  // because Solid.Loading transforms STATUS_ERROR into STATUS_PENDING, which
-  // prevents errors from propagating to an external Errored boundary.
-  const ResolvedSuspense =
-    router.options.disableGlobalCatchBoundary ||
-    (isServer ?? router.isServer) ||
-    (typeof document !== 'undefined' && router.ssr)
-      ? SafeFragment
-      : Solid.Loading
+  const ResolvedSuspense = _resolveMatchesLoadingBoundary(router)
 
   const rootRoute: () => AnyRoute = () => router.routesById[rootRouteId]
   const PendingComponent =

--- a/packages/solid-router/tests/matches-hydration-boundary.test.tsx
+++ b/packages/solid-router/tests/matches-hydration-boundary.test.tsx
@@ -1,0 +1,184 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { Loading, sharedConfig } from 'solid-js'
+import { cleanup, render, screen } from '@solidjs/testing-library'
+import { hydrate } from '@tanstack/router-core/ssr/client'
+import { dehydrateSsrMatchId } from '../../router-core/src/ssr/ssr-match-id'
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+import { _resolveMatchesLoadingBoundary } from '../src/Matches'
+import { SafeFragment } from '../src/SafeFragment'
+import { lazyRouteComponent } from '../src/lazyRouteComponent'
+
+afterEach(() => {
+  sharedConfig.hydrating = false
+  delete (window as any).$_TSR
+  vi.restoreAllMocks()
+  cleanup()
+})
+
+function createChunkedTestRouter(routerOptions?: Record<string, unknown>) {
+  let resolveIndexChunk!: (mod: { default: () => any }) => void
+  const indexChunkPromise = new Promise<{ default: () => any }>((resolve) => {
+    resolveIndexChunk = resolve
+  })
+  let resolveOtherChunk!: (mod: { default: () => any }) => void
+  const otherChunkPromise = new Promise<{ default: () => any }>((resolve) => {
+    resolveOtherChunk = resolve
+  })
+
+  const rootRoute = createRootRoute({})
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: lazyRouteComponent(() => indexChunkPromise),
+  })
+  const otherRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/other',
+    component: lazyRouteComponent(() => otherChunkPromise),
+  })
+
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute, otherRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+    ...routerOptions,
+  } as any)
+
+  return { router, resolveIndexChunk, resolveOtherChunk }
+}
+
+describe('Matches global loading boundary', () => {
+  test('renders the wrapper only when the app configured pending UI', async () => {
+    const { router, resolveIndexChunk } = createChunkedTestRouter({
+      defaultPendingComponent: () => <div>Pending...</div>,
+    })
+    resolveIndexChunk({ default: () => <div>Index</div> })
+    await router.load()
+
+    expect(_resolveMatchesLoadingBoundary(router)).toBe(Loading)
+  })
+
+  test('renders no wrapper when nothing is configured', async () => {
+    const { router, resolveIndexChunk } = createChunkedTestRouter()
+    resolveIndexChunk({ default: () => <div>Index</div> })
+    await router.load()
+
+    expect(_resolveMatchesLoadingBoundary(router)).toBe(SafeFragment)
+  })
+
+  test('the boundary decision ignores hydration state, so hydrated apps keep their configured pending UI for later navigations', async () => {
+    const { router, resolveIndexChunk } = createChunkedTestRouter({
+      defaultPendingComponent: () => <div>Pending...</div>,
+      defaultPendingMs: 0,
+      defaultPendingMinMs: 0,
+    })
+    resolveIndexChunk({ default: () => <div>Index loaded</div> })
+    await router.load()
+
+    // Regression guard for the frozen-decision bug: the decision is made
+    // once per `Matches` instance, so consulting "currently hydrating" here
+    // would permanently disable the configured pending UI for every
+    // post-hydration navigation of a hydrated app. The wrapper decision must
+    // be identical whether or not a hydration pass is in flight — the
+    // matching server render contains the same boundary (see the symmetry
+    // notes on `_resolveMatchesLoadingBoundary`).
+    sharedConfig.hydrating = true
+    try {
+      expect(_resolveMatchesLoadingBoundary(router)).toBe(Loading)
+    } finally {
+      sharedConfig.hydrating = false
+    }
+    expect(_resolveMatchesLoadingBoundary(router)).toBe(Loading)
+
+    // And behaviorally: navigating to a route whose chunk is unresolved
+    // must present the configured pending UI.
+    render(() => <RouterProvider router={router} />)
+    expect(await screen.findByText('Index loaded')).toBeInTheDocument()
+
+    router.navigate({ to: '/other' })
+    expect(await screen.findByText('Pending...')).toBeInTheDocument()
+  })
+
+  test('disableGlobalCatchBoundary always skips, even with configured pending UI', () => {
+    const rootRoute = createRootRoute({})
+    const router = createRouter({
+      routeTree: rootRoute,
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+      disableGlobalCatchBoundary: true,
+      defaultPendingComponent: () => <div>Pending...</div>,
+    })
+
+    expect(_resolveMatchesLoadingBoundary(router)).toBe(SafeFragment)
+  })
+
+  test('the $_TSR stream protocol (Start / RouterClient) still skips via router.ssr, even with pending data-only matches', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const rootRoute = createRootRoute({})
+    const reportRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/report',
+      ssr: 'data-only',
+      loader: () => 'report',
+      component: () => <div>Report</div>,
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([reportRoute]),
+      history: createMemoryHistory({ initialEntries: ['/report'] }),
+      defaultPendingComponent: () => <div>Pending...</div>,
+    })
+
+    const matches = router.matchRoutes(router.latestLocation)
+    window.$_TSR = {
+      router: {
+        dehydratedData: {},
+        manifest: { routes: {} },
+        matches: matches.map((match, index) => ({
+          i: dehydrateSsrMatchId(match.id),
+          s: 'success',
+          ssr: index === 1 ? 'data-only' : true,
+          l: index === 1 ? 'report' : undefined,
+          u: Date.now(),
+        })),
+      },
+      h: vi.fn(),
+      e: vi.fn(),
+      c: vi.fn(),
+      p: vi.fn(),
+      buffer: [],
+    }
+
+    await hydrate(router)
+
+    expect(router.ssr).toBeTruthy()
+    // The data-only match hydrates as pending — a legitimate protocol state
+    // where a settled boundary is not guaranteed, so the wrapper is skipped.
+    // `attachRouterServerSsrUtils` sets `router.ssr` on the server too, so
+    // the skip is symmetric with the server-rendered tree.
+    expect(
+      router.state.matches.some((match) => match.status === 'pending'),
+    ).toBe(true)
+    expect(_resolveMatchesLoadingBoundary(router)).toBe(SafeFragment)
+    expect(error).not.toHaveBeenCalled()
+  })
+
+  test('CSR with no pending UI and an unresolved chunk renders nothing, then content, without errors', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { router, resolveIndexChunk } = createChunkedTestRouter()
+
+    const { container } = render(() => <RouterProvider router={router} />)
+
+    // No implicit fallback: pending chunk state propagates as ordinary
+    // Solid async, so nothing is presented until the chunk resolves.
+    expect(container.textContent).toBe('')
+
+    resolveIndexChunk({ default: () => <div>Index loaded</div> })
+
+    expect(await screen.findByText('Index loaded')).toBeInTheDocument()
+    expect(error).not.toHaveBeenCalled()
+  })
+})

--- a/packages/solid-router/tests/server/matchesLoadingBoundary.test.tsx
+++ b/packages/solid-router/tests/server/matchesLoadingBoundary.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { Loading } from 'solid-js'
+import { renderToString } from '@solidjs/web'
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../../src'
+import { RouterProvider } from '../../src/RouterProvider'
+import { _resolveMatchesLoadingBoundary } from '../../src/Matches'
+import { SafeFragment } from '../../src/SafeFragment'
+
+function createTestRouter(routerOptions?: Record<string, unknown>) {
+  const rootRoute = createRootRoute({})
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <div>Index</div>,
+  })
+  return createRouter({
+    routeTree: rootRoute.addChildren([indexRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+    isServer: true,
+    ...routerOptions,
+  } as any)
+}
+
+describe('Matches global loading boundary (server)', () => {
+  // The boundary decision must be symmetric between server and client:
+  // Solid claims server nodes positionally through boundary structure, so
+  // the hydrating client may only render the wrapper where the server
+  // rendered it. External SSR (no `router.ssr`) with configured pending UI
+  // therefore renders the wrapper on the server too.
+  it('renders the wrapper on the server when pending UI is configured (external SSR shape)', async () => {
+    const router = createTestRouter({
+      defaultPendingComponent: () => <div>Pending...</div>,
+    })
+    await router.load()
+
+    expect(_resolveMatchesLoadingBoundary(router)).toBe(Loading)
+
+    const html = await renderToString(() => (
+      <RouterProvider router={router} />
+    ))
+    expect(html).toContain('Index')
+    expect(html).not.toContain('Pending...')
+  })
+
+  it('renders no wrapper on the server when nothing is configured', async () => {
+    const router = createTestRouter()
+    await router.load()
+
+    expect(_resolveMatchesLoadingBoundary(router)).toBe(SafeFragment)
+
+    const html = await renderToString(() => (
+      <RouterProvider router={router} />
+    ))
+    expect(html).toContain('Index')
+  })
+})

--- a/packages/solid-router/tests/server/matchesLoadingBoundary.test.tsx
+++ b/packages/solid-router/tests/server/matchesLoadingBoundary.test.tsx
@@ -40,9 +40,7 @@ describe('Matches global loading boundary (server)', () => {
 
     expect(_resolveMatchesLoadingBoundary(router)).toBe(Loading)
 
-    const html = await renderToString(() => (
-      <RouterProvider router={router} />
-    ))
+    const html = await renderToString(() => <RouterProvider router={router} />)
     expect(html).toContain('Index')
     expect(html).not.toContain('Pending...')
   })
@@ -53,9 +51,7 @@ describe('Matches global loading boundary (server)', () => {
 
     expect(_resolveMatchesLoadingBoundary(router)).toBe(SafeFragment)
 
-    const html = await renderToString(() => (
-      <RouterProvider router={router} />
-    ))
+    const html = await renderToString(() => <RouterProvider router={router} />)
     expect(html).toContain('Index')
   })
 })


### PR DESCRIPTION
Branch: `fix/solid-external-ssr-hydration-boundary` (based on `solid-router-v2-pre`)

## Problem

`Matches` in `packages/solid-router/src/Matches.tsx` wraps the match tree in a global
`Solid.Loading` boundary on the client unless `disableGlobalCatchBoundary`, `isServer`, or
`router.ssr` is set — even when the app configured no pending UI at all (the fallback is
then `null`). The server side of the same component always renders `SafeFragment`, so the
boundary is asymmetric.

`router.ssr` is only ever set by TanStack's `$_TSR` stream protocol — router-core
`hydrate()` on the client (invoked by `RouterClient`) and `attachRouterServerSsrUtils` on
the server — the SSR utility layer that TanStack Start builds on and that the documented
non-Start SSR path (`renderRouterToString/Stream` + `RouterServer` + `RouterClient`) also
uses. An app that server-renders HTML **without that protocol** — its own server entry
rendering `RouterProvider` directly with memory history, `await router.load()`, and
`renderToStream` — never sets it, so the client hydrates a tree containing a `Solid.Loading`
boundary the server never rendered.

### The reconcileArrays evidence

Hydrating against that extra boundary desyncs Solid's node claiming: the client tree
contains one more reactive branch than the server HTML encoded. The failure surfaces far
from the cause, as an opaque crash inside Solid's `reconcileArrays` —
`NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before which the new
node is to be inserted is not a child of this node.`

We verified the rest of the machinery is sound: with the boundary suppressed and
`router.load()` awaited before `hydrate()`, external SSR hydrates **byte-identically**,
including with `autoCodeSplitting` enabled. (Validated end-to-end in the Solid team's
vite-plugin-solid SSR template work that motivated this PR.)

## Design: loading UI belongs to the application

This PR removes the implicit wrapper rather than adding conditions to it. Three layered
arguments, all grounded in Solid 2's async model:

**1. Solid 2 never injects fallbacks the app didn't write.** Top-level async doesn't
insert loading UI; pending state propagates through the graph to whatever boundary the
application placed, or is held at the root if there is none. `lazy()` likewise: an
unresolved chunk is just a pending async value, with no implicit wrapper. A router
silently inserting a `Loading` boundary is the router making a presentation decision on
the app's behalf — and that invisible wrapper is exactly what made the external-SSR
hydration mismatch possible.

**2. Whatever boundary structure exists must be server/client-symmetric.** Solid claims
server-rendered nodes positionally through the boundary structure, so the client may only
render a boundary exactly where the server rendered one. We verified this is a hard
requirement, not a heuristic: in a real `renderToString` → `hydrate` round trip
(protocol-less external SSR, settled matches, configured `pendingComponent`), a
**client-only** wrapper — even a settled one that renders its children directly — shifts
hydration-key derivation for everything beneath it. Solid completes hydration with the
server nodes *unclaimed*: no crash in dev, but the reactive tree is detached from the
server DOM, and every subsequent navigation is a silent no-op. So the boundary decision
must resolve identically on the server and on the hydrating client. Symmetry is also what
makes the configured case safe to hydrate: TanStack's external-SSR recipe (`await
router.load()` before `hydrate()`) guarantees matched routes and chunks are settled —
Solid 2's own `lazy()` machinery is asset-gated the same way — so the boundary hydrates
straight through to its children with no pending flash (verified in the same round trip).

**3. Opt-in pending UI is strictly more predictable.** The existing API surface keeps
working, reframed as the app opting in: `pendingComponent` on the root route or
`defaultPendingComponent` is the app saying "I want root pending UI", and only then is
the wrapper rendered. Nothing configured means no wrapper, period — the previous behavior
there was a `Solid.Loading` with a `null` fallback, i.e. an invisible boundary that
swallowed pending into a blank frame and broke hydration.

### The new decision

The wrapper renders only when **all** of these hold, evaluated identically on the server
and on the client:

- the app configured root pending UI (root `pendingComponent` or
  `defaultPendingComponent`) — *new*;
- `router.ssr` is not set (the `$_TSR` protocol short-circuit, kept and pinned by tests —
  and itself symmetric: `attachRouterServerSsrUtils` sets it on the server before
  rendering, router-core `hydrate()` sets it on the client before rendering; that
  protocol legitimately hydrates `ssr: 'data-only'` matches in pending states, where a
  settled boundary is not guaranteed);
- `disableGlobalCatchBoundary` is not set (unchanged: `Solid.Loading` would convert
  errors to pending and starve external `Errored` boundaries).

Note what is **absent**: no `isServer` arm, no hydration probe, no match-state
inspection. The decision touches **zero Solid internals** and no environment state — it
reads only router configuration, so the server tree and the hydrating client tree cannot
disagree.

**Why no hydration clause (the frozen-decision bug).** An earlier revision of this branch
kept the wrapper off during hydration via `Solid.sharedConfig.hydrating`. That read is
non-reactive and the decision runs once per `Matches` instance, so a hydrated app froze
on `SafeFragment` forever — an app that configured root pending UI and hydrated lost that
pending UI for *all* post-hydration navigations. The regression test below pins this: the
boundary decision must be identical whether or not a hydration pass is in flight.

**Why symmetry instead of skip-on-hydration.** We empirically tested the tempting
alternative — drop the hydration clause and let the client render the configured wrapper
against server HTML that doesn't contain it, reasoning that a settled boundary "renders
its children directly anyway". It does render them, but hydration claiming still desyncs
(see design argument 2): Solid completed hydration with the server nodes unclaimed and
the app detached. Rendering the wrapper on the **server too** (the `isServer` arm is
gone) makes the claim path line up exactly; the same round trip then hydrates cleanly,
reuses the server DOM nodes, and keeps pending UI working for later navigations.

An earlier revision of this change also carried a dev-only recipe-violation diagnostic;
it is removed along with the hydration clause: detecting "currently hydrating" was the diagnostic's
trigger and required the same `sharedConfig` internals read. Breaking the recipe
(hydrating before `router.load()` settles) now surfaces through Solid's own dev
hydration diagnostics instead of a bespoke router-level warning.

## Blast radius (measured, not estimated)

Full `@tanstack/solid-router` suite under the rework: **844 passed | 2 skipped, zero type
errors** (jsdom + typecheck), server mode **4 passed** (2 new), eslint clean. **No
pre-existing test failed** — zero tests needed updating for the semantic change.

Why the radius is this small:

| Behavior | Before | After | Existing test coverage |
| --- | --- | --- | --- |
| CSR, pending UI configured | wrapper with `pendingComponent` fallback | unchanged (opt-in branch) | all 7 pending-UI test files (`link`, `loaders`, `createLazyRoute`, `pending-fallback-promise-replacement`, `redirect`, `store-updates-during-navigation`, `Matches`) configure a pending component — all pass unchanged |
| CSR, nothing configured | invisible `Solid.Loading` with `null` fallback (blank while pending) | no wrapper; pending propagates as ordinary Solid async — still blank at the root, content appears when chunks resolve, no error paths (behavioral test added) | no existing test observed the implicit wrapper |
| Navigation pending states | per-`Match` boundaries (symmetric server/client) | untouched | existing navigation/transition tests pass unchanged |
| Protocol hydration (Start / `RouterClient`) | skipped via `router.ssr` | identical short-circuit, pinned | `Scripts`, `router-client-stream-cleanup`, new protocol test |
| External-SSR hydration (no `$_TSR`), nothing configured | client-only boundary → `reconcileArrays` crash | no wrapper on either side → hydrates cleanly after awaited `router.load()` | new tests |
| External-SSR hydration (no `$_TSR`), pending UI configured | client-only boundary → crash | wrapper on **both** sides → hydrates cleanly, server nodes claimed and reused, no pending flash; pending UI intact for later navigations | round-trip repro + new server tests + regression test |
| External-SSR server HTML, pending UI configured | no wrapper in server output | server output now contains the boundary (hydration-key depth changes) — server and client must run the same solid-router version, as with any structural change | new server tests |
| Hydration with pending chunks (recipe broken) | crash | surfaces through Solid's own dev hydration diagnostics (no bespoke router warning) | — |
| `disableGlobalCatchBoundary` | skipped | skipped (unchanged) | `disableGlobalCatchBoundary` tests + new test |

Also in scope-but-unchanged: the per-`Match` `Solid.Loading` boundaries and the root
`Outlet` wrapper in `Match.tsx` render on **both** server and client, so they cannot cause
hydration mismatches; aligning them with the same opt-in philosophy is possible follow-up
work but deliberately out of scope here.

## Migration story (release-note text)

> The root loading boundary in `<Matches>` is now opt-in and rendered symmetrically on
> the server and the client. If you set a `pendingComponent` on your root route or a
> `defaultPendingComponent` on the router, behavior is unchanged on the client, and
> server-side rendering now includes the same boundary in its output (make sure server
> and client run the same solid-router version). If you configured neither, the router no
> longer wraps your matches in an invisible loading boundary: pending route/chunk states
> now propagate to your own `<Loading>` boundaries (or hold at the root) exactly like any
> other Solid 2 async. Visually this is the same blank-until-ready you had before — the
> wrapper's fallback was `null` — but errors during loading now reach your error
> boundaries directly, and hydration of externally server-rendered HTML no longer
> crashes. If you want root pending UI, say so: `defaultPendingComponent`.

An app relying on the implicit wrapper would observe: identical visuals in the
nothing-configured case (blank → content, now via async propagation instead of a hidden
`null` fallback); identical behavior in the configured case; and one semantic improvement
— errors thrown while the tree is pending are no longer laundered into "pending" by an
invisible `Solid.Loading` (which converts STATUS_ERROR to STATUS_PENDING) they never asked
for.

## Cross-framework divergence (owned explicitly)

The React adapter injects its root `Suspense` unconditionally (`router.ssr ? SafeFragment
: React.Suspense`), and after this PR the Solid adapter deliberately does not. We think
divergence is correct here, because the frameworks' semantics genuinely differ: React
apps *must* have a Suspense boundary above suspending content, so an implicit one is a
defensible default there; Solid 2's async model is explicitly designed so pending
propagates without one, making the implicit wrapper unnecessary (pending propagates) and
actively harmful (it is the hydration mismatch). We're framing this as the
Solid-idiomatic adapter behavior and invite pushback. If maintainers prefer a narrower
fix, we also built and tested a conditional-gate variant that keeps the implicit wrapper
and only skips it during hydration when every matched route is settled — same test
coverage, no opt-in semantic change. Happy to file that version instead if it's the
preferred direction.

We validated the React comparison empirically rather than by code inspection
(`@tanstack/react-router@1.170.25` + React 19.2.8, protocol-less
`renderToString`/`hydrateRoot` repro): React hits the *same* mismatch — its hydration
diff names the client-only `<Suspense>` under `<Matches>` — and recovers by discarding
the server DOM and fully client re-rendering (error #418 in prod). The severity
difference is React's forgiving recovery vs. Solid's strict node claiming; React apps
never notice because every documented React SSR path goes through `RouterClient`, which
sets `router.ssr`. Force-setting `router.ssr` alone in the repro yields byte-clean
hydration, proving the wrapper is the sole mismatch on this path in both frameworks.

## Future integration (not part of this PR)

The fuller alignment would be for the Solid adapter to register route chunks with Solid's
asset registry (the `lazy()`/asset seam): TanStack routes would then get automatic
modulepreload hints for matched chunks *and* automatic hydration deferral until those
chunks load — erasing even the manual `await router.load()` ordering requirement for
external SSR, and making the recipe-violation diagnostic unreachable too. We're open to
helping with that as a follow-up.

## Test coverage

`packages/solid-router/tests/matches-hydration-boundary.test.tsx` (style matches the
existing suite: jsdom, fabricated `$_TSR` protocol as in `Scripts.test.tsx`, lazy chunks
via `lazyRouteComponent` with a controlled import promise):

1. Configured pending UI → wrapper renders (opt-in preserved).
2. Nothing configured → no wrapper.
3. **Regression test:** the boundary decision is identical with
   and without a hydration pass in flight — a hydration-keyed decision would freeze
   `SafeFragment` into a hydrated app permanently. Then behaviorally: navigating to a
   route with an unresolved chunk presents the configured pending UI. This test fails on
   the previous revision of this branch (frozen decision) and passes now.
4. `disableGlobalCatchBoundary` → no wrapper even with configured pending UI.
5. `$_TSR` protocol (Start / `RouterClient`): `router.ssr` still short-circuits on its
   own, with legitimately-pending `data-only` matches — the protocol path is unchanged.
6. Behavioral: CSR, no pending UI, unresolved chunk → renders nothing (no errors), then
   content appears when the chunk resolves — pending propagated as ordinary Solid async.

`packages/solid-router/tests/server/matchesLoadingBoundary.test.tsx` (server-mode vitest
project, real `renderToString`):

1. External-SSR shape (no `router.ssr`) + configured pending UI → the server renders the
   wrapper (`Loading`), output contains the route content and no pending flash.
2. Nothing configured → `SafeFragment` on the server too.

Beyond the suite, the symmetry claims were verified against a real round trip (Solid
`renderToString` on a server-compiled bundle → `hydrate()` on a client-compiled bundle in
jsdom, protocol-less, `await router.load()` on both sides): configured pending UI
hydrates with zero console errors/warnings, zero unclaimed server nodes, the
server-rendered DOM node is reused by identity, no pending flash; a post-hydration
navigation to an unresolved chunk shows the pending UI and completes. The same round trip
run against the skip-on-hydration alternative is what surfaced the unclaimed-node
detachment described above.

## HMR / router-core pin note (no commit needed on this branch)

The published `@tanstack/solid-router@2.0.0-beta.29` pins `@tanstack/router-core@1.171.14`,
but the router-plugin HMR runtime (`handle-route-update.ts`) unconditionally calls
`router._replaceRouteChunk(...)`, which **first shipped in published router-core 1.171.16**
(`RouterCore.prototype._replaceRouteChunk` / `_refreshRoute`; implementation identical
through 1.171.19, typed in the `.d.ts` from 1.171.21). With beta.29's pin, HMR route
updates crash with `router._replaceRouteChunk is not a function`.

No package.json change is included because this monorepo derives the pin from workspace
versioning: `packages/solid-router` depends on `@tanstack/router-core@workspace:*`, and the
in-tree router-core on this branch is already `1.171.16`. The next solid-router beta cut
from this branch will resolve the published pin to ≥ 1.171.16 automatically. If a release
is cut from an older base, ensure the substituted router-core version is **≥ 1.171.16**
(≥ 1.171.21 if the typed surface is wanted).
