### PR TITLE
fix(react-router): handle falsy thrown values in CatchBoundary

### DIFF
--- a/packages/react-router/src/CatchBoundary.tsx
+++ b/packages/react-router/src/CatchBoundary.tsx
@@ -11,32 +11,36 @@ export class CatchBoundary extends React.Component<{
   errorComponent?: ErrorRouteComponent
   onCatch?: (error: Error, errorInfo: ErrorInfo) => void
 }> {
-  state = { error: null } as { error: Error | null; resetKey?: unknown }
+  state = { error: null, hasError: false } as {
+    error: Error | null
+    hasError: boolean
+    resetKey?: unknown
+  }
 
   static getDerivedStateFromProps(
     props: { getResetKey: () => unknown },
-    state: { resetKey?: unknown; error: Error | null },
+    state: { resetKey?: unknown; error: Error | null; hasError: boolean },
   ) {
     const resetKey = props.getResetKey()
 
-    if (state.error && state.resetKey !== resetKey) {
-      return { resetKey, error: null }
+    if (state.hasError && state.resetKey !== resetKey) {
+      return { resetKey, error: null, hasError: false }
     }
 
     return { resetKey }
   }
   static getDerivedStateFromError(error: Error) {
-    return { error }
+    return { error, hasError: true }
   }
   reset = () => {
-    this.setState({ error: null })
+    this.setState({ error: null, hasError: false })
   }
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     this.props.onCatch?.(error, errorInfo)
   }
   render() {
-    const error = this.state.error
-    if (error) {
+    if (this.state.hasError) {
+      const error = this.state.error
       const element = React.createElement(
         this.props.errorComponent ?? ErrorComponent,
         {
@@ -88,7 +92,7 @@ export function ErrorComponent({ error }: { error: any }) {
               overflow: 'auto',
             }}
           >
-            {error.message ? <code>{error.message}</code> : null}
+            {error?.message ? <code>{error.message}</code> : null}
           </pre>
         </div>
       ) : null}

--- a/packages/react-router/tests/errorComponent.test.tsx
+++ b/packages/react-router/tests/errorComponent.test.tsx
@@ -868,3 +868,36 @@ describe('notFoundComponent is rendered when an error is thrown in params.parse'
     expect(notFoundComponent).toBeInTheDocument()
   })
 })
+
+test.each([
+  { desc: 'undefined', value: undefined, expected: 'undefined' },
+  { desc: 'null', value: null, expected: 'null' },
+  { desc: 'empty string', value: '', expected: '""' },
+])(
+  'errorComponent is rendered when component throws falsy value: $desc',
+  async ({ value, expected }) => {
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: function Home() {
+        throw value
+      },
+      errorComponent: ({ error }) => (
+        <div>Caught falsy error: {JSON.stringify(error) ?? 'undefined'}</div>
+      ),
+    })
+
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    render(<RouterProvider router={router} />)
+
+    expect(
+      await screen.findByText(`Caught falsy error: ${expected}`),
+    ).toBeInTheDocument()
+  },
+)
+


### PR DESCRIPTION
## Problem

When a component throws a falsy value (such as `undefined`, `null`, `''`, or `false`), `CatchBoundary` fails to render the configured `errorComponent`. Instead, because `render()` and `getDerivedStateFromProps()` check the truthiness of `this.state.error`, `if (error)` evaluates to `false` and falls back to rendering children again, leading to unhandled uncaught errors and unmounting the tree.

## Root Cause

`CatchBoundary` tracked whether an error occurred solely via `this.state.error`. When the thrown error is falsy, `this.state.error` is falsy, causing the boundary to assume no error is active.

## Fix

- Track an explicit `hasError` boolean state alongside `error` in `CatchBoundary`.
- Update `getDerivedStateFromError`, `getDerivedStateFromProps`, `reset`, and `render` to evaluate `hasError` instead of the error value truthiness.
- Safely access `error?.message` in `ErrorComponent` to prevent runtime exceptions on nullish error objects.

## Testing

- Added test cases in `packages/react-router/tests/errorComponent.test.tsx` verifying that falsy thrown values (`undefined`, `null`, `''`) properly render the `errorComponent`.
- Verified with `pnpm vitest run tests/errorComponent.test.tsx` in `@tanstack/react-router`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when route components throw falsy values such as `null`, `undefined`, or an empty string.
  * Error components now render safely without causing an additional error when no error message is available.
  * Error state resets correctly when navigating to a new route or invoking a reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->