### PR TITLE
perf(router-core): dehydrate SSR match IDs in one pass

### DIFF
--- a/packages/router-core/src/ssr/ssr-match-id.ts
+++ b/packages/router-core/src/ssr/ssr-match-id.ts
@@ -1,12 +1,55 @@
+const dehydrateCache = new Map<string, string>()
+const DEHYDRATE_CACHE_MAX = 256
+const DEHYDRATE_CACHE_MAX_ID_LENGTH = 4096
+
 export function dehydrateSsrMatchId(id: string): string {
-  return id
-    .replaceAll('~', '~~')
-    .replaceAll('\0', '~0')
-    .replaceAll('\uFFFD', '~r')
-    .replaceAll('/', '\0')
+  const cached = dehydrateCache.get(id)
+  if (cached !== undefined) {
+    return cached
+  }
+
+  const result = dehydrateSsrMatchIdUncached(id)
+  if (id.length > DEHYDRATE_CACHE_MAX_ID_LENGTH) {
+    return result
+  }
+  if (dehydrateCache.size >= DEHYDRATE_CACHE_MAX) {
+    dehydrateCache.delete(dehydrateCache.keys().next().value!)
+  }
+  dehydrateCache.set(id, result)
+  return result
+}
+
+function dehydrateSsrMatchIdUncached(id: string): string {
+  const len = id.length
+  let last = 0
+  let out = ''
+  for (let i = 0; i < len; i++) {
+    const c = id.charCodeAt(i)
+    if (c === 126) {
+      out += id.slice(last, i) + '~~'
+      last = i + 1
+    } else if (c === 0) {
+      out += id.slice(last, i) + '~0'
+      last = i + 1
+    } else if (c === 0xfffd) {
+      out += id.slice(last, i) + '~r'
+      last = i + 1
+    } else if (c === 47) {
+      out += id.slice(last, i) + '\0'
+      last = i + 1
+    }
+  }
+  return last === 0 ? id : out + id.slice(last)
 }
 
 export function hydrateSsrMatchId(id: string): string {
+  if (
+    id.indexOf('\0') === -1 &&
+    id.indexOf('\uFFFD') === -1 &&
+    id.indexOf('~') === -1
+  ) {
+    return id
+  }
   return id
     .replaceAll('\0', '/')
     .replaceAll('\uFFFD', '/')

--- a/packages/router-core/tests/ssr-match-id.test.ts
+++ b/packages/router-core/tests/ssr-match-id.test.ts
@@ -39,4 +39,12 @@ describe('ssr match id codec', () => {
 
     expect(hydrateSsrMatchId(normalized)).toBe('/posts/1')
   })
+
+  it('dehydrates ids longer than the cache length limit', () => {
+    const id = `/${'a'.repeat(5000)}/posts`
+    const dehydratedId = dehydrateSsrMatchId(id)
+
+    expect(dehydratedId).not.toContain('/')
+    expect(hydrateSsrMatchId(dehydratedId)).toBe(id)
+  })
 })


### PR DESCRIPTION
## Summary

Split out of #8085 so bundle size and performance can be measured independently.

Typical route ids only contain slashes. Scan once, intern the result with a bounded cache (entry count and string-length limits), and skip hydrate work when the payload has no encoded characters.

## Test plan

- [x] `packages/router-core/tests/ssr-match-id.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-rendered match ID encoding and decoding for special characters, including slashes and replacement characters.
  * Added support for very long match IDs while maintaining reliable round-trip restoration.
  * Improved decoding performance when IDs contain no encoded characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->