### PR TITLE
fix(react-router): inject head() src scripts once, not on every navigation

### DIFF
--- a/packages/react-router/src/Asset.tsx
+++ b/packages/react-router/src/Asset.tsx
@@ -159,6 +159,14 @@ function Script({
     )
   }
 
+  // `attrs` is rebuilt as a fresh object on every head-tag computation, so
+  // keying this effect off object identity removes and re-injects `src`
+  // scripts on every navigation that changes head tags - re-executing
+  // third-party scripts (analytics, tag managers, widgets) each time.
+  // Serialize to a stable key so the effect only re-runs when the script
+  // actually changes.
+  const attrsKey = JSON.stringify(attrs ?? null)
+
   React.useEffect(() => {
     if (dataScript) return
 
@@ -217,7 +225,8 @@ function Script({
     }
 
     return undefined
-  }, [attrs, children, dataScript])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [attrsKey, children, dataScript])
 
   // --- Server rendering ---
   if (isServer ?? router.isServer) {

--- a/packages/react-router/tests/head-script-src-navigation.test.tsx
+++ b/packages/react-router/tests/head-script-src-navigation.test.tsx
@@ -1,0 +1,105 @@
+import { createPortal } from 'react-dom'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import { afterEach, expect, test, vi } from 'vitest'
+import {
+  HeadContent,
+  Link,
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+
+afterEach(() => {
+  cleanup()
+  document.head.innerHTML = ''
+  vi.restoreAllMocks()
+})
+
+// A head() script with `src` must be injected (and therefore executed) exactly
+// once. Before the fix, the injection effect keyed off the `attrs` object
+// identity, which changes on every navigation that rebuilds head tags - so
+// the script was removed and re-injected (re-executed) on every navigation.
+test('head() scripts with src are not re-injected on client-side navigations', async () => {
+  const rootRoute = createRootRoute({
+    head: () => ({
+      scripts: [{ src: '/track-test.js' }],
+    }),
+    component: () => (
+      <>
+        {createPortal(<HeadContent />, document.head)}
+        <Link to="/">index</Link>
+        <Link to="/pool/$id" params={{ id: '123' }}>
+          pool
+        </Link>
+        <Outlet />
+      </>
+    ),
+  })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    head: () => ({ meta: [{ title: 'Home Page' }] }),
+    component: () => <div data-testid="index-page">index</div>,
+  })
+  const poolRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/pool/$id',
+    head: () => ({ meta: [{ title: 'Pool Detail' }] }),
+    component: () => <div data-testid="pool-page">pool</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute, poolRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  const injections: Array<HTMLScriptElement> = []
+  const removals: Array<HTMLScriptElement> = []
+  const originalAppendChild = document.head.appendChild.bind(document.head)
+  vi.spyOn(document.head, 'appendChild').mockImplementation((node: any) => {
+    if (
+      node instanceof HTMLScriptElement &&
+      node.getAttribute('src') === '/track-test.js'
+    ) {
+      injections.push(node)
+    }
+    return originalAppendChild(node)
+  })
+  vi.spyOn(HTMLScriptElement.prototype, 'remove').mockImplementation(
+    function (this: HTMLScriptElement) {
+      if (this.getAttribute('src') === '/track-test.js') {
+        removals.push(this)
+      }
+      // Element.prototype.remove
+      this.parentNode?.removeChild(this)
+    },
+  )
+
+  render(<RouterProvider router={router} />)
+  expect(await screen.findByTestId('index-page')).toBeInTheDocument()
+  await waitFor(() => expect(document.title).toBe('Home Page'))
+  expect(injections).toHaveLength(1)
+
+  fireEvent.click(screen.getByRole('link', { name: 'pool' }))
+  expect(await screen.findByTestId('pool-page')).toBeInTheDocument()
+  await waitFor(() => expect(document.title).toBe('Pool Detail'))
+
+  fireEvent.click(screen.getByRole('link', { name: 'index' }))
+  expect(await screen.findByTestId('index-page')).toBeInTheDocument()
+  await waitFor(() => expect(document.title).toBe('Home Page'))
+
+  // Every re-injection re-executes the script in a real browser.
+  expect(injections).toHaveLength(1)
+  expect(removals).toHaveLength(0)
+  expect(
+    document.head.querySelectorAll('script[src="/track-test.js"]'),
+  ).toHaveLength(1)
+})


### PR DESCRIPTION
Fixes #8226.

## Problem

A script declared in `head()` with `src` is removed and re-executed on every client-side navigation that rebuilds head tags. Analytics count every internal click as a fresh visit; widgets re-boot constantly.

Live repro on 1.170.32 (Playwright + Chromium, repro repo linked in the issue): `window.__trackCount` goes 1 (SSR) -> 2 (nav) -> 3 (nav) instead of staying 1.

## Root cause

`Script`'s injection `useEffect` in `Asset.tsx` keyed off `[attrs, children, dataScript]`. `attrs` is a freshly spread object on every head-tag computation, so any navigation that rebuilds head tags re-fires the effect: cleanup removes the injected `<script src>`, the effect appends a new node, and the browser executes it again. (After the hydration flip the component renders `null`, so React removes the SSR-adopted node and the dedup loop can never match it - which is why even the first revisit re-executed.)

## Fix

Serialize the attributes into a stable `attrsKey` and key the effect off that instead of object identity. The effect now only re-runs when the script's actual attributes or content change, so a matched route's script is injected (and executed) exactly once, while route-scoped removal semantics on unmount are unchanged.

## Test

New `packages/react-router/tests/head-script-src-navigation.test.tsx`: root `head()` with `scripts: [{ src: '/track-test.js' }]`, two routes with different head titles; spies on `document.head.appendChild` and `HTMLScriptElement.prototype.remove`, navigates index -> pool -> index, and asserts exactly one injection, zero removals, one node in `<head>`. Fails on `main` (3 injections, 2 removals), passes with the fix.

> Built by breken, your AI support engineer - breken.ai - this one's on us.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented external scripts included in page headers from being removed and re-injected during client-side navigation when their attributes remain unchanged.
  * Ensured these scripts are injected and executed only once across navigation between routes.

* **Tests**
  * Added coverage verifying script persistence and preventing duplicate injections or removals during navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->