### PR TITLE
fix(solid-router): respect server flag during development SSR

### DIFF
--- a/.changeset/solid-router-dev-ssr-detection.md
+++ b/.changeset/solid-router-dev-ssr-detection.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/solid-router': patch
+---
+
+Fall back to the router instance's server flag during development SSR. This prevents router construction from entering client hydration on the server and restores provider-owned loading and match-state serialization.

--- a/packages/solid-router/src/RouterProvider.tsx
+++ b/packages/solid-router/src/RouterProvider.tsx
@@ -49,7 +49,9 @@ export function RouterContextProvider<
   // registry priming in the Router constructor plus Transitioner's
   // settled-time load.
   const ready = Solid.createMemo(() =>
-    isServer && !router._serverResult ? router.load().then(() => true) : true,
+    (isServer ?? router.isServer) && !router._serverResult
+      ? router.load().then(() => true)
+      : true,
   )
 
   const OptionalWrapper = router.options.Wrap || SafeFragment
@@ -65,7 +67,7 @@ export function RouterContextProvider<
             // live. Runs after the load gate so matches are committed. The
             // client half — the hydration-claiming boot — runs at router
             // creation, outside the render.
-            if (isServer) {
+            if (isServer ?? router.isServer) {
               serializeMatchTransfer(router)
             }
             return children()

--- a/packages/solid-router/src/router.ts
+++ b/packages/solid-router/src/router.ts
@@ -110,7 +110,7 @@ export class Router<
     // claiming walk. Inert without entries: an SPA page has no registry, and
     // a Start app transfers through its own channel (`router.serverSsr`),
     // so the first missing entry falls through to unchanged behavior.
-    if (!isServer) {
+    if (!(isServer ?? this.isServer)) {
       primeRouterFromRegistry(this)
     }
   }

--- a/packages/solid-router/tests/server/RouterProvider.test.tsx
+++ b/packages/solid-router/tests/server/RouterProvider.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest'
+import { renderToStream } from '@solidjs/web'
+import { isServer } from '@tanstack/router-core/isServer'
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../../src'
+
+vi.mock('@tanstack/router-core/isServer', async (importOriginal) => ({
+  ...(await importOriginal()),
+  isServer: undefined,
+}))
+
+describe('RouterProvider (development SSR)', () => {
+  it('creates a server router before request history is attached', () => {
+    expect(isServer).toBeUndefined()
+
+    const router = createRouter({ routeTree: createRootRoute() })
+
+    expect(router.isServer).toBe(true)
+    const history = createMemoryHistory({ initialEntries: ['/'] })
+    router.update({ history })
+    expect(router.history).toBe(history)
+    expect(router.stores.matches.get()).toEqual([])
+  })
+
+  it.each([false, true])(
+    'loads once and serializes matches when preloaded is %s',
+    async (preloaded) => {
+      expect(isServer).toBeUndefined()
+
+      const loader = vi.fn(() => Promise.resolve('server-loader-data'))
+      const rootRoute = createRootRoute()
+      const indexRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/',
+        loader,
+        component: () => <div>Index</div>,
+      })
+      const router = createRouter({
+        routeTree: rootRoute.addChildren([indexRoute]),
+        history: createMemoryHistory({ initialEntries: ['/'] }),
+        isServer: true,
+      })
+      const loadSpy = vi.spyOn(router, 'load')
+
+      if (preloaded) {
+        await router.load()
+      }
+
+      const html = await renderToStream(() => (
+        <RouterProvider router={router} />
+      ))
+
+      expect(loadSpy).toHaveBeenCalledTimes(1)
+      expect(loader).toHaveBeenCalledTimes(1)
+      expect(html).toContain('Index')
+      expect(html).toContain('tsr:__root__')
+      expect(html).toContain('tsr:/')
+      expect(html).toContain('server-loader-data')
+      loadSpy.mockRestore()
+    },
+  )
+})


### PR DESCRIPTION
Fixes https://github.com/solidjs/templates/issues/299

## Summary

`@tanstack/router-core/isServer` intentionally returns `undefined` in development so adapters can fall back to the router instance. The new hydration constructor and provider checks omitted that fallback.

- Use `isServer ?? router.isServer` (or `this.isServer` in the constructor) for the three affected checks.
- Prevent server-side router construction from entering client registry priming before stores are initialized.
- Restore provider-owned server loading and match-state serialization, avoiding missing hydration entries after the startup crash is fixed.
- Add three regression cases for construction without history and serialization with both preloaded and fresh routers, plus a patch changeset.

All three regression cases failed before the source changes and pass afterward.

## Verification

- Solid router unit target: 870 client tests and 7 server tests passed; 2 client tests skipped.
- Solid router type target: TypeScript 5.6, 5.7, 5.8, 5.9, 6.0, and 7.0 passed; package build passed.
- Solid router ESLint target passed with existing warnings in unrelated files and no new warnings.
- Prettier checks passed for all changed files.

Tests, types, and lint were run through the package-specific Nx targets with `CI=1 NX_DAEMON=false` and `--skipRemoteCache`.