### PR TITLE
chore(start): remove redundant splitChunks config from React plugin

### DIFF
--- a/benchmarks/bundle-size/scenarios/react-start-full/rsbuild.config.ts
+++ b/benchmarks/bundle-size/scenarios/react-start-full/rsbuild.config.ts
@@ -6,7 +6,7 @@ const outDir = process.env.BUNDLE_SIZE_DIST_DIR ?? 'dist-rsbuild'
 
 export default defineConfig({
   logLevel: 'silent',
-  plugins: [pluginReact({ splitChunks: false }), tanstackStart()],
+  plugins: [pluginReact(), tanstackStart()],
   output: {
     distPath: {
       root: outDir,

--- a/benchmarks/bundle-size/scenarios/react-start-minimal/rsbuild.config.ts
+++ b/benchmarks/bundle-size/scenarios/react-start-minimal/rsbuild.config.ts
@@ -16,7 +16,7 @@ const startOptions = clientOutput
 
 export default defineConfig({
   logLevel: 'silent',
-  plugins: [pluginReact({ splitChunks: false }), tanstackStart(startOptions)],
+  plugins: [pluginReact(), tanstackStart(startOptions)],
   output: {
     distPath: {
       root: outDir,

--- a/docs/start/framework/react/guide/server-components.md
+++ b/docs/start/framework/react/guide/server-components.md
@@ -74,7 +74,7 @@ import { tanstackStart } from '@tanstack/react-start/plugin/rsbuild'
 
 export default defineConfig({
   plugins: [
-    pluginReact({ splitChunks: false }),
+    pluginReact(),
     tanstackStart({
       rsc: {
         enabled: true,

--- a/e2e/react-start/basic/rsbuild.config.ts
+++ b/e2e/react-start/basic/rsbuild.config.ts
@@ -8,7 +8,7 @@ const startModeConfig = getStartModeConfig()
 
 export default defineConfig({
   plugins: [
-    pluginReact({ splitChunks: false }),
+    pluginReact(),
     tanstackStart(startModeConfig),
   ],
   output: {

--- a/e2e/react-start/css-inline/rsbuild.config.ts
+++ b/e2e/react-start/css-inline/rsbuild.config.ts
@@ -8,7 +8,7 @@ const transformInlineCssAssets =
 
 export default defineConfig({
   plugins: [
-    pluginReact({ splitChunks: false }),
+    pluginReact(),
     tanstackStart({
       server: {
         build: {

--- a/e2e/react-start/custom-server-rsbuild/rsbuild.config.ts
+++ b/e2e/react-start/custom-server-rsbuild/rsbuild.config.ts
@@ -28,7 +28,7 @@ import { tanstackStart } from '@tanstack/react-start/plugin/rsbuild'
 //     explicit prefix.
 export default defineConfig({
   plugins: [
-    pluginReact({ splitChunks: false }),
+    pluginReact(),
     tanstackStart({
       rsbuild: {
         installDevServerMiddleware: false,

--- a/e2e/react-start/deferred-hydration/rsbuild.config.ts
+++ b/e2e/react-start/deferred-hydration/rsbuild.config.ts
@@ -5,7 +5,7 @@ import { tanstackStart } from '@tanstack/react-start/plugin/rsbuild'
 const outDir = process.env.E2E_DIST_DIR ?? 'dist-rsbuild-ssr'
 
 export default defineConfig({
-  plugins: [pluginReact({ splitChunks: false }), tanstackStart()],
+  plugins: [pluginReact(), tanstackStart()],
   output: {
     distPath: {
       root: outDir,

--- a/e2e/react-start/hmr/rsbuild.config.ts
+++ b/e2e/react-start/hmr/rsbuild.config.ts
@@ -5,7 +5,7 @@ import { tanstackStart } from '@tanstack/react-start/plugin/rsbuild'
 const outDir = process.env.E2E_DIST_DIR ?? 'dist'
 
 export default defineConfig({
-  plugins: [pluginReact({ splitChunks: false }), tanstackStart()],
+  plugins: [pluginReact(), tanstackStart()],
   output: {
     distPath: {
       root: outDir,

--- a/e2e/react-start/rsbuild/rsbuild.config.ts
+++ b/e2e/react-start/rsbuild/rsbuild.config.ts
@@ -5,7 +5,7 @@ import { tanstackStart } from '@tanstack/react-start/plugin/rsbuild'
 const outDir = process.env.E2E_DIST_DIR ?? 'dist'
 
 export default defineConfig({
-  plugins: [pluginReact({ splitChunks: false }), tanstackStart()],
+  plugins: [pluginReact(), tanstackStart()],
   output: {
     distPath: {
       root: outDir,

--- a/e2e/react-start/rsc-rsbuild/rsbuild.config.ts
+++ b/e2e/react-start/rsc-rsbuild/rsbuild.config.ts
@@ -6,7 +6,7 @@ const outDir = process.env.E2E_DIST_DIR ?? 'dist'
 
 export default defineConfig({
   plugins: [
-    pluginReact({ splitChunks: false }),
+    pluginReact(),
     tanstackStart({
       rsc: {
         enabled: true,

--- a/e2e/react-start/rsc/rsbuild.config.ts
+++ b/e2e/react-start/rsc/rsbuild.config.ts
@@ -6,7 +6,7 @@ const outDir = process.env.E2E_DIST_DIR ?? 'dist'
 
 export default defineConfig({
   plugins: [
-    pluginReact({ splitChunks: false }),
+    pluginReact(),
     tanstackStart({
       rsc: {
         enabled: true,


### PR DESCRIPTION
TanStack Start already configures Rsbuild to split async chunks. This prevents `@rsbuild/plugin-react` from adding its chunk groups, so `splitChunks: false` is redundant.

This PR removes the option from benchmarks, e2e fixtures, and docs without changing build output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * React applications now use the default code-splitting behavior, enabling split chunks for improved bundle optimization.
  * Updated React examples, documentation, and end-to-end scenarios to reflect the default configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->