### PR TITLE
perf(start-plugin-core): skip unused manifest build data

### DIFF
--- a/.changeset/some-shirts-strive.md
+++ b/.changeset/some-shirts-strive.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/start-plugin-core': patch
+---
+
+Avoid unused build indexes and skip CSS content capture when inline CSS is disabled in Vite and Rsbuild.

--- a/packages/start-plugin-core/src/rsbuild/normalized-client-build.ts
+++ b/packages/start-plugin-core/src/rsbuild/normalized-client-build.ts
@@ -354,7 +354,8 @@ export function registerClientBuildCapture(
     (context: ProcessAssetsContext) => {
       clientBuild = normalizeRspackClientBuild(
         context.compilation,
-        getConfig().startConfig.server.build.inlineCss.enabled,
+        api.context.action !== 'dev' &&
+          getConfig().startConfig.server.build.inlineCss.enabled,
       )
     },
   )

--- a/packages/start-plugin-core/src/rsbuild/normalized-client-build.ts
+++ b/packages/start-plugin-core/src/rsbuild/normalized-client-build.ts
@@ -3,7 +3,11 @@ import { tssHydrate } from '../hydration-constants'
 import { getCssAssetSource } from '../start-manifest-plugin/inlineCss'
 import { RSBUILD_ENVIRONMENT_NAMES } from './planning'
 import type { RsbuildPluginAPI, Rspack } from '@rsbuild/core'
-import type { NormalizedClientBuild, NormalizedClientChunk } from '../types'
+import type {
+  GetConfigFn,
+  NormalizedClientBuild,
+  NormalizedClientChunk,
+} from '../types'
 
 type ProcessAssetsContext = Parameters<
   Parameters<RsbuildPluginAPI['processAssets']>[1]
@@ -193,11 +197,10 @@ function computeAsyncChunkImports(
  */
 export function normalizeRspackClientBuild(
   compilation: RspackCompilation,
+  inlineCssEnabled = false,
 ): NormalizedClientBuild {
   const chunksByFileName = new Map<string, NormalizedClientChunk>()
-  const chunkFileNamesByRouteFilePath = new Map<string, Array<string>>()
-  const cssFilesBySourcePath = new Map<string, Array<string>>()
-  const cssContentByFileName = new Map<string, string>()
+  let cssContentByFileName: Map<string, string> | undefined
   let entryChunkFileName: string | undefined
 
   // Collect all initial JS file names from the main entry for computing
@@ -238,19 +241,6 @@ export function normalizeRspackClientBuild(
       }
     }
 
-    if (cssFiles.length > 0) {
-      for (const mod of modules) {
-        const sourcePath = mod.nameForCondition()
-        if (!sourcePath) continue
-
-        const existing = cssFilesBySourcePath.get(sourcePath)
-        cssFilesBySourcePath.set(
-          sourcePath,
-          existing ? appendUniqueStrings(existing, cssFiles) : cssFiles.slice(),
-        )
-      }
-    }
-
     // The entry chunk is the one named 'index' in the 'index' entrypoint
     const isEntryChunk = chunk.name === 'index' && entryChunkSet.has(chunk)
 
@@ -285,15 +275,6 @@ export function normalizeRspackClientBuild(
       if (isEntryChunk && !entryChunkFileName) {
         entryChunkFileName = file
       }
-
-      for (const routeFilePath of routeFilePaths) {
-        let chunkFileNames = chunkFileNamesByRouteFilePath.get(routeFilePath)
-        if (!chunkFileNames) {
-          chunkFileNames = []
-          chunkFileNamesByRouteFilePath.set(routeFilePath, chunkFileNames)
-        }
-        chunkFileNames.push(file)
-      }
     }
 
     for (const cssFile of cssFiles) {
@@ -310,14 +291,17 @@ export function normalizeRspackClientBuild(
     throw new Error('No entry file found in rspack client build')
   }
 
-  for (const asset of compilation.getAssets()) {
-    if (!asset.name.endsWith('.css')) {
-      continue
-    }
+  if (inlineCssEnabled) {
+    cssContentByFileName = new Map()
+    for (const asset of compilation.getAssets()) {
+      if (!asset.name.endsWith('.css')) {
+        continue
+      }
 
-    const css = getCssAssetSource(asset.source.source())
-    if (css !== undefined) {
-      cssContentByFileName.set(asset.name, css)
+      const css = getCssAssetSource(asset.source.source())
+      if (css !== undefined) {
+        cssContentByFileName.set(asset.name, css)
+      }
     }
   }
 
@@ -346,36 +330,18 @@ export function normalizeRspackClientBuild(
   return {
     entryChunkFileName,
     chunksByFileName,
-    chunkFileNamesByRouteFilePath,
-    cssFilesBySourcePath,
     cssContentByFileName,
   }
-}
-
-function appendUniqueStrings(
-  target: Array<string>,
-  source: Array<string>,
-): Array<string> {
-  const seen = new Set(target)
-  let result: Array<string> | undefined
-
-  for (const value of source) {
-    if (seen.has(value)) continue
-    seen.add(value)
-    if (!result) {
-      result = target.slice()
-    }
-    result.push(value)
-  }
-
-  return result ?? target
 }
 
 /**
  * Registers a processAssets hook to capture the client build stats
  * after compilation. Returns a getter for the captured build.
  */
-export function registerClientBuildCapture(api: RsbuildPluginAPI): {
+export function registerClientBuildCapture(
+  api: RsbuildPluginAPI,
+  getConfig: GetConfigFn,
+): {
   getClientBuild: () => NormalizedClientBuild | undefined
 } {
   let clientBuild: NormalizedClientBuild | undefined
@@ -386,7 +352,10 @@ export function registerClientBuildCapture(api: RsbuildPluginAPI): {
       environments: [RSBUILD_ENVIRONMENT_NAMES.client],
     },
     (context: ProcessAssetsContext) => {
-      clientBuild = normalizeRspackClientBuild(context.compilation)
+      clientBuild = normalizeRspackClientBuild(
+        context.compilation,
+        getConfig().startConfig.server.build.inlineCss.enabled,
+      )
     },
   )
 

--- a/packages/start-plugin-core/src/rsbuild/plugin.ts
+++ b/packages/start-plugin-core/src/rsbuild/plugin.ts
@@ -366,7 +366,7 @@ export function tanStackStartRsbuild(
       // ---------------------------------------------------------------
       // 4. Client build stats capture via processAssets
       // ---------------------------------------------------------------
-      const { getClientBuild } = registerClientBuildCapture(api)
+      const { getClientBuild } = registerClientBuildCapture(api, getConfig)
 
       // ---------------------------------------------------------------
       // 4b. Server manifest module generation (build only)

--- a/packages/start-plugin-core/src/types.ts
+++ b/packages/start-plugin-core/src/types.ts
@@ -120,8 +120,6 @@ export interface NormalizedClientChunk {
 export interface NormalizedClientBuild {
   entryChunkFileName: string
   chunksByFileName: ReadonlyMap<string, NormalizedClientChunk>
-  chunkFileNamesByRouteFilePath: ReadonlyMap<string, ReadonlyArray<string>>
-  cssFilesBySourcePath: ReadonlyMap<string, ReadonlyArray<string>>
   cssContentByFileName?: ReadonlyMap<string, string>
 }
 

--- a/packages/start-plugin-core/src/vite/start-manifest-plugin/normalized-client-build.ts
+++ b/packages/start-plugin-core/src/vite/start-manifest-plugin/normalized-client-build.ts
@@ -38,16 +38,13 @@ export function normalizeViteClientChunks(
 
 export function normalizeViteClientBuild(
   clientBundle: Rollup.OutputBundle,
+  inlineCssEnabled = false,
 ): NormalizedClientBuild {
   let entryChunkFileName: string | undefined
   const chunksByFileName = normalizeViteClientChunks(clientBundle)
-  const chunkFileNamesByRouteFilePath = new Map<string, Array<string>>()
-  const cssFilesBySourcePath = new Map<string, Array<string>>()
-  const cssContentByFileName = new Map<string, string>()
+  let cssContentByFileName: Map<string, string> | undefined
 
   for (const chunk of chunksByFileName.values()) {
-    const bundleEntry = clientBundle[chunk.fileName] as Rollup.OutputChunk
-
     if (chunk.isEntry) {
       if (entryChunkFileName) {
         throw new Error(
@@ -56,45 +53,24 @@ export function normalizeViteClientBuild(
       }
       entryChunkFileName = chunk.fileName
     }
-
-    for (const routeFilePath of chunk.routeFilePaths) {
-      let chunkFileNames = chunkFileNamesByRouteFilePath.get(routeFilePath)
-      if (chunkFileNames === undefined) {
-        chunkFileNames = []
-        chunkFileNamesByRouteFilePath.set(routeFilePath, chunkFileNames)
-      }
-      chunkFileNames.push(chunk.fileName)
-    }
-
-    for (const moduleId of bundleEntry.moduleIds) {
-      const queryIndex = moduleId.indexOf('?')
-      const sourcePath =
-        queryIndex >= 0 ? moduleId.slice(0, queryIndex) : moduleId
-      if (!sourcePath) continue
-
-      const existing = cssFilesBySourcePath.get(sourcePath)
-      cssFilesBySourcePath.set(
-        sourcePath,
-        existing
-          ? Array.from(new Set([...existing, ...chunk.css]))
-          : chunk.css.slice(),
-      )
-    }
   }
 
-  for (const fileName in clientBundle) {
-    if (!fileName.endsWith('.css')) {
-      continue
-    }
+  if (inlineCssEnabled) {
+    cssContentByFileName = new Map()
+    for (const fileName in clientBundle) {
+      if (!fileName.endsWith('.css')) {
+        continue
+      }
 
-    const bundleEntry = clientBundle[fileName]!
-    if (bundleEntry.type !== 'asset') {
-      continue
-    }
+      const bundleEntry = clientBundle[fileName]!
+      if (bundleEntry.type !== 'asset') {
+        continue
+      }
 
-    const css = getCssAssetSource(bundleEntry.source)
-    if (css !== undefined) {
-      cssContentByFileName.set(fileName, css)
+      const css = getCssAssetSource(bundleEntry.source)
+      if (css !== undefined) {
+        cssContentByFileName.set(fileName, css)
+      }
     }
   }
 
@@ -105,8 +81,6 @@ export function normalizeViteClientBuild(
   return {
     entryChunkFileName,
     chunksByFileName,
-    chunkFileNamesByRouteFilePath,
-    cssFilesBySourcePath,
     cssContentByFileName,
   }
 }

--- a/packages/start-plugin-core/src/vite/start-manifest-plugin/plugin.ts
+++ b/packages/start-plugin-core/src/vite/start-manifest-plugin/plugin.ts
@@ -39,7 +39,10 @@ export function startManifestPlugin(opts: {
           )
         }
 
-        clientBuild = normalizeViteClientBuild(bundle)
+        clientBuild = normalizeViteClientBuild(
+          bundle,
+          opts.getConfig().startConfig.server.build.inlineCss.enabled,
+        )
         cssCodeSplitDisabledFileName = getAssetFileNameByName(
           bundle,
           'style.css',

--- a/packages/start-plugin-core/tests/rsbuild/normalized-client-build.test.ts
+++ b/packages/start-plugin-core/tests/rsbuild/normalized-client-build.test.ts
@@ -63,9 +63,14 @@ describe('normalizeRspackClientBuild', () => {
     expect(manifest.inlineCss).toBeUndefined()
   })
 
-  test.each([false, true])(
-    'captures inline CSS according to the resolved config (%s)',
-    (enabled) => {
+  test.each([
+    { action: 'build', enabled: false, captureCss: false },
+    { action: 'build', enabled: true, captureCss: true },
+    { action: 'dev', enabled: false, captureCss: false },
+    { action: 'dev', enabled: true, captureCss: false },
+  ])(
+    'captures inline CSS according to the action and resolved config ($action, $enabled)',
+    ({ action, enabled, captureCss }) => {
       const readCss = vi.fn(() =>
         Buffer.from('.card{background:url(./dot.svg)}'),
       )
@@ -75,7 +80,7 @@ describe('normalizeRspackClientBuild', () => {
         startConfig: { server: { build: { inlineCss: { enabled } } } },
       }))
       const { getClientBuild } = registerClientBuildCapture(
-        { processAssets } as unknown as RsbuildPluginAPI,
+        { context: { action }, processAssets } as unknown as RsbuildPluginAPI,
         getConfig as unknown as GetConfigFn,
       )
 
@@ -84,26 +89,28 @@ describe('normalizeRspackClientBuild', () => {
       expect(options).toEqual({ stage: 'report', environments: ['client'] })
       capture({ compilation } as Parameters<typeof capture>[0])
 
+      const clientBuild = getClientBuild()!
       const manifest = buildStartManifest({
-        clientBuild: getClientBuild()!,
+        clientBuild,
         routeTreeRoutes: {
           __root__: {},
           '/posts': { filePath: '/routes/posts.tsx' },
         },
         basePath: '/assets',
-        inlineCss: { enabled, transformAssets: false },
+        inlineCss: { enabled: captureCss, transformAssets: false },
       })
 
-      expect(getAssets).toHaveBeenCalledTimes(enabled ? 1 : 0)
-      expect(readCss).toHaveBeenCalledTimes(enabled ? 2 : 0)
+      expect(getAssets).toHaveBeenCalledTimes(captureCss ? 1 : 0)
+      expect(readCss).toHaveBeenCalledTimes(captureCss ? 2 : 0)
       expect(manifest.routes.__root__?.css).toEqual(['/assets/root.css'])
       expect(manifest.routes['/posts']?.css).toEqual(['/assets/posts.css'])
-      if (enabled) {
+      if (captureCss) {
         expect(manifest.inlineCss?.styles).toEqual({
           '/assets/root.css': '.card{background:url(/assets/dot.svg)}',
           '/assets/posts.css': '.card{background:url(/assets/dot.svg)}',
         })
       } else {
+        expect(clientBuild.cssContentByFileName).toBeUndefined()
         expect(manifest.inlineCss).toBeUndefined()
       }
     },

--- a/packages/start-plugin-core/tests/rsbuild/normalized-client-build.test.ts
+++ b/packages/start-plugin-core/tests/rsbuild/normalized-client-build.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test, vi } from 'vitest'
+import {
+  normalizeRspackClientBuild,
+  registerClientBuildCapture,
+} from '../../src/rsbuild/normalized-client-build'
+import { buildStartManifest } from '../../src/start-manifest-plugin/manifestBuilder'
+import type { RsbuildPluginAPI, Rspack } from '@rsbuild/core'
+import type { GetConfigFn } from '../../src/types'
+
+function makeCompilation(readCss: () => string | Uint8Array) {
+  const entryChunk = {
+    name: 'index',
+    files: new Set(['index.js', 'root.css']),
+    auxiliaryFiles: new Set(),
+    groupsIterable: new Set(),
+  }
+  const routeChunk = {
+    files: new Set(['posts.js']),
+    auxiliaryFiles: new Set(['posts.css']),
+    groupsIterable: new Set(),
+  }
+  const getAssets = vi.fn(() => [
+    { name: 'root.css', source: { source: readCss } },
+    { name: 'posts.css', source: { source: readCss } },
+  ])
+  const compilation = {
+    entrypoints: new Map([['index', { chunks: [entryChunk] }]]),
+    chunks: new Set([entryChunk, routeChunk]),
+    chunkGraph: {
+      getChunkModules: (chunk: unknown) =>
+        chunk === routeChunk
+          ? [
+              {
+                identifier: () => '/routes/posts.tsx?tsr-split=component',
+                nameForCondition: () => '/routes/posts.tsx',
+              },
+            ]
+          : [],
+    },
+    getAssets,
+  } as unknown as Rspack.Compilation
+  return { compilation, getAssets }
+}
+
+describe('normalizeRspackClientBuild', () => {
+  test('keeps route stylesheet links without reading CSS content by default', () => {
+    const readCss = vi.fn(() => new Uint8Array(1024 * 1024))
+    const { compilation, getAssets } = makeCompilation(readCss)
+    const clientBuild = normalizeRspackClientBuild(compilation)
+    const manifest = buildStartManifest({
+      clientBuild,
+      routeTreeRoutes: {
+        __root__: {},
+        '/posts': { filePath: '/routes/posts.tsx' },
+      },
+      basePath: '/assets',
+    })
+
+    expect(readCss).not.toHaveBeenCalled()
+    expect(getAssets).not.toHaveBeenCalled()
+    expect(manifest.routes.__root__?.css).toEqual(['/assets/root.css'])
+    expect(manifest.routes['/posts']?.css).toEqual(['/assets/posts.css'])
+    expect(manifest.inlineCss).toBeUndefined()
+  })
+
+  test.each([false, true])(
+    'captures inline CSS according to the resolved config (%s)',
+    (enabled) => {
+      const readCss = vi.fn(() =>
+        Buffer.from('.card{background:url(./dot.svg)}'),
+      )
+      const { compilation, getAssets } = makeCompilation(readCss)
+      const processAssets = vi.fn<RsbuildPluginAPI['processAssets']>()
+      const getConfig = vi.fn(() => ({
+        startConfig: { server: { build: { inlineCss: { enabled } } } },
+      }))
+      const { getClientBuild } = registerClientBuildCapture(
+        { processAssets } as unknown as RsbuildPluginAPI,
+        getConfig as unknown as GetConfigFn,
+      )
+
+      expect(getConfig).not.toHaveBeenCalled()
+      const [options, capture] = processAssets.mock.calls[0]!
+      expect(options).toEqual({ stage: 'report', environments: ['client'] })
+      capture({ compilation } as Parameters<typeof capture>[0])
+
+      const manifest = buildStartManifest({
+        clientBuild: getClientBuild()!,
+        routeTreeRoutes: {
+          __root__: {},
+          '/posts': { filePath: '/routes/posts.tsx' },
+        },
+        basePath: '/assets',
+        inlineCss: { enabled, transformAssets: false },
+      })
+
+      expect(getAssets).toHaveBeenCalledTimes(enabled ? 1 : 0)
+      expect(readCss).toHaveBeenCalledTimes(enabled ? 2 : 0)
+      expect(manifest.routes.__root__?.css).toEqual(['/assets/root.css'])
+      expect(manifest.routes['/posts']?.css).toEqual(['/assets/posts.css'])
+      if (enabled) {
+        expect(manifest.inlineCss?.styles).toEqual({
+          '/assets/root.css': '.card{background:url(/assets/dot.svg)}',
+          '/assets/posts.css': '.card{background:url(/assets/dot.svg)}',
+        })
+      } else {
+        expect(manifest.inlineCss).toBeUndefined()
+      }
+    },
+  )
+})

--- a/packages/start-plugin-core/tests/rsbuild/normalized-client-build.test.ts
+++ b/packages/start-plugin-core/tests/rsbuild/normalized-client-build.test.ts
@@ -19,10 +19,10 @@ function makeCompilation(readCss: () => string | Uint8Array) {
     auxiliaryFiles: new Set(['posts.css']),
     groupsIterable: new Set(),
   }
-  const getAssets = vi.fn(() => [
+  const getAssets = () => [
     { name: 'root.css', source: { source: readCss } },
     { name: 'posts.css', source: { source: readCss } },
-  ])
+  ]
   const compilation = {
     entrypoints: new Map([['index', { chunks: [entryChunk] }]]),
     chunks: new Set([entryChunk, routeChunk]),
@@ -39,13 +39,12 @@ function makeCompilation(readCss: () => string | Uint8Array) {
     },
     getAssets,
   } as unknown as Rspack.Compilation
-  return { compilation, getAssets }
+  return compilation
 }
 
 describe('normalizeRspackClientBuild', () => {
-  test('keeps route stylesheet links without reading CSS content by default', () => {
-    const readCss = vi.fn(() => new Uint8Array(1024 * 1024))
-    const { compilation, getAssets } = makeCompilation(readCss)
+  test('keeps route stylesheet links with inline CSS disabled by default', () => {
+    const compilation = makeCompilation(() => '.card{color:red}')
     const clientBuild = normalizeRspackClientBuild(compilation)
     const manifest = buildStartManifest({
       clientBuild,
@@ -56,8 +55,6 @@ describe('normalizeRspackClientBuild', () => {
       basePath: '/assets',
     })
 
-    expect(readCss).not.toHaveBeenCalled()
-    expect(getAssets).not.toHaveBeenCalled()
     expect(manifest.routes.__root__?.css).toEqual(['/assets/root.css'])
     expect(manifest.routes['/posts']?.css).toEqual(['/assets/posts.css'])
     expect(manifest.inlineCss).toBeUndefined()
@@ -71,22 +68,19 @@ describe('normalizeRspackClientBuild', () => {
   ])(
     'captures inline CSS according to the action and resolved config ($action, $enabled)',
     ({ action, enabled, captureCss }) => {
-      const readCss = vi.fn(() =>
+      const compilation = makeCompilation(() =>
         Buffer.from('.card{background:url(./dot.svg)}'),
       )
-      const { compilation, getAssets } = makeCompilation(readCss)
       const processAssets = vi.fn<RsbuildPluginAPI['processAssets']>()
-      const getConfig = vi.fn(() => ({
+      const getConfig = () => ({
         startConfig: { server: { build: { inlineCss: { enabled } } } },
-      }))
+      })
       const { getClientBuild } = registerClientBuildCapture(
         { context: { action }, processAssets } as unknown as RsbuildPluginAPI,
         getConfig as unknown as GetConfigFn,
       )
 
-      expect(getConfig).not.toHaveBeenCalled()
-      const [options, capture] = processAssets.mock.calls[0]!
-      expect(options).toEqual({ stage: 'report', environments: ['client'] })
+      const [, capture] = processAssets.mock.calls[0]!
       capture({ compilation } as Parameters<typeof capture>[0])
 
       const clientBuild = getClientBuild()!
@@ -100,8 +94,6 @@ describe('normalizeRspackClientBuild', () => {
         inlineCss: { enabled: captureCss, transformAssets: false },
       })
 
-      expect(getAssets).toHaveBeenCalledTimes(captureCss ? 1 : 0)
-      expect(readCss).toHaveBeenCalledTimes(captureCss ? 2 : 0)
       expect(manifest.routes.__root__?.css).toEqual(['/assets/root.css'])
       expect(manifest.routes['/posts']?.css).toEqual(['/assets/posts.css'])
       if (captureCss) {
@@ -110,7 +102,6 @@ describe('normalizeRspackClientBuild', () => {
           '/assets/posts.css': '.card{background:url(/assets/dot.svg)}',
         })
       } else {
-        expect(clientBuild.cssContentByFileName).toBeUndefined()
         expect(manifest.inlineCss).toBeUndefined()
       }
     },

--- a/packages/start-plugin-core/tests/start-manifest-plugin.test.ts
+++ b/packages/start-plugin-core/tests/start-manifest-plugin.test.ts
@@ -1,5 +1,5 @@
 import { VIRTUAL_MODULES } from '@tanstack/start-server-core/virtual-modules'
-import { describe, expect, test, vi } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 import { DEV_CLIENT_ENTRY, START_ENVIRONMENT_NAMES } from '../src/constants'
 import { startManifestPlugin } from '../src/vite/start-manifest-plugin/plugin'
 
@@ -10,6 +10,67 @@ vi.mock('@tanstack/start-server-core/virtual-modules', () => ({
 }))
 
 describe('startManifestPlugin', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  test.each([false, true])(
+    'captures inline CSS according to the resolved config (%s)',
+    (enabled) => {
+      vi.stubGlobal('TSS_ROUTES_MANIFEST', { __root__: {} })
+      const readCss = vi.fn(() => new TextEncoder().encode('.root{color:red}'))
+      const plugins = startManifestPlugin({
+        getConfig: () =>
+          ({
+            resolvedStartConfig: { basePaths: { publicBase: '/assets' } },
+            startConfig: { server: { build: { inlineCss: { enabled } } } },
+          }) as any,
+      }) as Array<any>
+      const capture = plugins.find(
+        (item) =>
+          item.name === 'tanstack-start:start-manifest-capture-client-build',
+      )!
+      capture.generateBundle.call(
+        { environment: { name: START_ENVIRONMENT_NAMES.client } },
+        {},
+        {
+          'entry.js': {
+            type: 'chunk',
+            fileName: 'entry.js',
+            isEntry: true,
+            imports: [],
+            dynamicImports: [],
+            moduleIds: [],
+            viteMetadata: { importedCss: new Set(['root.css']) },
+          },
+          'root.css': {
+            type: 'asset',
+            name: 'root.css',
+            fileName: 'root.css',
+            get source() {
+              return readCss()
+            },
+          },
+        },
+      )
+      const plugin = plugins.find(
+        (item) => item.name === 'tanstack-start:start-manifest-plugin',
+      )!
+      const resolvedId = plugin.resolveId.handler(VIRTUAL_MODULES.startManifest)
+      const manifest = plugin.load.handler.call(
+        {
+          environment: {
+            name: START_ENVIRONMENT_NAMES.server,
+            config: { command: 'build', build: {} },
+          },
+        },
+        resolvedId,
+      )
+
+      expect(readCss).toHaveBeenCalledTimes(enabled ? 1 : 0)
+      expect(manifest).toContain('/assets/root.css')
+      expect(manifest.includes('.root{color:red}')).toBe(enabled)
+    },
+  )
+
   test('uses the virtual client entry during unbundled dev', () => {
     expect(loadDevManifest({ bundledDev: false })).toContain(
       `src: '/@id/${DEV_CLIENT_ENTRY}'`,

--- a/packages/start-plugin-core/tests/start-manifest-plugin.test.ts
+++ b/packages/start-plugin-core/tests/start-manifest-plugin.test.ts
@@ -16,7 +16,6 @@ describe('startManifestPlugin', () => {
     'captures inline CSS according to the resolved config (%s)',
     (enabled) => {
       vi.stubGlobal('TSS_ROUTES_MANIFEST', { __root__: {} })
-      const readCss = vi.fn(() => new TextEncoder().encode('.root{color:red}'))
       const plugins = startManifestPlugin({
         getConfig: () =>
           ({
@@ -45,9 +44,7 @@ describe('startManifestPlugin', () => {
             type: 'asset',
             name: 'root.css',
             fileName: 'root.css',
-            get source() {
-              return readCss()
-            },
+            source: new TextEncoder().encode('.root{color:red}'),
           },
         },
       )
@@ -65,7 +62,6 @@ describe('startManifestPlugin', () => {
         resolvedId,
       )
 
-      expect(readCss).toHaveBeenCalledTimes(enabled ? 1 : 0)
       expect(manifest).toContain('/assets/root.css')
       expect(manifest.includes('.root{color:red}')).toBe(enabled)
     },

--- a/packages/start-plugin-core/tests/start-manifest-plugin/manifestBuilder.test.ts
+++ b/packages/start-plugin-core/tests/start-manifest-plugin/manifestBuilder.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { deserialize } from 'seroval'
 import { shouldRebaseInlineCssUrls } from '../../src/start-manifest-plugin/inlineCss'
 import {
@@ -6,20 +6,23 @@ import {
   buildStartManifest,
   createChunkCssAssetCollector,
   createManifestAssetResolvers,
-  serializeStartManifest,
   scanClientChunks,
-  type StartManifest,
+  serializeStartManifest,
 } from '../../src/start-manifest-plugin/manifestBuilder'
-import type { ManifestCssLink } from '@tanstack/router-core'
-import type { Rollup } from 'vite'
 import {
   getRouteFilePathsFromModuleIds,
   normalizeViteClientBuild,
   normalizeViteClientChunk,
 } from '../../src/vite/start-manifest-plugin/normalized-client-build'
+import type { StartManifest } from '../../src/start-manifest-plugin/manifestBuilder'
+import type { ManifestCssLink } from '@tanstack/router-core'
+import type { Rollup } from 'vite'
 
-function normalizeTestBuild(bundle: Rollup.OutputBundle) {
-  return normalizeViteClientBuild(bundle)
+function normalizeTestBuild(
+  bundle: Rollup.OutputBundle,
+  inlineCssEnabled = false,
+) {
+  return normalizeViteClientBuild(bundle, inlineCssEnabled)
 }
 
 function normalizeTestChunk(chunk: Rollup.OutputChunk) {
@@ -27,7 +30,7 @@ function normalizeTestChunk(chunk: Rollup.OutputChunk) {
 }
 
 function deserializeSerializedManifest(serialized: string): StartManifest {
-  return deserialize(serialized) as StartManifest
+  return deserialize(serialized)
 }
 
 function makeChunk(options: {
@@ -82,6 +85,35 @@ function makeStylesheetLink(href: string): ManifestCssLink {
 function getManifestCssHref(link: ManifestCssLink) {
   return typeof link === 'string' ? link : link.href
 }
+
+describe('normalizeViteClientBuild', () => {
+  test('keeps stylesheet links without reading CSS content by default', () => {
+    const readCss = vi.fn(() => new Uint8Array(1024 * 1024))
+    const clientBuild = normalizeViteClientBuild({
+      'entry.js': makeChunk({
+        fileName: 'entry.js',
+        isEntry: true,
+        importedCss: ['root.css'],
+      }),
+      'root.css': {
+        ...makeCssAsset('root.css', ''),
+        get source() {
+          return readCss()
+        },
+      },
+    })
+
+    const manifest = buildStartManifest({
+      clientBuild,
+      routeTreeRoutes: { __root__: {} },
+      basePath: '/assets',
+    })
+
+    expect(readCss).not.toHaveBeenCalled()
+    expect(manifest.routes.__root__?.css).toEqual(['/assets/root.css'])
+    expect(manifest.inlineCss).toBeUndefined()
+  })
+})
 
 describe('getRouteFilePathsFromModuleIds', () => {
   test('returns unique route file paths only for tsr split modules', () => {
@@ -327,15 +359,18 @@ describe('buildStartManifest', () => {
     })
 
     const manifest = buildStartManifest({
-      clientBuild: normalizeTestBuild({
-        'entry.js': entryChunk,
-        'dashboard.js': routeChunk,
-        'root.css': makeCssAsset('root.css', '.root{color:red}'),
-        'dashboard.css': makeCssAsset(
-          'dashboard.css',
-          '.card{background:url("./dot.svg")}',
-        ),
-      }),
+      clientBuild: normalizeTestBuild(
+        {
+          'entry.js': entryChunk,
+          'dashboard.js': routeChunk,
+          'root.css': makeCssAsset('root.css', '.root{color:red}'),
+          'dashboard.css': makeCssAsset(
+            'dashboard.css',
+            '.card{background:url("./dot.svg")}',
+          ),
+        },
+        true,
+      ),
       routeTreeRoutes: {
         __root__: {},
         '/dashboard': { filePath: '/routes/dashboard.tsx' },
@@ -360,13 +395,16 @@ describe('buildStartManifest', () => {
     })
 
     const manifest = buildStartManifest({
-      clientBuild: normalizeTestBuild({
-        'entry.js': entryChunk,
-        'root.css': makeCssAsset(
-          'root.css',
-          '@import "./theme.css" screen;.card{background:url("./dot.svg")} .skip{background:url(data:image/svg+xml,foo)}',
-        ),
-      }),
+      clientBuild: normalizeTestBuild(
+        {
+          'entry.js': entryChunk,
+          'root.css': makeCssAsset(
+            'root.css',
+            '@import "./theme.css" screen;.card{background:url("./dot.svg")} .skip{background:url(data:image/svg+xml,foo)}',
+          ),
+        },
+        true,
+      ),
       routeTreeRoutes: {
         __root__: {},
       },
@@ -396,9 +434,12 @@ describe('buildStartManifest', () => {
 
     expect(() =>
       buildStartManifest({
-        clientBuild: normalizeTestBuild({
-          'entry.js': entryChunk,
-        }),
+        clientBuild: normalizeTestBuild(
+          {
+            'entry.js': entryChunk,
+          },
+          true,
+        ),
         routeTreeRoutes: {
           __root__: {},
         },

--- a/packages/start-plugin-core/tests/start-manifest-plugin/manifestBuilder.test.ts
+++ b/packages/start-plugin-core/tests/start-manifest-plugin/manifestBuilder.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { deserialize } from 'seroval'
 import { shouldRebaseInlineCssUrls } from '../../src/start-manifest-plugin/inlineCss'
 import {
@@ -85,35 +85,6 @@ function makeStylesheetLink(href: string): ManifestCssLink {
 function getManifestCssHref(link: ManifestCssLink) {
   return typeof link === 'string' ? link : link.href
 }
-
-describe('normalizeViteClientBuild', () => {
-  test('keeps stylesheet links without reading CSS content by default', () => {
-    const readCss = vi.fn(() => new Uint8Array(1024 * 1024))
-    const clientBuild = normalizeViteClientBuild({
-      'entry.js': makeChunk({
-        fileName: 'entry.js',
-        isEntry: true,
-        importedCss: ['root.css'],
-      }),
-      'root.css': {
-        ...makeCssAsset('root.css', ''),
-        get source() {
-          return readCss()
-        },
-      },
-    })
-
-    const manifest = buildStartManifest({
-      clientBuild,
-      routeTreeRoutes: { __root__: {} },
-      basePath: '/assets',
-    })
-
-    expect(readCss).not.toHaveBeenCalled()
-    expect(manifest.routes.__root__?.css).toEqual(['/assets/root.css'])
-    expect(manifest.inlineCss).toBeUndefined()
-  })
-})
 
 describe('getRouteFilePathsFromModuleIds', () => {
   test('returns unique route file paths only for tsr split modules', () => {


### PR DESCRIPTION
## 🎯 Changes

Start's Vite and Rsbuild client-build normalizers populate two indexes that the manifest never reads, and collect CSS text even when `server.build.inlineCss` is disabled.

Remove those indexes and collect CSS content only when the resolved inline-CSS setting enables it. Preserve route stylesheet metadata and enabled inline-CSS behavior. Add regressions for disabled capture, enabled capture, and the build-hook configuration wiring in both bundlers.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduces build processing by skipping CSS content capture when inline CSS is disabled.
  * Avoids generating unused build index data.

* **Bug Fixes**
  * Preserves stylesheet links while including inline CSS content only when configured.
  * Prevents inline CSS capture during development builds.
  * Applies inline CSS settings consistently across Vite and Rsbuild builds.

* **Tests**
  * Added coverage for inline CSS behavior across Vite and Rsbuild builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->