### PR TITLE
fix(start): return 404 for unknown server function ids

### DIFF
--- a/.changeset/stale-server-fn-id-not-found.md
+++ b/.changeset/stale-server-fn-id-not-found.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/start-plugin-core': patch
+'@tanstack/start-server-core': patch
+---
+
+Answer `404` instead of an unhandled `500` when a server function is requested with an id that is not in the build's manifest. Every build mints new server function ids, so caches, crawlers and tabs that have not reloaded keep calling ids from a previous deployment, and each one was surfacing as an unhandled server error with a full stack trace. The generated resolver now flags that specific case, the request handler answers `404` and logs the unresolved id outside production, and every other resolution failure keeps its current behaviour. On the client, a call to a stale id now rejects with an error instead of resolving with the serialized `500` body.

--- a/docs/start/framework/react/guide/server-functions.md
+++ b/docs/start/framework/react/guide/server-functions.md
@@ -421,6 +421,8 @@ Server functions are addressed by a generated, stable function ID under the hood
 By default, IDs are SHA256 hashes of the same seed to keep bundles compact and avoid leaking file paths.
 If two server functions end up with the same ID (including when using a custom generator), the system de-duplicates by appending an incrementing suffix like `_1`, `_2`, etc.
 
+Because the IDs belong to a specific build, a deployment can still receive requests for IDs it no longer knows about — from a cached response, a crawler, or a tab that has not reloaded since the previous release. Those requests are answered with a `404`, and the client-side call rejects with an error rather than resolving. If your app should survive a version skew instead of surfacing the error, catch it where the server function is called and prompt a reload.
+
 Customization:
 
 You can customize function ID generation for the production build by providing a `generateFunctionId` function when configuring the TanStack Start build tool plugin.

--- a/packages/start-plugin-core/src/start-compiler/server-fn-resolver-module.ts
+++ b/packages/start-plugin-core/src/start-compiler/server-fn-resolver-module.ts
@@ -1,3 +1,4 @@
+import { SERVER_FN_NOT_FOUND } from '@tanstack/start-server-core/constants'
 import type { ServerFn } from './types'
 
 interface ResolverManifestEntry {
@@ -50,7 +51,13 @@ function getResolverBody(): string {
 export async function getServerFnById(id, access) {
   const serverFnInfo = manifest[id]
   if (!serverFnInfo) {
-    throw new Error('Server function info not found for ' + id)
+    // Every build mints new ids, so a cache, a crawler or a tab that has not
+    // reloaded keeps requesting ids from a previous deployment. Flagged so the
+    // request handler can answer 404; still a regular Error so the callers that
+    // are not serving an HTTP request keep the message and the stack.
+    const error = new Error('Server function info not found for ' + id)
+    error[${JSON.stringify(SERVER_FN_NOT_FOUND)}] = true
+    throw error
   }
 __CLIENT_REFERENCED_CHECK__
   const fnModule = serverFnInfo.module ?? (await serverFnInfo.importer())

--- a/packages/start-plugin-core/tests/server-fn-resolver-module.test.ts
+++ b/packages/start-plugin-core/tests/server-fn-resolver-module.test.ts
@@ -1,0 +1,133 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { afterEach, describe, expect, test } from 'vitest'
+import {
+  SERVER_FN_NOT_FOUND,
+  isServerFnNotFound,
+} from '@tanstack/start-server-core/constants'
+import { generateServerFnResolverModule } from '../src/start-compiler/server-fn-resolver-module'
+
+const KNOWN_SERVER_FN_ID = 'known-server-fn-id'
+const STALE_SERVER_FN_ID = 'stale-server-fn-id'
+
+const createdDirs: Array<string> = []
+
+afterEach(async () => {
+  await Promise.all(
+    createdDirs
+      .splice(0)
+      .map((dir) => rm(dir, { force: true, recursive: true })),
+  )
+})
+
+/**
+ * The resolver is emitted as source text, so the only faithful way to observe
+ * its runtime behaviour is to write it out and import it as a real module.
+ */
+async function loadGeneratedResolver(
+  opts: { extractedFilename?: string } = {},
+) {
+  const source = generateServerFnResolverModule({
+    serverFnsById: {
+      [KNOWN_SERVER_FN_ID]: {
+        functionName: 'knownServerFn',
+        extractedFilename: opts.extractedFilename ?? './known-server-fn.mjs',
+      } as never,
+    },
+    includeClientReferencedCheck: false,
+  })
+
+  const dir = await mkdtemp(join(tmpdir(), 'tsr-server-fn-resolver-'))
+  createdDirs.push(dir)
+
+  await writeFile(
+    join(dir, 'known-server-fn.mjs'),
+    'export const knownServerFn = () => "ok"\n',
+    'utf8',
+  )
+  const modulePath = join(dir, 'resolver.mjs')
+  await writeFile(modulePath, source, 'utf8')
+
+  return (await import(pathToFileURL(modulePath).href)) as {
+    getServerFnById: (
+      id: string,
+      access: { origin: 'client' | 'server' },
+    ) => Promise<unknown>
+  }
+}
+
+describe('generateServerFnResolverModule', () => {
+  // The flag name is interpolated from `@tanstack/start-server-core`. If that
+  // import ever resolves to a build without the constant, the emitted line
+  // becomes `error[undefined] = true` — valid JS that silently drops the flag
+  // and lets a stale id go back to being a 500.
+  test('emits the not-found flag by name', () => {
+    const source = generateServerFnResolverModule({
+      serverFnsById: {},
+      includeClientReferencedCheck: false,
+    })
+
+    expect(source).toContain(`error["${SERVER_FN_NOT_FOUND}"] = true`)
+  })
+
+  test('resolves a server function that is present in the manifest', async () => {
+    const { getServerFnById } = await loadGeneratedResolver()
+
+    const action = await getServerFnById(KNOWN_SERVER_FN_ID, {
+      origin: 'client',
+    })
+
+    expect(typeof action).toBe('function')
+  })
+
+  test('flags an id that is absent from the manifest so the handler can answer 404', async () => {
+    const { getServerFnById } = await loadGeneratedResolver()
+
+    const error = await getServerFnById(STALE_SERVER_FN_ID, {
+      origin: 'client',
+    }).then(
+      () => undefined,
+      (thrown: unknown) => thrown,
+    )
+
+    expect(isServerFnNotFound(error)).toBe(true)
+  })
+
+  // Only the request handler acts on the flag; every other caller of the resolver
+  // (SSR RPC, the RSC action loader, the serialization adapter) keeps propagating
+  // this value as-is, so it has to stay a real Error with a usable message.
+  test('keeps the missing id reportable as a regular Error', async () => {
+    const { getServerFnById } = await loadGeneratedResolver()
+
+    const error = await getServerFnById(STALE_SERVER_FN_ID, {
+      origin: 'client',
+    }).then(
+      () => undefined,
+      (thrown: unknown) => thrown,
+    )
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toContain(STALE_SERVER_FN_ID)
+    expect((error as Error).stack).toBeTruthy()
+  })
+
+  test('leaves a resolution failure that is not a missing id unflagged', async () => {
+    const { getServerFnById } = await loadGeneratedResolver({
+      // A manifest entry whose module cannot be imported is a real server fault,
+      // not a stale id, and must not be turned into a 404.
+      extractedFilename: './does-not-exist.mjs',
+    })
+
+    const error = await getServerFnById(KNOWN_SERVER_FN_ID, {
+      origin: 'client',
+    }).then(
+      () => undefined,
+      (thrown: unknown) => thrown,
+    )
+
+    expect(error).toBeInstanceOf(Error)
+    expect(isServerFnNotFound(error)).toBe(false)
+  })
+})

--- a/packages/start-server-core/src/constants.ts
+++ b/packages/start-server-core/src/constants.ts
@@ -16,11 +16,17 @@ export const HEADERS = {
  */
 export const SERVER_FN_NOT_FOUND = 'tssServerFnNotFound'
 
-/** Whether `error` is the resolver's "no such server function id" signal. */
+/**
+ * Whether `error` is the resolver's "no such server function id" signal.
+ *
+ * The marker has to be the error's own property: inheriting it would let an
+ * unrelated resolver failure be answered with `404` instead of surfacing.
+ */
 export function isServerFnNotFound(error: unknown): boolean {
   return (
     typeof error === 'object' &&
     error !== null &&
+    Object.prototype.hasOwnProperty.call(error, SERVER_FN_NOT_FOUND) &&
     (error as Record<string, unknown>)[SERVER_FN_NOT_FOUND] === true
   )
 }

--- a/packages/start-server-core/src/constants.ts
+++ b/packages/start-server-core/src/constants.ts
@@ -1,3 +1,26 @@
 export const HEADERS = {
   TSS_SHELL: 'X-TSS_SHELL',
 } as const
+
+/**
+ * Own property set on the error the generated server function resolver throws
+ * when an id is absent from the build's manifest.
+ *
+ * It is a flag on a regular `Error` rather than a distinct error type so that
+ * every consumer of the resolver keeps the message and the stack; only the
+ * request handler needs to recognise the case, so it can answer `404` instead
+ * of letting a stale id surface as an unhandled server error.
+ *
+ * `@tanstack/start-plugin-core` reads this constant when it emits the resolver
+ * module, so the two packages stay on one definition of the flag.
+ */
+export const SERVER_FN_NOT_FOUND = 'tssServerFnNotFound'
+
+/** Whether `error` is the resolver's "no such server function id" signal. */
+export function isServerFnNotFound(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as Record<string, unknown>)[SERVER_FN_NOT_FOUND] === true
+  )
+}

--- a/packages/start-server-core/src/server-functions-handler.ts
+++ b/packages/start-server-core/src/server-functions-handler.ts
@@ -14,6 +14,7 @@ import {
 import { fromJSON, toCrossJSONAsync, toCrossJSONStream } from 'seroval'
 import { getResponse } from './request-response'
 import { getServerFnById } from './getServerFnById'
+import { isServerFnNotFound } from './constants'
 import {
   TSS_CONTENT_TYPE_FRAMED_VERSIONED,
   createMultiplexedStream,
@@ -33,6 +34,13 @@ const FORM_DATA_CONTENT_TYPES = [
 // Maximum payload size for GET requests (1MB)
 const MAX_PAYLOAD_SIZE = 1_000_000
 
+// Answer for a server function id that this build does not know about. The body
+// deliberately omits the requested id so the response never echoes back a
+// caller-supplied path segment; the id is logged server-side outside production.
+const SERVER_FN_NOT_FOUND_STATUS = 404
+const SERVER_FN_NOT_FOUND_BODY = 'Server function not found'
+const SERVER_FN_NOT_FOUND_CONTENT_TYPE = 'text/plain; charset=utf-8'
+
 export const handleServerAction = async ({
   request,
   context,
@@ -46,7 +54,30 @@ export const handleServerAction = async ({
   const methodUpper = method.toUpperCase()
   const url = new URL(request.url)
 
-  const action = await getServerFnById(serverFnId, { origin: 'client' })
+  let action: Awaited<ReturnType<typeof getServerFnById>>
+  try {
+    action = await getServerFnById(serverFnId, { origin: 'client' })
+  } catch (error) {
+    // A genuine resolution failure (module that fails to import, missing export)
+    // is a server fault and keeps escaping as it does today.
+    if (!isServerFnNotFound(error)) {
+      throw error
+    }
+
+    // An id this build does not know about is a missing resource. Outside
+    // production it almost always means the registry is stale, so keep the
+    // diagnostic; in production the same id is routine cache and crawler traffic
+    // against a previous deployment, and logging it per request is the noise
+    // this branch exists to remove.
+    if (process.env.NODE_ENV !== 'production') {
+      console.error(error)
+    }
+
+    return new Response(SERVER_FN_NOT_FOUND_BODY, {
+      status: SERVER_FN_NOT_FOUND_STATUS,
+      headers: { 'Content-Type': SERVER_FN_NOT_FOUND_CONTENT_TYPE },
+    })
+  }
 
   // Early method check: reject mismatched HTTP methods before parsing
   // the request payload (FormData, JSON, query string, etc.)

--- a/packages/start-server-core/tests/server-functions-handler.test.ts
+++ b/packages/start-server-core/tests/server-functions-handler.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment node
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { SERVER_FN_NOT_FOUND } from '../src/constants'
+
+const resolverMocks = vi.hoisted(() => ({
+  getServerFnById: vi.fn(),
+}))
+
+vi.mock('../src/getServerFnById', () => ({
+  getServerFnById: resolverMocks.getServerFnById,
+}))
+
+const { handleServerAction } = await import('../src/server-functions-handler')
+
+const STALE_SERVER_FN_ID = 'stale-server-fn-id'
+const KNOWN_SERVER_FN_ID = 'known-server-fn-id'
+const SERVER_FN_URL = `http://localhost/_serverFn/${STALE_SERVER_FN_ID}`
+
+/** The shape `@tanstack/start-plugin-core` emits for an id it cannot resolve. */
+function serverFnNotFoundError(id: string) {
+  const error = new Error(`Server function info not found for ${id}`) as Error &
+    Record<string, unknown>
+  error[SERVER_FN_NOT_FOUND] = true
+  return error
+}
+
+function callHandler(serverFnId: string) {
+  return handleServerAction({
+    request: new Request(SERVER_FN_URL, { method: 'GET' }),
+    context: {},
+    serverFnId,
+  })
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllEnvs()
+})
+
+describe('handleServerAction', () => {
+  it('keeps dispatching to a server function that resolves', async () => {
+    const action = Object.assign(vi.fn(), { method: 'POST' as const })
+    resolverMocks.getServerFnById.mockResolvedValueOnce(action)
+
+    // A resolved function still reaches the existing method check, so this pins
+    // the successful resolution path that the not-found handling wraps.
+    const response = await callHandler(KNOWN_SERVER_FN_ID)
+
+    expect(resolverMocks.getServerFnById).toHaveBeenCalledWith(
+      KNOWN_SERVER_FN_ID,
+      { origin: 'client' },
+    )
+    expect(response.status).toBe(405)
+    expect(action).not.toHaveBeenCalled()
+  })
+
+  it('answers 404 when the id is not in this build', async () => {
+    resolverMocks.getServerFnById.mockImplementationOnce(() => {
+      throw serverFnNotFoundError(STALE_SERVER_FN_ID)
+    })
+
+    const response = await callHandler(STALE_SERVER_FN_ID)
+
+    expect(response).toBeInstanceOf(Response)
+    expect(response.status).toBe(404)
+    expect(response.headers.get('Content-Type')).toContain('text/plain')
+    // The requested id is caller-supplied, so it must not be echoed back.
+    expect(await response.text()).not.toContain(STALE_SERVER_FN_ID)
+  })
+
+  it('logs the unresolved id outside production', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const error = serverFnNotFoundError(STALE_SERVER_FN_ID)
+    resolverMocks.getServerFnById.mockImplementationOnce(() => {
+      throw error
+    })
+
+    await callHandler(STALE_SERVER_FN_ID)
+
+    expect(consoleError).toHaveBeenCalledWith(error)
+  })
+
+  it('stays quiet in production, where stale ids are routine traffic', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    resolverMocks.getServerFnById.mockImplementationOnce(() => {
+      throw serverFnNotFoundError(STALE_SERVER_FN_ID)
+    })
+
+    const response = await callHandler(STALE_SERVER_FN_ID)
+
+    expect(response.status).toBe(404)
+    expect(consoleError).not.toHaveBeenCalled()
+  })
+
+  it('still surfaces a genuine resolver failure instead of masking it as 404', async () => {
+    const resolverFailure = new Error('Server function module not resolved')
+    resolverMocks.getServerFnById.mockImplementationOnce(() => {
+      throw resolverFailure
+    })
+
+    await expect(callHandler(STALE_SERVER_FN_ID)).rejects.toBe(resolverFailure)
+  })
+})

--- a/packages/start-server-core/tests/server-functions-handler.test.ts
+++ b/packages/start-server-core/tests/server-functions-handler.test.ts
@@ -103,4 +103,19 @@ describe('handleServerAction', () => {
 
     await expect(callHandler(STALE_SERVER_FN_ID)).rejects.toBe(resolverFailure)
   })
+
+  it('does not treat an inherited marker as a missing id', async () => {
+    // Only the resolver sets the marker, and it sets it on the error itself.
+    // Honouring an inherited one would answer 404 for an unrelated failure.
+    class InheritsMarker extends Error {}
+    ;(InheritsMarker.prototype as unknown as Record<string, unknown>)[
+      SERVER_FN_NOT_FOUND
+    ] = true
+    const resolverFailure = new InheritsMarker('Server function module export')
+    resolverMocks.getServerFnById.mockImplementationOnce(() => {
+      throw resolverFailure
+    })
+
+    await expect(callHandler(STALE_SERVER_FN_ID)).rejects.toBe(resolverFailure)
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Fixes #7363.

Server function ids are minted per build. After a redeploy, caches, crawlers and tabs that have not reloaded keep calling ids the new build does not know about. Those requests were coming back as an unhandled `500` with a full stack trace in the server logs, which fires production alerts for what is really a missing resource.

The unknown-id case was also the one resolver failure `handleServerAction` could not see: it resolved the server function *outside* its `try`, so the rejection escaped the handler entirely.

- `generateServerFnResolverModule` still throws a regular `Error` for an id that is absent from the manifest, but sets a flag on it (`SERVER_FN_NOT_FOUND`, exported from `start-server-core/src/constants.ts` and interpolated into the emitted module, so both packages share one definition).
- `handleServerAction` resolves the function inside a `try`. A flagged error becomes a `404 text/plain` response and is logged outside production; every other resolution failure — a module that fails to import, a missing export — is rethrown and keeps its current behaviour.

Deliberately kept a real `Error` rather than a `notFound()`-shaped value: `createSsrRpc`, the RSC `loadServerAction` and `ServerFunctionSerializationAdapter` all call the resolver with no `catch`, so a not-found-shaped throw would have made an infrastructure error render the app's `notFoundComponent` and would have dropped the message and stack on those paths. Only the request handler acts on the flag.

The `404` body omits the requested id so the response never echoes back a caller-supplied path segment; the id is logged server-side outside production.

Scope notes:
- The dev-only Vite resolver is unchanged. Dev ids are base64url-encoded `{file, export}` payloads rather than manifest lookups, so the cross-deployment skew this fixes cannot happen there, and a loud dev error is more useful than a quiet `404`.
- The issue also suggests cache headers and `robots.txt` guidance for `/_serverFn` routes. Those are separate config/API decisions and are not part of this PR.

## Test verification (RED → GREEN)

New tests: 4 in `start-plugin-core` (the emitted resolver is written to a temp file and imported, so the generated JS is really executed) and 5 in `start-server-core`.

**RED** — production sources reverted to `main`, only the new tests applied:

```
--- start-server-core tests/server-functions-handler.test.ts ---
 × answers 404 when the id is not in this build
 × logs the unresolved id outside production
 × stays quiet in production, where stale ids are routine traffic
 Test Files  1 failed (1)
      Tests  3 failed | 2 passed (5)

--- start-plugin-core tests/server-fn-resolver-module.test.ts ---
 × flags an id that is absent from the manifest so the handler can answer 404
 × leaves a resolution failure that is not a missing id unflagged
 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
```

The tests that pass in both columns are the guards: a resolvable id still dispatches, and a genuine resolver failure still propagates instead of being masked as a `404`.

**GREEN** — full unit suites on the branch (`main` baseline was 118 and 512):

```
--- start-server-core ---
 Test Files  8 passed (8)
      Tests  123 passed (123)

--- start-plugin-core ---
 Test Files  32 passed (32)
      Tests  517 passed (517)
 Type Errors  no errors
```

**End-to-end, against a real production build** (`e2e/react-start/server-functions`, `vite build` + `srvx --prod`, `NODE_ENV=production`). Same-origin headers because a bare `curl` is rejected by the CSRF middleware with `403` before reaching the handler:

```
### WITHOUT FIX — main
$ curl -si .../_serverFn/test -H 'Origin: ...' -H 'x-tsr-serverFn: true'
HTTP/1.1 500 Internal Server Error
content-type: application/json;charset=UTF-8

{"status":500,"unhandled":true,"message":"HTTPError"}

server stderr:
Error: Server function info not found for test
    at getServerFnById (.../dist/server/server.js:4459:27)
  cause: Error: Server function info not found for test
      at getServerFnById (.../dist/server/server.js:4459:27)

### WITH FIX
HTTP/1.1 404
content-type: text/plain; charset=utf-8

Server function not found

server stderr: (nothing)
```

Client side, this also means the call now rejects with `Error: Server function not found` instead of resolving with the serialized `500` body.

### Full local suite

Replayed what `pnpm run test:pr` covers for the affected packages, on the upstream base and again on this branch — identical results, so no regression:

```
                      main (baseline)      this branch
format                PASS                 PASS
test:eslint           PASS                 PASS
test:types            PASS                 PASS   (ts56 - ts70)
test:unit             PASS                 PASS
build                 PASS                 PASS
test:build            PASS                 PASS   (publint --strict + attw)
```

Also green: the `tanstack-react-start-e2e-server-functions` e2e project (53 vite + 53 rsbuild + 3 rsbuild-cache passed) — the rsbuild-cache specs are the ones asserting the missing-id diagnostic stays absent from dev-server logs while the registry is intact, which is why the log was kept rather than dropped.

Bundle size: **0 byte gzip delta across all 18 benchmark scenarios**, as expected for a server-only change.

The full `test:e2e` matrix (~130 example/e2e apps, distributed over Nx Cloud agents in CI) was not reproducible on one machine; only the server-functions project above was run locally.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Requests for unavailable or outdated server-function IDs now return a clear `404` response.
  * Client calls to unavailable server functions now reject with an error instead of returning a serialized server error response.
  * Other server-function resolution failures continue to behave as before.

* **Documentation**
  * Added guidance for handling server-function version mismatches, including prompting users to reload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->