### PR TITLE
fix(start-plugin-core): prerender retryCount never retries, failOnError never fails the build

### DIFF
--- a/.changeset/prerender-retry-fail-on-error.md
+++ b/.changeset/prerender-retry-fail-on-error.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/start-plugin-core': patch
+---
+
+Fix `prerender.retryCount` never actually retrying a failed page (the path was already marked "seen" on the first attempt, so the retry was silently dropped), and fix `prerender.failOnError` not failing the build once retries were exhausted (the queued task's rejection was never awaited, so it became an unhandled promise rejection instead of stopping the build).

--- a/packages/start-plugin-core/src/prerender.ts
+++ b/packages/start-plugin-core/src/prerender.ts
@@ -86,6 +86,10 @@ export async function prerender({
     const seen = new Set<string>()
     const prerendered = new Set<string>()
     const retriesByPath = new Map<string, number>()
+    // Collects rejections from queue.add() tasks (e.g. failOnError) so they
+    // can be rethrown after the queue settles, instead of becoming unhandled
+    // promise rejections that let the build exit 0 with pages missing.
+    const taskErrors: Array<unknown> = []
     const concurrency = startConfig.prerender?.concurrency ?? os.cpus().length
     logger.info(`Concurrency: ${concurrency}`)
     const queue = new Queue({ concurrency })
@@ -105,6 +109,13 @@ export async function prerender({
     }
 
     await queue.start()
+
+    if (taskErrors.length) {
+      throw new AggregateError(
+        taskErrors,
+        `Failed to prerender ${taskErrors.length} page(s)`,
+      )
+    }
 
     return Array.from(prerendered)
 
@@ -131,7 +142,7 @@ export async function prerender({
         ...page.prerender,
       }
 
-      queue.add(async () => {
+      const task = queue.add(async () => {
         logger.info(`Crawling: ${page.path}`)
         const retries = retriesByPath.get(page.path) || 0
 
@@ -219,11 +230,25 @@ export async function prerender({
             )
             await new Promise((resolve) => setTimeout(resolve, retryDelay))
             retriesByPath.set(page.path, retries + 1)
+            // `seen` guards addCrawlPageTask against re-queuing a page that's
+            // already in flight/queued, but that also blocked the retry
+            // itself (the path was marked seen on the first attempt). Clear
+            // it so the retry actually gets queued.
+            seen.delete(page.path)
             addCrawlPageTask(page)
           } else if (prerenderOptions.failOnError ?? true) {
             throw error
           }
         }
+      })
+
+      // `queue.add()` returns a promise that settles with the task, but
+      // nothing awaited it here, so a rejection (failOnError) became an
+      // unhandled promise rejection - the queue's own `isSettled()` doesn't
+      // care whether tasks succeeded, so `await queue.start()` below resolved
+      // and the build could exit 0 with pages missing. Collect it instead.
+      task.catch((error: unknown) => {
+        taskErrors.push(error)
       })
     }
   }

--- a/packages/start-plugin-core/tests/prerender-retry.test.ts
+++ b/packages/start-plugin-core/tests/prerender-retry.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest'
+import { prerender } from '../src/prerender'
+
+vi.mock('../src/utils', async () => {
+  const actual = await vi.importActual<any>('../src/utils')
+  return {
+    ...actual,
+    createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {} }),
+  }
+})
+
+// Mock fs to prevent actual file system operations
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<any>('node:fs')
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      mkdir: vi.fn().mockResolvedValue(undefined),
+      writeFile: vi.fn().mockResolvedValue(undefined),
+    },
+  }
+})
+
+function makeStartConfig(
+  pagePath: string,
+  prerenderOverrides: Record<string, unknown> = {},
+) {
+  return {
+    prerender: {
+      enabled: true,
+      autoStaticPathsDiscovery: false,
+      concurrency: 1,
+      // keep retries fast in tests
+      retryDelay: 1,
+      ...prerenderOverrides,
+    },
+    pages: [{ path: pagePath }],
+    router: { basepath: '' },
+    spa: {
+      enabled: false,
+      prerender: {
+        outputPath: '/_shell',
+        crawlLinks: false,
+        retryCount: 0,
+        enabled: true,
+      },
+    },
+  } as any
+}
+
+const handler = {
+  getClientOutputDirectory: () => '/client',
+}
+
+describe('prerender retries', () => {
+  it('retries a page that fails and succeeds before exhausting retryCount', async () => {
+    let calls = 0
+    const request = vi.fn(() => {
+      calls++
+      if (calls <= 2) {
+        return new Response('nope', { status: 500 })
+      }
+      return new Response('<html></html>', {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    const startConfig = makeStartConfig('/about', { retryCount: 2 })
+
+    await expect(
+      prerender({ startConfig, handler: { ...handler, request } }),
+    ).resolves.not.toThrow()
+
+    // 1 initial attempt + 2 retries, third attempt succeeds
+    expect(request).toHaveBeenCalledTimes(3)
+  })
+
+  it('rethrows once retries are exhausted and failOnError is true', async () => {
+    const request = vi.fn(() => new Response('nope', { status: 500 }))
+
+    const startConfig = makeStartConfig('/about', {
+      retryCount: 1,
+      failOnError: true,
+    })
+
+    await expect(
+      prerender({ startConfig, handler: { ...handler, request } }),
+    ).rejects.toThrow()
+
+    // 1 initial attempt + 1 retry, both fail
+    expect(request).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not throw when retries are exhausted and failOnError is false', async () => {
+    const request = vi.fn(() => new Response('nope', { status: 500 }))
+
+    const startConfig = makeStartConfig('/about', {
+      retryCount: 1,
+      failOnError: false,
+    })
+
+    await expect(
+      prerender({ startConfig, handler: { ...handler, request } }),
+    ).resolves.not.toThrow()
+
+    expect(request).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/start-plugin-core/tests/prerender-retry.test.ts
+++ b/packages/start-plugin-core/tests/prerender-retry.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 import { prerender } from '../src/prerender'
+import type { TanStackStartOutputConfig } from '../src/schema'
+import type * as Utils from '../src/utils'
+import type * as Fs from 'node:fs'
 
 vi.mock('../src/utils', async () => {
-  const actual = await vi.importActual<any>('../src/utils')
+  const actual = await vi.importActual<typeof Utils>('../src/utils')
   return {
     ...actual,
     createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {} }),
@@ -11,7 +14,7 @@ vi.mock('../src/utils', async () => {
 
 // Mock fs to prevent actual file system operations
 vi.mock('node:fs', async () => {
-  const actual = await vi.importActual<any>('node:fs')
+  const actual = await vi.importActual<typeof Fs>('node:fs')
   return {
     ...actual,
     promises: {
@@ -46,7 +49,9 @@ function makeStartConfig(
         enabled: true,
       },
     },
-  } as any
+    // Only a subset of TanStackStartOutputConfig is needed to exercise
+    // prerender(); building the full parsed schema shape isn't worth it here.
+  } as unknown as TanStackStartOutputConfig
 }
 
 const handler = {


### PR DESCRIPTION
Written by an AI agent (Claude Code) on behalf of @TLSRUF, who directed and authorized this work but has not personally reviewed the diff line-by-line.

## 🎯 Changes

Two bugs in `packages/start-plugin-core/src/prerender.ts`'s `addCrawlPageTask`/`prerenderPages`, both from the reproduction and root-cause analysis in #8120:

1. **`retryCount` never retries.** The retry path calls `addCrawlPageTask(page)` again, but the page's path was already marked in the `seen` set on the first attempt, so it returns early without re-queuing — the error is logged as "retrying" but no retry actually happens. Fixed by deleting the path from `seen` before re-adding it.

2. **`failOnError` couldn't fail the build.** `queue.add(...)`'s returned promise was never awaited or attached to, so a rejection (thrown once retries were exhausted) became an unhandled promise rejection while `queue.start()` resolved regardless — its `onSettled` fires on success *or* failure, and `isSettled()` only checks that nothing is pending/active. The build exited `0` with the failed page missing from the output. Fixed by collecting each task's rejection into an array and throwing an `AggregateError` after `queue.start()` settles.

Added `packages/start-plugin-core/tests/prerender-retry.test.ts` covering:
- a page that fails twice then succeeds within `retryCount` (asserts the request is actually retried 3 times)
- `failOnError: true` rejecting the `prerender()` call once retries are exhausted
- `failOnError: false` still resolving without throwing (no regression for the tolerated-failure case)

Verified all three new assertions fail against the pre-fix code with the exact symptoms from the issue (request called once instead of 3 times; the promise resolving instead of rejecting) before restoring the fix and reconfirming green.

Fixes #8120

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [ ] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Verification

- `vitest run tests/prerender-retry.test.ts tests/prerender-ssrf.test.ts` in `packages/start-plugin-core`: 6/6 passed, no type errors.
- Full package `vitest run`: 89/89 tests that ran passed (the remaining suites fail to resolve unbuilt workspace packages like `@tanstack/router-core`/`@tanstack/router-utils` in a fresh, un-built checkout — unrelated to this change, none of them touch `prerender.ts`).
- `eslint src/prerender.ts tests/prerender-retry.test.ts`: clean.
- `prettier --check`: clean on both changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed prerender tasks so failed pages are retried as configured.
  * Builds now fail correctly when retries are exhausted and `failOnError` is enabled.
  * Preserved successful completion when `failOnError` is disabled.

* **Tests**
  * Added coverage for successful retries, exhausted retries, and configurable failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->