### PR TITLE
fix(router): apply preload delay to viewport links

### DIFF
--- a/.changeset/tidy-links-wait.md
+++ b/.changeset/tidy-links-wait.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/react-router': patch
+'@tanstack/solid-router': patch
+'@tanstack/vue-router': patch
+---
+
+Apply `preloadDelay` to viewport link preloading.

--- a/.changeset/tidy-links-wait.md
+++ b/.changeset/tidy-links-wait.md
@@ -4,4 +4,4 @@
 '@tanstack/vue-router': patch
 ---
 
-Apply `preloadDelay` to viewport link preloading.
+Apply `preloadDelay` to viewport link preloading and cancel pending preloads when links leave the viewport.

--- a/docs/router/api/router/LinkOptionsType.md
+++ b/docs/router/api/router/LinkOptionsType.md
@@ -42,7 +42,7 @@ The `LinkOptions` object accepts/contains the following properties:
 
 - Type: `number`
 - Optional
-- Delay focus, hover, and viewport preloading by this many milliseconds. Touch intent preloads immediately. If focus or hover exits before the delay, the preload will be cancelled.
+- Delay focus, hover, and viewport preloading by this many milliseconds. Touch intent preloads immediately. If focus or hover ends, or the link leaves the viewport before the delay, the preload will be cancelled.
 
 ### `disabled`
 

--- a/docs/router/api/router/LinkOptionsType.md
+++ b/docs/router/api/router/LinkOptionsType.md
@@ -42,7 +42,7 @@ The `LinkOptions` object accepts/contains the following properties:
 
 - Type: `number`
 - Optional
-- Delay focus and hover intent preloading by this many milliseconds. Touch intent preloads immediately. If focus or hover exits before the delay, the preload will be cancelled.
+- Delay focus, hover, and viewport preloading by this many milliseconds. Touch intent preloads immediately. If focus or hover exits before the delay, the preload will be cancelled.
 
 ### `disabled`
 

--- a/docs/router/api/router/RouterOptionsType.md
+++ b/docs/router/api/router/RouterOptionsType.md
@@ -59,7 +59,7 @@ The `RouterOptions` type accepts an object with the following properties and met
 - Type: `number`
 - Optional
 - Defaults to `50`
-- The delay in milliseconds that a route must be hovered over or touched before it is preloaded.
+- The delay in milliseconds before intent focus/hover and viewport preloading. Touch intent preloads immediately.
 
 ### `defaultComponent` property
 

--- a/docs/router/guide/navigation.md
+++ b/docs/router/guide/navigation.md
@@ -731,7 +731,7 @@ What's even better is that by using a cache-first library like `@tanstack/query`
 
 ### Link Preloading Delay
 
-For `'intent'` and `'viewport'` preloading, a configurable delay determines how long to wait before preloading begins after focus, hover, or viewport entry. If focus or hover ends before the delay, the queued preload is cancelled. Touch intent preloads immediately without waiting for the delay. The default delay is 50 milliseconds, but you can change it by passing a `preloadDelay` prop to the `Link` component:
+For `'intent'` and `'viewport'` preloading, a configurable delay determines how long to wait before preloading begins after focus, hover, or viewport entry. If focus or hover ends, or the link leaves the viewport before the delay, the queued preload is cancelled. Touch intent preloads immediately without waiting for the delay. The default delay is 50 milliseconds, but you can change it by passing a `preloadDelay` prop to the `Link` component:
 
 ```tsx
 const link = (

--- a/docs/router/guide/navigation.md
+++ b/docs/router/guide/navigation.md
@@ -731,7 +731,7 @@ What's even better is that by using a cache-first library like `@tanstack/query`
 
 ### Link Preloading Delay
 
-For `'intent'` preloading, a configurable delay determines how long a link must remain focused or hovered before preloading begins. If focus or hover ends before the delay, the queued preload is cancelled. Touch intent preloads immediately without waiting for the delay. The default delay is 50 milliseconds, but you can change it by passing a `preloadDelay` prop to the `Link` component:
+For `'intent'` and `'viewport'` preloading, a configurable delay determines how long to wait before preloading begins after focus, hover, or viewport entry. If focus or hover ends before the delay, the queued preload is cancelled. Touch intent preloads immediately without waiting for the delay. The default delay is 50 milliseconds, but you can change it by passing a `preloadDelay` prop to the `Link` component:
 
 ```tsx
 const link = (

--- a/docs/router/guide/preloading.md
+++ b/docs/router/guide/preloading.md
@@ -64,7 +64,7 @@ This will turn on `intent` preloading by default for all `<Link>` components in 
 
 ## Preload Delay
 
-By default, preloading will start after **50ms** of the user hovering or touching a `<Link>` component. You can change this delay by setting the `defaultPreloadDelay` option on your router:
+By default, intent focus/hover and viewport preloading start after **50ms**. Touch intent preloads immediately. You can change this delay by setting the `defaultPreloadDelay` option on your router:
 
 <!-- ::start:framework -->
 

--- a/docs/router/guide/preloading.md
+++ b/docs/router/guide/preloading.md
@@ -64,7 +64,7 @@ This will turn on `intent` preloading by default for all `<Link>` components in 
 
 ## Preload Delay
 
-By default, intent focus/hover and viewport preloading start after **50ms**. Touch intent preloads immediately. You can change this delay by setting the `defaultPreloadDelay` option on your router:
+By default, intent focus/hover and viewport preloading start after **50ms**. Pending preloads are cancelled if focus or hover ends, or the link leaves the viewport. Touch intent preloads immediately. You can change this delay by setting the `defaultPreloadDelay` option on your router:
 
 <!-- ::start:framework -->
 

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -616,20 +616,11 @@ export function useLinkProps<
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const enqueuePreload = React.useCallback(
-    (
-      e:
-        | React.MouseEvent
-        | React.FocusEvent
-        | IntersectionObserverEntry
-        | undefined,
-    ) => {
+    (e?: React.MouseEvent | React.FocusEvent | IntersectionObserverEntry) => {
       if (!e) {
         cancelPreload(innerRef)
         return
       }
-
-      const eventTarget =
-        (e as { currentTarget?: EventTarget | null }).currentTarget || innerRef
 
       if (
         !(
@@ -637,7 +628,9 @@ export function useLinkProps<
           preload === 'intent'
         )
       ) {
-        cancelPreload(eventTarget)
+        if ((e as IntersectionObserverEntry).isIntersecting === false) {
+          cancelPreload(innerRef)
+        }
         return
       }
 
@@ -646,14 +639,14 @@ export function useLinkProps<
         return
       }
 
-      if (timeoutMap.has(eventTarget)) {
+      if (timeoutMap.has(innerRef)) {
         return
       }
 
       timeoutMap.set(
-        eventTarget,
+        innerRef,
         setTimeout(() => {
-          timeoutMap.delete(eventTarget)
+          timeoutMap.delete(innerRef)
           doPreload()
         }, preloadDelay),
       )
@@ -739,8 +732,10 @@ export function useLinkProps<
     doPreload()
   }
 
-  const handleLeave = (e: React.MouseEvent | React.FocusEvent) => {
-    cancelPreload(e.currentTarget)
+  const handleLeave = () => {
+    if (preload === 'intent') {
+      cancelPreload(innerRef)
+    }
   }
 
   return {

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -623,13 +623,20 @@ export function useLinkProps<
         | IntersectionObserverEntry
         | undefined,
     ) => {
+      if (!e) {
+        return
+      }
+
+      const eventTarget =
+        (e as { currentTarget?: EventTarget | null }).currentTarget || doPreload
+
       if (
-        !e ||
         !(
           (e as IntersectionObserverEntry).isIntersecting ??
           preload === 'intent'
         )
       ) {
+        cancelPreload(eventTarget)
         return
       }
 
@@ -637,9 +644,6 @@ export function useLinkProps<
         doPreload()
         return
       }
-
-      const eventTarget =
-        (e as { currentTarget?: EventTarget | null }).currentTarget || doPreload
 
       if (timeoutMap.has(eventTarget)) {
         return
@@ -740,12 +744,7 @@ export function useLinkProps<
   }
 
   const handleLeave = (e: React.MouseEvent | React.FocusEvent) => {
-    const eventTarget = e.currentTarget
-    const id = timeoutMap.get(eventTarget)
-    if (id) {
-      clearTimeout(id)
-      timeoutMap.delete(eventTarget)
-    }
+    cancelPreload(e.currentTarget)
   }
 
   return {
@@ -777,6 +776,10 @@ const STATIC_ACTIVE_PROPS = { 'data-status': 'active', 'aria-current': 'page' }
 const STATIC_TRANSITIONING_PROPS = { 'data-transitioning': 'transitioning' }
 
 const timeoutMap = new WeakMap<object, ReturnType<typeof setTimeout>>()
+const cancelPreload = (eventTarget: object) => {
+  clearTimeout(timeoutMap.get(eventTarget))
+  timeoutMap.delete(eventTarget)
+}
 
 const intersectionObserverOptions: IntersectionObserverInit = {
   rootMargin: '100px',

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -661,12 +661,7 @@ export function useLinkProps<
   )
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  useIntersectionObserver(
-    innerRef,
-    enqueuePreload,
-    intersectionObserverOptions,
-    preload !== 'viewport',
-  )
+  useIntersectionObserver(innerRef, enqueuePreload, preload !== 'viewport')
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   React.useEffect(() => {
@@ -779,10 +774,6 @@ const timeoutMap = new WeakMap<object, ReturnType<typeof setTimeout>>()
 const cancelPreload = (eventTarget: object) => {
   clearTimeout(timeoutMap.get(eventTarget))
   timeoutMap.delete(eventTarget)
-}
-
-const intersectionObserverOptions: IntersectionObserverInit = {
-  rootMargin: '100px',
 }
 
 const composeHandlers =

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -624,11 +624,12 @@ export function useLinkProps<
         | undefined,
     ) => {
       if (!e) {
+        cancelPreload(innerRef)
         return
       }
 
       const eventTarget =
-        (e as { currentTarget?: EventTarget | null }).currentTarget || doPreload
+        (e as { currentTarget?: EventTarget | null }).currentTarget || innerRef
 
       if (
         !(
@@ -657,7 +658,7 @@ export function useLinkProps<
         }, preloadDelay),
       )
     },
-    [doPreload, preload, preloadDelay],
+    [doPreload, innerRef, preload, preloadDelay],
   )
 
   // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -598,7 +598,7 @@ export function useLinkProps<
   const hasRenderFetched = React.useRef(false)
 
   const preload =
-    options.reloadDocument || externalLink
+    options.reloadDocument || externalLink || disabled
       ? false
       : (userPreload ?? router.options.defaultPreload)
   const preloadDelay =
@@ -615,21 +615,53 @@ export function useLinkProps<
   }, [router, _options])
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  const preloadViewportIoCallback = React.useCallback(
-    (entry: IntersectionObserverEntry | undefined) => {
-      if (entry?.isIntersecting) {
-        doPreload()
+  const enqueuePreload = React.useCallback(
+    (
+      e:
+        | React.MouseEvent
+        | React.FocusEvent
+        | IntersectionObserverEntry
+        | undefined,
+    ) => {
+      if (
+        !e ||
+        !(
+          (e as IntersectionObserverEntry).isIntersecting ??
+          preload === 'intent'
+        )
+      ) {
+        return
       }
+
+      if (!preloadDelay) {
+        doPreload()
+        return
+      }
+
+      const eventTarget =
+        (e as { currentTarget?: EventTarget | null }).currentTarget || doPreload
+
+      if (timeoutMap.has(eventTarget)) {
+        return
+      }
+
+      timeoutMap.set(
+        eventTarget,
+        setTimeout(() => {
+          timeoutMap.delete(eventTarget)
+          doPreload()
+        }, preloadDelay),
+      )
     },
-    [doPreload],
+    [doPreload, preload, preloadDelay],
   )
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   useIntersectionObserver(
     innerRef,
-    preloadViewportIoCallback,
+    enqueuePreload,
     intersectionObserverOptions,
-    !!disabled || preload !== 'viewport',
+    preload !== 'viewport',
   )
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -637,11 +669,11 @@ export function useLinkProps<
     if (hasRenderFetched.current) {
       return
     }
-    if (!disabled && preload === 'render') {
+    if (preload === 'render') {
       doPreload()
       hasRenderFetched.current = true
     }
-  }, [disabled, doPreload, preload])
+  }, [doPreload, preload])
 
   // The click handler
   const handleClick = (e: React.MouseEvent) => {
@@ -702,34 +734,12 @@ export function useLinkProps<
     }
   }
 
-  const enqueueIntentPreload = (e: React.MouseEvent | React.FocusEvent) => {
-    if (disabled || preload !== 'intent') return
-
-    if (!preloadDelay) {
-      doPreload()
-      return
-    }
-
-    const eventTarget = e.currentTarget
-
-    if (timeoutMap.has(eventTarget)) {
-      return
-    }
-
-    const id = setTimeout(() => {
-      timeoutMap.delete(eventTarget)
-      doPreload()
-    }, preloadDelay)
-    timeoutMap.set(eventTarget, id)
-  }
-
-  const handleTouchStart = (_: React.TouchEvent) => {
-    if (disabled || preload !== 'intent') return
+  const handleTouchStart = () => {
+    if (preload !== 'intent') return
     doPreload()
   }
 
   const handleLeave = (e: React.MouseEvent | React.FocusEvent) => {
-    if (disabled || !preload || !preloadDelay) return
     const eventTarget = e.currentTarget
     const id = timeoutMap.get(eventTarget)
     if (id) {
@@ -746,8 +756,8 @@ export function useLinkProps<
     ref: innerRef as React.ComponentPropsWithRef<'a'>['ref'],
     onClick: composeHandlers([onClick, handleClick]),
     onBlur: composeHandlers([onBlur, handleLeave]),
-    onFocus: composeHandlers([onFocus, enqueueIntentPreload]),
-    onMouseEnter: composeHandlers([onMouseEnter, enqueueIntentPreload]),
+    onFocus: composeHandlers([onFocus, enqueuePreload]),
+    onMouseEnter: composeHandlers([onMouseEnter, enqueuePreload]),
     onMouseLeave: composeHandlers([onMouseLeave, handleLeave]),
     onTouchStart: composeHandlers([onTouchStart, handleTouchStart]),
     disabled: !!disabled,
@@ -766,7 +776,7 @@ const STATIC_DISABLED_PROPS = { role: 'link', 'aria-disabled': true }
 const STATIC_ACTIVE_PROPS = { 'data-status': 'active', 'aria-current': 'page' }
 const STATIC_TRANSITIONING_PROPS = { 'data-transitioning': 'transitioning' }
 
-const timeoutMap = new WeakMap<EventTarget, ReturnType<typeof setTimeout>>()
+const timeoutMap = new WeakMap<object, ReturnType<typeof setTimeout>>()
 
 const intersectionObserverOptions: IntersectionObserverInit = {
   rootMargin: '100px',
@@ -955,7 +965,7 @@ export function createLink<const TComp>(
  *
  * Props:
  * - `preload`: Controls route preloading (eg. 'intent', 'render', 'viewport', true/false)
- * - `preloadDelay`: Delay in ms before preloading on hover
+ * - `preloadDelay`: Delay in ms before preloading on focus, hover, or viewport entry
  * - `activeProps`/`inactiveProps`: Additional props merged when link is active/inactive
  * - `resetScroll`/`hashScrollIntoView`: Control scroll behavior on navigation
  * - `viewTransition`/`startTransition`: Use View Transitions/React transitions for navigation

--- a/packages/react-router/src/utils.ts
+++ b/packages/react-router/src/utils.ts
@@ -98,8 +98,8 @@ export function useIntersectionObserver<T extends Element>(
       return
     }
 
-    const observer = new IntersectionObserver(([entry]) => {
-      callback(entry)
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(callback)
     }, intersectionObserverOptions)
 
     observer.observe(ref.current)

--- a/packages/react-router/src/utils.ts
+++ b/packages/react-router/src/utils.ts
@@ -83,7 +83,7 @@ export function usePrevious<T>(value: T): T | null {
  */
 export function useIntersectionObserver<T extends Element>(
   ref: React.RefObject<T | null>,
-  callback: (entry: IntersectionObserverEntry | undefined) => void,
+  callback: (entry?: IntersectionObserverEntry) => void,
   disabled?: boolean,
 ) {
   React.useEffect(() => {
@@ -92,7 +92,7 @@ export function useIntersectionObserver<T extends Element>(
       disabled ||
       typeof IntersectionObserver !== 'function'
     ) {
-      return
+      return () => callback()
     }
 
     const observer = new IntersectionObserver(
@@ -106,7 +106,7 @@ export function useIntersectionObserver<T extends Element>(
 
     return () => {
       observer.disconnect()
-      callback(undefined)
+      callback()
     }
   }, [callback, disabled, ref])
 }

--- a/packages/react-router/src/utils.ts
+++ b/packages/react-router/src/utils.ts
@@ -106,6 +106,7 @@ export function useIntersectionObserver<T extends Element>(
 
     return () => {
       observer.disconnect()
+      callback(undefined)
     }
   }, [callback, disabled, ref])
 }

--- a/packages/react-router/src/utils.ts
+++ b/packages/react-router/src/utils.ts
@@ -66,9 +66,8 @@ export function usePrevious<T>(value: T): T | null {
  * When the intersection changes, the callback will be called with the `IntersectionObserverEntry`.
  *
  * @param ref - The ref to observe
- * @param intersectionObserverOptions - The options to pass to the IntersectionObserver
- * @param disabled - Whether observation is disabled
  * @param callback - The callback to call when the intersection changes
+ * @param disabled - Whether observation is disabled
  * @returns The IntersectionObserver instance
  * @example
  * ```tsx
@@ -77,7 +76,6 @@ export function usePrevious<T>(value: T): T | null {
  * useIntersectionObserver(
  *  ref,
  *  (entry) => { doSomething(entry) },
- *  { rootMargin: '10px' },
  *  false
  * )
  * return <div ref={ref} />
@@ -86,7 +84,6 @@ export function usePrevious<T>(value: T): T | null {
 export function useIntersectionObserver<T extends Element>(
   ref: React.RefObject<T | null>,
   callback: (entry: IntersectionObserverEntry | undefined) => void,
-  intersectionObserverOptions: IntersectionObserverInit = {},
   disabled?: boolean,
 ) {
   React.useEffect(() => {
@@ -98,16 +95,19 @@ export function useIntersectionObserver<T extends Element>(
       return
     }
 
-    const observer = new IntersectionObserver((entries) => {
-      callback(entries.pop())
-    }, intersectionObserverOptions)
+    const observer = new IntersectionObserver(
+      (entries) => {
+        callback(entries.pop())
+      },
+      { rootMargin: '100px' },
+    )
 
     observer.observe(ref.current)
 
     return () => {
       observer.disconnect()
     }
-  }, [callback, disabled, intersectionObserverOptions, ref])
+  }, [callback, disabled, ref])
 }
 
 /**

--- a/packages/react-router/src/utils.ts
+++ b/packages/react-router/src/utils.ts
@@ -99,7 +99,7 @@ export function useIntersectionObserver<T extends Element>(
     }
 
     const observer = new IntersectionObserver((entries) => {
-      entries.forEach(callback)
+      callback(entries.pop())
     }, intersectionObserverOptions)
 
     observer.observe(ref.current)

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -48,12 +48,16 @@ import type { RouterHistory } from '../src'
 
 const ioObserveMock = vi.fn()
 const ioDisconnectMock = vi.fn()
+let ioCallback: IntersectionObserverCallback
 let history: RouterHistory
 
 beforeEach(() => {
   const io = getIntersectionObserverMock({
     observe: ioObserveMock,
     disconnect: ioDisconnectMock,
+    onCreate: (callback) => {
+      ioCallback = callback
+    },
   })
   vi.stubGlobal('IntersectionObserver', io)
   history = createBrowserHistory()
@@ -61,6 +65,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  vi.useRealTimers()
   history.destroy()
   window.history.replaceState(null, 'root', '/')
   vi.resetAllMocks()
@@ -5117,6 +5122,85 @@ describe('Link', () => {
     })
     expect(ioObserveMock).toBeCalledTimes(2) // it should not observe again
     expect(ioDisconnectMock).toBeCalledTimes(1) // it should not disconnect again
+  })
+
+  test('Link.preload="viewport" should respect preloadDelay', async () => {
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => (
+        <>
+          <Link to="/about" preload="viewport" preloadDelay={50}>
+            Viewport Link
+          </Link>
+          <Link to="/about" preload="intent" preloadDelay={50}>
+            Intent Link
+          </Link>
+        </>
+      ),
+    })
+    const aboutRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/about',
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, aboutRoute]),
+      history,
+    })
+    const preloadRouteSpy = vi.spyOn(router, 'preloadRoute')
+
+    render(<RouterProvider router={router} />)
+
+    const viewportLink = await screen.findByRole('link', {
+      name: 'Viewport Link',
+    })
+    const intentLink = await screen.findByRole('link', { name: 'Intent Link' })
+    vi.useFakeTimers()
+
+    ioCallback([], {} as IntersectionObserver)
+    ioCallback(
+      [
+        {
+          isIntersecting: false,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    await vi.advanceTimersByTimeAsync(50)
+    expect(preloadRouteSpy).not.toHaveBeenCalled()
+
+    ioCallback(
+      [
+        {
+          isIntersecting: true,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    ioCallback(
+      [
+        {
+          isIntersecting: true,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    fireEvent.mouseLeave(viewportLink)
+
+    expect(preloadRouteSpy).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(49)
+    expect(preloadRouteSpy).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1)
+    expect(preloadRouteSpy).toHaveBeenCalledOnce()
+
+    fireEvent.mouseEnter(intentLink)
+    fireEvent.mouseLeave(intentLink)
+    await vi.advanceTimersByTimeAsync(50)
+    expect(preloadRouteSpy).toHaveBeenCalledOnce()
   })
 
   test("Router.preload='render', should trigger the route loader on render", async () => {

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -5246,6 +5246,106 @@ describe('Link', () => {
     expect(preloadRouteSpy).toHaveBeenCalledTimes(2)
   })
 
+  test('Link.preload="viewport" should cancel and use new link options after they change', async () => {
+    const rootRoute = createRootRoute()
+    const RouteComponent = () => {
+      const [to, setTo] = React.useState<'/about' | '/other'>('/about')
+      return (
+        <>
+          <button
+            onClick={() =>
+              setTo((current) => (current === '/about' ? '/other' : '/about'))
+            }
+          >
+            Change destination
+          </button>
+          <Link to={to} preload="viewport" preloadDelay={50}>
+            Viewport Link
+          </Link>
+        </>
+      )
+    }
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: RouteComponent,
+    })
+    const aboutRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/about',
+    })
+    const otherRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/other',
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, aboutRoute, otherRoute]),
+      history,
+    })
+    const preloadRouteSpy = vi.spyOn(router, 'preloadRoute')
+
+    render(<RouterProvider router={router} />)
+
+    const viewportLink = await screen.findByRole('link', {
+      name: 'Viewport Link',
+    })
+    const initialIoCallback = ioCallback
+    vi.useFakeTimers()
+
+    ioCallback(
+      [
+        {
+          isIntersecting: true,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Change destination' }))
+    expect(viewportLink).toHaveAttribute('href', '/other')
+    expect(ioCallback).not.toBe(initialIoCallback)
+
+    ioCallback(
+      [
+        {
+          isIntersecting: false,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    await vi.advanceTimersByTimeAsync(50)
+    expect(preloadRouteSpy).not.toHaveBeenCalled()
+
+    ioCallback(
+      [
+        {
+          isIntersecting: true,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Change destination' }))
+    expect(viewportLink).toHaveAttribute('href', '/about')
+
+    ioCallback(
+      [
+        {
+          isIntersecting: true,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    await vi.advanceTimersByTimeAsync(50)
+    expect(preloadRouteSpy).toHaveBeenCalledTimes(1)
+    expect(preloadRouteSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ to: '/about' }),
+    )
+  })
+
   test("Router.preload='render', should trigger the route loader on render", async () => {
     const mock = vi.fn()
 

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -5238,8 +5238,6 @@ describe('Link', () => {
       {} as IntersectionObserver,
     )
     await vi.advanceTimersByTimeAsync(1)
-    expect(preloadRouteSpy).toHaveBeenCalledOnce()
-    await vi.advanceTimersByTimeAsync(49)
     expect(preloadRouteSpy).toHaveBeenCalledTimes(2)
 
     fireEvent.mouseEnter(intentLink)

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -5250,6 +5250,9 @@ describe('Link', () => {
     const rootRoute = createRootRoute()
     const RouteComponent = () => {
       const [to, setTo] = React.useState<'/about' | '/other'>('/about')
+      const [preload, setPreload] = React.useState<
+        'viewport' | 'intent' | false
+      >('viewport')
       return (
         <>
           <button
@@ -5259,7 +5262,9 @@ describe('Link', () => {
           >
             Change destination
           </button>
-          <Link to={to} preload="viewport" preloadDelay={50}>
+          <button onClick={() => setPreload('intent')}>Use intent</button>
+          <button onClick={() => setPreload(false)}>Disable preload</button>
+          <Link to={to} preload={preload} preloadDelay={50}>
             Viewport Link
           </Link>
         </>
@@ -5344,6 +5349,14 @@ describe('Link', () => {
     expect(preloadRouteSpy).toHaveBeenCalledWith(
       expect.objectContaining({ to: '/about' }),
     )
+
+    preloadRouteSpy.mockClear()
+    fireEvent.click(screen.getByRole('button', { name: 'Use intent' }))
+    fireEvent.mouseEnter(viewportLink)
+    fireEvent.click(screen.getByRole('button', { name: 'Disable preload' }))
+    fireEvent.mouseLeave(viewportLink)
+    await vi.advanceTimersByTimeAsync(50)
+    expect(preloadRouteSpy).not.toHaveBeenCalled()
   })
 
   test("Router.preload='render', should trigger the route loader on render", async () => {

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -5197,6 +5197,27 @@ describe('Link', () => {
     await vi.advanceTimersByTimeAsync(1)
     expect(preloadRouteSpy).toHaveBeenCalledOnce()
 
+    ioCallback(
+      [
+        {
+          isIntersecting: true,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    ioCallback(
+      [
+        {
+          isIntersecting: false,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    await vi.advanceTimersByTimeAsync(50)
+    expect(preloadRouteSpy).toHaveBeenCalledOnce()
+
     fireEvent.mouseEnter(intentLink)
     fireEvent.mouseLeave(intentLink)
     await vi.advanceTimersByTimeAsync(50)

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -5203,11 +5203,6 @@ describe('Link', () => {
           isIntersecting: true,
           target: viewportLink,
         } as unknown as IntersectionObserverEntry,
-      ],
-      {} as IntersectionObserver,
-    )
-    ioCallback(
-      [
         {
           isIntersecting: false,
           target: viewportLink,
@@ -5218,10 +5213,39 @@ describe('Link', () => {
     await vi.advanceTimersByTimeAsync(50)
     expect(preloadRouteSpy).toHaveBeenCalledOnce()
 
+    ioCallback(
+      [
+        {
+          isIntersecting: true,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    await vi.advanceTimersByTimeAsync(49)
+
+    ioCallback(
+      [
+        {
+          isIntersecting: false,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+        {
+          isIntersecting: true,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    await vi.advanceTimersByTimeAsync(1)
+    expect(preloadRouteSpy).toHaveBeenCalledOnce()
+    await vi.advanceTimersByTimeAsync(49)
+    expect(preloadRouteSpy).toHaveBeenCalledTimes(2)
+
     fireEvent.mouseEnter(intentLink)
     fireEvent.mouseLeave(intentLink)
     await vi.advanceTimersByTimeAsync(50)
-    expect(preloadRouteSpy).toHaveBeenCalledOnce()
+    expect(preloadRouteSpy).toHaveBeenCalledTimes(2)
   })
 
   test("Router.preload='render', should trigger the route loader on render", async () => {

--- a/packages/react-router/tests/utils.ts
+++ b/packages/react-router/tests/utils.ts
@@ -20,9 +20,11 @@ export function createTimer() {
 export const getIntersectionObserverMock = ({
   observe,
   disconnect,
+  onCreate,
 }: {
   observe: Mock
   disconnect: Mock
+  onCreate?: (callback: IntersectionObserverCallback) => void
 }) => {
   return class IO implements IntersectionObserver {
     root: Document | Element | null
@@ -33,6 +35,7 @@ export const getIntersectionObserverMock = ({
       _cb: IntersectionObserverCallback,
       options?: IntersectionObserverInit,
     ) {
+      onCreate?.(_cb)
       this.root = options?.root ?? null
       this.rootMargin = options?.rootMargin ?? '0px'
       this.scrollMargin = options?.scrollMargin ?? '0px'

--- a/packages/router-core/src/link.ts
+++ b/packages/router-core/src/link.ts
@@ -677,9 +677,9 @@ export interface LinkOptionsProps {
    */
   preload?: false | 'intent' | 'viewport' | 'render'
   /**
-   * When the intent preload strategy is set, this delays focus and hover
-   * preloading by this many milliseconds. Touch intent preloads immediately.
-   * If focus or hover exits before this delay, the preload will be cancelled.
+   * Delays focus, hover, and viewport preloading by this many milliseconds.
+   * Touch intent preloads immediately. If focus or hover exits before this
+   * delay, the preload will be cancelled.
    */
   preloadDelay?: number
   /**

--- a/packages/router-core/src/link.ts
+++ b/packages/router-core/src/link.ts
@@ -678,8 +678,8 @@ export interface LinkOptionsProps {
   preload?: false | 'intent' | 'viewport' | 'render'
   /**
    * Delays focus, hover, and viewport preloading by this many milliseconds.
-   * Touch intent preloads immediately. If focus or hover exits before this
-   * delay, the preload will be cancelled.
+   * Touch intent preloads immediately. If focus or hover ends, or the link
+   * leaves the viewport before this delay, the preload will be cancelled.
    */
   preloadDelay?: number
   /**

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -213,7 +213,8 @@ export interface RouterOptions<
    */
   defaultPreload?: false | 'intent' | 'viewport' | 'render'
   /**
-   * The delay in milliseconds that a route must be hovered over or touched before it is preloaded.
+   * The delay in milliseconds before intent focus/hover and viewport preloading.
+   * Touch intent preloads immediately.
    *
    * @default 50
    * @link [API Docs](https://tanstack.com/router/latest/docs/framework/react/api/router/RouterOptionsType#defaultpreloaddelay-property)

--- a/packages/solid-router/src/link.tsx
+++ b/packages/solid-router/src/link.tsx
@@ -32,6 +32,10 @@ import type {
 } from './typePrimitives'
 
 const timeoutMap = new WeakMap<object, ReturnType<typeof setTimeout>>()
+const cancelPreload = (eventTarget: object) => {
+  clearTimeout(timeoutMap.get(eventTarget))
+  timeoutMap.delete(eventTarget)
+}
 
 export function useLinkProps<
   TRouter extends AnyRouter = RegisteredRouter,
@@ -258,13 +262,20 @@ export function useLinkProps<
   const enqueuePreload = (
     e: MouseEvent | FocusEvent | IntersectionObserverEntry | undefined,
   ) => {
+    if (!e) {
+      return
+    }
+
+    const eventTarget =
+      (e as { currentTarget?: EventTarget | null }).currentTarget || doPreload
+
     if (
-      !e ||
       !(
         (e as IntersectionObserverEntry).isIntersecting ??
         preload() === 'intent'
       )
     ) {
+      cancelPreload(eventTarget)
       return
     }
 
@@ -272,9 +283,6 @@ export function useLinkProps<
       doPreload()
       return
     }
-
-    const eventTarget =
-      (e as { currentTarget?: EventTarget | null }).currentTarget || doPreload
 
     if (!timeoutMap.has(eventTarget)) {
       timeoutMap.set(
@@ -378,9 +386,7 @@ export function useLinkProps<
     const eventTarget = e.currentTarget || e.target
 
     if (eventTarget) {
-      const id = timeoutMap.get(eventTarget)
-      clearTimeout(id)
-      timeoutMap.delete(eventTarget)
+      cancelPreload(eventTarget)
     }
   }
 

--- a/packages/solid-router/src/link.tsx
+++ b/packages/solid-router/src/link.tsx
@@ -259,15 +259,18 @@ export function useLinkProps<
         console.warn(preloadWarning)
       })
 
+  const [ref, setRef] = Solid.createSignal<Element | null>(null)
+
   const enqueuePreload = (
     e: MouseEvent | FocusEvent | IntersectionObserverEntry | undefined,
   ) => {
     if (!e) {
+      cancelPreload(ref)
       return
     }
 
     const eventTarget =
-      (e as { currentTarget?: EventTarget | null }).currentTarget || doPreload
+      (e as { currentTarget?: EventTarget | null }).currentTarget || ref
 
     if (
       !(
@@ -295,9 +298,7 @@ export function useLinkProps<
     }
   }
 
-  const [ref, setRef] = Solid.createSignal<Element | null>(null)
-
-  useIntersectionObserver(ref, enqueuePreload, preload() !== 'viewport')
+  useIntersectionObserver(ref, enqueuePreload, () => preload() !== 'viewport')
 
   Solid.createEffect(() => {
     if (hasRenderFetched) {

--- a/packages/solid-router/src/link.tsx
+++ b/packages/solid-router/src/link.tsx
@@ -262,15 +262,12 @@ export function useLinkProps<
   const [ref, setRef] = Solid.createSignal<Element | null>(null)
 
   const enqueuePreload = (
-    e: MouseEvent | FocusEvent | IntersectionObserverEntry | undefined,
+    e?: MouseEvent | FocusEvent | IntersectionObserverEntry,
   ) => {
     if (!e) {
       cancelPreload(ref)
       return
     }
-
-    const eventTarget =
-      (e as { currentTarget?: EventTarget | null }).currentTarget || ref
 
     if (
       !(
@@ -278,7 +275,9 @@ export function useLinkProps<
         preload() === 'intent'
       )
     ) {
-      cancelPreload(eventTarget)
+      if ((e as IntersectionObserverEntry).isIntersecting === false) {
+        cancelPreload(ref)
+      }
       return
     }
 
@@ -287,11 +286,11 @@ export function useLinkProps<
       return
     }
 
-    if (!timeoutMap.has(eventTarget)) {
+    if (!timeoutMap.has(ref)) {
       timeoutMap.set(
-        eventTarget,
+        ref,
         setTimeout(() => {
-          timeoutMap.delete(eventTarget)
+          timeoutMap.delete(ref)
           doPreload()
         }, preloadDelay()),
       )
@@ -378,11 +377,9 @@ export function useLinkProps<
     doPreload()
   }
 
-  const handleLeave = (e: MouseEvent | FocusEvent) => {
-    const eventTarget = e.currentTarget || e.target
-
-    if (eventTarget) {
-      cancelPreload(eventTarget)
+  const handleLeave = () => {
+    if (preload() === 'intent') {
+      cancelPreload(ref)
     }
   }
 

--- a/packages/solid-router/src/link.tsx
+++ b/packages/solid-router/src/link.tsx
@@ -297,12 +297,7 @@ export function useLinkProps<
 
   const [ref, setRef] = Solid.createSignal<Element | null>(null)
 
-  useIntersectionObserver(
-    ref,
-    enqueuePreload,
-    { rootMargin: '100px' },
-    preload() !== 'viewport',
-  )
+  useIntersectionObserver(ref, enqueuePreload, preload() !== 'viewport')
 
   Solid.createEffect(() => {
     if (hasRenderFetched) {

--- a/packages/solid-router/src/link.tsx
+++ b/packages/solid-router/src/link.tsx
@@ -31,7 +31,7 @@ import type {
   ValidateLinkOptionsArray,
 } from './typePrimitives'
 
-const timeoutMap = new WeakMap<EventTarget, ReturnType<typeof setTimeout>>()
+const timeoutMap = new WeakMap<object, ReturnType<typeof setTimeout>>()
 
 export function useLinkProps<
   TRouter extends AnyRouter = RegisteredRouter,
@@ -190,7 +190,7 @@ export function useLinkProps<
   })
 
   const preload = Solid.createMemo(() => {
-    if (options.reloadDocument || externalLink()) {
+    if (options.reloadDocument || externalLink() || local.disabled) {
       return false
     }
     return local.preload ?? router.options.defaultPreload
@@ -255,11 +255,35 @@ export function useLinkProps<
         console.warn(preloadWarning)
       })
 
-  const preloadViewportIoCallback = (
-    entry: IntersectionObserverEntry | undefined,
+  const enqueuePreload = (
+    e: MouseEvent | FocusEvent | IntersectionObserverEntry | undefined,
   ) => {
-    if (entry?.isIntersecting) {
+    if (
+      !e ||
+      !(
+        (e as IntersectionObserverEntry).isIntersecting ??
+        preload() === 'intent'
+      )
+    ) {
+      return
+    }
+
+    if (!preloadDelay()) {
       doPreload()
+      return
+    }
+
+    const eventTarget =
+      (e as { currentTarget?: EventTarget | null }).currentTarget || doPreload
+
+    if (!timeoutMap.has(eventTarget)) {
+      timeoutMap.set(
+        eventTarget,
+        setTimeout(() => {
+          timeoutMap.delete(eventTarget)
+          doPreload()
+        }, preloadDelay()),
+      )
     }
   }
 
@@ -267,16 +291,16 @@ export function useLinkProps<
 
   useIntersectionObserver(
     ref,
-    preloadViewportIoCallback,
+    enqueuePreload,
     { rootMargin: '100px' },
-    !!local.disabled || preload() !== 'viewport',
+    preload() !== 'viewport',
   )
 
   Solid.createEffect(() => {
     if (hasRenderFetched) {
       return
     }
-    if (!local.disabled && preload() === 'render') {
+    if (preload() === 'render') {
       doPreload()
       hasRenderFetched = true
     }
@@ -345,34 +369,12 @@ export function useLinkProps<
     }
   }
 
-  const enqueueIntentPreload = (e: MouseEvent | FocusEvent) => {
-    if (local.disabled || preload() !== 'intent') return
-
-    if (!preloadDelay()) {
-      doPreload()
-      return
-    }
-
-    const eventTarget = e.currentTarget || e.target
-
-    if (!eventTarget || timeoutMap.has(eventTarget)) return
-
-    timeoutMap.set(
-      eventTarget,
-      setTimeout(() => {
-        timeoutMap.delete(eventTarget)
-        doPreload()
-      }, preloadDelay()),
-    )
-  }
-
-  const handleTouchStart = (_: TouchEvent) => {
-    if (local.disabled || preload() !== 'intent') return
+  const handleTouchStart = () => {
+    if (preload() !== 'intent') return
     doPreload()
   }
 
   const handleLeave = (e: MouseEvent | FocusEvent) => {
-    if (local.disabled) return
     const eventTarget = e.currentTarget || e.target
 
     if (eventTarget) {
@@ -392,17 +394,14 @@ export function useLinkProps<
 
   const onClick = createComposedHandler(() => local.onClick, handleClick)
   const onBlur = createComposedHandler(() => local.onBlur, handleLeave)
-  const onFocus = createComposedHandler(
-    () => local.onFocus,
-    enqueueIntentPreload,
-  )
+  const onFocus = createComposedHandler(() => local.onFocus, enqueuePreload)
   const onMouseEnter = createComposedHandler(
     () => local.onMouseEnter,
-    enqueueIntentPreload,
+    enqueuePreload,
   )
   const onMouseOver = createComposedHandler(
     () => local.onMouseOver,
-    enqueueIntentPreload,
+    enqueuePreload,
   )
   const onMouseLeave = createComposedHandler(
     () => local.onMouseLeave,

--- a/packages/solid-router/src/utils.ts
+++ b/packages/solid-router/src/utils.ts
@@ -8,9 +8,8 @@ import * as Solid from 'solid-js'
  * When the intersection changes, the callback will be called with the `IntersectionObserverEntry`.
  *
  * @param ref - The ref to observe
- * @param intersectionObserverOptions - The options to pass to the IntersectionObserver
- * @param disabled - Whether observation is disabled
  * @param callback - The callback to call when the intersection changes
+ * @param disabled - Whether observation is disabled
  * @returns The IntersectionObserver instance
  * @example
  * ```tsx
@@ -19,7 +18,6 @@ import * as Solid from 'solid-js'
  * useIntersectionObserver(
  *  ref,
  *  (entry) => { doSomething(entry) },
- *  { rootMargin: '10px' },
  *  false
  * )
  * return <div ref={ref} />
@@ -28,7 +26,6 @@ import * as Solid from 'solid-js'
 export function useIntersectionObserver<T extends Element>(
   ref: Solid.Accessor<T | null>,
   callback: (entry: IntersectionObserverEntry | undefined) => void,
-  intersectionObserverOptions: IntersectionObserverInit = {},
   disabled?: boolean,
 ): Solid.Accessor<IntersectionObserver | null> {
   const isIntersectionObserverAvailable =
@@ -41,9 +38,12 @@ export function useIntersectionObserver<T extends Element>(
       return
     }
 
-    observerRef = new IntersectionObserver((entries) => {
-      callback(entries.pop())
-    }, intersectionObserverOptions)
+    observerRef = new IntersectionObserver(
+      (entries) => {
+        callback(entries.pop())
+      },
+      { rootMargin: '100px' },
+    )
 
     observerRef.observe(r)
 

--- a/packages/solid-router/src/utils.ts
+++ b/packages/solid-router/src/utils.ts
@@ -25,7 +25,7 @@ import * as Solid from 'solid-js'
  */
 export function useIntersectionObserver<T extends Element>(
   ref: Solid.Accessor<T | null>,
-  callback: (entry: IntersectionObserverEntry | undefined) => void,
+  callback: (entry?: IntersectionObserverEntry) => void,
   disabled: Solid.Accessor<boolean>,
 ): Solid.Accessor<IntersectionObserver | null> {
   const isIntersectionObserverAvailable =
@@ -34,7 +34,8 @@ export function useIntersectionObserver<T extends Element>(
 
   Solid.createEffect(() => {
     const r = ref()
-    if (!r || !isIntersectionObserverAvailable || disabled()) {
+    if (disabled() || !r || !isIntersectionObserverAvailable) {
+      Solid.onCleanup(() => callback())
       return
     }
 
@@ -49,7 +50,7 @@ export function useIntersectionObserver<T extends Element>(
 
     Solid.onCleanup(() => {
       observerRef?.disconnect()
-      callback(undefined)
+      callback()
     })
   })
 

--- a/packages/solid-router/src/utils.ts
+++ b/packages/solid-router/src/utils.ts
@@ -26,7 +26,7 @@ import * as Solid from 'solid-js'
 export function useIntersectionObserver<T extends Element>(
   ref: Solid.Accessor<T | null>,
   callback: (entry: IntersectionObserverEntry | undefined) => void,
-  disabled?: boolean,
+  disabled: Solid.Accessor<boolean>,
 ): Solid.Accessor<IntersectionObserver | null> {
   const isIntersectionObserverAvailable =
     typeof IntersectionObserver === 'function'
@@ -34,7 +34,7 @@ export function useIntersectionObserver<T extends Element>(
 
   Solid.createEffect(() => {
     const r = ref()
-    if (!r || !isIntersectionObserverAvailable || disabled) {
+    if (!r || !isIntersectionObserverAvailable || disabled()) {
       return
     }
 
@@ -49,6 +49,7 @@ export function useIntersectionObserver<T extends Element>(
 
     Solid.onCleanup(() => {
       observerRef?.disconnect()
+      callback(undefined)
     })
   })
 

--- a/packages/solid-router/src/utils.ts
+++ b/packages/solid-router/src/utils.ts
@@ -42,7 +42,7 @@ export function useIntersectionObserver<T extends Element>(
     }
 
     observerRef = new IntersectionObserver((entries) => {
-      entries.forEach(callback)
+      callback(entries.pop())
     }, intersectionObserverOptions)
 
     observerRef.observe(r)

--- a/packages/solid-router/src/utils.ts
+++ b/packages/solid-router/src/utils.ts
@@ -41,8 +41,8 @@ export function useIntersectionObserver<T extends Element>(
       return
     }
 
-    observerRef = new IntersectionObserver(([entry]) => {
-      callback(entry)
+    observerRef = new IntersectionObserver((entries) => {
+      entries.forEach(callback)
     }, intersectionObserverOptions)
 
     observerRef.observe(r)

--- a/packages/solid-router/tests/link.test.tsx
+++ b/packages/solid-router/tests/link.test.tsx
@@ -5116,8 +5116,6 @@ describe('Link', () => {
       {} as IntersectionObserver,
     )
     await vi.advanceTimersByTimeAsync(1)
-    expect(preloadRouteSpy).toHaveBeenCalledOnce()
-    await vi.advanceTimersByTimeAsync(49)
     expect(preloadRouteSpy).toHaveBeenCalledTimes(2)
 
     fireEvent.mouseEnter(intentLink)

--- a/packages/solid-router/tests/link.test.tsx
+++ b/packages/solid-router/tests/link.test.tsx
@@ -5081,11 +5081,6 @@ describe('Link', () => {
           isIntersecting: true,
           target: viewportLink,
         } as unknown as IntersectionObserverEntry,
-      ],
-      {} as IntersectionObserver,
-    )
-    ioCallback(
-      [
         {
           isIntersecting: false,
           target: viewportLink,
@@ -5096,10 +5091,39 @@ describe('Link', () => {
     await vi.advanceTimersByTimeAsync(50)
     expect(preloadRouteSpy).toHaveBeenCalledOnce()
 
+    ioCallback(
+      [
+        {
+          isIntersecting: true,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    await vi.advanceTimersByTimeAsync(49)
+
+    ioCallback(
+      [
+        {
+          isIntersecting: false,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+        {
+          isIntersecting: true,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    await vi.advanceTimersByTimeAsync(1)
+    expect(preloadRouteSpy).toHaveBeenCalledOnce()
+    await vi.advanceTimersByTimeAsync(49)
+    expect(preloadRouteSpy).toHaveBeenCalledTimes(2)
+
     fireEvent.mouseEnter(intentLink)
     fireEvent.mouseLeave(intentLink)
     await vi.advanceTimersByTimeAsync(50)
-    expect(preloadRouteSpy).toHaveBeenCalledOnce()
+    expect(preloadRouteSpy).toHaveBeenCalledTimes(2)
   })
 
   test("Router.preload='render', should trigger the route loader on render", async () => {

--- a/packages/solid-router/tests/link.test.tsx
+++ b/packages/solid-router/tests/link.test.tsx
@@ -5075,6 +5075,27 @@ describe('Link', () => {
     await vi.advanceTimersByTimeAsync(1)
     expect(preloadRouteSpy).toHaveBeenCalledOnce()
 
+    ioCallback(
+      [
+        {
+          isIntersecting: true,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    ioCallback(
+      [
+        {
+          isIntersecting: false,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    await vi.advanceTimersByTimeAsync(50)
+    expect(preloadRouteSpy).toHaveBeenCalledOnce()
+
     fireEvent.mouseEnter(intentLink)
     fireEvent.mouseLeave(intentLink)
     await vi.advanceTimersByTimeAsync(50)

--- a/packages/solid-router/tests/link.test.tsx
+++ b/packages/solid-router/tests/link.test.tsx
@@ -43,12 +43,16 @@ import type { RouterHistory } from '../src'
 
 const ioObserveMock = vi.fn()
 const ioDisconnectMock = vi.fn()
+let ioCallback: IntersectionObserverCallback
 let history: RouterHistory
 
 beforeEach(() => {
   const io = getIntersectionObserverMock({
     observe: ioObserveMock,
     disconnect: ioDisconnectMock,
+    onCreate: (callback) => {
+      ioCallback = callback
+    },
   })
   vi.stubGlobal('IntersectionObserver', io)
   history = createBrowserHistory()
@@ -56,6 +60,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  vi.useRealTimers()
   history.destroy?.()
   window.history.replaceState(null, 'root', '/')
   vi.resetAllMocks()
@@ -4995,6 +5000,85 @@ describe('Link', () => {
     })
     expect(ioObserveMock).toHaveBeenCalledOnce() // it should not observe again
     expect(ioDisconnectMock).not.toHaveBeenCalled() // it should not disconnect again
+  })
+
+  test('Link.preload="viewport" should respect preloadDelay', async () => {
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => (
+        <>
+          <Link to="/about" preload="viewport" preloadDelay={50}>
+            Viewport Link
+          </Link>
+          <Link to="/about" preload="intent" preloadDelay={50}>
+            Intent Link
+          </Link>
+        </>
+      ),
+    })
+    const aboutRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/about',
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, aboutRoute]),
+      history,
+    })
+    const preloadRouteSpy = vi.spyOn(router, 'preloadRoute')
+
+    render(() => <RouterProvider router={router} />)
+
+    const viewportLink = await screen.findByRole('link', {
+      name: 'Viewport Link',
+    })
+    const intentLink = await screen.findByRole('link', { name: 'Intent Link' })
+    vi.useFakeTimers()
+
+    ioCallback([], {} as IntersectionObserver)
+    ioCallback(
+      [
+        {
+          isIntersecting: false,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    await vi.advanceTimersByTimeAsync(50)
+    expect(preloadRouteSpy).not.toHaveBeenCalled()
+
+    ioCallback(
+      [
+        {
+          isIntersecting: true,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    ioCallback(
+      [
+        {
+          isIntersecting: true,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    fireEvent.mouseLeave(viewportLink)
+
+    expect(preloadRouteSpy).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(49)
+    expect(preloadRouteSpy).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1)
+    expect(preloadRouteSpy).toHaveBeenCalledOnce()
+
+    fireEvent.mouseEnter(intentLink)
+    fireEvent.mouseLeave(intentLink)
+    await vi.advanceTimersByTimeAsync(50)
+    expect(preloadRouteSpy).toHaveBeenCalledOnce()
   })
 
   test("Router.preload='render', should trigger the route loader on render", async () => {

--- a/packages/solid-router/tests/utils.ts
+++ b/packages/solid-router/tests/utils.ts
@@ -20,9 +20,11 @@ export function createTimer() {
 export const getIntersectionObserverMock = ({
   observe,
   disconnect,
+  onCreate,
 }: {
   observe: Mock
   disconnect: Mock
+  onCreate?: (callback: IntersectionObserverCallback) => void
 }) => {
   return class IO implements IntersectionObserver {
     root: Document | Element | null
@@ -33,6 +35,7 @@ export const getIntersectionObserverMock = ({
       _cb: IntersectionObserverCallback,
       options?: IntersectionObserverInit,
     ) {
+      onCreate?.(_cb)
       this.root = options?.root ?? null
       this.rootMargin = options?.rootMargin ?? '0px'
       this.scrollMargin = options?.scrollMargin ?? '0px'

--- a/packages/vue-router/src/link.tsx
+++ b/packages/vue-router/src/link.tsx
@@ -255,11 +255,13 @@ export function useLinkProps<
     e: MouseEvent | FocusEvent | IntersectionObserverEntry | undefined,
   ) => {
     if (!e) {
+      clearTimeout(timeoutMap.get(ref))
+      timeoutMap.delete(ref)
       return
     }
 
     const eventTarget =
-      (e as { currentTarget?: EventTarget | null }).currentTarget || doPreload
+      (e as { currentTarget?: EventTarget | null }).currentTarget || ref
 
     if (
       !(

--- a/packages/vue-router/src/link.tsx
+++ b/packages/vue-router/src/link.tsx
@@ -252,7 +252,7 @@ export function useLinkProps<
       })
 
   const enqueuePreload = (
-    e: MouseEvent | FocusEvent | IntersectionObserverEntry | undefined,
+    e?: MouseEvent | FocusEvent | IntersectionObserverEntry,
   ) => {
     if (!e) {
       clearTimeout(timeoutMap.get(ref))
@@ -260,17 +260,16 @@ export function useLinkProps<
       return
     }
 
-    const eventTarget =
-      (e as { currentTarget?: EventTarget | null }).currentTarget || ref
-
     if (
       !(
         (e as IntersectionObserverEntry).isIntersecting ??
         preload.value === 'intent'
       )
     ) {
-      clearTimeout(timeoutMap.get(eventTarget))
-      timeoutMap.delete(eventTarget)
+      if ((e as IntersectionObserverEntry).isIntersecting === false) {
+        clearTimeout(timeoutMap.get(ref))
+        timeoutMap.delete(ref)
+      }
       return
     }
 
@@ -279,11 +278,11 @@ export function useLinkProps<
       return
     }
 
-    if (!timeoutMap.has(eventTarget)) {
+    if (!timeoutMap.has(ref)) {
       timeoutMap.set(
-        eventTarget,
+        ref,
         setTimeout(() => {
-          timeoutMap.delete(eventTarget)
+          timeoutMap.delete(ref)
           doPreload()
         }, preloadDelay.value),
       )
@@ -354,12 +353,10 @@ export function useLinkProps<
     doPreload()
   }
 
-  const handleLeave = (e: MouseEvent | FocusEvent) => {
-    const eventTarget = e.currentTarget || e.target
-
-    if (eventTarget) {
-      clearTimeout(timeoutMap.get(eventTarget))
-      timeoutMap.delete(eventTarget)
+  const handleLeave = () => {
+    if (preload.value === 'intent') {
+      clearTimeout(timeoutMap.get(ref))
+      timeoutMap.delete(ref)
     }
   }
 

--- a/packages/vue-router/src/link.tsx
+++ b/packages/vue-router/src/link.tsx
@@ -291,7 +291,6 @@ export function useLinkProps<
   useIntersectionObserver(
     ref,
     enqueuePreload,
-    { rootMargin: '100px' },
     () => preload.value !== 'viewport',
   )
 

--- a/packages/vue-router/src/link.tsx
+++ b/packages/vue-router/src/link.tsx
@@ -29,7 +29,7 @@ import type {
 
 type EventHandler<TEvent = Event> = (e: TEvent) => void
 
-const timeoutMap = new WeakMap<EventTarget, ReturnType<typeof setTimeout>>()
+const timeoutMap = new WeakMap<object, ReturnType<typeof setTimeout>>()
 
 type DataAttributes = {
   [K in `data-${string}`]?: unknown
@@ -224,7 +224,7 @@ export function useLinkProps<
   })
 
   const preload = Vue.computed(() => {
-    if (options.reloadDocument) {
+    if (options.reloadDocument || options.disabled) {
       return false
     }
     return options.preload ?? router.options.defaultPreload
@@ -251,26 +251,50 @@ export function useLinkProps<
         console.warn(preloadWarning)
       })
 
-  const preloadViewportIoCallback = (
-    entry: IntersectionObserverEntry | undefined,
+  const enqueuePreload = (
+    e: MouseEvent | FocusEvent | IntersectionObserverEntry | undefined,
   ) => {
-    if (entry?.isIntersecting) {
+    if (
+      !e ||
+      !(
+        (e as IntersectionObserverEntry).isIntersecting ??
+        preload.value === 'intent'
+      )
+    ) {
+      return
+    }
+
+    if (!preloadDelay.value) {
       doPreload()
+      return
+    }
+
+    const eventTarget =
+      (e as { currentTarget?: EventTarget | null }).currentTarget || doPreload
+
+    if (!timeoutMap.has(eventTarget)) {
+      timeoutMap.set(
+        eventTarget,
+        setTimeout(() => {
+          timeoutMap.delete(eventTarget)
+          doPreload()
+        }, preloadDelay.value),
+      )
     }
   }
 
   useIntersectionObserver(
     ref,
-    preloadViewportIoCallback,
+    enqueuePreload,
     { rootMargin: '100px' },
-    () => !!options.disabled || preload.value !== 'viewport',
+    () => preload.value !== 'viewport',
   )
 
   Vue.effect(() => {
     if (hasRenderFetched) {
       return
     }
-    if (!options.disabled && preload.value === 'render') {
+    if (preload.value === 'render') {
       doPreload()
       hasRenderFetched = true
     }
@@ -319,34 +343,12 @@ export function useLinkProps<
     }
   }
 
-  const enqueueIntentPreload = (e: MouseEvent | FocusEvent) => {
-    if (options.disabled || preload.value !== 'intent') return
-
-    if (!preloadDelay.value) {
-      doPreload()
-      return
-    }
-
-    const eventTarget = e.currentTarget || e.target
-
-    if (!eventTarget || timeoutMap.has(eventTarget)) return
-
-    timeoutMap.set(
-      eventTarget,
-      setTimeout(() => {
-        timeoutMap.delete(eventTarget)
-        doPreload()
-      }, preloadDelay.value),
-    )
-  }
-
-  const handleTouchStart = (_: TouchEvent) => {
-    if (options.disabled || preload.value !== 'intent') return
+  const handleTouchStart = () => {
+    if (preload.value !== 'intent') return
     doPreload()
   }
 
   const handleLeave = (e: MouseEvent | FocusEvent) => {
-    if (options.disabled) return
     const eventTarget = e.currentTarget || e.target
 
     if (eventTarget) {
@@ -384,15 +386,15 @@ export function useLinkProps<
     onBlur: composeEventHandlers<FocusEvent>([options.onBlur, handleLeave]),
     onFocus: composeEventHandlers<FocusEvent>([
       options.onFocus,
-      enqueueIntentPreload,
+      enqueuePreload,
     ]),
     onMouseenter: composeEventHandlers<MouseEvent>([
       eventHandlers.onMouseenter,
-      enqueueIntentPreload,
+      enqueuePreload,
     ]),
     onMouseover: composeEventHandlers<MouseEvent>([
       eventHandlers.onMouseover,
-      enqueueIntentPreload,
+      enqueuePreload,
     ]),
     onMouseleave: composeEventHandlers<MouseEvent>([
       eventHandlers.onMouseleave,

--- a/packages/vue-router/src/link.tsx
+++ b/packages/vue-router/src/link.tsx
@@ -254,13 +254,21 @@ export function useLinkProps<
   const enqueuePreload = (
     e: MouseEvent | FocusEvent | IntersectionObserverEntry | undefined,
   ) => {
+    if (!e) {
+      return
+    }
+
+    const eventTarget =
+      (e as { currentTarget?: EventTarget | null }).currentTarget || doPreload
+
     if (
-      !e ||
       !(
         (e as IntersectionObserverEntry).isIntersecting ??
         preload.value === 'intent'
       )
     ) {
+      clearTimeout(timeoutMap.get(eventTarget))
+      timeoutMap.delete(eventTarget)
       return
     }
 
@@ -268,9 +276,6 @@ export function useLinkProps<
       doPreload()
       return
     }
-
-    const eventTarget =
-      (e as { currentTarget?: EventTarget | null }).currentTarget || doPreload
 
     if (!timeoutMap.has(eventTarget)) {
       timeoutMap.set(
@@ -352,8 +357,7 @@ export function useLinkProps<
     const eventTarget = e.currentTarget || e.target
 
     if (eventTarget) {
-      const id = timeoutMap.get(eventTarget)
-      clearTimeout(id)
+      clearTimeout(timeoutMap.get(eventTarget))
       timeoutMap.delete(eventTarget)
     }
   }

--- a/packages/vue-router/src/utils.ts
+++ b/packages/vue-router/src/utils.ts
@@ -66,7 +66,7 @@ export function useIntersectionObserver<T extends Element>(
     }
 
     const observer = new IntersectionObserver((entries) => {
-      entries.forEach(callback)
+      callback(entries.pop())
     }, intersectionObserverOptions)
 
     observerRef.value = observer

--- a/packages/vue-router/src/utils.ts
+++ b/packages/vue-router/src/utils.ts
@@ -65,8 +65,8 @@ export function useIntersectionObserver<T extends Element>(
       return
     }
 
-    const observer = new IntersectionObserver(([entry]) => {
-      callback(entry)
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(callback)
     }, intersectionObserverOptions)
 
     observerRef.value = observer

--- a/packages/vue-router/src/utils.ts
+++ b/packages/vue-router/src/utils.ts
@@ -75,6 +75,7 @@ export function useIntersectionObserver<T extends Element>(
     onCleanup(() => {
       observer.disconnect()
       observerRef.value = null
+      callback(undefined)
     })
   })
 

--- a/packages/vue-router/src/utils.ts
+++ b/packages/vue-router/src/utils.ts
@@ -48,7 +48,7 @@ export const usePrevious = (fn: () => boolean) => {
  */
 export function useIntersectionObserver<T extends Element>(
   ref: Vue.Ref<T | null>,
-  callback: (entry: IntersectionObserverEntry | undefined) => void,
+  callback: (entry?: IntersectionObserverEntry) => void,
   disabled: () => boolean,
 ): Vue.Ref<IntersectionObserver | null> {
   const isIntersectionObserverAvailable =
@@ -58,7 +58,8 @@ export function useIntersectionObserver<T extends Element>(
   // Use watchEffect with cleanup to properly manage the observer lifecycle
   Vue.watchEffect((onCleanup) => {
     const r = ref.value
-    if (!r || !isIntersectionObserverAvailable || disabled()) {
+    if (disabled() || !r || !isIntersectionObserverAvailable) {
+      onCleanup(() => callback())
       return
     }
 
@@ -75,7 +76,7 @@ export function useIntersectionObserver<T extends Element>(
     onCleanup(() => {
       observer.disconnect()
       observerRef.value = null
-      callback(undefined)
+      callback()
     })
   })
 

--- a/packages/vue-router/src/utils.ts
+++ b/packages/vue-router/src/utils.ts
@@ -31,9 +31,8 @@ export const usePrevious = (fn: () => boolean) => {
  * When the intersection changes, the callback will be called with the `IntersectionObserverEntry`.
  *
  * @param ref - The ref to observe
- * @param intersectionObserverOptions - The options to pass to the IntersectionObserver
- * @param disabled - Whether observation is disabled
  * @param callback - The callback to call when the intersection changes
+ * @param disabled - Whether observation is disabled
  * @returns The IntersectionObserver instance
  * @example
  * ```tsx
@@ -42,7 +41,6 @@ export const usePrevious = (fn: () => boolean) => {
  * useIntersectionObserver(
  *  ref,
  *  (entry) => { doSomething(entry) },
- *  { rootMargin: '10px' },
  *  () => false
  * )
  * return <div ref={ref} />
@@ -51,7 +49,6 @@ export const usePrevious = (fn: () => boolean) => {
 export function useIntersectionObserver<T extends Element>(
   ref: Vue.Ref<T | null>,
   callback: (entry: IntersectionObserverEntry | undefined) => void,
-  intersectionObserverOptions: IntersectionObserverInit = {},
   disabled: () => boolean,
 ): Vue.Ref<IntersectionObserver | null> {
   const isIntersectionObserverAvailable =
@@ -65,9 +62,12 @@ export function useIntersectionObserver<T extends Element>(
       return
     }
 
-    const observer = new IntersectionObserver((entries) => {
-      callback(entries.pop())
-    }, intersectionObserverOptions)
+    const observer = new IntersectionObserver(
+      (entries) => {
+        callback(entries.pop())
+      },
+      { rootMargin: '100px' },
+    )
 
     observerRef.value = observer
     observer.observe(r)

--- a/packages/vue-router/tests/link.test.tsx
+++ b/packages/vue-router/tests/link.test.tsx
@@ -5219,7 +5219,6 @@ describe('Link', () => {
         useIntersectionObserver(
           element,
           () => {},
-          {},
           () => disabled.value,
         )
 

--- a/packages/vue-router/tests/link.test.tsx
+++ b/packages/vue-router/tests/link.test.tsx
@@ -5173,8 +5173,6 @@ describe('Link', () => {
       {} as IntersectionObserver,
     )
     await vi.advanceTimersByTimeAsync(1)
-    expect(preloadRouteSpy).toHaveBeenCalledOnce()
-    await vi.advanceTimersByTimeAsync(49)
     expect(preloadRouteSpy).toHaveBeenCalledTimes(2)
 
     fireEvent.mouseEnter(intentLink)

--- a/packages/vue-router/tests/link.test.tsx
+++ b/packages/vue-router/tests/link.test.tsx
@@ -5132,6 +5132,27 @@ describe('Link', () => {
     await vi.advanceTimersByTimeAsync(1)
     expect(preloadRouteSpy).toHaveBeenCalledOnce()
 
+    ioCallback(
+      [
+        {
+          isIntersecting: true,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    ioCallback(
+      [
+        {
+          isIntersecting: false,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    await vi.advanceTimersByTimeAsync(50)
+    expect(preloadRouteSpy).toHaveBeenCalledOnce()
+
     fireEvent.mouseEnter(intentLink)
     fireEvent.mouseLeave(intentLink)
     await vi.advanceTimersByTimeAsync(50)

--- a/packages/vue-router/tests/link.test.tsx
+++ b/packages/vue-router/tests/link.test.tsx
@@ -5138,11 +5138,6 @@ describe('Link', () => {
           isIntersecting: true,
           target: viewportLink,
         } as unknown as IntersectionObserverEntry,
-      ],
-      {} as IntersectionObserver,
-    )
-    ioCallback(
-      [
         {
           isIntersecting: false,
           target: viewportLink,
@@ -5153,10 +5148,39 @@ describe('Link', () => {
     await vi.advanceTimersByTimeAsync(50)
     expect(preloadRouteSpy).toHaveBeenCalledOnce()
 
+    ioCallback(
+      [
+        {
+          isIntersecting: true,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    await vi.advanceTimersByTimeAsync(49)
+
+    ioCallback(
+      [
+        {
+          isIntersecting: false,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+        {
+          isIntersecting: true,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    await vi.advanceTimersByTimeAsync(1)
+    expect(preloadRouteSpy).toHaveBeenCalledOnce()
+    await vi.advanceTimersByTimeAsync(49)
+    expect(preloadRouteSpy).toHaveBeenCalledTimes(2)
+
     fireEvent.mouseEnter(intentLink)
     fireEvent.mouseLeave(intentLink)
     await vi.advanceTimersByTimeAsync(50)
-    expect(preloadRouteSpy).toHaveBeenCalledOnce()
+    expect(preloadRouteSpy).toHaveBeenCalledTimes(2)
   })
 
   test('Link.disabled should disable viewport observation', async () => {

--- a/packages/vue-router/tests/link.test.tsx
+++ b/packages/vue-router/tests/link.test.tsx
@@ -43,12 +43,16 @@ import type { RouterHistory } from '../src'
 
 const ioObserveMock = vi.fn()
 const ioDisconnectMock = vi.fn()
+let ioCallback: IntersectionObserverCallback
 let history: RouterHistory
 
 beforeEach(() => {
   const io = getIntersectionObserverMock({
     observe: ioObserveMock,
     disconnect: ioDisconnectMock,
+    onCreate: (callback) => {
+      ioCallback = callback
+    },
   })
   vi.stubGlobal('IntersectionObserver', io)
   history = createBrowserHistory()
@@ -56,6 +60,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  vi.useRealTimers()
   history.destroy?.()
   window.history.replaceState(null, 'root', '/')
   vi.resetAllMocks()
@@ -5052,6 +5057,85 @@ describe('Link', () => {
     })
     expect(ioObserveMock).toHaveBeenCalledOnce() // it should not observe again
     expect(ioDisconnectMock).not.toHaveBeenCalled() // it should not disconnect again
+  })
+
+  test('Link.preload="viewport" should respect preloadDelay', async () => {
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => (
+        <>
+          <Link to="/about" preload="viewport" preloadDelay={50}>
+            Viewport Link
+          </Link>
+          <Link to="/about" preload="intent" preloadDelay={50}>
+            Intent Link
+          </Link>
+        </>
+      ),
+    })
+    const aboutRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/about',
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, aboutRoute]),
+      history,
+    })
+    const preloadRouteSpy = vi.spyOn(router, 'preloadRoute')
+
+    render(<RouterProvider router={router} />)
+
+    const viewportLink = await screen.findByRole('link', {
+      name: 'Viewport Link',
+    })
+    const intentLink = await screen.findByRole('link', { name: 'Intent Link' })
+    vi.useFakeTimers()
+
+    ioCallback([], {} as IntersectionObserver)
+    ioCallback(
+      [
+        {
+          isIntersecting: false,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    await vi.advanceTimersByTimeAsync(50)
+    expect(preloadRouteSpy).not.toHaveBeenCalled()
+
+    ioCallback(
+      [
+        {
+          isIntersecting: true,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    ioCallback(
+      [
+        {
+          isIntersecting: true,
+          target: viewportLink,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    )
+    fireEvent.mouseLeave(viewportLink)
+
+    expect(preloadRouteSpy).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(49)
+    expect(preloadRouteSpy).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1)
+    expect(preloadRouteSpy).toHaveBeenCalledOnce()
+
+    fireEvent.mouseEnter(intentLink)
+    fireEvent.mouseLeave(intentLink)
+    await vi.advanceTimersByTimeAsync(50)
+    expect(preloadRouteSpy).toHaveBeenCalledOnce()
   })
 
   test('Link.disabled should disable viewport observation', async () => {

--- a/packages/vue-router/tests/utils.ts
+++ b/packages/vue-router/tests/utils.ts
@@ -20,9 +20,11 @@ export function createTimer() {
 export const getIntersectionObserverMock = ({
   observe,
   disconnect,
+  onCreate,
 }: {
   observe: Mock
   disconnect: Mock
+  onCreate?: (callback: IntersectionObserverCallback) => void
 }) => {
   return class IO implements IntersectionObserver {
     root: Document | Element | null
@@ -33,6 +35,7 @@ export const getIntersectionObserverMock = ({
       _cb: IntersectionObserverCallback,
       options?: IntersectionObserverInit,
     ) {
+      onCreate?.(_cb)
       this.root = options?.root ?? null
       this.rootMargin = options?.rootMargin ?? '0px'
       this.scrollMargin = options?.scrollMargin ?? '0px'


### PR DESCRIPTION
Fixes https://github.com/TanStack/router/discussions/8029

## Summary

- apply `preloadDelay` to viewport link preloading in the React, Solid, and Vue adapters
- cancel delayed viewport preloads when links leave the viewport, observation stops, or link options change
- key viewport timers by stable per-link refs so observer callback identity changes cannot orphan pending work
- use the latest queued observer entry so brief exit/re-entry cycles delivered in one callback retain the existing delay
- inline the fixed `{ rootMargin: "100px" }` configuration inside each adapter observer utility and remove its options parameter
- share delayed viewport and intent scheduling while preserving immediate touch preloads and cancelable focus/hover intent
- deduplicate repeated viewport observer notifications and document the updated behavior
- add React regression coverage for changing destinations while a viewport preload is pending
- add a patch changeset for all three router adapters

## Testing

- `pnpm nx run-many --target=test:unit --projects=@tanstack/react-router,@tanstack/solid-router,@tanstack/vue-router`
- `pnpm nx run-many --target=test:types --projects=@tanstack/router-core,@tanstack/react-router,@tanstack/solid-router,@tanstack/vue-router`
- `pnpm nx run-many --target=test:eslint --projects=@tanstack/router-core,@tanstack/react-router,@tanstack/solid-router,@tanstack/vue-router`
- full 17-scenario bundle-size build

## Bundle Size

Affected gzip fixtures remain effectively flat versus the base commit:

- React Router minimal/full: `-2 B` / `-9 B`
- Solid Router minimal/full: `+5 B` / `+3 B`
- Vue Router minimal/full: `0 B` / `-10 B`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Link preloading now supports configurable delays for viewport, focus, and hover triggers across React, Solid, and Vue routers.
- Touch-based intent preloading remains immediate.
- Duplicate preload requests are consolidated.

## Bug Fixes
- Pending preloads are cancelled when links leave the viewport or interactions end.
- Disabled, external, and document-reload links no longer trigger preloading.

## Documentation
- Clarified preload timing, cancellation, and trigger behavior in router guides and API references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->