### PR TITLE
fix(start-server-core): return 499 when the client disconnects mid-request

### DIFF
--- a/.changeset/client-disconnect-499.md
+++ b/.changeset/client-disconnect-499.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/start-server-core': patch
+---
+
+Return `499 Client Closed Request` instead of an unhandled 500 when the client disconnects mid-request. Applies to SSR, server routes, and server functions.

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -779,6 +779,15 @@ export function createStartHandler<TRegister = Register>(
       request.signal.throwIfAborted()
       responseOwnsCleanup = response.serverSsrCleanup === 'stream'
       return response.response
+    } catch (err) {
+      // classify a client disconnect as 499 instead of an unhandled 500
+      if (request.signal.aborted && err === request.signal.reason) {
+        return new Response(null, {
+          status: 499,
+          statusText: 'Client Closed Request',
+        })
+      }
+      throw err
     } finally {
       if (router?.serverSsr && !responseOwnsCleanup) {
         // Clean up router SSR state if it was set up but won't be cleaned up by the callback

--- a/packages/start-server-core/tests/createStartHandler.test.ts
+++ b/packages/start-server-core/tests/createStartHandler.test.ts
@@ -406,7 +406,7 @@ describe('createStartHandler request cancellation', () => {
       const cancellation = new Error('request disconnected')
       requestController.abort(cancellation)
 
-      expect((await response).status).toBe(500)
+      expect((await response).status).toBe(499)
       expect(routeSignal?.aborted).toBe(true)
       expect(routeSignal?.reason).toBe(cancellation)
       expect(render).not.toHaveBeenCalled()
@@ -463,7 +463,7 @@ describe('createStartHandler request cancellation', () => {
     await renderStarted
     requestController.abort(new Error('request disconnected'))
 
-    expect((await response).status).toBe(500)
+    expect((await response).status).toBe(499)
     expect(cleanupCalls).toBe(1)
     expect(router.serverSsr).toBeUndefined()
 
@@ -503,7 +503,7 @@ describe('createStartHandler request cancellation', () => {
     const cancellation = new Error('request disconnected')
     requestController.abort(cancellation)
 
-    expect((await response).status).toBe(500)
+    expect((await response).status).toBe(499)
     resolveRender(new Response(new ReadableStream({ cancel })))
     await vi.waitFor(() => {
       expect(cancel).toHaveBeenCalledTimes(1)
@@ -542,7 +542,7 @@ describe('createStartHandler request cancellation', () => {
     const cancellation = new Error('request disconnected')
     requestController.abort(cancellation)
 
-    expect((await response).status).toBe(500)
+    expect((await response).status).toBe(499)
     resolveMiddleware(new Response(new ReadableStream({ cancel })))
     await vi.waitFor(() => {
       expect(cancel).toHaveBeenCalledTimes(1)
@@ -594,7 +594,7 @@ describe('createStartHandler request cancellation', () => {
 
       await renderStarted
       requestController.abort(new Error('request disconnected'))
-      expect((await response).status).toBe(500)
+      expect((await response).status).toBe(499)
 
       resolveRender({
         response: new Response('stream'),
@@ -657,7 +657,7 @@ describe('createStartHandler request cancellation', () => {
       await middlewareStarted
       requestController.abort(new Error('request disconnected'))
 
-      expect((await response).status).toBe(500)
+      expect((await response).status).toBe(499)
       await vi.waitFor(() => {
         expect(consoleError).toHaveBeenCalledWith(cleanupError)
       })
@@ -731,7 +731,7 @@ describe('createStartHandler request cancellation', () => {
     await middlewareStarted
     requestController.abort(new Error('request disconnected'))
 
-    expect((await response).status).toBe(500)
+    expect((await response).status).toBe(499)
     expect(render).not.toHaveBeenCalled()
 
     releaseMiddleware({
@@ -779,7 +779,7 @@ describe('createStartHandler request cancellation', () => {
     await innerStarted
     requestController.abort(new Error('request disconnected'))
 
-    expect((await response).status).toBe(500)
+    expect((await response).status).toBe(499)
     expect(outerFinally).toHaveBeenCalledOnce()
     expect(render).not.toHaveBeenCalled()
   })
@@ -812,7 +812,7 @@ describe('createStartHandler request cancellation', () => {
     await innerStarted
     requestController.abort(new Error('request disconnected'))
 
-    expect((await response).status).toBe(500)
+    expect((await response).status).toBe(499)
     expect(render).not.toHaveBeenCalled()
   })
 
@@ -838,7 +838,7 @@ describe('createStartHandler request cancellation', () => {
       {},
     )
 
-    expect(response.status).toBe(500)
+    expect(response.status).toBe(499)
     expect(render).not.toHaveBeenCalled()
   })
 
@@ -882,7 +882,7 @@ describe('createStartHandler request cancellation', () => {
       {},
     )
 
-    expect(response.status).toBe(500)
+    expect(response.status).toBe(499)
     await vi.waitFor(() => expect(observedErrors).toEqual([reason]))
     await vi.waitFor(() => {
       expect(dispose).toHaveBeenCalledOnce()
@@ -920,7 +920,7 @@ describe('createStartHandler request cancellation', () => {
       {},
     )
 
-    expect(response.status).toBe(500)
+    expect(response.status).toBe(499)
     await vi.waitFor(() => {
       expect(dispose).toHaveBeenCalledOnce()
       expect(dispose).toHaveBeenCalledWith(reason)
@@ -985,7 +985,7 @@ describe('createStartHandler request cancellation', () => {
     const dispose = vi.spyOn(ssrResponse as any, 'dispose')
     requestController.abort(reason)
 
-    expect((await result).status).toBe(500)
+    expect((await result).status).toBe(499)
     releaseMiddleware()
     await lateResultDelivered
     await vi.waitFor(() => {
@@ -995,6 +995,101 @@ describe('createStartHandler request cancellation', () => {
       expect(cancel).toHaveBeenCalledWith(reason)
     })
     expect(router.serverSsr).toBeUndefined()
+  })
+
+  it('returns 499 when the client disconnects during SSR rendering', async () => {
+    const router = makeRouter()
+    startMocks.router = router
+    const requestController = new AbortController()
+    let notifyRenderStarted!: () => void
+    const renderStarted = new Promise<void>((resolve) => {
+      notifyRenderStarted = resolve
+    })
+    const handler = createStartHandler(() => {
+      notifyRenderStarted()
+      return new Promise<Response>(() => {})
+    })
+    const response = handler(
+      new Request('http://localhost/', {
+        signal: requestController.signal,
+      }),
+      {},
+    )
+
+    await renderStarted
+    requestController.abort(new Error('request disconnected'))
+
+    const result = await response
+    expect(result.status).toBe(499)
+    expect(result.statusText).toBe('Client Closed Request')
+  })
+
+  it('returns 499 when the client disconnects during a server route handler', async () => {
+    const rootRoute = new BaseRootRoute({})
+    let notifyHandlerStarted!: () => void
+    const handlerStarted = new Promise<void>((resolve) => {
+      notifyHandlerStarted = resolve
+    })
+    const apiRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/api/slow',
+      server: {
+        handlers: {
+          GET: () => {
+            notifyHandlerStarted()
+            return new Promise<Response>(() => {})
+          },
+        },
+      },
+    })
+    const router = new RouterCore(
+      {
+        history: createMemoryHistory({ initialEntries: ['/api/slow'] }),
+        routeTree: rootRoute.addChildren([apiRoute]),
+      },
+      getStoreConfig,
+    )
+    router.isServer = true
+    startMocks.router = router
+    const requestController = new AbortController()
+    const render = vi.fn(() => new Response('must not render'))
+    const handler = createStartHandler(render)
+    const response = handler(
+      new Request('http://localhost/api/slow', {
+        signal: requestController.signal,
+      }),
+      {},
+    )
+
+    await handlerStarted
+    requestController.abort(new Error('request disconnected'))
+
+    const result = await response
+    expect(result.status).toBe(499)
+    expect(result.statusText).toBe('Client Closed Request')
+    expect(render).not.toHaveBeenCalled()
+  })
+
+  it('returns 499 when the client disconnects during a server function call', async () => {
+    const router = makeRouter()
+    startMocks.router = router
+    startMocks.serverFnResult = new Promise<Response>(() => {})
+    const requestController = new AbortController()
+    const handler = createStartHandler(() => new Response('unused'))
+    const response = handler(
+      new Request('http://localhost/_serverFn/test', {
+        headers: { 'x-tsr-serverFn': 'true' },
+        signal: requestController.signal,
+      }),
+      {},
+    )
+
+    await Promise.resolve()
+    requestController.abort(new Error('request disconnected'))
+
+    const result = await response
+    expect(result.status).toBe(499)
+    expect(result.statusText).toBe('Client Closed Request')
   })
 })
 


### PR DESCRIPTION
Fixes #7991.

## Problem

`startRequestResolver` in `createStartHandler` has no `catch` around its `try/finally`. When a client disconnects, the abort is re-thrown internally as `signal.reason` so that in-flight work unwinds and gets disposed. That rejection then escapes the request boundary. h3 marks it as unhandled, logs it with `console.error`, and responds 500.

The app has no way to opt out:

- Start calls `toResponse(value, h3Event)` without a config, so h3's `silent` / `onError` options never apply.
- A handler that observes the signal and returns a response gets discarded, because `executeMiddleware` re-throws `signal.reason` at the end when the signal is aborted.

More background in my comment on the issue: https://github.com/TanStack/router/issues/7991#issuecomment-5342562494

## Change

Catch the abort at the outermost request boundary and return `499 Client Closed Request`:

```ts
} catch (err) {
  if (request.signal.aborted && err === request.signal.reason) {
    return new Response(null, { status: 499, statusText: 'Client Closed Request' })
  }
  throw err
}
```

- The internal `throw signal.reason` calls are untouched. They are still needed to drive cleanup. Only the final classification changes.
- The check compares identity with `request.signal.reason` instead of matching `err.name === 'AbortError'`, so unrelated `AbortError`s thrown by app code still propagate as real errors.
- This is option 1 from https://github.com/TanStack/router/issues/7991#issuecomment-3493614284. The fix sits at the shared boundary, so it covers SSR, server routes, and server functions at once.
- A patch changeset for `@tanstack/start-server-core` is included.

### Why 499

Per [RFC 9110 §15.6](https://www.rfc-editor.org/rfc/rfc9110#section-15.6), 5xx means the server itself failed. A disconnect is the client withdrawing the request, so 500 misclassifies it. There is no standard code for this case because the response never reaches the client; it only matters for logs and middleware. nginx's non-standard [499 (`NGX_HTTP_CLIENT_CLOSED_REQUEST`)](https://github.com/nginx/nginx/blob/master/src/http/ngx_http_request.h) became the de facto convention for it.

The adjacent layers already handle it this way: [h3's `proxy()` returns 499](https://github.com/h3js/h3/blob/main/src/utils/proxy.ts) when `event.req.signal.aborted` (since 2.0.1-rc.23), and srvx's node adapter suppresses `console.error` for aborted requests. Start is currently the only layer in the stack that turns a disconnect into an unhandled 500.

## Behavioral change

Disconnects that previously produced a 500 and an error log now produce a 499 and no log. If you alert on 5xx rates, expect fewer entries. The client never sees either response, so nothing changes on the wire.

## Tests

13 existing assertions in the `createStartHandler request cancellation` suite expected `status === 500` after `requestController.abort(...)`. They now expect 499. That is the whole extent of the behavior change. The side-effect assertions in those tests (cleanup runs once, streams disposed with the abort reason, render never called) are unchanged. The one 500 assertion that is not abort-related (middleware throwing a real error) is also unchanged.

Three new tests assert that a disconnect returns `499 Client Closed Request` on each request path:

- SSR render
- server route handler
- server function call

To run locally:

```sh
pnpm nx run @tanstack/start-server-core:test:unit -- tests/createStartHandler.test.ts
```

`test:unit` (33 passed), `test:types`, and `test:eslint` pass on the package.

## Verification

I applied this diff with `pnpm patch` to `@tanstack/start-server-core@1.169.26` in a production Start app (server routes proxying Connect RPC to a backend), and compared the same screens with and without it:

| | `AbortError` logs | unhandled 500s |
|---|---|---|
| without patch | 6 | 6 |
| with patch | 0 | 0 |

## Related PRs

- #6539 returns 499 for aborts inside the React SSR stream. Same conclusion, narrower scope. No file overlap.
- #7930 makes aborted SSR throw instead of returning a 200 shell. Complementary: once it throws, this boundary classifies it. No file overlap.
- No open PR touches this file or addresses #7991.

If you prefer a different status code, or want to settle the policy discussion in #7991 first, I'm happy to adjust.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Client disconnects during server-side rendering, route handling, or server function calls now return HTTP 499 “Client Closed Request” instead of an internal server error.
  * Prevents unnecessary rendering after a client connection has been closed.
* **Release**
  * Includes a patch release for the server core package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->