### PR TITLE
perf: unify route bindings in constructors

### DIFF
--- a/.changeset/easy-streets-stare.md
+++ b/.changeset/easy-streets-stare.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/react-router': patch
+'@tanstack/solid-router': patch
+'@tanstack/vue-router': patch
+---
+
+unify route bindings for byte shaving

--- a/packages/react-router/src/route.tsx
+++ b/packages/react-router/src/route.tsx
@@ -258,55 +258,17 @@ export class Route<
     >,
   ) {
     super(options)
+    initReactRouteApi(this)
   }
 
-  useMatch: UseMatchRoute<TId> = (opts) => {
-    return useMatch({
-      select: opts?.select,
-      from: this.id,
-      structuralSharing: opts?.structuralSharing,
-    } as any) as any
-  }
-
-  useRouteContext: UseRouteContextRoute<TId> = (opts?) => {
-    return useRouteContext({ ...(opts as any), from: this.id })
-  }
-
-  useSearch: UseSearchRoute<TId> = (opts) => {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    return useSearch({
-      select: opts?.select,
-      structuralSharing: opts?.structuralSharing,
-      from: this.id,
-    } as any) as any
-  }
-
-  useParams: UseParamsRoute<TId> = (opts) => {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    return useParams({
-      select: opts?.select,
-      structuralSharing: opts?.structuralSharing,
-      from: this.id,
-    } as any) as any
-  }
-
-  useLoaderDeps: UseLoaderDepsRoute<TId> = (opts) => {
-    return useLoaderDeps({ ...opts, from: this.id } as any)
-  }
-
-  useLoaderData: UseLoaderDataRoute<TId> = (opts) => {
-    return useLoaderData({ ...opts, from: this.id } as any)
-  }
-
-  useNavigate = (): UseNavigateResult<TFullPath> => {
-    return useNavigate({ from: this.fullPath })
-  }
-
-  Link: LinkComponentRoute<TFullPath> = React.forwardRef(
-    (props, ref: React.ForwardedRef<HTMLAnchorElement>) => {
-      return <Link ref={ref} from={this.fullPath as never} {...props} />
-    },
-  ) as unknown as LinkComponentRoute<TFullPath>
+  declare useMatch: UseMatchRoute<TId>
+  declare useRouteContext: UseRouteContextRoute<TId>
+  declare useSearch: UseSearchRoute<TId>
+  declare useParams: UseParamsRoute<TId>
+  declare useLoaderDeps: UseLoaderDepsRoute<TId>
+  declare useLoaderData: UseLoaderDataRoute<TId>
+  declare useNavigate: () => UseNavigateResult<TFullPath>
+  declare Link: LinkComponentRoute<TFullPath>
 }
 
 /**
@@ -529,56 +491,63 @@ export class RootRoute<
     >,
   ) {
     super(options)
+    initReactRouteApi(this)
   }
 
-  useMatch: UseMatchRoute<RootRouteId> = (opts) => {
+  declare useMatch: UseMatchRoute<RootRouteId>
+  declare useRouteContext: UseRouteContextRoute<RootRouteId>
+  declare useSearch: UseSearchRoute<RootRouteId>
+  declare useParams: UseParamsRoute<RootRouteId>
+  declare useLoaderDeps: UseLoaderDepsRoute<RootRouteId>
+  declare useLoaderData: UseLoaderDataRoute<RootRouteId>
+  declare useNavigate: () => UseNavigateResult<'/'>
+  declare Link: LinkComponentRoute<'/'>
+}
+
+/* eslint-disable react-hooks/rules-of-hooks -- These route fields are custom hooks assigned during construction. */
+function initReactRouteApi(route: AnyRoute) {
+  route.useMatch = (opts) => {
     return useMatch({
       select: opts?.select,
-      from: this.id,
+      from: route.id,
       structuralSharing: opts?.structuralSharing,
     } as any) as any
   }
-
-  useRouteContext: UseRouteContextRoute<RootRouteId> = (opts) => {
-    return useRouteContext({ ...(opts as any), from: this.id })
+  route.useRouteContext = (opts) => {
+    return useRouteContext({ ...(opts as any), from: route.id })
   }
-
-  useSearch: UseSearchRoute<RootRouteId> = (opts) => {
+  route.useSearch = (opts) => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     return useSearch({
       select: opts?.select,
       structuralSharing: opts?.structuralSharing,
-      from: this.id,
+      from: route.id,
     } as any) as any
   }
-
-  useParams: UseParamsRoute<RootRouteId> = (opts) => {
+  route.useParams = (opts) => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     return useParams({
       select: opts?.select,
       structuralSharing: opts?.structuralSharing,
-      from: this.id,
+      from: route.id,
     } as any) as any
   }
-
-  useLoaderDeps: UseLoaderDepsRoute<RootRouteId> = (opts) => {
-    return useLoaderDeps({ ...opts, from: this.id } as any)
+  route.useLoaderDeps = (opts) => {
+    return useLoaderDeps({ ...opts, from: route.id } as any)
   }
-
-  useLoaderData: UseLoaderDataRoute<RootRouteId> = (opts) => {
-    return useLoaderData({ ...opts, from: this.id } as any)
+  route.useLoaderData = (opts) => {
+    return useLoaderData({ ...opts, from: route.id } as any)
   }
-
-  useNavigate = (): UseNavigateResult<'/'> => {
-    return useNavigate({ from: this.fullPath })
+  route.useNavigate = () => {
+    return useNavigate({ from: route.fullPath })
   }
-
-  Link: LinkComponentRoute<'/'> = React.forwardRef(
+  route.Link = React.forwardRef(
     (props, ref: React.ForwardedRef<HTMLAnchorElement>) => {
-      return <Link ref={ref} from={this.fullPath} {...props} />
+      return <Link ref={ref} from={route.fullPath as never} {...props} />
     },
-  ) as unknown as LinkComponentRoute<'/'>
+  ) as unknown as LinkComponentRoute<string>
 }
+/* eslint-enable react-hooks/rules-of-hooks */
 
 /**
  * Creates a root Route instance used to build your route tree.

--- a/packages/react-router/tests/route.test.tsx
+++ b/packages/react-router/tests/route.test.tsx
@@ -75,6 +75,15 @@ describe('createRoute has the same hooks as getRouteApi', () => {
       expect(route[hookName as keyof typeof route]).toBeDefined()
     },
   )
+
+  it.each([
+    ['route', route],
+    ['root route', createRootRoute()],
+  ])('defines React APIs as own properties on the %s', (_, instance) => {
+    for (const key of [...hookNames, 'Link']) {
+      expect(Object.prototype.hasOwnProperty.call(instance, key)).toBe(true)
+    }
+  })
 })
 
 /* disabled until HMR bug is fixed 

--- a/packages/solid-router/src/route.tsx
+++ b/packages/solid-router/src/route.tsx
@@ -243,48 +243,17 @@ export class Route<
     >,
   ) {
     super(options)
+    initSolidRouteApi(this)
   }
 
-  useMatch: UseMatchRoute<TId> = (opts) => {
-    return useMatch({
-      select: opts?.select,
-      from: this.id,
-    } as any) as any
-  }
-
-  useRouteContext: UseRouteContextRoute<TId> = (opts?) => {
-    return useRouteContext({ ...(opts as any), from: this.id }) as any
-  }
-
-  useSearch: UseSearchRoute<TId> = (opts) => {
-    return useSearch({
-      select: opts?.select,
-      from: this.id,
-    } as any) as any
-  }
-
-  useParams: UseParamsRoute<TId> = (opts) => {
-    return useParams({
-      select: opts?.select,
-      from: this.id,
-    } as any) as any
-  }
-
-  useLoaderDeps: UseLoaderDepsRoute<TId> = (opts) => {
-    return useLoaderDeps({ ...opts, from: this.id } as any)
-  }
-
-  useLoaderData: UseLoaderDataRoute<TId> = (opts) => {
-    return useLoaderData({ ...opts, from: this.id } as any)
-  }
-
-  useNavigate = (): UseNavigateResult<TFullPath> => {
-    return useNavigate({ from: this.fullPath })
-  }
-
-  Link: LinkComponentRoute<TFullPath> = ((props) => {
-    return <Link from={this.fullPath} {...props} />
-  }) as LinkComponentRoute<TFullPath>
+  declare useMatch: UseMatchRoute<TId>
+  declare useRouteContext: UseRouteContextRoute<TId>
+  declare useSearch: UseSearchRoute<TId>
+  declare useParams: UseParamsRoute<TId>
+  declare useLoaderDeps: UseLoaderDepsRoute<TId>
+  declare useLoaderData: UseLoaderDataRoute<TId>
+  declare useNavigate: () => UseNavigateResult<TFullPath>
+  declare Link: LinkComponentRoute<TFullPath>
 }
 
 export function createRoute<
@@ -481,48 +450,53 @@ export class RootRoute<
     >,
   ) {
     super(options)
+    initSolidRouteApi(this)
   }
 
-  useMatch: UseMatchRoute<RootRouteId> = (opts) => {
+  declare useMatch: UseMatchRoute<RootRouteId>
+  declare useRouteContext: UseRouteContextRoute<RootRouteId>
+  declare useSearch: UseSearchRoute<RootRouteId>
+  declare useParams: UseParamsRoute<RootRouteId>
+  declare useLoaderDeps: UseLoaderDepsRoute<RootRouteId>
+  declare useLoaderData: UseLoaderDataRoute<RootRouteId>
+  declare useNavigate: () => UseNavigateResult<'/'>
+  declare Link: LinkComponentRoute<'/'>
+}
+
+function initSolidRouteApi(route: AnyRoute) {
+  route.useMatch = (opts) => {
     return useMatch({
       select: opts?.select,
-      from: this.id,
+      from: route.id,
     } as any) as any
   }
-
-  useRouteContext: UseRouteContextRoute<RootRouteId> = (opts) => {
-    return useRouteContext({ ...(opts as any), from: this.id })
+  route.useRouteContext = (opts) => {
+    return useRouteContext({ ...(opts as any), from: route.id }) as any
   }
-
-  useSearch: UseSearchRoute<RootRouteId> = (opts) => {
+  route.useSearch = (opts) => {
     return useSearch({
       select: opts?.select,
-      from: this.id,
+      from: route.id,
     } as any) as any
   }
-
-  useParams: UseParamsRoute<RootRouteId> = (opts) => {
+  route.useParams = (opts) => {
     return useParams({
       select: opts?.select,
-      from: this.id,
+      from: route.id,
     } as any) as any
   }
-
-  useLoaderDeps: UseLoaderDepsRoute<RootRouteId> = (opts) => {
-    return useLoaderDeps({ ...opts, from: this.id } as any)
+  route.useLoaderDeps = (opts) => {
+    return useLoaderDeps({ ...opts, from: route.id } as any)
   }
-
-  useLoaderData: UseLoaderDataRoute<RootRouteId> = (opts) => {
-    return useLoaderData({ ...opts, from: this.id } as any)
+  route.useLoaderData = (opts) => {
+    return useLoaderData({ ...opts, from: route.id } as any)
   }
-
-  useNavigate = (): UseNavigateResult<'/'> => {
-    return useNavigate({ from: this.fullPath })
+  route.useNavigate = () => {
+    return useNavigate({ from: route.fullPath })
   }
-
-  Link: LinkComponentRoute<'/'> = ((props) => {
-    return <Link from={this.fullPath} {...(props as any)} />
-  }) as LinkComponentRoute<'/'>
+  route.Link = ((props) => {
+    return <Link from={route.fullPath} {...(props as any)} />
+  }) as LinkComponentRoute<string>
 }
 
 export function createRouteMask<

--- a/packages/solid-router/tests/route.test.tsx
+++ b/packages/solid-router/tests/route.test.tsx
@@ -74,6 +74,15 @@ describe('createRoute has the same hooks as getRouteApi', () => {
       expect(route[hookName as keyof typeof route]).toBeDefined()
     },
   )
+
+  it.each([
+    ['route', route],
+    ['root route', createRootRoute()],
+  ])('defines Solid APIs as own properties on the %s', (_, instance) => {
+    for (const key of [...hookNames, 'Link']) {
+      expect(Object.prototype.hasOwnProperty.call(instance, key)).toBe(true)
+    }
+  })
 })
 
 /* disabled until HMR bug is fixed 

--- a/packages/vue-router/src/route.ts
+++ b/packages/vue-router/src/route.ts
@@ -249,52 +249,17 @@ export class Route<
     >,
   ) {
     super(options)
+    initVueRouteApi(this)
   }
 
-  useMatch: UseMatchRoute<TId> = (opts) => {
-    return useMatch({
-      select: opts?.select,
-      from: this.id,
-    } as any) as any
-  }
-
-  useRouteContext: UseRouteContextRoute<TId> = (opts?) => {
-    return useRouteContext({ ...(opts as any), from: this.id })
-  }
-
-  useSearch: UseSearchRoute<TId> = (opts) => {
-    return useSearch({
-      select: opts?.select,
-      from: this.id,
-    } as any) as any
-  }
-
-  useParams: UseParamsRoute<TId> = (opts) => {
-    return useParams({
-      select: opts?.select,
-      from: this.id,
-    } as any) as any
-  }
-
-  useLoaderDeps: UseLoaderDepsRoute<TId> = (opts) => {
-    return useLoaderDeps({ ...opts, from: this.id } as any)
-  }
-
-  useLoaderData: UseLoaderDataRoute<TId> = (opts) => {
-    return useLoaderData({ ...opts, from: this.id } as any)
-  }
-
-  useNavigate = (): UseNavigateResult<TFullPath> => {
-    return useNavigate({ from: this.fullPath })
-  }
-
-  Link: LinkComponentRoute<TFullPath> = ((props, ctx?: Vue.SetupContext) => {
-    return Vue.h(
-      Link as any,
-      { from: this.fullPath as never, ...(props as any) },
-      ctx?.slots,
-    )
-  }) as LinkComponentRoute<TFullPath>
+  declare useMatch: UseMatchRoute<TId>
+  declare useRouteContext: UseRouteContextRoute<TId>
+  declare useSearch: UseSearchRoute<TId>
+  declare useParams: UseParamsRoute<TId>
+  declare useLoaderDeps: UseLoaderDepsRoute<TId>
+  declare useLoaderData: UseLoaderDataRoute<TId>
+  declare useNavigate: () => UseNavigateResult<TFullPath>
+  declare Link: LinkComponentRoute<TFullPath>
 }
 
 export function createRoute<
@@ -491,48 +456,57 @@ export class RootRoute<
     >,
   ) {
     super(options)
+    initVueRouteApi(this)
   }
 
-  useMatch: UseMatchRoute<RootRouteId> = (opts) => {
+  declare useMatch: UseMatchRoute<RootRouteId>
+  declare useRouteContext: UseRouteContextRoute<RootRouteId>
+  declare useSearch: UseSearchRoute<RootRouteId>
+  declare useParams: UseParamsRoute<RootRouteId>
+  declare useLoaderDeps: UseLoaderDepsRoute<RootRouteId>
+  declare useLoaderData: UseLoaderDataRoute<RootRouteId>
+  declare useNavigate: () => UseNavigateResult<'/'>
+  declare Link: LinkComponentRoute<'/'>
+}
+
+function initVueRouteApi(route: AnyRoute) {
+  route.useMatch = (opts) => {
     return useMatch({
       select: opts?.select,
-      from: this.id,
+      from: route.id,
     } as any) as any
   }
-
-  useRouteContext: UseRouteContextRoute<RootRouteId> = (opts) => {
-    return useRouteContext({ ...(opts as any), from: this.id })
+  route.useRouteContext = (opts) => {
+    return useRouteContext({ ...(opts as any), from: route.id })
   }
-
-  useSearch: UseSearchRoute<RootRouteId> = (opts) => {
+  route.useSearch = (opts) => {
     return useSearch({
       select: opts?.select,
-      from: this.id,
+      from: route.id,
     } as any) as any
   }
-
-  useParams: UseParamsRoute<RootRouteId> = (opts) => {
+  route.useParams = (opts) => {
     return useParams({
       select: opts?.select,
-      from: this.id,
+      from: route.id,
     } as any) as any
   }
-
-  useLoaderDeps: UseLoaderDepsRoute<RootRouteId> = (opts) => {
-    return useLoaderDeps({ ...opts, from: this.id } as any)
+  route.useLoaderDeps = (opts) => {
+    return useLoaderDeps({ ...opts, from: route.id } as any)
   }
-
-  useLoaderData: UseLoaderDataRoute<RootRouteId> = (opts) => {
-    return useLoaderData({ ...opts, from: this.id } as any)
+  route.useLoaderData = (opts) => {
+    return useLoaderData({ ...opts, from: route.id } as any)
   }
-
-  useNavigate = (): UseNavigateResult<'/'> => {
-    return useNavigate({ from: this.fullPath })
+  route.useNavigate = () => {
+    return useNavigate({ from: route.fullPath })
   }
-
-  Link: LinkComponentRoute<'/'> = ((props, ctx?: Vue.SetupContext) => {
-    return Vue.h(Link, { from: this.fullPath as never, ...props }, ctx?.slots)
-  }) as LinkComponentRoute<'/'>
+  route.Link = ((props, ctx?: Vue.SetupContext) => {
+    return Vue.h(
+      Link as any,
+      { from: route.fullPath as never, ...(props as any) },
+      ctx?.slots,
+    )
+  }) as LinkComponentRoute<string>
 }
 
 export function createRouteMask<

--- a/packages/vue-router/tests/route.test.tsx
+++ b/packages/vue-router/tests/route.test.tsx
@@ -74,6 +74,15 @@ describe('createRoute has the same hooks as getRouteApi', () => {
       expect(route[hookName as keyof typeof route]).toBeDefined()
     },
   )
+
+  it.each([
+    ['route', route],
+    ['root route', createRootRoute()],
+  ])('defines Vue APIs as own properties on the %s', (_, instance) => {
+    for (const key of [...hookNames, 'Link']) {
+      expect(Object.prototype.hasOwnProperty.call(instance, key)).toBe(true)
+    }
+  })
 })
 
 /* disabled until HMR bug is fixed 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reduced router bundle size across React, Solid, and Vue integrations through unified route API bindings.
  * Preserved route-specific hooks, navigation, matching, data access, and `Link` behavior.

* **Bug Fixes**
  * Ensured regular and root routes consistently expose all expected framework APIs and link functionality.

* **Tests**
  * Added coverage verifying route and root route API availability across all supported frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->