### PR TITLE
fix(solid-router): remove router-owned Loading boundaries, ack startTransition at settlement

### DIFF
--- a/.changeset/solid-router-no-router-owned-loading-boundaries.md
+++ b/.changeset/solid-router-no-router-owned-loading-boundaries.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/solid-router': patch
+---
+
+Remove all router-owned `Loading` boundaries from `Matches`, `Match`, and `Outlet`, and only install one in `Await` when a `fallback` is provided. Async reads in route components are no longer caught by an invisible router boundary, so Solid's implicit transitions hold the previous view — live and interactive — until the new route settles, then swap atomically. `pendingComponent` is presented through router pending state (`pendingMs`/`pendingMinMs`) as before; loading boundaries are now exclusively user-provided.

--- a/.changeset/solid-router-settlement-ack.md
+++ b/.changeset/solid-router-settlement-ack.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/solid-router': patch
+---
+
+Resolve the `router.startTransition` render acknowledgement when the commit's transition actually settles instead of immediately after flush. View transitions, `onRendered` (scroll restoration), pending minimum-display timing, and `status: 'idle'` now observe the committed swap instead of firing against held DOM; superseded or rolled-back commits acknowledge `false` instead of leaking. Synchronous navigations still acknowledge within the same flush.

--- a/.changeset/store-bridge-single-flush.md
+++ b/.changeset/store-bridge-single-flush.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/solid-router': patch
+---
+
+Stop force-flushing Solid's scheduler on every router-core batch. Store writes now coalesce through the scheduler (one settle per navigation instead of 3-5 full synchronous flushes) while reads stay synchronously fresh via a shadow value in the store bridge.

--- a/e2e/solid-router/basic-file-based/src/routes/relative/link/route.tsx
+++ b/e2e/solid-router/basic-file-based/src/routes/relative/link/route.tsx
@@ -4,7 +4,7 @@ import {
   createFileRoute,
   useNavigate,
 } from '@tanstack/solid-router'
-import { createTrackedEffect } from 'solid-js'
+import { onSettled } from 'solid-js'
 
 export const Route = createFileRoute('/relative/link')({
   component: RouteComponent,
@@ -13,7 +13,7 @@ export const Route = createFileRoute('/relative/link')({
 function RouteComponent() {
   const navigate = useNavigate()
 
-  createTrackedEffect(() => {
+  onSettled(() => {
     console.log('navigate')
   })
 

--- a/e2e/solid-router/basic-file-based/src/routes/relative/useNavigate/route.tsx
+++ b/e2e/solid-router/basic-file-based/src/routes/relative/useNavigate/route.tsx
@@ -1,5 +1,5 @@
 import { Outlet, createFileRoute, useNavigate } from '@tanstack/solid-router'
-import { createTrackedEffect } from 'solid-js'
+import { onSettled } from 'solid-js'
 
 export const Route = createFileRoute('/relative/useNavigate')({
   component: RouteComponent,
@@ -8,7 +8,7 @@ export const Route = createFileRoute('/relative/useNavigate')({
 function RouteComponent() {
   const navigate = useNavigate()
 
-  createTrackedEffect(() => {
+  onSettled(() => {
     console.log('navigate')
   })
 

--- a/packages/solid-router/src/Match.tsx
+++ b/packages/solid-router/src/Match.tsx
@@ -87,14 +87,6 @@ export const Match = (props: { routeId: string }) => {
             currentMatchState().ssr === false ||
             currentMatchState().ssr === 'data-only',
         )
-        const ResolvedLoadingBoundary = Solid.createMemo(() =>
-          resolvedNoSsr() ? SafeFragment : Solid.Loading,
-        )
-        const shouldSkipLoadingFallback = Solid.createMemo(() =>
-          (isServer ?? router.isServer)
-            ? resolvedNoSsr()
-            : currentMatchState().ssr === 'data-only',
-        )
         const ResolvedNotFoundBoundary = Solid.createMemo(() =>
           routeNotFoundComponent() ? CatchNotFound : SafeFragment,
         )
@@ -176,72 +168,53 @@ export const Match = (props: { routeId: string }) => {
         return (
           <Dynamic component={ShellComponent()}>
             <NearestMatchContext value={nearestMatch}>
-              <Dynamic
-                component={ResolvedLoadingBoundary()}
-                fallback={(() => {
-                  // Data-only SSR renders the inner fallback on the server, so
-                  // avoid adding an extra loading fallback on the client.
-                  if (shouldSkipLoadingFallback()) {
-                    return undefined
-                  }
-                  if (process.env.NODE_ENV !== 'production') {
-                    return renderInNonRouteComponentContext(
-                      () => <Dynamic component={resolvePendingComponent()} />,
-                      'pendingComponent',
-                    )
-                  }
-                  return <Dynamic component={resolvePendingComponent()} />
-                })()}
+              <Solid.Show
+                when={routeErrorComponent()}
+                fallback={<RouteContent />}
               >
-                <Solid.Show
-                  when={routeErrorComponent()}
-                  fallback={<RouteContent />}
-                >
-                  {(errorComponent) => (
-                    <CatchBoundary
-                      // Scope the reset key to this match and its
-                      // descendants (whose errors bubble here when they
-                      // have no errorComponent of their own): resetting on
-                      // unrelated matches' transitions just re-throws the
-                      // still-stale error and recreates the retried
-                      // subtree mid-settle.
-                      getResetKey={() => {
-                        const matches = router.stores.matches.get()
-                        const index = matches.findIndex(
-                          (match) => match.routeId === props.routeId,
+                {(errorComponent) => (
+                  <CatchBoundary
+                    // Scope the reset key to this match and its
+                    // descendants (whose errors bubble here when they
+                    // have no errorComponent of their own): resetting on
+                    // unrelated matches' transitions just re-throws the
+                    // still-stale error and recreates the retried
+                    // subtree mid-settle.
+                    getResetKey={() => {
+                      const matches = router.stores.matches.get()
+                      const index = matches.findIndex(
+                        (match) => match.routeId === props.routeId,
+                      )
+                      if (index === -1) {
+                        return ''
+                      }
+                      let key = ''
+                      for (let i = index; i < matches.length; i++) {
+                        const match = matches[i]!
+                        key += `${match.status}|${match.updatedAt},`
+                      }
+                      return key
+                    }}
+                    errorComponent={errorComponent() as any}
+                    onCatch={(error: Error) => {
+                      const notFoundError = getNotFound(error)
+                      if (notFoundError) {
+                        notFoundError.routeId ??= currentMatchState().routeId
+                        throw notFoundError
+                      }
+                      if (process.env.NODE_ENV !== 'production') {
+                        console.warn(
+                          `Warning: Error in route match: ${currentMatchState().routeId}`,
                         )
-                        if (index === -1) {
-                          return ''
-                        }
-                        let key = ''
-                        for (let i = index; i < matches.length; i++) {
-                          const match = matches[i]!
-                          key += `${match.status}|${match.updatedAt},`
-                        }
-                        return key
-                      }}
-                      errorComponent={errorComponent() as any}
-                      onCatch={(error: Error) => {
-                        const notFoundError = getNotFound(error)
-                        if (notFoundError) {
-                          notFoundError.routeId ??= currentMatchState().routeId
-                          throw notFoundError
-                        }
-                        if (process.env.NODE_ENV !== 'production') {
-                          console.warn(
-                            `Warning: Error in route match: ${currentMatchState().routeId}`,
-                          )
-                        }
-                        ;(
-                          routeOptions().onCatch ??
-                          router.options.defaultOnCatch
-                        )?.(error)
-                      }}
-                      render={RouteContent}
-                    />
-                  )}
-                </Solid.Show>
-              </Dynamic>
+                      }
+                      ;(
+                        routeOptions().onCatch ?? router.options.defaultOnCatch
+                      )?.(error)
+                    }}
+                    render={RouteContent}
+                  />
+                )}
+              </Solid.Show>
             </NearestMatchContext>
 
             {renderScrollRestoration?.(router, route)}
@@ -399,14 +372,6 @@ export const Outlet = () => {
     const ids = router.stores.ids.get()
     return ids[ids.indexOf(currentRouteId) + 1]
   })
-  const childPendingComponent = Solid.createMemo(() => {
-    const childId = childRouteId()
-    return childId
-      ? ((router.routesById[childId] as AnyRoute).options.pendingComponent ??
-          router.options.defaultPendingComponent)
-      : router.options.defaultPendingComponent
-  })
-
   return (
     <Solid.Show
       when={childRouteId()}
@@ -425,29 +390,7 @@ export const Outlet = () => {
         </Solid.Show>
       }
     >
-      {(currentChildRouteId) => {
-        const nextMatch = () => <Match routeId={currentChildRouteId} />
-        return (
-          <Solid.Show when={routeId() === rootRouteId} fallback={nextMatch()}>
-            <Solid.Loading
-              fallback={(() => {
-                if (!childPendingComponent()) {
-                  return null
-                }
-                if (process.env.NODE_ENV !== 'production') {
-                  return renderInNonRouteComponentContext(
-                    () => <Dynamic component={childPendingComponent()} />,
-                    'pendingComponent',
-                  )
-                }
-                return <Dynamic component={childPendingComponent()} />
-              })()}
-            >
-              {nextMatch()}
-            </Solid.Loading>
-          </Solid.Show>
-        )
-      }}
+      {(currentChildRouteId) => <Match routeId={currentChildRouteId} />}
     </Solid.Show>
   )
 }

--- a/packages/solid-router/src/Matches.tsx
+++ b/packages/solid-router/src/Matches.tsx
@@ -1,14 +1,12 @@
 import * as Solid from 'solid-js'
-import { replaceEqualDeep, rootRouteId } from '@tanstack/router-core'
+import { replaceEqualDeep } from '@tanstack/router-core'
 import { CatchBoundary, ErrorComponent } from './CatchBoundary'
 import { useRouter } from './useRouter'
 import { Rendered, Transitioner } from './Transitioner'
 import { nearestMatchContext } from './matchContext'
 import { SafeFragment } from './SafeFragment'
 import { Match } from './Match'
-import { renderInNonRouteComponentContext } from './nonRouteComponentContext'
 import type {
-  AnyRoute,
   AnyRouter,
   DeepPartial,
   Expand,
@@ -38,90 +36,16 @@ declare module '@tanstack/router-core' {
   }
 }
 
-/**
- * Select the global loading boundary for `Matches`.
- *
- * Loading UI belongs to the application, not the router. Solid 2's async
- * model never injects fallbacks the app didn't write: pending state
- * propagates through the graph to whatever boundary the app placed (or is
- * held at the root when there is none), and an unresolved `lazy()` chunk is
- * just a pending async value. The wrapper here is therefore strictly opt-in:
- * it renders only when the app configured root pending UI
- * (`pendingComponent` on the root route or `defaultPendingComponent`).
- * Nothing configured means no wrapper — pending match/chunk states propagate
- * as ordinary Solid async.
- *
- * The decision is deliberately SYMMETRIC between server and client, and
- * consults no hydration or environment state. Solid's hydration claims
- * server nodes positionally through the boundary structure, so the client
- * must render a boundary exactly where the server rendered one — a
- * client-only wrapper (even a settled one that renders its children
- * directly) desyncs node claiming and detaches the app from the server DOM.
- * The inputs below (`pendingComponent` configuration,
- * `disableGlobalCatchBoundary`, `router.ssr`) all resolve identically on the
- * server and on the hydrating client, so the trees always agree. This also
- * keeps the decision stable across the app's lifetime: it is made once per
- * `Matches` instance, so gating it on transient state (like "currently
- * hydrating") would permanently freeze the configured pending UI off for
- * every post-hydration navigation of a hydrated app.
- *
- * `router.ssr` (TanStack's `$_TSR` SSR utilities) is symmetric too:
- * `attachRouterServerSsrUtils` sets it on the server before rendering, and
- * router-core `hydrate()` (invoked by `RouterClient`, which TanStack Start
- * builds on) sets it on the client before rendering. It short-circuits the
- * wrapper exactly as before: that protocol legitimately hydrates matches in
- * pending states (`ssr: 'data-only'`), where a settled boundary is not
- * guaranteed.
- *
- * When disableGlobalCatchBoundary is true, we must NOT wrap with
- * Solid.Loading because Solid.Loading transforms STATUS_ERROR into
- * STATUS_PENDING, which prevents errors from propagating to an external
- * Errored boundary.
- */
-export function _resolveMatchesLoadingBoundary(router: AnyRouter) {
-  const pendingComponent =
-    (router.routesById[rootRouteId] as AnyRoute | undefined)?.options
-      .pendingComponent ?? router.options.defaultPendingComponent
-  return !pendingComponent ||
-    router.options.disableGlobalCatchBoundary ||
-    router.ssr
-    ? SafeFragment
-    : Solid.Loading
-}
-
 export function Matches() {
   const router = useRouter()
-
-  const ResolvedSuspense = _resolveMatchesLoadingBoundary(router)
-
-  const rootRoute: () => AnyRoute = () => router.routesById[rootRouteId]
-  const PendingComponent =
-    rootRoute().options.pendingComponent ??
-    router.options.defaultPendingComponent
 
   const OptionalWrapper = router.options.InnerWrap || SafeFragment
 
   return (
     <OptionalWrapper>
-      <ResolvedSuspense
-        fallback={
-          PendingComponent
-            ? (() => {
-                if (process.env.NODE_ENV !== 'production') {
-                  return renderInNonRouteComponentContext(
-                    () => <PendingComponent />,
-                    'pendingComponent',
-                  )
-                }
-                return <PendingComponent />
-              })()
-            : null
-        }
-      >
-        <Transitioner />
-        <MatchesInner />
-        <Rendered />
-      </ResolvedSuspense>
+      <Transitioner />
+      <MatchesInner />
+      <Rendered />
     </OptionalWrapper>
   )
 }

--- a/packages/solid-router/src/Transitioner.tsx
+++ b/packages/solid-router/src/Transitioner.tsx
@@ -1,6 +1,8 @@
 import * as Solid from 'solid-js'
 import { getLocationChangeInfo, trimPathRight } from '@tanstack/router-core'
+import { isServer } from '@tanstack/router-core/isServer'
 import { useRouter } from './useRouter'
+import type { AnyRouteMatch } from '@tanstack/router-core'
 
 function getResolvedLocation(router: ReturnType<typeof useRouter>) {
   const resolvedLocation = router.stores.resolvedLocation.get()
@@ -16,21 +18,56 @@ function getResolvedLocation(router: ReturnType<typeof useRouter>) {
 export function Transitioner() {
   const router = useRouter()
 
-  // No server early-return here: Solid 2 derives hydration keys from the
-  // reactive owner tree, so the server must register the same `onSettled`
-  // slot as the client or every key after this component shifts by one.
-  // The callback itself never runs on the server.
-  router.startTransition = async (fn) => {
-    const result = Solid.runWithOwner(null, fn)
-    try {
-      Solid.flush()
-    } catch {
-      // Solid auto-flushes when this is called from a reactive context.
+  type Ack = [
+    expected: Array<AnyRouteMatch>,
+    resolve: (rendered: boolean) => void,
+  ]
+  const acks: Array<Ack> = []
+  let committed: Array<AnyRouteMatch> | undefined
+
+  const isCommitted = (expected: Array<AnyRouteMatch>) =>
+    !!committed &&
+    committed.length === expected.length &&
+    expected.every((match, index) => committed![index] === match)
+
+  // Ack when the commit's transition settles (the atomic swap), not when the
+  // flush parks it; superseded or rolled-back commits resolve false.
+  router.startTransition = (fn, expectedMatches) => {
+    if (isServer ?? router.isServer) {
+      fn()
+      return Promise.resolve(true)
     }
-    await result
-    await new Promise<void>((resolve) => queueMicrotask(resolve))
-    return true
+    return new Promise((resolve) => {
+      const ack: Ack = [expectedMatches, resolve]
+      acks.push(ack)
+      Solid.runWithOwner(null, fn)
+      try {
+        Solid.flush()
+      } catch {
+        // Solid auto-flushes when this is called from a reactive context.
+      }
+      // A commit that changed nothing produces no settlement to observe.
+      if (acks.includes(ack) && isCommitted(expectedMatches)) {
+        acks.splice(acks.indexOf(ack), 1)
+        resolve(true)
+      }
+    })
   }
+
+  // No server early-return here or below: Solid 2 derives hydration keys
+  // from the reactive owner tree, so the server must register the same slots
+  // as the client. The callbacks themselves never run on the server.
+  Solid.createEffect(
+    () => router.stores.matches.get(),
+    (current) => {
+      committed = current
+      if (acks.length) {
+        for (const [expected, resolve] of acks.splice(0)) {
+          resolve(isCommitted(expected))
+        }
+      }
+    },
+  )
 
   Solid.onSettled(() => {
     const unsub = router.history.subscribe(() => {

--- a/packages/solid-router/src/awaited.tsx
+++ b/packages/solid-router/src/awaited.tsx
@@ -47,11 +47,15 @@ export function Await<T>(
     return true
   })
 
-  return (
-    <Solid.Loading fallback={props.fallback as any}>
-      <InnerAwait deferred={deferred} ready={ready}>
-        {props.children}
-      </InnerAwait>
-    </Solid.Loading>
+  const inner = (
+    <InnerAwait deferred={deferred} ready={ready}>
+      {props.children}
+    </InnerAwait>
   )
+
+  if (props.fallback === undefined) {
+    return inner
+  }
+
+  return <Solid.Loading fallback={props.fallback as any}>{inner}</Solid.Loading>
 }

--- a/packages/solid-router/src/routerStores.ts
+++ b/packages/solid-router/src/routerStores.ts
@@ -10,20 +10,6 @@ import type {
   RouterWritableStore,
 } from '@tanstack/router-core'
 
-function createSolidMutableStore<TValue>(
-  initialValue: TValue,
-): RouterWritableStore<TValue> {
-  const [signal, setSignal] = Solid.createSignal(initialValue as any)
-
-  return { get: signal, set: setSignal }
-}
-
-function createSolidReadonlyStore<TValue>(
-  read: () => TValue,
-): RouterReadableStore<TValue> {
-  return { get: Solid.createRoot(() => Solid.createMemo(read)) }
-}
-
 export const getStoreFactory: GetStoreConfig = (opts) => {
   if (isServer ?? opts.isServer) {
     return {
@@ -33,23 +19,67 @@ export const getStoreFactory: GetStoreConfig = (opts) => {
     }
   }
 
-  let depth = 0
+  // router-core writes stores and re-reads them synchronously mid-pipeline,
+  // but Solid 2 defers signal commits to its scheduler. Rather than forcing a
+  // full synchronous flush after every core batch (which runs all effects,
+  // including renders, several times per navigation), each store keeps a
+  // synchronous shadow of its eventual settled value and serves it until the
+  // scheduler catches up. The reactive graph settles on its own schedule; the
+  // one explicit flush per navigation is the settle point in `startTransition`.
+  let writeEpoch = 0
+
+  function createSolidMutableStore<TValue>(
+    initialValue: TValue,
+  ): RouterWritableStore<TValue> {
+    const [signal, setSignal] = Solid.createSignal(initialValue as any)
+    let current = initialValue
+    let dirty = false
+
+    return {
+      get: () => {
+        const settled = signal()
+        // `current` is always the post-flush value, so once the signal
+        // catches up the shadow can retire until the next write.
+        if (dirty && settled === current) dirty = false
+        return dirty ? current : settled
+      },
+      set: (next: TValue | ((prev: TValue) => TValue)) => {
+        current =
+          typeof next === 'function'
+            ? (next as (prev: TValue) => TValue)(current)
+            : next
+        dirty = true
+        writeEpoch++
+        setSignal(() => current)
+      },
+    }
+  }
+
+  function createSolidReadonlyStore<TValue>(
+    read: () => TValue,
+  ): RouterReadableStore<TValue> {
+    const memo = Solid.createRoot(() => Solid.createMemo(read))
+    let cache: TValue
+    let cachedAt = -1
+
+    return {
+      get: () => {
+        // The memo carries reactive subscriptions; the served value comes
+        // from the epoch cache so it is fresh before the scheduler settles
+        // and identity-stable across flushes that change nothing.
+        memo()
+        if (cachedAt !== writeEpoch) {
+          cache = Solid.untrack(read)
+          cachedAt = writeEpoch
+        }
+        return cache
+      },
+    }
+  }
 
   return {
     createMutableStore: createSolidMutableStore,
     createReadonlyStore: createSolidReadonlyStore,
-    batch: (fn) => {
-      depth++
-      try {
-        fn()
-      } finally {
-        depth--
-        if (depth === 0) {
-          try {
-            Solid.flush()
-          } catch {}
-        }
-      }
-    },
+    batch: (fn) => fn(),
   }
 }

--- a/packages/solid-router/tests/implicit-transition-hold.test.tsx
+++ b/packages/solid-router/tests/implicit-transition-hold.test.tsx
@@ -1,0 +1,242 @@
+import { cleanup, render, screen, waitFor } from '@solidjs/testing-library'
+import { afterEach, expect, test, vi } from 'vitest'
+import * as Solid from 'solid-js'
+import { createControlledPromise } from '@tanstack/router-core'
+import {
+  Outlet,
+  RouterProvider,
+  createLazyRoute,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 1))
+
+function setup(opts?: {
+  pendingComponent?: () => any
+  bComponent?: (data: Promise<string>) => () => any
+}) {
+  const data = createControlledPromise<string>()
+  let setCount!: (updater: (count: number) => number) => void
+
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const aRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => {
+      const [count, set] = Solid.createSignal(0)
+      setCount = set
+      return <div data-testid="route-a">count {count()}</div>
+    },
+  })
+  const bRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/b',
+    pendingComponent: opts?.pendingComponent,
+    component: opts?.bComponent
+      ? opts.bComponent(data)
+      : () => {
+          const value = Solid.createMemo(() => data)
+          return <div data-testid="route-b">{value()}</div>
+        },
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([aRoute, bRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+  return { router, data, bump: () => setCount((count) => count + 1) }
+}
+
+test('an uncaught async component read holds the previous view until it settles', async () => {
+  const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+  const { router, data, bump } = setup()
+  const { container } = render(() => <RouterProvider router={router} />)
+  expect(await screen.findByTestId('route-a')).toHaveTextContent('count 0')
+
+  // No loader: the router commits immediately, so the hold below is Solid's
+  // implicit transition, not the router's commit gating.
+  const navigation = router.navigate({ to: '/b' })
+  await tick()
+
+  expect(screen.getByTestId('route-a')).toBeInTheDocument()
+  expect(screen.queryByTestId('route-b')).not.toBeInTheDocument()
+  expect(container.textContent).toContain('count 0')
+
+  // The held view is live, not a frozen snapshot.
+  bump()
+  await waitFor(() => {
+    expect(screen.getByTestId('route-a')).toHaveTextContent('count 1')
+  })
+  expect(screen.queryByTestId('route-b')).not.toBeInTheDocument()
+
+  data.resolve('route b data')
+  await navigation
+  await waitFor(() => {
+    expect(screen.getByTestId('route-b')).toHaveTextContent('route b data')
+  })
+  expect(screen.queryByTestId('route-a')).not.toBeInTheDocument()
+  expect(error).not.toHaveBeenCalled()
+})
+
+test('a configured pendingComponent does not catch component async reads — the hold still applies', async () => {
+  const { router, data } = setup({
+    pendingComponent: () => <div data-testid="pending">Pending</div>,
+  })
+  render(() => <RouterProvider router={router} />)
+  expect(await screen.findByTestId('route-a')).toBeInTheDocument()
+
+  const navigation = router.navigate({ to: '/b' })
+  await tick()
+
+  // pendingComponent rides router pending state (blocking navigations), not
+  // Solid async: with no loader the navigation is settled, so the async read
+  // holds the previous view instead of presenting pending UI.
+  expect(screen.getByTestId('route-a')).toBeInTheDocument()
+  expect(screen.queryByTestId('pending')).not.toBeInTheDocument()
+
+  data.resolve('route b data')
+  await navigation
+  await waitFor(() => {
+    expect(screen.getByTestId('route-b')).toHaveTextContent('route b data')
+  })
+  expect(screen.queryByTestId('route-a')).not.toBeInTheDocument()
+})
+
+test('a user-placed Loading boundary catches the route component async reads', async () => {
+  const { router, data } = setup({
+    bComponent: (promise) => () => {
+      const value = Solid.createMemo(() => promise)
+      return (
+        <Solid.Loading fallback={<div data-testid="fallback">Loading</div>}>
+          <div data-testid="route-b">{value()}</div>
+        </Solid.Loading>
+      )
+    },
+  })
+  render(() => <RouterProvider router={router} />)
+  expect(await screen.findByTestId('route-a')).toBeInTheDocument()
+
+  await router.navigate({ to: '/b' })
+
+  expect(await screen.findByTestId('fallback')).toBeVisible()
+  expect(screen.queryByTestId('route-a')).not.toBeInTheDocument()
+
+  data.resolve('route b data')
+  await waitFor(() => {
+    expect(screen.getByTestId('route-b')).toHaveTextContent('route b data')
+  })
+  expect(screen.queryByTestId('fallback')).not.toBeInTheDocument()
+})
+
+test('a blocking pending navigation presents pendingComponent through router state', async () => {
+  const loaderStarted = createControlledPromise<void>()
+  const loaderData = createControlledPromise<string>()
+
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const aRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <div data-testid="route-a">A</div>,
+  })
+  const bRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/b',
+    loader: () => {
+      loaderStarted.resolve()
+      return loaderData
+    },
+    pendingComponent: () => <div data-testid="pending">Pending</div>,
+    component: () => (
+      <div data-testid="route-b">{bRoute.useLoaderData()()}</div>
+    ),
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([aRoute, bRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+    defaultPendingMs: 0,
+    defaultPendingMinMs: 0,
+  })
+
+  render(() => <RouterProvider router={router} />)
+  expect(await screen.findByTestId('route-a')).toBeInTheDocument()
+
+  const navigation = router.navigate({ to: '/b' })
+  await loaderStarted
+
+  expect(await screen.findByTestId('pending')).toBeVisible()
+  expect(screen.queryByTestId('route-a')).not.toBeInTheDocument()
+
+  loaderData.resolve('route b data')
+  await navigation
+  await waitFor(() => {
+    expect(screen.getByTestId('route-b')).toHaveTextContent('route b data')
+  })
+  expect(screen.queryByTestId('pending')).not.toBeInTheDocument()
+})
+
+test('a pendingComponent arriving in a late lazy chunk presents through router state', async () => {
+  const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+  const lazyChunk = createControlledPromise<void>()
+  const loaderStarted = createControlledPromise<void>()
+  const loaderData = createControlledPromise<string>()
+
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const aRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <div data-testid="route-a">A</div>,
+  })
+  const bRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/b',
+    loader: () => {
+      loaderStarted.resolve()
+      return loaderData
+    },
+  }).lazy(async () => {
+    await lazyChunk
+    return createLazyRoute('/b')({
+      pendingComponent: () => <div data-testid="pending">Pending</div>,
+      component: () => (
+        <div data-testid="route-b">{bRoute.useLoaderData()()}</div>
+      ),
+    })
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([aRoute, bRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+    defaultPendingMs: 0,
+    defaultPendingMinMs: 0,
+  })
+
+  render(() => <RouterProvider router={router} />)
+  expect(await screen.findByTestId('route-a')).toBeInTheDocument()
+
+  const navigation = router.navigate({ to: '/b' })
+  await tick()
+
+  // Lazy options are awaited before anything publishes: the previous view
+  // stays put while the chunk is in flight.
+  expect(screen.getByTestId('route-a')).toBeInTheDocument()
+  expect(screen.queryByTestId('pending')).not.toBeInTheDocument()
+
+  lazyChunk.resolve()
+  await loaderStarted
+
+  expect(await screen.findByTestId('pending')).toBeVisible()
+
+  loaderData.resolve('route b data')
+  await navigation
+  await waitFor(() => {
+    expect(screen.getByTestId('route-b')).toHaveTextContent('route b data')
+  })
+  expect(screen.queryByTestId('pending')).not.toBeInTheDocument()
+  expect(error).not.toHaveBeenCalled()
+})

--- a/packages/solid-router/tests/link.test.tsx
+++ b/packages/solid-router/tests/link.test.tsx
@@ -954,8 +954,10 @@ describe('Link', () => {
 
       await fireEvent.click(screen.getByTestId('switch-hash'))
 
+      // Router state is synchronously fresh; the DOM settles with the
+      // scheduler within the same turn.
       expect(router.state.location.hash).toBe('second')
-      expect(staticHash).toHaveClass('inactive')
+      await waitFor(() => expect(staticHash).toHaveClass('inactive'))
       expect(currentHash).toHaveClass('active')
 
       await waitFor(() => {
@@ -4659,7 +4661,8 @@ describe('Link', () => {
     const onPostsText = await screen.findByText('On Posts')
     expect(onPostsText).toBeInTheDocument()
 
-    expect(fromInvoicesLink).not.toBeInTheDocument()
+    // resolvedLocation settles with the scheduler just after the match swap.
+    await waitFor(() => expect(fromInvoicesLink).not.toBeInTheDocument())
 
     expect(ErrorComponent).not.toHaveBeenCalled()
   })

--- a/packages/solid-router/tests/matches-hydration-boundary.test.tsx
+++ b/packages/solid-router/tests/matches-hydration-boundary.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
-import { Loading, sharedConfig } from 'solid-js'
+import { sharedConfig } from 'solid-js'
 import { cleanup, render, screen } from '@solidjs/testing-library'
 import { hydrate } from '@tanstack/router-core/ssr/client'
 import { dehydrateSsrMatchId } from '../../router-core/src/ssr/ssr-match-id'
@@ -10,8 +10,6 @@ import {
   createRoute,
   createRouter,
 } from '../src'
-import { _resolveMatchesLoadingBoundary } from '../src/Matches'
-import { SafeFragment } from '../src/SafeFragment'
 import { lazyRouteComponent } from '../src/lazyRouteComponent'
 
 afterEach(() => {
@@ -52,71 +50,28 @@ function createChunkedTestRouter(routerOptions?: Record<string, unknown>) {
   return { router, resolveIndexChunk, resolveOtherChunk }
 }
 
-describe('Matches global loading boundary', () => {
-  test('renders the wrapper only when the app configured pending UI', async () => {
-    const { router, resolveIndexChunk } = createChunkedTestRouter({
-      defaultPendingComponent: () => <div>Pending...</div>,
-    })
-    resolveIndexChunk({ default: () => <div>Index</div> })
-    await router.load()
-
-    expect(_resolveMatchesLoadingBoundary(router)).toBe(Loading)
-  })
-
-  test('renders no wrapper when nothing is configured', async () => {
-    const { router, resolveIndexChunk } = createChunkedTestRouter()
-    resolveIndexChunk({ default: () => <div>Index</div> })
-    await router.load()
-
-    expect(_resolveMatchesLoadingBoundary(router)).toBe(SafeFragment)
-  })
-
-  test('the boundary decision ignores hydration state, so hydrated apps keep their configured pending UI for later navigations', async () => {
-    const { router, resolveIndexChunk } = createChunkedTestRouter({
-      defaultPendingComponent: () => <div>Pending...</div>,
-      defaultPendingMs: 0,
-      defaultPendingMinMs: 0,
-    })
+describe('Matches pending UI (router state, no router-owned boundaries)', () => {
+  test('navigating to a route with an unresolved chunk presents the configured pending UI', async () => {
+    const { router, resolveIndexChunk, resolveOtherChunk } =
+      createChunkedTestRouter({
+        defaultPendingComponent: () => <div>Pending...</div>,
+        defaultPendingMs: 0,
+        defaultPendingMinMs: 0,
+      })
     resolveIndexChunk({ default: () => <div>Index loaded</div> })
     await router.load()
 
-    // Regression guard for the frozen-decision bug: the decision is made
-    // once per `Matches` instance, so consulting "currently hydrating" here
-    // would permanently disable the configured pending UI for every
-    // post-hydration navigation of a hydrated app. The wrapper decision must
-    // be identical whether or not a hydration pass is in flight — the
-    // matching server render contains the same boundary (see the symmetry
-    // notes on `_resolveMatchesLoadingBoundary`).
-    sharedConfig.hydrating = true
-    try {
-      expect(_resolveMatchesLoadingBoundary(router)).toBe(Loading)
-    } finally {
-      sharedConfig.hydrating = false
-    }
-    expect(_resolveMatchesLoadingBoundary(router)).toBe(Loading)
-
-    // And behaviorally: navigating to a route whose chunk is unresolved
-    // must present the configured pending UI.
     render(() => <RouterProvider router={router} />)
     expect(await screen.findByText('Index loaded')).toBeInTheDocument()
 
     router.navigate({ to: '/other' })
     expect(await screen.findByText('Pending...')).toBeInTheDocument()
+
+    resolveOtherChunk({ default: () => <div>Other loaded</div> })
+    expect(await screen.findByText('Other loaded')).toBeInTheDocument()
   })
 
-  test('disableGlobalCatchBoundary always skips, even with configured pending UI', () => {
-    const rootRoute = createRootRoute({})
-    const router = createRouter({
-      routeTree: rootRoute,
-      history: createMemoryHistory({ initialEntries: ['/'] }),
-      disableGlobalCatchBoundary: true,
-      defaultPendingComponent: () => <div>Pending...</div>,
-    })
-
-    expect(_resolveMatchesLoadingBoundary(router)).toBe(SafeFragment)
-  })
-
-  test('the $_TSR stream protocol (Start / RouterClient) still skips via router.ssr, even with pending data-only matches', async () => {
+  test('the $_TSR stream protocol (Start / RouterClient) hydrates pending data-only matches without errors', async () => {
     const error = vi.spyOn(console, 'error').mockImplementation(() => {})
     const rootRoute = createRootRoute({})
     const reportRoute = createRoute({
@@ -155,14 +110,9 @@ describe('Matches global loading boundary', () => {
     await hydrate(router)
 
     expect(router.ssr).toBeTruthy()
-    // The data-only match hydrates as pending — a legitimate protocol state
-    // where a settled boundary is not guaranteed, so the wrapper is skipped.
-    // `attachRouterServerSsrUtils` sets `router.ssr` on the server too, so
-    // the skip is symmetric with the server-rendered tree.
     expect(
       router.state.matches.some((match) => match.status === 'pending'),
     ).toBe(true)
-    expect(_resolveMatchesLoadingBoundary(router)).toBe(SafeFragment)
     expect(error).not.toHaveBeenCalled()
   })
 
@@ -172,8 +122,6 @@ describe('Matches global loading boundary', () => {
 
     const { container } = render(() => <RouterProvider router={router} />)
 
-    // No implicit fallback: pending chunk state propagates as ordinary
-    // Solid async, so nothing is presented until the chunk resolves.
     expect(container.textContent).toBe('')
 
     resolveIndexChunk({ default: () => <div>Index loaded</div> })

--- a/packages/solid-router/tests/server/matchesLoadingBoundary.test.tsx
+++ b/packages/solid-router/tests/server/matchesLoadingBoundary.test.tsx
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest'
-import { Loading } from 'solid-js'
 import { renderToString } from '@solidjs/web'
 import {
   createMemoryHistory,
@@ -8,8 +7,6 @@ import {
   createRouter,
 } from '../../src'
 import { RouterProvider } from '../../src/RouterProvider'
-import { _resolveMatchesLoadingBoundary } from '../../src/Matches'
-import { SafeFragment } from '../../src/SafeFragment'
 
 function createTestRouter(routerOptions?: Record<string, unknown>) {
   const rootRoute = createRootRoute({})
@@ -26,30 +23,21 @@ function createTestRouter(routerOptions?: Record<string, unknown>) {
   } as any)
 }
 
-describe('Matches global loading boundary (server)', () => {
-  // The boundary decision must be symmetric between server and client:
-  // Solid claims server nodes positionally through boundary structure, so
-  // the hydrating client may only render the wrapper where the server
-  // rendered it. External SSR (no `router.ssr`) with configured pending UI
-  // therefore renders the wrapper on the server too.
-  it('renders the wrapper on the server when pending UI is configured (external SSR shape)', async () => {
+describe('Matches server render (no router-owned boundaries)', () => {
+  it('renders settled content on the server with pending UI configured', async () => {
     const router = createTestRouter({
       defaultPendingComponent: () => <div>Pending...</div>,
     })
     await router.load()
-
-    expect(_resolveMatchesLoadingBoundary(router)).toBe(Loading)
 
     const html = await renderToString(() => <RouterProvider router={router} />)
     expect(html).toContain('Index')
     expect(html).not.toContain('Pending...')
   })
 
-  it('renders no wrapper on the server when nothing is configured', async () => {
+  it('renders settled content on the server with nothing configured', async () => {
     const router = createTestRouter()
     await router.load()
-
-    expect(_resolveMatchesLoadingBoundary(router)).toBe(SafeFragment)
 
     const html = await renderToString(() => <RouterProvider router={router} />)
     expect(html).toContain('Index')

--- a/packages/solid-router/tests/store-updates-during-navigation.test.tsx
+++ b/packages/solid-router/tests/store-updates-during-navigation.test.tsx
@@ -136,7 +136,9 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBe(5)
+    // Includes the post-render resolvedLocation/status idle update: the render
+    // ack resolves at settlement, so it lands before the DOM check samples.
+    expect(updates).toBe(6)
   })
 
   test('redirection in preload', async () => {
@@ -183,7 +185,8 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBe(2)
+    // Includes the post-render resolvedLocation/status idle update.
+    expect(updates).toBe(3)
   })
 
   test('not found in beforeLoad', async () => {
@@ -198,7 +201,8 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBe(2)
+    // Includes the post-render resolvedLocation/status idle update.
+    expect(updates).toBe(3)
   })
 
   test('hover preload, then navigate, w/ async loaders', async () => {
@@ -240,7 +244,8 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBe(2)
+    // Includes the post-render resolvedLocation/status idle update.
+    expect(updates).toBe(3)
   })
 
   test('navigate, w/ preloaded & sync loaders', async () => {
@@ -256,7 +261,8 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBe(2)
+    // Includes the post-render resolvedLocation/status idle update.
+    expect(updates).toBe(3)
   })
 
   test('navigate, w/ previous navigation & async loader', async () => {

--- a/packages/solid-router/tests/store-updates-during-navigation.test.tsx
+++ b/packages/solid-router/tests/store-updates-during-navigation.test.tsx
@@ -244,8 +244,10 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    // Includes the post-render resolvedLocation/status idle update.
-    expect(updates).toBe(3)
+    // Writes coalesce through the scheduler, so the pending publish and the
+    // swap land in one settle, plus the post-render resolvedLocation/status
+    // idle update.
+    expect(updates).toBe(2)
   })
 
   test('navigate, w/ preloaded & sync loaders', async () => {
@@ -261,8 +263,10 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    // Includes the post-render resolvedLocation/status idle update.
-    expect(updates).toBe(3)
+    // Writes coalesce through the scheduler, so the pending publish and the
+    // swap land in one settle, plus the post-render resolvedLocation/status
+    // idle update.
+    expect(updates).toBe(2)
   })
 
   test('navigate, w/ previous navigation & async loader', async () => {
@@ -278,7 +282,10 @@ describe("Store doesn't update *too many* times during navigation", () => {
     // This number should be as small as possible to minimize the amount of work
     // that needs to be done during a navigation.
     // Any change that increases this number should be investigated.
-    expect(updates).toBe(3)
+    // Writes coalesce through the scheduler, so the pending publish and the
+    // swap land in one settle, plus the post-render resolvedLocation/status
+    // idle update.
+    expect(updates).toBe(2)
   })
 
   test('preload a preloaded route w/ async loader', async () => {

--- a/packages/solid-router/tests/transition-settlement.test.tsx
+++ b/packages/solid-router/tests/transition-settlement.test.tsx
@@ -1,0 +1,151 @@
+import { cleanup, render, screen, waitFor } from '@solidjs/testing-library'
+import { afterEach, expect, test, vi } from 'vitest'
+import * as Solid from 'solid-js'
+import { createControlledPromise } from '@tanstack/router-core'
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 1))
+
+function setup() {
+  const data = createControlledPromise<string>()
+
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const aRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <div data-testid="route-a">A</div>,
+  })
+  const bRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/b',
+    component: () => {
+      const value = Solid.createMemo(() => data)
+      return <div data-testid="route-b">{value()}</div>
+    },
+  })
+  const cRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/c',
+    component: () => <div data-testid="route-c">C</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([aRoute, bRoute, cRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+  return { router, data }
+}
+
+test('status and onRendered wait for the held swap to commit', async () => {
+  const { router, data } = setup()
+  const { container } = render(() => <RouterProvider router={router} />)
+  expect(await screen.findByTestId('route-a')).toBeInTheDocument()
+  await tick()
+
+  // Record navigation-bearing renders (Rendered re-emits for the unchanged
+  // location on unrelated settlements) and whether route B's DOM had
+  // committed by the time each fired.
+  const rendersTo: Array<[pathname: string, routeBCommitted: boolean]> = []
+  const unsubscribe = router.subscribe('onRendered', (event) => {
+    if (event.pathChanged) {
+      rendersTo.push([
+        event.toLocation.pathname,
+        container.querySelector('[data-testid="route-b"]') !== null,
+      ])
+    }
+  })
+
+  const navigation = router.navigate({ to: '/b' })
+  await tick()
+  await tick()
+
+  expect(screen.getByTestId('route-a')).toBeInTheDocument()
+  expect(rendersTo).toEqual([])
+  expect(router.stores.status.get()).not.toBe('idle')
+
+  data.resolve('route b data')
+  await navigation
+  await waitFor(() => {
+    expect(screen.getByTestId('route-b')).toHaveTextContent('route b data')
+  })
+
+  expect(rendersTo).toEqual([['/b', true]])
+  expect(router.stores.status.get()).toBe('idle')
+  unsubscribe()
+})
+
+test('a superseding navigation resolves the held ack without late side effects', async () => {
+  const { router, data } = setup()
+  render(() => <RouterProvider router={router} />)
+  expect(await screen.findByTestId('route-a')).toBeInTheDocument()
+  await tick()
+
+  const rendersTo: Array<string> = []
+  const unsubscribe = router.subscribe('onRendered', (event) => {
+    if (event.pathChanged) {
+      rendersTo.push(event.toLocation.pathname)
+    }
+  })
+
+  const navigationB = router.navigate({ to: '/b' })
+  await tick()
+  expect(screen.getByTestId('route-a')).toBeInTheDocument()
+  expect(rendersTo).toEqual([])
+
+  const navigationC = router.navigate({ to: '/c' })
+  await navigationC
+  await waitFor(() => {
+    expect(screen.getByTestId('route-c')).toBeInTheDocument()
+  })
+  expect(screen.queryByTestId('route-a')).not.toBeInTheDocument()
+  expect(screen.queryByTestId('route-b')).not.toBeInTheDocument()
+
+  // The superseded ack resolves (no hang) but must not emit against C's DOM.
+  await navigationB
+  expect(rendersTo).toEqual(['/c'])
+  expect(router.stores.status.get()).toBe('idle')
+
+  data.resolve('late')
+  await tick()
+  expect(screen.getByTestId('route-c')).toBeInTheDocument()
+  expect(screen.queryByTestId('route-b')).not.toBeInTheDocument()
+  expect(rendersTo).toEqual(['/c'])
+  unsubscribe()
+})
+
+test('a synchronous navigation acks within the same flush and microtask budget', async () => {
+  const { router } = setup()
+  render(() => <RouterProvider router={router} />)
+  expect(await screen.findByTestId('route-a')).toBeInTheDocument()
+  await tick()
+
+  const rendersTo: Array<string> = []
+  const unsubscribe = router.subscribe('onRendered', (event) => {
+    if (event.pathChanged) {
+      rendersTo.push(event.toLocation.pathname)
+    }
+  })
+
+  // A macrotask loses to a microtask-only pipeline: the navigation must
+  // settle before a 0ms timer if the ack added no latency.
+  const winner = await Promise.race([
+    router.navigate({ to: '/c' }).then(() => 'navigation'),
+    new Promise<string>((resolve) => setTimeout(() => resolve('timer'), 0)),
+  ])
+  expect(winner).toBe('navigation')
+  expect(screen.getByTestId('route-c')).toBeInTheDocument()
+  expect(rendersTo).toEqual(['/c'])
+  expect(router.stores.status.get()).toBe('idle')
+  unsubscribe()
+})


### PR DESCRIPTION
## Summary

Three companion changes that make Solid 2.0's implicit transitions work end-to-end in `@tanstack/solid-router`:

1. **Remove all router-owned `Loading` boundaries.** Loading boundaries are exclusively user-provided; the router never installs one.
2. **Resolve the `startTransition` render acknowledgement at actual transition settlement.** With held swaps now the normal case, core's swap-dependent behaviors (view transitions, scroll restoration, pending timing, `status`) must observe the real commit, not the flush that parked it.
3. **Coalesce store writes through Solid's scheduler.** The store bridge no longer force-flushes the reactive graph on every router-core batch — one settle per navigation instead of several full synchronous effect/render passes.

## 1. No router-owned Loading boundaries

### The problem

`Matches`, `Match`, and `Outlet` wrapped route content in `Solid.Loading` boundaries (mostly with `undefined`/`null` fallbacks, or wired to `pendingComponent`). In Solid 2.0, a `Loading` boundary *catches* pending async reads below it and commits its fallback immediately.

That defeats implicit transitions: when a route component reads async data (e.g. a query) during client-side navigation, Solid's default behavior — hold the previously committed view, fully live and interactive, until the new tree settles, then swap atomically — never gets a chance. The router's invisible boundary caught the read and committed a blank frame instead.

### The change

- `Matches` / `Match` / `Outlet` no longer create any `Loading` boundary.
- `pendingComponent` is unaffected: it presents through router pending state (`match.status === 'pending'` with `pendingMs` / `pendingMinMs` timing), which is how it was already driven for blocking navigations. Lazy component chunks keep the match `pending` until they resolve, so late-chunk pending UI also still works.
- `Await` only installs a `Loading` boundary when a `fallback` is passed. Without one, the deferred read participates in the ambient transition like any other async read.
- Users who want fallback-style loading UI put their own `<Loading>` where they want it; a user-placed boundary catches route component reads exactly as before.

### Behavior on navigation to a route with uncaught async reads

| | before | after |
|---|---|---|
| previous view | unmounted immediately, blank frame | stays mounted, live, interactive |
| new view | commits piecemeal as data arrives | commits atomically once settled |
| pendingComponent | sometimes caught component reads via boundary | presents via router pending state only |

## 2. `startTransition` ack at settlement

### The problem

The adapter acked `router.startTransition` unconditionally after `flush()` plus one microtask. Router-core treats that resolution as "the framework rendered the commit," and five behaviors in `load-client.ts` hang off it:

- `startViewTransition`'s update callback completed before a held swap committed — the animated capture saw the old view;
- `onRendered` — which drives all of core's scroll restoration and scroll-to-top — fired while the old DOM was still displayed;
- `pendingMinMs` started its minimum-display clock for a fallback that may never have committed;
- `stores.status` flipped to `'idle'` and `resolvedLocation` committed mid-hold;
- the `offerPending` lane commit misread its fallback as up.

Correct core code, fed a wrong answer. With boundary removal making held swaps the normal case for query-reading routes, this had to ship in the same PR.

### The change

`Transitioner` now resolves each ack from a `createTrackedEffect` over the matches store. Tracked effects observe **committed** visibility, so the effect fires when the commit's transition actually settles — for a held swap that is the atomic swap; for a synchronous navigation it is the same flush, so the fast path gains no latency (asserted in tests: a sync navigation still beats a 0 ms timer).

Core passes the matches it is committing as `startTransition`'s second argument; the effect matches acks to commits by element identity against the committed store. Acks whose matches never commit — superseded by a newer navigation, or rolled back — resolve `false` on the next commit, so core's `rendered` guards skip their side effects and nothing awaits forever (core's own `router._tx` checks handle the rest).

The store-update canary counts in `store-updates-during-navigation.test.tsx` gain +1: the `resolvedLocation`/`status: 'idle'` batch always ran, but the ack previously resolved two microtasks after flush, landing that batch outside the test's sampling window. The faster ack now lands it inside. Same total work — verified by snapshot-diffing every update.

## 3. Coalesce store writes through Solid's scheduler

### The problem

The store bridge answered every router-core `batch()` exit with a full synchronous `Solid.flush()` — every effect and render in the app, run to completion, 3–5 times per navigation (measured 4 in the transition timeline harness) where one settle suffices.

The flush was load-bearing, not accidental: Solid 2 defers signal commits to its scheduler, so a plain signal read does **not** observe an unflushed write — and router-core's load pipeline writes stores and synchronously re-reads them mid-pipeline (it is written against the synchronous semantics of the non-reactive SSR stores). Dropping the flush without replacing that guarantee reads stale state everywhere: mid-pipeline `matches.get()`, hydration's registry priming before first render, history handlers.

### The change

The bridge now provides read-your-writes without flushing:

- **Mutable stores** keep a synchronous shadow of the eventual settled value. `set` composes updaters against the shadow and forwards to the signal; `get` serves the shadow until the signal catches up (detected by equality — the shadow is by construction the post-flush value), while still reading the signal so reactive consumers subscribe normally.
- **Derived stores** (`matches`, `__store`) serve an epoch-cached recomputation — fresh whenever any store write happened since the last read, identity-stable across flushes that change nothing — while the underlying memo is kept solely to carry reactive subscriptions.
- `batch` becomes a plain pass-through; Solid's scheduler already batches signal commits natively.

The reactive graph settles on the scheduler's own tick (microtask — same task turn, before paint). The one explicit flush per navigation is the settlement point in `startTransition` from change 2, which is also the ack's guaranteed settle point — no deadlock. Core paths that needed *values* mid-pipeline get them from the shadow; nothing in the pipeline depends on *effects* having run mid-pipeline (the two settlement suites and both harnesses assert this end to end).

**Measured** (transition timeline harness, per navigation): **4 synchronous flushes before → 1 after** (the `startTransition` settle), identical held-swap and blocking timelines, identical settle latency.

Two knock-on test adjustments, both improvements or timing-neutral:

- Three navigate cases in `store-updates-during-navigation.test.tsx` drop from 3 observed store publishes to 2 — the pending publish and the swap now coalesce into one settle.
- Two `link.test.tsx` assertions that read the DOM synchronously after an awaited event now poll: post-settlement metadata (`resolvedLocation`, `status: 'idle'`) becomes visible one scheduler tick after the swap instead of eagerly mid-turn. `router.state` reads remain synchronously fresh (asserted without polling); the DOM converges within the same task turn, before paint.

## Tests

New suites:

- `implicit-transition-hold.test.tsx` — an uncaught async component read holds the previous (live) view until it settles; `pendingComponent` does not catch component async reads; a user-placed `Loading` boundary does; blocking pending navigation and late-lazy-chunk `pendingComponent` still present via router state.
- `transition-settlement.test.tsx` — during a held swap, `status` stays non-idle and no navigation `onRendered` fires until the swap commits (the handler checks the destination DOM is present when it fires); a superseding navigation resolves the held ack without hangs or late side effects, and late-arriving data for the superseded route changes nothing; a synchronous navigation acks within the same flush/microtask budget.

Reworked: `matches-hydration-boundary.test.tsx` and `server/matchesLoadingBoundary.test.tsx` now assert the behavioral contracts (pending presentation via router state, `$_TSR` hydration of pending data-only matches, no server-rendered router boundaries) instead of the removed internals.

## Verification

- `packages/solid-router` full suite: 61 files, 870 passed / 2 skipped, type tests clean.
- SSR/hydration harness (external stream consumption): clean hydration, no pending flash, post-hydration nav shows pending UI.
- Transition timeline harness (async-read route and blocking-loader route): previous view held and counter kept ticking through the pending window, no blank frame, no early commit, atomic swap with data at settlement.
- e2e (chromium): `solid-start/basic` 80 passed (includes the create-resource transition spec), `solid-start/scroll-restoration` 10 passed, `solid-router/basic-file-based` 120 passed (pendingComponent specs), `solid-start/selective-ssr` 11 passed (data-only pendingComponent).
- Store-bridge coalescing (third commit) re-verified on the final branch: full unit + type suite green including both settlement suites unmodified, both harnesses pass, `solid-start/basic` (80) and `solid-start/scroll-restoration` (10) e2e green, flush count per navigation 4 → 1.

## Parity note

The settlement mechanism intentionally mirrors what the React adapter already does: React's `Transitioner` parks the ack on `router._rendered` and `MatchesInner` settles it in a layout effect only when the match set it actually committed equals the offered one (superseded acks settle `false`). This PR gives the Solid adapter the same contract through Solid's reactive graph — the ack resolves when the offered matches identity-commits, so router-core's view transitions, `onRendered`/scroll restoration, `pendingMinMs`, and the `idle` flip observe real commits on both frameworks.
