### PR TITLE
perf(router-core): inline buildWithMatches inside buildLocation

### DIFF
--- a/.changeset/whole-bars-smash.md
+++ b/.changeset/whole-bars-smash.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+inline buildWithMatches inside buildLocation for byte shaving

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -2082,18 +2082,14 @@ export class RouterCore<
       }
     }
 
-    let maskedDest: BuildNextOptions | undefined
+    const next = build(opts)
+
     if (opts.mask) {
-      maskedDest = {
+      next.maskedLocation = build({
         from: opts.from,
         ...opts.mask,
-      }
-    }
-
-    const next = build(opts)
-    let maskedNext = maskedDest ? build(maskedDest) : undefined
-
-    if (!maskedNext && this.options.routeMasks) {
+      })
+    } else if (this.options.routeMasks) {
       const match = findFlatMatch<RouteMask<TRouteTree>>(
         next.pathname,
         this.processedTree,
@@ -2106,17 +2102,12 @@ export class RouterCore<
         // Otherwise, use the matched params or the provided params value
         const nextParams = resolveNextParams(maskParams, params)
 
-        maskedDest = {
+        next.maskedLocation = build({
           from: opts.from,
           ...maskProps,
           params: nextParams,
-        }
-        maskedNext = build(maskedDest)
+        })
       }
-    }
-
-    if (maskedNext) {
-      next.maskedLocation = maskedNext
     }
 
     return next

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -2082,59 +2082,44 @@ export class RouterCore<
       }
     }
 
-    const buildWithMatches = (
-      dest: BuildNextOptions = {},
-      maskedDest?: BuildNextOptions,
-    ) => {
-      const next = build(dest)
-
-      let maskedNext = maskedDest ? build(maskedDest) : undefined
-
-      if (!maskedNext) {
-        const params = Object.create(null)
-
-        if (this.options.routeMasks) {
-          const match = findFlatMatch<RouteMask<TRouteTree>>(
-            next.pathname,
-            this.processedTree,
-          )
-          if (match) {
-            Object.assign(params, match.rawParams) // Copy params, because they're cached
-            const {
-              from: _from,
-              params: maskParams,
-              ...maskProps
-            } = match.route
-
-            // If mask has a params function, call it with the matched params as context
-            // Otherwise, use the matched params or the provided params value
-            const nextParams = resolveNextParams(maskParams, params)
-
-            maskedDest = {
-              from: opts.from,
-              ...maskProps,
-              params: nextParams,
-            }
-            maskedNext = build(maskedDest)
-          }
-        }
-      }
-
-      if (maskedNext) {
-        next.maskedLocation = maskedNext
-      }
-
-      return next
-    }
-
+    let maskedDest: BuildNextOptions | undefined
     if (opts.mask) {
-      return buildWithMatches(opts, {
+      maskedDest = {
         from: opts.from,
         ...opts.mask,
-      })
+      }
     }
 
-    return buildWithMatches(opts)
+    const next = build(opts)
+    let maskedNext = maskedDest ? build(maskedDest) : undefined
+
+    if (!maskedNext && this.options.routeMasks) {
+      const match = findFlatMatch<RouteMask<TRouteTree>>(
+        next.pathname,
+        this.processedTree,
+      )
+      if (match) {
+        const params = Object.assign(Object.create(null), match.rawParams)
+        const { from: _from, params: maskParams, ...maskProps } = match.route
+
+        // If mask has a params function, call it with the matched params as context
+        // Otherwise, use the matched params or the provided params value
+        const nextParams = resolveNextParams(maskParams, params)
+
+        maskedDest = {
+          from: opts.from,
+          ...maskProps,
+          params: nextParams,
+        }
+        maskedNext = build(maskedDest)
+      }
+    }
+
+    if (maskedNext) {
+      next.maskedLocation = maskedNext
+    }
+
+    return next
   }
 
   _commitPromise: (Promise<void> & { resolve: () => void }) | undefined

--- a/packages/router-core/tests/mask.test.ts
+++ b/packages/router-core/tests/mask.test.ts
@@ -92,6 +92,29 @@ describe('buildLocation - route masks', () => {
     expect(location.pathname).toBe('/photos/123/modal')
   })
 
+  test('should prefer an explicit mask over a configured route mask', () => {
+    const routeMasks: Array<RouteMask<any>> = [
+      {
+        routeTree: null as any,
+        from: '/photos/$photoId/modal',
+        to: '/photos/$photoId',
+        params: () => {
+          throw new Error('Configured mask should not be applied')
+        },
+      },
+    ]
+    const router = setup(routeMasks)
+
+    const location = router.buildLocation({
+      to: '/photos/$photoId/modal',
+      params: { photoId: '123' },
+      mask: { to: '/posts' },
+    })
+
+    expect(location.pathname).toBe('/photos/123/modal')
+    expect(location.maskedLocation?.pathname).toBe('/posts')
+  })
+
   test('should set params to {} when maskParams is false', () => {
     const routeMasks: Array<RouteMask<any>> = [
       {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Explicit route masks now take precedence over configured route masks.
  * Masked locations are generated more consistently when building navigation destinations.
  * Navigation paths now reflect explicitly requested masking behavior more reliably.

* **Tests**
  * Added coverage confirming explicit masks are used without evaluating configured mask parameters.

* **Chores**
  * Included a patch release note for the router core package.
  * Reduced internal processing overhead when constructing navigation locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->