### PR TITLE
perf(router-core): cache route mask misses

### DIFF
--- a/packages/router-core/src/new-process-route-tree.ts
+++ b/packages/router-core/src/new-process-route-tree.ts
@@ -582,7 +582,7 @@ export function findFlatMatch<T extends Extract<RouteLike, { from: string }>>(
 ) {
   path ||= '/'
   const cached = processedTree.flatCache!.get(path)
-  if (cached) return cached
+  if (cached !== undefined) return cached
   const result = findMatch(path, processedTree.masksTree!)
   processedTree.flatCache!.set(path, result)
   return result

--- a/packages/router-core/tests/new-process-route-tree.test.ts
+++ b/packages/router-core/tests/new-process-route-tree.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
 import {
   findFlatMatch,
   findRouteMatch,
@@ -1847,6 +1847,15 @@ describe('processRouteMasks', { sequential: true }, () => {
   it('can match static routes masks w/ `findFlatMatch`', () => {
     const res = findFlatMatch('/a/b/c', processedTree)
     expect(res?.route.from).toBe('/a/b/c')
+  })
+  it('caches route mask misses', () => {
+    const localTree = processRouteTree(routeTree).processedTree
+    processRouteMasks(routeMasks, localTree)
+    const cacheSet = vi.spyOn(localTree.flatCache!, 'set')
+
+    expect(findFlatMatch('/missing', localTree)).toBeNull()
+    expect(findFlatMatch('/missing', localTree)).toBeNull()
+    expect(cacheSet).toHaveBeenCalledTimes(1)
   })
   it('matches uppercase static route masks case-insensitively', () => {
     const res = findFlatMatch('/admin/panel', processedTree)

--- a/packages/router-core/tests/new-process-route-tree.test.ts
+++ b/packages/router-core/tests/new-process-route-tree.test.ts
@@ -1856,6 +1856,7 @@ describe('processRouteMasks', { sequential: true }, () => {
     expect(findFlatMatch('/missing', localTree)).toBeNull()
     expect(findFlatMatch('/missing', localTree)).toBeNull()
     expect(cacheSet).toHaveBeenCalledTimes(1)
+    cacheSet.mockRestore()
   })
   it('matches uppercase static route masks case-insensitively', () => {
     const res = findFlatMatch('/admin/panel', processedTree)


### PR DESCRIPTION
## Summary

- treat cached `null` route-mask results as cache hits
- avoid repeating mask-tree traversal for paths known not to match a configured mask
- add coverage proving repeated misses populate the cache only once

`findFlatMatch` already stores `null` for misses, but its truthy cache check ignored those entries. Successful matches were cached correctly; misses were recomputed on every repeated link build.

## Benchmark setup

A real `RouterCore` with 1,200 routes and one configured route mask builds 1,200 locations per sample. Production, browser-conditioned bundles run in Node with `createMemoryHistory` and `RouterCore` configured as server. `main` and this branch were bundled separately, loaded into the same process, and alternated for 1,500-2,000 samples. Each workload was rerun with candidate/baseline construction order reversed.

Times are median milliseconds per 1,200 `buildLocation()` calls. Arrows are `main` -> candidate.

### Warm-cache best case: repeated destinations that do not match a mask

```text
main constructed first:      1.096 -> 0.917 ms  (-16.3%)
candidate constructed first: 1.025 -> 0.892 ms  (-12.9%)
```

### Cache-thrashing case: 1,200 unique misses with a 1,000-entry cache

```text
main constructed first:      2.265 -> 2.250 ms
candidate constructed first: 2.309 -> 2.301 ms
```

### Worst measured control: repeated successful mask matches

```text
main constructed first:      3.892 -> 3.895 ms  (+0.1%)
candidate constructed first: 3.952 -> 3.949 ms  (-0.1%)
```

Successful matches were already cached, so this is intentionally neutral. The unique-miss workload continually evicts earlier misses; medians and means disagree amid large tail outliers, so it is reported as no demonstrated difference.

## Rough workload distribution

These are requested gross estimates, not project telemetry. They are heuristic assumptions based on the affected API conditions:

- **95-99% of applications:** no `routeMasks`; this code path is not entered and performance is unchanged
- **70-95% of builds within applications using masks:** destinations do not match a mask; repeated/rendered links can receive the best-case benefit while resident in the 1,000-entry cache
- **5-30% within mask-using applications:** destinations successfully match a mask and remain neutral
- **less than 1% overall:** sustained streams of more than 1,000 unique non-matching destinations, approximating the cache-thrashing neutral case

Mask usage and mask coverage vary substantially by application, so the estimates describe likely shape rather than measured ecosystem adoption.

## Bundle size

`react-router.minimal` compared with `main`:

```text
gzip:   85,828 -> 85,831 bytes  (+3)
raw:   268,920 -> 268,929 bytes  (+9)
brotli: 74,750 -> 74,708 bytes  (-42)
```

## Test plan

- [x] `pnpm nx run @tanstack/router-core:test:unit`
- [x] `pnpm nx run @tanstack/router-core:test:types`
- [x] `pnpm nx run @tanstack/router-core:test:eslint`
- [x] `react-router.minimal` bundle-size comparison


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route matching performance by correctly reusing cached “no match” results.
  * Prevented repeated route lookup work for the same missing route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->