### PR TITLE
perf(router-core): skip the cleanPath regex when there are no double slashes

### DIFF
--- a/packages/router-core/src/path.ts
+++ b/packages/router-core/src/path.ts
@@ -22,7 +22,8 @@ export function joinPaths(paths: Array<string | undefined>) {
 
 /** Remove repeated slashes from a path string. */
 export function cleanPath(path: string) {
-  // remove double slashes
+  // Most paths never contain '//' — skip the regex on that common case.
+  if (path.indexOf('//') === -1) return path
   return path.replace(/\/{2,}/g, '/')
 }
 


### PR DESCRIPTION
## Summary

Split out of #8085 so bundle size and performance can be measured independently.

`cleanPath` runs on `joinPaths` / `resolvePath` for every navigation. Most paths never contain `//`, so the `/{2,}` regex is wasted work.

Return the input as-is when `indexOf('//')` misses. Same result when it hits.

## Test plan

- [x] `packages/router-core/tests/path.test.ts`
- [x] `packages/router-core/tests/optional-path-params.test.ts`
- [x] `packages/router-core/tests/optional-path-params-clean.test.ts`