### PR TITLE
fix(router-core): retain not-found boundary during navigation

### DIFF
--- a/.changeset/fuzzy-boundaries-remain.md
+++ b/.changeset/fuzzy-boundaries-remain.md
@@ -1,0 +1,8 @@
+---
+'@tanstack/react-router': patch
+'@tanstack/solid-router': patch
+'@tanstack/router-core': patch
+'@tanstack/vue-router': patch
+---
+
+Retain successful not-found matches as terminal shared boundaries during client navigation, preserving route context while the destination loads.

--- a/packages/react-router/tests/issue-8128-context.test.tsx
+++ b/packages/react-router/tests/issue-8128-context.test.tsx
@@ -1,0 +1,116 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { expect, onTestFinished, test, vi } from 'vitest'
+import { dehydrateSsrMatchId } from '../../router-core/src/ssr/ssr-match-id'
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+import { hydrate } from '../src/ssr/client'
+
+test('#8128: leaving a hydrated root not-found page preserves beforeLoad context', async () => {
+  const rootRenders: Array<string | undefined> = []
+
+  vi.useFakeTimers()
+  onTestFinished(async () => {
+    cleanup()
+    delete window.$_TSR
+    delete (window as Window & { $R?: unknown }).$R
+    vi.useRealTimers()
+  })
+
+  const rootRoute = createRootRoute({
+    beforeLoad: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 250))
+      return { locale: 'en' }
+    },
+    component: () => {
+      const context = rootRoute.useRouteContext()
+      rootRenders.push(context.locale)
+
+      return (
+        <>
+          <output data-testid="root-locale">
+            Locale: {context.locale ?? 'missing'}
+          </output>
+          <Outlet />
+        </>
+      )
+    },
+    notFoundComponent: () => <div>Not found</div>,
+  })
+  const dashboardRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/dashboard',
+    component: () => <div>Dashboard</div>,
+  })
+
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([dashboardRoute]),
+    history: createMemoryHistory({
+      initialEntries: ['/any-not-found-url'],
+    }),
+    defaultPendingComponent: () => <div>Loading</div>,
+    defaultPendingMs: 150,
+    defaultPendingMinMs: 0,
+  })
+  const rootMatch = router.matchRoutes(router.latestLocation)[0]!
+  // Model the public server bootstrap for a hydrated root-level not-found.
+  window.$_TSR = {
+    router: {
+      manifest: { routes: {} },
+      dehydratedData: {},
+      matches: [
+        {
+          i: dehydrateSsrMatchId(rootMatch.id),
+          b: { locale: 'en' },
+          u: Date.now(),
+          s: 'success',
+          ssr: true,
+          g: true,
+        },
+      ],
+    },
+    h: vi.fn(),
+    e: vi.fn(),
+    c: vi.fn(),
+    p: vi.fn(),
+    buffer: [],
+    initialized: false,
+  }
+
+  await hydrate(router)
+  render(<RouterProvider router={router} />)
+
+  expect(router.state.matches[0]).toMatchObject({
+    status: 'success',
+    _notFound: true,
+    context: { locale: 'en' },
+  })
+  expect(screen.getByText('Not found')).toBeInTheDocument()
+
+  let navigation!: Promise<void>
+  await act(async () => {
+    navigation = router.navigate({ to: '/dashboard' })
+    await vi.advanceTimersByTimeAsync(150)
+  })
+
+  expect(router.state.matches[0]).toMatchObject({
+    status: 'success',
+    _notFound: true,
+    context: { locale: 'en' },
+  })
+  expect(screen.getByTestId('root-locale')).toHaveTextContent('Locale: en')
+  expect(screen.getByText('Not found')).toBeInTheDocument()
+  expect(screen.queryByText('Loading')).not.toBeInTheDocument()
+  expect(rootRenders).not.toContain(undefined)
+
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(100)
+    await navigation
+  })
+  expect(screen.getByText('Dashboard')).toBeInTheDocument()
+})

--- a/packages/react-router/tests/issue-8128-source-notfound-retention-boundary.test.tsx
+++ b/packages/react-router/tests/issue-8128-source-notfound-retention-boundary.test.tsx
@@ -106,3 +106,200 @@ test('#8128: returning from a layout-owned fuzzy not-found retains only through 
     })
   }
 })
+
+test('#8128: retention stops at the earlier committed boundary when the presented boundary is deeper', async () => {
+  const groupsBeforeLoadStarted = createGate()
+  const groupsBeforeLoadGate = createGate()
+  const workspaceReloadStarted = createGate()
+  const workspaceReloadGate = createGate()
+  const agentsReloadStarted = createGate()
+  const agentsReloadGate = createGate()
+  let agentsLoaderCalls = 0
+
+  const rootRoute = createRootRoute({ component: Outlet })
+  const workspaceLayoutRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    id: '_workspace',
+    component: () => (
+      <section>
+        <h1>Workspace</h1>
+        <Outlet />
+      </section>
+    ),
+    notFoundComponent: () => <p>Workspace page not found</p>,
+    beforeLoad: ({ location }) => {
+      if (
+        location.pathname === '/agents' &&
+        (location.search as { reload?: number }).reload === 1
+      ) {
+        workspaceReloadStarted.resolve()
+        return workspaceReloadGate.promise
+      }
+      return undefined
+    },
+    pendingMs: 0,
+    pendingMinMs: 0,
+    pendingComponent: () => <p role="status">Loading workspace</p>,
+  })
+  const agentsRoute = createRoute({
+    getParentRoute: () => workspaceLayoutRoute,
+    path: '/agents',
+    validateSearch: (search: Record<string, unknown>) => ({
+      reload: Number(search.reload ?? 0),
+    }),
+    shouldReload: ({ location }) =>
+      (location.search as { reload: number }).reload === 1,
+    loader: {
+      staleReloadMode: 'blocking',
+      handler: async () => {
+        agentsLoaderCalls++
+        if (agentsLoaderCalls === 2) {
+          agentsReloadStarted.resolve()
+          await agentsReloadGate.promise
+        }
+        return { generation: agentsLoaderCalls }
+      },
+    },
+    pendingMs: 0,
+    pendingMinMs: 0,
+    pendingComponent: () => <p role="status">Loading agents destination</p>,
+    component: () => (
+      <section>
+        <h2>Agents area</h2>
+        <Outlet />
+      </section>
+    ),
+  })
+  const groupsRoute = createRoute({
+    getParentRoute: () => agentsRoute,
+    path: 'groups',
+    beforeLoad: async () => {
+      groupsBeforeLoadStarted.resolve()
+      await groupsBeforeLoadGate.promise
+    },
+    pendingMs: 0,
+    pendingMinMs: 0,
+    pendingComponent: () => <p role="status">Loading groups</p>,
+    component: Outlet,
+  })
+  const groupsBoundaryRoute = createRoute({
+    getParentRoute: () => groupsRoute,
+    id: '_groups',
+    component: Outlet,
+    notFoundComponent: () => <p>Group page not found</p>,
+  })
+  const knownGroupRoute = createRoute({
+    getParentRoute: () => groupsBoundaryRoute,
+    path: 'known',
+    component: () => <p>Known group</p>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([
+      workspaceLayoutRoute.addChildren([
+        agentsRoute.addChildren([
+          groupsRoute.addChildren([
+            groupsBoundaryRoute.addChildren([knownGroupRoute]),
+          ]),
+        ]),
+      ]),
+    ]),
+    history: createMemoryHistory({ initialEntries: ['/agents'] }),
+  })
+
+  let deeperNavigation: Promise<void> | undefined
+  let agentsNavigation: Promise<void> | undefined
+  try {
+    render(<RouterProvider router={router} />)
+    expect(
+      await screen.findByRole('heading', { name: 'Agents area' }),
+    ).toBeVisible()
+
+    await act(async () => {
+      await router.navigate({ to: '/agents/missing' } as any)
+    })
+
+    expect(screen.getByText('Workspace page not found')).toBeVisible()
+    const committedBoundaryIndex = router.state.matches.findIndex(
+      (match) => match._notFound,
+    )
+    expect(committedBoundaryIndex).toBeGreaterThanOrEqual(0)
+    expect(router.state.matches[committedBoundaryIndex]?.routeId).toBe(
+      workspaceLayoutRoute.id,
+    )
+    expect(
+      router.state.matches.find((match) => match.routeId === agentsRoute.id),
+    ).toMatchObject({ status: 'success' })
+
+    await act(async () => {
+      deeperNavigation = router.navigate({
+        to: '/agents/groups/known/missing',
+      } as any)
+      await groupsBeforeLoadStarted.promise
+    })
+
+    expect(await screen.findByText('Loading groups')).toBeVisible()
+    const presentedBoundaryIndex = router.state.matches.findIndex(
+      (match) => match._notFound,
+    )
+    expect(presentedBoundaryIndex).toBeGreaterThan(committedBoundaryIndex)
+    expect(router.state.matches[presentedBoundaryIndex]?.routeId).toBe(
+      groupsBoundaryRoute.id,
+    )
+    expect(
+      router.state.matches.find((match) => match.routeId === agentsRoute.id),
+    ).toMatchObject({ status: 'success' })
+    expect(
+      router.state.matches.find((match) => match.routeId === groupsRoute.id),
+    ).toMatchObject({ status: 'pending' })
+
+    await act(async () => {
+      agentsNavigation = router.navigate({
+        to: '/agents',
+        search: { reload: 1 },
+      })
+      await workspaceReloadStarted.promise
+    })
+
+    expect(screen.getByText('Loading groups')).toBeVisible()
+    expect(screen.queryByText('Loading workspace')).not.toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Workspace' })).toBeVisible()
+    expect(router.state.matches[presentedBoundaryIndex]?.routeId).toBe(
+      groupsBoundaryRoute.id,
+    )
+
+    await act(async () => {
+      workspaceReloadGate.resolve()
+      await agentsReloadStarted.promise
+    })
+
+    expect(await screen.findByText('Loading agents destination')).toBeVisible()
+    expect(
+      router.state.matches.find((match) => match.routeId === agentsRoute.id),
+    ).toMatchObject({ status: 'pending' })
+
+    await act(async () => {
+      agentsReloadGate.resolve()
+      await agentsNavigation
+    })
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Agents area' })).toBeVisible()
+    expect(router.state.location).toMatchObject({
+      pathname: '/agents',
+      search: { reload: 1 },
+    })
+    expect(router.state.matches.some((match) => match._notFound)).toBe(false)
+    expect(agentsLoaderCalls).toBe(2)
+  } finally {
+    groupsBeforeLoadGate.resolve()
+    workspaceReloadGate.resolve()
+    agentsReloadGate.resolve()
+    await act(async () => {
+      await Promise.allSettled(
+        [deeperNavigation, agentsNavigation].filter(
+          (navigation): navigation is Promise<void> => navigation !== undefined,
+        ),
+      )
+    })
+  }
+})

--- a/packages/react-router/tests/issue-8128-source-notfound-retention-boundary.test.tsx
+++ b/packages/react-router/tests/issue-8128-source-notfound-retention-boundary.test.tsx
@@ -1,0 +1,108 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, expect, onTestFinished, test } from 'vitest'
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+
+function createGate() {
+  let resolve!: () => void
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+
+  return { promise, resolve }
+}
+
+afterEach(cleanup)
+
+test('#8128: returning from a layout-owned fuzzy not-found retains only through its owner', async () => {
+  const beforeLoadStarted = createGate()
+  const beforeLoadGate = createGate()
+  onTestFinished(() => beforeLoadGate.resolve())
+  let gateNextBeforeLoad = false
+
+  const rootRoute = createRootRoute({ component: Outlet })
+  const agentsLayoutRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    id: '_agents',
+    component: () => (
+      <section>
+        <h1>Agent operations</h1>
+        <Outlet />
+      </section>
+    ),
+    notFoundComponent: () => <p>Agent page not found</p>,
+  })
+  const agentsRoute = createRoute({
+    getParentRoute: () => agentsLayoutRoute,
+    path: '/agents',
+    beforeLoad: async () => {
+      if (gateNextBeforeLoad) {
+        gateNextBeforeLoad = false
+        beforeLoadStarted.resolve()
+        await beforeLoadGate.promise
+      }
+    },
+    pendingMs: 0,
+    pendingMinMs: 0,
+    pendingComponent: () => <p role="status">Loading agents</p>,
+    component: () => <p>Agents directory</p>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([
+      agentsLayoutRoute.addChildren([agentsRoute]),
+    ]),
+    history: createMemoryHistory({ initialEntries: ['/agents'] }),
+  })
+
+  let navigation: Promise<void> | undefined
+  try {
+    render(<RouterProvider router={router} />)
+
+    expect(await screen.findByText('Agents directory')).toBeVisible()
+    expect(
+      screen.getByRole('heading', { name: 'Agent operations' }),
+    ).toBeVisible()
+
+    await act(async () => {
+      navigation = router.navigate({ to: '/agents/missing' } as any)
+      await navigation
+    })
+
+    expect(
+      screen.getByRole('heading', { name: 'Agent operations' }),
+    ).toBeVisible()
+    expect(screen.getByText('Agent page not found')).toBeVisible()
+    expect(screen.queryByText('Agents directory')).not.toBeInTheDocument()
+
+    gateNextBeforeLoad = true
+    await act(async () => {
+      navigation = router.navigate({ to: '/agents' })
+      await beforeLoadStarted.promise
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(
+      screen.getByRole('heading', { name: 'Agent operations' }),
+    ).toBeVisible()
+    expect(screen.queryByText('Agent page not found')).not.toBeInTheDocument()
+    expect(screen.getByRole('status')).toHaveTextContent('Loading agents')
+
+    await act(async () => {
+      beforeLoadGate.resolve()
+      await navigation
+    })
+
+    expect(screen.getByText('Agents directory')).toBeVisible()
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  } finally {
+    await act(async () => {
+      await Promise.allSettled(navigation ? [navigation] : [])
+    })
+  }
+})

--- a/packages/router-core/src/load-client.ts
+++ b/packages/router-core/src/load-client.ts
@@ -1308,15 +1308,16 @@ async function executeClientLane(
       if (
         committed?.id !== match.id ||
         committed.status !== 'success' ||
-        committed._notFound ||
         match.preload ||
         visible?.id !== match.id ||
-        visible.status !== 'success' ||
-        visible._notFound
+        visible.status !== 'success'
       ) {
         break
       }
       retainedEnd++
+      if (committed._notFound || visible._notFound) {
+        break
+      }
     }
     const tasks: Array<LoaderTask> = []
     const start = options[6 /* resolvedPrefix */] ?? 0


### PR DESCRIPTION
## 🎯 Changes

Retain a successful not-found match as the terminal shared boundary during navigation. Its completed context remains available while the destination loads, and hidden descendants are excluded from retention.

Regression coverage includes hydrated root context, returning from a layout-owned not-found page, and overlapping navigations where the displayed not-found boundary is deeper than the last committed boundary. The production fix is unchanged; this update rebases onto current main and adds the overlapping-navigation case.

Validation: router-core and react-router unit, type, and lint targets passed locally, as did all five pathless-layout Chromium tests. CodSpeed reports are known to be unstable and are not used to assess this change.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [ ] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved navigation from not-found pages so route context and boundary UI remain available while destination data loads.
  - Cleared outdated not-found states when returning to valid routes, including nested layout scenarios.
  - Preserved the correct committed not-found boundary during deeper route transitions.
  - Prevented unnecessary loading-state flicker during hydration and navigation.

- **Tests**
  - Added regression coverage for hydrated, nested, and asynchronous navigation scenarios.

- **Release**
  - Included patch updates for React, Solid, Vue, and core router packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->