### PR TITLE
fix(router-core): qualify pagehide event listener

### DIFF
--- a/packages/router-core/src/scroll-restoration.ts
+++ b/packages/router-core/src/scroll-restoration.ts
@@ -219,7 +219,7 @@ export function setupScrollRestoration(router: AnyRouter, force?: boolean) {
       }
       trackedScrollTargets.clear()
     })
-    addEventListener('pagehide', () => {
+    window.addEventListener('pagehide', () => {
       snapshotCurrentScrollTargets(
         getKey(
           router.stores.resolvedLocation.get() ?? router.stores.location.get(),

--- a/packages/router-core/tests/scroll-restoration.test.ts
+++ b/packages/router-core/tests/scroll-restoration.test.ts
@@ -71,9 +71,11 @@ describe('setupScrollRestoration', () => {
     expect(router._scroll.restoring).toBe(true)
     expect(router._scroll.restoration).toBe(true)
     expect(window.history.scrollRestoration).toBe('manual')
-    expect(
-      windowAddEventListener.mock.calls.some(([event]) => event === 'pagehide'),
-    ).toBe(true)
+    const pagehideCallIndex = windowAddEventListener.mock.calls.findIndex(
+      ([event]) => event === 'pagehide',
+    )
+    expect(pagehideCallIndex).toBeGreaterThanOrEqual(0)
+    expect(windowAddEventListener.mock.contexts[pagehideCallIndex]).toBe(window)
     expect(
       documentAddEventListener.mock.calls.some(
         ([event, _listener, options]) => event === 'scroll' && options === true,


### PR DESCRIPTION
## Summary

Qualify the `pagehide` listener registration with `window.addEventListener`.

This ensures the correct receiver is used when `EventTarget.prototype.addEventListener` has been patched by instrumentation libraries.

A regression assertion was added to verify that the `pagehide` listener is registered with `window` as its context.

Fixes #8024

## Tests

```bash
pnpm nx run @tanstack/router-core:test:unit -- tests/scroll-restoration.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scroll restoration reliability by ensuring page navigation events are registered on the browser window.
- **Tests**
  - Added coverage confirming the scroll restoration listener is attached to the correct browser target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->