### PR TITLE
perf(react-router): direct export of CatchBoundary class component, remove function wrapper

### DIFF
--- a/.changeset/whole-bikes-grin.md
+++ b/.changeset/whole-bikes-grin.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-router': patch
+---
+
+direct export of CatchBoundary class component, remove function wrapper

--- a/packages/react-router/src/CatchBoundary.tsx
+++ b/packages/react-router/src/CatchBoundary.tsx
@@ -5,16 +5,7 @@ import { wrapInNonRouteComponentContext } from './nonRouteComponentContext'
 import type { ErrorRouteComponent } from './route'
 import type { ErrorInfo } from 'react'
 
-export function CatchBoundary(props: {
-  getResetKey: () => unknown
-  children: React.ReactNode
-  errorComponent?: ErrorRouteComponent
-  onCatch?: (error: Error, errorInfo: ErrorInfo) => void
-}) {
-  return <CatchBoundaryImpl {...props} />
-}
-
-class CatchBoundaryImpl extends React.Component<{
+export class CatchBoundary extends React.Component<{
   getResetKey: () => unknown
   children: React.ReactNode
   errorComponent?: ErrorRouteComponent


### PR DESCRIPTION
minor change to reduce bundle size. 
technically not exactly the same at runtime, but for all intents and purposes it should be equivalent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `CatchBoundary` is now directly available as a React class component, providing a more consistent integration option for applications using React Router.

* **Bug Fixes**
  * Improved the component’s public export behavior without changing its supported props or error-handling capabilities.

* **Documentation**
  * Added a patch release note documenting the updated `CatchBoundary` export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->