### PR TITLE
fix(react-router): render errorComponent for thrown falsy values

### DIFF
--- a/packages/react-router/src/CatchBoundary.tsx
+++ b/packages/react-router/src/CatchBoundary.tsx
@@ -11,36 +11,45 @@ export class CatchBoundary extends React.Component<{
   errorComponent?: ErrorRouteComponent
   onCatch?: (error: Error, errorInfo: ErrorInfo) => void
 }> {
-  state = { error: null } as { error: Error | null; resetKey?: unknown }
+  // hasError tracks the caught state separately from the error value: a thrown
+  // falsy value (undefined, null, 0, '') would otherwise re-render the crashing
+  // children and escalate to an uncaught error at the root.
+  state = { error: null, hasError: false } as {
+    error: Error | null
+    hasError: boolean
+    resetKey?: unknown
+  }
 
   static getDerivedStateFromProps(
     props: { getResetKey: () => unknown },
-    state: { resetKey?: unknown; error: Error | null },
+    state: { resetKey?: unknown; error: Error | null; hasError: boolean },
   ) {
     const resetKey = props.getResetKey()
 
-    if (state.error && state.resetKey !== resetKey) {
-      return { resetKey, error: null }
+    if (state.hasError && state.resetKey !== resetKey) {
+      return { resetKey, error: null, hasError: false }
     }
 
     return { resetKey }
   }
   static getDerivedStateFromError(error: Error) {
-    return { error }
+    return { error, hasError: true }
   }
   reset = () => {
-    this.setState({ error: null })
+    this.setState({ error: null, hasError: false })
   }
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     this.props.onCatch?.(error, errorInfo)
   }
   render() {
     const error = this.state.error
-    if (error) {
+    if (this.state.hasError) {
       const element = React.createElement(
         this.props.errorComponent ?? ErrorComponent,
         {
-          error,
+          // The value passes through as thrown; non-Error throws already reached
+          // errorComponent under the previous truthy gate with this same typing.
+          error: error as Error,
           reset: this.reset,
         },
       )
@@ -88,7 +97,7 @@ export function ErrorComponent({ error }: { error: any }) {
               overflow: 'auto',
             }}
           >
-            {error.message ? <code>{error.message}</code> : null}
+            {error?.message ? <code>{error.message}</code> : null}
           </pre>
         </div>
       ) : null}

--- a/packages/react-router/src/CatchBoundary.tsx
+++ b/packages/react-router/src/CatchBoundary.tsx
@@ -11,9 +11,7 @@ export class CatchBoundary extends React.Component<{
   errorComponent?: ErrorRouteComponent
   onCatch?: (error: Error, errorInfo: ErrorInfo) => void
 }> {
-  // hasError tracks the caught state separately from the error value: a thrown
-  // falsy value (undefined, null, 0, '') would otherwise re-render the crashing
-  // children and escalate to an uncaught error at the root.
+  // Tracked separately from the value so thrown falsy values still render the boundary
   state = { error: null, hasError: false } as {
     error: Error | null
     hasError: boolean
@@ -47,8 +45,6 @@ export class CatchBoundary extends React.Component<{
       const element = React.createElement(
         this.props.errorComponent ?? ErrorComponent,
         {
-          // The value passes through as thrown; non-Error throws already reached
-          // errorComponent under the previous truthy gate with this same typing.
           error: error as Error,
           reset: this.reset,
         },

--- a/packages/react-router/tests/issue-8098-falsy-error-boundary.test.tsx
+++ b/packages/react-router/tests/issue-8098-falsy-error-boundary.test.tsx
@@ -33,9 +33,6 @@ function setupThrowingRoute(thrownValue: unknown) {
   })
 }
 
-// issue #8098: the boundary gated on the error value's truthiness, so a thrown
-// falsy value re-rendered the crashing children and escalated to an uncaught
-// root error instead of rendering the errorComponent.
 test.each([
   ['undefined', undefined],
   ['null', null],

--- a/packages/react-router/tests/issue-8098-falsy-error-boundary.test.tsx
+++ b/packages/react-router/tests/issue-8098-falsy-error-boundary.test.tsx
@@ -47,7 +47,8 @@ test.each([
     const router = setupThrowingRoute(thrownValue)
     render(<RouterProvider router={router} />)
 
-    expect(await screen.findByTestId('route-error')).toBeInTheDocument()
+    const errorEl = await screen.findByTestId('route-error')
+    expect(errorEl.textContent).toBe(String(thrownValue))
   },
 )
 

--- a/packages/react-router/tests/issue-8098-falsy-error-boundary.test.tsx
+++ b/packages/react-router/tests/issue-8098-falsy-error-boundary.test.tsx
@@ -1,0 +1,66 @@
+import { afterEach, expect, test, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { createMemoryHistory } from '@tanstack/history'
+import {
+  RouterProvider,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+function setupThrowingRoute(thrownValue: unknown) {
+  const rootRoute = createRootRoute({
+    errorComponent: ({ error }) => (
+      <div data-testid="route-error">{String(error)}</div>
+    ),
+  })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: function Boom(): never {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error
+      throw thrownValue
+    },
+  })
+  return createRouter({
+    routeTree: rootRoute.addChildren([indexRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+}
+
+// issue #8098: the boundary gated on the error value's truthiness, so a thrown
+// falsy value re-rendered the crashing children and escalated to an uncaught
+// root error instead of rendering the errorComponent.
+test.each([
+  ['undefined', undefined],
+  ['null', null],
+  ['zero', 0],
+  ['empty string', ''],
+])(
+  'renders the errorComponent when a component throws %s',
+  async (_label, thrownValue) => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const router = setupThrowingRoute(thrownValue)
+    render(<RouterProvider router={router} />)
+
+    expect(await screen.findByTestId('route-error')).toBeInTheDocument()
+  },
+)
+
+test('passes real errors through to the errorComponent unchanged', async () => {
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+  const router = setupThrowingRoute(new Error('real failure'))
+  render(<RouterProvider router={router} />)
+
+  const errorEl = await screen.findByTestId('route-error')
+  expect(errorEl.textContent).toContain('real failure')
+})


### PR DESCRIPTION
Closes #8098.

`CatchBoundary` gated its reset and render logic on the caught value's truthiness, so a thrown falsy value (`undefined`, `null`, `0`, `''`) re-rendered the crashing children and React escalated it to an uncaught root error instead of rendering the route's `errorComponent` — the escalation path behind #7753/#7457, still reproducible after #7805.

This tracks the caught state in a separate `hasError` flag and passes the thrown value through unchanged. The default `ErrorComponent` gets an `error?.message` guard so it renders non-Error values too. Test named per the issue: 4 of its 5 cases fail without the fix.

Standalone repro that motivated the issue: https://github.com/antur84/tanstack-router-falsy-error-boundary-repro

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error boundaries so thrown falsy values—including `undefined`, `null`, `0`, and empty strings—are still caught and rendered.
  * Preserved original `Error` instances when passing them to configured error components.
  * Improved handling when no error message is available.

* **Tests**
  * Added coverage for falsy thrown values and standard `Error` instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->