### PR TITLE
fix(router-core): keep percent-encoded caret in paths to prevent an infinite redirect loop

### DIFF
--- a/.changeset/caret-path-percent-encode.md
+++ b/.changeset/caret-path-percent-encode.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+preserve percent-encoded caret (U+005E) in paths to prevent an infinite redirect loop

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -532,7 +532,7 @@ export function findLast<T>(
 /**
  * Re-encode characters that are unsafe in URL paths.
  * Includes ASCII control characters (0x00-0x1F, 0x7F) and a subset of the
- * WHATWG URL "path percent-encode set" (", <, >, `, {, }).
+ * WHATWG URL "path percent-encode set" (", <, >, ^, `, {, }).
  *
  * Space (0x20) is intentionally excluded — decodeURI decodes %20 to space
  * and the router stores decoded spaces in location.pathname. The existing
@@ -543,7 +543,7 @@ export function findLast<T>(
  * interpret the URL, preventing infinite redirect loops and path mismatches.
  */
 // eslint-disable-next-line no-control-regex
-const PATH_UNSAFE_RE = /[\x00-\x1f\x7f"<>`{}]/g
+const PATH_UNSAFE_RE = /[\x00-\x1f\x7f"<>^`{}]/g
 
 function sanitizePathSegment(segment: string): string {
   return segment.replace(

--- a/packages/router-core/tests/utils.test.ts
+++ b/packages/router-core/tests/utils.test.ts
@@ -626,6 +626,14 @@ describe('decodePath', () => {
       expect(decodePath('/back%60tick').path).toBe('/back%60tick')
     })
 
+    it('should keep caret encoded', () => {
+      expect(decodePath('/1000-1500%5EABC').path).toBe('/1000-1500%5EABC')
+    })
+
+    it('should normalize lowercase caret encoding to uppercase', () => {
+      expect(decodePath('/1000-1500%5eABC').path).toBe('/1000-1500%5EABC')
+    })
+
     it('should decode space (handled by encodePathLikeUrl for outgoing URLs)', () => {
       expect(decodePath('/file%20name').path).toBe('/file name')
     })


### PR DESCRIPTION
Closes #8041

The WHATWG URL path percent-encode set includes U+005E (`^`), but the `PATH_UNSAFE_RE` set introduced in #7695 didn't. `decodeURI` decodes `%5E` to a literal caret which nothing re-encodes, while browsers and the WHATWG URL parser always re-encode it — so the canonical `publicHref` built from the decoded pathname never matches the incoming raw href, and the server canonicalization redirect fires on every request: `GET /%5E` → `307 /^` → browser re-encodes → `GET /%5E`, forever.

Adding `^` to the preserved set makes the decode/encode round-trip stable, exactly like the other characters #7695 covered. Lowercase `%5e` normalizes to `%5E` in a single converging redirect, same as `%7b` → `%7B` today.

Tests follow the existing "WHATWG path percent-encode set preserved" suite; both fail without the one-character fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL path handling by preserving percent-encoded caret characters.
  * Prevented potential infinite redirect loops caused by caret characters in paths.
  * Normalized lowercase caret encodings to uppercase `%5E`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->