### PR TITLE
fix(react-router): render errorComponent for falsy thrown values

### DIFF
--- a/.changeset/catch-boundary-falsy-errors.md
+++ b/.changeset/catch-boundary-falsy-errors.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-router': patch
+---
+
+Fix `CatchBoundary` so falsy thrown values (`undefined`, `null`, `''`) render the nearest `errorComponent` instead of escalating past every boundary and unmounting the app. The boundary now tracks that an error was caught separately from the thrown value's truthiness.

--- a/packages/react-router/src/CatchBoundary.tsx
+++ b/packages/react-router/src/CatchBoundary.tsx
@@ -11,36 +11,41 @@ export class CatchBoundary extends React.Component<{
   errorComponent?: ErrorRouteComponent
   onCatch?: (error: Error, errorInfo: ErrorInfo) => void
 }> {
-  state = { error: null } as { error: Error | null; resetKey?: unknown }
+  // The caught error is boxed so that a falsy thrown value (`throw undefined`,
+  // `throw ''`) still marks the boundary as having caught something.
+  state = { caught: null } as {
+    caught: { error: Error } | null
+    resetKey?: unknown
+  }
 
   static getDerivedStateFromProps(
     props: { getResetKey: () => unknown },
-    state: { resetKey?: unknown; error: Error | null },
+    state: { resetKey?: unknown; caught: { error: Error } | null },
   ) {
     const resetKey = props.getResetKey()
 
-    if (state.error && state.resetKey !== resetKey) {
-      return { resetKey, error: null }
+    if (state.caught && state.resetKey !== resetKey) {
+      return { resetKey, caught: null }
     }
 
     return { resetKey }
   }
   static getDerivedStateFromError(error: Error) {
-    return { error }
+    return { caught: { error } }
   }
   reset = () => {
-    this.setState({ error: null })
+    this.setState({ caught: null })
   }
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     this.props.onCatch?.(error, errorInfo)
   }
   render() {
-    const error = this.state.error
-    if (error) {
+    const caught = this.state.caught
+    if (caught) {
       const element = React.createElement(
         this.props.errorComponent ?? ErrorComponent,
         {
-          error,
+          error: caught.error,
           reset: this.reset,
         },
       )
@@ -88,7 +93,7 @@ export function ErrorComponent({ error }: { error: any }) {
               overflow: 'auto',
             }}
           >
-            {error.message ? <code>{error.message}</code> : null}
+            {error?.message ? <code>{error.message}</code> : null}
           </pre>
         </div>
       ) : null}

--- a/packages/react-router/src/Matches.tsx
+++ b/packages/react-router/src/Matches.tsx
@@ -111,11 +111,11 @@ function MatchesInner() {
           getResetKey={() => match}
           onCatch={
             process.env.NODE_ENV !== 'production'
-              ? (error) => {
+              ? (error: any) => {
                   console.warn(
                     `Warning: The following error wasn't caught by any route! At the very least, consider setting an 'errorComponent' in your RootRoute!`,
                   )
-                  console.warn(`Warning: ${error.message || error.toString()}`)
+                  console.warn(`Warning: ${String(error?.message || error)}`)
                 }
               : undefined
           }

--- a/packages/react-router/tests/errorComponent.test.tsx
+++ b/packages/react-router/tests/errorComponent.test.tsx
@@ -422,6 +422,93 @@ test('errorComponent receives primitive errors thrown from beforeLoad', async ()
   expect(screen.queryByText('About route content')).not.toBeInTheDocument()
 })
 
+const falsyThrownValues = [
+  { label: 'undefined', value: undefined },
+  { label: 'null', value: null },
+  { label: 'an empty string', value: '' },
+]
+
+test.each(falsyThrownValues)(
+  'errorComponent is rendered when $label is thrown from the route component',
+  async ({ value }) => {
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: function Home() {
+        throw value
+      },
+      errorComponent: ({ error }) => (
+        <div>
+          <div>route errorComponent</div>
+          <div data-testid="thrown-value">{String(error)}</div>
+        </div>
+      ),
+    })
+
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute]),
+      history,
+    })
+
+    render(<RouterProvider router={router} />)
+
+    expect(await screen.findByText('route errorComponent')).toBeInTheDocument()
+    expect(screen.getByTestId('thrown-value').textContent).toBe(String(value))
+  },
+)
+
+test.each(falsyThrownValues)(
+  'errorComponent is rendered when $label is thrown from the route loader',
+  async ({ value }) => {
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      loader: () => {
+        throw value
+      },
+      component: function Home() {
+        return <div>Index route content</div>
+      },
+      errorComponent: () => <div>route errorComponent</div>,
+    })
+
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute]),
+      history,
+    })
+
+    render(<RouterProvider router={router} />)
+
+    expect(await screen.findByText('route errorComponent')).toBeInTheDocument()
+    expect(screen.queryByText('Index route content')).not.toBeInTheDocument()
+  },
+)
+
+test.each(falsyThrownValues)(
+  'the global catch boundary is rendered when $label is thrown and no errorComponent is configured',
+  async ({ value }) => {
+    const rootRoute = createRootRoute()
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: function Home() {
+        throw value
+      },
+    })
+
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute]),
+      history,
+    })
+
+    render(<RouterProvider router={router} />)
+
+    expect(await screen.findByText('Something went wrong!')).toBeInTheDocument()
+  },
+)
+
 test.each(['beforeLoad', 'loader'] as const)(
   'a Promise synchronously thrown from %s renders the route error UI',
   async (hook) => {


### PR DESCRIPTION
## 🎯 Changes

Fixes #8123.

`CatchBoundary` decided whether it had caught an error from the truthiness of the thrown value. A falsy throw (`throw undefined`, `null`, `''`) was stored but the render check failed, so the boundary re-rendered the same crashing children and React escalated the error past it. Since every route boundary and the global boundary run the same check, the error skipped every `errorComponent` and unmounted the whole tree.

- `CatchBoundary` state holds a boxed `caught: { error } | null`, so the presence of the box marks "caught" independently of the value. The `getDerivedStateFromProps` reset path and `reset()` clear the box.
- The default `ErrorComponent` reads `error?.message`. With the boundary fixed it now receives `undefined`/`null`, and the previous `error.message` threw inside its own fallback — which escalated again and still blanked the page.
- The global boundary's development warning uses `String(error?.message || error)` for the same reason. This keeps the old `toString()` fallback, so `new Error('')` and error-shaped objects still print an identity.
- Tests in `errorComponent.test.tsx` cover `undefined`, `null` and `''` thrown from a route component, from a loader, and with no `errorComponent` configured. All nine fail on `main`.

The same truthiness check exists in `lazyRouteComponent` (an import rejected with a falsy reason retries forever instead of throwing) and in `vue-router`'s `CatchBoundary`. Both are left out to keep this PR to the reported issue; happy to send follow-ups.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Route error components now render correctly when routes throw falsy values such as `null`, `undefined`, or an empty string.
  - Applications no longer unexpectedly unmount or escalate these errors to the global boundary.
  - Error messages and development warnings now handle missing or falsy error values safely.
- **Tests**
  - Added coverage for falsy errors thrown by route components and loaders, including fallback behavior when no route error component is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->