### PR TITLE
fix(examples): migrate remaining legacy createEffect calls to Solid 2.0 two-phase signature

### DIFF
--- a/examples/solid/kitchen-sink-solid-query-file-based/src/hooks/useSessionStorage.tsx
+++ b/examples/solid/kitchen-sink-solid-query-file-based/src/hooks/useSessionStorage.tsx
@@ -6,9 +6,10 @@ export function useSessionStorage<T>(key: string, initialValue: T) {
     stored ? JSON.parse(stored) : initialValue,
   )
 
-  Solid.createEffect(() => {
-    sessionStorage.setItem(key, JSON.stringify(state()))
-  }, [state()])
+  Solid.createEffect(
+    () => JSON.stringify(state()),
+    (json) => sessionStorage.setItem(key, json),
+  )
 
   return [state, setState]
 }

--- a/examples/solid/kitchen-sink-solid-query-file-based/src/routes/dashboard.invoices.$invoiceId.tsx
+++ b/examples/solid/kitchen-sink-solid-query-file-based/src/routes/dashboard.invoices.$invoiceId.tsx
@@ -38,7 +38,7 @@ function InvoiceComponent() {
   const updateInvoiceMutation = useUpdateInvoiceMutation(params().invoiceId)
   const [notes, setNotes] = Solid.createSignal(search().notes ?? '')
 
-  Solid.createEffect(() => {
+  Solid.createEffect(notes, () => {
     navigate({
       search: (old) => ({
         ...old,
@@ -47,7 +47,7 @@ function InvoiceComponent() {
       replace: true,
       params: true,
     })
-  }, [notes])
+  })
 
   return (
     <form

--- a/examples/solid/start-bun/src/routes/demo.start.api-request.tsx
+++ b/examples/solid/start-bun/src/routes/demo.start.api-request.tsx
@@ -12,9 +12,12 @@ export const Route = createFileRoute('/demo/start/api-request')({
 function Home() {
   const [names, setNames] = createSignal<Array<string>>([])
 
-  createEffect(() => {
-    getNames().then(setNames)
-  }, [])
+  createEffect(
+    () => {},
+    () => {
+      getNames().then(setNames)
+    },
+  )
 
   return (
     <div


### PR DESCRIPTION
## Summary

Follow-up to the rc.6 bump: three example call sites still use React-style `createEffect(fn, depsArray)` / single-argument forms that SolidJS 2.0.0-rc.6 no longer accepts (the deprecated overload was removed from `@solidjs/signals` types, and side effects in the compute phase don't run reliably under 2.0 semantics).

These escaped CI because the affected examples build with plain `vite build` (no `tsc --noEmit` step):

- `examples/solid/kitchen-sink-solid-query-file-based/src/hooks/useSessionStorage.tsx` — compute returns the serialized value, effect writes to `sessionStorage`
- `examples/solid/kitchen-sink-solid-query-file-based/src/routes/dashboard.invoices.$invoiceId.tsx` — `createEffect(notes, () => navigate(...))`, matching the style already used in `kitchen-sink-file-based`
- `examples/solid/start-bun/src/routes/demo.start.api-request.tsx` — mount-time one-shot: empty compute, fetch in the effect phase

Examples-only change; no package sources touched.

Made with [Cursor](https://cursor.com)