### PR TITLE
fix(router-core): fix dangling reference to stripped field

### DIFF
--- a/.changeset/dehydrated-match-before-load-context-type.md
+++ b/.changeset/dehydrated-match-before-load-context-type.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+Fix `DehydratedMatch['b']`, which was typed by `RouteMatch['__beforeLoadContext']` — a field tagged `@internal`. This worked fine until `stripInternal` was enabled in fd341ad (PR #4907), which strips `@internal` members from the published `.d.ts` and left this reference dangling since `router-core@1.171.16`. Consumers with `skipLibCheck: false` (the TS default) hit a `tsc` error on `@tanstack/router-core`'s own shipped types. Fixed by giving `b` the declared type of `__beforeLoadContext` instead of indexing into the stripped member.

--- a/packages/router-core/src/ssr/types.ts
+++ b/packages/router-core/src/ssr/types.ts
@@ -3,7 +3,7 @@ import type { MakeRouteMatch } from '../Matches'
 
 export interface DehydratedMatch {
   i: MakeRouteMatch['id']
-  b?: MakeRouteMatch['__beforeLoadContext']
+  b?: Record<string, unknown>
   l?: MakeRouteMatch['loaderData']
   e?: MakeRouteMatch['error']
   u: MakeRouteMatch['updatedAt']


### PR DESCRIPTION

## 🎯 Changes

`DehydratedMatch['b']` is typed by `RouteMatch['__beforeLoadContext']`, and `RouteMatch['__beforeLoadContext']` is tagged `@internal`. This worked fine until `stripInternal` was enabled in fd341ad(PR #4907), which strips `@internal` members from the published `.d.ts`. This has made this reference dangling since `router-core@1.171.16`. f330532 (PR #6118) later moved the interface to its current file unchanged. When 45c4ad8 (PR #7805) rewrote to `load-client.ts` and started importing from `./ssr/types`, the dangling reference was surfaced for consumers with `skipLibCheck: false` in this error:

  error TS2339: Property '__beforeLoadContext' does not exist on type 'MakeRouteMatch'.

**We solve this by giving `b` the declared type of `__beforeLoadContext`, instead of indexing into the stripped member.**

Verified against a built package: the emitted `dist/esm/ssr/types.d.ts` no longer references the internal member, and a minimal consumer repro type-checks cleanly with this dist swapped in.

Fixes #8203 


## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a published TypeScript declaration issue affecting dehydrated route data.
  - Resolved compilation errors for consumers using stricter type-checking settings.
  - Improved compatibility by using a stable, publicly available context type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->