### PR TITLE
ci: migrate CodSpeed to v5

### DIFF
--- a/.github/workflows/client-nav-benchmarks.yml
+++ b/.github/workflows/client-nav-benchmarks.yml
@@ -72,7 +72,7 @@ jobs:
           @benchmarks/${{ matrix.benchmark }}:build:${{ matrix.framework }}
 
       - name: Run ${{ matrix.benchmark }}:${{ matrix.framework }} CodSpeed benchmark
-        uses: CodSpeedHQ/action@9d332c4d90b43981c3e55ae8e38e68709996240f # v4.17.0
+        uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
         with:
           mode: ${{ matrix.mode }}
           run: >-


### PR DESCRIPTION
## Summary

- upgrade the pinned CodSpeed action from v4.17.0 to v5.0.3
- adopt runner v5.0.2 and its cycle-estimation default for simulation benchmarks
- keep allocation exclusion disabled because allocation cost is part of the measured Router workloads

The Vitest integration is already on `@codspeed/vitest-plugin` v5.5.0, so no package or lockfile migration is required. The first v5 default-branch run should be treated as the new simulation baseline because cycle estimation changes the measurement model.

## Testing

- `CI=1 NX_DAEMON=false pnpm nx run @benchmarks/client-nav:test:types --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @benchmarks/ssr:test:types --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @benchmarks/memory-server:test:types --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @benchmarks/memory-client:test:types --outputStyle=stream --skipRemoteCache`
- `CI=1 NX_DAEMON=false pnpm nx run @benchmarks/ssr:test:unit --outputStyle=stream --skipRemoteCache`
- `pnpm exec prettier --experimental-cli --check ".github/workflows/client-nav-benchmarks.yml"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the benchmarking workflow to use a newer CodSpeed action version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->