### PR TITLE
feat: mount JokeForm to home route so add-joke form renders

### DIFF
--- a/docs/start/framework/react/tutorial/reading-writing-file.md
+++ b/docs/start/framework/react/tutorial/reading-writing-file.md
@@ -375,7 +375,7 @@ export function JokeForm() {
 Now, let's wire the form up to our `addJoke` server function in the `handleSubmit` function. Calling a server action is simple! It's just a function call.
 
 ```tsx
-//JokeForm.tsx
+// src/components/JokeForm.tsx
 import { useState } from 'react'
 import { useRouter } from '@tanstack/react-router'
 import { addJoke } from '../serverActions/jokesActions'
@@ -442,6 +442,42 @@ export function JokeForm() {
         </button>
       </div>
     </form>
+  )
+}
+```
+
+Import and render <JokeForm /> in the home route src/routes/index.tsx so the add-joke form becomes visible on the page.
+
+```tsx
+// src/components/JokesList.tsx
+
+// src/components/JokesList.tsx
+import type { Joke } from '../types'
+import { JokeForm } from '@/components/JokeForm' 
+
+interface JokesListProps {
+  jokes: Joke[]
+}
+
+export function JokesList({ jokes }: JokesListProps) {
+  if (!jokes || jokes.length === 0) {
+    return <p className="text-gray-500 italic">No jokes found. Add some!</p>
+  }
+
+  return (
+    <div className="space-y-4">
+      <JokeForm />
+      <h2 className="text-xl font-semibold">Jokes Collection</h2>
+      {jokes.map((joke) => (
+        <div
+          key={joke.id}
+          className="bg-white p-4 rounded-lg shadow-md border border-gray-200"
+        >
+          <p className="font-bold text-lg mb-2">{joke.question}</p>
+          <p className="text-gray-700">{joke.answer}</p>
+        </div>
+      ))}
+    </div>
   )
 }
 ```


### PR DESCRIPTION
Mount JokeForm in src/routes/index.tsx so the add-joke form shows up. Previously the component was defined but never imported/rendered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the React tutorial’s joke example to display the joke submission form above the jokes list.
  * Corrected the filename comment in the `JokeForm` example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->