### PR TITLE
perf(router-core): reduce client loader bundle size

### DIFF
--- a/e2e/react-start/basic/rsbuild.config.ts
+++ b/e2e/react-start/basic/rsbuild.config.ts
@@ -7,10 +7,7 @@ const outDir = process.env.E2E_DIST_DIR ?? 'dist'
 const startModeConfig = getStartModeConfig()
 
 export default defineConfig({
-  plugins: [
-    pluginReact(),
-    tanstackStart(startModeConfig),
-  ],
+  plugins: [pluginReact(), tanstackStart(startModeConfig)],
   output: {
     distPath: {
       root: outDir,

--- a/packages/router-core/src/load-client.ts
+++ b/packages/router-core/src/load-client.ts
@@ -48,16 +48,18 @@ function loadComponents(
   onPendingReady?: () => void,
 ): Promise<void> | undefined {
   const component = preloadComponent(route, 'component')
-  const pending = preloadComponent(route, 'pendingComponent')
-  const pendingReady =
-    onPendingReady && pending ? pending.then(onPendingReady) : pending
-  if (onPendingReady && !pending) {
-    onPendingReady()
+  let pending = preloadComponent(route, 'pendingComponent')
+  if (onPendingReady) {
+    if (pending) {
+      pending = pending.then(onPendingReady)
+    } else {
+      onPendingReady()
+    }
   }
-  if (component && pendingReady) {
-    return Promise.all([component, pendingReady]).then(() => {})
+  if (component && pending) {
+    return Promise.all([component, pending]).then(() => {})
   }
-  return component ?? pendingReady
+  return component ?? pending
 }
 
 export function loadRouteChunk(
@@ -306,10 +308,13 @@ function normalize(
     value.routeId ||= routeId
     return [NOT_FOUND, value]
   }
-  if (rejected && typeof (value as any)?.then === 'function') {
+  if (!rejected) {
+    return [SUCCESS, value]
+  }
+  if (typeof (value as any)?.then === 'function') {
     value = new Error('A Promise was thrown', { cause: value })
   }
-  return rejected ? [ERROR, value] : [SUCCESS, value]
+  return [ERROR, value]
 }
 
 function normalizeError(route: AnyRoute, cause: unknown): RawLoaderOutcome {
@@ -672,18 +677,19 @@ function settleInto(
   result: LoaderOutcome,
   preload: boolean,
 ): asserts match is SettledMatch {
+  if (result[0 /* kind */] === REDIRECTED) {
+    return
+  }
+  // Reduction installs only the selected terminal failure. Every other
+  // settled attempt remains a renderable, stale match in that lane.
+  match.status = 'success'
+  match.error = undefined
   if (result[0 /* kind */] === SUCCESS) {
     match.loaderData = result[1 /* data */]
-    match.error = undefined
-    match.status = 'success'
     match.invalid = false
     match.updatedAt = Date.now()
     match.preload = preload
-  } else if (result[0 /* kind */] !== REDIRECTED) {
-    // Reduction installs only the selected terminal failure. Every other
-    // settled attempt remains a renderable, stale match in that lane.
-    match.status = 'success'
-    match.error = undefined
+  } else {
     match.invalid = true
   }
 }
@@ -774,7 +780,7 @@ function createLoaderTask(
         reload = true
       } else {
         const staleAge =
-          options[3 /* preload */] || match.preload
+          preload || match.preload
             ? (route.options.preloadStaleTime ??
               router.options.defaultPreloadStaleTime ??
               30_000)
@@ -800,10 +806,11 @@ function createLoaderTask(
     reloadFailure = normalizeLaneError(router, lane, route, cause, options)
   }
   const routeLoader = route.options.loader
-  const loader =
-    typeof routeLoader === 'function' ? routeLoader : routeLoader?.handler
+  const isLoaderFn = typeof routeLoader === 'function'
+  const loader = isLoaderFn ? routeLoader : routeLoader?.handler
+  const preloadable = !preload || route.options.preload !== false
   let donor =
-    (!preload || route.options.preload !== false) &&
+    preloadable &&
     routeLoader &&
     !(process.env.NODE_ENV !== 'production' && router._tx?.[6 /* refresh */])
       ? router._flights?.get(match.id)
@@ -823,12 +830,10 @@ function createLoaderTask(
     match.status === 'success' &&
     !preload &&
     !options[4 /* sync */] &&
-    ((typeof routeLoader === 'function'
-      ? undefined
-      : routeLoader?.staleReloadMode) ??
+    ((isLoaderFn ? undefined : routeLoader.staleReloadMode) ??
       router.options.defaultStaleReloadMode) !== 'blocking'
   )
-  const loaded = reload && (!preload || route.options.preload !== false)
+  const loaded = reload && preloadable
   const blocking =
     loaded && !background && (match.status !== 'success' || !!routeLoader)
   const onReady = index >= retainedEnd ? options[7 /* onReady */] : undefined
@@ -1056,15 +1061,16 @@ function materializeRedirect(
 ): LoaderOutcome {
   while (outcome[0 /* kind */] === REDIRECTED) {
     const redirect = outcome[1 /* redirect */]
+    const redirectOptions = redirect.options
     if (
-      redirect.options.reloadDocument
+      redirectOptions.reloadDocument
         ? options[3 /* preload */]
         : options[1 /* redirects */] >= 20
     ) {
       return outcome
     }
     try {
-      if (redirect.options.href && redirect.options.reloadDocument) {
+      if (redirectOptions.href && redirectOptions.reloadDocument) {
         router.resolveRedirect(redirect)
         return outcome
       }
@@ -1072,7 +1078,7 @@ function materializeRedirect(
         REDIRECTED,
         redirect,
         router.buildLocation({
-          ...redirect.options,
+          ...redirectOptions,
           _fromLocation: lane[0 /* location */],
           _includeValidateSearch: true,
         }),
@@ -1284,15 +1290,13 @@ async function executeClientLane(
     if (router.options.notFoundMode !== 'root' && plannedBoundary >= 0) {
       const boundary = await getNotFoundBoundary(
         router,
-        matched[1 /* matches */],
+        matches as Array<WorkMatch>,
         undefined,
         signal,
         plannedBoundary,
       )
-      if (boundary !== plannedBoundary) {
-        matches[plannedBoundary]!._notFound = undefined
-        matches[boundary]!._notFound = true
-      }
+      matches[plannedBoundary]!._notFound = undefined
+      matches[boundary]!._notFound = true
       plannedBoundary = boundary
     }
     let end = plannedBoundary < 0 ? matches.length : plannedBoundary + 1
@@ -1317,7 +1321,7 @@ async function executeClientLane(
     const tasks: Array<LoaderTask> = []
     const start = options[6 /* resolvedPrefix */] ?? 0
     let semanticParent = start
-      ? Promise.resolve(matched[1 /* matches */][start - 1]!)
+      ? Promise.resolve(matches[start - 1] as WorkMatch)
       : undefined
     const planSuccessfulLane = () => {
       for (let index = start; index < end; index++) {
@@ -1352,7 +1356,7 @@ async function executeClientLane(
       if (failure[1 /* outcome */][0 /* kind */] === NOT_FOUND) {
         const boundary = await getNotFoundBoundary(
           router,
-          matched[1 /* matches */],
+          matches as Array<WorkMatch>,
           failure,
           signal,
         )
@@ -1390,9 +1394,7 @@ async function executeClientLane(
         undefined,
         reduction.then(
           (foreground) =>
-            isControl(foreground)
-              ? 0
-              : _getRenderedMatches(foreground[1 /* matches */]).length,
+            isControl(foreground) ? 0 : _getRenderedMatches(matches).length,
           () => 0,
         ),
       )
@@ -1412,7 +1414,7 @@ async function executeClientLane(
     router,
     reduced,
     signal,
-    options[6 /* resolvedPrefix */] === reduced[1 /* matches */].length
+    options[6 /* resolvedPrefix */] === matches.length
       ? options[6 /* resolvedPrefix */]
       : 0,
   )
@@ -1442,7 +1444,7 @@ function offerPending(router: CoordinatorRouter, tx: LoadTransaction): void {
     }
     const route = getRoute(router, match as WorkMatch)
     const delay =
-      (success && presentedPending) || match.invalid
+      success || match.invalid
         ? 0
         : (route.options.pendingMs ?? router.options.defaultPendingMs)
     const component =
@@ -1667,39 +1669,37 @@ async function awaitCurrent(
   }
 }
 
-async function followRedirect(
+function followRedirect(
   router: CoordinatorRouter,
   tx: LoadTransaction,
   outcome: RedirectOutcome,
 ): Promise<void> {
-  const redirect = outcome[1 /* redirect */]
+  const options = outcome[1 /* redirect */].options
   const location = outcome[2 /* location */]
   if (!location) {
-    await router.navigate({
-      ...redirect.options,
+    return router.navigate({
+      ...options,
       replace: true,
       ignoreBlocker: true,
     } as any)
-    return
   }
-  if (redirect.options.reloadDocument) {
-    await router.navigate({
+  if (options.reloadDocument) {
+    return router.navigate({
       href: location.publicHref,
       reloadDocument: true,
       replace: true,
       ignoreBlocker: true,
     } as any)
-    return
   }
   ;(location as ParsedLocation & { _redirects?: number })._redirects =
     tx[1 /* redirects */] + 1
   router._pendingLocation = location
   const committed = router.commitLocation({
     ...location,
-    viewTransition: redirect.options.viewTransition,
+    viewTransition: options.viewTransition,
     replace: true,
-    resetScroll: redirect.options.resetScroll,
-    hashScrollIntoView: redirect.options.hashScrollIntoView,
+    resetScroll: options.resetScroll,
+    hashScrollIntoView: options.hashScrollIntoView,
     ignoreBlocker: true,
   })
   queueMicrotask(() => {
@@ -1707,7 +1707,7 @@ async function followRedirect(
       router._pendingLocation = undefined
     }
   })
-  await committed
+  return committed
 }
 
 async function runBackground(
@@ -1750,24 +1750,20 @@ async function runBackground(
     }
     return
   }
-  const projected = await projectLane(
-    router,
-    reduced,
-    tx[0 /* controller */].signal,
-  )
+  await projectLane(router, reduced, tx[0 /* controller */].signal)
   if (router._tx !== tx || router._committed !== base) {
-    transferMatchResources(router, projected[1 /* matches */])
+    transferMatchResources(router, next)
     return
   }
-  for (const match of projected[1 /* matches */] as Array<WorkMatch>) {
+  for (const match of next as Array<WorkMatch>) {
     const cached = router._cache.get(match.id) as WorkMatch | undefined
     if (cached?._flight && cached._flight === match._flight) {
       router._cache.delete(match.id)
       releaseFlight(router, cached)
     }
   }
-  publishMatches(router, projected[1 /* matches */])
-  transferMatchResources(router, base, projected[1 /* matches */])
+  publishMatches(router, next)
+  transferMatchResources(router, base, next)
 }
 
 async function runClientTransaction(
@@ -1778,21 +1774,20 @@ async function runClientTransaction(
   sync?: boolean,
   resolvedPrefix?: number,
 ): Promise<void> {
-  const options: ExecuteLaneOptions = [
-    tx[0 /* controller */],
-    tx[1 /* redirects */],
-    router._committed,
-    undefined,
-    sync,
-    forceStaleReload,
-    resolvedPrefix,
-    onReady,
-  ]
   const result = await executeClientLane(
     router,
     tx[2 /* location */],
     tx[3 /* matches */],
-    options,
+    [
+      tx[0 /* controller */],
+      tx[1 /* redirects */],
+      router._committed,
+      undefined,
+      sync,
+      forceStaleReload,
+      resolvedPrefix,
+      onReady,
+    ],
   )
 
   if (isControl(result)) {
@@ -1815,18 +1810,15 @@ async function runClientTransaction(
     await followRedirect(router, tx, result)
     return
   }
-  if (router._tx !== tx) {
-    finishPending(router, tx)
-    transferMatchResources(router, result[1 /* matches */])
-    discardBackground(router, result)
-    return
+  const matches = result[1 /* matches */]
+  if (router._tx === tx) {
+    // Only an acknowledged fallback owns a minimum. Recheck at the commit
+    // boundary because native view transitions can defer their update callback.
+    await awaitPendingMinimum(router, tx)
   }
-  // Only an acknowledged fallback owns a minimum. Recheck at the commit
-  // boundary because native view transitions can defer their update callback.
-  await awaitPendingMinimum(router, tx)
   if (router._tx !== tx) {
     finishPending(router, tx)
-    transferMatchResources(router, result[1 /* matches */])
+    transferMatchResources(router, matches)
     discardBackground(router, result)
     return
   }
@@ -1837,22 +1829,18 @@ async function runClientTransaction(
   )
   const background = result[2 /* background */]
   await router.startViewTransition(async () => {
-    if (router._tx !== tx) {
-      finishPending(router, tx)
-      transferMatchResources(router, result[1 /* matches */])
-      discardBackground(router, result)
-      return
+    if (router._tx === tx) {
+      await awaitPendingMinimum(router, tx)
     }
-    await awaitPendingMinimum(router, tx)
     if (router._tx !== tx) {
       finishPending(router, tx)
-      transferMatchResources(router, result[1 /* matches */])
+      transferMatchResources(router, matches)
       discardBackground(router, result)
       return
     }
     const commit = () => {
       finishPending(router, tx)
-      commitMatches(router, tx, result[1 /* matches */], resolvedPrefix)
+      commitMatches(router, tx, matches, resolvedPrefix)
       if (router._tx !== tx) {
         return
       }
@@ -1861,10 +1849,7 @@ async function runClientTransaction(
         router.emit({ type: 'onBeforeRouteMount', ...changeInfo })
       }
     }
-    const rendered = await router.startTransition(
-      commit,
-      result[1 /* matches */],
-    )
+    const rendered = await router.startTransition(commit, matches)
     if (process.env.NODE_ENV !== 'production' && tx[6 /* refresh */]) {
       tx[6 /* refresh */] = undefined
     }
@@ -1879,7 +1864,7 @@ async function runClientTransaction(
       runBackground(
         router,
         tx,
-        result[1 /* matches */],
+        matches,
         background,
         result[3 /* backgroundSettlement */]!,
       ).catch(console.error)
@@ -1934,15 +1919,12 @@ export async function loadClientRoute(
   previousPreflight?.abort()
   // The preflight controller is not exposed to route hooks. Every replacement
   // aborts its predecessor, so a live signal is the sole authority here.
-  if (preflight.signal.aborted) {
-    await awaitCurrent(router, previousOwner)
-    return
-  }
-
-  const changeInfo = getLocationChangeInfo(location, resolvedLocation)
-  router.emit({ type: 'onBeforeNavigate', ...changeInfo })
   if (!preflight.signal.aborted) {
-    router.emit({ type: 'onBeforeLoad', ...changeInfo })
+    const changeInfo = getLocationChangeInfo(location, resolvedLocation)
+    router.emit({ type: 'onBeforeNavigate', ...changeInfo })
+    if (!preflight.signal.aborted) {
+      router.emit({ type: 'onBeforeLoad', ...changeInfo })
+    }
   }
   if (preflight.signal.aborted) {
     await awaitCurrent(router, previousOwner)
@@ -2109,24 +2091,16 @@ export async function preloadClientRoute<
   for (let redirects = 0; ; redirects++) {
     const base = router._committed
     const controller = new AbortController()
-    let matches: Array<AnyRouteMatch>
+    let matches: Array<AnyRouteMatch> | undefined
+    let active: boolean | Map<AbortController, Array<AnyRouteMatch>> | undefined
+    let result: LaneResult
     try {
-      matches = router.matchRoutes(location, {
-        _controller: controller,
-      })
-      acquireMatchResources(matches)
-    } catch (cause) {
-      controller.abort()
-      if (!isNotFound(cause)) {
-        console.error(cause)
-      }
-      return
-    }
-    ;(router._preloads ??= new Map()).set(controller, matches)
-    let active: boolean
-    try {
-      let result: LaneResult
       try {
+        matches = router.matchRoutes(location, {
+          _controller: controller,
+        })
+        acquireMatchResources(matches)
+        active = (router._preloads ??= new Map()).set(controller, matches)
         result = await executeClientLane(router, location, matches, [
           controller,
           redirects,
@@ -2134,8 +2108,12 @@ export async function preloadClientRoute<
           true,
         ])
       } finally {
-        active = router._preloads.delete(controller)
-        transferMatchResources(router, matches)
+        if (active) {
+          active = (
+            active as Map<AbortController, Array<AnyRouteMatch>>
+          ).delete(controller)
+          transferMatchResources(router, matches!)
+        }
         controller.abort()
       }
       if (!isControl(result)) {
@@ -2348,21 +2326,19 @@ export async function hydrate(router: AnyRouter): Promise<void> {
   const chunks = committed.map(async (match) => {
     try {
       const route = getRoute(router, match)
-      if (match._notFound) {
-        await Promise.all([
-          loadRouteChunk(route),
-          loadRouteChunk(route, 'notFoundComponent'),
-        ])
-      } else {
-        await loadRouteChunk(
-          route,
-          match.status === 'error'
-            ? 'errorComponent'
-            : match.status === 'notFound'
-              ? 'notFoundComponent'
-              : undefined,
-        )
-      }
+      await (match._notFound
+        ? Promise.all([
+            loadRouteChunk(route),
+            loadRouteChunk(route, 'notFoundComponent'),
+          ])
+        : loadRouteChunk(
+            route,
+            match.status === 'error'
+              ? 'errorComponent'
+              : match.status === 'notFound'
+                ? 'notFoundComponent'
+                : undefined,
+          ))
       return true
     } catch {
       return false


### PR DESCRIPTION
## Summary

- remove redundant client lane lookups, branches, and temporary values
- reuse loader, redirect, and match state already available in each loading phase
- simplify preload cleanup, pending checks, and hydration chunk selection without changing scheduling boundaries
- keep these byte offsets independent from route asset parallelization

## Testing

- `pnpm nx run @tanstack/router-core:test:unit`
- `pnpm nx run @tanstack/router-core:test:types`
- `pnpm nx run @tanstack/router-core:test:eslint`
- full bundle-size scenario build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route loading behavior for successful and failed navigations.
  * Prevented canceled pre-navigation work from continuing unnecessarily.
  * Improved redirect handling and navigation completion.
  * Ensured preloaded routes are cleaned up correctly when matching or loading fails.

* **Performance**
  * Made route preloading and hydration more consistent.
  * Improved pending-state handling to reduce unnecessary loading transitions.
  * Improved background navigation and route transition reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->