### PR TITLE
test(react-router): cover pending and not-found context

### DIFF
--- a/packages/react-router/tests/not-found-pending-context.test.tsx
+++ b/packages/react-router/tests/not-found-pending-context.test.tsx
@@ -1,0 +1,118 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { expect, test } from 'vitest'
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRouteWithContext,
+  createRoute,
+  createRouter,
+} from '../src'
+
+function createGate() {
+  let resolve!: () => void
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+
+  return { promise, resolve }
+}
+
+test('an automatic not-found destination shows pending UI until owner context is ready', async () => {
+  const beforeLoadStarted = createGate()
+  const beforeLoadGate = createGate()
+  let gateNextBeforeLoad = false
+
+  const rootRoute = createRootRouteWithContext<{ product: string }>()({
+    beforeLoad: async () => {
+      if (gateNextBeforeLoad) {
+        gateNextBeforeLoad = false
+        beforeLoadStarted.resolve()
+        await beforeLoadGate.promise
+
+        return { user: 'Grace', access: 'editor' }
+      }
+
+      return { user: 'Ada', access: 'reader' }
+    },
+    pendingMs: 0,
+    pendingMinMs: 0,
+    pendingComponent: () => <p role="status">Loading account</p>,
+    component: () => {
+      const context = rootRoute.useRouteContext()
+
+      return (
+        <main>
+          <h1>Account portal</h1>
+          <output data-testid="owner-context">
+            {context.product} / {context.user} / {context.access}
+          </output>
+          <Outlet />
+        </main>
+      )
+    },
+    notFoundComponent: () => {
+      const context = rootRoute.useRouteContext()
+
+      return (
+        <p data-testid="not-found-context">
+          Missing page for {context.product} / {context.user} / {context.access}
+        </p>
+      )
+    },
+  })
+  const dashboardRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/dashboard',
+    component: () => <p>Dashboard</p>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([dashboardRoute]),
+    history: createMemoryHistory({ initialEntries: ['/dashboard'] }),
+    context: { product: 'Router Cloud' },
+  })
+
+  let navigation: Promise<void> | undefined
+  try {
+    render(<RouterProvider router={router} />)
+
+    expect(await screen.findByText('Dashboard')).toBeVisible()
+    expect(screen.getByTestId('owner-context')).toHaveTextContent(
+      'Router Cloud / Ada / reader',
+    )
+
+    gateNextBeforeLoad = true
+    await act(async () => {
+      navigation = router.navigate({ to: '/missing' } as any)
+      await beforeLoadStarted.promise
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(screen.getByRole('status')).toHaveTextContent('Loading account')
+    expect(screen.getByTestId('owner-context')).not.toBeVisible()
+
+    await act(async () => {
+      beforeLoadGate.resolve()
+      await navigation
+    })
+
+    expect(
+      screen.getByRole('heading', { name: 'Account portal' }),
+    ).toBeVisible()
+    expect(screen.getByTestId('owner-context')).toBeVisible()
+    expect(screen.getByTestId('owner-context')).toHaveTextContent(
+      'Router Cloud / Grace / editor',
+    )
+    expect(screen.getByTestId('not-found-context')).toHaveTextContent(
+      'Missing page for Router Cloud / Grace / editor',
+    )
+    expect(screen.queryByText('Dashboard')).not.toBeInTheDocument()
+    expect(screen.queryByText('Loading account')).not.toBeInTheDocument()
+  } finally {
+    beforeLoadGate.resolve()
+    await act(async () => {
+      await Promise.allSettled(navigation ? [navigation] : [])
+    })
+    cleanup()
+  }
+})

--- a/packages/react-router/tests/not-found-route-context.test.tsx
+++ b/packages/react-router/tests/not-found-route-context.test.tsx
@@ -1,0 +1,184 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, expect, test, vi } from 'vitest'
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRootRouteWithContext,
+  createRoute,
+  createRouter,
+  notFound,
+} from '../src'
+import {
+  RouterServer,
+  createRequestHandler,
+  renderRouterToString,
+} from '../src/ssr/server'
+
+afterEach(cleanup)
+
+const expectedContext = 'from router / from root / from parent'
+
+function createRouteTree() {
+  const rootRoute = createRootRouteWithContext<{
+    routerValue: string
+  }>()({
+    context: () => ({ rootValue: 'from root' }),
+  })
+  const parentRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/parent',
+    context: () => ({ parentValue: 'from parent' }),
+    component: ParentComponent,
+  })
+  const childRoute = createRoute({
+    getParentRoute: () => parentRoute,
+    path: '/child',
+    context: (): { childValue: string } => {
+      throw notFound()
+    },
+    component: () => <div>Child content</div>,
+    notFoundComponent: ChildNotFoundComponent,
+  })
+
+  function ParentComponent() {
+    const context = parentRoute.useRouteContext()
+
+    return (
+      <>
+        <output data-testid="parent-context">
+          {[context.routerValue, context.rootValue, context.parentValue].join(
+            ' / ',
+          )}
+        </output>
+        <Outlet />
+      </>
+    )
+  }
+
+  function ChildNotFoundComponent() {
+    const context = parentRoute.useRouteContext()
+
+    return (
+      <output data-testid="not-found-context">
+        {[context.routerValue, context.rootValue, context.parentValue].join(
+          ' / ',
+        )}
+      </output>
+    )
+  }
+
+  return rootRoute.addChildren([parentRoute.addChildren([childRoute])])
+}
+
+test('a client load-phase not-found preserves inherited ancestor context', async () => {
+  const router = createRouter({
+    routeTree: createRouteTree(),
+    history: createMemoryHistory({ initialEntries: ['/parent/child'] }),
+    context: { routerValue: 'from router' },
+  })
+
+  render(<RouterProvider router={router} />)
+
+  expect(await screen.findByTestId('not-found-context')).toHaveTextContent(
+    expectedContext,
+  )
+  expect(screen.getByTestId('parent-context')).toHaveTextContent(
+    expectedContext,
+  )
+  expect(screen.queryByText('Child content')).not.toBeInTheDocument()
+})
+
+test('an SSR load-phase not-found preserves inherited ancestor context', async () => {
+  const response = await createRequestHandler({
+    request: new Request('http://localhost/parent/child'),
+    createRouter: () =>
+      createRouter({
+        routeTree: createRouteTree(),
+        context: { routerValue: 'from router' },
+        isServer: true,
+      }),
+  })(({ router, responseHeaders }) =>
+    renderRouterToString({
+      router,
+      responseHeaders,
+      children: <RouterServer router={router} />,
+    }),
+  )
+
+  const html = await response.text()
+
+  const document = new DOMParser().parseFromString(html, 'text/html')
+  expect(
+    document.querySelector('[data-testid="parent-context"]')?.textContent,
+  ).toBe(expectedContext)
+  expect(
+    document.querySelector('[data-testid="not-found-context"]')?.textContent,
+  ).toBe(expectedContext)
+  expect(html).not.toContain('Child content')
+})
+
+test('a root beforeLoad not-found exposes only completed root data', async () => {
+  const loader = vi.fn(() => ({ loaderValue: 'from loader' }))
+
+  const rootRoute = createRootRoute({
+    context: () => ({ contextValue: 'from context' }),
+    beforeLoad: (): { beforeLoadValue: string } => {
+      throw notFound()
+    },
+    loader,
+    component: RootComponent,
+    notFoundComponent: () => (
+      <div data-testid="root-not-found">Root not found</div>
+    ),
+  })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <div>Index content</div>,
+  })
+
+  function RootComponent() {
+    const context = rootRoute.useRouteContext()
+    const loaderData = rootRoute.useLoaderData()
+
+    return (
+      <main data-testid="root-component">
+        <output data-testid="context-value">
+          Context: {context.contextValue ?? 'unavailable'}
+        </output>
+        <output data-testid="before-load-value">
+          Before load: {context.beforeLoadValue ?? 'unavailable'}
+        </output>
+        <output data-testid="loader-value">
+          Loader: {loaderData?.loaderValue ?? 'unavailable'}
+        </output>
+        <Outlet />
+      </main>
+    )
+  }
+
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  render(<RouterProvider router={router} />)
+
+  const notFoundContent = await screen.findByTestId('root-not-found')
+  const rootComponent = screen.getByTestId('root-component')
+
+  expect(rootComponent).toContainElement(notFoundContent)
+  expect(screen.getByTestId('context-value')).toHaveTextContent(
+    'Context: from context',
+  )
+  expect(screen.getByTestId('before-load-value')).toHaveTextContent(
+    'Before load: unavailable',
+  )
+  expect(screen.getByTestId('loader-value')).toHaveTextContent(
+    'Loader: unavailable',
+  )
+  expect(screen.queryByText('Index content')).not.toBeInTheDocument()
+  expect(loader).not.toHaveBeenCalled()
+})

--- a/packages/react-router/tests/pending-route-context.test.tsx
+++ b/packages/react-router/tests/pending-route-context.test.tsx
@@ -1,0 +1,298 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, expect, test } from 'vitest'
+import {
+  Outlet,
+  RouterProvider,
+  createControlledPromise,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+
+afterEach(cleanup)
+
+test('a pending child observes settled ancestor context during beforeLoad and loader waits', async () => {
+  const childBeforeLoadStarted = createControlledPromise<void>()
+  const childBeforeLoadGate = createControlledPromise<void>()
+  const childLoaderStarted = createControlledPromise<void>()
+  const childLoaderGate = createControlledPromise<void>()
+  let navigation: Promise<void> | undefined
+
+  const rootRoute = createRootRoute({
+    context: () => ({
+      workspace: 'Router Team',
+      role: 'maintainer',
+    }),
+    component: RootComponent,
+  })
+  const homeRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: HomeComponent,
+  })
+  const reportsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/reports',
+    beforeLoad: async ({ context }) => {
+      childBeforeLoadStarted.resolve()
+      await childBeforeLoadGate
+
+      return {
+        report: 'Activity',
+        access: `${context.workspace}:${context.role}`,
+      }
+    },
+    loader: async () => {
+      childLoaderStarted.resolve()
+      await childLoaderGate
+    },
+    pendingMs: 0,
+    pendingMinMs: 0,
+    pendingComponent: ReportsPendingComponent,
+    component: ReportsComponent,
+  })
+
+  function RootComponent() {
+    const context = rootRoute.useRouteContext()
+
+    return (
+      <main>
+        <header>
+          <h1>{context.workspace}</h1>
+          <output data-testid="root-context">
+            Workspace {context.workspace}; role {context.role}
+          </output>
+        </header>
+        <Outlet />
+      </main>
+    )
+  }
+
+  function HomeComponent() {
+    const navigate = homeRoute.useNavigate()
+
+    return (
+      <section>
+        <h2>Home</h2>
+        <button
+          onClick={() => {
+            navigation = navigate({ to: '/reports' })
+          }}
+        >
+          View reports
+        </button>
+      </section>
+    )
+  }
+
+  function ReportsPendingComponent() {
+    const parentContext = rootRoute.useRouteContext()
+
+    return (
+      <section data-testid="reports-pending" role="status">
+        Loading reports
+        <output data-testid="pending-ancestor-context">
+          Workspace {parentContext.workspace}; role {parentContext.role}
+        </output>
+      </section>
+    )
+  }
+
+  function ReportsComponent() {
+    const context = reportsRoute.useRouteContext()
+
+    return (
+      <section>
+        <h2>Reports</h2>
+        <output data-testid="child-context">
+          Workspace {context.workspace}; role {context.role}; report{' '}
+          {context.report}; access {context.access}
+        </output>
+      </section>
+    )
+  }
+
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([homeRoute, reportsRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+  const view = render(<RouterProvider router={router} />)
+
+  try {
+    expect(await screen.findByRole('heading', { name: 'Home' })).toBeVisible()
+    expect(screen.getByTestId('root-context')).toHaveTextContent(
+      'Workspace Router Team; role maintainer',
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'View reports' }))
+    await act(async () => {
+      await childBeforeLoadStarted
+    })
+
+    expect(await screen.findByTestId('reports-pending')).toHaveTextContent(
+      'Loading reports',
+    )
+    expect(screen.getByTestId('root-context')).toHaveTextContent(
+      'Workspace Router Team; role maintainer',
+    )
+    expect(screen.getByTestId('pending-ancestor-context')).toHaveTextContent(
+      'Workspace Router Team; role maintainer',
+    )
+    expect(screen.queryByTestId('child-context')).not.toBeInTheDocument()
+
+    await act(async () => {
+      childBeforeLoadGate.resolve()
+      await childLoaderStarted
+    })
+
+    expect(screen.getByTestId('reports-pending')).toHaveTextContent(
+      'Loading reports',
+    )
+    expect(screen.getByTestId('root-context')).toHaveTextContent(
+      'Workspace Router Team; role maintainer',
+    )
+    expect(screen.getByTestId('pending-ancestor-context')).toHaveTextContent(
+      'Workspace Router Team; role maintainer',
+    )
+    expect(screen.queryByTestId('child-context')).not.toBeInTheDocument()
+
+    const childNavigation = navigation
+    if (!childNavigation) {
+      throw new Error('Expected child navigation to start')
+    }
+
+    await act(async () => {
+      childLoaderGate.resolve()
+      await childNavigation
+    })
+
+    expect(screen.queryByTestId('reports-pending')).not.toBeInTheDocument()
+    expect(screen.getByTestId('root-context')).toHaveTextContent(
+      'Workspace Router Team; role maintainer',
+    )
+    expect(screen.getByTestId('child-context')).toHaveTextContent(
+      'Workspace Router Team; role maintainer; report Activity; access Router Team:maintainer',
+    )
+  } finally {
+    childBeforeLoadGate.resolve()
+    childLoaderGate.resolve()
+    await act(async () => {
+      await Promise.allSettled(navigation ? [navigation] : [])
+    })
+    view.unmount()
+  }
+})
+
+test('overlapping invalidations keep the latest context through completion', async () => {
+  const secondChildLoaderStarted = createControlledPromise<void>()
+  const secondChildLoaderGate = createControlledPromise<void>()
+  const thirdRootBeforeLoadStarted = createControlledPromise<void>()
+  const thirdRootBeforeLoadGate = createControlledPromise<void>()
+  let contextGeneration = 0
+  let childLoaderGeneration = 0
+
+  const rootRoute = createRootRoute({
+    beforeLoad: async () => {
+      const generation = ++contextGeneration
+
+      if (generation === 3) {
+        thirdRootBeforeLoadStarted.resolve()
+        await thirdRootBeforeLoadGate
+      }
+
+      return { generation }
+    },
+    component: () => (
+      <main>
+        <output data-testid="root-context">
+          Root generation {rootRoute.useRouteContext().generation}
+        </output>
+        <Outlet />
+      </main>
+    ),
+  })
+  const childRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    loader: async () => {
+      if (++childLoaderGeneration === 2) {
+        secondChildLoaderStarted.resolve()
+        await secondChildLoaderGate
+      }
+    },
+    pendingMs: 0,
+    pendingMinMs: 0,
+    pendingComponent: () => <p data-testid="child-pending">Loading child</p>,
+    component: () => <p>Child content</p>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([childRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+  const view = render(<RouterProvider router={router} />)
+  let firstInvalidation: Promise<void> | undefined
+  let secondInvalidation: Promise<void> | undefined
+
+  try {
+    expect(await screen.findByText('Child content')).toBeInTheDocument()
+    expect(screen.getByTestId('root-context')).toHaveTextContent(
+      'Root generation 1',
+    )
+
+    await act(async () => {
+      firstInvalidation = router.invalidate({ forcePending: true })
+      await secondChildLoaderStarted
+      await Promise.resolve()
+    })
+    expect(screen.getByTestId('child-pending')).toHaveTextContent(
+      'Loading child',
+    )
+    expect(screen.getByTestId('root-context')).toHaveTextContent(
+      'Root generation 2',
+    )
+
+    await act(async () => {
+      secondInvalidation = router.invalidate({ forcePending: true })
+      await thirdRootBeforeLoadStarted
+      await Promise.resolve()
+    })
+
+    expect(screen.getByTestId('child-pending')).toHaveTextContent(
+      'Loading child',
+    )
+    expect(screen.getByTestId('root-context')).toHaveTextContent(
+      'Root generation 2',
+    )
+    await act(async () => {
+      thirdRootBeforeLoadGate.resolve()
+      await secondInvalidation
+    })
+    expect(screen.getByTestId('root-context')).toHaveTextContent(
+      'Root generation 3',
+    )
+    expect(screen.getByText('Child content')).toBeVisible()
+    expect(screen.queryByTestId('child-pending')).not.toBeInTheDocument()
+
+    await act(async () => {
+      secondChildLoaderGate.resolve()
+      await firstInvalidation
+    })
+    expect(screen.getByTestId('root-context')).toHaveTextContent(
+      'Root generation 3',
+    )
+    expect(screen.getByText('Child content')).toBeVisible()
+  } finally {
+    await act(async () => {
+      secondChildLoaderGate.resolve()
+      thirdRootBeforeLoadGate.resolve()
+      await Promise.allSettled(
+        [firstInvalidation, secondInvalidation].filter(
+          (invalidation): invalidation is Promise<void> =>
+            invalidation !== undefined,
+        ),
+      )
+    })
+    view.unmount()
+  }
+})


### PR DESCRIPTION
## 🎯 Changes

Add six regression tests for context availability during pending navigation and not-found handling:

- A pending child reads completed ancestor context while its beforeLoad and loader wait.
- Overlapping invalidations retain the latest displayed context, publish the next generation on completion, and resist rollback from obsolete work.
- A root beforeLoad throwing not-found exposes only completed root data and does not run its loader.
- A child context throwing not-found preserves ancestor context in client and server rendering.
- An automatic not-found destination follows its configured pending UI and publishes fresh owner context after beforeLoad completes.

The SSR assertions check each output independently. These cases consolidate the recovered investigation probes and cover existing behavior. Stacked on #8165.

Validation: the full react-router unit, type, and lint targets passed locally (1,047 unit tests passed; one skipped).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [ ] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for pending-route context during navigation and loading.
  - Added coverage ensuring not-found routes preserve the appropriate inherited context in client-side and server-rendered scenarios.
  - Added coverage for automatic not-found navigation while route context is still pending.
  - Added tests for overlapping navigations and ensuring the latest context is retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->