### PR TITLE
fix(react-router): avoid rewriting unchanged head assets

### DIFF
--- a/.changeset/spotty-poems-smell.md
+++ b/.changeset/spotty-poems-smell.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-router': patch
+---
+
+Fix repeated `innerHTML` writes for unchanged styles and data scripts during React re-renders. This prevents unnecessary CSS parsing and Trusted Types errors during client navigation.

--- a/e2e/react-start/css-inline/src/routes/app/dashboard/index.tsx
+++ b/e2e/react-start/css-inline/src/routes/app/dashboard/index.tsx
@@ -3,6 +3,9 @@ import { NestedPanel } from '~/components/NestedPanel'
 import styles from '~/styles/dashboard-index.module.css'
 
 export const Route = createFileRoute('/app/dashboard/')({
+  head: () => ({
+    meta: [{ title: 'Inline CSS dashboard' }],
+  }),
   component: DashboardIndex,
 })
 

--- a/e2e/react-start/css-inline/tests/css-inline.spec.ts
+++ b/e2e/react-start/css-inline/tests/css-inline.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test'
-import { test } from '@tanstack/router-e2e-utils'
+import { collectBrowserErrors, test } from '@tanstack/router-e2e-utils'
 
 const buildUrl = (baseURL: string, pathname: string) =>
   baseURL.replace(/\/$/, '') + pathname
@@ -151,6 +151,23 @@ test('client navigation preserves the SSR inline shell stylesheet', async ({
   await page.goto(buildUrl(baseURL!, '/'))
   await waitForHydration(page)
 
+  const inlineStyle = page.locator('style[data-tsr-inline-css]')
+  await expect(inlineStyle).toHaveCount(1)
+  const original = await inlineStyle.evaluateHandle(
+    (style: HTMLStyleElement) => {
+      const mutations: Array<MutationRecord> = []
+      const observer = new MutationObserver((records) => {
+        mutations.push(...records)
+      })
+      observer.observe(style, {
+        childList: true,
+        characterData: true,
+        subtree: true,
+      })
+      return { style, sheet: style.sheet, observer, mutations }
+    },
+  )
+
   await expect.poll(() => getInlineCssTexts(page)).toHaveLength(1)
   await expect
     .poll(() => getInlineCssTexts(page))
@@ -161,6 +178,28 @@ test('client navigation preserves the SSR inline shell stylesheet', async ({
 
   await page.getByTestId('nav-dashboard').click()
   await page.waitForURL('**/app/dashboard')
+  await expect(page).toHaveTitle('Inline CSS dashboard')
+  await expect(page.getByTestId('dashboard-card')).toBeVisible()
+
+  await page.getByTestId('nav-home').click()
+  await expect(page).toHaveTitle('Inline CSS E2E')
+  await expect(page.getByTestId('home')).toBeVisible()
+
+  // #8250: unchanged CSS text can hide a redundant innerHTML write that
+  // replaces the stylesheet or fails under Trusted Types. Observe native DOM
+  // mutations and CSSOM identity without patching the innerHTML setter.
+  expect(
+    await original.evaluate(({ style, sheet, observer, mutations }) => {
+      const mutationCount = mutations.length + observer.takeRecords().length
+      observer.disconnect()
+      return {
+        connected: style.isConnected,
+        sameSheet: style.sheet === sheet,
+        mutationCount,
+      }
+    }),
+  ).toEqual({ connected: true, sameSheet: true, mutationCount: 0 })
+  await original.dispose()
 
   await expect.poll(() => getInlineCssTexts(page)).toHaveLength(1)
   await expect
@@ -169,4 +208,46 @@ test('client navigation preserves the SSR inline shell stylesheet', async ({
   await expect
     .poll(() => getStyle(page, 'shell', 'background-color'))
     .toBe('rgb(240, 249, 255)')
+})
+
+test('client navigation preserves inline CSS with Trusted Types enforced', async ({
+  page,
+}) => {
+  const browserErrors = collectBrowserErrors(page)
+  const csp = "require-trusted-types-for 'script'; trusted-types 'none'"
+  await page.route('/', async (route) => {
+    const response = await route.fetch()
+    await route.fulfill({
+      response,
+      headers: { ...response.headers(), 'content-security-policy': csp },
+    })
+  })
+
+  const response = await page.goto('/')
+  expect(response?.headers()['content-security-policy']).toBe(csp)
+  expect(await page.evaluate(() => 'trustedTypes' in window)).toBe(true)
+  await waitForHydration(page)
+
+  const violations = await page.evaluateHandle(() => {
+    const directives: Array<string> = []
+    document.addEventListener('securitypolicyviolation', (event) => {
+      directives.push(event.effectiveDirective)
+    })
+    return directives
+  })
+
+  await page.getByTestId('nav-dashboard').click()
+  await expect(page).toHaveTitle('Inline CSS dashboard')
+  await expect(page.getByTestId('dashboard-card')).toBeVisible()
+  await expect
+    .poll(() => getStyle(page, 'shell', 'background-color'))
+    .toBe('rgb(240, 249, 255)')
+
+  await page.getByTestId('nav-home').click()
+  await expect(page).toHaveTitle('Inline CSS E2E')
+  await expect(page.getByTestId('home')).toBeVisible()
+
+  expect(await violations.jsonValue()).toEqual([])
+  expect(browserErrors).toEqual([])
+  await violations.dispose()
 })

--- a/packages/react-router/src/Asset.tsx
+++ b/packages/react-router/src/Asset.tsx
@@ -42,6 +42,11 @@ export function Asset(
   },
 ): React.ReactElement | null {
   const { attrs, children, nonce, preventScriptHoist } = asset
+  // React 19 compares this object by reference before assigning innerHTML.
+  const innerHTML = React.useMemo(
+    () => (children === undefined ? undefined : { __html: children }),
+    [children],
+  )
 
   switch (asset.tag) {
     case 'title':
@@ -78,11 +83,7 @@ export function Asset(
       }
 
       return (
-        <style
-          {...attrs}
-          dangerouslySetInnerHTML={{ __html: children as string }}
-          nonce={nonce}
-        />
+        <style {...attrs} dangerouslySetInnerHTML={innerHTML} nonce={nonce} />
       )
     case 'script':
       return (
@@ -119,12 +120,13 @@ function InlineCssStyle({
   const html = isInlineCssPlaceholder
     ? (hydratedInlineCss ?? '')
     : (children ?? '')
+  const innerHTML = React.useMemo(() => ({ __html: html }), [html])
 
   return (
     <style
       {...attrs}
       {...{ [INLINE_CSS_HYDRATION_ATTR]: '' }}
-      dangerouslySetInnerHTML={{ __html: html }}
+      dangerouslySetInnerHTML={innerHTML}
       nonce={nonce}
       suppressHydrationWarning
     />
@@ -142,6 +144,10 @@ function Script({
 }) {
   const router = useRouter()
   const hydrated = useHydrated()
+  const innerHTML = React.useMemo(
+    () => (children === undefined ? undefined : { __html: children }),
+    [children],
+  )
   const dataScript =
     typeof attrs?.type === 'string' &&
     attrs.type !== '' &&
@@ -160,19 +166,17 @@ function Script({
   }
 
   React.useEffect(() => {
-    if (dataScript) return
+    if (dataScript) {
+      return
+    }
 
     if (attrs?.src) {
-      const normSrc = (() => {
-        try {
-          const base = document.baseURI || window.location.href
-          return new URL(attrs.src, base).href
-        } catch {
-          return attrs.src
-        }
-      })()
-      for (const el of document.querySelectorAll('script[src]')) {
-        if ((el as HTMLScriptElement).src === normSrc) {
+      // Anchors resolve relative URLs and preserve invalid URLs without throwing.
+      const link = document.createElement('a')
+      link.href = attrs.src
+      const normSrc = link.href
+      for (const el of document.scripts) {
+        if (el.src === normSrc) {
           return
         }
       }
@@ -191,8 +195,8 @@ function Script({
         typeof attrs?.type === 'string' ? attrs.type : 'text/javascript'
       const nonceAttr =
         typeof attrs?.nonce === 'string' ? attrs.nonce : undefined
-      for (const el of document.querySelectorAll('script:not([src])')) {
-        if (!(el instanceof HTMLScriptElement)) {
+      for (const el of document.scripts) {
+        if (el.hasAttribute('src')) {
           continue
         }
 
@@ -242,7 +246,7 @@ function Script({
       return (
         <script
           {...attrs}
-          dangerouslySetInnerHTML={{ __html: children }}
+          dangerouslySetInnerHTML={innerHTML}
           suppressHydrationWarning
         />
       )
@@ -260,7 +264,7 @@ function Script({
       <script
         {...attrs}
         suppressHydrationWarning
-        dangerouslySetInnerHTML={{ __html: children }}
+        dangerouslySetInnerHTML={innerHTML}
       />
     )
   }
@@ -277,7 +281,7 @@ function Script({
       return (
         <script
           {...attrs}
-          dangerouslySetInnerHTML={{ __html: children }}
+          dangerouslySetInnerHTML={innerHTML}
           suppressHydrationWarning
         />
       )

--- a/packages/react-router/tests/Asset.test.tsx
+++ b/packages/react-router/tests/Asset.test.tsx
@@ -1,0 +1,166 @@
+import { afterEach, expect, test, vi } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import {
+  Asset,
+  RouterContextProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+} from '../src'
+import type { RouterManagedTag } from '@tanstack/router-core'
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllEnvs()
+})
+
+test.each([
+  ['style', { tag: 'style' }],
+  ['inline CSS', { tag: 'style', inlineCss: true }],
+  ['JSON-LD script', { tag: 'script', attrs: { type: 'application/ld+json' } }],
+  ['JSON script', { tag: 'script', attrs: { type: 'application/json' } }],
+] satisfies Array<[string, RouterManagedTag]>)(
+  '%s only replaces content when it changes',
+  (_name, asset: Extract<RouterManagedTag, { tag: 'style' | 'script' }>) => {
+    vi.stubEnv('TSS_INLINE_CSS_ENABLED', 'true')
+    const router = createRouter({
+      routeTree: createRootRoute(),
+      history: createMemoryHistory(),
+    })
+    const initial =
+      asset.tag === 'style' ? '.asset{color:red}' : '{"value":"initial"}'
+    const updated =
+      asset.tag === 'style' ? '.asset{color:blue}' : '{"value":"updated"}'
+    const renderAsset = (children: string, version: string) => (
+      <RouterContextProvider router={router}>
+        <Asset
+          {...asset}
+          attrs={{
+            ...asset.attrs,
+            'data-testid': 'asset',
+            'data-version': version,
+          }}
+        >
+          {children}
+        </Asset>
+      </RouterContextProvider>
+    )
+    const { getByTestId, rerender } = render(renderAsset(initial, 'initial'))
+    const element = getByTestId('asset')
+    const text = element.firstChild
+    expect(element.textContent).toBe(initial)
+    expect(text).not.toBeNull()
+
+    rerender(renderAsset(initial, 'rerender'))
+    expect(getByTestId('asset')).toBe(element)
+    expect(element).toHaveAttribute('data-version', 'rerender')
+    expect(element.firstChild).toBe(text)
+
+    rerender(renderAsset(updated, 'updated'))
+    expect(getByTestId('asset')).toBe(element)
+    expect(element.textContent).toBe(updated)
+    expect(element.firstChild).not.toBe(text)
+
+    rerender(renderAsset('', 'empty'))
+    expect(element.textContent).toBe('')
+  },
+)
+
+test.each([undefined, '/asset.js'])(
+  'injects and cleans up executable scripts with src=%s',
+  (src) => {
+    const router = createRouter({
+      routeTree: createRootRoute(),
+      history: createMemoryHistory(),
+    })
+    const { unmount } = render(
+      <RouterContextProvider router={router}>
+        <Asset
+          tag="script"
+          attrs={{
+            id: 'injected-asset',
+            src,
+            async: true,
+            defer: false,
+            nonce: 'asset-nonce',
+            'data-empty': '',
+            'data-omitted': undefined,
+            suppressHydrationWarning: true,
+          }}
+        >
+          {src ? undefined : 'void 0'}
+        </Asset>
+      </RouterContextProvider>,
+    )
+    const script =
+      document.head.querySelector<HTMLScriptElement>('#injected-asset')
+    expect(script).toHaveAttribute('async', '')
+    expect(script).not.toHaveAttribute('defer')
+    expect(script).toHaveAttribute('data-empty', '')
+    expect(script).not.toHaveAttribute('data-omitted')
+    expect(script).not.toHaveAttribute('suppresshydrationwarning')
+    expect(script?.nonce).toBe('asset-nonce')
+    expect(script?.textContent).toBe(src ? '' : 'void 0')
+    expect(script?.getAttribute('src')).toBe(src ?? null)
+
+    unmount()
+    expect(script).not.toBeInTheDocument()
+  },
+)
+
+test.each(['/asset.js', '//cdn.example.com/asset.js', 'http://['])(
+  'reuses existing executable scripts with src=%s',
+  (src) => {
+    const existing = document.createElement('script')
+    existing.src = src
+    document.head.appendChild(existing)
+    const router = createRouter({
+      routeTree: createRootRoute(),
+      history: createMemoryHistory(),
+    })
+
+    try {
+      const { unmount } = render(
+        <RouterContextProvider router={router}>
+          <Asset tag="script" attrs={{ src }} />
+        </RouterContextProvider>,
+      )
+      expect(Array.from(document.scripts)).toEqual([existing])
+
+      unmount()
+      expect(existing).toBeInTheDocument()
+    } finally {
+      existing.remove()
+    }
+  },
+)
+
+test.each([undefined, '', '/asset.js'])(
+  'only deduplicates inline content against scripts without src (src=%s)',
+  (src) => {
+    const existing = document.createElement('script')
+    existing.textContent = 'void 0'
+    if (src !== undefined) {
+      existing.setAttribute('src', src)
+    }
+    document.head.appendChild(existing)
+    const router = createRouter({
+      routeTree: createRootRoute(),
+      history: createMemoryHistory(),
+    })
+
+    try {
+      const { unmount } = render(
+        <RouterContextProvider router={router}>
+          <Asset tag="script">void 0</Asset>
+        </RouterContextProvider>,
+      )
+      expect(document.scripts).toHaveLength(src === undefined ? 1 : 2)
+
+      unmount()
+      expect(Array.from(document.scripts)).toEqual([existing])
+    } finally {
+      existing.remove()
+    }
+  },
+)


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

React 19 rewrites unchanged head content when `dangerouslySetInnerHTML` gets a new object. This replaces the stylesheet during navigation and can fail under Trusted Types.

- Memoize HTML payloads for styles and data scripts.
- Extend the existing inline-CSS e2e fixture with native DOM/CSSOM assertions and enforced-CSP navigation coverage for Vite and Rsbuild. No setter patches or permissive policies.
- Use native script lookup and URL resolution to offset the added code. Keep server guards directly in conditionals for dead-code elimination.

This prevents redundant writes after hydration, but does not add general Trusted Types support.

All 18 bundle scenarios match or improve the primary gzip metric against `origin/main`: eight shrink by 19-31 bytes. Raw output shrinks by 47 bytes in affected scenarios. Brotli increases by 57-175 bytes in five scenarios.

Fixes #8250

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary rewrites of unchanged inline styles and scripts during React re-renders.
  * Improved client navigation compatibility with Trusted Types policies, avoiding related security errors.
  * Preserved inline stylesheets across route changes, reducing unnecessary CSS processing.
  * Prevented duplicate external and inline scripts from being added during navigation.
  * Ensured asset content and DOM elements remain stable when rendered content has not changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->