### PR TITLE
feat(react-router): allow pendingComponent: false to opt out of the default pending fallback

### DIFF
--- a/docs/router/api/router/RouteOptionsType.md
+++ b/docs/router/api/router/RouteOptionsType.md
@@ -41,9 +41,10 @@ The `RouteOptions` type accepts an object with the following properties:
 
 ### `pendingComponent` property
 
-- Type: `RouteComponent` or `LazyRouteComponent`
+- Type: `false`, `RouteComponent`, or `LazyRouteComponent`
 - Optional - Defaults to `routerOptions.defaultPendingComponent`
 - The content to be rendered if and when the route is pending and has reached its pendingMs threshold.
+- Set to `false` to opt out of `routerOptions.defaultPendingComponent` for this route and render nothing instead.
 
 ### `notFoundComponent` property
 

--- a/packages/react-router/src/route.tsx
+++ b/packages/react-router/src/route.tsx
@@ -53,7 +53,7 @@ declare module '@tanstack/router-core' {
     component?: RouteComponent
     errorComponent?: false | null | undefined | ErrorRouteComponent
     notFoundComponent?: NotFoundRouteComponent
-    pendingComponent?: RouteComponent
+    pendingComponent?: false | null | undefined | RouteComponent
   }
 
   export interface RootRouteOptionsExtensions {

--- a/packages/react-router/tests/issue-7773-pending-component-opt-out.test.tsx
+++ b/packages/react-router/tests/issue-7773-pending-component-opt-out.test.tsx
@@ -1,0 +1,96 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, expect, test, vi } from 'vitest'
+import {
+  Outlet,
+  RouterProvider,
+  createControlledPromise,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+// https://github.com/TanStack/router/issues/7773
+test('pendingComponent: false suppresses the router-wide default pending fallback', async () => {
+  vi.useFakeTimers()
+
+  const loaderGate = createControlledPromise<string>()
+  const rootRoute = createRootRoute({ component: Outlet })
+  const optedOutRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/opted-out',
+    pendingComponent: false,
+    loader: () => loaderGate,
+    component: () => (
+      <div data-testid="content">{optedOutRoute.useLoaderData()}</div>
+    ),
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([optedOutRoute]),
+    history: createMemoryHistory({ initialEntries: ['/opted-out'] }),
+    defaultPendingComponent: () => <div data-testid="pending">Pending</div>,
+    defaultPendingMs: 0,
+    defaultPendingMinMs: 100,
+  })
+
+  render(<RouterProvider router={router} />)
+
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0)
+  })
+  expect(screen.queryByTestId('pending')).not.toBeInTheDocument()
+  expect(screen.queryByTestId('content')).not.toBeInTheDocument()
+
+  loaderGate.resolve('loaded')
+
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0)
+  })
+  expect(screen.queryByTestId('pending')).not.toBeInTheDocument()
+  expect(screen.getByTestId('content')).toHaveTextContent('loaded')
+})
+
+// Contrast case: confirms the type widening didn't disturb default inheritance
+// for routes that don't opt out.
+test('a sibling route without pendingComponent: false still uses the router-wide default', async () => {
+  vi.useFakeTimers()
+
+  const loaderGate = createControlledPromise<string>()
+  const rootRoute = createRootRoute({ component: Outlet })
+  const defaultRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/default',
+    loader: () => loaderGate,
+    component: () => (
+      <div data-testid="content">{defaultRoute.useLoaderData()}</div>
+    ),
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([defaultRoute]),
+    history: createMemoryHistory({ initialEntries: ['/default'] }),
+    defaultPendingComponent: () => <div data-testid="pending">Pending</div>,
+    defaultPendingMs: 0,
+    defaultPendingMinMs: 100,
+  })
+
+  render(<RouterProvider router={router} />)
+
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0)
+  })
+  expect(screen.getByTestId('pending')).toBeInTheDocument()
+  expect(screen.queryByTestId('content')).not.toBeInTheDocument()
+
+  loaderGate.resolve('loaded')
+
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(100)
+  })
+  expect(screen.queryByTestId('pending')).not.toBeInTheDocument()
+  expect(screen.getByTestId('content')).toHaveTextContent('loaded')
+})

--- a/packages/react-router/tests/issue-7773-pending-component-opt-out.test.tsx
+++ b/packages/react-router/tests/issue-7773-pending-component-opt-out.test.tsx
@@ -17,8 +17,6 @@ afterEach(() => {
 
 // https://github.com/TanStack/router/issues/7773
 test('pendingComponent: false suppresses the router-wide default pending fallback', async () => {
-  vi.useFakeTimers()
-
   const loaderGate = createControlledPromise<string>()
   const rootRoute = createRootRoute({ component: Outlet })
   const optedOutRoute = createRoute({
@@ -39,18 +37,14 @@ test('pendingComponent: false suppresses the router-wide default pending fallbac
   })
 
   render(<RouterProvider router={router} />)
-
-  await act(async () => {
-    await vi.advanceTimersByTimeAsync(0)
-  })
   expect(screen.queryByTestId('pending')).not.toBeInTheDocument()
   expect(screen.queryByTestId('content')).not.toBeInTheDocument()
 
-  loaderGate.resolve('loaded')
-
   await act(async () => {
-    await vi.advanceTimersByTimeAsync(0)
+    loaderGate.resolve('loaded')
+    await loaderGate
   })
+
   expect(screen.queryByTestId('pending')).not.toBeInTheDocument()
   expect(screen.getByTestId('content')).toHaveTextContent('loaded')
 })
@@ -79,17 +73,19 @@ test('a sibling route without pendingComponent: false still uses the router-wide
   })
 
   render(<RouterProvider router={router} />)
-
-  await act(async () => {
-    await vi.advanceTimersByTimeAsync(0)
-  })
   expect(screen.getByTestId('pending')).toBeInTheDocument()
   expect(screen.queryByTestId('content')).not.toBeInTheDocument()
 
   loaderGate.resolve('loaded')
 
+  // pendingMinMs (100) hasn't elapsed yet -- the default fallback must stay up.
   await act(async () => {
-    await vi.advanceTimersByTimeAsync(100)
+    await vi.advanceTimersByTimeAsync(99)
+  })
+  expect(screen.getByTestId('pending')).toBeInTheDocument()
+
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(1)
   })
   expect(screen.queryByTestId('pending')).not.toBeInTheDocument()
   expect(screen.getByTestId('content')).toHaveTextContent('loaded')


### PR DESCRIPTION
### Description

Fixes #7773.

Adds a way to opt a route out of the router-wide default pending fallback entirely, using the same convention `errorComponent` already ships with:

```ts
// packages/react-router/src/route.tsx
errorComponent?: false | null | undefined | ErrorRouteComponent
pendingComponent?: false | null | undefined | RouteComponent // <- this PR
```

### Why this is a one-line, logic-free change

Both `pendingComponent` and `errorComponent` are read through the same `?? default` pattern, and `??` only falls through on `null`/`undefined` — `false` is not nullish, so it survives.

- `Match.tsx#renderPending` (render): `route?.options.pendingComponent ?? router.options.defaultPendingComponent`, then `if (!PendingComponent) return null`.
- `load-client.ts` (pending-status timing calc): same `??`, then `if (!component ...) return`.

`false ?? default` stays `false`, and the subsequent truthy checks already treat falsy as "nothing to render" — same as `errorComponent`'s `routeErrorComponent ? CatchBoundary : SafeFragment`. So the runtime already does the right thing with `false`; it's only blocked by the type today. No changes needed in either file, confirmed by tracing every reference to `.pendingComponent` in the React path.

### Test plan

Added `packages/react-router/tests/issue-7773-pending-component-opt-out.test.tsx`:
- A route with `pendingComponent: false` never shows the router-wide `defaultPendingComponent`, even with `defaultPendingMs: 0`, and still renders its real content once the loader resolves.
- A contrast case: a sibling route *without* the opt-out still shows the default normally, confirming the type widening doesn't disturb default inheritance.

Ran together with the existing pending/error-boundary suites — 64/64 passing, no regressions.

- [x] `test:types` (tsc on `src`) — clean
- [x] `eslint` on changed files — clean
- [x] `prettier --check` — clean
- [x] `vitest run` on the new + related pending/error test files — 64/64 pass

### Status

Opening as a **draft** — proposed this approach on #7773 and haven't gotten maintainer sign-off yet, since it's technically an API surface change per CONTRIBUTING.md. Marking draft rather than requesting review until that lands.

### AI assistance

Used AI to help trace the `??`/fallback-chain call sites and draft the diff and test. Reviewed and verified the control-flow claims myself and can walk through the reasoning in review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Routes can now opt out of displaying the router’s default pending/loading component by setting `pendingComponent` to `false`.
  * Routes without this setting continue to use the shared pending fallback.

* **Documentation**
  * Updated route option documentation to describe the new opt-out behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->