### PR TITLE
perf(router-core): share settle chain between superseded navigation waiters

### DIFF
--- a/.changeset/await-current-shared-settle.md
+++ b/.changeset/await-current-shared-settle.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+Make each load transaction's completion follow its current successor so a burst of back-to-back loads wakes each superseded waiter once instead of once per successor. Previously every superseded `load()` re-polled the current transaction on each later completion, which was quadratic in microtask work.

--- a/packages/router-core/src/load-client.ts
+++ b/packages/router-core/src/load-client.ts
@@ -1655,16 +1655,19 @@ function commitMatches(
   runRouteLifecycle(router, previous, matches, tx)
 }
 
+/**
+ * Resolve once the router has settled on a transaction other than `owner`.
+ * Each transaction's completion follows its current successor, so all waiters
+ * share the same chain instead of polling every successor independently.
+ */
 async function awaitCurrent(
   router: CoordinatorRouter,
   owner?: LoadTransaction,
 ): Promise<void> {
   let current = router._tx
   while (current && current !== owner) {
+    owner = current
     await current[5 /* done */]
-    if (router._tx === current) {
-      return
-    }
     current = router._tx
   }
 }
@@ -1974,7 +1977,7 @@ export async function loadClientRoute(
     location,
     matches,
     Date.now(),
-    done,
+    done.then(() => awaitCurrent(router, tx)),
   ]
   if (process.env.NODE_ENV !== 'production' && rematerialize) {
     tx[6 /* refresh */] = [handoff]
@@ -2021,8 +2024,7 @@ export async function loadClientRoute(
   }
   // Let explicit synchronous loads publish ready pending work before paint.
   settle?.(run())
-  await done
-  await awaitCurrent(router, tx)
+  await tx[5 /* done */]
 }
 
 export async function refreshClientRoute(

--- a/packages/router-core/tests/navigation-burst-settle.test.ts
+++ b/packages/router-core/tests/navigation-burst-settle.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import { BaseRootRoute, BaseRoute } from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+/**
+ * A superseded navigation resolves only once the router has settled on a
+ * transaction nobody replaced. A burst of same-tick navigations used to make
+ * every superseded waiter re-poll `router._tx` on each successor's
+ * completion, which was quadratic in microtask work and kept every
+ * superseded transaction alive until the router went idle. The waiters now
+ * share one memoized settle chain per transaction; this pins the observable
+ * contract that the chain preserves.
+ */
+describe('same-tick navigation burst', () => {
+  test('every superseded navigate() resolves after the router settles on the last one', async () => {
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const itemRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/items/$id',
+    })
+
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute, itemRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+    const unsubscribe = router.history.subscribe(router.load)
+
+    try {
+      // Location and status observed by each navigation when it resolved.
+      const observed: Array<[pathname: string, status: string]> = []
+      const burst = Array.from({ length: 25 }, (_, index) =>
+        router
+          .navigate({ to: '/items/$id', params: { id: String(index) } })
+          .then(() => {
+            observed.push([router.state.location.pathname, router.state.status])
+          }),
+      )
+
+      await Promise.all(burst)
+
+      expect(router.state.location.pathname).toBe('/items/24')
+      expect(router.state.status).toBe('idle')
+      // No navigation resolves before the router settled on the winner.
+      expect(observed).toHaveLength(25)
+      expect(new Set(observed.map(([pathname]) => pathname))).toEqual(
+        new Set(['/items/24']),
+      )
+      expect(new Set(observed.map(([, status]) => status))).toEqual(
+        new Set(['idle']),
+      )
+      expect(router.state.matches.map((m) => m.status)).toEqual([
+        'success',
+        'success',
+      ])
+    } finally {
+      unsubscribe()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

`awaitCurrent` in `load-client.ts` looped `await current.done` and re-read `router._tx` after each completion. Under back-to-back navigations (anything that starts the next navigation in the same tick as `onRendered`, which includes the `benchmarks/client-nav` harness) every superseded waiter woke on every successor. A burst of N navigations cost N²/2 microtask iterations and kept every superseded transaction (matches, closures, controllers) alive until the router went idle.

Each transaction's `done` promise now follows its current successor, so every waiter on a transaction shares one chain instead of polling successors independently. Semantics are unchanged: a waiter resolves once the router has settled on a transaction other than its owner. A new test pins that contract for a same-tick burst.

## Evidence

Instrumenting the built baseline benchmark bundle before the change: 15,867 navigations, 125,857,045 `awaitCurrent` loop iterations (= N²/2). In the CPU profiles this shows up as `awaitCurrent` at 20 to 42 percent self time plus `(program)` at 30 to 44 percent in the baseline, search-params, route-tree-scale and nested-params scenarios. Loaders and mount are unaffected because their timer hops let the chain settle.

Navigations per 10 seconds in `benchmarks/client-nav` (react, jsdom, same harness), measured by patching the built bundle:

| scenario | before | after |
|---|---|---|
| baseline | 15.4K | 43.2K |
| route-tree-scale | 17.9K | 98.2K |
| search-params | 16.5K | 54.8K |

Real-world impact is bounded to navigation bursts within a tick, but the retained transactions were a leak until idle, and the CodSpeed client-nav numbers were dominated by this, so any perf work benchmarked after this lands should be re-baselined.

## Test plan

- [x] `packages/router-core`: vitest (107 files, 1613 passed), tsc, eslint
- [x] `packages/react-router`: vitest (77 files, 1037 passed)
- [x] New `navigation-burst-settle.test.ts`
- [x] Bundle size (gzip, benchmarks/bundle-size): react-router.minimal -1 B, react-router.full +3 B (vs main)
- [ ] CodSpeed client-nav run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1tX2n8xegVBsZqoJPu7iv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved navigation settling during rapid successive navigations.
  - Superseded navigation requests now wait for the latest navigation to finish before resolving.
  - Prevented intermediate navigation waiters from completing prematurely or being awakened repeatedly.
  - Ensured navigation promises consistently resolve with the router in an idle state and displaying the final destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->