### PR TITLE
fix(e2e): run Basic Auth tests against Vite preview

### DIFF
--- a/e2e/react-start/basic-auth/package.json
+++ b/e2e/react-start/basic-auth/package.json
@@ -8,7 +8,7 @@
     "dev:e2e": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
-    "start": "vite preview --host 127.0.0.1 --port $PORT",
+    "start": "vite preview --host 127.0.0.1 --port $PORT --strictPort",
     "prisma-generate": "prisma generate",
     "test:e2e": "rm -rf port*.txt; pnpm run prisma-generate && playwright test --project=chromium"
   },

--- a/e2e/react-start/basic-auth/package.json
+++ b/e2e/react-start/basic-auth/package.json
@@ -8,9 +8,9 @@
     "dev:e2e": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
-    "start": "node .output/server/index.mjs",
+    "start": "vite preview --host 127.0.0.1 --port $PORT",
     "prisma-generate": "prisma generate",
-    "test:e2e": "exit 0; rm -rf port*.txt; pnpm run prisma-generate && playwright test --project=chromium"
+    "test:e2e": "rm -rf port*.txt; pnpm run prisma-generate && playwright test --project=chromium"
   },
   "dependencies": {
     "@libsql/client": "^0.15.15",


### PR DESCRIPTION
Fixes #7798

The Basic Auth E2E package now starts its built application through the current TanStack Start Vite preview adapter on Playwright's assigned port. The issue originally suggested executing `dist/server/server.js` directly, but that artifact now exports a Fetch handler and exits without listening; `vite preview` is the project-native adapter that serves the same production build.

This also removes the leading `exit 0` so the E2E script actually invokes Playwright.

Validation:
- `playwright test tests/app.spec.ts --project=chromium --grep "Posts redirects to login when not authenticated"` — passed (1/1)
- `CI=1 NX_DAEMON=false pnpm nx run tanstack-react-start-e2e-basic-auth:build --outputStyle=stream --skipRemoteCache` — passed with 19 dependency tasks
- `prettier --check e2e/react-start/basic-auth/package.json` — passed
- `git diff --check` — passed
- `pnpm test:eslint`, `pnpm test:types`, and `pnpm test:unit` — no tasks apply to this private E2E package

The full Basic Auth suite is currently blocked before test execution by existing Prisma 7 setup/teardown files importing `PrismaClient` from the `@prisma/client` CommonJS stub. I reproduced the same discovery failure on the clean base with this script change removed, so it is outside this focused fix.

No changeset is included because this only repairs scripts in a private E2E package and does not change a published package.

I used Codex to help inspect the repository and run the validation. I reviewed and adapted the final change; no separate human review was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled end-to-end testing for the React starter example.
  * Updated the preview server to run on the configured port and local address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->