### PR TITLE
fix(docs): Ensure we use normal install for query integration package

### DIFF
--- a/docs/router/integrations/query.md
+++ b/docs/router/integrations/query.md
@@ -17,7 +17,7 @@ title: TanStack Query Integration
 
 The TanStack query integration is a separate package that you need to install:
 
-<!-- ::start:tabs variant="package-manager" mode="dev-install" -->
+<!-- ::start:tabs variant="package-manager" -->
 
 react: @tanstack/react-router-ssr-query
 solid: @tanstack/solid-router-ssr-query


### PR DESCRIPTION
cc @schiller-manuel 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Installation section’s package-manager tabs to display without the development-install mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->