### PR TITLE
perf(router-core): inline getOpenAndCloseBraces in parseSegment

### DIFF
--- a/.changeset/fresh-bats-begin.md
+++ b/.changeset/fresh-bats-begin.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+inline getOpenAndCloseBraces in parseSegment for byte shaving

--- a/packages/router-core/src/new-process-route-tree.ts
+++ b/packages/router-core/src/new-process-route-tree.ts
@@ -27,18 +27,6 @@ type ExtendedSegmentKind =
   | typeof SEGMENT_TYPE_INDEX
   | typeof SEGMENT_TYPE_PATHLESS
 
-function getOpenAndCloseBraces(
-  part: string,
-): [openBrace: number, closeBrace: number] | null {
-  const openBrace = part.indexOf('{')
-  if (openBrace === -1) return null
-  const closeBrace = part.indexOf('}', openBrace)
-  if (closeBrace === -1) return null
-  const afterOpen = openBrace + 1
-  if (afterOpen >= part.length) return null
-  return [openBrace, closeBrace]
-}
-
 type ParsedSegment = Uint16Array & {
   /** segment type (0 = pathname, 1 = param, 2 = wildcard, 3 = optional param) */
   0: SegmentKind
@@ -116,9 +104,13 @@ export function parseSegment(
     return output as ParsedSegment
   }
 
-  const braces = getOpenAndCloseBraces(part)
-  if (braces) {
-    const [openBrace, closeBrace] = braces
+  const openBrace = part.indexOf('{')
+  let closeBrace
+  if (
+    openBrace !== -1 &&
+    openBrace + 1 < part.length &&
+    (closeBrace = part.indexOf('}', openBrace)) !== -1
+  ) {
     const firstChar = part.charCodeAt(openBrace + 1)
 
     // Check for {-$...} (optional param)

--- a/packages/router-core/tests/optional-path-params.test.ts
+++ b/packages/router-core/tests/optional-path-params.test.ts
@@ -169,6 +169,30 @@ describe('Optional Path Parameters', () => {
           { type: SEGMENT_TYPE_OPTIONAL_PARAM, value: 'day' },
         ],
       },
+      {
+        name: 'unclosed optional param is static',
+        to: '/{-$slug',
+        expected: [
+          { type: SEGMENT_TYPE_PATHNAME, value: '' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '{-$slug' },
+        ],
+      },
+      {
+        name: 'empty optional param is static',
+        to: '/{-$}',
+        expected: [
+          { type: SEGMENT_TYPE_PATHNAME, value: '' },
+          { type: SEGMENT_TYPE_PATHNAME, value: '{-$}' },
+        ],
+      },
+      {
+        name: 'unmatched closing brace is static',
+        to: '/foo}bar$',
+        expected: [
+          { type: SEGMENT_TYPE_PATHNAME, value: '' },
+          { type: SEGMENT_TYPE_PATHNAME, value: 'foo}bar$' },
+        ],
+      },
     ] satisfies ParsePathnameTestScheme)('$name', ({ to, expected }) => {
       const result = parsePathname(to)
       expect(result).toEqual(expected)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route parsing for optional parameters and brace-based path segments.
  * Unclosed, empty, or unmatched parameter braces are now handled safely as static path text when appropriate.

* **Tests**
  * Added coverage for invalid and edge-case optional path parameters.

* **Chores**
  * Prepared a patch release for the router core package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->