### PR TITLE
fix(start-static-server-functions): fall back to the server function on a cache miss

### DIFF
--- a/.changeset/static-server-fn-cache-miss-fallback.md
+++ b/.changeset/static-server-fn-cache-miss-fallback.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/start-static-server-functions': patch
+---
+
+Fix `staticFunctionMiddleware` failing with `Unexpected token '<', "<!DOCTYPE "... is not valid JSON` when no prerendered cache file exists for a call. The client now treats an unreadable or non-JSON cache response as a miss and invokes the server function instead, and a cache hit is reused from the client cache rather than refetched.

--- a/docs/start/framework/react/guide/static-server-functions.md
+++ b/docs/start/framework/react/guide/static-server-functions.md
@@ -33,3 +33,4 @@ This pattern goes as follows:
   - Initially, the prerendered page's html is served and the server function data is embedded in the html
   - When the client mounts, the embedded server function data is hydrated
   - For future client-side invocations, the server function is replaced with a fetch call to the static JSON file
+  - If no cached file exists for that key, the call falls back to invoking the server function normally. This happens when prerendering is disabled, or when the call is made from a route that the prerender pass never reached, so a static server function stays usable instead of failing

--- a/packages/start-static-server-functions/package.json
+++ b/packages/start-static-server-functions/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "clean": "rimraf ./dist && rimraf ./coverage",
     "test": "pnpm test:eslint && pnpm test:types && pnpm test:build && pnpm test:unit",
-    "test:unit": "exit 0; vitest",
+    "test:unit": "vitest",
     "test:unit:dev": "vitest --watch",
     "test:eslint": "eslint ./src",
     "test:types": "pnpm run \"/^test:types:ts[0-9]{2}$/\"",

--- a/packages/start-static-server-functions/src/staticFunctionMiddleware.ts
+++ b/packages/start-static-server-functions/src/staticFunctionMiddleware.ts
@@ -104,6 +104,17 @@ async function addItemToCache({
   }
 }
 
+/**
+ * Look up a prerendered result for this call.
+ *
+ * Returns `undefined` for a cache miss so the caller can fall back to invoking
+ * the server function. A miss is the normal case whenever the cache file was
+ * never written, for example when `prerender` is disabled or when the route
+ * that makes this call is not reached during the prerender pass. The request
+ * for the missing file is then answered by the application's catch-all route,
+ * which serves the HTML shell, so neither the status code nor the body can be
+ * trusted without checking.
+ */
 const fetchItem = async ({
   data,
   functionId,
@@ -114,13 +125,42 @@ const fetchItem = async ({
   const hash = jsonToFilenameSafeString(data)
   const url = await getStaticCacheUrl({ functionId, hash })
 
-  let result: any = staticClientCache?.get(url)
+  const cached = staticClientCache?.get(url)
+  if (cached !== undefined) {
+    return cached
+  }
 
-  result = await fetch(url, {
-    method: 'GET',
-  })
-    .then((r) => r.json())
-    .then((d) => fromJSON(d, { plugins: getDefaultSerovalPlugins() }))
+  let response: Response
+  try {
+    response = await fetch(url, {
+      method: 'GET',
+    })
+  } catch {
+    // The cache file could not be requested at all.
+    return undefined
+  }
+
+  if (!response.ok) {
+    return undefined
+  }
+
+  // The HTML shell is served with a 200 in some setups, so the content type is
+  // what actually distinguishes a cache hit from the fallback document.
+  if (!response.headers.get('content-type')?.includes('application/json')) {
+    return undefined
+  }
+
+  let result: any
+  try {
+    result = fromJSON(await response.json(), {
+      plugins: getDefaultSerovalPlugins(),
+    })
+  } catch {
+    // The file exists but is not a payload this build can read.
+    return undefined
+  }
+
+  staticClientCache?.set(url, result)
 
   return result
 }

--- a/packages/start-static-server-functions/src/staticFunctionMiddleware.ts
+++ b/packages/start-static-server-functions/src/staticFunctionMiddleware.ts
@@ -160,6 +160,21 @@ const fetchItem = async ({
     return undefined
   }
 
+  // Decoding can succeed for a payload that is not a cached result, for
+  // example a JSON asset that another build step left at this path. Such a
+  // value is truthy, so without a shape check the caller would treat it as a
+  // hit and hand back an undefined result instead of calling the server
+  // function. `addItemToCache` always writes both keys, and seroval keeps them
+  // even when the context is undefined.
+  if (
+    result === null ||
+    typeof result !== 'object' ||
+    !Object.prototype.hasOwnProperty.call(result, 'result') ||
+    !Object.prototype.hasOwnProperty.call(result, 'context')
+  ) {
+    return undefined
+  }
+
   staticClientCache?.set(url, result)
 
   return result

--- a/packages/start-static-server-functions/tests/staticFunctionMiddleware.test.ts
+++ b/packages/start-static-server-functions/tests/staticFunctionMiddleware.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { toJSONAsync } from 'seroval'
+
+// `getDefaultSerovalPlugins` reads the Start options through an isomorphic
+// function. Uncompiled, that chain resolves to its server implementation and
+// wants a Start context in AsyncLocalStorage, which a browser never has. The
+// adapter list is irrelevant to the cache lookup under test, so stub it out and
+// serialize the fixtures the same way.
+vi.mock('@tanstack/start-client-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@tanstack/start-client-core')>()
+  return { ...actual, getDefaultSerovalPlugins: () => [] }
+})
+
+const { staticFunctionMiddleware } =
+  await import('../src/staticFunctionMiddleware')
+
+const clientMiddleware = staticFunctionMiddleware.options.client!
+
+/** The result the live server function produces when the cache is not used. */
+const LIVE_RESULT = { result: 'from the server function' }
+
+/**
+ * Each test uses its own `data`, so it hashes to its own cache URL and cannot
+ * be served by the module level client cache another test populated.
+ */
+function callClientMiddleware(data: unknown) {
+  const next = vi.fn(async () => LIVE_RESULT)
+  const promise = clientMiddleware({
+    serverFnMeta: { id: 'test_fn' },
+    data,
+    context: {},
+    next,
+  } as any)
+  return { promise, next }
+}
+
+function jsonResponse(body: string, status = 200) {
+  return new Response(body, {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+/** What the application's catch-all route serves for a missing cache file. */
+function htmlShellResponse(status = 200) {
+  return new Response('<!DOCTYPE html><html><body></body></html>', {
+    status,
+    headers: { 'content-type': 'text/html' },
+  })
+}
+
+beforeEach(() => {
+  vi.stubEnv('NODE_ENV', 'production')
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('staticFunctionMiddleware client on a cache miss', () => {
+  test('falls back to the server function when the HTML shell is served with a 200', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => htmlShellResponse(200)),
+    )
+
+    const { promise, next } = callClientMiddleware({ case: 'html-200' })
+
+    await expect(promise).resolves.toBe(LIVE_RESULT)
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  test('falls back to the server function on a 404', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => htmlShellResponse(404)),
+    )
+
+    const { promise, next } = callClientMiddleware({ case: 'html-404' })
+
+    await expect(promise).resolves.toBe(LIVE_RESULT)
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  test('falls back to the server function when the body is not valid JSON', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse('not json at all')),
+    )
+
+    const { promise, next } = callClientMiddleware({ case: 'bad-json' })
+
+    await expect(promise).resolves.toBe(LIVE_RESULT)
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  test('falls back to the server function when the request fails outright', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('Failed to fetch')
+      }),
+    )
+
+    const { promise, next } = callClientMiddleware({ case: 'network-error' })
+
+    await expect(promise).resolves.toBe(LIVE_RESULT)
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('staticFunctionMiddleware client on a cache hit', () => {
+  test('returns the prerendered result without calling the server function', async () => {
+    const payload = JSON.stringify(
+      await toJSONAsync({
+        result: 'from the static cache',
+        context: { user: 'sean' },
+      }),
+    )
+    const fetchMock = vi.fn(async () => jsonResponse(payload))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const first = callClientMiddleware({ case: 'hit' })
+    await expect(first.promise).resolves.toMatchObject({
+      result: 'from the static cache',
+      context: { user: 'sean' },
+    })
+    expect(first.next).not.toHaveBeenCalled()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // The same call is served from the client cache rather than refetched.
+    const second = callClientMiddleware({ case: 'hit' })
+    await expect(second.promise).resolves.toMatchObject({
+      result: 'from the static cache',
+    })
+    expect(second.next).not.toHaveBeenCalled()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('staticFunctionMiddleware client outside production', () => {
+  test('does not request the cache at all', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    const fetchMock = vi.fn(async () => jsonResponse('{}'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { promise, next } = callClientMiddleware({ case: 'development' })
+
+    await expect(promise).resolves.toBe(LIVE_RESULT)
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/start-static-server-functions/tests/staticFunctionMiddleware.test.ts
+++ b/packages/start-static-server-functions/tests/staticFunctionMiddleware.test.ts
@@ -97,6 +97,35 @@ describe('staticFunctionMiddleware client on a cache miss', () => {
     expect(next).toHaveBeenCalledTimes(1)
   })
 
+  test('falls back to the server function when the payload is not a cached result', async () => {
+    // Valid seroval, but for a plain string rather than a StaticCachedResult.
+    // It decodes to a truthy value, so only a shape check can tell it apart
+    // from a real hit.
+    const payload = JSON.stringify(await toJSONAsync('not a cached result'))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse(payload)),
+    )
+
+    const { promise, next } = callClientMiddleware({ case: 'wrong-shape' })
+
+    await expect(promise).resolves.toBe(LIVE_RESULT)
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  test('falls back to the server function when the payload is missing context', async () => {
+    const payload = JSON.stringify(await toJSONAsync({ result: 'partial' }))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse(payload)),
+    )
+
+    const { promise, next } = callClientMiddleware({ case: 'partial-shape' })
+
+    await expect(promise).resolves.toBe(LIVE_RESULT)
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
   test('falls back to the server function when the request fails outright', async () => {
     vi.stubGlobal(
       'fetch',


### PR DESCRIPTION
## 🎯 Changes

Fixes #7876. Also fixes the failure reported in #7630.

The client half of `staticFunctionMiddleware` runs for every call in a production browser build, and fetched the derived cache URL with no checks at all:

```ts
result = await fetch(url, { method: 'GET' })
  .then((r) => r.json())
  .then((d) => fromJSON(d, { plugins: getDefaultSerovalPlugins() }))
```

A cache file is only written for calls the prerender pass actually executed, by the `.server()` half when `TSS_CLIENT_OUTPUT_DIR` is set. So with `prerender` disabled, or for a route the crawler never reached, nothing exists at `/__tsr/staticServerFnCache/<hash>.json`. The request is answered by the application's catch-all route, which serves the HTML shell, and `r.json()` rejects with:

```
SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON
```

That rejection propagates out of the middleware and takes the loader or navigation down with it, rather than falling through to the live server function. It is the same error reported in #7630.

### The fix

Treat an unreadable cache response as a miss. A failed request, a non-ok status, a body that is not JSON, and a body that does not parse all return `undefined`, which the middleware already handles:

```ts
if (response) {
  return { result: response.result, ... }
}
return ctx.next()
```

The content type has to be checked as well as the status, because the HTML shell is served with a 200 in some setups, so the status alone cannot distinguish a hit from the fallback document.

I also wired up `staticClientCache`. Its lookup was immediately overwritten by the fetch result on the next line, so it never served anything and every repeat call refetched.

### Not fixed: the SPA half of the report

The second half of #7876 asks that enabling `spa` populate the cache. I did not implement that, and I do not think it can work in general: the SPA shell prerender only runs the root route's loaders, and the build cannot know which server functions a client-only route will call at runtime. With this change that case degrades to a live server function call, which is the correct outcome, so the crash is gone even though the caching is not extended. Happy to be corrected if you had a specific mechanism in mind.

### Tests

This package had no tests and its `test:unit` script was the `exit 0; vitest` placeholder, so I enabled it. Its `vite.config.ts` already configured vitest with jsdom, and `vitest` and `jsdom` were already devDependencies. Say the word if you would rather keep the script disabled and I will revert that line.

Five of the six new tests fail on `main`:

| scenario | before | after |
| --- | --- | --- |
| HTML shell served with 200 | rejects with the `<!DOCTYPE` SyntaxError | calls the server function |
| 404 for the cache file | rejects | calls the server function |
| body is not valid JSON | rejects | calls the server function |
| fetch itself throws | rejects | calls the server function |
| valid cache file, called twice | refetches on the second call | second call served from the client cache |

The sixth asserts that a non-production build never requests the cache, which passes both before and after.

One test-harness note worth flagging: `getDefaultSerovalPlugins` reads the Start options through `createIsomorphicFn`, and uncompiled that chain resolves to its server implementation, which wants a Start context in AsyncLocalStorage that a browser never has. The test stubs that one function out rather than faking a server context, since the adapter list is irrelevant to the cache lookup being tested.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

Local verification:

- `pnpm nx run @tanstack/start-static-server-functions:test:unit` passes, 6 tests, no type errors
- `pnpm nx run @tanstack/start-static-server-functions:test:types` passes
- `pnpm nx run @tanstack/start-static-server-functions:test:eslint` passes
- `pnpm nx run @tanstack/start-static-server-functions:test:build` passes
- `node scripts/verify-links.ts` passes for the docs change

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Static server function calls now fall back to server execution when prerendered cache data is unavailable, invalid, malformed, or fails to load.
  - Valid cached results are reused without unnecessary refetching.

- **Documentation**
  - Clarified behavior when prerendered cache files are missing.

- **Tests**
  - Added coverage for cache hits, missing or invalid responses, malformed cached data, fetch failures, and non-production behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->