### PR TITLE
fix: return AsyncRouteComponent from lazyRouteComponent

### DIFF
--- a/.changeset/lazy-route-component-return-type.md
+++ b/.changeset/lazy-route-component-return-type.md
@@ -1,0 +1,9 @@
+---
+'@tanstack/react-router': patch
+'@tanstack/solid-router': patch
+'@tanstack/vue-router': patch
+---
+
+Return `AsyncRouteComponent` from `lazyRouteComponent` instead of a `never` conditional
+
+The previous `T[K] extends (props: infer P) => any ? AsyncRouteComponent<P> : never` return type is resolved as `error` by tsgolint (and similar checkers that cannot instantiate that conditional). Named-export inference is unchanged via a default `TProps` type parameter.

--- a/packages/react-router/src/lazyRouteComponent.tsx
+++ b/packages/react-router/src/lazyRouteComponent.tsx
@@ -16,12 +16,11 @@ import type { AsyncRouteComponent } from './route'
 export function lazyRouteComponent<
   T extends Record<string, any>,
   TKey extends keyof T = 'default',
+  TProps = T[TKey] extends (props: infer P) => any ? P : unknown,
 >(
   importer: () => Promise<T>,
   exportName?: TKey,
-): T[TKey] extends (props: infer TProps) => any
-  ? AsyncRouteComponent<TProps>
-  : never {
+): AsyncRouteComponent<TProps> {
   let loadPromise: Promise<any> | undefined
   let comp: T[TKey] | T['default']
   let error: any

--- a/packages/react-router/tests/lazyRouteComponent.test-d.tsx
+++ b/packages/react-router/tests/lazyRouteComponent.test-d.tsx
@@ -1,0 +1,23 @@
+import { expectTypeOf, test } from 'vitest'
+import { lazyRouteComponent } from '../src'
+import type { AsyncRouteComponent } from '../src'
+
+test('default export infers props and is not never', () => {
+  const Comp = lazyRouteComponent(async () => ({
+    default: (_props: { id: string }) => null,
+  }))
+
+  expectTypeOf(Comp).toEqualTypeOf<AsyncRouteComponent<{ id: string }>>()
+  expectTypeOf(Comp).not.toEqualTypeOf<never>()
+})
+
+test('named export infers props', () => {
+  const Comp = lazyRouteComponent(
+    async () => ({
+      Page: (_props: { title: string }) => null,
+    }),
+    'Page',
+  )
+
+  expectTypeOf(Comp).toEqualTypeOf<AsyncRouteComponent<{ title: string }>>()
+})

--- a/packages/solid-router/src/lazyRouteComponent.tsx
+++ b/packages/solid-router/src/lazyRouteComponent.tsx
@@ -7,12 +7,11 @@ import type { AsyncRouteComponent } from './route'
 export function lazyRouteComponent<
   T extends Record<string, any>,
   TKey extends keyof T = 'default',
+  TProps = T[TKey] extends (props: infer P) => any ? P : unknown,
 >(
   importer: () => Promise<T>,
   exportName?: TKey,
-): T[TKey] extends (props: infer TProps) => any
-  ? AsyncRouteComponent<TProps>
-  : never {
+): AsyncRouteComponent<TProps> {
   let loadPromise: Promise<any> | undefined
   let comp: T[TKey] | T['default']
   let error: any

--- a/packages/vue-router/src/lazyRouteComponent.tsx
+++ b/packages/vue-router/src/lazyRouteComponent.tsx
@@ -23,13 +23,12 @@ function isModuleNotFoundError(error: any): boolean {
 export function lazyRouteComponent<
   T extends Record<string, any>,
   TKey extends keyof T = 'default',
+  TProps = T[TKey] extends (props: infer P) => any ? P : unknown,
 >(
   importer: () => Promise<T>,
   exportName?: TKey,
   ssr?: () => boolean,
-): T[TKey] extends (props: infer TProps) => any
-  ? AsyncRouteComponent<TProps>
-  : never {
+): AsyncRouteComponent<TProps> {
   let loadPromise: Promise<any> | undefined
   let comp: T[TKey] | T['default'] | null = null
   let error: any = null


### PR DESCRIPTION
## Summary

`lazyRouteComponent` currently returns:

```ts
T[TKey] extends (props: infer TProps) => any
  ? AsyncRouteComponent<TProps>
  : never
```

tsgolint (and similar checkers that cannot instantiate that conditional) resolve the whole function as `error`. Call sites then fail type-aware lint (`no-unsafe-assignment`, `no-unsafe-call`) even though `tsc` is fine.

This keeps `T` / `TKey` named-export inference, moves the props conditional into a default `TProps` type parameter, and always returns `AsyncRouteComponent<TProps>`.

Applies to `@tanstack/react-router`, `@tanstack/solid-router`, and `@tanstack/vue-router`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type resolution for `lazyRouteComponent` across React, Solid, and Vue routers.
  * Prevented valid default and named component exports from being incorrectly typed as unavailable.
  * Preserved accurate component prop inference for lazy-loaded routes.

* **Documentation**
  * Added release metadata for the router package updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->