### PR TITLE
refactor(solid): retire solid-router-ssr-query — native channels carry the Router + Query pairing

### DIFF
--- a/.changeset/retire-solid-router-ssr-query.md
+++ b/.changeset/retire-solid-router-ssr-query.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/solid-router-ssr-query': patch
+---
+
+Deprecated: Solid Query's `QueryClientProvider` now carries the Router + Query SSR pairing natively (registry hydration, named single-flight sources, redirect handling via userland glue), so this integration package is no longer needed. See the README for the migration.

--- a/e2e/solid-start/basic-solid-query/package.json
+++ b/e2e/solid-start/basic-solid-query/package.json
@@ -17,7 +17,6 @@
     "@tanstack/solid-query-devtools": "^6.0.0-rc.1",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
-    "@tanstack/solid-router-ssr-query": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "redaxios": "^0.5.1",
     "solid-js": "^2.0.0-rc.4",

--- a/e2e/solid-start/basic-solid-query/src/router.tsx
+++ b/e2e/solid-start/basic-solid-query/src/router.tsx
@@ -1,9 +1,9 @@
-import { QueryClient } from '@tanstack/solid-query'
-import { createRouter } from '@tanstack/solid-router'
-import { setupRouterSsrQueryIntegration } from '@tanstack/solid-router-ssr-query'
+import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
+import { createRouter, isRedirect } from '@tanstack/solid-router'
 import { routeTree } from './routeTree.gen'
 import { DefaultCatchBoundary } from './components/DefaultCatchBoundary'
 import { NotFound } from './components/NotFound'
+import type { AnyRouter } from '@tanstack/solid-router'
 
 export function getRouter() {
   const queryClient = new QueryClient()
@@ -14,10 +14,43 @@ export function getRouter() {
     defaultPreload: 'intent',
     defaultErrorComponent: DefaultCatchBoundary,
     defaultNotFoundComponent: () => <NotFound />,
+    // No integration package: on Solid, SSR transfer is native to
+    // QueryClientProvider (it serializes the request's cache into Solid's
+    // hydration registry and primes the client cache from it).
+    Wrap: (props) => (
+      <QueryClientProvider client={queryClient}>
+        {props.children}
+      </QueryClientProvider>
+    ),
   })
-  setupRouterSsrQueryIntegration({
-    router,
-    queryClient,
-  })
+  routeCacheRedirects(router, queryClient)
   return router
+}
+
+// Redirects thrown where the router is driving — beforeLoad, loaders, and
+// any queryFn a loader awaits — are the router's own to handle. Cache-driven
+// fetches (mount fetches, background refetches, mutations) run outside it,
+// so redirect() errors from both caches hand off to the router here.
+// Client-only runtime navigation glue, not an SSR concern: on the server a
+// redirect thrown during render resolves through the stream handler.
+function routeCacheRedirects(router: AnyRouter, queryClient: QueryClient) {
+  if (typeof document === 'undefined') return
+  const navigateOnRedirect = <TRest extends Array<unknown>>(
+    onError?: (error: Error, ...rest: TRest) => void,
+  ) => {
+    return (error: Error, ...rest: TRest) => {
+      if (isRedirect(error)) {
+        error.options._fromLocation = router.stores.location.get()
+        void router.navigate(router.resolveRedirect(error).options)
+        return
+      }
+      onError?.(error, ...rest)
+    }
+  }
+  const queryCache = queryClient.getQueryCache()
+  const mutationCache = queryClient.getMutationCache()
+  queryCache.config.onError = navigateOnRedirect(queryCache.config.onError)
+  mutationCache.config.onError = navigateOnRedirect(
+    mutationCache.config.onError,
+  )
 }

--- a/e2e/solid-start/server-functions/package.json
+++ b/e2e/solid-start/server-functions/package.json
@@ -17,7 +17,6 @@
     "@tanstack/solid-query-devtools": "^6.0.0-rc.1",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
-    "@tanstack/solid-router-ssr-query": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "js-cookie": "^3.0.5",
     "redaxios": "^0.5.1",

--- a/e2e/solid-start/server-functions/src/router.tsx
+++ b/e2e/solid-start/server-functions/src/router.tsx
@@ -1,6 +1,6 @@
-import { createRouter } from '@tanstack/solid-router'
-import { setupRouterSsrQueryIntegration } from '@tanstack/solid-router-ssr-query'
-import { QueryClient } from '@tanstack/solid-query'
+import { createRouter, isRedirect } from '@tanstack/solid-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
+import type { AnyRouter } from '@tanstack/solid-router'
 import { routeTree } from './routeTree.gen'
 import { DefaultCatchBoundary } from './components/DefaultCatchBoundary'
 import { NotFound } from './components/NotFound'
@@ -18,11 +18,47 @@ export function getRouter() {
         bar: 'baz',
       },
     },
+    // No integration package: on Solid, SSR transfer is native to
+    // QueryClientProvider (it serializes the request's cache into Solid's
+    // hydration registry and primes the client cache from it).
+    Wrap: (props) => (
+      <QueryClientProvider client={queryClient}>
+        {props.children}
+      </QueryClientProvider>
+    ),
   })
 
-  setupRouterSsrQueryIntegration({ router, queryClient })
+  routeCacheRedirects(router, queryClient)
 
   return router
+}
+
+// Redirects thrown where the router is driving — beforeLoad, loaders, and
+// any queryFn a loader awaits — are the router's own to handle. Cache-driven
+// fetches (mount fetches, background refetches, mutations) run outside it,
+// so redirect() errors from both caches hand off to the router here.
+// Client-only runtime navigation glue, not an SSR concern: on the server a
+// redirect thrown during render resolves through the stream handler.
+function routeCacheRedirects(router: AnyRouter, queryClient: QueryClient) {
+  if (typeof document === 'undefined') return
+  const navigateOnRedirect = <TRest extends Array<unknown>>(
+    onError?: (error: Error, ...rest: TRest) => void,
+  ) => {
+    return (error: Error, ...rest: TRest) => {
+      if (isRedirect(error)) {
+        error.options._fromLocation = router.stores.location.get()
+        void router.navigate(router.resolveRedirect(error).options)
+        return
+      }
+      onError?.(error, ...rest)
+    }
+  }
+  const queryCache = queryClient.getQueryCache()
+  const mutationCache = queryClient.getMutationCache()
+  queryCache.config.onError = navigateOnRedirect(queryCache.config.onError)
+  mutationCache.config.onError = navigateOnRedirect(
+    mutationCache.config.onError,
+  )
 }
 
 declare module '@tanstack/solid-router' {

--- a/e2e/solid-start/server-routes/package.json
+++ b/e2e/solid-start/server-routes/package.json
@@ -16,7 +16,6 @@
     "@tanstack/solid-query": "^6.0.0-rc.1",
     "@tanstack/solid-router": "workspace:^",
     "@tanstack/solid-router-devtools": "workspace:^",
-    "@tanstack/solid-router-ssr-query": "workspace:^",
     "@tanstack/solid-start": "workspace:^",
     "js-cookie": "^3.0.5",
     "redaxios": "^0.5.1",

--- a/e2e/solid-start/server-routes/src/router.tsx
+++ b/e2e/solid-start/server-routes/src/router.tsx
@@ -1,9 +1,9 @@
-import { createRouter } from '@tanstack/solid-router'
-import { setupRouterSsrQueryIntegration } from '@tanstack/solid-router-ssr-query'
-import { QueryClient } from '@tanstack/solid-query'
+import { createRouter, isRedirect } from '@tanstack/solid-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
 import { routeTree } from './routeTree.gen'
 import { DefaultCatchBoundary } from './components/DefaultCatchBoundary'
 import { NotFound } from './components/NotFound'
+import type { AnyRouter } from '@tanstack/solid-router'
 
 export function getRouter() {
   const queryClient = new QueryClient()
@@ -13,8 +13,44 @@ export function getRouter() {
     defaultErrorComponent: DefaultCatchBoundary,
     defaultNotFoundComponent: () => <NotFound />,
     scrollRestoration: true,
+    // No integration package: on Solid, SSR transfer is native to
+    // QueryClientProvider (it serializes the request's cache into Solid's
+    // hydration registry and primes the client cache from it).
+    Wrap: (props) => (
+      <QueryClientProvider client={queryClient}>
+        {props.children}
+      </QueryClientProvider>
+    ),
   })
-  setupRouterSsrQueryIntegration({ router, queryClient })
+  routeCacheRedirects(router, queryClient)
 
   return router
+}
+
+// Redirects thrown where the router is driving — beforeLoad, loaders, and
+// any queryFn a loader awaits — are the router's own to handle. Cache-driven
+// fetches (mount fetches, background refetches, mutations) run outside it,
+// so redirect() errors from both caches hand off to the router here.
+// Client-only runtime navigation glue, not an SSR concern: on the server a
+// redirect thrown during render resolves through the stream handler.
+function routeCacheRedirects(router: AnyRouter, queryClient: QueryClient) {
+  if (typeof document === 'undefined') return
+  const navigateOnRedirect = <TRest extends Array<unknown>>(
+    onError?: (error: Error, ...rest: TRest) => void,
+  ) => {
+    return (error: Error, ...rest: TRest) => {
+      if (isRedirect(error)) {
+        error.options._fromLocation = router.stores.location.get()
+        void router.navigate(router.resolveRedirect(error).options)
+        return
+      }
+      onError?.(error, ...rest)
+    }
+  }
+  const queryCache = queryClient.getQueryCache()
+  const mutationCache = queryClient.getMutationCache()
+  queryCache.config.onError = navigateOnRedirect(queryCache.config.onError)
+  mutationCache.config.onError = navigateOnRedirect(
+    mutationCache.config.onError,
+  )
 }

--- a/packages/solid-router-ssr-query/README.md
+++ b/packages/solid-router-ssr-query/README.md
@@ -16,6 +16,18 @@
 
 # @tanstack/solid-router-ssr-query
 
+> [!IMPORTANT]
+> **Deprecated on the Solid v2 line.** Solid 2.0's native channels make this
+> package's transport unnecessary: `QueryClientProvider` in
+> `@tanstack/solid-query` v6 serializes the request's cache into Solid's
+> hydration registry during SSR and primes the client cache from it — running
+> this package alongside it ships every query payload twice. The two runtime
+> conveniences it bundled are each a few lines of userland composition on
+> public APIs (see the Solid Start e2e apps under `e2e/solid-start/`): wrap
+> the router tree in `QueryClientProvider` via the router's `Wrap` option,
+> and hand cache-driven `redirect()` errors to `router.navigate` from the
+> caches' `config.onError`.
+
 SSR query integration for TanStack Solid Router and TanStack Solid Query.
 
 This package provides seamless integration between TanStack Router and TanStack Query for server-side rendering in Solid applications.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4934,9 +4934,6 @@ importers:
       '@tanstack/solid-router-devtools':
         specifier: workspace:^
         version: link:../../../packages/solid-router-devtools
-      '@tanstack/solid-router-ssr-query':
-        specifier: workspace:*
-        version: link:../../../packages/solid-router-ssr-query
       '@tanstack/solid-start':
         specifier: workspace:*
         version: link:../../../packages/solid-start
@@ -5460,9 +5457,6 @@ importers:
       '@tanstack/solid-router-devtools':
         specifier: workspace:^
         version: link:../../../packages/solid-router-devtools
-      '@tanstack/solid-router-ssr-query':
-        specifier: workspace:*
-        version: link:../../../packages/solid-router-ssr-query
       '@tanstack/solid-start':
         specifier: workspace:*
         version: link:../../../packages/solid-start
@@ -5533,9 +5527,6 @@ importers:
       '@tanstack/solid-router-devtools':
         specifier: workspace:^
         version: link:../../../packages/solid-router-devtools
-      '@tanstack/solid-router-ssr-query':
-        specifier: workspace:*
-        version: link:../../../packages/solid-router-ssr-query
       '@tanstack/solid-start':
         specifier: workspace:*
         version: link:../../../packages/solid-start


### PR DESCRIPTION
**Draft — for discussion.** Works against published packages today (`@tanstack/solid-query@6.0.0-rc.1`, `solid-js@2.0.0-rc.4`); all three converted e2e suites pass.

## Summary

On the Solid v2 line, `@tanstack/solid-router-ssr-query` bundles three unrelated things, and each now has a better home:

1. **SSR transport (the bulk of the package — `router-ssr-query-core`'s dehydrate + query stream + client hydrate).** Native to solid-query v6: `QueryClientProvider` serializes the request's cache into Solid's hydration registry (content-addressed by query hash, promise-valued at fetch-dispatch so pending queries stream, covering never-mounted loader prefetches) and primes the client cache from it. **Running the package alongside it ships every query payload twice** — which is what the e2e apps were doing: once through the router's dehydration stream, once through the hydration registry.
2. **`wrapQueryClient`.** A JSX expression — the router's own `Wrap` option:

```tsx
Wrap: (props) => (
  <QueryClientProvider client={queryClient}>{props.children}</QueryClientProvider>
)
```

3. **`handleRedirects`.** Runtime navigation glue, not an SSR concern: cache-driven fetches (mount fetches, background refetches, mutations) run outside the router, so a `queryFn`/`mutationFn` throwing `redirect()` needs handing to `router.navigate`. That's a small userland composition of public APIs on both sides — `isRedirect`/`resolveRedirect` from the router, `config.onError` on the query/mutation caches (see `routeCacheRedirects` in the converted apps). Loader-driven redirects were never the package's: they propagate through the loader and the router handles them on both sides.

This PR converts the three Solid Start e2e apps (`basic-solid-query`, `server-functions`, `server-routes`) to the composition, removes the dependency, and marks the package deprecated for the v2 line in its README.

## Verification

- `basic-solid-query`: 6/6 — SSR hydration, nested layouts, suspense transitions, query-preserving navigation, all on the native transport only.
- `server-functions`: 29/29 — **including `redirect-test` (mount-time query redirect via the `onError` glue) and `redirect-test-ssr` (render-time query redirect resolving through the stream handler)**, demonstrating `handleRedirects` is fully replaced.
- `server-routes`: 2/2.

## Notes

- The same composition is the reference pattern in solidjs/templates' `fullstack-tanstack` (bare vite + TanStack Router + Query, no Start — solidjs/templates#287), which is the point: none of it is Start-specific.
- Complementary to [#8192](https://github.com/TanStack/router/pull/8192) (named single-flight sources + `loadFlightTarget`): this PR is the SSR/read side going native, that one is the mutation/write side. Together they remove the need for any `*-ssr-query` package on Solid.
- `docs/router/integrations/query.md`'s Solid tab still shows the old setup — happy to rewrite it once there's agreement on direction.
- React/Vue packages untouched; the `router-ssr-query-core` transport remains correct for frameworks without a native serialization channel.

Made with [Cursor](https://cursor.com)