### PR TITLE
fix(start-server-core): return 406 instead of 500 for non-HTML AcceptHeaders

### DIFF
--- a/.changeset/accept-header-not-acceptable.md
+++ b/.changeset/accept-header-not-acceptable.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/start-server-core': patch
+---
+
+Return `406 Not Acceptable` instead of `500 Internal Server Error` when a page route receives a request whose `Accept` header excludes HTML.

--- a/e2e/react-start/basic/tests/accept-header.spec.ts
+++ b/e2e/react-start/basic/tests/accept-header.spec.ts
@@ -1,0 +1,30 @@
+import { expect } from '@playwright/test'
+import { test } from '@tanstack/router-e2e-utils'
+import { isPrerender } from './utils/isPrerender'
+import { isSpaMode } from './utils/isSpaMode'
+
+test.skip(
+  isSpaMode || isPrerender,
+  'Accept negotiation only runs when the document is server-rendered',
+)
+
+test.describe('Accept header negotiation', () => {
+  test('responds 406 when Accept excludes HTML', async ({ request }) => {
+    const response = await request.get('/', {
+      headers: { Accept: 'application/json' },
+    })
+
+    expect(response.status()).toBe(406)
+    expect(await response.json()).toEqual({
+      error: 'Only HTML requests are supported here',
+    })
+  })
+
+  test('responds 200 when Accept allows HTML', async ({ request }) => {
+    const response = await request.get('/', {
+      headers: { Accept: 'text/html' },
+    })
+
+    expect(response.status()).toBe(200)
+  })
+})

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -653,7 +653,7 @@ export function createStartHandler<TRegister = Register>(
           return normalizeSsrResponse(
             Response.json(
               { error: 'Only HTML requests are supported here' },
-              { status: 500 },
+              { status: 406 },
             ),
           )
         }


### PR DESCRIPTION
## 🎯 Changes
Corrects the status code returned when requesting non-HTML from server error to unacceptable.

Fixes https://github.com/TanStack/router/issues/7913
Supersedes abandoned PR https://github.com/TanStack/router/pull/7925

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests for server-rendered pages with an `Accept` header that excludes HTML now return the correct `406 Not Acceptable` response instead of `500 Internal Server Error`.
  * Requests accepting HTML continue to return the page successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->