### PR TITLE
test(router-core): assert state structural sharing

### DIFF
--- a/packages/router-core/tests/build-location.test.ts
+++ b/packages/router-core/tests/build-location.test.ts
@@ -1227,32 +1227,38 @@ describe('buildLocation - state', () => {
     expect(location.state).not.toBe(emptyState)
   })
 
-  test('no state option does not enumerate non-plain current state', async () => {
+  test('explicit state structurally shares unchanged nested values', async () => {
     const rootRoute = new BaseRootRoute({})
     const postsRoute = new BaseRoute({
       getParentRoute: () => rootRoute,
       path: '/posts',
     })
+    const history = createMemoryHistory({ initialEntries: ['/posts'] })
+    history.replace('/posts', {
+      user: { id: 1, name: 'Test' },
+      count: 1,
+    })
     const router = createTestRouter({
       routeTree: rootRoute.addChildren([postsRoute]),
-      history: createMemoryHistory({ initialEntries: ['/posts'] }),
+      history,
     })
     await router.load()
 
-    const state = new Proxy(new (class {})(), {
-      ownKeys: () => {
-        throw new Error('state should not be enumerated')
-      },
-    })
+    const currentState = router.state.location.state as any
     const location = router.buildLocation({
       to: '/posts',
-      _fromLocation: {
-        ...router.state.location,
-        state,
-      },
-    } as any)
+      state: {
+        user: { id: 1, name: 'Test' },
+        count: 2,
+      } as any,
+    })
 
-    expect(location.state).toEqual({})
+    expect(location.state).toEqual({
+      user: { id: 1, name: 'Test' },
+      count: 2,
+    })
+    expect((location.state as any).user).toBe(currentState.user)
+    expect(location.state).not.toBe(currentState)
   })
 
   test('state can contain complex nested objects', async () => {


### PR DESCRIPTION
## Summary

- replace the implementation-oriented non-plain state enumeration test
- assert the observable structural-sharing behavior for explicit navigation state
- verify an unchanged nested value keeps its reference while a changed sibling produces a new outer state object

Follow-up to #8110.

## Test plan

- `pnpm nx run @tanstack/router-core:test:unit -- tests/build-location.test.ts`
- `pnpm nx run @tanstack/router-core:test:types`
- `pnpm nx run @tanstack/router-core:test:eslint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated routing tests to verify structural sharing when location state is supplied.
  * Confirmed that top-level state is recreated while nested objects retain their existing references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->