### PR TITLE
fix(solid-router): don't install intent-preload listeners when preloading is off

### DIFF
--- a/.changeset/solid-link-idle-preload-listeners.md
+++ b/.changeset/solid-link-idle-preload-listeners.md
@@ -6,7 +6,7 @@ Stop installing intent-preload listeners on `<Link>` when intent preloading is o
 
 `useLinkProps` handed out `onFocus`/`onBlur`/`onMouseEnter`/`onMouseLeave` (and the
 mouse-over/out/touch-start pair) unconditionally, with the `preload() !== 'intent'`
-check living *inside* each handler. Solid does not delegate `mouseenter`,
+check living _inside_ each handler. Solid does not delegate `mouseenter`,
 `mouseleave`, `focus` or `blur`, so every anchor installed four real listeners that
 did nothing but return — on a list view that is four per row (a 165-row board
 measured 660 listeners whose only job was to bail).

--- a/.changeset/solid-link-idle-preload-listeners.md
+++ b/.changeset/solid-link-idle-preload-listeners.md
@@ -1,0 +1,18 @@
+---
+'@tanstack/solid-router': patch
+---
+
+Stop installing intent-preload listeners on `<Link>` when intent preloading is off.
+
+`useLinkProps` handed out `onFocus`/`onBlur`/`onMouseEnter`/`onMouseLeave` (and the
+mouse-over/out/touch-start pair) unconditionally, with the `preload() !== 'intent'`
+check living *inside* each handler. Solid does not delegate `mouseenter`,
+`mouseleave`, `focus` or `blur`, so every anchor installed four real listeners that
+did nothing but return — on a list view that is four per row (a 165-row board
+measured 660 listeners whose only job was to bail).
+
+The handlers are now resolved through getters: with intent preloading off the
+property yields whatever the consumer passed (or `undefined`, which `spread()`
+treats as removal), and nothing is attached. Behaviour is unchanged — the getters
+stay reactive, so flipping `preload` back to `'intent'` re-runs the consuming
+spread and attaches the composed handler.

--- a/packages/solid-router/src/link.tsx
+++ b/packages/solid-router/src/link.tsx
@@ -522,13 +522,31 @@ export function useLinkProps<
 
   linkProps.ref = composedRef
   linkProps.onClick = onClick
-  linkProps.onBlur = onBlur
-  linkProps.onFocus = onFocus
-  linkProps.onMouseEnter = onMouseEnter
-  linkProps.onMouseOver = onMouseOver
-  linkProps.onMouseLeave = onMouseLeave
-  linkProps.onMouseOut = onMouseOut
-  linkProps.onTouchStart = onTouchStart
+
+  // Intent preloading is the only thing these handlers do, and each of them
+  // already bails at a `preload() !== 'intent'` gate. Handing them out anyway
+  // is not free: Solid does not delegate mouseenter/mouseleave/focus/blur, so
+  // every anchor installs four real listeners that exist only to return. On a
+  // list view — a table of rows, a calendar of spans — that is four listeners
+  // per row for no behaviour at all.
+  //
+  // So when intent preloading is off, the property resolves to whatever the
+  // user passed (or undefined), and spread()/assign() installs nothing. The
+  // getters keep this reactive: flipping `preload` back to 'intent' re-runs
+  // the consuming spread, which attaches the composed handler then.
+  const onIntent =
+    (composed: (event: any) => void, user: () => unknown) => () =>
+      preload() === 'intent' ? composed : user()
+
+  defineGetters({
+    onBlur: onIntent(onBlur, () => local.onBlur),
+    onFocus: onIntent(onFocus, () => local.onFocus),
+    onMouseEnter: onIntent(onMouseEnter, () => local.onMouseEnter),
+    onMouseOver: onIntent(onMouseOver, () => local.onMouseOver),
+    onMouseLeave: onIntent(onMouseLeave, () => local.onMouseLeave),
+    onMouseOut: onIntent(onMouseOut, () => local.onMouseOut),
+    onTouchStart: onIntent(onTouchStart, () => local.onTouchStart),
+  })
 
   defineGetters({
     href: () => hrefOption()?.href,

--- a/packages/solid-router/tests/link.test.tsx
+++ b/packages/solid-router/tests/link.test.tsx
@@ -4966,6 +4966,121 @@ describe('Link', () => {
     },
   )
 
+  test.each([false, 'viewport', 'render'] as const)(
+    'Router.preload="%s", Link should not install intent-preload listeners',
+    async (preload) => {
+      const addEventListener = vi.spyOn(
+        HTMLAnchorElement.prototype,
+        'addEventListener',
+      )
+
+      const rootRoute = createRootRoute()
+      const indexRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/',
+        component: () => (
+          <>
+            <h1>Index Heading</h1>
+            <Link to="/">Index Link</Link>
+          </>
+        ),
+      })
+
+      const router = createRouter({
+        routeTree: rootRoute.addChildren([indexRoute]),
+        defaultPreload: preload,
+      })
+
+      render(() => <RouterProvider router={router} />)
+
+      const indexLink = await screen.findByRole('link', { name: 'Index Link' })
+      expect(indexLink).toBeInTheDocument()
+
+      // mouseenter/mouseleave/focus/blur are not delegated by Solid, so every
+      // one of them is a real listener on the anchor.
+      const types = addEventListener.mock.calls.map(([type]) => type)
+      expect(types).not.toContain('mouseenter')
+      expect(types).not.toContain('mouseleave')
+      expect(types).not.toContain('focus')
+      expect(types).not.toContain('blur')
+
+      addEventListener.mockRestore()
+    },
+  )
+
+  test('Router.preload="intent", Link installs the intent-preload listeners', async () => {
+    const addEventListener = vi.spyOn(
+      HTMLAnchorElement.prototype,
+      'addEventListener',
+    )
+
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => (
+        <>
+          <h1>Index Heading</h1>
+          <Link to="/">Index Link</Link>
+        </>
+      ),
+    })
+
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute]),
+      defaultPreload: 'intent',
+    })
+
+    render(() => <RouterProvider router={router} />)
+
+    const indexLink = await screen.findByRole('link', { name: 'Index Link' })
+    expect(indexLink).toBeInTheDocument()
+
+    const types = addEventListener.mock.calls.map(([type]) => type)
+    expect(types).toContain('mouseenter')
+    expect(types).toContain('mouseleave')
+
+    addEventListener.mockRestore()
+  })
+
+  test('Link.preload={false} still calls the user\'s own hover handlers', async () => {
+    const onMouseEnter = vi.fn()
+    const onFocus = vi.fn()
+
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => (
+        <>
+          <h1>Index Heading</h1>
+          <Link
+            to="/"
+            preload={false}
+            onMouseEnter={onMouseEnter}
+            onFocus={onFocus}
+          >
+            Index Link
+          </Link>
+        </>
+      ),
+    })
+
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute]),
+      defaultPreload: 'intent',
+    })
+
+    render(() => <RouterProvider router={router} />)
+
+    const indexLink = await screen.findByRole('link', { name: 'Index Link' })
+    fireEvent.mouseEnter(indexLink)
+    fireEvent.focus(indexLink)
+
+    await waitFor(() => expect(onMouseEnter).toHaveBeenCalledTimes(1))
+    expect(onFocus).toHaveBeenCalledTimes(1)
+  })
+
   test('Router.preload="viewport", should trigger the IntersectionObserver\'s observe and disconnect methods', async () => {
     const rootRoute = createRootRoute()
     const RouteComponent = () => {

--- a/packages/solid-router/tests/link.test.tsx
+++ b/packages/solid-router/tests/link.test.tsx
@@ -5043,7 +5043,7 @@ describe('Link', () => {
     addEventListener.mockRestore()
   })
 
-  test('Link.preload={false} still calls the user\'s own hover handlers', async () => {
+  test("Link.preload={false} still calls the user's own hover handlers", async () => {
     const onMouseEnter = vi.fn()
     const onFocus = vi.fn()
 


### PR DESCRIPTION
## Problem

`useLinkProps` assigns the preload handlers unconditionally ([`link.tsx`](https://github.com/TanStack/router/blob/solid-router-v2-pre/packages/solid-router/src/link.tsx)):

```ts
linkProps.onClick = onClick
linkProps.onBlur = onBlur
linkProps.onFocus = onFocus
linkProps.onMouseEnter = onMouseEnter
linkProps.onMouseOver = onMouseOver
linkProps.onMouseLeave = onMouseLeave
linkProps.onMouseOut = onMouseOut
linkProps.onTouchStart = onTouchStart
```

The `preload` check lives *inside* the handlers (`if (preload() !== 'intent') return`), so with preloading off they are still attached and still fire — they just return.

That is not free. Solid's `DelegatedEvents` set does not include `mouseenter`, `mouseleave`, `focus` or `blur` (they don't bubble), so `assignProp` installs a **real `addEventListener` per anchor** for each of them. `click`, `mouseover`, `mouseout` and `touchstart` are delegated and cost nothing.

Net effect: **four listeners per `<Link>` that do nothing at all** whenever `preload` is `false`, `'viewport'` or `'render'`.

I hit this on a booking board where every row is a link. Measured in Chrome on a real page, counting `addEventListener` calls for one client-side navigation onto the screen:

| | listeners |
|---|---|
| 165 rows rendered with `<Link preload={false}>` | 660 (`blur`/`focus`/`mouseenter`/`mouseleave` × 165) |
| same rows, handlers not attached | 0 |

## Fix

Resolve those props through getters (the file already relies on this: *"values that no longer apply resolve to undefined, which spread()/assign() treats as attribute removal"*). With intent preloading off, the property yields whatever the consumer passed — or `undefined`, and nothing gets attached:

```ts
const onIntent =
  (composed: (event: any) => void, user: () => unknown) => () =>
    preload() === 'intent' ? composed : user()
```

Behaviour is unchanged:

- `preload: 'intent'` — identical to before.
- `'viewport'` — preloading runs through the IntersectionObserver; the events were already no-ops there.
- `'render'` — preloading runs in an effect; same.
- A consumer's own `onMouseEnter`/`onFocus`/… still fires, because the getter falls back to it.
- Still reactive: flipping `preload` back to `'intent'` re-runs the consuming `spread()`, which attaches the composed handler then (and `assignProp` removes a stale non-delegated listener before adding).

## Tests

Added to `tests/link.test.tsx`, alongside the existing preload/IntersectionObserver ones:

- `Router.preload="false" | "viewport" | "render"` — no `mouseenter`/`mouseleave`/`focus`/`blur` listeners on the anchor (spying on `HTMLAnchorElement.prototype.addEventListener`).
- `Router.preload="intent"` — the listeners are installed, as before.
- `Link.preload={false}` with the consumer's own `onMouseEnter`/`onFocus` — both still fire.

Verified the new tests fail without the fix (3 of them) and pass with it.

Ran locally on `solid-router-v2-pre`:

- `eslint src/link.tsx tests/link.test.tsx` — clean
- `tsc -p tsconfig.legacy.json` — clean
- `vitest run` — 59 files, 870 passed / 2 skipped
- `vitest run --mode server` — 3 files, 4 passed

Changeset included (patch).