### PR TITLE
perf(router-core): skip impossible state sharing

### DIFF
--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -9,7 +9,6 @@ import {
   functionalUpdate,
   hasKeys,
   isDangerousProtocol,
-  isPlainObject,
   last,
   nullReplaceEqualDeep,
   replaceEqualDeep,
@@ -2046,12 +2045,7 @@ export class RouterCore<
             : {}
 
       // Replace the equal deep
-      if (
-        isServer ||
-        destState ||
-        !isPlainObject(currentState) ||
-        !currentState.__TSR_key
-      ) {
+      if (destState) {
         nextState = replaceEqualDeep(currentState, nextState)
       }
 

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -2043,7 +2043,9 @@ export class RouterCore<
             : {}
 
       // Replace the equal deep
-      nextState = replaceEqualDeep(currentLocation.state, nextState)
+      if (dest.state || !hasKeys(currentLocation.state)) {
+        nextState = replaceEqualDeep(currentLocation.state, nextState)
+      }
 
       // Create the full path of the location
       const fullPath = `${nextPathname}${searchStr}${hashStr}`

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -2035,18 +2035,16 @@ export class RouterCore<
       const hashStr = hash ? `#${hash}` : ''
 
       // Resolve the next state
-      const destState = dest.state
-      const currentState = currentLocation.state
       let nextState =
-        destState === true
-          ? currentState
-          : destState
-            ? functionalUpdate(destState, currentState)
+        dest.state === true
+          ? currentLocation.state
+          : dest.state
+            ? functionalUpdate(dest.state, currentLocation.state)
             : {}
 
       // Replace the equal deep
-      if (destState) {
-        nextState = replaceEqualDeep(currentState, nextState)
+      if (dest.state) {
+        nextState = replaceEqualDeep(currentLocation.state, nextState)
       }
 
       // Create the full path of the location

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -9,6 +9,7 @@ import {
   functionalUpdate,
   hasKeys,
   isDangerousProtocol,
+  isPlainObject,
   last,
   nullReplaceEqualDeep,
   replaceEqualDeep,
@@ -2035,16 +2036,23 @@ export class RouterCore<
       const hashStr = hash ? `#${hash}` : ''
 
       // Resolve the next state
+      const destState = dest.state
+      const currentState = currentLocation.state
       let nextState =
-        dest.state === true
-          ? currentLocation.state
-          : dest.state
-            ? functionalUpdate(dest.state, currentLocation.state)
+        destState === true
+          ? currentState
+          : destState
+            ? functionalUpdate(destState, currentState)
             : {}
 
       // Replace the equal deep
-      if (dest.state || !hasKeys(currentLocation.state)) {
-        nextState = replaceEqualDeep(currentLocation.state, nextState)
+      if (
+        isServer ||
+        destState ||
+        !isPlainObject(currentState) ||
+        !currentState.__TSR_key
+      ) {
+        nextState = replaceEqualDeep(currentState, nextState)
       }
 
       // Create the full path of the location

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -211,7 +211,7 @@ export function functionalUpdate<TPrevious, TResult = TPrevious>(
 export const hasOwn = Object.prototype.hasOwnProperty
 const isEnumerable = Object.prototype.propertyIsEnumerable
 
-export function hasKeys(obj: Record<string, unknown>) {
+export function hasKeys(obj: object) {
   for (const key in obj) {
     if (hasOwn.call(obj, key)) return true
   }

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -211,7 +211,7 @@ export function functionalUpdate<TPrevious, TResult = TPrevious>(
 export const hasOwn = Object.prototype.hasOwnProperty
 const isEnumerable = Object.prototype.propertyIsEnumerable
 
-export function hasKeys(obj: object) {
+export function hasKeys(obj: Record<string, unknown>) {
   for (const key in obj) {
     if (hasOwn.call(obj, key)) return true
   }

--- a/packages/router-core/tests/build-location.test.ts
+++ b/packages/router-core/tests/build-location.test.ts
@@ -1164,6 +1164,34 @@ describe('buildLocation - state', () => {
     expect(location.state).toBe(emptyState)
   })
 
+  test('no state option does not enumerate non-plain current state', async () => {
+    const rootRoute = new BaseRootRoute({})
+    const postsRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/posts',
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([postsRoute]),
+      history: createMemoryHistory({ initialEntries: ['/posts'] }),
+    })
+    await router.load()
+
+    const state = new Proxy(new (class {})(), {
+      ownKeys: () => {
+        throw new Error('state should not be enumerated')
+      },
+    })
+    const location = router.buildLocation({
+      to: '/posts',
+      _fromLocation: {
+        ...router.state.location,
+        state,
+      },
+    } as any)
+
+    expect(location.state).toEqual({})
+  })
+
   test('state can contain complex nested objects', async () => {
     const rootRoute = new BaseRootRoute({})
     const postsRoute = new BaseRoute({

--- a/packages/router-core/tests/build-location.test.ts
+++ b/packages/router-core/tests/build-location.test.ts
@@ -1137,6 +1137,31 @@ describe('buildLocation - state', () => {
     })
 
     expect(location.state).toEqual({})
+    expect(location.state).not.toBe(router.state.location.state)
+  })
+
+  test('no state option preserves an already-empty state reference', async () => {
+    const rootRoute = new BaseRootRoute({})
+    const postsRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/posts',
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([postsRoute]),
+      history: createMemoryHistory({ initialEntries: ['/posts'] }),
+    })
+    await router.load()
+
+    const emptyState = {}
+    const location = router.buildLocation({
+      to: '/posts',
+      _fromLocation: {
+        ...router.state.location,
+        state: emptyState,
+      },
+    } as any)
+
+    expect(location.state).toBe(emptyState)
   })
 
   test('state can contain complex nested objects', async () => {

--- a/packages/router-core/tests/build-location.test.ts
+++ b/packages/router-core/tests/build-location.test.ts
@@ -1140,7 +1140,7 @@ describe('buildLocation - state', () => {
     expect(location.state).not.toBe(router.state.location.state)
   })
 
-  test('no state option preserves an already-empty state reference', async () => {
+  test('no state option replaces an already-empty custom state', async () => {
     const rootRoute = new BaseRootRoute({})
     const postsRoute = new BaseRoute({
       getParentRoute: () => rootRoute,
@@ -1161,7 +1161,8 @@ describe('buildLocation - state', () => {
       },
     } as any)
 
-    expect(location.state).toBe(emptyState)
+    expect(location.state).toEqual({})
+    expect(location.state).not.toBe(emptyState)
   })
 
   test('no state option does not enumerate non-plain current state', async () => {


### PR DESCRIPTION
## Summary

- call `replaceEqualDeep` only when the destination supplies `state`
- skip an unnecessary deep comparison whenever state is omitted

When no destination state is provided, the next state is always a fresh empty object. Comparing it with the current state can only preserve a reference when the current state is also structurally empty; it cannot share any children. This change intentionally treats that empty-object identity as non-contractual and skips the comparison.

Explicit state objects, state updaters, and `state: true` retain the structural-sharing path.

## Condition

```ts
if (dest.state) {
  nextState = replaceEqualDeep(currentLocation.state, nextState)
}
```

- `state: true` is truthy, so the current state is retained.
- A state object or updater is truthy, so its result is structurally shared with the current state.
- Omitted state produces `{}` and skips sharing because there is no destination state to preserve.
- Server builds also skip the call when state is omitted. This is equivalent because server-side `replaceEqualDeep` already returns the new value without traversing it.

The observable edge-case change is that an omitted state no longer preserves the reference of an already-empty custom `_fromLocation.state`; it returns a fresh `{}` with the same contents. A regression test documents this behavior.

## `_fromLocation` audit

`_fromLocation` has many source references, but call-site count does not represent runtime frequency. The dominant producers are React, Solid, and Vue links, which pass the router location store and can build once per rendered link. Those locations normally come from bundled browser or memory history, both of which install `__TSR_key` in state.

Loader navigation, redirects, Start/query integrations, and server paths are more numerous as source call sites but execute less frequently. They also generally pass `router.latestLocation` or another parsed history location. The legitimate keyless cases are caller-supplied `_fromLocation` objects and uncommitted locations built during preload/redirect chains.

The previous "less than 1%" estimate referred only to the intersection of a custom/keyless `_fromLocation`, omitted destination state, and a structurally empty current state. It did not mean `_fromLocation` itself was rare. That percentage was a heuristic rather than telemetry and was stated too precisely; with the simplified guard, it is no longer a separate slow workload.

## Benchmark setup

A real `RouterCore` builds 1,200 locations per sample across 24 repeated static destinations. `main` and this branch were bundled separately with the browser-conditioned `isServer` export, loaded into the same process, and alternated for 2,000 samples. Each workload was rerun with candidate/baseline construction order reversed.

Times are median milliseconds per 1,200 `buildLocation()` calls. Arrows are `main` -> candidate.

### Omitted state with normal history state

```text
main constructed first:      1.303 -> 1.125 ms (-13.7%)
candidate constructed first: 1.300 -> 1.131 ms (-13.0%)
```

### Omitted state with empty custom `_fromLocation.state`

```text
main constructed first:      1.262 -> 1.111 ms (-11.9%)
candidate constructed first: 1.301 -> 1.155 ms (-11.2%)
```

### Control: explicit state

```text
main constructed first:      1.262 -> 1.263 ms  (+0.2%)
candidate constructed first: 1.275 -> 1.275 ms  (+0.0%)
```

Explicit-state code still performs structural sharing and remains effectively neutral.

## Rough workload distribution

These are gross estimates, not project telemetry:

- **85-95% omitted state:** ordinary links and location builds do not provide navigation state
- **5-15% explicit state:** callers provide a state object/updater or use `state: true`

All omitted-state sources now use the same fast path, including normal history locations, custom `_fromLocation` objects, preload-built locations, and server builds.

## Bundle size

`react-router.minimal` compared with `main`:

```text
gzip:    85,828 -> 85,829 bytes   (+1)
initial: 85,688 -> 85,690 bytes   (+2)
raw:    268,920 -> 268,931 bytes  (+11)
brotli:  74,750 -> 74,694 bytes  (-56)
```

## Test plan

- [x] `pnpm nx run @tanstack/router-core:test:unit -- tests/build-location.test.ts`
- [x] `pnpm nx run @tanstack/router-core:test:types`
- [x] `pnpm nx run @tanstack/router-core:test:eslint`
- [x] full bundle-size benchmark across React, Solid, and Vue Router/Start scenarios


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation state handling when destination state is omitted.
  * Prevented unintended copying or enumeration of custom and non-plain state objects.
  * Ensured navigation creates an independent empty state when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->