### PR TITLE
fix(router-utils): clone cached nodes to release Babel's traversal cache

### DIFF
--- a/.changeset/start-compiler-module-info-ast-retention.md
+++ b/.changeset/start-compiler-module-info-ast-retention.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-utils': patch
+---
+
+Stop the Start compiler's module cache from retaining parsed ASTs. `extractModuleInfoFromAst` now stores a detached clone of each binding's initializer, so a cached module no longer keeps the `@babel/traverse` `NodePath` and `Scope` graph of the file it came from reachable.

--- a/packages/router-utils/src/compiler-helpers.ts
+++ b/packages/router-utils/src/compiler-helpers.ts
@@ -95,7 +95,9 @@ function addVariableDeclarationModuleInfo(
     for (const name of collectIdentifiersFromPattern(declarator.id)) {
       bindings.set(name, {
         type: 'var',
-        init: declarator.init ?? null,
+        // Detached: `@babel/traverse` keys its caches on node identity, so
+        // storing the original would pin this file's whole traversal graph.
+        init: declarator.init ? t.cloneNode(declarator.init, true, true) : null,
       })
       exportMap?.set(name, name)
     }
@@ -552,7 +554,9 @@ export function extractModuleInfoFromAst(ast: t.File): ExtractedModuleInfo {
         const synth = '__default_export__'
         bindings.set(synth, {
           type: 'var',
-          init: t.isExpression(declaration) ? declaration : null,
+          init: t.isExpression(declaration)
+            ? t.cloneNode(declaration, true, true)
+            : null,
         })
         exportMap.set('default', synth)
       }


### PR DESCRIPTION
## 🎯 Changes

`@babel/traverse` keys its `NodePath` and `Scope` caches on node identity using a
WeakMap. The Start compiler keeps a reference to the initializer node in its module
cache for the life of the dev server, so that entry is never collected, and neither
is the whole file's traversal graph hanging off it.

Cache a cloned node instead, to prevent the original staying alive as a WeakMap key.
The only readers look at the node type and `callee`/`object`/`property`/`name`, so a
clone is equivalent for them. Build output was byte-identical across every run.

This gives 11.6% less peak dev-server memory in our app.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compiler memory management by preventing cached module information from retaining source-file traversal data.
  * Preserved module initializer information using detached copies, reducing the risk of unnecessary memory retention during compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->