### PR TITLE
fix(start): migrate to Rsbuild splitChunks config

### DIFF
--- a/.changeset/modern-chunks-split.md
+++ b/.changeset/modern-chunks-split.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/start-plugin-core': patch
+---
+
+Migrate the Rsbuild client chunk configuration to the v2 `splitChunks` option while preserving async-only chunk splitting.

--- a/e2e/vue-start/basic/rsbuild.config.ts
+++ b/e2e/vue-start/basic/rsbuild.config.ts
@@ -16,11 +16,6 @@ export default defineConfig({
     pluginVueJsx(),
     tanstackStart(),
   ],
-  performance: {
-    chunkSplit: {
-      strategy: 'split-by-experience',
-    },
-  },
   source: {
     define: {
       __TSR_PRERENDER__: JSON.stringify(isPrerender),

--- a/packages/start-plugin-core/src/rsbuild/planning.ts
+++ b/packages/start-plugin-core/src/rsbuild/planning.ts
@@ -153,13 +153,9 @@ export function createRsbuildEnvironmentPlan(opts: {
           // Only split async chunks (route code-splitting). Keep all initial
           // vendor/shared code inlined in the entry chunk so the SSR HTML only
           // needs the single client entry bootstrap.
-          performance: {
-            chunkSplit: {
-              strategy: 'custom',
-              override: {
-                chunks: 'async',
-              },
-            },
+          splitChunks: {
+            preset: 'none',
+            chunks: 'async',
           },
         },
         environmentOverrides.all,


### PR DESCRIPTION
## Summary

Rsbuild v2 deprecates `performance.chunkSplit` in favor of the top-level `splitChunks` option.

This migrates the Start Rsbuild client config to `splitChunks` with `preset: 'none'` and `chunks: 'async'`, preserving the existing behavior of splitting only async route chunks.

The Vue Start e2e config no longer supplies the deprecated override.

## Related Links

- [Rsbuild v1 to v2 migration guide](https://rsbuild.rs/guide/upgrade/v1-to-v2#migrate-performancechunksplit)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated client-side chunk splitting to the Rsbuild v2 configuration format.
  * Preserved asynchronous route code splitting while preventing unnecessary vendor and shared chunks.

* **Chores**
  * Added a patch release note for the updated chunk configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->