### PR TITLE
Tweak a few NODE_ENV placements

### DIFF
--- a/packages/react-start-rsc/src/serialization.server.ts
+++ b/packages/react-start-rsc/src/serialization.server.ts
@@ -204,8 +204,8 @@ const adapter = createSerializationAdapter({
       : {}
 
     const slotUsagesStream =
-      kind === 'composite' &&
       process.env.NODE_ENV === 'development' &&
+      kind === 'composite' &&
       RSC_SLOT_USAGES_STREAM in component
         ? ((component as any)[RSC_SLOT_USAGES_STREAM] as unknown as
             | ReadableStream<any>

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1227,8 +1227,8 @@ export class RouterCore<
       this.routeTree = this.options.routeTree as TRouteTree
       let processRouteTreeResult: ProcessRouteTreeResult<TRouteTree>
       if (
-        (isServer ?? this.isServer) &&
         process.env.NODE_ENV !== 'development' &&
+        (isServer ?? this.isServer) &&
         globalThis.__TSR_CACHE__ &&
         globalThis.__TSR_CACHE__.routeTree === this.routeTree
       ) {
@@ -1240,8 +1240,8 @@ export class RouterCore<
         processRouteTreeResult = this.buildRouteTree()
         // only cache if nothing else is cached yet
         if (
-          (isServer ?? this.isServer) &&
           process.env.NODE_ENV !== 'development' &&
+          (isServer ?? this.isServer) &&
           globalThis.__TSR_CACHE__ === undefined
         ) {
           globalThis.__TSR_CACHE__ = {
@@ -1865,8 +1865,8 @@ export class RouterCore<
       // check that from path exists in the current route tree
       // do this check only on navigations during test or development
       if (
-        dest.from &&
         process.env.NODE_ENV !== 'production' &&
+        dest.from &&
         dest._isNavigate
       ) {
         const [allFromMatches] = this.getMatchedRoutes(dest.from)

--- a/packages/vue-router/src/link.tsx
+++ b/packages/vue-router/src/link.tsx
@@ -558,7 +558,7 @@ function getExternalLinkProps(
     options.to as string,
     router.protocolAllowlist,
   )
-  if (dangerous && process.env.NODE_ENV !== 'production') {
+  if (process.env.NODE_ENV !== 'production' && dangerous) {
     console.warn(`Blocked Link with dangerous protocol: ${options.to}`)
   }
 


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

While playing around with Vite's `build.rolldownOptions.treeshake.*` settings, I found that a lone `dest.from;` expression was removed by `propertyReadSideEffects: false`.
As bundlers/minifiers may consider property reads as having side effects, it's typically best to check for `NODE_ENV` before other checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Reordered internal environment checks across React, router, and Vue routing logic.
  - Preserved existing runtime behavior, including development warnings and server-side handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->