### PR TITLE
fix(history): prevent open redirect via backslash protocol-relative URLs

### DIFF
--- a/.changeset/fix-sanitizepath-backslash.md
+++ b/.changeset/fix-sanitizepath-backslash.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/history': patch
+---
+
+Prevent open redirects via backslash protocol-relative URLs. `sanitizePath` only collapsed leading forward slashes, but browsers treat backslashes as forward slashes in the authority, so hrefs like `\\evil.com`, `/\evil.com` and `\/evil.com` bypassed the guard. Leading runs of two or more slashes/backslashes are now collapsed to a single slash.

--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -632,10 +632,13 @@ function sanitizePath(path: string): string {
   // eslint-disable-next-line no-control-regex
   let sanitized = path.replace(/[\x00-\x1f\x7f]/g, '')
 
-  // Prevent open redirect via protocol-relative URLs (e.g. "//evil.com")
-  // Collapse leading double slashes to a single slash
-  if (sanitized.startsWith('//')) {
-    sanitized = '/' + sanitized.replace(/^\/+/, '')
+  // Prevent open redirect via protocol-relative URLs (e.g. "//evil.com").
+  // Per the WHATWG URL spec, browsers treat backslashes as forward slashes in
+  // the authority, so "\\evil.com", "/\evil.com" and "\/evil.com" are
+  // equivalent to "//evil.com". Collapse any run of two or more leading
+  // slashes/backslashes to a single slash so all of these stay same-origin.
+  if (/^[/\\]{2,}/.test(sanitized)) {
+    sanitized = '/' + sanitized.replace(/^[/\\]+/, '')
   }
 
   return sanitized

--- a/packages/history/tests/parseHref.test.ts
+++ b/packages/history/tests/parseHref.test.ts
@@ -38,6 +38,17 @@ describe('parseHref', () => {
       expect(parsed.pathname).toBe('/evil.com/path')
     })
 
+    test('collapses leading backslashes to prevent protocol-relative URLs', () => {
+      // Browsers treat backslashes as forward slashes in the authority, so
+      // these are equivalent to "//evil.com" and would otherwise redirect.
+      for (const href of ['\\\\evil.com/path', '/\\evil.com/path', '\\/evil.com/path']) {
+        const parsed = parseHref(href, undefined)
+        expect(parsed.pathname).toBe('/evil.com/path')
+        const url = new URL(parsed.href, 'http://localhost:3000')
+        expect(url.origin).toBe('http://localhost:3000')
+      }
+    })
+
     test('sanitized href resolves safely to same origin', () => {
       const parsed = parseHref('/\r/evil.com/', undefined)
       const url = new URL(parsed.href, 'http://localhost:3000')


### PR DESCRIPTION
## Summary

`sanitizePath` guards against open redirects via protocol-relative URLs by collapsing leading `//` (e.g. `//evil.com` → `/evil.com`), but it only handled forward slashes. Per the [WHATWG URL spec](https://url.spec.whatwg.org/#url-representation), browsers treat backslashes as forward slashes in the authority of a special-scheme URL, so the following all bypassed the guard and resolved cross-origin:

- `\\evil.com/path`
- `/\evil.com/path`
- `\/evil.com/path`

## Fix

Collapse any run of two or more leading slashes **or backslashes** to a single slash:

```ts
if (/^[/\\]{2,}/.test(sanitized)) {
  sanitized = '/' + sanitized.replace(/^[/\\]+/, '')
}
```

The existing `//` behavior is unchanged; single leading slashes/backslashes (same-origin paths) are untouched.

## Test

Extended the `open redirect prevention` block in `parseHref.test.ts` with a case covering the three backslash variants, asserting the pathname collapses to `/evil.com/path` and the resolved `URL` stays same-origin. It fails on `main` (the backslashes are left intact, so the resolved origin becomes `evil.com`) and passes with this change. A changeset is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path sanitization to prevent open redirects caused by leading backslashes.
  * Leading combinations of slashes and backslashes are now normalized to a safe same-origin path.
  * Added regression coverage for backslash-based protocol-relative URL variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->