### PR TITLE
perf(router-core): skip disabled search validation

### DIFF
--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -2777,24 +2777,22 @@ function applySearchMiddleware(
     }
 
     const routeValidateSearch = routeOptions.validateSearch
-    if (routeValidateSearch) {
+    if (includeValidateSearch && routeValidateSearch) {
       const validate: SearchMiddleware<any> = ({ search, next, meta }) => {
         const result = next(search)
-        if (includeValidateSearch) {
-          try {
-            const validated = validateSearch(routeValidateSearch, result) as any
+        try {
+          const validated = validateSearch(routeValidateSearch, result) as any
 
-            if (meta && validated) {
-              for (const key in validated) {
-                if (!(key in result)) {
-                  ;(meta.defaulted ||= new Map()).set(key, validated[key])
-                }
+          if (meta && validated) {
+            for (const key in validated) {
+              if (!(key in result)) {
+                ;(meta.defaulted ||= new Map()).set(key, validated[key])
               }
             }
-            return { ...result, ...validated }
-          } catch {
-            // ignore errors here because they are already handled in matchRoutes
           }
+          return { ...result, ...validated }
+        } catch {
+          // ignore errors here because they are already handled in matchRoutes
         }
         return result
       }

--- a/packages/router-core/tests/build-location.test.ts
+++ b/packages/router-core/tests/build-location.test.ts
@@ -238,7 +238,15 @@ describe('buildLocation - search params', () => {
       ...search,
       validated: true,
     }))
-    const rootRoute = new BaseRootRoute({ validateSearch })
+    const middleware = vi.fn(
+      ({ search, next }: { search: any; next: (search: any) => any }) => {
+        return { ...next(search), middleware: true }
+      },
+    )
+    const rootRoute = new BaseRootRoute({
+      validateSearch,
+      search: { middlewares: [middleware] },
+    })
     const indexRoute = new BaseRoute({
       getParentRoute: () => rootRoute,
       path: '/',
@@ -257,7 +265,8 @@ describe('buildLocation - search params', () => {
       search: { explicit: true },
     })
     expect(validateSearch).not.toHaveBeenCalled()
-    expect(unvalidated.search).toEqual({ explicit: true })
+    expect(middleware).toHaveBeenCalled()
+    expect(unvalidated.search).toEqual({ explicit: true, middleware: true })
 
     const validated = router.buildLocation({
       to: '/',
@@ -265,7 +274,11 @@ describe('buildLocation - search params', () => {
       _includeValidateSearch: true,
     } as any)
     expect(validateSearch).toHaveBeenCalled()
-    expect(validated.search).toEqual({ explicit: true, validated: true })
+    expect(validated.search).toEqual({
+      explicit: true,
+      middleware: true,
+      validated: true,
+    })
   })
 
   test('retainSearchParams should preserve current search over defaults during navigation', async () => {

--- a/packages/router-core/tests/build-location.test.ts
+++ b/packages/router-core/tests/build-location.test.ts
@@ -233,6 +233,41 @@ describe('buildLocation - params function receives parsed params', () => {
 })
 
 describe('buildLocation - search params', () => {
+  test('only applies route validation when requested', async () => {
+    const validateSearch = vi.fn((search: Record<string, unknown>) => ({
+      ...search,
+      validated: true,
+    }))
+    const rootRoute = new BaseRootRoute({ validateSearch })
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+    await router.load()
+
+    router.buildLocation({ to: '/' })
+    validateSearch.mockClear()
+
+    const unvalidated = router.buildLocation({
+      to: '/',
+      search: { explicit: true },
+    })
+    expect(validateSearch).not.toHaveBeenCalled()
+    expect(unvalidated.search).toEqual({ explicit: true })
+
+    const validated = router.buildLocation({
+      to: '/',
+      search: { explicit: true },
+      _includeValidateSearch: true,
+    } as any)
+    expect(validateSearch).toHaveBeenCalled()
+    expect(validated.search).toEqual({ explicit: true, validated: true })
+  })
+
   test('retainSearchParams should preserve current search over defaults during navigation', async () => {
     const rootRoute = new BaseRootRoute({
       validateSearch: (search: Record<string, unknown>) => ({

--- a/packages/router-core/tests/build-location.test.ts
+++ b/packages/router-core/tests/build-location.test.ts
@@ -6,6 +6,7 @@ import {
   retainSearchParams,
   stripSearchParams,
 } from '../src'
+import type { SearchMiddleware } from '../src'
 import { _getUserHistoryState } from '../src/router'
 import { createTestRouter } from './routerTestUtils'
 
@@ -234,13 +235,17 @@ describe('buildLocation - params function receives parsed params', () => {
 
 describe('buildLocation - search params', () => {
   test('only applies route validation when requested', async () => {
-    const validateSearch = vi.fn((search: Record<string, unknown>) => ({
-      ...search,
-      validated: true,
-    }))
-    const middleware = vi.fn(
-      ({ search, next }: { search: any; next: (search: any) => any }) => {
-        return { ...next(search), middleware: true }
+    const events: Array<string> = []
+    const validateSearch = vi.fn((search: Record<string, unknown>) => {
+      events.push('validate')
+      return { ...search, validated: true }
+    })
+    const middleware = vi.fn<SearchMiddleware<{ validated: boolean }>>(
+      ({ search, next }) => {
+        events.push('middleware:before')
+        const result = next(search)
+        events.push('middleware:after')
+        return { ...result, middleware: true }
       },
     )
     const rootRoute = new BaseRootRoute({
@@ -259,21 +264,30 @@ describe('buildLocation - search params', () => {
 
     router.buildLocation({ to: '/' })
     validateSearch.mockClear()
+    middleware.mockClear()
+    events.length = 0
 
     const unvalidated = router.buildLocation({
       to: '/',
       search: { explicit: true },
     })
     expect(validateSearch).not.toHaveBeenCalled()
-    expect(middleware).toHaveBeenCalled()
+    expect(middleware).toHaveBeenCalledOnce()
+    expect(events).toEqual(['middleware:before', 'middleware:after'])
     expect(unvalidated.search).toEqual({ explicit: true, middleware: true })
 
+    events.length = 0
     const validated = router.buildLocation({
       to: '/',
       search: { explicit: true },
       _includeValidateSearch: true,
-    } as any)
-    expect(validateSearch).toHaveBeenCalled()
+    })
+    expect(validateSearch).toHaveBeenCalledOnce()
+    expect(events).toEqual([
+      'middleware:before',
+      'validate',
+      'middleware:after',
+    ])
     expect(validated.search).toEqual({
       explicit: true,
       middleware: true,


### PR DESCRIPTION
## Summary

- avoid creating identity validation middleware when `_includeValidateSearch` is disabled
- remove the now-redundant flag check inside validation middleware
- preserve enabled validation, metadata collection, error handling, and middleware ordering

Normal link construction does not request search validation. Previously, every matched route with `validateSearch` still allocated a closure and added a recursive `next()` layer that returned its input unchanged.

## Benchmark setup

A real `RouterCore` builds 1,200 locations per sample across 24 repeated static destinations. The best-case router has validators on the root and parent route. Production, browser-conditioned bundles run in Node with `createMemoryHistory` and `RouterCore` configured as server. `main` and this branch were bundled separately, loaded into the same process, and alternated for 1,500-2,000 samples. Each workload was rerun with candidate/baseline construction order reversed.

Times are median milliseconds per 1,200 `buildLocation()` calls. Arrows are `main` -> candidate.

### Best case: validators present, validation disabled

```text
main constructed first:      0.967 -> 0.889 ms  (-8.0%)
candidate constructed first: 0.926 -> 0.878 ms  (-5.2%)
```

### Validation enabled

```text
main constructed first:      1.035 -> 1.034 ms  (-0.1%)
candidate constructed first: 1.329 -> 1.297 ms  (-2.4%)
```

The inner flag branch is removed because enabled validation is now the only path that can create the closure. The absolute timings shift substantially with construction order, so this is treated as no stable enabled-validation improvement.

### Worst measured control: no route validators

```text
main constructed first:      0.913 -> 0.927 ms  (+1.5%)
candidate constructed first: 0.934 -> 0.924 ms  (-1.0%)
```

This changes direction with construction order and should be treated as no demonstrated difference, not as either a regression or a win.

## Rough workload distribution

These are requested gross estimates, not project telemetry. They are heuristic assumptions based on the affected API conditions, and the bands are intentionally approximate:

- **20-35% best case:** ordinary link/build calls whose destination branch contains one or more search validators while `_includeValidateSearch` is unset
- **5-10% enabled case:** navigation builds that explicitly request validation
- **55-75% neutral/worst case:** destination branches without search validators

Applications that use search validation heavily will skew toward the best case because link rendering generally outnumbers committed navigations. Applications without `validateSearch` remain effectively unchanged.

## Bundle size

`react-router.minimal` compared with `main`:

```text
gzip:   85,828 -> 85,826 bytes  (-2)
raw:   268,920 -> 268,918 bytes  (-2)
brotli: 74,750 -> 74,732 bytes  (-18)
```

## Test plan

- [x] `pnpm nx run @tanstack/router-core:test:unit`
- [x] `pnpm nx run @tanstack/router-core:test:types`
- [x] `pnpm nx run @tanstack/router-core:test:eslint`
- [x] `react-router.minimal` bundle-size comparison


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search parameters are validated only when explicitly enabled.
  * Route locations now preserve unvalidated search parameters by default.
  * Validated and defaulted search values continue to be applied when validation is enabled.
  * Middleware-added search fields are preserved alongside validated values.
  * Validation errors remain ignored when validation is disabled.

* **Tests**
  * Added coverage for default behavior, opt-in validation, middleware execution order, and preserved search fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->