### PR TITLE
perf(router-core): optimize buildLocation path resolution

### DIFF
--- a/packages/router-core/src/path.ts
+++ b/packages/router-core/src/path.ts
@@ -139,6 +139,9 @@ export function resolvePath({
   if (isBase) {
     baseSegments = base.split('/')
   } else {
+    if (base.includes('//')) {
+      base = cleanPath(base)
+    }
     baseSegments = base.split('/')
     while (baseSegments.length > 1 && last(baseSegments) === '') {
       baseSegments.pop()

--- a/packages/router-core/src/path.ts
+++ b/packages/router-core/src/path.ts
@@ -115,10 +115,8 @@ export function resolvePath({
   if (to.includes('//')) {
     to = cleanPath(to)
   }
-  const isBase = to === '.'
-  const isAbsolute = to.startsWith('/')
 
-  if (isAbsolute) {
+  if (to.startsWith('/')) {
     if (to.length === 1 || trailingSlash === 'preserve') {
       return to
     }
@@ -128,10 +126,11 @@ export function resolvePath({
     return to.endsWith('/') ? to.slice(0, -1) : to
   }
 
+  const isBase = to === '.'
   let key
   if (cache) {
     // `trailingSlash` is static per router, so it doesn't need to be part of the cache key
-    key = isAbsolute ? to : isBase ? base : base + '\0' + to
+    key = isBase ? base : base + '\0' + to
     const cached = cache.get(key)
     if (cached) return cached
   }
@@ -139,8 +138,6 @@ export function resolvePath({
   let baseSegments: Array<string>
   if (isBase) {
     baseSegments = base.split('/')
-  } else if (isAbsolute) {
-    baseSegments = to.split('/')
   } else {
     baseSegments = base.split('/')
     while (baseSegments.length > 1 && last(baseSegments) === '') {

--- a/packages/router-core/src/path.ts
+++ b/packages/router-core/src/path.ts
@@ -112,8 +112,21 @@ export function resolvePath({
   trailingSlash = 'never',
   cache,
 }: ResolvePathOptions) {
+  if (to.includes('//')) {
+    to = cleanPath(to)
+  }
   const isBase = to === '.'
   const isAbsolute = to.startsWith('/')
+
+  if (isAbsolute) {
+    if (to.length === 1 || trailingSlash === 'preserve') {
+      return to
+    }
+    if (trailingSlash === 'always') {
+      return to.endsWith('/') ? to : `${to}/`
+    }
+    return to.endsWith('/') ? to.slice(0, -1) : to
+  }
 
   let key
   if (cache) {

--- a/packages/router-core/src/path.ts
+++ b/packages/router-core/src/path.ts
@@ -184,7 +184,8 @@ export function resolvePath({
     }
   }
 
-  const result = cleanPath(baseSegments.join('/')) || '/'
+  const joined = baseSegments.join('/')
+  const result = (isBase ? cleanPath(joined) : joined) || '/'
   if (key && cache) cache.set(key, result)
   return result
 }

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -22,7 +22,6 @@ import {
   processRouteTree,
 } from './new-process-route-tree'
 import {
-  cleanPath,
   compileDecodeCharMap,
   interpolatePath,
   resolvePath,
@@ -1469,7 +1468,7 @@ export class RouterCore<
   resolvePathWithBase = (from: string, path: string) => {
     return resolvePath({
       base: from,
-      to: path.includes('//') ? cleanPath(path) : path,
+      to: path,
       trailingSlash: this.options.trailingSlash,
       cache: this.resolvePathCache,
     })
@@ -1892,28 +1891,19 @@ export class RouterCore<
         dest.unsafeRelative === 'path'
           ? currentLocation.pathname
           : (dest.from ?? lightweightResult[1 /* fullPath */])
-      const destTo = dest.to ? `${dest.to}` : undefined
 
       // From search should always use the current location
       const fromSearch = lightweightResult[2 /* search */]
       // Same with params. It can't hurt to provide as many as possible
-      const fromParams = Object.assign(
-        Object.create(null),
-        lightweightResult[3 /* params */],
+      const fromParams = lightweightResult[3 /* params */]
+
+      const nextTo = this.resolvePathWithBase(
+        defaultedFromPath,
+        dest.to ? `${dest.to}` : '.',
       )
 
-      const isAbsoluteTo = destTo?.charCodeAt(0) === 47
-      const sourcePath = isAbsoluteTo
-        ? '/'
-        : this.resolvePathWithBase(defaultedFromPath, '.')
-
-      // Resolve the destination. Absolute destinations don't need the source path.
-      const nextTo = destTo
-        ? this.resolvePathWithBase(sourcePath, destTo)
-        : sourcePath
-
       // Resolve the next params
-      const nextParams = resolveNextParams(dest.params, fromParams)
+      let nextParams = resolveNextParams(dest.params, fromParams)
 
       const destRoute = this.routesByPath[
         trimPathRight(nextTo) as keyof typeof this.routesByPath
@@ -1945,6 +1935,9 @@ export class RouterCore<
           const fn =
             route.options.params?.stringify ?? route.options.stringifyParams
           if (fn) {
+            if (nextParams === fromParams) {
+              nextParams = Object.assign(Object.create(null), nextParams)
+            }
             try {
               Object.assign(nextParams, fn(nextParams))
             } catch {
@@ -2864,11 +2857,14 @@ function resolveNextParams(
   spec: unknown,
   base: Record<string, unknown>,
 ): Record<string, unknown> {
-  return spec === false || spec === null
-    ? Object.create(null)
-    : (spec ?? true) === true
-      ? base
-      : Object.assign(base, functionalUpdate(spec as any, base))
+  if (spec === false || spec === null) {
+    return Object.create(null)
+  }
+  if ((spec ?? true) === true) {
+    return base
+  }
+  const next = Object.assign(Object.create(null), base)
+  return Object.assign(next, functionalUpdate(spec as any, next))
 }
 
 function extractStrictParams(

--- a/packages/router-core/tests/build-location.test.ts
+++ b/packages/router-core/tests/build-location.test.ts
@@ -1613,6 +1613,37 @@ describe('buildLocation - params edge cases', () => {
     expect(location.pathname).toBe('/users/000042')
   })
 
+  test('params.stringify should not mutate current params', async () => {
+    const rootRoute = new BaseRootRoute({})
+    const userRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/users/$userId',
+      params: {
+        parse: ({ userId }: { userId: string }) => ({
+          userId: parseInt(userId, 10),
+        }),
+        stringify: (params: { userId: number }) => {
+          const userId = params.userId
+          params.userId = 999
+          return { userId: String(userId).padStart(6, '0') }
+        },
+      },
+    })
+
+    const routeTree = rootRoute.addChildren([userRoute])
+    const router = createTestRouter({
+      routeTree,
+      history: createMemoryHistory({ initialEntries: ['/users/000123'] }),
+    })
+
+    await router.load()
+
+    expect(router.buildLocation({ to: '/users/$userId' }).pathname).toBe(
+      '/users/000123',
+    )
+    expect(router.state.matches.at(-1)?.params).toEqual({ userId: 123 })
+  })
+
   test('params.stringify should run for params.parse route templates', async () => {
     const rootRoute = new BaseRootRoute({})
     const languageRoute = new BaseRoute({

--- a/packages/router-core/tests/build-location.test.ts
+++ b/packages/router-core/tests/build-location.test.ts
@@ -1300,6 +1300,39 @@ describe('buildLocation - relative paths', () => {
     expect(location.pathname).toBe('/a/d')
   })
 
+  test('unsafe path-relative navigation ignores repeated slash segments', async () => {
+    const rootRoute = new BaseRootRoute({})
+    const aRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/a',
+    })
+    const bRoute = new BaseRoute({
+      getParentRoute: () => aRoute,
+      path: '/b',
+    })
+    const cRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/c',
+    })
+    const routeTree = rootRoute.addChildren([
+      aRoute.addChildren([bRoute]),
+      cRoute,
+    ])
+    const router = createTestRouter({
+      routeTree,
+      history: createMemoryHistory({ initialEntries: ['/a//b'] }),
+    })
+
+    await router.load()
+
+    expect(
+      router.buildLocation({
+        to: '../../c',
+        unsafeRelative: 'path',
+      }).pathname,
+    ).toBe('/c')
+  })
+
   test('over-root traversal stays rooted for javascript-like segments', async () => {
     const rootRoute = new BaseRootRoute({})
     const indexRoute = new BaseRoute({

--- a/packages/router-core/tests/path.test.ts
+++ b/packages/router-core/tests/path.test.ts
@@ -109,6 +109,8 @@ describe('resolvePath', () => {
     ['/a/b/c', '../..', '/a'],
     ['/a/b/c', '../../..', '/'],
     ['/a/b/c/', '../../..', '/'],
+    ['/a//b', '../../c', '/c'],
+    ['/a///b', '../c', '/a/c'],
     ['/', '../javascript:alert(1)', '/javascript:alert(1)'],
     ['/posts', '../../data:text/html,test', '/data:text/html,test'],
   ])('resolves correctly', (a, b, eq) => {

--- a/packages/router-core/tests/path.test.ts
+++ b/packages/router-core/tests/path.test.ts
@@ -125,6 +125,10 @@ describe('resolvePath', () => {
     })
   })
 
+  it('normalizes repeated slashes when resolving the base path', () => {
+    expect(resolvePath({ base: '/a//b', to: '.' })).toBe('/a/b')
+  })
+
   describe('trailingSlash', () => {
     describe(`'always'`, () => {
       it('keeps trailing slash', () => {

--- a/packages/router-core/tests/path.test.ts
+++ b/packages/router-core/tests/path.test.ts
@@ -184,6 +184,17 @@ describe('resolvePath', () => {
         ).toBe('/a/b/c/d')
       })
     })
+
+    it.each([
+      ['always', '/a//b', '/a/b/'],
+      ['never', '/a//b///', '/a/b'],
+      ['preserve', '/a//b///', '/a/b/'],
+    ] as const)(
+      "normalizes repeated slashes with trailingSlash '%s'",
+      (trailingSlash, to, expected) => {
+        expect(resolvePath({ base: '/', to, trailingSlash })).toBe(expected)
+      },
+    )
   })
 
   describe.each([{ base: '/' }, { base: '/nested' }])(


### PR DESCRIPTION
Inspired by https://github.com/TanStack/router/pull/8086

## Summary

- return normalized absolute paths directly from `resolvePath`, avoiding the LRU, `split`, `join`, and final regex pass
- resolve relative `buildLocation` destinations in one pass instead of first resolving `from` against `.`
- normalize relative bases containing repeated slashes before parent traversal, preserving cases such as `/a//b` + `../../c` -> `/c`
- reuse inherited params until an updater or route stringifier can mutate them, then clone lazily
- preserve repeated-slash and trailing-slash behavior and protect current params from mutating stringifiers

The production diff is ten net lines: `path.ts` adds 14 and `router.ts` removes 4. Benchmark source is intentionally not included in this PR.

## Benchmark setup

The benchmark constructs a real `RouterCore` with a 1,200-route tree and executes 1,200 `buildLocation()` calls per sample. Production, browser-conditioned bundles run in Node with `createMemoryHistory` and `RouterCore` configured as server. Baseline (`main`) and the final candidate were bundled separately, loaded into the same process, and alternated for 1,500-2,000 samples. Each case was also rerun with candidate/baseline construction order reversed.

Times below are median milliseconds per 1,200 `buildLocation()` calls. Arrows are baseline -> candidate.

### Important wins

```text
repeated static absolute destinations
  baseline first:  0.858 -> 0.669 ms  (-22.0%)
  candidate first: 0.898 -> 0.722 ms  (-19.7%)

repeated relative destinations
  baseline first:  1.048 -> 0.897 ms  (-14.4%)
  candidate first: 1.058 -> 0.909 ms  (-14.0%)

1,200 unique relative destinations (sustained LRU misses)
  baseline first:  1.619 -> 1.542 ms  (-4.7%)
  candidate first: 1.619 -> 1.557 ms  (-3.8%)

1,200 mixed unique destinations
  baseline first:  1.972 -> 1.010 ms  (-48.8%)
  candidate first: 1.872 -> 1.009 ms  (-46.1%)
```

The mixed-unique case intentionally exceeds the 1,000-entry resolve-path LRU. The large win comes from one-off absolute destinations bypassing the LRU instead of evicting useful relative-path entries. It is a large-app/cache-pressure case, not the expected gain for every navigation.

The unique-relative case also exceeds the LRU and measures the final redundant `cleanPath` scan on every relative cache miss. Repeated relative paths that remain cached do not receive this additional 3.8-4.7% gain.

The repository Vitest benchmark, rerun in production mode in separate processes, also improved:

```text
1,200 unique mixed destinations:   2.418 -> 1.507 ms  (37.7% faster)
1,200 repeated mixed destinations: 1.623 -> 1.459 ms  (10.1% faster)
1,200 double-slash destinations:   2.450 -> 1.568 ms  (36.0% faster)
```

### Neutral case

```text
repeated dynamic-param destinations
  baseline first:  2.133 -> 2.130 ms  (-0.1%)
  candidate first: 2.091 -> 2.083 ms  (-0.4%)
```

The sub-percent differences should be treated as no demonstrated change.

### Bundle size

`react-router.minimal` compared with `main`:

```text
gzip:   85,828 -> 85,844 bytes  (+16)
raw:   268,920 -> 269,051 bytes  (+131)
brotli: 74,750 -> 74,768 bytes  (+18)
```

## Test plan

- [x] `pnpm nx run @tanstack/router-core:test:unit -- tests/path.test.ts tests/build-location.test.ts tests/optional-path-params.test.ts tests/optional-path-params-clean.test.ts`
- [x] `pnpm nx run @tanstack/router-core:test:types`
- [x] `pnpm nx run @tanstack/router-core:test:eslint`
- [x] `react-router.minimal` bundle-size comparison

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL path resolution by normalizing duplicate slashes.
  * Applied trailing-slash settings consistently to absolute paths.
  * Preserved route parameters when generating locations, preventing accidental mutation of current route state.
  * Ensured inherited parameters remain unchanged when building or updating locations.

* **Tests**
  * Added coverage for repeated slashes and trailing-slash modes.
  * Added regression coverage for parameter formatting without state mutation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
