### PR TITLE
fix(start-server-core): return a Response to non-RPC server function callers

### DIFF
--- a/.changeset/server-fn-form-action-response.md
+++ b/.changeset/server-fn-form-action-response.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/start-server-core': patch
+---
+
+Fix a server function used as a form action failing with "It looks like you forgot to return a response from your server route handler" unless its handler returned a `Response`. A native form submission does not send the RPC header, and that path returned the handler's raw value straight to the HTTP layer. Non-RPC callers now receive a serialized `Response`, while a handler-provided `Response` or `redirect()` is still passed through untouched.

--- a/docs/start/framework/react/guide/server-functions.md
+++ b/docs/start/framework/react/guide/server-functions.md
@@ -396,6 +396,8 @@ Return `Response` objects binary data, or custom content types.
 
 Use server functions without JavaScript by leveraging the `.url` property with HTML forms.
 
+A native form submission is not an RPC call, so the response goes to the browser rather than to the client runtime. Return a `Response`, or a `redirect()`, to control what the browser does next. A redirect is the usual choice, because it sends the browser to a real page instead of leaving it on the server function URL. Any other serializable return value is sent as a JSON body, which the browser will display as-is.
+
 ### Middleware
 
 Compose server functions with middleware for authentication, logging, and shared logic. See the [Middleware guide](./middleware.md).

--- a/packages/start-server-core/src/server-functions-handler.ts
+++ b/packages/start-server-core/src/server-functions-handler.ts
@@ -166,10 +166,17 @@ export const handleServerAction = async ({
       }
 
       if (!isServerFn) {
-        return unwrapped
-      }
-
-      if (unwrapped instanceof Response) {
+        // Non-RPC callers, such as a native form submission that posts to
+        // `serverFn.url` or a direct HTTP request, get the handler's own
+        // Response (including a redirect) untouched. Any other value still
+        // has to be serialized: returning it raw lets a plain JS value escape
+        // to the HTTP layer, which then fails the request with "you forgot to
+        // return a response from your server route handler" instead of
+        // delivering the result.
+        if (unwrapped instanceof Response) {
+          return unwrapped
+        }
+      } else if (unwrapped instanceof Response) {
         if (isRedirect(unwrapped)) {
           return unwrapped
         }

--- a/packages/start-server-core/tests/server-functions-handler.test.ts
+++ b/packages/start-server-core/tests/server-functions-handler.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const action = vi.fn()
+
+vi.mock('../src/getServerFnById', () => ({
+  getServerFnById: vi.fn(async () => action),
+}))
+
+const { handleServerAction } = await import('../src/server-functions-handler')
+const { requestHandler } = await import('../src/request-response')
+const { runWithStartContext } = await import('@tanstack/start-storage-context')
+
+const SERVER_FN_ID = 'test-server-fn'
+
+/**
+ * Invoke `handleServerAction` the way the request pipeline does, and hand back
+ * whatever it returned so the test can assert on the raw value. The pipeline
+ * requires a Response, so returning anything else is the defect under test.
+ */
+async function invokeServerFn(options: {
+  returns: { result?: unknown; error?: unknown }
+  /** Set the header the RPC client sends. Native form posts do not send it. */
+  rpc?: boolean
+}) {
+  action.mockImplementation(async () => options.returns)
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+  }
+  if (options.rpc) {
+    headers['x-tsr-serverFn'] = 'true'
+  }
+
+  const request = new Request(`http://localhost/_serverFn/${SERVER_FN_ID}`, {
+    method: 'POST',
+    headers,
+    body: 'name=Sean',
+  })
+
+  let returned: unknown
+  const handler = requestHandler(async () =>
+    runWithStartContext(
+      {
+        getRouter: () => ({}) as any,
+        request,
+        startOptions: {},
+        contextAfterGlobalMiddlewares: {},
+        executedRequestMiddlewares: new Set(),
+        handlerType: 'serverFn',
+      },
+      async () => {
+        returned = await handleServerAction({
+          request,
+          context: {},
+          serverFnId: SERVER_FN_ID,
+        })
+        return new Response('unused')
+      },
+    ),
+  )
+
+  await handler(request, {})
+  return returned
+}
+
+beforeEach(() => {
+  action.mockReset()
+  Object.assign(action, { method: 'POST' })
+})
+
+describe('handleServerAction with a non-RPC caller', () => {
+  test('serializes a plain object into a Response', async () => {
+    const returned = await invokeServerFn({ returns: { result: { ok: true } } })
+
+    expect(returned).toBeInstanceOf(Response)
+    const response = returned as Response
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+    await expect(response.text()).resolves.toContain('ok')
+  })
+
+  test('returns a Response for a handler that returns nothing', async () => {
+    const returned = await invokeServerFn({ returns: { result: undefined } })
+
+    expect(returned).toBeInstanceOf(Response)
+    expect((returned as Response).status).toBe(200)
+  })
+
+  test('returns a Response when the handler produced an error', async () => {
+    const returned = await invokeServerFn({
+      returns: { result: undefined, error: new Error('boom') },
+    })
+
+    expect(returned).toBeInstanceOf(Response)
+  })
+
+  test('passes a handler-provided Response through untouched', async () => {
+    const returned = await invokeServerFn({
+      returns: {
+        result: new Response('done', {
+          status: 201,
+          headers: { 'Content-Type': 'text/plain' },
+        }),
+      },
+    })
+
+    expect(returned).toBeInstanceOf(Response)
+    const response = returned as Response
+    expect(response.status).toBe(201)
+    expect(response.headers.get('Content-Type')).toBe('text/plain')
+    // A non-RPC caller is a browser or an external client, so the internal
+    // raw-response marker must not be added.
+    expect(response.headers.get('x-tss-raw')).toBeNull()
+    await expect(response.text()).resolves.toBe('done')
+  })
+
+  test('passes a redirect Response through untouched', async () => {
+    const { redirect } = await import('@tanstack/router-core')
+    const returned = await invokeServerFn({
+      returns: { result: redirect({ href: '/after-submit', statusCode: 302 }) },
+    })
+
+    expect(returned).toBeInstanceOf(Response)
+    const response = returned as Response
+    expect(response.status).toBe(302)
+    expect(response.headers.get('Location')).toBe('/after-submit')
+  })
+})
+
+describe('handleServerAction with the RPC client', () => {
+  test('still serializes a plain object', async () => {
+    const returned = await invokeServerFn({
+      returns: { result: { ok: true } },
+      rpc: true,
+    })
+
+    expect(returned).toBeInstanceOf(Response)
+    const response = returned as Response
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+    expect(response.headers.get('x-tss-serialized')).toBe('true')
+  })
+
+  test('still marks a raw Response for the client to unwrap', async () => {
+    const returned = await invokeServerFn({
+      returns: { result: new Response('done', { status: 201 }) },
+      rpc: true,
+    })
+
+    expect(returned).toBeInstanceOf(Response)
+    const response = returned as Response
+    expect(response.status).toBe(201)
+    expect(response.headers.get('x-tss-raw')).toBe('true')
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Fixes #7745.

Posting a native HTML form to `serverFn.url` failed with an unhandled 500:

```
Error: It looks like you forgot to return a response from your server route handler.
    at throwRouteHandlerError (.../createStartHandler.ts)
```

A native form submission is not an RPC call, so it does not send the `x-tsr-serverFn` header that the RPC fetcher sends. In `handleServerAction` that branch returned the unwrapped handler value straight out:

```ts
const unwrapped = res.result || res.error
if (!isServerFn) {
  return unwrapped
}
```

For a handler that returns a plain object, returns nothing, or produces an error, `unwrapped` is a raw JS value rather than a `Response`. It flows back through `executeMiddleware`, where `handleCtxResult` only recognises `Response`, redirect and `SsrResponse`, so `ctx.response` is never set and `getFinalResponse` throws `ERR_NO_RESPONSE`. Only handlers that already returned a `Response` worked, which matches the reporter's workaround.

This path is a regression from the middleware refactor in #5517, which introduced the shortcut. Before it, every caller went through the serialization path and always produced a `Response`.

### The fix

Restrict the shortcut to values that are already a `Response`, and let everything else fall through to the existing `serializeResult`:

```ts
if (!isServerFn) {
  if (unwrapped instanceof Response) {
    return unwrapped
  }
} else if (unwrapped instanceof Response) {
  // unchanged RPC handling
}

return serializeResult(res)
```

Redirects are covered by the same check, because `redirect()` returns a `Response` subclass and `isRedirect` is `obj instanceof Response && !!obj.options`. So a form action that returns `redirect()` still passes through byte for byte, and a handler-provided `Response` still reaches the browser without the internal `x-tss-raw` marker that only RPC callers need.

Non-RPC callers now get the same `application/json` body the RPC path produces, which is the pre-#5517 behaviour. If you would rather non-RPC callers receive plain `Response.json(value)` instead of the seroval encoding, or a non-redirect error mapped to a 500 rather than a 200, I am happy to change it. I kept the restoration minimal because those are format decisions rather than part of the bug.

### Tests

New `packages/start-server-core/tests/server-functions-handler.test.ts` drives `handleServerAction` through `requestHandler` and `runWithStartContext` and asserts on the value it returns, since the invariant being broken is that it must always return a `Response`.

Three tests fail on `main` and pass with this change:

| handler returns | before | after |
| --- | --- | --- |
| `{ ok: true }` | the raw object | 200 `application/json` |
| nothing | `undefined` | 200 |
| an error | the raw `Error` | a `Response` |

Four more are regression guards that pass both before and after: a handler-provided `Response` passes through with its status, content type and no `x-tss-raw` marker, a `redirect()` keeps its 302 and `Location`, and both RPC paths keep serializing and marking exactly as they did.

### Docs

Added a short note to the Progressive Enhancement section explaining what a native form submission receives, and that a `redirect()` is usually what you want so the browser does not stay on the server function URL.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

Local verification:

- `pnpm nx run @tanstack/start-server-core:test:unit` passes, 8 files and 125 tests
- `pnpm nx run @tanstack/start-server-core:test:types` passes
- `pnpm nx run @tanstack/start-server-core:test:eslint` passes
- `node scripts/verify-links.ts` passes for the docs change

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Native HTML form submissions now receive serializable server-function results as JSON responses.
  * Handler-provided responses and redirects are preserved, allowing applications to control the browser’s next action.
  * RPC response handling remains unchanged.

* **Documentation**
  * Clarified how native form submissions differ from RPC calls and how to return responses or redirects.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->