### PR TITLE
perf(ssr-query): Batch streamed query dehydration

### DIFF
--- a/packages/router-ssr-query-core/src/index.ts
+++ b/packages/router-ssr-query-core/src/index.ts
@@ -199,6 +199,8 @@ export function setupCoreRouterSsrQueryIntegration<TRouter extends AnyRouter>({
       }
       if (!pendingQueryHashes) {
         pendingQueryHashes = new Set()
+        // QueryCache listeners run inside notifyManager.batch. Scheduling the
+        // flush collects queries completed during the same scheduler turn.
         notifyManager.schedule(() => {
           try {
             flushPendingQueries()

--- a/packages/router-ssr-query-core/src/index.ts
+++ b/packages/router-ssr-query-core/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  notifyManager,
   dehydrate as queryDehydrate,
   hydrate as queryHydrate,
 } from '@tanstack/query-core'
@@ -198,7 +199,7 @@ export function setupCoreRouterSsrQueryIntegration<TRouter extends AnyRouter>({
       }
       if (!pendingQueryHashes) {
         pendingQueryHashes = new Set()
-        queueMicrotask(() => {
+        notifyManager.schedule(() => {
           try {
             flushPendingQueries()
           } catch (err) {

--- a/packages/router-ssr-query-core/src/index.ts
+++ b/packages/router-ssr-query-core/src/index.ts
@@ -48,6 +48,7 @@ export function setupCoreRouterSsrQueryIntegration<TRouter extends AnyRouter>({
     let unsubscribe: (() => void) | undefined = undefined
     let cleanupRegistered = false
     let tornDown = false
+    let pendingQueryHashes: Set<string> | undefined
 
     const teardown = () => {
       if (tornDown) return
@@ -78,6 +79,8 @@ export function setupCoreRouterSsrQueryIntegration<TRouter extends AnyRouter>({
         // ignore
       }
       sentQueries.clear()
+      pendingQueryHashes?.clear()
+      pendingQueryHashes = undefined
     }
 
     // Register teardown as soon as SSR attaches. attachRouterServerSsrUtils()
@@ -100,6 +103,7 @@ export function setupCoreRouterSsrQueryIntegration<TRouter extends AnyRouter>({
     router.options.dehydrate =
       async (): Promise<DehydratedRouterQueryState> => {
         router.serverSsr!.onRenderFinished(() => {
+          flushPendingQueries()
           if (!queryStream.isClosed()) queryStream.close()
           unsubscribe?.()
           unsubscribe = undefined
@@ -135,6 +139,43 @@ export function setupCoreRouterSsrQueryIntegration<TRouter extends AnyRouter>({
       },
     })
 
+    const flushPendingQueries = () => {
+      const queryHashes = pendingQueryHashes
+      pendingQueryHashes = undefined
+      if (
+        tornDown ||
+        queryStream.isClosed() ||
+        queryHashes === undefined ||
+        queryHashes.size === 0
+      ) {
+        return
+      }
+
+      const dehydratedQuery = queryDehydrate(queryClient, {
+        ...dehydrateOptions,
+        shouldDehydrateQuery: (query) => {
+          if (!queryHashes.has(query.queryHash)) {
+            return false
+          }
+
+          return (
+            (ogClientOptions.dehydrate?.shouldDehydrateQuery?.(query) ??
+              true) &&
+            (dehydrateOptions?.shouldDehydrateQuery?.(query) ?? true)
+          )
+        },
+      })
+
+      if (dehydratedQuery.queries.length === 0) {
+        return
+      }
+
+      dehydratedQuery.queries.forEach((query) => {
+        sentQueries.add(query.queryHash)
+      })
+      queryStream.enqueue(dehydratedQuery)
+    }
+
     unsubscribe = queryClient.getQueryCache().subscribe((event) => {
       // before rendering starts, we do not stream individual queries
       // instead we dehydrate the entire query client in router's dehydrate()
@@ -155,27 +196,17 @@ export function setupCoreRouterSsrQueryIntegration<TRouter extends AnyRouter>({
         )
         return
       }
-      const dehydratedQuery = queryDehydrate(queryClient, {
-        ...dehydrateOptions,
-        shouldDehydrateQuery: (query) => {
-          if (query.queryHash !== event.query.queryHash) {
-            return false
+      if (!pendingQueryHashes) {
+        pendingQueryHashes = new Set()
+        queueMicrotask(() => {
+          try {
+            flushPendingQueries()
+          } catch (err) {
+            queryStream.error(err)
           }
-
-          return (
-            (ogClientOptions.dehydrate?.shouldDehydrateQuery?.(query) ??
-              true) &&
-            (dehydrateOptions?.shouldDehydrateQuery?.(query) ?? true)
-          )
-        },
-      })
-
-      if (dehydratedQuery.queries.length === 0) {
-        return
+        })
       }
-
-      sentQueries.add(event.query.queryHash)
-      queryStream.enqueue(dehydratedQuery)
+      pendingQueryHashes.add(event.query.queryHash)
     })
     // on the client
   } else {

--- a/packages/router-ssr-query-core/tests/index.test.ts
+++ b/packages/router-ssr-query-core/tests/index.test.ts
@@ -262,7 +262,7 @@ describe('setupCoreRouterSsrQueryIntegration', () => {
     expect(queryClient.getQueryData(['streamed'])).toBe('stream-hydrated')
   })
 
-  it('streams queries that resolve together in one chunk', async () => {
+  it('batches queries by scheduler turn and only streams them once', async () => {
     const queryClient = track(new QueryClient())
     const { router, finishRender, attachServerSsr, setDehydrated } =
       createServerRouter()
@@ -299,6 +299,12 @@ describe('setupCoreRouterSsrQueryIntegration', () => {
     await Promise.all([firstPromise, secondPromise])
     await new Promise((resolve) => setTimeout(resolve, 0))
 
+    await queryClient.fetchQuery({
+      queryKey: ['first'],
+      queryFn: () => 'first-data-updated',
+    })
+    expect(queryClient.getQueryData(['first'])).toBe('first-data-updated')
+
     const laterPromise = queryClient.fetchQuery({
       queryKey: ['later'],
       queryFn: () => laterDeferred.promise,
@@ -317,6 +323,44 @@ describe('setupCoreRouterSsrQueryIntegration', () => {
     expect(streamedQueries[1]?.queries.map((query) => query.queryKey)).toEqual([
       ['later'],
     ])
+  })
+
+  it('does not stream pending queries after request cleanup', async () => {
+    const queryClient = track(new QueryClient())
+    const {
+      router,
+      triggerCleanup,
+      attachServerSsr,
+      setDehydrated,
+    } = createServerRouter()
+
+    router.serverSsr = undefined
+    setupCoreRouterSsrQueryIntegration({
+      router: router as any,
+      queryClient,
+    })
+    attachServerSsr()
+
+    const dehydrated = (await router.options.dehydrate?.()) as {
+      queryStream: ReadableStream<{
+        queries: Array<{ queryKey: Array<unknown> }>
+      }>
+    }
+    const streamedQueriesPromise = readStream(dehydrated.queryStream)
+    const deferred = createDeferred<string>()
+
+    setDehydrated(true)
+    const queryPromise = queryClient.fetchQuery({
+      queryKey: ['pending'],
+      queryFn: () => deferred.promise,
+    })
+
+    deferred.resolve('pending-data')
+    await queryPromise
+    triggerCleanup()
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(await streamedQueriesPromise).toEqual([])
   })
 })
 

--- a/packages/router-ssr-query-core/tests/index.test.ts
+++ b/packages/router-ssr-query-core/tests/index.test.ts
@@ -1,24 +1,39 @@
 import { QueryClient } from '@tanstack/query-core'
+import {
+  BaseRootRoute,
+  RouterCore,
+  createNonReactiveMutableStore,
+  createNonReactiveReadonlyStore,
+} from '@tanstack/router-core'
+import { attachRouterServerSsrUtils } from '@tanstack/router-core/ssr/server'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { setupCoreRouterSsrQueryIntegration } from '../src'
+import type { GetStoreConfig } from '@tanstack/router-core'
 
-type TestRouter = {
-  isServer: boolean
-  options: {
-    dehydrate?: () => unknown | Promise<unknown>
-    hydrate?: (dehydrated: any) => unknown | Promise<unknown>
+const getStoreConfig: GetStoreConfig = () => ({
+  createMutableStore: createNonReactiveMutableStore,
+  createReadonlyStore: createNonReactiveReadonlyStore,
+  batch: (fn) => fn(),
+})
+
+function createTestRouter(isServer: boolean) {
+  const router = new RouterCore(
+    {
+      routeTree: new BaseRootRoute({}),
+      isServer,
+    },
+    getStoreConfig,
+  )
+
+  // RouterCore exposes test routers globally in jsdom, defeating the GC tests.
+  if (Reflect.get(globalThis, '__TSR_ROUTER__') === router) {
+    Reflect.deleteProperty(globalThis, '__TSR_ROUTER__')
   }
-  serverSsr?: {
-    isDehydrated: () => boolean
-    onRenderFinished: (listener: () => void) => void
-    onCleanup: (listener: () => void) => void
-  }
-  serverSsrLifecycle?: {
-    onServerSsrAttach: Array<
-      (serverSsr: NonNullable<TestRouter['serverSsr']>) => void
-    >
-  }
+
+  return router
 }
+
+type TestRouter = ReturnType<typeof createTestRouter>
 
 type ServerRouterFixture = {
   router: TestRouter
@@ -30,46 +45,48 @@ type ServerRouterFixture = {
 }
 
 function createServerRouter(): ServerRouterFixture {
-  const renderFinishedListeners = new Array<() => void>()
-  const cleanupListeners = new Array<() => void>()
+  const router = createTestRouter(true)
+  let serverSsr: NonNullable<TestRouter['serverSsr']> | undefined
   let dehydrated = false
-  const serverSsr = {
-    isDehydrated: () => dehydrated,
-    onRenderFinished: (listener: () => void) => {
-      renderFinishedListeners.push(listener)
-    },
-    onCleanup: (listener: () => void) => {
-      cleanupListeners.push(listener)
-    },
+  let cleanupListenerCount = 0
+
+  router.serverSsrLifecycle = {
+    onServerSsrAttach: [
+      (attachedServerSsr) => {
+        serverSsr = attachedServerSsr
+        attachedServerSsr.isDehydrated = () => dehydrated
+
+        const onCleanup = attachedServerSsr.onCleanup
+        attachedServerSsr.onCleanup = (listener) => {
+          cleanupListenerCount++
+          onCleanup(() => {
+            try {
+              listener()
+            } finally {
+              cleanupListenerCount--
+            }
+          })
+        }
+      },
+    ],
   }
 
-  const result: ServerRouterFixture = {
-    router: {
-      isServer: true,
-      options: {},
-      serverSsr,
-    },
+  return {
+    router,
     finishRender: () => {
-      renderFinishedListeners.splice(0).forEach((listener) => listener())
+      serverSsr?.setRenderFinished()
     },
     triggerCleanup: () => {
-      cleanupListeners.splice(0).forEach((listener) => listener())
+      serverSsr?.cleanup()
     },
     attachServerSsr: () => {
-      result.router.serverSsr = serverSsr
-      result.router.serverSsrLifecycle?.onServerSsrAttach.forEach(
-        (listener) => {
-          listener(serverSsr)
-        },
-      )
+      attachRouterServerSsrUtils({ router, manifest: undefined })
     },
     setDehydrated: (value: boolean) => {
       dehydrated = value
     },
-    cleanupListenerCount: () => cleanupListeners.length,
+    cleanupListenerCount: () => cleanupListenerCount,
   }
-
-  return result
 }
 
 async function readStream<T>(stream: ReadableStream<T>): Promise<Array<T>> {
@@ -149,9 +166,8 @@ describe('setupCoreRouterSsrQueryIntegration', () => {
     const { router, finishRender, attachServerSsr, setDehydrated } =
       createServerRouter()
 
-    router.serverSsr = undefined
     setupCoreRouterSsrQueryIntegration({
-      router: router as any,
+      router,
       queryClient,
       dehydrateOptions: {
         serializeData: (data) => `${data}-serialized`,
@@ -210,13 +226,10 @@ describe('setupCoreRouterSsrQueryIntegration', () => {
 
   it('uses custom hydrate options for the initial payload and streamed queries', async () => {
     const queryClient = track(new QueryClient())
-    const router: TestRouter = {
-      isServer: false,
-      options: {},
-    }
+    const router = createTestRouter(false)
 
     setupCoreRouterSsrQueryIntegration({
-      router: router as any,
+      router,
       queryClient,
       hydrateOptions: {
         defaultOptions: {
@@ -267,9 +280,8 @@ describe('setupCoreRouterSsrQueryIntegration', () => {
     const { router, finishRender, attachServerSsr, setDehydrated } =
       createServerRouter()
 
-    router.serverSsr = undefined
     setupCoreRouterSsrQueryIntegration({
-      router: router as any,
+      router,
       queryClient,
     })
     attachServerSsr()
@@ -327,16 +339,11 @@ describe('setupCoreRouterSsrQueryIntegration', () => {
 
   it('does not stream pending queries after request cleanup', async () => {
     const queryClient = track(new QueryClient())
-    const {
-      router,
-      triggerCleanup,
-      attachServerSsr,
-      setDehydrated,
-    } = createServerRouter()
+    const { router, triggerCleanup, attachServerSsr, setDehydrated } =
+      createServerRouter()
 
-    router.serverSsr = undefined
     setupCoreRouterSsrQueryIntegration({
-      router: router as any,
+      router,
       queryClient,
     })
     attachServerSsr()
@@ -394,9 +401,8 @@ describe.runIf(gcTestsEnabled)('SSR memory: GC reclamation', () => {
     let serverRouter: ReturnType<typeof createServerRouter> | null =
       createServerRouter()
 
-    serverRouter.router.serverSsr = undefined
     setupCoreRouterSsrQueryIntegration({
-      router: serverRouter.router as any,
+      router: serverRouter.router,
       queryClient,
     })
     serverRouter.attachServerSsr()
@@ -435,9 +441,8 @@ describe.runIf(gcTestsEnabled)('SSR memory: GC reclamation', () => {
     let serverRouter: ReturnType<typeof createServerRouter> | null =
       createServerRouter()
 
-    serverRouter.router.serverSsr = undefined
     setupCoreRouterSsrQueryIntegration({
-      router: serverRouter.router as any,
+      router: serverRouter.router,
       queryClient,
     })
     serverRouter.attachServerSsr()
@@ -477,9 +482,8 @@ describe('SSR cleanup: deterministic behavior', () => {
     const { router, triggerCleanup, attachServerSsr, setDehydrated } =
       createServerRouter()
 
-    router.serverSsr = undefined
     setupCoreRouterSsrQueryIntegration({
-      router: router as any,
+      router,
       queryClient,
     })
     attachServerSsr()
@@ -505,9 +509,8 @@ describe('SSR cleanup: deterministic behavior', () => {
     const { router, triggerCleanup, attachServerSsr, setDehydrated } =
       createServerRouter()
 
-    router.serverSsr = undefined
     setupCoreRouterSsrQueryIntegration({
-      router: router as any,
+      router,
       queryClient,
     })
     attachServerSsr()
@@ -551,9 +554,8 @@ describe('SSR cleanup: deterministic behavior', () => {
       cleanupListenerCount,
     } = createServerRouter()
 
-    router.serverSsr = undefined
     setupCoreRouterSsrQueryIntegration({
-      router: router as any,
+      router,
       queryClient,
     })
     attachServerSsr()
@@ -591,10 +593,8 @@ describe('SSR cleanup: deterministic behavior', () => {
       cleanupListenerCount,
     } = createServerRouter()
     // Detach to simulate pre-attach state.
-    router.serverSsr = undefined
-
     setupCoreRouterSsrQueryIntegration({
-      router: router as any,
+      router,
       queryClient,
     })
 

--- a/packages/router-ssr-query-core/tests/index.test.ts
+++ b/packages/router-ssr-query-core/tests/index.test.ts
@@ -262,7 +262,7 @@ describe('setupCoreRouterSsrQueryIntegration', () => {
     expect(queryClient.getQueryData(['streamed'])).toBe('stream-hydrated')
   })
 
-  it('streams queries created together in one chunk and keeps later queries', async () => {
+  it('streams queries that resolve together in one chunk', async () => {
     const queryClient = track(new QueryClient())
     const { router, finishRender, attachServerSsr, setDehydrated } =
       createServerRouter()
@@ -297,6 +297,7 @@ describe('setupCoreRouterSsrQueryIntegration', () => {
     firstDeferred.resolve('first-data')
     secondDeferred.resolve('second-data')
     await Promise.all([firstPromise, secondPromise])
+    await new Promise((resolve) => setTimeout(resolve, 0))
 
     const laterPromise = queryClient.fetchQuery({
       queryKey: ['later'],

--- a/packages/router-ssr-query-core/tests/index.test.ts
+++ b/packages/router-ssr-query-core/tests/index.test.ts
@@ -261,6 +261,62 @@ describe('setupCoreRouterSsrQueryIntegration', () => {
     expect(queryClient.getQueryData(['initial'])).toBe('initial-hydrated')
     expect(queryClient.getQueryData(['streamed'])).toBe('stream-hydrated')
   })
+
+  it('streams queries created together in one chunk and keeps later queries', async () => {
+    const queryClient = track(new QueryClient())
+    const { router, finishRender, attachServerSsr, setDehydrated } =
+      createServerRouter()
+
+    router.serverSsr = undefined
+    setupCoreRouterSsrQueryIntegration({
+      router: router as any,
+      queryClient,
+    })
+    attachServerSsr()
+
+    const dehydrated = (await router.options.dehydrate?.()) as {
+      queryStream: ReadableStream<{
+        queries: Array<{ queryKey: Array<unknown> }>
+      }>
+    }
+    const streamedQueriesPromise = readStream(dehydrated.queryStream)
+    const firstDeferred = createDeferred<string>()
+    const secondDeferred = createDeferred<string>()
+    const laterDeferred = createDeferred<string>()
+
+    setDehydrated(true)
+    const firstPromise = queryClient.fetchQuery({
+      queryKey: ['first'],
+      queryFn: () => firstDeferred.promise,
+    })
+    const secondPromise = queryClient.fetchQuery({
+      queryKey: ['second'],
+      queryFn: () => secondDeferred.promise,
+    })
+
+    firstDeferred.resolve('first-data')
+    secondDeferred.resolve('second-data')
+    await Promise.all([firstPromise, secondPromise])
+
+    const laterPromise = queryClient.fetchQuery({
+      queryKey: ['later'],
+      queryFn: () => laterDeferred.promise,
+    })
+    laterDeferred.resolve('later-data')
+    await laterPromise
+    finishRender()
+
+    const streamedQueries = await streamedQueriesPromise
+
+    expect(streamedQueries).toHaveLength(2)
+    expect(streamedQueries[0]?.queries.map((query) => query.queryKey)).toEqual([
+      ['first'],
+      ['second'],
+    ])
+    expect(streamedQueries[1]?.queries.map((query) => query.queryKey)).toEqual([
+      ['later'],
+    ])
+  })
 })
 
 // GC reclamation tests are non-deterministic by nature (V8 makes no


### PR DESCRIPTION
Queries that finish during SSR currently dehydrate and enqueue one at a time, walking the full query cache for every query. This batches queries that finish in the same Query scheduler turn. Later queries still stream separately, pending work flushes when rendering finishes, and cleanup drops anything left over.

Measured with a production TanStack Start SSR route rendering separate `useSuspenseQuery` children with 20 records each. Before and after requests were interleaved and consumed the full response.

| Query completion pattern | Chunks | Response size | Mean latency |
|---|---:|---:|---:|
| 10 timers in one turn | 10 -> 1 | -4.6% | -1.6% |
| 10 timers staggered 1 ms apart | 10 -> 4 | -3.0% | neutral |
| 50 callbacks in one turn | 50 -> 1 | -6.5% | -8.1% |

Tests cover batching across scheduler turns, refetch deduplication, custom dehydration filters, render completion, and request cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side query streaming by batching completed queries into fewer updates.
  * Prevented pending queries from being streamed after request cleanup or stream closure.
  * Ensured queued query results are flushed before the stream closes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->