### PR TITLE
fix(start): retry failed prerenders and fail the build on error

### DIFF
--- a/.changeset/prerender-retry-and-fail-on-error.md
+++ b/.changeset/prerender-retry-and-fail-on-error.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/start-plugin-core': patch
+---
+
+Fix prerendering so that `retryCount` actually retries a failed page, and a page that still fails with `failOnError` enabled now fails the build instead of exiting successfully.

--- a/packages/start-plugin-core/src/prerender.ts
+++ b/packages/start-plugin-core/src/prerender.ts
@@ -86,6 +86,7 @@ export async function prerender({
     const seen = new Set<string>()
     const prerendered = new Set<string>()
     const retriesByPath = new Map<string, number>()
+    const errors: Array<unknown> = []
     const concurrency = startConfig.prerender?.concurrency ?? os.cpus().length
     logger.info(`Concurrency: ${concurrency}`)
     const queue = new Queue({ concurrency })
@@ -106,6 +107,16 @@ export async function prerender({
 
     await queue.start()
 
+    if (errors.length > 0) {
+      if (errors.length === 1) {
+        throw errors[0]
+      }
+      throw new AggregateError(
+        errors,
+        `Prerendering failed for ${errors.length} pages`,
+      )
+    }
+
     return Array.from(prerendered)
 
     function addCrawlPageTask(page: Page) {
@@ -113,7 +124,7 @@ export async function prerender({
 
       seen.add(page.path)
 
-      if (page.fromCrawl) {
+      if (page.fromCrawl && !startConfig.pages.includes(page)) {
         startConfig.pages.push(page)
       }
 
@@ -219,9 +230,10 @@ export async function prerender({
             )
             await new Promise((resolve) => setTimeout(resolve, retryDelay))
             retriesByPath.set(page.path, retries + 1)
+            seen.delete(page.path)
             addCrawlPageTask(page)
           } else if (prerenderOptions.failOnError ?? true) {
-            throw error
+            errors.push(error)
           }
         }
       })

--- a/packages/start-plugin-core/tests/prerender-retry.test.ts
+++ b/packages/start-plugin-core/tests/prerender-retry.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from 'vitest'
+import { prerender } from '../src/prerender'
+
+vi.mock('../src/utils', async () => {
+  const actual = await vi.importActual<any>('../src/utils')
+  return {
+    ...actual,
+    createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {} }),
+  }
+})
+
+// Mock fs to prevent actual file system operations
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<any>('node:fs')
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      mkdir: vi.fn().mockResolvedValue(undefined),
+      writeFile: vi.fn().mockResolvedValue(undefined),
+    },
+  }
+})
+
+function okResponse() {
+  return new Response('<html></html>', {
+    status: 200,
+    headers: { 'content-type': 'text/html' },
+  })
+}
+
+function failResponse() {
+  return new Response('boom', { status: 500 })
+}
+
+function makeStartConfig(
+  pagePath: string,
+  prerenderOverrides: Record<string, unknown>,
+) {
+  return {
+    prerender: {
+      enabled: true,
+      autoStaticPathsDiscovery: false,
+      concurrency: 1,
+      crawlLinks: false,
+      retryDelay: 0,
+      ...prerenderOverrides,
+    },
+    pages: [{ path: pagePath }],
+    router: { basepath: '' },
+    spa: {
+      enabled: false,
+      prerender: {
+        outputPath: '/_shell',
+        crawlLinks: false,
+        retryCount: 0,
+        enabled: true,
+      },
+    },
+  } as any
+}
+
+describe('prerender retry and failOnError', () => {
+  it('retries a failing page up to retryCount times until it succeeds', async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(failResponse())
+      .mockResolvedValueOnce(failResponse())
+      .mockResolvedValue(okResponse())
+    const handler = { getClientOutputDirectory: () => '/client', request }
+    const startConfig = makeStartConfig('/flaky', {
+      retryCount: 2,
+      failOnError: true,
+    })
+
+    await expect(prerender({ startConfig, handler })).resolves.not.toThrow()
+    // 1 initial attempt + 2 retries, succeeding on the third
+    expect(request).toHaveBeenCalledTimes(3)
+  })
+
+  it('fails the build when a page fails and failOnError is set', async () => {
+    const request = vi.fn().mockResolvedValue(failResponse())
+    const handler = { getClientOutputDirectory: () => '/client', request }
+    const startConfig = makeStartConfig('/broken', {
+      retryCount: 0,
+      failOnError: true,
+    })
+
+    await expect(prerender({ startConfig, handler })).rejects.toThrow(
+      /Failed to fetch/,
+    )
+    expect(request).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries then fails the build when the page never recovers', async () => {
+    const request = vi.fn().mockResolvedValue(failResponse())
+    const handler = { getClientOutputDirectory: () => '/client', request }
+    const startConfig = makeStartConfig('/broken', {
+      retryCount: 2,
+      failOnError: true,
+    })
+
+    await expect(prerender({ startConfig, handler })).rejects.toThrow(
+      /Failed to fetch/,
+    )
+    // 1 initial attempt + 2 retries before giving up
+    expect(request).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not fail the build when failOnError is disabled', async () => {
+    const request = vi.fn().mockResolvedValue(failResponse())
+    const handler = { getClientOutputDirectory: () => '/client', request }
+    const startConfig = makeStartConfig('/broken', {
+      retryCount: 0,
+      failOnError: false,
+    })
+
+    await expect(prerender({ startConfig, handler })).resolves.not.toThrow()
+  })
+
+  it('records a retried crawled page only once', async () => {
+    let childAttempts = 0
+    const request = vi.fn((path: string) => {
+      if (path.includes('child')) {
+        childAttempts++
+        return Promise.resolve(
+          childAttempts === 1 ? failResponse() : okResponse(),
+        )
+      }
+      return Promise.resolve(
+        new Response('<html><a href="/child">child</a></html>', {
+          status: 200,
+          headers: { 'content-type': 'text/html' },
+        }),
+      )
+    })
+    const handler = { getClientOutputDirectory: () => '/client', request }
+    const startConfig = makeStartConfig('/', {
+      crawlLinks: true,
+      retryCount: 1,
+      failOnError: false,
+    })
+
+    await prerender({ startConfig, handler })
+
+    // The crawled page fails once and is retried, but must be recorded once.
+    const childEntries = startConfig.pages.filter(
+      (page: { path: string }) => page.path === '/child',
+    )
+    expect(childEntries).toHaveLength(1)
+  })
+
+  it('aggregates multiple page failures into an AggregateError', async () => {
+    const request = vi.fn().mockResolvedValue(failResponse())
+    const handler = { getClientOutputDirectory: () => '/client', request }
+    const startConfig = makeStartConfig('/a', {
+      retryCount: 0,
+      failOnError: true,
+    })
+    startConfig.pages = [{ path: '/a' }, { path: '/b' }]
+
+    let error: unknown
+    try {
+      await prerender({ startConfig, handler })
+    } catch (e) {
+      error = e
+    }
+
+    expect(error).toBeInstanceOf(AggregateError)
+    if (error instanceof AggregateError) {
+      expect(error.errors).toHaveLength(2)
+    }
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Fixes the two bugs reported in #8120 in the Start prerenderer (`packages/start-plugin-core/src/prerender.ts`), where a page whose loader throws is announced for a retry that never happens and the build still exits `0` with the page missing from the output.

**1. `retryCount` never retried.** On failure the retry called `addCrawlPageTask(page)`, but that function returns early when `seen.has(page.path)` is `true`, and the path was added to `seen` on the first attempt. The retry therefore did nothing. The path is now deleted from `seen` before re-queuing so the page is actually re-crawled.

**2. `failOnError` could not fail the build.** The queued task's `throw` rejected the promise returned by `queue.add(...)`, which is never awaited, so the rejection was orphaned. `Queue.start()` resolves via its `onSettled` callback regardless of task failures, so `await queue.start()` never saw the error and the build exited `0`. Page failures are now collected and rethrown after the queue settles: a single failure is rethrown as-is (preserving the original error and its `cause`), and multiple failures are wrapped in an `AggregateError`.

While fixing (1), the crawl-discovery push for `fromCrawl` pages is guarded so that retrying a crawled page does not record it twice in `startConfig.pages`, since that list feeds sitemap generation.

### Testing

Added `tests/prerender-retry.test.ts` covering:

- `retryCount` retries a failing page until it succeeds (asserts the attempt count is `retryCount + 1`).
- A page that keeps failing with `failOnError` enabled rejects the build.
- Retries are exhausted before the build is failed.
- `failOnError: false` does not fail the build.

The retry and `failOnError` assertions fail against the current code and pass with this change, matching the reproducer's described symptoms (one attempt instead of three, and a resolved build instead of a non-zero exit).

Verified locally: `pnpm nx run @tanstack/start-plugin-core:test:unit` (510 tests pass), `pnpm nx run @tanstack/start-plugin-core:test:types` (TypeScript 5.6 through 7.0), and `eslint ./src` all pass.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved prerendering so pages can be retried successfully after temporary failures.
  - Build processes now correctly fail when persistent prerendering errors occur and error handling is enabled.
  - Consolidated multiple prerendering failures for clearer error reporting.
  - Prevented duplicate pages from being added during crawling.
  - Preserved non-failing behavior when error enforcement is disabled.

- **Tests**
  - Added coverage for retries, exhausted retries, build failures, duplicate prevention, aggregated errors, and optional error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->