### PR TITLE
ci: add timeout-minutes to codspeed step in benchmarks

### DIFF
--- a/.github/workflows/client-nav-benchmarks.yml
+++ b/.github/workflows/client-nav-benchmarks.yml
@@ -73,6 +73,7 @@ jobs:
 
       - name: Run ${{ matrix.benchmark }}:${{ matrix.framework }} CodSpeed benchmark
         uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
+        timeout-minutes: 20
         with:
           mode: ${{ matrix.mode }}
           run: >-

--- a/.github/workflows/client-nav-benchmarks.yml
+++ b/.github/workflows/client-nav-benchmarks.yml
@@ -21,6 +21,11 @@ on:
       - 'benchmarks/**'
   workflow_dispatch:
 
+concurrency:
+  group: client-nav-benchmarks-${{ github.ref }}
+  cancel-in-progress: false
+  queue: single
+
 permissions:
   contents: read # required for actions/checkout
   id-token: write # required for OIDC authentication with CodSpeed


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Benchmark runs now use a single queue to prevent overlapping checks.
  * Added a 20-minute timeout to benchmark runs, preventing stalled performance checks from running indefinitely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->