### PR TITLE
fix(react-router): useMatchRoute w/ React Compiler (changeset)

### DIFF
--- a/.changeset/dry-dots-judge.md
+++ b/.changeset/dry-dots-judge.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-router': patch
+---
+
+useMatchRoute w/ React Compiler


### PR DESCRIPTION
Forgot changeset for https://github.com/TanStack/router/pull/8015

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented React Compiler compatibility for the `useMatchRoute` functionality in React Router.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->