### PR TITLE
fix: preserve shouldThrow in route-scoped hooks

### DIFF
--- a/.changeset/route-scoped-use-match-should-throw.md
+++ b/.changeset/route-scoped-use-match-should-throw.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/react-router": patch
+---
+
+Fix route-scoped useMatch APIs to forward the shouldThrow option.

--- a/.changeset/route-scoped-use-match-should-throw.md
+++ b/.changeset/route-scoped-use-match-should-throw.md
@@ -1,5 +1,5 @@
 ---
-"@tanstack/react-router": patch
+'@tanstack/react-router': patch
 ---
 
 Fix route-scoped useMatch APIs to forward the shouldThrow option.

--- a/.changeset/route-scoped-use-match-should-throw.md
+++ b/.changeset/route-scoped-use-match-should-throw.md
@@ -1,5 +1,7 @@
 ---
 '@tanstack/react-router': patch
+'@tanstack/solid-router': patch
+'@tanstack/vue-router': patch
 ---
 
-Fix route-scoped useMatch APIs to forward the shouldThrow option.
+Fix route-scoped `useMatch`, `useSearch`, and `useParams` APIs to forward the `shouldThrow` option and preserve optional return types when `shouldThrow: false`.

--- a/packages/react-router/src/fileRoute.ts
+++ b/packages/react-router/src/fileRoute.ts
@@ -221,6 +221,7 @@ export class LazyRoute<TRoute extends AnyRoute> {
     return useMatch({
       select: opts?.select,
       from: this.options.id,
+      shouldThrow: opts?.shouldThrow,
       structuralSharing: opts?.structuralSharing,
     } as any) as any
   }

--- a/packages/react-router/src/fileRoute.ts
+++ b/packages/react-router/src/fileRoute.ts
@@ -218,12 +218,7 @@ export class LazyRoute<TRoute extends AnyRoute> {
   }
 
   useMatch: UseMatchRoute<TRoute['id']> = (opts) => {
-    return useMatch({
-      select: opts?.select,
-      from: this.options.id,
-      shouldThrow: opts?.shouldThrow,
-      structuralSharing: opts?.structuralSharing,
-    } as any) as any
+    return useMatch({ ...opts, from: this.options.id } as any) as any
   }
 
   useRouteContext: UseRouteContextRoute<TRoute['id']> = (opts) => {
@@ -231,21 +226,11 @@ export class LazyRoute<TRoute extends AnyRoute> {
   }
 
   useSearch: UseSearchRoute<TRoute['id']> = (opts) => {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    return useSearch({
-      select: opts?.select,
-      structuralSharing: opts?.structuralSharing,
-      from: this.options.id,
-    } as any) as any
+    return useSearch({ ...opts, from: this.options.id } as any)
   }
 
   useParams: UseParamsRoute<TRoute['id']> = (opts) => {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    return useParams({
-      select: opts?.select,
-      structuralSharing: opts?.structuralSharing,
-      from: this.options.id,
-    } as any) as any
+    return useParams({ ...opts, from: this.options.id } as any)
   }
 
   useLoaderDeps: UseLoaderDepsRoute<TRoute['id']> = (opts) => {

--- a/packages/react-router/src/route.tsx
+++ b/packages/react-router/src/route.tsx
@@ -110,6 +110,7 @@ export class RouteApi<
     return useMatch({
       select: opts?.select,
       from: this.id,
+      shouldThrow: opts?.shouldThrow,
       structuralSharing: opts?.structuralSharing,
     } as any) as any
   }
@@ -264,6 +265,7 @@ export class Route<
     return useMatch({
       select: opts?.select,
       from: this.id,
+      shouldThrow: opts?.shouldThrow,
       structuralSharing: opts?.structuralSharing,
     } as any) as any
   }
@@ -535,6 +537,7 @@ export class RootRoute<
     return useMatch({
       select: opts?.select,
       from: this.id,
+      shouldThrow: opts?.shouldThrow,
       structuralSharing: opts?.structuralSharing,
     } as any) as any
   }

--- a/packages/react-router/src/route.tsx
+++ b/packages/react-router/src/route.tsx
@@ -107,12 +107,7 @@ export class RouteApi<
   }
 
   useMatch: UseMatchRoute<TId> = (opts) => {
-    return useMatch({
-      select: opts?.select,
-      from: this.id,
-      shouldThrow: opts?.shouldThrow,
-      structuralSharing: opts?.structuralSharing,
-    } as any) as any
+    return useMatch({ ...opts, from: this.id } as any) as any
   }
 
   useRouteContext: UseRouteContextRoute<TId> = (opts) => {
@@ -120,21 +115,11 @@ export class RouteApi<
   }
 
   useSearch: UseSearchRoute<TId> = (opts) => {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    return useSearch({
-      select: opts?.select,
-      structuralSharing: opts?.structuralSharing,
-      from: this.id,
-    } as any) as any
+    return useSearch({ ...opts, from: this.id } as any)
   }
 
   useParams: UseParamsRoute<TId> = (opts) => {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    return useParams({
-      select: opts?.select,
-      structuralSharing: opts?.structuralSharing,
-      from: this.id,
-    } as any) as any
+    return useParams({ ...opts, from: this.id } as any)
   }
 
   useLoaderDeps: UseLoaderDepsRoute<TId> = (opts) => {
@@ -262,12 +247,7 @@ export class Route<
   }
 
   useMatch: UseMatchRoute<TId> = (opts) => {
-    return useMatch({
-      select: opts?.select,
-      from: this.id,
-      shouldThrow: opts?.shouldThrow,
-      structuralSharing: opts?.structuralSharing,
-    } as any) as any
+    return useMatch({ ...opts, from: this.id } as any) as any
   }
 
   useRouteContext: UseRouteContextRoute<TId> = (opts?) => {
@@ -275,21 +255,11 @@ export class Route<
   }
 
   useSearch: UseSearchRoute<TId> = (opts) => {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    return useSearch({
-      select: opts?.select,
-      structuralSharing: opts?.structuralSharing,
-      from: this.id,
-    } as any) as any
+    return useSearch({ ...opts, from: this.id } as any)
   }
 
   useParams: UseParamsRoute<TId> = (opts) => {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    return useParams({
-      select: opts?.select,
-      structuralSharing: opts?.structuralSharing,
-      from: this.id,
-    } as any) as any
+    return useParams({ ...opts, from: this.id } as any)
   }
 
   useLoaderDeps: UseLoaderDepsRoute<TId> = (opts) => {
@@ -534,12 +504,7 @@ export class RootRoute<
   }
 
   useMatch: UseMatchRoute<RootRouteId> = (opts) => {
-    return useMatch({
-      select: opts?.select,
-      from: this.id,
-      shouldThrow: opts?.shouldThrow,
-      structuralSharing: opts?.structuralSharing,
-    } as any) as any
+    return useMatch({ ...opts, from: this.id } as any) as any
   }
 
   useRouteContext: UseRouteContextRoute<RootRouteId> = (opts) => {
@@ -547,21 +512,11 @@ export class RootRoute<
   }
 
   useSearch: UseSearchRoute<RootRouteId> = (opts) => {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    return useSearch({
-      select: opts?.select,
-      structuralSharing: opts?.structuralSharing,
-      from: this.id,
-    } as any) as any
+    return useSearch({ ...opts, from: this.id } as any)
   }
 
   useParams: UseParamsRoute<RootRouteId> = (opts) => {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    return useParams({
-      select: opts?.select,
-      structuralSharing: opts?.structuralSharing,
-      from: this.id,
-    } as any) as any
+    return useParams({ ...opts, from: this.id } as any)
   }
 
   useLoaderDeps: UseLoaderDepsRoute<RootRouteId> = (opts) => {

--- a/packages/react-router/src/useMatch.tsx
+++ b/packages/react-router/src/useMatch.tsx
@@ -79,17 +79,18 @@ export type UseMatchRoute<out TFrom> = <
   TRouter extends AnyRouter = RegisteredRouter,
   TSelected = unknown,
   TStructuralSharing extends boolean = boolean,
+  TThrow extends boolean = true,
 >(
   opts?: UseMatchBaseOptions<
     TRouter,
     TFrom,
     true,
-    true,
+    TThrow,
     TSelected,
     TStructuralSharing
   > &
     StructuralSharingOption<TRouter, TSelected, TStructuralSharing>,
-) => UseMatchResult<TRouter, TFrom, true, TSelected>
+) => ThrowOrOptional<UseMatchResult<TRouter, TFrom, true, TSelected>, TThrow>
 
 export type UseMatchOptions<
   TRouter extends AnyRouter,

--- a/packages/react-router/src/useParams.tsx
+++ b/packages/react-router/src/useParams.tsx
@@ -49,17 +49,18 @@ export type UseParamsRoute<out TFrom> = <
   TRouter extends AnyRouter = RegisteredRouter,
   TSelected = unknown,
   TStructuralSharing extends boolean = boolean,
+  TThrow extends boolean = true,
 >(
   opts?: UseParamsBaseOptions<
     TRouter,
     TFrom,
     /* TStrict */ true,
-    /* TThrow */ true,
+    TThrow,
     TSelected,
     TStructuralSharing
   > &
     StructuralSharingOption<TRouter, TSelected, TStructuralSharing>,
-) => UseParamsResult<TRouter, TFrom, true, TSelected>
+) => ThrowOrOptional<UseParamsResult<TRouter, TFrom, true, TSelected>, TThrow>
 
 /**
  * Access the current route's path parameters with type-safety.

--- a/packages/react-router/src/useSearch.tsx
+++ b/packages/react-router/src/useSearch.tsx
@@ -49,17 +49,18 @@ export type UseSearchRoute<out TFrom> = <
   TRouter extends AnyRouter = RegisteredRouter,
   TSelected = unknown,
   TStructuralSharing extends boolean = boolean,
+  TThrow extends boolean = true,
 >(
   opts?: UseSearchBaseOptions<
     TRouter,
     TFrom,
     /* TStrict */ true,
-    /* TThrow */ true,
+    TThrow,
     TSelected,
     TStructuralSharing
   > &
     StructuralSharingOption<TRouter, TSelected, TStructuralSharing>,
-) => UseSearchResult<TRouter, TFrom, true, TSelected>
+) => ThrowOrOptional<UseSearchResult<TRouter, TFrom, true, TSelected>, TThrow>
 
 /**
  * Read and select the current route's search parameters with type-safety.

--- a/packages/react-router/tests/routeApi.test-d.tsx
+++ b/packages/react-router/tests/routeApi.test-d.tsx
@@ -87,6 +87,25 @@ describe('getRouteApi', () => {
     expectTypeOf(invoiceRouteApi.useMatch<DefaultRouter>()).toEqualTypeOf<
       MakeRouteMatch<typeof routeTree, '/invoices/$invoiceId'>
     >()
+
+    expectTypeOf(
+      invoiceRouteApi.useMatch<DefaultRouter>({ shouldThrow: true }),
+    ).toEqualTypeOf<MakeRouteMatch<typeof routeTree, '/invoices/$invoiceId'>>()
+
+    expectTypeOf(
+      invoiceRouteApi.useMatch<DefaultRouter, unknown, boolean, false>({
+        shouldThrow: false,
+      }),
+    ).toEqualTypeOf<
+      MakeRouteMatch<typeof routeTree, '/invoices/$invoiceId'> | undefined
+    >()
+
+    expectTypeOf(
+      invoiceRouteApi.useMatch<DefaultRouter, string, boolean, false>({
+        shouldThrow: false,
+        select: (match) => match.params.invoiceId,
+      }),
+    ).toEqualTypeOf<string | undefined>()
   })
   test('Link', () => {
     const Link = invoiceRouteApi.Link

--- a/packages/react-router/tests/routeApi.test-d.tsx
+++ b/packages/react-router/tests/routeApi.test-d.tsx
@@ -60,6 +60,12 @@ describe('getRouteApi', () => {
     expectTypeOf(invoiceRouteApi.useParams<DefaultRouter>()).toEqualTypeOf<{
       invoiceId: string
     }>()
+
+    expectTypeOf(
+      invoiceRouteApi.useParams<DefaultRouter, unknown, boolean, false>({
+        shouldThrow: false,
+      }),
+    ).toEqualTypeOf<{ invoiceId: string } | undefined>()
   })
   test('useContext', () => {
     expectTypeOf(
@@ -72,6 +78,12 @@ describe('getRouteApi', () => {
     expectTypeOf(invoiceRouteApi.useSearch<DefaultRouter>()).toEqualTypeOf<{
       page: number
     }>()
+
+    expectTypeOf(
+      invoiceRouteApi.useSearch<DefaultRouter, unknown, boolean, false>({
+        shouldThrow: false,
+      }),
+    ).toEqualTypeOf<{ page: number } | undefined>()
   })
   test('useLoaderData', () => {
     expectTypeOf(invoiceRouteApi.useLoaderData<DefaultRouter>()).toEqualTypeOf<{

--- a/packages/react-router/tests/routeScopedShouldThrow.test.tsx
+++ b/packages/react-router/tests/routeScopedShouldThrow.test.tsx
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  getRouteApi,
+} from '../src'
+import type { RouteComponent, RouterHistory } from '../src'
+
+afterEach(() => {
+  window.history.replaceState(null, 'root', '/')
+  cleanup()
+})
+
+function createPostsRouter(
+  RootComponent: RouteComponent,
+  history?: RouterHistory,
+) {
+  const rootRoute = createRootRoute({
+    component: RootComponent,
+  })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <h1>IndexTitle</h1>,
+  })
+  const postsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/posts/$postId',
+    validateSearch: () => ({ page: 0 }),
+    component: () => <h1>PostsTitle</h1>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute, postsRoute]),
+    history: history ?? createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  return { postsRoute, router }
+}
+
+describe('Route.useSearch', () => {
+  test('returns undefined when the target route is inactive and shouldThrow is false', async () => {
+    const route = {} as {
+      current: ReturnType<typeof createPostsRouter>['postsRoute']
+    }
+
+    function RootComponent() {
+      const search = route.current.useSearch({ shouldThrow: false })
+      expect(search).toBeUndefined()
+      return <Outlet />
+    }
+
+    const created = createPostsRouter(RootComponent)
+    route.current = created.postsRoute
+    render(<RouterProvider router={created.router} />)
+    expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
+  })
+
+  test.each([undefined, true])(
+    'throws when the target route is inactive and shouldThrow is %s',
+    async (shouldThrow) => {
+      const route = {} as {
+        current: ReturnType<typeof createPostsRouter>['postsRoute']
+      }
+
+      function RootComponent() {
+        route.current.useSearch({ shouldThrow })
+        return <Outlet />
+      }
+
+      const created = createPostsRouter(RootComponent)
+      route.current = created.postsRoute
+      render(<RouterProvider router={created.router} />)
+      const postsError = await screen.findByText(
+        'Invariant failed: Could not find an active match from "/posts/$postId"',
+      )
+      expect(postsError).toBeInTheDocument()
+    },
+  )
+})
+
+describe('Route.useParams', () => {
+  test('returns undefined when the target route is inactive and shouldThrow is false', async () => {
+    const route = {} as {
+      current: ReturnType<typeof createPostsRouter>['postsRoute']
+    }
+
+    function RootComponent() {
+      const params = route.current.useParams({ shouldThrow: false })
+      expect(params).toBeUndefined()
+      return <Outlet />
+    }
+
+    const created = createPostsRouter(RootComponent)
+    route.current = created.postsRoute
+    render(<RouterProvider router={created.router} />)
+    expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
+  })
+
+  test.each([undefined, true])(
+    'throws when the target route is inactive and shouldThrow is %s',
+    async (shouldThrow) => {
+      const route = {} as {
+        current: ReturnType<typeof createPostsRouter>['postsRoute']
+      }
+
+      function RootComponent() {
+        route.current.useParams({ shouldThrow })
+        return <Outlet />
+      }
+
+      const created = createPostsRouter(RootComponent)
+      route.current = created.postsRoute
+      render(<RouterProvider router={created.router} />)
+      const postsError = await screen.findByText(
+        'Invariant failed: Could not find an active match from "/posts/$postId"',
+      )
+      expect(postsError).toBeInTheDocument()
+    },
+  )
+})
+
+describe('RouteApi.useSearch', () => {
+  test('returns undefined when the target route is inactive and shouldThrow is false', async () => {
+    const postsRouteApi = getRouteApi('/posts/$postId')
+
+    function RootComponent() {
+      const search = postsRouteApi.useSearch({ shouldThrow: false })
+      expect(search).toBeUndefined()
+      return <Outlet />
+    }
+
+    const created = createPostsRouter(RootComponent)
+    render(<RouterProvider router={created.router} />)
+    expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
+  })
+})
+
+describe('RouteApi.useParams', () => {
+  test('returns undefined when the target route is inactive and shouldThrow is false', async () => {
+    const postsRouteApi = getRouteApi('/posts/$postId')
+
+    function RootComponent() {
+      const params = postsRouteApi.useParams({ shouldThrow: false })
+      expect(params).toBeUndefined()
+      return <Outlet />
+    }
+
+    const created = createPostsRouter(RootComponent)
+    render(<RouterProvider router={created.router} />)
+    expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
+  })
+})

--- a/packages/react-router/tests/routeScopedShouldThrow.test.tsx
+++ b/packages/react-router/tests/routeScopedShouldThrow.test.tsx
@@ -1,157 +1,76 @@
-import { afterEach, describe, expect, test } from 'vitest'
+import { afterEach, expect, test } from 'vitest'
 import { cleanup, render, screen } from '@testing-library/react'
 import {
   Outlet,
   RouterProvider,
+  createLazyRoute,
   createMemoryHistory,
   createRootRoute,
   createRoute,
   createRouter,
   getRouteApi,
 } from '../src'
-import type { RouteComponent, RouterHistory } from '../src'
 
 afterEach(() => {
   window.history.replaceState(null, 'root', '/')
   cleanup()
 })
 
-function createPostsRouter(
-  RootComponent: RouteComponent,
-  history?: RouterHistory,
-) {
+test('route-scoped hooks render undefined for an inactive route when shouldThrow is false', async () => {
   const rootRoute = createRootRoute({
-    component: RootComponent,
-  })
-  const indexRoute = createRoute({
-    getParentRoute: () => rootRoute,
-    path: '/',
-    component: () => <h1>IndexTitle</h1>,
+    component: Outlet,
   })
   const postsRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/posts/$postId',
     validateSearch: () => ({ page: 0 }),
-    component: () => <h1>PostsTitle</h1>,
+  })
+  const postsRouteApi = getRouteApi('/posts/$postId')
+  const lazyPostsRoute = createLazyRoute('/posts/$postId')({})
+
+  function IndexComponent() {
+    const routeMatch = postsRoute.useMatch({ shouldThrow: false })
+    const routeSearch = postsRoute.useSearch({ shouldThrow: false })
+    const routeParams = postsRoute.useParams({ shouldThrow: false })
+    const routeApiMatch = postsRouteApi.useMatch({ shouldThrow: false })
+    const routeApiSearch = postsRouteApi.useSearch({ shouldThrow: false })
+    const routeApiParams = postsRouteApi.useParams({ shouldThrow: false })
+    const lazyRouteMatch = lazyPostsRoute.useMatch({ shouldThrow: false })
+    const lazyRouteSearch = lazyPostsRoute.useSearch({ shouldThrow: false })
+    const lazyRouteParams = lazyPostsRoute.useParams({ shouldThrow: false })
+
+    return (
+      <>
+        <div data-testid="route-use-match">{String(routeMatch)}</div>
+        <div data-testid="route-use-search">{String(routeSearch)}</div>
+        <div data-testid="route-use-params">{String(routeParams)}</div>
+        <div data-testid="route-api-use-match">{String(routeApiMatch)}</div>
+        <div data-testid="route-api-use-search">{String(routeApiSearch)}</div>
+        <div data-testid="route-api-use-params">{String(routeApiParams)}</div>
+        <div data-testid="lazy-route-use-match">{String(lazyRouteMatch)}</div>
+        <div data-testid="lazy-route-use-search">{String(lazyRouteSearch)}</div>
+        <div data-testid="lazy-route-use-params">{String(lazyRouteParams)}</div>
+      </>
+    )
+  }
+
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: IndexComponent,
   })
   const router = createRouter({
     routeTree: rootRoute.addChildren([indexRoute, postsRoute]),
-    history: history ?? createMemoryHistory({ initialEntries: ['/'] }),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
   })
 
-  return { postsRoute, router }
-}
+  render(<RouterProvider router={router} />)
 
-describe('Route.useSearch', () => {
-  test('returns undefined when the target route is inactive and shouldThrow is false', async () => {
-    const route = {} as {
-      current: ReturnType<typeof createPostsRouter>['postsRoute']
-    }
-
-    function RootComponent() {
-      const search = route.current.useSearch({ shouldThrow: false })
-      expect(search).toBeUndefined()
-      return <Outlet />
-    }
-
-    const created = createPostsRouter(RootComponent)
-    route.current = created.postsRoute
-    render(<RouterProvider router={created.router} />)
-    expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
-  })
-
-  test.each([undefined, true])(
-    'throws when the target route is inactive and shouldThrow is %s',
-    async (shouldThrow) => {
-      const route = {} as {
-        current: ReturnType<typeof createPostsRouter>['postsRoute']
-      }
-
-      function RootComponent() {
-        route.current.useSearch({ shouldThrow })
-        return <Outlet />
-      }
-
-      const created = createPostsRouter(RootComponent)
-      route.current = created.postsRoute
-      render(<RouterProvider router={created.router} />)
-      const postsError = await screen.findByText(
-        'Invariant failed: Could not find an active match from "/posts/$postId"',
+  for (const scope of ['route', 'route-api', 'lazy-route']) {
+    for (const hook of ['use-match', 'use-search', 'use-params']) {
+      expect(await screen.findByTestId(`${scope}-${hook}`)).toHaveTextContent(
+        'undefined',
       )
-      expect(postsError).toBeInTheDocument()
-    },
-  )
-})
-
-describe('Route.useParams', () => {
-  test('returns undefined when the target route is inactive and shouldThrow is false', async () => {
-    const route = {} as {
-      current: ReturnType<typeof createPostsRouter>['postsRoute']
     }
-
-    function RootComponent() {
-      const params = route.current.useParams({ shouldThrow: false })
-      expect(params).toBeUndefined()
-      return <Outlet />
-    }
-
-    const created = createPostsRouter(RootComponent)
-    route.current = created.postsRoute
-    render(<RouterProvider router={created.router} />)
-    expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
-  })
-
-  test.each([undefined, true])(
-    'throws when the target route is inactive and shouldThrow is %s',
-    async (shouldThrow) => {
-      const route = {} as {
-        current: ReturnType<typeof createPostsRouter>['postsRoute']
-      }
-
-      function RootComponent() {
-        route.current.useParams({ shouldThrow })
-        return <Outlet />
-      }
-
-      const created = createPostsRouter(RootComponent)
-      route.current = created.postsRoute
-      render(<RouterProvider router={created.router} />)
-      const postsError = await screen.findByText(
-        'Invariant failed: Could not find an active match from "/posts/$postId"',
-      )
-      expect(postsError).toBeInTheDocument()
-    },
-  )
-})
-
-describe('RouteApi.useSearch', () => {
-  test('returns undefined when the target route is inactive and shouldThrow is false', async () => {
-    const postsRouteApi = getRouteApi('/posts/$postId')
-
-    function RootComponent() {
-      const search = postsRouteApi.useSearch({ shouldThrow: false })
-      expect(search).toBeUndefined()
-      return <Outlet />
-    }
-
-    const created = createPostsRouter(RootComponent)
-    render(<RouterProvider router={created.router} />)
-    expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
-  })
-})
-
-describe('RouteApi.useParams', () => {
-  test('returns undefined when the target route is inactive and shouldThrow is false', async () => {
-    const postsRouteApi = getRouteApi('/posts/$postId')
-
-    function RootComponent() {
-      const params = postsRouteApi.useParams({ shouldThrow: false })
-      expect(params).toBeUndefined()
-      return <Outlet />
-    }
-
-    const created = createPostsRouter(RootComponent)
-    render(<RouterProvider router={created.router} />)
-    expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
-  })
+  }
 })

--- a/packages/react-router/tests/useMatch.test.tsx
+++ b/packages/react-router/tests/useMatch.test.tsx
@@ -14,6 +14,7 @@ import {
   createRootRoute,
   createRoute,
   createRouter,
+  getRouteApi,
   useMatch,
 } from '../src'
 import type { RouteComponent, RouterHistory } from '../src'
@@ -286,5 +287,121 @@ describe('useMatch', () => {
         expect(select).not.toHaveBeenCalled()
       })
     })
+  })
+})
+
+describe('Route.useMatch', () => {
+  function createPostsRouter(
+    RootComponent: RouteComponent,
+    history?: RouterHistory,
+  ) {
+    const rootRoute = createRootRoute({
+      component: RootComponent,
+    })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => <h1>IndexTitle</h1>,
+    })
+    const postsRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/posts',
+      component: () => <h1>PostsTitle</h1>,
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, postsRoute]),
+      history: history ?? createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    return { postsRoute, router }
+  }
+
+  type PostsRoute = ReturnType<typeof createPostsRouter>['postsRoute']
+
+  test('returns undefined when the target route is inactive and shouldThrow is false', async () => {
+    const route = {} as { current: PostsRoute }
+
+    function RootComponent() {
+      const match = route.current.useMatch({ shouldThrow: false })
+      expect(match).toBeUndefined()
+      return <Outlet />
+    }
+
+    const created = createPostsRouter(RootComponent)
+    route.current = created.postsRoute
+    render(<RouterProvider router={created.router} />)
+    expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
+  })
+
+  test.each([undefined, true])(
+    'throws when the target route is inactive and shouldThrow is %s',
+    async (shouldThrow) => {
+      const route = {} as { current: PostsRoute }
+
+      function RootComponent() {
+        route.current.useMatch({ shouldThrow })
+        return <Outlet />
+      }
+
+      const created = createPostsRouter(RootComponent)
+      route.current = created.postsRoute
+      render(<RouterProvider router={created.router} />)
+      const postsError = await screen.findByText(
+        'Invariant failed: Could not find an active match from "/posts"',
+      )
+      expect(postsError).toBeInTheDocument()
+    },
+  )
+
+  test('returns the match when the target route is active and shouldThrow is false', async () => {
+    const route = {} as { current: PostsRoute }
+
+    function RootComponent() {
+      const match = route.current.useMatch({ shouldThrow: false })
+      expect(match).toBeDefined()
+      expect(match?.routeId).toBe('/posts')
+      return <Outlet />
+    }
+
+    const created = createPostsRouter(
+      RootComponent,
+      createMemoryHistory({ initialEntries: ['/posts'] }),
+    )
+    route.current = created.postsRoute
+    render(<RouterProvider router={created.router} />)
+    expect(await screen.findByText('PostsTitle')).toBeInTheDocument()
+  })
+})
+
+describe('RouteApi.useMatch', () => {
+  test('returns undefined when the target route is inactive and shouldThrow is false', async () => {
+    const postsRouteApi = getRouteApi('/posts')
+
+    function RootComponent() {
+      const match = postsRouteApi.useMatch({ shouldThrow: false })
+      expect(match).toBeUndefined()
+      return <Outlet />
+    }
+
+    const rootRoute = createRootRoute({
+      component: RootComponent,
+    })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => <h1>IndexTitle</h1>,
+    })
+    const postsRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/posts',
+      component: () => <h1>PostsTitle</h1>,
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, postsRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    render(<RouterProvider router={router} />)
+    expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
   })
 })

--- a/packages/react-router/tests/useMatch.test.tsx
+++ b/packages/react-router/tests/useMatch.test.tsx
@@ -14,7 +14,6 @@ import {
   createRootRoute,
   createRoute,
   createRouter,
-  getRouteApi,
   useMatch,
 } from '../src'
 import type { RouteComponent, RouterHistory } from '../src'
@@ -287,121 +286,5 @@ describe('useMatch', () => {
         expect(select).not.toHaveBeenCalled()
       })
     })
-  })
-})
-
-describe('Route.useMatch', () => {
-  function createPostsRouter(
-    RootComponent: RouteComponent,
-    history?: RouterHistory,
-  ) {
-    const rootRoute = createRootRoute({
-      component: RootComponent,
-    })
-    const indexRoute = createRoute({
-      getParentRoute: () => rootRoute,
-      path: '/',
-      component: () => <h1>IndexTitle</h1>,
-    })
-    const postsRoute = createRoute({
-      getParentRoute: () => rootRoute,
-      path: '/posts',
-      component: () => <h1>PostsTitle</h1>,
-    })
-    const router = createRouter({
-      routeTree: rootRoute.addChildren([indexRoute, postsRoute]),
-      history: history ?? createMemoryHistory({ initialEntries: ['/'] }),
-    })
-
-    return { postsRoute, router }
-  }
-
-  type PostsRoute = ReturnType<typeof createPostsRouter>['postsRoute']
-
-  test('returns undefined when the target route is inactive and shouldThrow is false', async () => {
-    const route = {} as { current: PostsRoute }
-
-    function RootComponent() {
-      const match = route.current.useMatch({ shouldThrow: false })
-      expect(match).toBeUndefined()
-      return <Outlet />
-    }
-
-    const created = createPostsRouter(RootComponent)
-    route.current = created.postsRoute
-    render(<RouterProvider router={created.router} />)
-    expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
-  })
-
-  test.each([undefined, true])(
-    'throws when the target route is inactive and shouldThrow is %s',
-    async (shouldThrow) => {
-      const route = {} as { current: PostsRoute }
-
-      function RootComponent() {
-        route.current.useMatch({ shouldThrow })
-        return <Outlet />
-      }
-
-      const created = createPostsRouter(RootComponent)
-      route.current = created.postsRoute
-      render(<RouterProvider router={created.router} />)
-      const postsError = await screen.findByText(
-        'Invariant failed: Could not find an active match from "/posts"',
-      )
-      expect(postsError).toBeInTheDocument()
-    },
-  )
-
-  test('returns the match when the target route is active and shouldThrow is false', async () => {
-    const route = {} as { current: PostsRoute }
-
-    function RootComponent() {
-      const match = route.current.useMatch({ shouldThrow: false })
-      expect(match).toBeDefined()
-      expect(match?.routeId).toBe('/posts')
-      return <Outlet />
-    }
-
-    const created = createPostsRouter(
-      RootComponent,
-      createMemoryHistory({ initialEntries: ['/posts'] }),
-    )
-    route.current = created.postsRoute
-    render(<RouterProvider router={created.router} />)
-    expect(await screen.findByText('PostsTitle')).toBeInTheDocument()
-  })
-})
-
-describe('RouteApi.useMatch', () => {
-  test('returns undefined when the target route is inactive and shouldThrow is false', async () => {
-    const postsRouteApi = getRouteApi('/posts')
-
-    function RootComponent() {
-      const match = postsRouteApi.useMatch({ shouldThrow: false })
-      expect(match).toBeUndefined()
-      return <Outlet />
-    }
-
-    const rootRoute = createRootRoute({
-      component: RootComponent,
-    })
-    const indexRoute = createRoute({
-      getParentRoute: () => rootRoute,
-      path: '/',
-      component: () => <h1>IndexTitle</h1>,
-    })
-    const postsRoute = createRoute({
-      getParentRoute: () => rootRoute,
-      path: '/posts',
-      component: () => <h1>PostsTitle</h1>,
-    })
-    const router = createRouter({
-      routeTree: rootRoute.addChildren([indexRoute, postsRoute]),
-      history: createMemoryHistory({ initialEntries: ['/'] }),
-    })
-
-    render(<RouterProvider router={router} />)
-    expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
   })
 })

--- a/packages/solid-router/src/fileRoute.ts
+++ b/packages/solid-router/src/fileRoute.ts
@@ -208,10 +208,7 @@ export class LazyRoute<TRoute extends AnyRoute> {
   }
 
   useMatch: UseMatchRoute<TRoute['id']> = (opts) => {
-    return useMatch({
-      select: opts?.select,
-      from: this.options.id,
-    } as any) as any
+    return useMatch({ ...opts, from: this.options.id } as any) as any
   }
 
   useRouteContext: UseRouteContextRoute<TRoute['id']> = (opts) => {
@@ -219,17 +216,11 @@ export class LazyRoute<TRoute extends AnyRoute> {
   }
 
   useSearch: UseSearchRoute<TRoute['id']> = (opts) => {
-    return useSearch({
-      select: opts?.select,
-      from: this.options.id,
-    } as any) as any
+    return useSearch({ ...opts, from: this.options.id } as any)
   }
 
   useParams: UseParamsRoute<TRoute['id']> = (opts) => {
-    return useParams({
-      select: opts?.select,
-      from: this.options.id,
-    } as any) as any
+    return useParams({ ...opts, from: this.options.id } as any)
   }
 
   useLoaderDeps: UseLoaderDepsRoute<TRoute['id']> = (opts) => {

--- a/packages/solid-router/src/route.tsx
+++ b/packages/solid-router/src/route.tsx
@@ -98,10 +98,7 @@ export class RouteApi<
   }
 
   useMatch: UseMatchRoute<TId> = (opts) => {
-    return useMatch({
-      select: opts?.select,
-      from: this.id,
-    } as any) as any
+    return useMatch({ ...opts, from: this.id } as any) as any
   }
 
   useRouteContext: UseRouteContextRoute<TId> = (opts) => {
@@ -109,17 +106,11 @@ export class RouteApi<
   }
 
   useSearch: UseSearchRoute<TId> = (opts) => {
-    return useSearch({
-      select: opts?.select,
-      from: this.id,
-    } as any) as any
+    return useSearch({ ...opts, from: this.id } as any)
   }
 
   useParams: UseParamsRoute<TId> = (opts) => {
-    return useParams({
-      select: opts?.select,
-      from: this.id,
-    } as any) as any
+    return useParams({ ...opts, from: this.id } as any)
   }
 
   useLoaderDeps: UseLoaderDepsRoute<TId> = (opts) => {
@@ -246,10 +237,7 @@ export class Route<
   }
 
   useMatch: UseMatchRoute<TId> = (opts) => {
-    return useMatch({
-      select: opts?.select,
-      from: this.id,
-    } as any) as any
+    return useMatch({ ...opts, from: this.id } as any) as any
   }
 
   useRouteContext: UseRouteContextRoute<TId> = (opts?) => {
@@ -257,17 +245,11 @@ export class Route<
   }
 
   useSearch: UseSearchRoute<TId> = (opts) => {
-    return useSearch({
-      select: opts?.select,
-      from: this.id,
-    } as any) as any
+    return useSearch({ ...opts, from: this.id } as any)
   }
 
   useParams: UseParamsRoute<TId> = (opts) => {
-    return useParams({
-      select: opts?.select,
-      from: this.id,
-    } as any) as any
+    return useParams({ ...opts, from: this.id } as any)
   }
 
   useLoaderDeps: UseLoaderDepsRoute<TId> = (opts) => {
@@ -484,10 +466,7 @@ export class RootRoute<
   }
 
   useMatch: UseMatchRoute<RootRouteId> = (opts) => {
-    return useMatch({
-      select: opts?.select,
-      from: this.id,
-    } as any) as any
+    return useMatch({ ...opts, from: this.id } as any) as any
   }
 
   useRouteContext: UseRouteContextRoute<RootRouteId> = (opts) => {
@@ -495,17 +474,11 @@ export class RootRoute<
   }
 
   useSearch: UseSearchRoute<RootRouteId> = (opts) => {
-    return useSearch({
-      select: opts?.select,
-      from: this.id,
-    } as any) as any
+    return useSearch({ ...opts, from: this.id } as any)
   }
 
   useParams: UseParamsRoute<RootRouteId> = (opts) => {
-    return useParams({
-      select: opts?.select,
-      from: this.id,
-    } as any) as any
+    return useParams({ ...opts, from: this.id } as any)
   }
 
   useLoaderDeps: UseLoaderDepsRoute<RootRouteId> = (opts) => {

--- a/packages/solid-router/src/useMatch.tsx
+++ b/packages/solid-router/src/useMatch.tsx
@@ -28,9 +28,12 @@ export interface UseMatchBaseOptions<
 export type UseMatchRoute<out TFrom> = <
   TRouter extends AnyRouter = RegisteredRouter,
   TSelected = unknown,
+  TThrow extends boolean = true,
 >(
-  opts?: UseMatchBaseOptions<TRouter, TFrom, true, true, TSelected>,
-) => Solid.Accessor<UseMatchResult<TRouter, TFrom, true, TSelected>>
+  opts?: UseMatchBaseOptions<TRouter, TFrom, true, TThrow, TSelected>,
+) => Solid.Accessor<
+  ThrowOrOptional<UseMatchResult<TRouter, TFrom, true, TSelected>, TThrow>
+>
 
 export type UseMatchOptions<
   TRouter extends AnyRouter,

--- a/packages/solid-router/src/useParams.tsx
+++ b/packages/solid-router/src/useParams.tsx
@@ -33,15 +33,18 @@ export type UseParamsOptions<
 export type UseParamsRoute<out TFrom> = <
   TRouter extends AnyRouter = RegisteredRouter,
   TSelected = unknown,
+  TThrow extends boolean = true,
 >(
   opts?: UseParamsBaseOptions<
     TRouter,
     TFrom,
     /* TStrict */ true,
-    /* TThrow */ true,
+    TThrow,
     TSelected
   >,
-) => Accessor<UseParamsResult<TRouter, TFrom, true, TSelected>>
+) => Accessor<
+  ThrowOrOptional<UseParamsResult<TRouter, TFrom, true, TSelected>, TThrow>
+>
 
 export function useParams<
   TRouter extends AnyRouter = RegisteredRouter,

--- a/packages/solid-router/src/useSearch.tsx
+++ b/packages/solid-router/src/useSearch.tsx
@@ -33,15 +33,18 @@ export type UseSearchOptions<
 export type UseSearchRoute<out TFrom> = <
   TRouter extends AnyRouter = RegisteredRouter,
   TSelected = unknown,
+  TThrow extends boolean = true,
 >(
   opts?: UseSearchBaseOptions<
     TRouter,
     TFrom,
     /* TStrict */ true,
-    /* TThrow */ true,
+    TThrow,
     TSelected
   >,
-) => Accessor<UseSearchResult<TRouter, TFrom, true, TSelected>>
+) => Accessor<
+  ThrowOrOptional<UseSearchResult<TRouter, TFrom, true, TSelected>, TThrow>
+>
 
 export function useSearch<
   TRouter extends AnyRouter = RegisteredRouter,

--- a/packages/solid-router/tests/routeApi.test-d.tsx
+++ b/packages/solid-router/tests/routeApi.test-d.tsx
@@ -63,6 +63,12 @@ describe('getRouteApi', () => {
         invoiceId: string
       }>
     >()
+
+    expectTypeOf(
+      invoiceRouteApi.useParams<DefaultRouter, unknown, false>({
+        shouldThrow: false,
+      }),
+    ).toEqualTypeOf<Accessor<{ invoiceId: string } | undefined>>()
   })
   test('useContext', () => {
     expectTypeOf(
@@ -79,6 +85,12 @@ describe('getRouteApi', () => {
         page: number
       }>
     >()
+
+    expectTypeOf(
+      invoiceRouteApi.useSearch<DefaultRouter, unknown, false>({
+        shouldThrow: false,
+      }),
+    ).toEqualTypeOf<Accessor<{ page: number } | undefined>>()
   })
   test('useLoaderData', () => {
     expectTypeOf(invoiceRouteApi.useLoaderData<DefaultRouter>()).toEqualTypeOf<
@@ -97,6 +109,16 @@ describe('getRouteApi', () => {
   test('useMatch', () => {
     expectTypeOf(invoiceRouteApi.useMatch<DefaultRouter>()).toEqualTypeOf<
       Accessor<MakeRouteMatch<typeof routeTree, '/invoices/$invoiceId'>>
+    >()
+
+    expectTypeOf(
+      invoiceRouteApi.useMatch<DefaultRouter, unknown, false>({
+        shouldThrow: false,
+      }),
+    ).toEqualTypeOf<
+      Accessor<
+        MakeRouteMatch<typeof routeTree, '/invoices/$invoiceId'> | undefined
+      >
     >()
   })
   test('Link', () => {

--- a/packages/solid-router/tests/routeScopedShouldThrow.test.tsx
+++ b/packages/solid-router/tests/routeScopedShouldThrow.test.tsx
@@ -1,91 +1,80 @@
-import { afterEach, describe, expect, test } from 'vitest'
+import { afterEach, expect, test } from 'vitest'
 import { cleanup, render, screen } from '@solidjs/testing-library'
 import {
   Outlet,
   RouterProvider,
+  createLazyRoute,
   createMemoryHistory,
   createRootRoute,
   createRoute,
   createRouter,
   getRouteApi,
 } from '../src'
-import type { RouteComponent, RouterHistory } from '../src'
 
 afterEach(() => {
   window.history.replaceState(null, 'root', '/')
   cleanup()
 })
 
-function createPostsRouter(
-  RootComponent: RouteComponent,
-  history?: RouterHistory,
-) {
+test('route-scoped hooks render undefined for an inactive route when shouldThrow is false', async () => {
   const rootRoute = createRootRoute({
-    component: RootComponent,
-  })
-  const indexRoute = createRoute({
-    getParentRoute: () => rootRoute,
-    path: '/',
-    component: () => <h1>IndexTitle</h1>,
+    component: Outlet,
   })
   const postsRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/posts/$postId',
     validateSearch: () => ({ page: 0 }),
-    component: () => <h1>PostsTitle</h1>,
+  })
+  const postsRouteApi = getRouteApi('/posts/$postId')
+  const lazyPostsRoute = createLazyRoute('/posts/$postId')({})
+
+  function IndexComponent() {
+    const routeMatch = postsRoute.useMatch({ shouldThrow: false })
+    const routeSearch = postsRoute.useSearch({ shouldThrow: false })
+    const routeParams = postsRoute.useParams({ shouldThrow: false })
+    const routeApiMatch = postsRouteApi.useMatch({ shouldThrow: false })
+    const routeApiSearch = postsRouteApi.useSearch({ shouldThrow: false })
+    const routeApiParams = postsRouteApi.useParams({ shouldThrow: false })
+    const lazyRouteMatch = lazyPostsRoute.useMatch({ shouldThrow: false })
+    const lazyRouteSearch = lazyPostsRoute.useSearch({ shouldThrow: false })
+    const lazyRouteParams = lazyPostsRoute.useParams({ shouldThrow: false })
+
+    return (
+      <>
+        <div data-testid="route-use-match">{String(routeMatch())}</div>
+        <div data-testid="route-use-search">{String(routeSearch())}</div>
+        <div data-testid="route-use-params">{String(routeParams())}</div>
+        <div data-testid="route-api-use-match">{String(routeApiMatch())}</div>
+        <div data-testid="route-api-use-search">{String(routeApiSearch())}</div>
+        <div data-testid="route-api-use-params">{String(routeApiParams())}</div>
+        <div data-testid="lazy-route-use-match">{String(lazyRouteMatch())}</div>
+        <div data-testid="lazy-route-use-search">
+          {String(lazyRouteSearch())}
+        </div>
+        <div data-testid="lazy-route-use-params">
+          {String(lazyRouteParams())}
+        </div>
+      </>
+    )
+  }
+
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: IndexComponent,
   })
   const router = createRouter({
     routeTree: rootRoute.addChildren([indexRoute, postsRoute]),
-    history: history ?? createMemoryHistory({ initialEntries: ['/'] }),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
   })
 
-  return { postsRoute, router }
-}
+  render(() => <RouterProvider router={router} />)
 
-describe('RouteApi.useSearch', () => {
-  test('returns undefined when the target route is inactive and shouldThrow is false', async () => {
-    const postsRouteApi = getRouteApi('/posts/$postId')
-
-    function RootComponent() {
-      const search = postsRouteApi.useSearch({ shouldThrow: false })
-      expect(search()).toBeUndefined()
-      return <Outlet />
+  for (const scope of ['route', 'route-api', 'lazy-route']) {
+    for (const hook of ['use-match', 'use-search', 'use-params']) {
+      expect(await screen.findByTestId(`${scope}-${hook}`)).toHaveTextContent(
+        'undefined',
+      )
     }
-
-    const created = createPostsRouter(RootComponent)
-    render(() => <RouterProvider router={created.router} />)
-    expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
-  })
-})
-
-describe('RouteApi.useParams', () => {
-  test('returns undefined when the target route is inactive and shouldThrow is false', async () => {
-    const postsRouteApi = getRouteApi('/posts/$postId')
-
-    function RootComponent() {
-      const params = postsRouteApi.useParams({ shouldThrow: false })
-      expect(params()).toBeUndefined()
-      return <Outlet />
-    }
-
-    const created = createPostsRouter(RootComponent)
-    render(() => <RouterProvider router={created.router} />)
-    expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
-  })
-})
-
-describe('RouteApi.useMatch', () => {
-  test('returns undefined when the target route is inactive and shouldThrow is false', async () => {
-    const postsRouteApi = getRouteApi('/posts/$postId')
-
-    function RootComponent() {
-      const match = postsRouteApi.useMatch({ shouldThrow: false })
-      expect(match()).toBeUndefined()
-      return <Outlet />
-    }
-
-    const created = createPostsRouter(RootComponent)
-    render(() => <RouterProvider router={created.router} />)
-    expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
-  })
+  }
 })

--- a/packages/solid-router/tests/routeScopedShouldThrow.test.tsx
+++ b/packages/solid-router/tests/routeScopedShouldThrow.test.tsx
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import { cleanup, render, screen } from '@solidjs/testing-library'
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  getRouteApi,
+} from '../src'
+import type { RouteComponent, RouterHistory } from '../src'
+
+afterEach(() => {
+  window.history.replaceState(null, 'root', '/')
+  cleanup()
+})
+
+function createPostsRouter(
+  RootComponent: RouteComponent,
+  history?: RouterHistory,
+) {
+  const rootRoute = createRootRoute({
+    component: RootComponent,
+  })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <h1>IndexTitle</h1>,
+  })
+  const postsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/posts/$postId',
+    validateSearch: () => ({ page: 0 }),
+    component: () => <h1>PostsTitle</h1>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute, postsRoute]),
+    history: history ?? createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  return { postsRoute, router }
+}
+
+describe('RouteApi.useSearch', () => {
+  test('returns undefined when the target route is inactive and shouldThrow is false', async () => {
+    const postsRouteApi = getRouteApi('/posts/$postId')
+
+    function RootComponent() {
+      const search = postsRouteApi.useSearch({ shouldThrow: false })
+      expect(search()).toBeUndefined()
+      return <Outlet />
+    }
+
+    const created = createPostsRouter(RootComponent)
+    render(() => <RouterProvider router={created.router} />)
+    expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
+  })
+})
+
+describe('RouteApi.useParams', () => {
+  test('returns undefined when the target route is inactive and shouldThrow is false', async () => {
+    const postsRouteApi = getRouteApi('/posts/$postId')
+
+    function RootComponent() {
+      const params = postsRouteApi.useParams({ shouldThrow: false })
+      expect(params()).toBeUndefined()
+      return <Outlet />
+    }
+
+    const created = createPostsRouter(RootComponent)
+    render(() => <RouterProvider router={created.router} />)
+    expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
+  })
+})
+
+describe('RouteApi.useMatch', () => {
+  test('returns undefined when the target route is inactive and shouldThrow is false', async () => {
+    const postsRouteApi = getRouteApi('/posts/$postId')
+
+    function RootComponent() {
+      const match = postsRouteApi.useMatch({ shouldThrow: false })
+      expect(match()).toBeUndefined()
+      return <Outlet />
+    }
+
+    const created = createPostsRouter(RootComponent)
+    render(() => <RouterProvider router={created.router} />)
+    expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
+  })
+})

--- a/packages/vue-router/src/fileRoute.ts
+++ b/packages/vue-router/src/fileRoute.ts
@@ -208,10 +208,7 @@ export class LazyRoute<TRoute extends AnyRoute> {
   }
 
   useMatch: UseMatchRoute<TRoute['id']> = (opts) => {
-    return useMatch({
-      select: opts?.select,
-      from: this.options.id,
-    } as any) as any
+    return useMatch({ ...opts, from: this.options.id } as any) as any
   }
 
   useRouteContext: UseRouteContextRoute<TRoute['id']> = (opts) => {
@@ -219,17 +216,11 @@ export class LazyRoute<TRoute extends AnyRoute> {
   }
 
   useSearch: UseSearchRoute<TRoute['id']> = (opts) => {
-    return useSearch({
-      select: opts?.select,
-      from: this.options.id,
-    } as any) as any
+    return useSearch({ ...opts, from: this.options.id } as any)
   }
 
   useParams: UseParamsRoute<TRoute['id']> = (opts) => {
-    return useParams({
-      select: opts?.select,
-      from: this.options.id,
-    } as any) as any
+    return useParams({ ...opts, from: this.options.id } as any)
   }
 
   useLoaderDeps: UseLoaderDepsRoute<TRoute['id']> = (opts) => {

--- a/packages/vue-router/src/route.ts
+++ b/packages/vue-router/src/route.ts
@@ -99,10 +99,7 @@ export class RouteApi<
   }
 
   useMatch: UseMatchRoute<TId> = (opts) => {
-    return useMatch({
-      select: opts?.select,
-      from: this.id,
-    } as any) as any
+    return useMatch({ ...opts, from: this.id } as any) as any
   }
 
   useRouteContext: UseRouteContextRoute<TId> = (opts) => {
@@ -110,17 +107,11 @@ export class RouteApi<
   }
 
   useSearch: UseSearchRoute<TId> = (opts) => {
-    return useSearch({
-      select: opts?.select,
-      from: this.id,
-    } as any) as any
+    return useSearch({ ...opts, from: this.id } as any)
   }
 
   useParams: UseParamsRoute<TId> = (opts) => {
-    return useParams({
-      select: opts?.select,
-      from: this.id,
-    } as any) as any
+    return useParams({ ...opts, from: this.id } as any)
   }
 
   useLoaderDeps: UseLoaderDepsRoute<TId> = (opts) => {
@@ -252,10 +243,7 @@ export class Route<
   }
 
   useMatch: UseMatchRoute<TId> = (opts) => {
-    return useMatch({
-      select: opts?.select,
-      from: this.id,
-    } as any) as any
+    return useMatch({ ...opts, from: this.id } as any) as any
   }
 
   useRouteContext: UseRouteContextRoute<TId> = (opts?) => {
@@ -263,17 +251,11 @@ export class Route<
   }
 
   useSearch: UseSearchRoute<TId> = (opts) => {
-    return useSearch({
-      select: opts?.select,
-      from: this.id,
-    } as any) as any
+    return useSearch({ ...opts, from: this.id } as any)
   }
 
   useParams: UseParamsRoute<TId> = (opts) => {
-    return useParams({
-      select: opts?.select,
-      from: this.id,
-    } as any) as any
+    return useParams({ ...opts, from: this.id } as any)
   }
 
   useLoaderDeps: UseLoaderDepsRoute<TId> = (opts) => {
@@ -494,10 +476,7 @@ export class RootRoute<
   }
 
   useMatch: UseMatchRoute<RootRouteId> = (opts) => {
-    return useMatch({
-      select: opts?.select,
-      from: this.id,
-    } as any) as any
+    return useMatch({ ...opts, from: this.id } as any) as any
   }
 
   useRouteContext: UseRouteContextRoute<RootRouteId> = (opts) => {
@@ -505,17 +484,11 @@ export class RootRoute<
   }
 
   useSearch: UseSearchRoute<RootRouteId> = (opts) => {
-    return useSearch({
-      select: opts?.select,
-      from: this.id,
-    } as any) as any
+    return useSearch({ ...opts, from: this.id } as any)
   }
 
   useParams: UseParamsRoute<RootRouteId> = (opts) => {
-    return useParams({
-      select: opts?.select,
-      from: this.id,
-    } as any) as any
+    return useParams({ ...opts, from: this.id } as any)
   }
 
   useLoaderDeps: UseLoaderDepsRoute<RootRouteId> = (opts) => {

--- a/packages/vue-router/src/useMatch.tsx
+++ b/packages/vue-router/src/useMatch.tsx
@@ -30,9 +30,12 @@ export interface UseMatchBaseOptions<
 export type UseMatchRoute<out TFrom> = <
   TRouter extends AnyRouter = RegisteredRouter,
   TSelected = unknown,
+  TThrow extends boolean = true,
 >(
-  opts?: UseMatchBaseOptions<TRouter, TFrom, true, true, TSelected>,
-) => Vue.Ref<UseMatchResult<TRouter, TFrom, true, TSelected>>
+  opts?: UseMatchBaseOptions<TRouter, TFrom, true, TThrow, TSelected>,
+) => Vue.Ref<
+  ThrowOrOptional<UseMatchResult<TRouter, TFrom, true, TSelected>, TThrow>
+>
 
 export type UseMatchOptions<
   TRouter extends AnyRouter,

--- a/packages/vue-router/src/useParams.tsx
+++ b/packages/vue-router/src/useParams.tsx
@@ -33,15 +33,18 @@ export type UseParamsOptions<
 export type UseParamsRoute<out TFrom> = <
   TRouter extends AnyRouter = RegisteredRouter,
   TSelected = unknown,
+  TThrow extends boolean = true,
 >(
   opts?: UseParamsBaseOptions<
     TRouter,
     TFrom,
     /* TStrict */ true,
-    /* TThrow */ true,
+    TThrow,
     TSelected
   >,
-) => Vue.Ref<UseParamsResult<TRouter, TFrom, true, TSelected>>
+) => Vue.Ref<
+  ThrowOrOptional<UseParamsResult<TRouter, TFrom, true, TSelected>, TThrow>
+>
 
 export function useParams<
   TRouter extends AnyRouter = RegisteredRouter,

--- a/packages/vue-router/src/useSearch.tsx
+++ b/packages/vue-router/src/useSearch.tsx
@@ -33,15 +33,18 @@ export type UseSearchOptions<
 export type UseSearchRoute<out TFrom> = <
   TRouter extends AnyRouter = RegisteredRouter,
   TSelected = unknown,
+  TThrow extends boolean = true,
 >(
   opts?: UseSearchBaseOptions<
     TRouter,
     TFrom,
     /* TStrict */ true,
-    /* TThrow */ true,
+    TThrow,
     TSelected
   >,
-) => Vue.Ref<UseSearchResult<TRouter, TFrom, true, TSelected>>
+) => Vue.Ref<
+  ThrowOrOptional<UseSearchResult<TRouter, TFrom, true, TSelected>, TThrow>
+>
 
 export function useSearch<
   TRouter extends AnyRouter = RegisteredRouter,

--- a/packages/vue-router/tests/routeApi.test-d.tsx
+++ b/packages/vue-router/tests/routeApi.test-d.tsx
@@ -62,6 +62,12 @@ describe('getRouteApi', () => {
         invoiceId: string
       }>
     >()
+
+    expectTypeOf(
+      invoiceRouteApi.useParams<DefaultRouter, unknown, false>({
+        shouldThrow: false,
+      }),
+    ).toEqualTypeOf<Vue.Ref<{ invoiceId: string } | undefined>>()
   })
   test('useContext', () => {
     expectTypeOf(
@@ -78,6 +84,12 @@ describe('getRouteApi', () => {
         page: number
       }>
     >()
+
+    expectTypeOf(
+      invoiceRouteApi.useSearch<DefaultRouter, unknown, false>({
+        shouldThrow: false,
+      }),
+    ).toEqualTypeOf<Vue.Ref<{ page: number } | undefined>>()
   })
   test('useLoaderData', () => {
     expectTypeOf(invoiceRouteApi.useLoaderData<DefaultRouter>()).toEqualTypeOf<
@@ -96,6 +108,16 @@ describe('getRouteApi', () => {
   test('useMatch', () => {
     expectTypeOf(invoiceRouteApi.useMatch<DefaultRouter>()).toEqualTypeOf<
       Vue.Ref<MakeRouteMatch<typeof routeTree, '/invoices/$invoiceId'>>
+    >()
+
+    expectTypeOf(
+      invoiceRouteApi.useMatch<DefaultRouter, unknown, false>({
+        shouldThrow: false,
+      }),
+    ).toEqualTypeOf<
+      Vue.Ref<
+        MakeRouteMatch<typeof routeTree, '/invoices/$invoiceId'> | undefined
+      >
     >()
   })
 })

--- a/packages/vue-router/tests/routeScopedShouldThrow.test.tsx
+++ b/packages/vue-router/tests/routeScopedShouldThrow.test.tsx
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/vue'
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  getRouteApi,
+} from '../src'
+import type { RouteComponent, RouterHistory } from '../src'
+
+afterEach(() => {
+  window.history.replaceState(null, 'root', '/')
+  cleanup()
+})
+
+function createPostsRouter(
+  RootComponent: RouteComponent,
+  history?: RouterHistory,
+) {
+  const rootRoute = createRootRoute({
+    component: RootComponent,
+  })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <h1>IndexTitle</h1>,
+  })
+  const postsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/posts/$postId',
+    validateSearch: () => ({ page: 0 }),
+    component: () => <h1>PostsTitle</h1>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute, postsRoute]),
+    history: history ?? createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  return { postsRoute, router }
+}
+
+describe('RouteApi.useSearch', () => {
+  test('returns undefined when the target route is inactive and shouldThrow is false', async () => {
+    const postsRouteApi = getRouteApi('/posts/$postId')
+
+    function RootComponent() {
+      const search = postsRouteApi.useSearch({ shouldThrow: false })
+      expect(search.value).toBeUndefined()
+      return <Outlet />
+    }
+
+    const created = createPostsRouter(RootComponent)
+    render(<RouterProvider router={created.router} />)
+    expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
+  })
+})
+
+describe('RouteApi.useParams', () => {
+  test('returns undefined when the target route is inactive and shouldThrow is false', async () => {
+    const postsRouteApi = getRouteApi('/posts/$postId')
+
+    function RootComponent() {
+      const params = postsRouteApi.useParams({ shouldThrow: false })
+      expect(params.value).toBeUndefined()
+      return <Outlet />
+    }
+
+    const created = createPostsRouter(RootComponent)
+    render(<RouterProvider router={created.router} />)
+    expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
+  })
+})
+
+describe('RouteApi.useMatch', () => {
+  test('returns undefined when the target route is inactive and shouldThrow is false', async () => {
+    const postsRouteApi = getRouteApi('/posts/$postId')
+
+    function RootComponent() {
+      const match = postsRouteApi.useMatch({ shouldThrow: false })
+      expect(match.value).toBeUndefined()
+      return <Outlet />
+    }
+
+    const created = createPostsRouter(RootComponent)
+    render(<RouterProvider router={created.router} />)
+    expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
+  })
+})

--- a/packages/vue-router/tests/routeScopedShouldThrow.test.tsx
+++ b/packages/vue-router/tests/routeScopedShouldThrow.test.tsx
@@ -1,91 +1,88 @@
-import { afterEach, describe, expect, test } from 'vitest'
+import { afterEach, expect, test } from 'vitest'
 import { cleanup, render, screen } from '@testing-library/vue'
 import {
   Outlet,
   RouterProvider,
+  createLazyRoute,
   createMemoryHistory,
   createRootRoute,
   createRoute,
   createRouter,
   getRouteApi,
 } from '../src'
-import type { RouteComponent, RouterHistory } from '../src'
 
 afterEach(() => {
   window.history.replaceState(null, 'root', '/')
   cleanup()
 })
 
-function createPostsRouter(
-  RootComponent: RouteComponent,
-  history?: RouterHistory,
-) {
+test('route-scoped hooks render undefined for an inactive route when shouldThrow is false', async () => {
   const rootRoute = createRootRoute({
-    component: RootComponent,
-  })
-  const indexRoute = createRoute({
-    getParentRoute: () => rootRoute,
-    path: '/',
-    component: () => <h1>IndexTitle</h1>,
+    component: Outlet,
   })
   const postsRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/posts/$postId',
     validateSearch: () => ({ page: 0 }),
-    component: () => <h1>PostsTitle</h1>,
+  })
+  const postsRouteApi = getRouteApi('/posts/$postId')
+  const lazyPostsRoute = createLazyRoute('/posts/$postId')({})
+
+  function IndexComponent() {
+    const routeMatch = postsRoute.useMatch({ shouldThrow: false })
+    const routeSearch = postsRoute.useSearch({ shouldThrow: false })
+    const routeParams = postsRoute.useParams({ shouldThrow: false })
+    const routeApiMatch = postsRouteApi.useMatch({ shouldThrow: false })
+    const routeApiSearch = postsRouteApi.useSearch({ shouldThrow: false })
+    const routeApiParams = postsRouteApi.useParams({ shouldThrow: false })
+    const lazyRouteMatch = lazyPostsRoute.useMatch({ shouldThrow: false })
+    const lazyRouteSearch = lazyPostsRoute.useSearch({ shouldThrow: false })
+    const lazyRouteParams = lazyPostsRoute.useParams({ shouldThrow: false })
+
+    return (
+      <>
+        <div data-testid="route-use-match">{String(routeMatch.value)}</div>
+        <div data-testid="route-use-search">{String(routeSearch.value)}</div>
+        <div data-testid="route-use-params">{String(routeParams.value)}</div>
+        <div data-testid="route-api-use-match">
+          {String(routeApiMatch.value)}
+        </div>
+        <div data-testid="route-api-use-search">
+          {String(routeApiSearch.value)}
+        </div>
+        <div data-testid="route-api-use-params">
+          {String(routeApiParams.value)}
+        </div>
+        <div data-testid="lazy-route-use-match">
+          {String(lazyRouteMatch.value)}
+        </div>
+        <div data-testid="lazy-route-use-search">
+          {String(lazyRouteSearch.value)}
+        </div>
+        <div data-testid="lazy-route-use-params">
+          {String(lazyRouteParams.value)}
+        </div>
+      </>
+    )
+  }
+
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: IndexComponent,
   })
   const router = createRouter({
     routeTree: rootRoute.addChildren([indexRoute, postsRoute]),
-    history: history ?? createMemoryHistory({ initialEntries: ['/'] }),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
   })
 
-  return { postsRoute, router }
-}
+  render(<RouterProvider router={router} />)
 
-describe('RouteApi.useSearch', () => {
-  test('returns undefined when the target route is inactive and shouldThrow is false', async () => {
-    const postsRouteApi = getRouteApi('/posts/$postId')
-
-    function RootComponent() {
-      const search = postsRouteApi.useSearch({ shouldThrow: false })
-      expect(search.value).toBeUndefined()
-      return <Outlet />
+  for (const scope of ['route', 'route-api', 'lazy-route']) {
+    for (const hook of ['use-match', 'use-search', 'use-params']) {
+      expect(await screen.findByTestId(`${scope}-${hook}`)).toHaveTextContent(
+        'undefined',
+      )
     }
-
-    const created = createPostsRouter(RootComponent)
-    render(<RouterProvider router={created.router} />)
-    expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
-  })
-})
-
-describe('RouteApi.useParams', () => {
-  test('returns undefined when the target route is inactive and shouldThrow is false', async () => {
-    const postsRouteApi = getRouteApi('/posts/$postId')
-
-    function RootComponent() {
-      const params = postsRouteApi.useParams({ shouldThrow: false })
-      expect(params.value).toBeUndefined()
-      return <Outlet />
-    }
-
-    const created = createPostsRouter(RootComponent)
-    render(<RouterProvider router={created.router} />)
-    expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
-  })
-})
-
-describe('RouteApi.useMatch', () => {
-  test('returns undefined when the target route is inactive and shouldThrow is false', async () => {
-    const postsRouteApi = getRouteApi('/posts/$postId')
-
-    function RootComponent() {
-      const match = postsRouteApi.useMatch({ shouldThrow: false })
-      expect(match.value).toBeUndefined()
-      return <Outlet />
-    }
-
-    const created = createPostsRouter(RootComponent)
-    render(<RouterProvider router={created.router} />)
-    expect(await screen.findByText('IndexTitle')).toBeInTheDocument()
-  })
+  }
 })


### PR DESCRIPTION
## 🎯 Changes

Route-scoped `useMatch`, `useSearch`, and `useParams` wrappers were dropping `shouldThrow` when delegating to the standalone hooks. As a result, `shouldThrow: false` fell back to the default `true` behavior and threw when the target route was inactive.

This PR fixes that across **React, Solid, and Vue** by:

- forwarding all hook options via spread (`{ ...opts, from: this.id }`) in `RouteApi`, `Route`, `RootRoute`, and `LazyRoute`
- adding `TThrow` to route-scoped hook types so `shouldThrow: false` correctly returns `undefined` instead of being a type error
- adding runtime and type regression coverage for each framework

### Spread vs explicit forwarding

Compared corrected explicit forwarding against spread on `*.minimal` scenarios:

| Scenario | explicit (gzip) | spread (gzip) |
| --- | ---: | ---: |
| react-router.minimal | 85862 | 85865 |
| solid-router.minimal | 34005 | 33982 |
| vue-router.minimal | 50647 | 50627 |

Differences are negligible. Spread was chosen to avoid future option-forwarding omissions.

Fixes #8168
Fixes #3482

Related to #3642 — Overlaps with #3642, which previously explored `shouldThrow` support for route-scoped `useSearch` / `useParams`.

Related to #7331

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Route-scoped `useMatch`, `useSearch`, and `useParams` hooks now forward all supplied options.
  * Using `shouldThrow: false` correctly returns optional results, including `undefined` for inactive routes.
  * Type definitions now accurately reflect optional results across React, Solid, and Vue routers.

* **Bug Fixes**
  * Improved consistency for route, route API, and lazy route hooks across supported frameworks.

* **Tests**
  * Added coverage for optional return values and inactive-route behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->