### PR TITLE
fix(start-plugin-core): install the dev server middleware when vite is duplicated, and warn when it is skipped

### DIFF
--- a/.changeset/dev-server-middleware-duplicated-vite.md
+++ b/.changeset/dev-server-middleware-duplicated-vite.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/start-plugin-core': patch
+---
+
+Detect a runnable SSR environment structurally so the dev server middleware is still installed when the plugin and the dev server resolve different copies of vite, and warn instead of silently skipping the middleware when no environment can server render. Previously such a setup fell through to Vite's default handler and served `Cannot GET /` with no diagnostic, and opting in via `installDevServerMiddleware: true` threw `the SSR environment is not a RunnableDevEnvironment` for an environment that was in fact runnable.

--- a/packages/start-plugin-core/src/vite/dev-server-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/vite/dev-server-plugin/plugin.ts
@@ -6,7 +6,12 @@ import {
   collectDevStyles,
   normalizeCssModuleCacheKey,
 } from './dev-styles'
-import type { Connect, DevEnvironment, PluginOption } from 'vite'
+import type {
+  Connect,
+  DevEnvironment,
+  PluginOption,
+  RunnableDevEnvironment,
+} from 'vite'
 import type { GetConfigFn } from '../../types'
 
 export function devServerPlugin({
@@ -144,16 +149,20 @@ export function devServerPlugin({
             }
 
             // do not install middleware if SSR env in case another plugin already did
-            if (
-              !isRunnableDevEnvironment(serverEnv) ||
-              // do not check via `isFetchableDevEnvironment` since nitro does implement the `FetchableDevEnvironment` interface but not via inheritance (which this helper checks)
-              'dispatchFetch' in serverEnv
-            ) {
+            // do not check via `isFetchableDevEnvironment` since nitro does implement the `FetchableDevEnvironment` interface but not via inheritance (which this helper checks)
+            if ('dispatchFetch' in serverEnv) {
+              return
+            }
+
+            if (!isRunnableEnvironment(serverEnv)) {
+              viteDevServer.config.logger.warn(
+                `[tanstack-start] the "${VITE_ENVIRONMENT_NAMES.server}" environment is neither runnable nor fetchable, so the dev server middleware was not installed and requests will not be server rendered. If another plugin serves them, set \`installDevServerMiddleware: false\` to silence this warning.`,
+              )
               return
             }
           }
 
-          if (!isRunnableDevEnvironment(serverEnv)) {
+          if (!isRunnableEnvironment(serverEnv)) {
             throw new Error(
               'cannot install vite dev server middleware for TanStack Start since the SSR environment is not a RunnableDevEnvironment',
             )
@@ -253,6 +262,22 @@ export function devServerPlugin({
       },
     },
   ]
+}
+
+/**
+ * `isRunnableDevEnvironment` is an `instanceof` check against the copy of vite this
+ * package resolves. When the dev server is created by a different copy of vite - Vite+,
+ * or a workspace that ends up with a duplicated vite install - that check is false even
+ * though the environment is a runnable one, so fall back to a structural check.
+ * This is the same reason the `dispatchFetch` check above does not go through
+ * `isFetchableDevEnvironment`.
+ * @param environment
+ * @returns
+ */
+function isRunnableEnvironment(
+  environment: DevEnvironment,
+): environment is RunnableDevEnvironment {
+  return isRunnableDevEnvironment(environment) || 'runner' in environment
 }
 
 /**

--- a/packages/start-plugin-core/tests/vite/dev-server-plugin.test.ts
+++ b/packages/start-plugin-core/tests/vite/dev-server-plugin.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test, vi } from 'vitest'
+import { devServerPlugin } from '../../src/vite/dev-server-plugin/plugin'
+import { VITE_ENVIRONMENT_NAMES } from '../../src/constants'
+import type { GetConfigFn } from '../../src/types'
+
+/**
+ * A runnable SSR environment created by a *different* copy of vite than the one
+ * this plugin imports, as happens with Vite+ or a duplicated vite install.
+ * It is structurally a RunnableDevEnvironment, but `instanceof` against our copy
+ * of vite is false, so `isRunnableDevEnvironment()` rejects it.
+ */
+class ForeignRunnableDevEnvironment {
+  get runner() {
+    return { import: () => Promise.resolve({}) }
+  }
+}
+
+function runDevServerPlugin({
+  serverEnv,
+  installDevServerMiddleware,
+}: {
+  serverEnv: unknown
+  installDevServerMiddleware?: boolean
+}) {
+  const warn = vi.fn()
+  const use = vi.fn()
+  const viteDevServer = {
+    config: {
+      server: { middlewareMode: false },
+      experimental: { bundledDev: false },
+      logger: { warn },
+    },
+    environments: { [VITE_ENVIRONMENT_NAMES.server]: serverEnv },
+    middlewares: { use },
+    watcher: { add: vi.fn() },
+  }
+
+  const [plugin] = devServerPlugin({
+    getConfig: (() => ({})) as unknown as GetConfigFn,
+    devSsrStylesEnabled: false,
+    installDevServerMiddleware,
+  }) as Array<any>
+
+  const postHook = plugin.configureServer(viteDevServer as any)
+  postHook?.()
+
+  return { warn, use }
+}
+
+describe('dev server plugin middleware installation', () => {
+  test('installs the middleware for a runnable SSR environment from another vite instance', () => {
+    const { use, warn } = runDevServerPlugin({
+      serverEnv: new ForeignRunnableDevEnvironment(),
+    })
+
+    expect(use).toHaveBeenCalledTimes(1)
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  test('does not throw when opting in with a runnable environment from another vite instance', () => {
+    expect(() =>
+      runDevServerPlugin({
+        serverEnv: new ForeignRunnableDevEnvironment(),
+        installDevServerMiddleware: true,
+      }),
+    ).not.toThrow()
+  })
+
+  test('warns instead of silently skipping when the SSR environment cannot render', () => {
+    const { use, warn } = runDevServerPlugin({ serverEnv: {} })
+
+    expect(use).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0]?.[0]).toContain('installDevServerMiddleware')
+  })
+
+  test('stays silent when another plugin already serves the SSR environment', () => {
+    const { use, warn } = runDevServerPlugin({
+      serverEnv: { dispatchFetch: () => Promise.resolve(new Response()) },
+    })
+
+    expect(use).not.toHaveBeenCalled()
+    expect(warn).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Fixes #7614. Also the root cause of #7218, which has been on `information needed` since April for want of a reproducer that does not require installing Vite+ - the reproduction below needs only two plain npm copies of vite.

The Start dev server can stop server rendering with no diagnostic at all: the browser gets `Cannot GET /`, and the Start plugin logs nothing. Two separate things combine to produce that.

`isRunnableDevEnvironment()` is a bare `instanceof RunnableDevEnvironment` against the copy of vite that imports it. When the dev server is created by a *different* copy of vite - Vite+, or a workspace that ends up with a duplicated vite install - the check returns `false` for an environment that is structurally runnable. `devServerPlugin` then takes the "another plugin must already serve SSR" branch and returns without installing its middleware, so the request falls through to Vite's default handler and 404s.

Opting out of that branch with `vite: { installDevServerMiddleware: true }` does not help, because the next check throws `cannot install vite dev server middleware for TanStack Start since the SSR environment is not a RunnableDevEnvironment` - for an environment that is one.

This PR does two things:

- Adds `isRunnableEnvironment()`, which falls back to a structural `'runner' in environment` check when the `instanceof` helper says no. That is the same reasoning the neighbouring `dispatchFetch` check already uses to avoid `isFetchableDevEnvironment` for nitro. `runner` is a prototype getter on `RunnableDevEnvironment`, so `in` resolves it without instantiating the module runner.
- Splits the combined skip condition, so "nitro already serves SSR" (silent, intended) stays distinct from "nothing here can server render" (now a warning naming `installDevServerMiddleware`). The second case previously produced no output at all, which is what makes this failure so hard to diagnose from the outside.

### Reproduction

`examples/react/start-basic` on Vite 8.2.2 against the published `@tanstack/start-plugin-core@1.171.39`, with a second vite copy (8.0.14, installed as an npm alias) creating the dev server so that the server and the plugin resolve different copies. No Vite+ involved, and `middlewareMode` is `false` throughout, so this is not the intentional middleware-mode skip. This matches the finding in #7218 that the `@tanstack/*` version is not the variable.

| Setup | `GET /` before | `GET /` after |
| --- | --- | --- |
| One vite copy, with nitro | 200, 3597 bytes | 200, 3597 bytes |
| One vite copy, without nitro | 200, 3597 bytes | 200, 3597 bytes |
| Two vite copies | **404 `Cannot GET /`**, no plugin output | 200, 3597 bytes |
| Two vite copies + `installDevServerMiddleware: true` | **throws on startup** | 200, 3597 bytes |

The guard itself, on the same environment object:

```
vite (copy that owns the server) isRunnableDevEnvironment: true
vite (copy the plugin resolves)  isRunnableDevEnvironment: false
typeof ssr.runner: object   dispatchFetch present: false   ctor: RunnableDevEnvironment
```

### What this does not cover

I reproduced the duplicated-vite condition with two npm copies of vite rather than by running Vite+ itself, so this is verified against the mechanism - `instanceof` across module instances - rather than against the `vp dev` CLI specifically. Happy to confirm against Vite+ before this lands if you would rather see that.

The new warning fires for any SSR environment that is neither runnable nor exposes `dispatchFetch`. A plugin that serves SSR some other way would now see a warning where it previously saw nothing; `installDevServerMiddleware: false` silences it, which the message says. Say the word if you would rather that case stayed quiet.

### Tests

`packages/start-plugin-core/tests/vite/dev-server-plugin.test.ts` covers the four branches: a runnable environment from another vite instance installs the middleware and does not throw when opted into, an environment that cannot render warns instead of skipping silently, and an environment that another plugin already serves stays silent. The first three fail on `main`.

Ran `eslint`, `tsc`, and `vitest` for `@tanstack/start-plugin-core` (32 files, 516 tests, no type errors). The 5 pre-existing eslint errors in `handleCreateServerFn.ts` and `manifestBuilder.ts` are present on a clean tree and untouched here.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved development server middleware installation when multiple Vite copies are present.
  - Added support for detecting compatible server-rendering environments across Vite versions or instances.
  - Added clearer warnings when no server-renderable environment is available.
  - Avoided unnecessary warnings when another plugin already handles request processing.

- **Tests**
  - Added coverage for middleware installation, opt-in behavior, warnings, and compatibility with alternate Vite environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->