### PR TITLE
fix(start-client-core): add safe fallback for TSS_SERVER_FN_BASE in createClientRpc

### DIFF
--- a/packages/start-client-core/src/client-rpc/createClientRpc.ts
+++ b/packages/start-client-core/src/client-rpc/createClientRpc.ts
@@ -4,7 +4,12 @@ import { serverFnFetcher } from './serverFnFetcher'
 import type { ClientFnMeta } from '../constants'
 
 export function createClientRpc(functionId: string) {
-  const url = process.env.TSS_SERVER_FN_BASE + functionId
+  const serverFnBase =
+    (typeof process !== 'undefined' && process.env?.TSS_SERVER_FN_BASE) ||
+    (typeof import.meta !== 'undefined' &&
+      (import.meta as any).env?.TSS_SERVER_FN_BASE) ||
+    '/_serverFn/'
+  const url = serverFnBase + functionId
   const serverFnMeta: ClientFnMeta = { id: functionId }
 
   const clientFn = (...args: Array<any>) => {

--- a/packages/start-client-core/tests/createClientRpc.test.ts
+++ b/packages/start-client-core/tests/createClientRpc.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createClientRpc } from '../src/client-rpc/createClientRpc'
+import { TSS_SERVER_FUNCTION } from '../src/constants'
+
+describe('createClientRpc', () => {
+  const originalEnv = process.env.TSS_SERVER_FN_BASE
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.TSS_SERVER_FN_BASE = originalEnv
+    } else {
+      delete process.env.TSS_SERVER_FN_BASE
+    }
+  })
+
+  it('uses process.env.TSS_SERVER_FN_BASE when defined', () => {
+    process.env.TSS_SERVER_FN_BASE = '/custom-base/'
+    const rpc = createClientRpc('testFn')
+
+    expect(rpc.url).toBe('/custom-base/testFn')
+    expect(rpc.serverFnMeta).toEqual({ id: 'testFn' })
+    expect(rpc[TSS_SERVER_FUNCTION]).toBe(true)
+  })
+
+  it('falls back to default server function base when TSS_SERVER_FN_BASE is undefined', () => {
+    delete process.env.TSS_SERVER_FN_BASE
+    const rpc = createClientRpc('testFn')
+
+    expect(rpc.url).toBe('/_serverFn/testFn')
+  })
+
+  it('safely falls back without ReferenceError when global process is undefined', () => {
+    const originalProcess = globalThis.process
+    try {
+      // @ts-expect-error simulating browser environment where process is not defined
+      delete globalThis.process
+
+      const rpc = createClientRpc('testFn')
+      expect(rpc.url).toBe('/_serverFn/testFn')
+    } finally {
+      globalThis.process = originalProcess
+    }
+  })
+})


### PR DESCRIPTION
## Problem
In `createClientRpc()`, `process.env.TSS_SERVER_FN_BASE` is evaluated directly to construct the server function URL. In browser environments where `globalThis.process` is not defined (e.g. Vite dev servers with `server.hmr: false` where `@vite/client` preamble is omitted), evaluating `process.env` throws a `ReferenceError: process is not defined`. Furthermore, when `process.env.TSS_SERVER_FN_BASE` is undefined, string concatenation produces `"undefined" + functionId`, resulting in a relative URL that fails with 500 when called from nested routes.

## Root Cause
`createClientRpc` directly accessed `process.env.TSS_SERVER_FN_BASE` without guarding against `process` being undefined or falling back to the default server function base prefix `/_serverFn/`.

## Fix
1. Safely resolve `serverFnBase` by checking `typeof process !== 'undefined'` and `typeof import.meta !== 'undefined'` before reading `TSS_SERVER_FN_BASE`.
2. Fall back to the standard default `/_serverFn/` when `TSS_SERVER_FN_BASE` is not set.

## Testing
1. Added unit tests in `packages/start-client-core/tests/createClientRpc.test.ts` covering:
   - Custom `process.env.TSS_SERVER_FN_BASE` resolution
   - Default fallback `/_serverFn/` when `TSS_SERVER_FN_BASE` is undefined
   - Safe execution without `ReferenceError` when `globalThis.process` is undefined
2. Ran vitest test suite across `start-client-core` (91 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-function URL detection across browser and server environments.
  * Prevented errors when the `process` object is unavailable in browser runtimes.
  * Added support for custom server-function base URLs with a reliable default fallback.

* **Tests**
  * Added coverage for custom URLs, default behavior, RPC metadata, and environments without `process`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->