### PR TITLE
perf(router-core): parallelize route asset projection

### DIFF
--- a/e2e/react-start/basic/rsbuild.config.ts
+++ b/e2e/react-start/basic/rsbuild.config.ts
@@ -7,10 +7,7 @@ const outDir = process.env.E2E_DIST_DIR ?? 'dist'
 const startModeConfig = getStartModeConfig()
 
 export default defineConfig({
-  plugins: [
-    pluginReact(),
-    tanstackStart(startModeConfig),
-  ],
+  plugins: [pluginReact(), tanstackStart(startModeConfig)],
   output: {
     distPath: {
       root: outDir,

--- a/packages/router-core/src/load-client.ts
+++ b/packages/router-core/src/load-client.ts
@@ -1231,25 +1231,41 @@ export async function projectLane(
   end = lane[1 /* matches */].length,
 ): Promise<ProjectedLane> {
   const matches = lane[1 /* matches */]
+  let projections: Array<[WorkMatch, Promise<any>]> | undefined
   for (let index = start; index < end; index++) {
     const match = matches[index]!
     const routeOptions = getRoute(router, match).options
     if (routeOptions.head || routeOptions.scripts) {
+      const context = {
+        ssr: router.options.ssr,
+        matches,
+        match,
+        params: match.params,
+        loaderData: match.loaderData,
+      }
+      let projection
       try {
-        const context = {
-          ssr: router.options.ssr,
-          matches,
-          match,
-          params: match.params,
-          loaderData: match.loaderData,
-        }
-        const [head, scripts] = await waitFor(
+        projection = waitFor(
           Promise.all([
             routeOptions.head?.(context),
             routeOptions.scripts?.(context),
           ]),
           signal,
         )
+      } catch (cause) {
+        projection = Promise.reject(cause)
+      }
+      void projection.catch(() => {})
+      ;(projections ??= []).push([match, projection])
+    }
+    if (match.status !== 'success' || match._notFound) {
+      break
+    }
+  }
+  if (projections) {
+    for (const [match, projection] of projections) {
+      try {
+        const [head, scripts] = await projection
         match.meta = head?.meta
         match.links = head?.links
         match.headScripts = head?.scripts
@@ -1261,9 +1277,6 @@ export async function projectLane(
         }
         console.error(cause)
       }
-    }
-    if (match.status !== 'success' || match._notFound) {
-      break
     }
   }
   return lane as ProjectedLane

--- a/packages/router-core/src/load-server.ts
+++ b/packages/router-core/src/load-server.ts
@@ -620,6 +620,7 @@ async function projectLane(
   lane: ReducedLane,
   signal?: AbortSignal,
 ): Promise<void> {
+  let projections: Array<[AnyRouteMatch, Promise<any>]> | undefined
   for (const match of lane.matches) {
     const routeOptions = getRoute(router, match).options
     if (routeOptions.head || routeOptions.scripts || routeOptions.headers) {
@@ -630,12 +631,27 @@ async function projectLane(
         params: match.params,
         loaderData: match.loaderData,
       }
+      let projection
       try {
-        const [head, scripts, headers] = await Promise.all([
+        projection = Promise.all([
           routeOptions.head?.(context),
           routeOptions.scripts?.(context),
           routeOptions.headers?.(context),
         ])
+      } catch (cause) {
+        projection = Promise.reject(cause)
+      }
+      void projection.catch(() => {})
+      ;(projections ??= []).push([match, projection])
+    }
+    if (match.ssr === false || match.status !== 'success' || match._notFound) {
+      break
+    }
+  }
+  if (projections) {
+    for (const [match, projection] of projections) {
+      try {
+        const [head, scripts, headers] = await projection
         signal?.throwIfAborted()
         match.meta = head?.meta
         match.links = head?.links
@@ -647,9 +663,6 @@ async function projectLane(
         signal?.throwIfAborted()
         console.error(cause)
       }
-    }
-    if (match.ssr === false || match.status !== 'success' || match._notFound) {
-      break
     }
   }
 }

--- a/packages/router-core/tests/route-assets-parallel.test.ts
+++ b/packages/router-core/tests/route-assets-parallel.test.ts
@@ -1,0 +1,66 @@
+import { createMemoryHistory } from '@tanstack/history'
+import { describe, expect, test, vi } from 'vitest'
+import { BaseRootRoute, BaseRoute, createControlledPromise } from '../src'
+import { createTestRouter, loadServerResponse } from './routerTestUtils'
+
+describe.each([false, true])(
+  'route asset projection (server: %s)',
+  (isServer) => {
+    test('starts child assets before parent assets settle', async () => {
+      const parentStarted = createControlledPromise<void>()
+      const parentHead = createControlledPromise<{
+        meta: Array<{ title: string }>
+      }>()
+      const parentScripts =
+        createControlledPromise<Array<{ children: string }>>()
+      const childHead = vi.fn(() => ({
+        meta: [{ title: 'child' }],
+      }))
+      const childScripts = vi.fn(() => [{ children: 'window.child = true' }])
+
+      const rootRoute = new BaseRootRoute({})
+      const parentRoute = new BaseRoute({
+        getParentRoute: () => rootRoute,
+        path: '/parent',
+        head: () => {
+          parentStarted.resolve()
+          return parentHead
+        },
+        scripts: () => parentScripts,
+      })
+      const childRoute = new BaseRoute({
+        getParentRoute: () => parentRoute,
+        path: '/child',
+        head: childHead,
+        scripts: childScripts,
+      })
+      const router = createTestRouter({
+        routeTree: rootRoute.addChildren([
+          parentRoute.addChildren([childRoute]),
+        ]),
+        history: createMemoryHistory({ initialEntries: ['/parent/child'] }),
+        isServer,
+      })
+
+      const loading = isServer
+        ? loadServerResponse(router, '/parent/child')
+        : router.load()
+      try {
+        await parentStarted
+
+        expect(parentScripts.status).toBe('pending')
+        expect(childHead).toHaveBeenCalledTimes(1)
+        expect(childScripts).toHaveBeenCalledTimes(1)
+      } finally {
+        parentHead.resolve({ meta: [{ title: 'parent' }] })
+        parentScripts.resolve([{ children: 'window.parent = true' }])
+        await loading
+      }
+
+      expect(router.state.matches.at(-1)).toMatchObject({
+        meta: [{ title: 'child' }],
+        scripts: [{ children: 'window.child = true' }],
+      })
+    })
+  },
+)


### PR DESCRIPTION
## Summary

- start `head`, `scripts`, and server `headers` projections across the rendered route prefix before awaiting them
- continue applying projection results in route order and preserve abort/error/boundary behavior
- attach rejection observers immediately so later promises cannot become unhandled while an earlier route is pending
- cover client and server concurrency with a focused regression test

## Testing

- `pnpm nx run @tanstack/router-core:test:unit`
- `pnpm nx run @tanstack/router-core:test:types`
- `pnpm nx run @tanstack/router-core:test:eslint`
- full bundle-size scenario build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Route metadata, scripts, and headers now begin loading in parallel across eligible routes.
  * Child-route assets can begin loading before slower parent assets finish, improving navigation responsiveness.

* **Reliability**
  * Route asset ordering and error handling remain consistent during parallel loading.

* **Tests**
  * Added coverage verifying parallel asset loading for both client-side and server-side navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->