### PR TITLE
perf(router): remove prebuilt preload locations

### DIFF
--- a/.changeset/calm-links-preload.md
+++ b/.changeset/calm-links-preload.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/router-core': patch
+'@tanstack/solid-router': patch
+'@tanstack/vue-router': patch
+---
+
+Build client preload locations on demand and remove the prebuilt-location argument used by framework links.

--- a/packages/router-core/src/load-client.ts
+++ b/packages/router-core/src/load-client.ts
@@ -8,6 +8,7 @@ import type { GLOBAL_SEROVAL, GLOBAL_TSR } from './ssr/constants'
 import type { AnySerializationAdapter } from './ssr/serializer/transformer'
 import type { TsrSsrGlobal } from './ssr/types'
 import type { ParsedLocation } from './location'
+import type { NavigateOptions } from './link'
 import type { AnyRouteMatch } from './Matches'
 import type { NotFoundError } from './not-found'
 import type {
@@ -18,7 +19,9 @@ import type {
   RouteLoaderFn,
 } from './route'
 import type { AnyRedirect } from './redirect'
-import type { AnyRouter } from './router'
+import type { AnyRouter, RouterCore, TrailingSlashOption } from './router'
+import type { RoutePaths } from './routeInfo'
+import type { RouterHistory } from '@tanstack/history'
 
 type RouteComponentType =
   | 'component'
@@ -2071,71 +2074,101 @@ export async function refreshClientRoute(
   await loadClientRoute(router, { sync: true })
 }
 
-export async function preloadClientRoute(
-  router: CoordinatorRouter,
-  opts: any,
-  redirects = 0,
-  builtLocation?: ParsedLocation,
+export async function preloadClientRoute<
+  TRouteTree extends AnyRoute,
+  TTrailingSlashOption extends TrailingSlashOption,
+  TDefaultStructuralSharingOption extends boolean,
+  TRouterHistory extends RouterHistory,
+  TDehydrated extends Record<string, any> = Record<string, any>,
+  TFrom extends RoutePaths<TRouteTree> | string = string,
+  TTo extends string | undefined = undefined,
+  TMaskFrom extends RoutePaths<TRouteTree> | string = TFrom,
+  TMaskTo extends string = '',
+>(
+  router: RouterCore<
+    TRouteTree,
+    TTrailingSlashOption,
+    TDefaultStructuralSharingOption,
+    TRouterHistory,
+    TDehydrated
+  >,
+  opts: NavigateOptions<
+    RouterCore<
+      TRouteTree,
+      TTrailingSlashOption,
+      TDefaultStructuralSharingOption,
+      TRouterHistory,
+      TDehydrated
+    >,
+    TFrom,
+    TTo,
+    TMaskFrom,
+    TMaskTo
+  >,
 ): Promise<Array<AnyRouteMatch> | undefined> {
   if (
     process.env.NODE_ENV !== 'production' &&
-    (router._refreshNextLoad || router._tx?.[6 /* refresh */])
+    ((router as CoordinatorRouter)._refreshNextLoad ||
+      router._tx?.[6 /* refresh */])
   ) {
     return
   }
-  const location = builtLocation ?? router.buildLocation(opts)
-  const base = router._committed
-  const controller = new AbortController()
-  let matches: Array<AnyRouteMatch>
-  try {
-    matches = router.matchRoutes(location, {
-      _controller: controller,
-    })
-    acquireMatchResources(matches)
-  } catch (cause) {
-    controller.abort()
-    if (!isNotFound(cause)) {
-      console.error(cause)
-    }
-    return
-  }
-  ;(router._preloads ??= new Map()).set(controller, matches)
-  let active: boolean
-  try {
-    let result: LaneResult
+  let location = router.buildLocation(
+    opts as Parameters<typeof router.buildLocation>[0],
+  )
+  for (let redirects = 0; ; redirects++) {
+    const base = router._committed
+    const controller = new AbortController()
+    let matches: Array<AnyRouteMatch>
     try {
-      result = await executeClientLane(router, location, matches, [
-        controller,
-        redirects,
-        base,
-        true,
-      ])
-    } finally {
-      active = router._preloads.delete(controller)
-      transferMatchResources(router, matches)
+      matches = router.matchRoutes(location, {
+        _controller: controller,
+      })
+      acquireMatchResources(matches)
+    } catch (cause) {
       controller.abort()
+      if (!isNotFound(cause)) {
+        console.error(cause)
+      }
+      return
     }
-    if (!isControl(result)) {
-      return result[1 /* matches */]
-    }
-    if (
-      active &&
-      result[0 /* kind */] === REDIRECTED &&
-      !result[1 /* redirect */].options.reloadDocument
-    ) {
-      return preloadClientRoute(
-        router,
-        result[1 /* redirect */].options,
-        redirects + 1,
-        result[2 /* location */],
-      )
-    }
-  } catch (cause) {
-    if (!isNotFound(cause)) {
-      console.error(cause)
+    ;(router._preloads ??= new Map()).set(controller, matches)
+    let active: boolean
+    try {
+      let result: LaneResult
+      try {
+        result = await executeClientLane(router, location, matches, [
+          controller,
+          redirects,
+          base,
+          true,
+        ])
+      } finally {
+        active = router._preloads.delete(controller)
+        transferMatchResources(router, matches)
+        controller.abort()
+      }
+      if (!isControl(result)) {
+        return result[1 /* matches */]
+      }
+      // Only a materialized redirect has a third tuple item.
+      if (
+        !active ||
+        result.length < 3 ||
+        (process.env.NODE_ENV !== 'production' &&
+          ((router as CoordinatorRouter)._refreshNextLoad ||
+            router._tx?.[6 /* refresh */]))
+      ) {
+        return
+      }
+      location = result[2 /* location */]!
+    } catch (cause) {
+      if (!isNotFound(cause)) {
+        console.error(cause)
+      }
+      return
     }
   }
-  return
 }
 
 // --- SSR hydration (client entry via @tanstack/router-core/ssr/client) ---

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -674,6 +674,7 @@ export type PreloadRouteFn<
   TTrailingSlashOption extends TrailingSlashOption,
   TDefaultStructuralSharingOption extends boolean,
   TRouterHistory extends RouterHistory,
+  TDehydrated extends Record<string, any> = Record<string, any>,
 > = <
   TFrom extends RoutePaths<TRouteTree> | string = string,
   TTo extends string | undefined = undefined,
@@ -685,7 +686,8 @@ export type PreloadRouteFn<
       TRouteTree,
       TTrailingSlashOption,
       TDefaultStructuralSharingOption,
-      TRouterHistory
+      TRouterHistory,
+      TDehydrated
     >,
     TFrom,
     TTo,
@@ -2584,9 +2586,9 @@ export class RouterCore<
     TRouteTree,
     TTrailingSlashOption,
     TDefaultStructuralSharingOption,
-    TRouterHistory
-  > = (opts: any, builtLocation?: ParsedLocation) =>
-    preloadClientRoute(this, opts, 0, builtLocation)
+    TRouterHistory,
+    TDehydrated
+  > = (opts) => preloadClientRoute(this, opts)
 
   matchRoute: MatchRouteFn<
     TRouteTree,

--- a/packages/solid-router/src/link.tsx
+++ b/packages/solid-router/src/link.tsx
@@ -251,15 +251,12 @@ export function useLinkProps<
   })
 
   const doPreload = () =>
-    (
-      router.preloadRoute as (
-        opts: typeof options,
-        builtLocation: ReturnType<typeof router.buildLocation>,
-      ) => ReturnType<typeof router.preloadRoute>
-    )(options, next()).catch((err: any) => {
-      console.warn(err)
-      console.warn(preloadWarning)
-    })
+    router
+      .preloadRoute(options as Parameters<typeof router.preloadRoute>[0])
+      .catch((err: any) => {
+        console.warn(err)
+        console.warn(preloadWarning)
+      })
 
   const [ref, setRef] = Solid.createSignal<Element | null>(null)
 

--- a/packages/solid-router/tests/link.test.tsx
+++ b/packages/solid-router/tests/link.test.tsx
@@ -5273,7 +5273,10 @@ describe('Link', () => {
     await waitFor(() =>
       expect(preloadRouteSpy).toHaveBeenCalledTimes(baselineCalls + 3),
     )
-    expect(updateSearch).toHaveBeenCalledTimes(baselineSearchCalls)
+    expect(updateSearch).toHaveBeenCalledTimes(baselineSearchCalls + 3)
+    for (const call of preloadRouteSpy.mock.calls.slice(baselineCalls)) {
+      expect(call).toHaveLength(1)
+    }
   })
 
   test('Router.preload="intent", pendingComponent renders during unresolved route loader', async () => {

--- a/packages/vue-router/src/link.tsx
+++ b/packages/vue-router/src/link.tsx
@@ -231,15 +231,12 @@ function useLinkPropsImpl(
 
   const doPreload = () => {
     const options = getOptions()
-    return (
-      router.preloadRoute as (
-        opts: typeof options,
-        builtLocation: ReturnType<typeof router.buildLocation>,
-      ) => ReturnType<typeof router.preloadRoute>
-    )(options, next.value).catch((err: any) => {
-      console.warn(err)
-      console.warn(preloadWarning)
-    })
+    return router
+      .preloadRoute(options as Parameters<typeof router.preloadRoute>[0])
+      .catch((err: any) => {
+        console.warn(err)
+        console.warn(preloadWarning)
+      })
   }
 
   let pendingPreload: 'intent' | 'viewport' | undefined

--- a/packages/vue-router/tests/link.test.tsx
+++ b/packages/vue-router/tests/link.test.tsx
@@ -5713,7 +5713,10 @@ describe('Link', () => {
     await waitFor(() =>
       expect(preloadRouteSpy).toHaveBeenCalledTimes(baselineCalls + 3),
     )
-    expect(updateSearch).toHaveBeenCalledTimes(baselineSearchCalls)
+    expect(updateSearch).toHaveBeenCalledTimes(baselineSearchCalls + 3)
+    for (const call of preloadRouteSpy.mock.calls.slice(baselineCalls)) {
+      expect(call).toHaveLength(1)
+    }
   })
 
   test('Router.preload="intent", pendingComponent renders during unresolved route loader', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Client-side route preloading now builds link destinations on demand.
  - Framework links use simplified preloading behavior without requiring a prebuilt location.

- **Bug Fixes**
  - Improved handling of redirects, inactive preloads, document reloads, and development refresh states.
  - Ensured preload resources are cleaned up after each attempt.

- **Tests**
  - Updated Solid and Vue link tests to verify search updates and streamlined preload calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->