### PR TITLE
fix(start-plugin-core): guard hotUpdate against missing this.environment

### DIFF
--- a/.changeset/start-compiler-hot-update-bundled-dev.md
+++ b/.changeset/start-compiler-hot-update-bundled-dev.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/start-plugin-core': patch
+---
+
+Guard the start compiler plugin's `hotUpdate` hook against a missing `this.environment`, which crashed every hot update (and left the dev server serving stale output) when Vite's `experimental.bundledDev` passes the hook to Rolldown's dev engine.

--- a/packages/start-plugin-core/src/vite/start-compiler-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/vite/start-compiler-plugin/plugin.ts
@@ -396,12 +396,12 @@ export function startCompilerPlugin(
       },
 
       hotUpdate(ctx) {
-        // With `experimental.bundledDev`, Vite passes this hook to Rolldown's
-        // dev engine, which invokes it without an environment on the context.
-        // Compiler invalidation happens via `watchChange` on that path, so
-        // there is nothing to do here.
+        // Rolldown's dev engine (`experimental.bundledDev`) invokes this hook
+        // without an environment; invalidation then happens via `watchChange`.
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        if (!this.environment) return
+        if (!this.environment) {
+          return
+        }
         const compiler = compilers.get(this.environment.name)
         const idsToInvalidate = new Set<string>()
         const transitiveCompilerImportersToInvalidate = new Set<string>()

--- a/packages/start-plugin-core/src/vite/start-compiler-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/vite/start-compiler-plugin/plugin.ts
@@ -396,6 +396,12 @@ export function startCompilerPlugin(
       },
 
       hotUpdate(ctx) {
+        // With `experimental.bundledDev`, Vite passes this hook to Rolldown's
+        // dev engine, which invokes it without an environment on the context.
+        // Compiler invalidation happens via `watchChange` on that path, so
+        // there is nothing to do here.
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        if (!this.environment) return
         const compiler = compilers.get(this.environment.name)
         const idsToInvalidate = new Set<string>()
         const transitiveCompilerImportersToInvalidate = new Set<string>()


### PR DESCRIPTION
Fixes #8062

## The bug

When Vite's `experimental.bundledDev` (full bundle mode) is enabled, the client environment is driven by Rolldown's dev engine. Vite passes environment plugins into that build, but `injectEnvironmentToHooks` only wraps hooks listed in `ROLLUP_HOOKS`, and `hotUpdate` is not in that list. Rolldown therefore invokes `hotUpdate` with its own `PluginContextImpl` as `this`, which has no `environment` property, so the first line of the hook throws:

```
✘ Build error: Build failed with 1 error:

[plugin tanstack-start-core::server-fn:client]
TypeError: Cannot read properties of undefined (reading 'name')
    at PluginContextImpl.hotUpdate (.../start-plugin-core/dist/esm/vite/start-compiler-plugin/plugin.js:183:53)
    at plugin (.../rolldown/dist/shared/bindingify-input-options-C-Zsy1EG.mjs:1734:24)
```

The dev server does not crash: Rolldown swallows the throw into a build error, the rebuild fails, and the dev server serves stale output on every subsequent edit until restart. Fires on 100% of hot updates. Present in `@tanstack/start-plugin-core` 1.171.17 through 1.171.34.

Minimal repro (vite 8.2.1, one `createServerFn`, `bundledDev: true`): https://github.com/TIMTOMTOP/tanstack-hotupdate-repro

## The fix

Early-return when `this.environment` is absent. Optional chaining on the first read is not enough: `finishHotUpdate()` dereferences `this.environment` again later. Compiler invalidation under bundledDev already happens via `watchChange` (which Vite calls with the environment injected), so the guard loses nothing.

Verified against the repro: with the guard the crash is gone. Note that nitro's `hotUpdate` hooks then crash the same way (the root cause is arguably that Vite hands an unwrapped `hotUpdate` to Rolldown, which affects any plugin using environment-dependent `hotUpdate` hooks), but the guard is correct for this plugin regardless of where the systemic fix lands.

`test:eslint`, `test:types`, and `test:unit` pass for the affected package. The guard needs an `eslint-disable` for `no-unnecessary-condition` because Vite's types declare `this.environment` as always present; at runtime under bundledDev it is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved development-mode stability when using Vite’s bundled development workflow.
  - Prevented hot updates from failing when the required development environment is unavailable.
  - Ensured development changes continue to be handled safely when environment details are not available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
