### PR TITLE
docs: warn about <Outlet /> requirement in layout route files

### DIFF
--- a/docs/start/framework/react/guide/routing.md
+++ b/docs/start/framework/react/guide/routing.md
@@ -202,6 +202,28 @@ To create a route, create a new file that corresponds to the path of the route y
 | `/posts/:postId` | `posts/$postId.tsx` | Dynamic Route  |
 | `/rest/*`        | `rest/$.tsx`        | Wildcard Route |
 
+> [!WARNING]
+> **Layout routes need an `<Outlet />` to render child routes.**
+>
+> When you create a layout route file (e.g. `posts.tsx`), the development server will auto-fill it with a basic component. If you later add child routes (e.g. `posts/index.tsx` or `posts/$postId.tsx`), those child routes will **not appear** until you add `<Outlet />` to the layout route's component:
+>
+> ```tsx
+> // posts.tsx — a layout route for all /posts/* routes
+> import { createFileRoute, Outlet } from '@tanstack/react-router'
+>
+> export const Route = createFileRoute('/posts')({
+>   component: () => (
+>     <div>
+>       <h1>My Posts</h1>
+>       {/* Child routes (/posts, /posts/123, etc.) render here */}
+>       <Outlet />
+>     </div>
+>   ),
+> })
+> ```
+>
+> If you skip this step, navigating to `/posts/123` will appear to do nothing — the layout renders but the child route component never appears. This is a common first-time-user gotcha.
+
 ## Defining Routes
 
 To define a route, use the `createFileRoute` function to export the route as the `Route` variable.


### PR DESCRIPTION
## Summary
Add a documentation warning to the TanStack Start routing guide explaining that layout route files (e.g. `posts.tsx`) need an `<Outlet />` to render child routes.

## Problem
Closes [#5351](https://github.com/TanStack/router/issues/5351)

New users following the getting started guide can get stuck when creating nested routes. The development server auto-fills layout route files with a basic component, but without an `<Outlet />`, child routes silently fail to render. The user sees no error — the dynamic URL just appears to do nothing. This creates a poor first experience.

## Solution
Added a `[!WARNING]` callout directly in the "Creating File Routes" section of `docs/start/framework/react/guide/routing.md`. The callout:

- Explains that layout routes need `<Outlet />` to render children
- Shows a concrete code example with the correct pattern
- Explicitly calls out the symptom (navigating to `/posts/123` appears to do nothing)

## Changes Made
- `docs/start/framework/react/guide/routing.md`: Added `[!WARNING]` callout after the file-routes table, before the "Defining Routes" section

## Testing
- Documentation-only change — verified the file parses correctly
- Ran `prettier --check` on the modified file (documentation format is consistent)

## Checklist
- [x] Documentation updated
- [x] No unrelated changes
- [x] No test changes required (this is a docs-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance explaining that layout routes require an `<Outlet />` to render child routes.
  * Included an example demonstrating the behavior when `<Outlet />` is omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->