### PR TITLE
fix(router-ssr-query-core): skip hydrate on stream close

### DIFF
--- a/.changeset/olive-pugs-shave.md
+++ b/.changeset/olive-pugs-shave.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-ssr-query-core': patch
+---
+
+skip hydration when the query stream closes

--- a/packages/router-ssr-query-core/src/index.ts
+++ b/packages/router-ssr-query-core/src/index.ts
@@ -195,10 +195,10 @@ export function setupCoreRouterSsrQueryIntegration<TRouter extends AnyRouter>({
       reader
         .read()
         .then(async function handle({ done, value }) {
-          queryHydrate(queryClient, value, hydrateOptions)
           if (done) {
             return
           }
+          queryHydrate(queryClient, value, hydrateOptions)
           const result = await reader.read()
           return handle(result)
         })

--- a/packages/router-ssr-query-core/tests/stream-close.test.ts
+++ b/packages/router-ssr-query-core/tests/stream-close.test.ts
@@ -1,0 +1,38 @@
+import { QueryClient, hydrate } from '@tanstack/query-core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { setupCoreRouterSsrQueryIntegration } from '../src'
+
+vi.mock('@tanstack/query-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/query-core')>()
+  return { ...actual, hydrate: vi.fn(actual.hydrate) }
+})
+
+describe('setupCoreRouterSsrQueryIntegration', () => {
+  beforeEach(() => {
+    vi.mocked(hydrate).mockClear()
+  })
+
+  it('does not hydrate once the query stream is closed', async () => {
+    const queryClient = new QueryClient()
+    const router = { isServer: false, options: {} } as {
+      isServer: boolean
+      options: { hydrate?: (dehydrated: any) => unknown | Promise<unknown> }
+    }
+
+    setupCoreRouterSsrQueryIntegration({ router: router as any, queryClient })
+
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue({ mutations: [], queries: [] })
+        controller.close()
+      },
+    })
+
+    await router.options.hydrate?.({ queryStream: stream })
+    await vi.waitFor(() => expect(hydrate).toHaveBeenCalled())
+
+    expect(
+      vi.mocked(hydrate).mock.calls.some(([, state]) => state === undefined),
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
fixes #8158

`hydrate()` runs before the `done` check, so the final read of a closed query stream passes `undefined`. `@tanstack/query-core` used to return early for a non-object, but 5.102.1 (TanStack/query#11260) removed that guard, so this now throws on every SSR page load:

```
TypeError: Cannot read properties of undefined (reading 'mutations')
```

Moving the `done` check above the call also narrows `value` to a non-undefined type, which matches query-core's new `Partial<DehydratedState>` signature.

This repo pins query-core 5.99.0, which still has the guard, so the existing tests pass with or without the change. The added test asserts `hydrate` is never called with `undefined`, so it fails on the old ordering regardless of which query-core is installed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented query hydration from running when the server-side query stream closes without a final payload.
  * Improved reliability during stream completion, avoiding hydration with missing data.

* **Tests**
  * Added coverage confirming that closed query streams do not trigger hydration with an undefined state.

* **Release**
  * Included a patch release update for the SSR query integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
