### PR TITLE
perf(router-core,react-router): reuse a Link's built location when it reads none of the current one

### DIFF
--- a/.changeset/link-deps-lean.md
+++ b/.changeset/link-deps-lean.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/router-core': patch
+'@tanstack/react-router': patch
+---
+
+Mounted `<Link>`s whose destination never reads the current location (an absolute `to`, params they supply themselves, a literal or absent `search`/`hash`/`state`, no mask) no longer rebuild it on every navigation: `buildLocation` reuses the location it already built. Pages with many such links navigate substantially faster.

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -20,6 +20,7 @@ import { useHydrated } from './ClientOnly'
 import type {
   ActiveOptions,
   AnyRouter,
+  BuildLocationCache,
   Constrain,
   LinkOptions,
   ParsedLocation,
@@ -513,6 +514,16 @@ export function useLinkProps<
     ],
   )
 
+  // A link whose destination never reads the current location (absolute `to`,
+  // params it supplies itself, a literal or absent `search`/`hash`/`state`)
+  // builds the same location forever, so `buildLocation` hands the previous one
+  // back and a navigation only costs the active state comparison below.
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const buildCache = React.useMemo(
+    () => ({}) as BuildLocationCache,
+    [_options, router],
+  )
+
   // Derive inside the selector so `compareLinkState` can bail out. Deriving after
   // the subscription instead re-renders every link on every navigation, because
   // the comparator only sees the location, not whether this link's output moved.
@@ -521,6 +532,7 @@ export function useLinkProps<
     (location: ParsedLocation): LinkState => {
       const next = router.buildLocation({
         _fromLocation: location,
+        _buildCache: buildCache,
         ..._options,
       } as any)
 
@@ -554,7 +566,15 @@ export function useLinkProps<
         ),
       ]
     },
-    [stableActiveOptions, disabled, isHydrated, _options, router, to],
+    [
+      stableActiveOptions,
+      disabled,
+      isHydrated,
+      _options,
+      router,
+      to,
+      buildCache,
+    ],
   )
 
   // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/packages/react-router/tests/link-build-memo.test.tsx
+++ b/packages/react-router/tests/link-build-memo.test.tsx
@@ -1,0 +1,251 @@
+import React from 'react'
+import { afterEach, describe, expect, test } from 'vitest'
+import { act, cleanup, render, screen } from '@testing-library/react'
+import {
+  Link,
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouteMask,
+  createRouter,
+  retainSearchParams,
+} from '../src'
+
+afterEach(() => {
+  cleanup()
+})
+
+/**
+ * `useLinkProps` memoizes `buildLocation` per stable options object and only
+ * rebuilds when a part of the current location that the options actually read
+ * has changed. These cases all read something, so their hrefs and active state
+ * must keep moving with the location.
+ */
+function setup(
+  linkGrid: () => React.ReactNode,
+  opts?: { routeMasks?: boolean },
+) {
+  const rootRoute = createRootRoute({
+    validateSearch: (search: Record<string, unknown>) => search,
+    search: { middlewares: [retainSearchParams(['tab'])] },
+    component: () => (
+      <>
+        <nav>{linkGrid()}</nav>
+        <Outlet />
+      </>
+    ),
+  })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <div>index</div>,
+  })
+  const itemsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/items/$id',
+    component: () => <Outlet />,
+  })
+  const detailRoute = createRoute({
+    getParentRoute: () => itemsRoute,
+    path: '/detail',
+    component: () => <div>detail</div>,
+  })
+  const routeTree = rootRoute.addChildren([
+    indexRoute,
+    itemsRoute.addChildren([detailRoute]),
+  ])
+
+  const router = createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: ['/items/1?tab=a#one'] }),
+    routeMasks: opts?.routeMasks
+      ? [
+          createRouteMask({
+            routeTree,
+            from: '/items/$id/detail',
+            to: '/items/$id',
+            params: (prev) => ({ id: prev.id ?? '' }),
+          }),
+        ]
+      : undefined,
+  })
+
+  return { router }
+}
+
+async function renderRouter(router: any) {
+  await act(async () => {
+    render(<RouterProvider router={router} />)
+    await router.load()
+  })
+}
+
+function hrefOf(testId: string) {
+  return screen.getByTestId(testId).getAttribute('href')
+}
+
+describe('Link buildLocation memo', () => {
+  test('relative, inherited-param, search and hash links follow the location', async () => {
+    const { router } = setup(() => (
+      <>
+        <Link to="." data-testid="self">
+          self
+        </Link>
+        <Link to="/items/$id/detail" data-testid="inherited">
+          inherited
+        </Link>
+        <Link to="/items/$id/detail" params={true} data-testid="params-true">
+          params true
+        </Link>
+        <Link
+          to="/items/$id/detail"
+          params={(prev: any) => ({ id: `${prev.id}0` })}
+          data-testid="params-fn"
+        >
+          params fn
+        </Link>
+        <Link to="/" search={true} data-testid="search-true">
+          search true
+        </Link>
+        <Link
+          to="/"
+          search={(prev: any) => ({ ...prev, extra: 1 })}
+          data-testid="search-fn"
+        >
+          search fn
+        </Link>
+        <Link to="/" data-testid="retained">
+          retained
+        </Link>
+        <Link to="/" hash={true} data-testid="hash-true">
+          hash true
+        </Link>
+        <Link
+          to="/items/$id"
+          params={{ id: '9' }}
+          data-testid="independent"
+          activeProps={{ className: 'is-active' }}
+        >
+          independent
+        </Link>
+      </>
+    ))
+    await renderRouter(router)
+
+    expect(hrefOf('self')).toBe('/items/1?tab=a')
+    expect(hrefOf('inherited')).toBe('/items/1/detail?tab=a')
+    expect(hrefOf('params-true')).toBe('/items/1/detail?tab=a')
+    expect(hrefOf('params-fn')).toBe('/items/10/detail?tab=a')
+    expect(hrefOf('search-true')).toBe('/?tab=a')
+    expect(hrefOf('search-fn')).toBe('/?tab=a&extra=1')
+    expect(hrefOf('retained')).toBe('/?tab=a')
+    expect(hrefOf('hash-true')).toBe('/?tab=a#one')
+    expect(hrefOf('independent')).toBe('/items/9?tab=a')
+    expect(screen.getByTestId('independent').className).not.toContain(
+      'is-active',
+    )
+
+    await act(async () => {
+      await router.navigate({
+        to: '/items/$id',
+        params: { id: '9' },
+        search: { tab: 'b' },
+        hash: 'two',
+      })
+    })
+
+    expect(hrefOf('self')).toBe('/items/9?tab=b')
+    expect(hrefOf('inherited')).toBe('/items/9/detail?tab=b')
+    expect(hrefOf('params-true')).toBe('/items/9/detail?tab=b')
+    expect(hrefOf('params-fn')).toBe('/items/90/detail?tab=b')
+    expect(hrefOf('search-true')).toBe('/?tab=b')
+    expect(hrefOf('search-fn')).toBe('/?tab=b&extra=1')
+    expect(hrefOf('retained')).toBe('/?tab=b')
+    expect(hrefOf('hash-true')).toBe('/?tab=b#two')
+    // The independent link's href never moves, but its active state does.
+    expect(hrefOf('independent')).toBe('/items/9?tab=b')
+    expect(screen.getByTestId('independent').className).toContain('is-active')
+
+    await act(async () => {
+      await router.navigate({ to: '/', search: { tab: 'b' } })
+    })
+
+    expect(hrefOf('self')).toBe('/?tab=b')
+    expect(screen.getByTestId('independent').className).not.toContain(
+      'is-active',
+    )
+  })
+
+  test('includeHash active option tracks the current hash', async () => {
+    const { router } = setup(() => (
+      <Link
+        to="/items/$id"
+        params={{ id: '1' }}
+        hash="one"
+        activeOptions={{ includeHash: true, includeSearch: false }}
+        activeProps={{ className: 'is-active' }}
+        data-testid="hashed"
+      >
+        hashed
+      </Link>
+    ))
+    await renderRouter(router)
+
+    expect(screen.getByTestId('hashed').className).toContain('is-active')
+
+    await act(async () => {
+      await router.navigate({
+        to: '/items/$id',
+        params: { id: '1' },
+        hash: 'two',
+      })
+    })
+    expect(screen.getByTestId('hashed').className).not.toContain('is-active')
+  })
+
+  test('an explicit mask keeps resolving against the current location', async () => {
+    const { router } = setup(() => (
+      <Link
+        to="/items/$id"
+        params={{ id: '9' }}
+        mask={{ to: '/items/$id/detail', params: true }}
+        data-testid="masked"
+      >
+        masked
+      </Link>
+    ))
+    await renderRouter(router)
+
+    expect(hrefOf('masked')).toBe('/items/1/detail?tab=a')
+
+    await act(async () => {
+      await router.navigate({ to: '/items/$id', params: { id: '5' } })
+    })
+    expect(hrefOf('masked')).toBe('/items/5/detail?tab=a')
+  })
+
+  test('routeMasks keep resolving across navigations', async () => {
+    const { router } = setup(
+      () => (
+        <Link
+          to="/items/$id/detail"
+          params={{ id: '9' }}
+          data-testid="auto-masked"
+        >
+          auto masked
+        </Link>
+      ),
+      { routeMasks: true },
+    )
+    await renderRouter(router)
+
+    expect(hrefOf('auto-masked')).toBe('/items/9?tab=a')
+
+    await act(async () => {
+      await router.navigate({ to: '/items/$id', params: { id: '5' } })
+    })
+    expect(hrefOf('auto-masked')).toBe('/items/9?tab=a')
+  })
+})

--- a/packages/router-core/src/RouterProvider.ts
+++ b/packages/router-core/src/RouterProvider.ts
@@ -1,7 +1,11 @@
 import type { NavigateOptions, ToOptions } from './link'
 import type { ParsedLocation } from './location'
 import type { RoutePaths } from './routeInfo'
-import type { RegisteredRouter, ViewTransitionOptions } from './router'
+import type {
+  BuildLocationCache,
+  RegisteredRouter,
+  ViewTransitionOptions,
+} from './router'
 
 export interface MatchLocation {
   to?: string | number | null
@@ -43,5 +47,7 @@ export type BuildLocationFn = <
     leaveParams?: boolean
     _includeValidateSearch?: boolean
     _isNavigate?: boolean
+    /** @internal */
+    _buildCache?: BuildLocationCache
   },
 ) => ParsedLocation

--- a/packages/router-core/src/index.ts
+++ b/packages/router-core/src/index.ts
@@ -255,6 +255,7 @@ export type {
   RegisteredRouter,
   RouterState,
   BuildNextOptions,
+  BuildLocationCache,
   RouterListener,
   RouterEvent,
   ListenerFn,

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -576,6 +576,30 @@ export interface BuildNextOptions {
   _fromLocation?: ParsedLocation
   unsafeRelative?: 'path'
   _isNavigate?: boolean
+  /** @internal */
+  _buildCache?: BuildLocationCache
+}
+
+/**
+ * Caller-owned memo slot for `buildLocation`.
+ *
+ * A build that never reads the *current* location (absolute `to`, params it
+ * supplies itself, a literal or absent `search`/`hash`/`state`, no mask) always
+ * produces the same location, so `r` can be handed back until the router
+ * options or the route tree change. Anything that does read the current
+ * location clears `r` and pays the normal build every time.
+ *
+ * The cached `ParsedLocation` is shared, so callers must treat it as immutable.
+ *
+ * @internal
+ */
+export interface BuildLocationCache {
+  /** `router.options` identity `r` was built against. */
+  o?: unknown
+  /** Route tree identity `r` was built against (HMR replaces it). */
+  t?: unknown
+  /** The memoized result, absent when the build read the current location. */
+  r?: ParsedLocation
 }
 
 type NavigationEventInfo = {
@@ -1836,6 +1860,17 @@ export class RouterCore<
    * @link https://tanstack.com/router/latest/docs/framework/react/api/router/RouterType#buildlocation-method
    */
   buildLocation: BuildLocationFn = (opts) => {
+    const cache = (opts as BuildNextOptions)._buildCache
+    if (
+      cache?.r &&
+      cache.o === this.options &&
+      cache.t === this.processedTree
+    ) {
+      return cache.r
+    }
+    // A masked build resolves its own current location, so treat it as a read.
+    let readsLocation: unknown = opts.mask || this.options.routeMasks?.length
+
     const build = (
       dest: BuildNextOptions & {
         unmaskOnReload?: boolean
@@ -1899,10 +1934,12 @@ export class RouterCore<
       // Same with params. It can't hurt to provide as many as possible
       const fromParams = lightweightResult[3 /* params */]
 
-      const nextTo = this.resolvePathWithBase(
-        defaultedFromPath,
-        dest.to ? `${dest.to}` : '.',
-      )
+      // `resolvePath` returns an absolute `to` untouched; only a relative one
+      // reads the current location's path.
+      const to = dest.to ? `${dest.to}` : '.'
+      readsLocation ||= to.charCodeAt(0) !== 47 /* '/' */
+
+      const nextTo = this.resolvePathWithBase(defaultedFromPath, to)
 
       // Resolve the next params
       let nextParams = resolveNextParams(dest.params, fromParams)
@@ -1937,6 +1974,9 @@ export class RouterCore<
           const fn =
             route.options.params?.stringify ?? route.options.stringifyParams
           if (fn) {
+            // `stringify` sees inherited params too, so the result can move
+            // with the current location.
+            readsLocation = true
             if (nextParams === fromParams) {
               nextParams = Object.assign(Object.create(null), nextParams)
             }
@@ -1953,17 +1993,32 @@ export class RouterCore<
         }
       }
 
-      const nextPathname = opts.leaveParams
-        ? // Keep path params uninterpolated for matchRoute/template matching.
-          nextTo
-        : decodePath(
-            interpolatePath({
-              path: nextTo,
-              params: nextParams,
-              decoder: this.pathParamsDecoder,
-              server: this.isServer,
-            }).interpolatedPath,
-          ).path
+      let nextPathname: string
+      if (opts.leaveParams) {
+        // Keep path params uninterpolated for matchRoute/template matching.
+        nextPathname = nextTo
+      } else {
+        const interpolated = interpolatePath({
+          path: nextTo,
+          params: nextParams,
+          decoder: this.pathParamsDecoder,
+          server: this.isServer,
+        })
+        nextPathname = decodePath(interpolated.interpolatedPath).path
+
+        // `usedParams` holds exactly the values that reached the pathname. Only
+        // a plain object supplying every one of them keeps the pathname
+        // location-independent; anything else inherits from the current params.
+        const spec = dest.params
+        const inherits = spec === null || typeof spec !== 'object'
+        for (const key in interpolated.usedParams) {
+          // `*` is only ever an alias of `_splat`, which is checked too.
+          if (inherits || (key !== '*' && !(key in spec))) {
+            readsLocation = true
+            break
+          }
+        }
+      }
 
       if (
         process.env.NODE_ENV !== 'production' &&
@@ -2005,6 +2060,13 @@ export class RouterCore<
         nextSearch = validatedSearch
       }
 
+      // A literal `search` object replaces the current search wholesale, so only
+      // `true`, an updater, a route middleware or validation reads what came in.
+      readsLocation ||=
+        readsCurrent(dest.search) ||
+        opts._includeValidateSearch ||
+        destRoutes.some(routeReadsSearch)
+
       nextSearch = applySearchMiddleware(
         nextSearch,
         dest,
@@ -2017,6 +2079,10 @@ export class RouterCore<
 
       // Stringify the next search
       const searchStr = this.options.stringifySearch(nextSearch)
+
+      // Literal `hash`/`state` values are used as-is; `true` and updaters read
+      // the current ones.
+      readsLocation ||= readsCurrent(dest.hash) || readsCurrent(dest.state)
 
       // Resolve the next hash
       const hash =
@@ -2112,6 +2178,12 @@ export class RouterCore<
           params: nextParams,
         })
       }
+    }
+
+    if (cache) {
+      cache.o = this.options
+      cache.t = this.processedTree
+      cache.r = readsLocation ? undefined : next
     }
 
     return next
@@ -2833,6 +2905,20 @@ function applySearchMiddleware(
   }
 
   return applyNext(0, search)
+}
+
+/** `true` and updater functions read the current value; literals do not. */
+function readsCurrent(spec: unknown) {
+  return spec === true || typeof spec === 'function'
+}
+
+/**
+ * Conservative mirror of the middleware collection in `applySearchMiddleware`:
+ * a route that declares any of these can read the incoming search.
+ */
+function routeReadsSearch(route: AnyRoute) {
+  const o = route.options
+  return !!(o.search?.middlewares || o.preSearchFilters || o.postSearchFilters)
 }
 
 function findGlobalNotFoundRouteId(

--- a/packages/router-core/tests/build-location-cache.test.ts
+++ b/packages/router-core/tests/build-location-cache.test.ts
@@ -112,6 +112,63 @@ describe('buildLocation memo (_buildCache)', () => {
     expect(second.location.href).toBe('/items/9?tab=specs#section-9')
   })
 
+  // A plain `params` object does not have to be complete: `resolveNextParams`
+  // merges it over the current location's params, so anything it leaves out is
+  // inherited. Skipping the `usedParams` check and treating every plain object
+  // as self-sufficient would memoize these links and freeze their href.
+  test('a plain `params` object that omits a needed param still follows the current location', async () => {
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const postRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/posts/$postId',
+    })
+    const editRoute = new BaseRoute({
+      getParentRoute: () => postRoute,
+      path: '/edit',
+    })
+    const tabRoute = new BaseRoute({
+      getParentRoute: () => postRoute,
+      path: '/tab/$tab',
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([
+        indexRoute,
+        postRoute.addChildren([editRoute, tabRoute]),
+      ]),
+      history: createMemoryHistory({ initialEntries: ['/posts/1'] }),
+    })
+    await router.load()
+
+    const empty: BuildLocationCache = {}
+    const partial: BuildLocationCache = {}
+    const emptyOpts = { to: '/posts/$postId/edit', params: {} }
+    const partialOpts = {
+      to: '/posts/$postId/tab/$tab',
+      params: { tab: 'stats' },
+    }
+
+    expect(buildBoth(router, empty, emptyOpts).location.href).toBe(
+      '/posts/1/edit',
+    )
+    expect(buildBoth(router, partial, partialOpts).location.href).toBe(
+      '/posts/1/tab/stats',
+    )
+
+    await router.navigate({ to: '/posts/$postId', params: { postId: '2' } })
+
+    const emptyAfter = buildBoth(router, empty, emptyOpts)
+    expect(emptyAfter.hit).toBe(false)
+    expect(emptyAfter.location.href).toBe('/posts/2/edit')
+
+    const partialAfter = buildBoth(router, partial, partialOpts)
+    expect(partialAfter.hit).toBe(false)
+    expect(partialAfter.location.href).toBe('/posts/2/tab/stats')
+  })
+
   test('inherited params (`params` omitted) follow the current location', async () => {
     const router = makeRouter('/items/1')
     await router.load()

--- a/packages/router-core/tests/build-location-cache.test.ts
+++ b/packages/router-core/tests/build-location-cache.test.ts
@@ -1,0 +1,473 @@
+import { describe, expect, test } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import { BaseRootRoute, BaseRoute, retainSearchParams } from '../src'
+import { createTestRouter } from './routerTestUtils'
+import type { AnyRouter, BuildLocationCache, ParsedLocation } from '../src'
+
+function makeRouter(initialEntry = '/items/1') {
+  const rootRoute = new BaseRootRoute({})
+  const indexRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+  })
+  const itemsRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/items/$id',
+  })
+  const itemsDetailRoute = new BaseRoute({
+    getParentRoute: () => itemsRoute,
+    path: '/detail',
+  })
+  const aboutRoute = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/about',
+  })
+  const routeTree = rootRoute.addChildren([
+    indexRoute,
+    itemsRoute.addChildren([itemsDetailRoute]),
+    aboutRoute,
+  ])
+
+  return createTestRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [initialEntry] }),
+  })
+}
+
+/**
+ * Build `opts` with and without a memo slot and assert the memo did not change
+ * the answer. Returns whether the memo actually served its previous object,
+ * which happens only when the build never read the current location, so both
+ * the fast path and the correctness of the classification are pinned.
+ */
+function buildBoth(
+  router: AnyRouter,
+  cache: BuildLocationCache,
+  opts: Record<string, unknown>,
+) {
+  const previous = cache.r
+  const cached: ParsedLocation = router.buildLocation({
+    ...opts,
+    _buildCache: cache,
+  } as any)
+  const fresh: ParsedLocation = router.buildLocation({ ...opts } as any)
+
+  expect(cached.href).toBe(fresh.href)
+  expect(cached.publicHref).toBe(fresh.publicHref)
+  expect(cached.pathname).toBe(fresh.pathname)
+  expect(cached.searchStr).toBe(fresh.searchStr)
+  expect(cached.hash).toBe(fresh.hash)
+  expect(cached.search).toEqual(fresh.search)
+  expect(cached.state).toEqual(fresh.state)
+  expect(cached.maskedLocation?.href).toBe(fresh.maskedLocation?.href)
+
+  return {
+    location: cached,
+    hit: previous !== undefined && cached === previous,
+  }
+}
+
+describe('buildLocation memo (_buildCache)', () => {
+  test('a location-independent destination is served from the memo across navigations', async () => {
+    const router = makeRouter('/items/1')
+    await router.load()
+    const cache: BuildLocationCache = {}
+    const opts = { to: '/items/$id', params: { id: '9' } }
+
+    expect(buildBoth(router, cache, opts).location.href).toBe('/items/9')
+
+    await router.navigate({ to: '/items/$id', params: { id: '2' } })
+    const second = buildBoth(router, cache, opts)
+    expect(second.hit).toBe(true)
+    expect(second.location.href).toBe('/items/9')
+
+    await router.navigate({ to: '/about' })
+    const third = buildBoth(router, cache, opts)
+    expect(third.hit).toBe(true)
+    expect(third.location.href).toBe('/items/9')
+  })
+
+  test('a literal search and hash stay location-independent', async () => {
+    const router = makeRouter('/items/1')
+    await router.load()
+    const cache: BuildLocationCache = {}
+    const opts = {
+      to: '/items/$id',
+      params: { id: '9' },
+      search: { tab: 'specs' },
+      hash: 'section-9',
+    }
+
+    expect(buildBoth(router, cache, opts).location.href).toBe(
+      '/items/9?tab=specs#section-9',
+    )
+
+    await router.navigate({
+      to: '/items/$id',
+      params: { id: '2' },
+      search: { q: 'x' },
+    })
+    const second = buildBoth(router, cache, opts)
+    expect(second.hit).toBe(true)
+    expect(second.location.href).toBe('/items/9?tab=specs#section-9')
+  })
+
+  test('inherited params (`params` omitted) follow the current location', async () => {
+    const router = makeRouter('/items/1')
+    await router.load()
+    const cache: BuildLocationCache = {}
+    const opts = { to: '/items/$id/detail' }
+
+    expect(buildBoth(router, cache, opts).location.href).toBe('/items/1/detail')
+
+    await router.navigate({ to: '/items/$id', params: { id: '2' } })
+    const second = buildBoth(router, cache, opts)
+    expect(second.hit).toBe(false)
+    expect(second.location.href).toBe('/items/2/detail')
+  })
+
+  test('`params: true` follows the current location', async () => {
+    const router = makeRouter('/items/1')
+    await router.load()
+    const cache: BuildLocationCache = {}
+    const opts = { to: '/items/$id/detail', params: true }
+
+    expect(buildBoth(router, cache, opts).location.href).toBe('/items/1/detail')
+    await router.navigate({ to: '/items/$id', params: { id: '7' } })
+    expect(buildBoth(router, cache, opts).location.href).toBe('/items/7/detail')
+  })
+
+  test('a params updater function follows the current location', async () => {
+    const router = makeRouter('/items/1')
+    await router.load()
+    const cache: BuildLocationCache = {}
+    const opts = {
+      to: '/items/$id/detail',
+      params: (prev: any) => ({ id: `${prev.id}-x` }),
+    }
+
+    expect(buildBoth(router, cache, opts).location.href).toBe(
+      '/items/1-x/detail',
+    )
+    await router.navigate({ to: '/items/$id', params: { id: '7' } })
+    expect(buildBoth(router, cache, opts).location.href).toBe(
+      '/items/7-x/detail',
+    )
+  })
+
+  test('a relative `to` follows the current location', async () => {
+    const router = makeRouter('/items/1')
+    await router.load()
+    const cache: BuildLocationCache = {}
+    const opts = { to: 'detail' }
+
+    expect(buildBoth(router, cache, opts).location.href).toBe('/items/1/detail')
+    await router.navigate({ to: '/about' })
+    const second = buildBoth(router, cache, opts)
+    expect(second.hit).toBe(false)
+    expect(second.location.href).toBe('/about/detail')
+  })
+
+  test('`unsafeRelative: path` follows the current pathname', async () => {
+    const router = makeRouter('/items/1')
+    await router.load()
+    const cache: BuildLocationCache = {}
+    const opts = { to: 'detail', unsafeRelative: 'path' as const }
+
+    expect(buildBoth(router, cache, opts).location.href).toBe('/items/1/detail')
+    await router.navigate({ to: '/items/$id', params: { id: '5' } })
+    const second = buildBoth(router, cache, opts)
+    expect(second.hit).toBe(false)
+    expect(second.location.href).toBe('/items/5/detail')
+  })
+
+  test('`search: true` follows the current search', async () => {
+    const router = makeRouter('/items/1?tab=a')
+    await router.load()
+    const cache: BuildLocationCache = {}
+    const opts = { to: '/about', search: true }
+
+    expect(buildBoth(router, cache, opts).location.href).toBe('/about?tab=a')
+    await router.navigate({
+      to: '/items/$id',
+      params: { id: '2' },
+      search: { tab: 'b' },
+    })
+    const second = buildBoth(router, cache, opts)
+    expect(second.hit).toBe(false)
+    expect(second.location.href).toBe('/about?tab=b')
+  })
+
+  test('a search updater function follows the current search', async () => {
+    const router = makeRouter('/items/1?tab=a')
+    await router.load()
+    const cache: BuildLocationCache = {}
+    const opts = {
+      to: '/about',
+      search: (prev: any) => ({ tab: prev.tab, extra: 1 }),
+    }
+
+    expect(buildBoth(router, cache, opts).location.href).toBe(
+      '/about?tab=a&extra=1',
+    )
+    await router.navigate({
+      to: '/items/$id',
+      params: { id: '2' },
+      search: { tab: 'b' },
+    })
+    expect(buildBoth(router, cache, opts).location.href).toBe(
+      '/about?tab=b&extra=1',
+    )
+  })
+
+  test('retainSearchParams middleware follows the current search', async () => {
+    const rootRoute = new BaseRootRoute({
+      validateSearch: (search: { tab?: string }) => search,
+      search: { middlewares: [retainSearchParams(['tab'])] },
+    })
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const aboutRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/about',
+    })
+    const itemsRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/items/$id',
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute, aboutRoute, itemsRoute]),
+      history: createMemoryHistory({ initialEntries: ['/items/1?tab=a'] }),
+    })
+    await router.load()
+
+    const cache: BuildLocationCache = {}
+    const opts = { to: '/about' }
+
+    expect(buildBoth(router, cache, opts).location.href).toBe('/about?tab=a')
+    await router.navigate({
+      to: '/items/$id',
+      params: { id: '2' },
+      search: { tab: 'b' },
+    })
+    const second = buildBoth(router, cache, opts)
+    expect(second.hit).toBe(false)
+    expect(second.location.href).toBe('/about?tab=b')
+  })
+
+  test('`hash: true` and hash updaters follow the current hash', async () => {
+    const router = makeRouter('/items/1#one')
+    await router.load()
+    const inherit: BuildLocationCache = {}
+    const updater: BuildLocationCache = {}
+
+    expect(
+      buildBoth(router, inherit, { to: '/about', hash: true }).location.href,
+    ).toBe('/about#one')
+    expect(
+      buildBoth(router, updater, {
+        to: '/about',
+        hash: (prev: string) => `${prev}-x`,
+      }).location.href,
+    ).toBe('/about#one-x')
+
+    await router.navigate({
+      to: '/items/$id',
+      params: { id: '2' },
+      hash: 'two',
+    })
+
+    expect(
+      buildBoth(router, inherit, { to: '/about', hash: true }).location.href,
+    ).toBe('/about#two')
+    expect(
+      buildBoth(router, updater, {
+        to: '/about',
+        hash: (prev: string) => `${prev}-x`,
+      }).location.href,
+    ).toBe('/about#two-x')
+  })
+
+  test('`state: true` follows the current state', async () => {
+    const router = makeRouter('/items/1')
+    await router.load()
+    const cache: BuildLocationCache = {}
+    const opts = { to: '/about', state: true }
+
+    buildBoth(router, cache, opts)
+    await router.navigate({
+      to: '/items/$id',
+      params: { id: '2' },
+      state: { a: 1 } as any,
+    })
+    const second = buildBoth(router, cache, opts)
+    expect(second.hit).toBe(false)
+    expect((second.location.state as any).a).toBe(1)
+  })
+
+  test('a route with params.stringify keeps following the current params', async () => {
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const itemsRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/items/$id',
+      params: {
+        // `stringify` reads a param the destination does not supply, so the
+        // built location depends on the current location's params after all.
+        stringify: (p: any) => ({ id: `${p.id}${p.suffix ?? ''}` }),
+      },
+    })
+    const suffixRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/s/$suffix',
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute, itemsRoute, suffixRoute]),
+      history: createMemoryHistory({ initialEntries: ['/s/a'] }),
+    })
+    await router.load()
+
+    const cache: BuildLocationCache = {}
+    const opts = { to: '/items/$id', params: { id: '9' } }
+    expect(buildBoth(router, cache, opts).location.href).toBe('/items/9a')
+
+    await router.navigate({ to: '/s/$suffix', params: { suffix: 'b' } })
+    const second = buildBoth(router, cache, opts)
+    expect(second.hit).toBe(false)
+    expect(second.location.href).toBe('/items/9b')
+  })
+
+  test('an explicit mask stays correct (memo disabled)', async () => {
+    const router = makeRouter('/items/1')
+    await router.load()
+    const cache: BuildLocationCache = {}
+    const opts = {
+      to: '/items/$id',
+      params: { id: '9' },
+      mask: { to: '/items/$id/detail', params: true },
+    }
+
+    const first = buildBoth(router, cache, opts)
+    expect(first.location.href).toBe('/items/9')
+    expect(first.location.maskedLocation?.href).toBe('/items/1/detail')
+
+    await router.navigate({ to: '/items/$id', params: { id: '2' } })
+    const second = buildBoth(router, cache, opts)
+    expect(second.hit).toBe(false)
+    expect(second.location.maskedLocation?.href).toBe('/items/2/detail')
+  })
+
+  test('routeMasks disable the memo and keep resolving per navigation', async () => {
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const itemsRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/items/$id',
+    })
+    const detailRoute = new BaseRoute({
+      getParentRoute: () => itemsRoute,
+      path: '/detail',
+    })
+    const routeTree = rootRoute.addChildren([
+      indexRoute,
+      itemsRoute.addChildren([detailRoute]),
+    ])
+    const router = createTestRouter({
+      routeTree,
+      history: createMemoryHistory({ initialEntries: ['/items/1'] }),
+      routeMasks: [
+        {
+          routeTree,
+          from: '/items/$id/detail',
+          to: '/items/$id',
+        } as any,
+      ],
+    })
+    await router.load()
+
+    const cache: BuildLocationCache = {}
+    const opts = { to: '/items/$id/detail', params: { id: '9' } }
+    const first = buildBoth(router, cache, opts)
+    expect(first.hit).toBe(false)
+    expect(first.location.maskedLocation?.href).toBe('/items/9')
+
+    await router.navigate({ to: '/items/$id', params: { id: '2' } })
+    const second = buildBoth(router, cache, opts)
+    expect(second.hit).toBe(false)
+    expect(second.location.maskedLocation?.href).toBe('/items/9')
+  })
+
+  test('the memo is invalidated when router options change', async () => {
+    const router = makeRouter('/items/1')
+    await router.load()
+    const cache: BuildLocationCache = {}
+    const opts = { to: '/items/$id', params: { id: '9' } }
+
+    expect(buildBoth(router, cache, opts).location.href).toBe('/items/9')
+    router.update({ ...router.options, basepath: '/app' })
+    const second = buildBoth(router, cache, opts)
+    expect(second.hit).toBe(false)
+    expect(second.location.href).toBe('/app/items/9')
+  })
+
+  test('the memo is invalidated when the route tree is rebuilt (HMR)', async () => {
+    const router = makeRouter('/items/1')
+    await router.load()
+    const cache: BuildLocationCache = {}
+    const opts = { to: '/items/$id', params: { id: '9' } }
+
+    expect(buildBoth(router, cache, opts).location.href).toBe('/items/9')
+    // `handleRouteUpdate` in router-plugin swaps route options in place and
+    // rebuilds the tree without touching `router.options`.
+    router.setRoutes(router.buildRouteTree())
+    expect(buildBoth(router, cache, opts).hit).toBe(false)
+  })
+
+  test('a splat destination that supplies _splat is location-independent', async () => {
+    const rootRoute = new BaseRootRoute({})
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const filesRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/files/$',
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute, filesRoute]),
+      history: createMemoryHistory({ initialEntries: ['/files/a/b'] }),
+    })
+    await router.load()
+
+    const supplied: BuildLocationCache = {}
+    const inherited: BuildLocationCache = {}
+    expect(
+      buildBoth(router, supplied, { to: '/files/$', params: { _splat: 'x/y' } })
+        .location.href,
+    ).toBe('/files/x/y')
+    expect(buildBoth(router, inherited, { to: '/files/$' }).location.href).toBe(
+      '/files/a/b',
+    )
+
+    await router.navigate({ to: '/files/$', params: { _splat: 'c/d' } })
+
+    const suppliedAfter = buildBoth(router, supplied, {
+      to: '/files/$',
+      params: { _splat: 'x/y' },
+    })
+    expect(suppliedAfter.hit).toBe(true)
+    expect(suppliedAfter.location.href).toBe('/files/x/y')
+
+    const inheritedAfter = buildBoth(router, inherited, { to: '/files/$' })
+    expect(inheritedAfter.hit).toBe(false)
+    expect(inheritedAfter.location.href).toBe('/files/c/d')
+  })
+})


### PR DESCRIPTION
## Summary

In the `links` client-nav scenario (200 mounted `<Link>`s), about 40% of non-idle CPU was `router.buildLocation` running inside every link's store selector on every location change, because `useSyncExternalStoreWithSelector` re-runs each selector synchronously in the notification. Inside that build the cost was `interpolatePath`, `resolveNextParams`, `nullReplaceEqualDeep` on search, `matchRoutesLightweight` and `stringifySearch`, all recomputing the same href.

Most links do not depend on the current location at all: an absolute `to`, a plain `params` object that supplies every path param, and a literal or absent `search`/`hash`/`state`. Only their active state does.

`buildLocation` now tracks one boolean, "this build read the current location", set exactly by:

- a relative `to` or `unsafeRelative: 'path'`
- a param that reached the pathname but was not supplied by a plain `params` object (from `interpolatePath`'s `usedParams`), or any `params.stringify` in the destination branch
- `search`, `hash` or `state` given as `true` or an updater, `_includeValidateSearch`, or any destination route declaring search middlewares
- any mask

Callers can pass an internal `_buildCache` slot; while the bit stays false the previously built location is handed back until `router.options` or the route tree changes identity (the router-plugin HMR path calls `setRoutes` without touching options, so both are checked). `useLinkProps` holds one slot per stable options identity. Everything that does read the current location pays the normal build every time, so behavior is unchanged for those links.

## Measurements

`links` scenario, jsdom, production build, paired back to back on a quiet machine:

| | hz | mean | min |
|---|---|---|---|
| before | 199.13 | 5.022 ms | 4.584 ms |
| after | 486.87 | 2.054 ms | 1.908 ms |

`mount` unchanged (686 → 700 hz). All 202 links in the scenario are location-independent under the bit (measured by instrumenting the built bundle).

Bundle gzip vs the pre-change build: `react-router.minimal` +210 B, `react-router.full` +235 B.

Variants measured and not taken:

- Per-dependency tracking (which location fields were read, so `retainSearchParams` apps still memoize when the retained search is unchanged): +394 / +404 B for the same benchmark result. Kept on a local branch.
- Dropping the `usedParams` loop and assuming a plain `params` object is complete: −34 B, but incorrect. A plain object that omits a param inherits it from the current location (`<Link to="/posts/$postId/edit" params={{}}>` under `/posts/$postId`), and the href would go stale. A test pins that shape.
- Dropping the route-tree identity guard: −14 / −20 B, but it would need router-plugin's HMR path to also replace `router.options` identity, coupling the two packages for a dev-time correctness property.

## Tests

- `packages/router-core/tests/build-location-cache.test.ts` (19): every dependent shape builds identically with and without the memo, and asserts whether the memo served a hit: relative `to`, `unsafeRelative`, inherited params (including a partial plain object), `params: true`, params updater, `search: true`, search updater, `retainSearchParams`, `hash`/`state` as `true`/updater, `params.stringify`, splat supplied vs inherited, explicit mask, `routeMasks`, options change, HMR `setRoutes`.
- `packages/react-router/tests/link-build-memo.test.tsx` (4): hrefs and active class update across navigations for the dependent link shapes, `includeHash`, masks.
- Suites: router-core 109 files / 1633 passed / 4 expected fail; react-router 78 / 1041 / 1 skipped; solid-router 887; vue-router 871; `tsc --noEmit` clean.

## Notes for review

The cached `ParsedLocation` is shared between calls, so callers passing `_buildCache` must treat it as immutable; `useLinkProps` only reads from it. Dev-only warnings inside `build()` are skipped on a memo hit; they are deterministic for a given result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1tX2n8xegVBsZqoJPu7iv
