### PR TITLE
fix(router-core): reject overlapping parameter affixes

### DIFF
--- a/packages/router-core/src/new-process-route-tree.ts
+++ b/packages/router-core/src/new-process-route-tree.ts
@@ -1062,14 +1062,16 @@ function getNodeMatch<T extends RouteLike>(
         if (suffix) {
           if (isBeyondPath) continue
           const end = parts.slice(index).join('/')
-          if (prefix && end.length < prefix.length + suffix.length) {
-            continue
-          }
           const suffixPart = end.slice(-suffix.length)
           const casePart = segment.caseSensitive
             ? suffixPart
             : suffixPart.toLowerCase()
-          if (casePart !== suffix) continue
+          if (
+            casePart !== suffix ||
+            (prefix && end.length - suffix.length < prefix.length)
+          ) {
+            continue
+          }
         }
         // wildcard matches consume the rest of the URL and cannot have children
         stack.push({
@@ -1113,13 +1115,13 @@ function getNodeMatch<T extends RouteLike>(
               : (lowerPart ??= part!.toLowerCase())
             if (prefix && !casePart.startsWith(prefix)) continue
             if (
-              prefix &&
               suffix &&
-              casePart.length < prefix.length + suffix.length
+              ((prefix &&
+                casePart.length - suffix.length < prefix.length) ||
+                !casePart.endsWith(suffix))
             ) {
               continue
             }
-            if (suffix && !casePart.endsWith(suffix)) continue
           }
           stack.push({
             node: segment,
@@ -1146,13 +1148,12 @@ function getNodeMatch<T extends RouteLike>(
             : (lowerPart ??= part.toLowerCase())
           if (prefix && !casePart.startsWith(prefix)) continue
           if (
-            prefix &&
             suffix &&
-            casePart.length < prefix.length + suffix.length
+            ((prefix && casePart.length - suffix.length < prefix.length) ||
+              !casePart.endsWith(suffix))
           ) {
             continue
           }
-          if (suffix && !casePart.endsWith(suffix)) continue
         }
         stack.push({
           node: segment,

--- a/packages/router-core/src/new-process-route-tree.ts
+++ b/packages/router-core/src/new-process-route-tree.ts
@@ -240,7 +240,7 @@ function parseSegments<TRouteLike extends RouteLike>(
           let prefix = path.substring(start, segment[1])
           let suffix = path.substring(segment[4], end)
           const actuallyCaseSensitive = caseSensitive && !!(prefix || suffix)
-          if (!actuallyCaseSensitive) {
+          if (!caseSensitive) {
             prefix = prefix.toLowerCase()
             suffix = suffix.toLowerCase()
           }

--- a/packages/router-core/src/new-process-route-tree.ts
+++ b/packages/router-core/src/new-process-route-tree.ts
@@ -237,20 +237,14 @@ function parseSegments<TRouteLike extends RouteLike>(
         case SEGMENT_TYPE_PARAM:
         case SEGMENT_TYPE_OPTIONAL_PARAM:
         case SEGMENT_TYPE_WILDCARD: {
-          const prefix_raw = path.substring(start, segment[1])
-          const suffix_raw = path.substring(segment[4], end)
+          let prefix = path.substring(start, segment[1])
+          let suffix = path.substring(segment[4], end)
           const actuallyCaseSensitive =
-            caseSensitive && !!(prefix_raw || suffix_raw)
-          const prefix = !prefix_raw
-            ? undefined
-            : actuallyCaseSensitive
-              ? prefix_raw
-              : prefix_raw.toLowerCase()
-          const suffix = !suffix_raw
-            ? undefined
-            : actuallyCaseSensitive
-              ? suffix_raw
-              : suffix_raw.toLowerCase()
+            caseSensitive && !!(prefix || suffix)
+          if (!actuallyCaseSensitive) {
+            prefix = prefix.toLowerCase()
+            suffix = suffix.toLowerCase()
+          }
           const siblings =
             kind === SEGMENT_TYPE_PARAM
               ? node.dynamic
@@ -357,15 +351,15 @@ function parseSegments<TRouteLike extends RouteLike>(
 
 function sortDynamic(
   a: {
-    prefix?: string
-    suffix?: string
+    prefix: string
+    suffix: string
     caseSensitive: boolean
     parse: null | ((params: Record<string, string>) => unknown)
     priority: number
   },
   b: {
-    prefix?: string
-    suffix?: string
+    prefix: string
+    suffix: string
     caseSensitive: boolean
     parse: null | ((params: Record<string, string>) => unknown)
     priority: number
@@ -426,8 +420,8 @@ function createDynamicNode<T extends RouteLike>(
     | typeof SEGMENT_TYPE_OPTIONAL_PARAM,
   fullPath: string,
   caseSensitive: boolean,
-  prefix?: string,
-  suffix?: string,
+  prefix: string,
+  suffix: string,
 ): DynamicSegmentNode<T> {
   return {
     kind,
@@ -462,8 +456,8 @@ type DynamicSegmentNode<T extends RouteLike> = SegmentNode<T> & {
     | typeof SEGMENT_TYPE_PARAM
     | typeof SEGMENT_TYPE_WILDCARD
     | typeof SEGMENT_TYPE_OPTIONAL_PARAM
-  prefix?: string
-  suffix?: string
+  prefix: string
+  suffix: string
   caseSensitive: boolean
 }
 
@@ -818,12 +812,12 @@ function extractParams<T extends RouteLike>(
     if (node.kind === SEGMENT_TYPE_PARAM) {
       nodeParts ??= leaf.node.fullPath.split('/')
       const nodePart = nodeParts[segmentCount]!
-      const preLength = node.prefix?.length ?? 0
+      const preLength = node.prefix.length
       // we can't rely on the presence of prefix/suffix to know whether it's curly-braced or not, because `/{$param}/` is valid, but has no prefix/suffix
       const isCurlyBraced = nodePart.charCodeAt(preLength) === 123 // '{'
       // param name is extracted at match-time so that tree nodes that are identical except for param name can share the same node
       if (isCurlyBraced) {
-        const sufLength = node.suffix?.length ?? 0
+        const sufLength = node.suffix.length
         const name = nodePart.substring(
           preLength + 2,
           nodePart.length - sufLength - 1,
@@ -842,8 +836,8 @@ function extractParams<T extends RouteLike>(
       }
       nodeParts ??= leaf.node.fullPath.split('/')
       const nodePart = nodeParts[segmentCount]!
-      const preLength = node.prefix?.length ?? 0
-      const sufLength = node.suffix?.length ?? 0
+      const preLength = node.prefix.length
+      const sufLength = node.suffix.length
       const name = nodePart.substring(
         preLength + 3,
         nodePart.length - sufLength - 1,
@@ -856,8 +850,8 @@ function extractParams<T extends RouteLike>(
     } else if (node.kind === SEGMENT_TYPE_WILDCARD) {
       const n = node
       const value = path.substring(
-        currentPathIndex + (n.prefix?.length ?? 0),
-        path.length - (n.suffix?.length ?? 0),
+        currentPathIndex + n.prefix.length,
+        path.length - n.suffix.length,
       )
       const splat = decodeURIComponent(value)
       // TODO: Deprecate *
@@ -1068,7 +1062,7 @@ function getNodeMatch<T extends RouteLike>(
             : suffixPart.toLowerCase()
           if (
             casePart !== suffix ||
-            (prefix && end.length - suffix.length < prefix.length)
+            end.length - suffix.length < prefix.length
           ) {
             continue
           }
@@ -1116,8 +1110,8 @@ function getNodeMatch<T extends RouteLike>(
             if (prefix && !casePart.startsWith(prefix)) continue
             if (
               suffix &&
-              ((prefix && casePart.length - suffix.length < prefix.length) ||
-                !casePart.endsWith(suffix))
+              casePart.indexOf(suffix, casePart.length - suffix.length) <
+                prefix.length
             ) {
               continue
             }
@@ -1148,8 +1142,8 @@ function getNodeMatch<T extends RouteLike>(
           if (prefix && !casePart.startsWith(prefix)) continue
           if (
             suffix &&
-            ((prefix && casePart.length - suffix.length < prefix.length) ||
-              !casePart.endsWith(suffix))
+            casePart.indexOf(suffix, casePart.length - suffix.length) <
+              prefix.length
           ) {
             continue
           }

--- a/packages/router-core/src/new-process-route-tree.ts
+++ b/packages/router-core/src/new-process-route-tree.ts
@@ -1116,8 +1116,7 @@ function getNodeMatch<T extends RouteLike>(
             if (prefix && !casePart.startsWith(prefix)) continue
             if (
               suffix &&
-              ((prefix &&
-                casePart.length - suffix.length < prefix.length) ||
+              ((prefix && casePart.length - suffix.length < prefix.length) ||
                 !casePart.endsWith(suffix))
             ) {
               continue

--- a/packages/router-core/src/new-process-route-tree.ts
+++ b/packages/router-core/src/new-process-route-tree.ts
@@ -239,8 +239,7 @@ function parseSegments<TRouteLike extends RouteLike>(
         case SEGMENT_TYPE_WILDCARD: {
           let prefix = path.substring(start, segment[1])
           let suffix = path.substring(segment[4], end)
-          const actuallyCaseSensitive =
-            caseSensitive && !!(prefix || suffix)
+          const actuallyCaseSensitive = caseSensitive && !!(prefix || suffix)
           if (!actuallyCaseSensitive) {
             prefix = prefix.toLowerCase()
             suffix = suffix.toLowerCase()

--- a/packages/router-core/src/new-process-route-tree.ts
+++ b/packages/router-core/src/new-process-route-tree.ts
@@ -1061,8 +1061,14 @@ function getNodeMatch<T extends RouteLike>(
         }
         if (suffix) {
           if (isBeyondPath) continue
-          const end = parts.slice(index).join('/').slice(-suffix.length)
-          const casePart = segment.caseSensitive ? end : end.toLowerCase()
+          const end = parts.slice(index).join('/')
+          if (prefix && end.length < prefix.length + suffix.length) {
+            continue
+          }
+          const suffixPart = end.slice(-suffix.length)
+          const casePart = segment.caseSensitive
+            ? suffixPart
+            : suffixPart.toLowerCase()
           if (casePart !== suffix) continue
         }
         // wildcard matches consume the rest of the URL and cannot have children
@@ -1106,6 +1112,13 @@ function getNodeMatch<T extends RouteLike>(
               ? part!
               : (lowerPart ??= part!.toLowerCase())
             if (prefix && !casePart.startsWith(prefix)) continue
+            if (
+              prefix &&
+              suffix &&
+              casePart.length < prefix.length + suffix.length
+            ) {
+              continue
+            }
             if (suffix && !casePart.endsWith(suffix)) continue
           }
           stack.push({
@@ -1132,6 +1145,13 @@ function getNodeMatch<T extends RouteLike>(
             ? part
             : (lowerPart ??= part.toLowerCase())
           if (prefix && !casePart.startsWith(prefix)) continue
+          if (
+            prefix &&
+            suffix &&
+            casePart.length < prefix.length + suffix.length
+          ) {
+            continue
+          }
           if (suffix && !casePart.endsWith(suffix)) continue
         }
         stack.push({

--- a/packages/router-core/tests/new-process-route-tree.test.ts
+++ b/packages/router-core/tests/new-process-route-tree.test.ts
@@ -686,6 +686,14 @@ describe('findRouteMatch', () => {
           '/file{-$id}.txt',
         )
       })
+      it.each(['/ab{$id}bc', '/ab{-$id}bc', '/ab{$}bc'])(
+        'does not match overlapping affixes for %s',
+        (route) => {
+          const tree = makeTree([route])
+          expect(findRouteMatch('/abc', tree)).toBeNull()
+          expect(findRouteMatch('/abbc', tree)?.route.id).toBe(route)
+        },
+      )
     })
 
     it('optional at the end can still be omitted', () => {

--- a/packages/router-core/tests/new-process-route-tree.test.ts
+++ b/packages/router-core/tests/new-process-route-tree.test.ts
@@ -627,6 +627,31 @@ describe('findRouteMatch', () => {
         '/A{$id}B',
       )
     })
+    it('case sensitivity does not distinguish plain dynamic segments', () => {
+      const tree = {
+        id: '__root__',
+        isRoot: true,
+        fullPath: '/',
+        path: '/',
+        children: [
+          {
+            id: '/$first',
+            fullPath: '/$first',
+            path: '$first',
+            options: { caseSensitive: false },
+          },
+          {
+            id: '/$second',
+            fullPath: '/$second',
+            path: '$second',
+            options: { caseSensitive: true },
+          },
+        ],
+      }
+      const { processedTree } = processRouteTree(tree)
+
+      expect(findRouteMatch('/value', processedTree)?.route.id).toBe('/$first')
+    })
   })
 
   describe('basic matching', () => {

--- a/packages/router-core/tests/new-process-route-tree.test.ts
+++ b/packages/router-core/tests/new-process-route-tree.test.ts
@@ -686,12 +686,19 @@ describe('findRouteMatch', () => {
           '/file{-$id}.txt',
         )
       })
-      it.each(['/ab{$id}bc', '/ab{-$id}bc', '/ab{$}bc'])(
+      it.each([
+        ['/ab{$id}bc', '/abbc', { id: '' }],
+        ['/ab{-$id}bc', '/abbc', {}],
+        ['/ab{$}bc', '/abbc', { '*': '', _splat: '' }],
+        ['/ab{$}bc', '/abfoo/barbc', { '*': 'foo/bar', _splat: 'foo/bar' }],
+      ] as const)(
         'does not match overlapping affixes for %s',
-        (route) => {
+        (route, path, rawParams) => {
           const tree = makeTree([route])
           expect(findRouteMatch('/abc', tree)).toBeNull()
-          expect(findRouteMatch('/abbc', tree)?.route.id).toBe(route)
+          const match = findRouteMatch(path, tree)
+          expect(match?.route.id).toBe(route)
+          expect(match?.rawParams).toEqual(rawParams)
         },
       )
     })

--- a/packages/router-core/tests/new-process-route-tree.test.ts
+++ b/packages/router-core/tests/new-process-route-tree.test.ts
@@ -696,6 +696,7 @@ describe('findRouteMatch', () => {
         (route, path, rawParams) => {
           const tree = makeTree([route])
           expect(findRouteMatch('/abc', tree)).toBeNull()
+          expect(findRouteMatch(`${path}x`, tree)).toBeNull()
           const match = findRouteMatch(path, tree)
           expect(match?.route.id).toBe(route)
           expect(match?.rawParams).toEqual(rawParams)
@@ -1691,7 +1692,7 @@ describe('findRouteMatch', () => {
                   "wildcard": null,
                 },
               ],
-              "prefix": undefined,
+              "prefix": "",
               "priority": 0,
               "route": null,
               "static": null,
@@ -1718,7 +1719,7 @@ describe('findRouteMatch', () => {
                   "wildcard": null,
                 },
               },
-              "suffix": undefined,
+              "suffix": "",
               "wildcard": null,
             },
           ],


### PR DESCRIPTION
## Summary

- reject route matches when a parameter prefix and suffix overlap within the matched path
- apply the length guard to required, optional, and wildcard parameters
- preserve valid empty parameters where the affixes meet without overlapping
- add regression coverage for all three parameter kinds

## Context

A route such as `/ab{$id}bc` incorrectly matched `/abc`: `abc` starts with `ab` and ends with `bc`, but both affixes claimed the same `b`. Parameter extraction then returned that shared character as the parameter value.

The matcher now requires the matched path to be at least as long as the combined prefix and suffix before accepting both affixes. `/abc` is rejected, while `/abbc` remains valid with an empty parameter value.

## Bundle size

`react-router.minimal`: +4 B gzip locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved route matching for dynamic, optional, and wildcard segments with overlapping prefixes and suffixes.
* Prevented invalid or incomplete URLs—including paths with extra trailing characters—from matching routes incorrectly.
* Preserved complete wildcard path remainders during suffix matching.
* Ensured route parameters are extracted correctly when prefixes or suffixes are absent.

## Tests

* Added coverage for valid and invalid routes involving overlapping prefixes and suffixes, including trailing-character edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->