### PR TITLE
fix(history): handle blockers consistently across history traversal

### DIFF
--- a/.changeset/swift-tigers-kick.md
+++ b/.changeset/swift-tigers-kick.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/history': patch
+---
+
+Preserve beforeunload warnings during back and forward navigation unless `ignoreBlocker` is requested. Clear the bypass after same-document traversal so later document navigation still warns about unsaved changes.

--- a/.changeset/swift-tigers-kick.md
+++ b/.changeset/swift-tigers-kick.md
@@ -2,4 +2,4 @@
 '@tanstack/history': patch
 ---
 
-Preserve beforeunload warnings during back and forward navigation unless `ignoreBlocker` is requested. Clear the bypass after same-document traversal so later document navigation still warns about unsaved changes.
+Respect `ignoreBlocker` during `go()` navigation, including document unload warnings. Preserve beforeunload warnings during back and forward navigation unless `ignoreBlocker` is requested, and clear the bypass after same-document traversal so later document navigation still warns about unsaved changes.

--- a/.changeset/swift-tigers-kick.md
+++ b/.changeset/swift-tigers-kick.md
@@ -3,3 +3,5 @@
 ---
 
 Respect `ignoreBlocker` during `go()` navigation, including document unload warnings. Preserve beforeunload warnings during back and forward navigation unless `ignoreBlocker` is requested, and clear the bypass after same-document traversal so later document navigation still warns about unsaved changes.
+
+Restore the original browser history entry when forward or multi-entry navigation is blocked.

--- a/e2e/react-router/basic-file-based/src/routeTree.gen.ts
+++ b/e2e/react-router/basic-file-based/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as ComponentTypesTestRouteImport } from './routes/component-types
 import { Route as EditingARouteImport } from './routes/editing-a'
 import { Route as EditingBRouteImport } from './routes/editing-b'
 import { Route as FullpathTestRouteRouteImport } from './routes/fullpath-test/route'
+import { Route as HistoryBlockingRouteImport } from './routes/history-blocking'
 import { Route as HoverPreloadHashRouteImport } from './routes/hover-preload-hash'
 import { Route as LazyErrorRouteImport } from './routes/lazy-error'
 import { Route as MasksRouteImport } from './routes/masks'
@@ -162,6 +163,11 @@ const EditingBRoute = EditingBRouteImport.update({
 const FullpathTestRouteRoute = FullpathTestRouteRouteImport.update({
   id: '/fullpath-test',
   path: '/fullpath-test',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const HistoryBlockingRoute = HistoryBlockingRouteImport.update({
+  id: '/history-blocking',
+  path: '/history-blocking',
   getParentRoute: () => rootRouteImport,
 } as any)
 const HoverPreloadHashRoute = HoverPreloadHashRouteImport.update({
@@ -789,6 +795,7 @@ export interface FileRoutesByFullPath {
   '/component-types-test': typeof ComponentTypesTestRoute
   '/editing-a': typeof EditingARoute
   '/editing-b': typeof EditingBRoute
+  '/history-blocking': typeof HistoryBlockingRoute
   '/hover-preload-hash': typeof HoverPreloadHashRoute
   '/lazy-error': typeof LazyErrorRoute
   '/masks': typeof MasksRouteWithChildren
@@ -905,6 +912,7 @@ export interface FileRoutesByTo {
   '/component-types-test': typeof ComponentTypesTestRoute
   '/editing-a': typeof EditingARoute
   '/editing-b': typeof EditingBRoute
+  '/history-blocking': typeof HistoryBlockingRoute
   '/hover-preload-hash': typeof HoverPreloadHashRoute
   '/lazy-error': typeof LazyErrorRoute
   '/masks': typeof MasksRouteWithChildren
@@ -1013,6 +1021,7 @@ export interface FileRoutesById {
   '/component-types-test': typeof ComponentTypesTestRoute
   '/editing-a': typeof EditingARoute
   '/editing-b': typeof EditingBRoute
+  '/history-blocking': typeof HistoryBlockingRoute
   '/hover-preload-hash': typeof HoverPreloadHashRoute
   '/lazy-error': typeof LazyErrorRoute
   '/masks': typeof MasksRouteWithChildren
@@ -1136,6 +1145,7 @@ export interface FileRouteTypes {
     | '/component-types-test'
     | '/editing-a'
     | '/editing-b'
+    | '/history-blocking'
     | '/hover-preload-hash'
     | '/lazy-error'
     | '/masks'
@@ -1252,6 +1262,7 @@ export interface FileRouteTypes {
     | '/component-types-test'
     | '/editing-a'
     | '/editing-b'
+    | '/history-blocking'
     | '/hover-preload-hash'
     | '/lazy-error'
     | '/masks'
@@ -1359,6 +1370,7 @@ export interface FileRouteTypes {
     | '/component-types-test'
     | '/editing-a'
     | '/editing-b'
+    | '/history-blocking'
     | '/hover-preload-hash'
     | '/lazy-error'
     | '/masks'
@@ -1482,6 +1494,7 @@ export interface RootRouteChildren {
   ComponentTypesTestRoute: typeof ComponentTypesTestRoute
   EditingARoute: typeof EditingARoute
   EditingBRoute: typeof EditingBRoute
+  HistoryBlockingRoute: typeof HistoryBlockingRoute
   HoverPreloadHashRoute: typeof HoverPreloadHashRoute
   LazyErrorRoute: typeof LazyErrorRoute
   MasksRoute: typeof MasksRouteWithChildren
@@ -1568,6 +1581,13 @@ declare module '@tanstack/react-router' {
       path: '/fullpath-test'
       fullPath: '/fullpath-test'
       preLoaderRoute: typeof FullpathTestRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/history-blocking': {
+      id: '/history-blocking'
+      path: '/history-blocking'
+      fullPath: '/history-blocking'
+      preLoaderRoute: typeof HistoryBlockingRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/hover-preload-hash': {
@@ -2880,6 +2900,7 @@ const rootRouteChildren: RootRouteChildren = {
   ComponentTypesTestRoute: ComponentTypesTestRoute,
   EditingARoute: EditingARoute,
   EditingBRoute: EditingBRoute,
+  HistoryBlockingRoute: HistoryBlockingRoute,
   HoverPreloadHashRoute: HoverPreloadHashRoute,
   LazyErrorRoute: LazyErrorRoute,
   MasksRoute: MasksRouteWithChildren,

--- a/e2e/react-router/basic-file-based/src/routes/history-blocking.tsx
+++ b/e2e/react-router/basic-file-based/src/routes/history-blocking.tsx
@@ -18,7 +18,7 @@ function HistoryBlocking() {
   const { step } = Route.useSearch()
   const [draft, setDraft] = React.useState('')
   const [ignoreBlocker, setIgnoreBlocker] = React.useState(false)
-  const { status } = useBlocker({
+  const { status, reset } = useBlocker({
     shouldBlockFn: () => draft.length > 0,
     enableBeforeUnload: draft.length > 0,
     withResolver: true,
@@ -45,6 +45,7 @@ function HistoryBlocking() {
       </label>
       <p>{draft ? 'Unsaved changes' : 'No changes'}</p>
       <p>Blocker status: {status}</p>
+      {status === 'blocked' && <button onClick={reset}>Stay here</button>}
       <Link to="/history-blocking" search={{ step: step + 1 }}>
         Add history entry
       </Link>

--- a/e2e/react-router/basic-file-based/src/routes/history-blocking.tsx
+++ b/e2e/react-router/basic-file-based/src/routes/history-blocking.tsx
@@ -45,7 +45,7 @@ function HistoryBlocking() {
       </label>
       <p>{draft ? 'Unsaved changes' : 'No changes'}</p>
       <p>Blocker status: {status}</p>
-      <Link to="/history-blocking" search={{ step: 1 }}>
+      <Link to="/history-blocking" search={{ step: step + 1 }}>
         Add history entry
       </Link>
       <button
@@ -66,6 +66,19 @@ function HistoryBlocking() {
       >
         History forward
       </button>
+      {[-2, -1, 0, 1, 2].map((delta) => (
+        <button
+          key={delta}
+          onClick={() =>
+            router.history.go(
+              delta,
+              ignoreBlocker ? { ignoreBlocker: true } : undefined,
+            )
+          }
+        >
+          History go({delta})
+        </button>
+      ))}
       <a href="/">Leave document</a>
     </div>
   )

--- a/e2e/react-router/basic-file-based/src/routes/history-blocking.tsx
+++ b/e2e/react-router/basic-file-based/src/routes/history-blocking.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react'
+import {
+  Link,
+  createFileRoute,
+  useBlocker,
+  useRouter,
+} from '@tanstack/react-router'
+
+export const Route = createFileRoute('/history-blocking')({
+  validateSearch: (search: Record<string, unknown>) => ({
+    step: Number(search.step) || 0,
+  }),
+  component: HistoryBlocking,
+})
+
+function HistoryBlocking() {
+  const router = useRouter()
+  const { step } = Route.useSearch()
+  const [draft, setDraft] = React.useState('')
+  const [ignoreBlocker, setIgnoreBlocker] = React.useState(false)
+  const { status } = useBlocker({
+    shouldBlockFn: () => draft.length > 0,
+    enableBeforeUnload: draft.length > 0,
+    withResolver: true,
+  })
+
+  return (
+    <div>
+      <h1>History blocking</h1>
+      <p>Step {step}</p>
+      <label>
+        Draft
+        <input
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+        />
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={ignoreBlocker}
+          onChange={(event) => setIgnoreBlocker(event.target.checked)}
+        />
+        Ignore blockers
+      </label>
+      <p>{draft ? 'Unsaved changes' : 'No changes'}</p>
+      <p>Blocker status: {status}</p>
+      <Link to="/history-blocking" search={{ step: 1 }}>
+        Add history entry
+      </Link>
+      <button
+        onClick={() =>
+          router.history.back(
+            ignoreBlocker ? { ignoreBlocker: true } : undefined,
+          )
+        }
+      >
+        History back
+      </button>
+      <button
+        onClick={() =>
+          router.history.forward(
+            ignoreBlocker ? { ignoreBlocker: true } : undefined,
+          )
+        }
+      >
+        History forward
+      </button>
+      <a href="/">Leave document</a>
+    </div>
+  )
+}

--- a/e2e/react-router/basic-file-based/tests/history-blocking.spec.ts
+++ b/e2e/react-router/basic-file-based/tests/history-blocking.spec.ts
@@ -1,21 +1,44 @@
 import { expect, test } from '@playwright/test'
 import type { Page } from '@playwright/test'
 
-async function prepareDocumentTraversal(
-  page: Page,
-  direction: 'back' | 'forward',
-) {
-  if (direction === 'back') {
-    await page.goto('/')
+async function prepareDocumentTraversal(page: Page, delta: number) {
+  if (delta < 0) {
+    for (let i = 0; i < Math.abs(delta); i++) {
+      await page.goto(`/?entry=${i}`)
+    }
     await page.goto('/history-blocking')
   } else {
     await page.goto('/history-blocking')
-    await page.goto('/')
-    await page.goBack()
+    for (let i = 0; i < delta; i++) {
+      await page.goto(`/?entry=${i}`)
+    }
+    for (let i = 0; i < delta; i++) {
+      await page.goBack()
+    }
   }
   await expect(
     page.getByRole('heading', { name: 'History blocking' }),
   ).toBeVisible()
+  await page.getByLabel('Draft', { exact: true }).fill('Unsaved draft')
+  await expect(page.getByText('Unsaved changes', { exact: true })).toBeVisible()
+}
+
+async function prepareSameDocumentTraversal(page: Page, delta: number) {
+  await page.goto('/history-blocking')
+  for (let step = 1; step <= Math.abs(delta); step++) {
+    await page.getByRole('link', { name: 'Add history entry' }).click()
+    await expect(page.getByText(`Step ${step}`, { exact: true })).toBeVisible()
+  }
+  if (delta > 0) {
+    for (let step = delta - 1; step >= 0; step--) {
+      await page
+        .getByRole('button', { name: 'History back', exact: true })
+        .click()
+      await expect(
+        page.getByText(`Step ${step}`, { exact: true }),
+      ).toBeVisible()
+    }
+  }
   await page.getByLabel('Draft', { exact: true }).fill('Unsaved draft')
   await expect(page.getByText('Unsaved changes', { exact: true })).toBeVisible()
 }
@@ -29,11 +52,18 @@ function dismissUnloadDialogs(page: Page) {
   return dialogs
 }
 
-for (const direction of ['back', 'forward'] as const) {
+for (const [direction, delta] of [
+  ['back', -1],
+  ['forward', 1],
+  ['go(-1)', -1],
+  ['go(1)', 1],
+  ['go(-2)', -2],
+  ['go(2)', 2],
+] as const) {
   test(`history ${direction} to another document warns before losing edits`, async ({
     page,
   }) => {
-    await prepareDocumentTraversal(page, direction)
+    await prepareDocumentTraversal(page, delta)
     const dialogs = dismissUnloadDialogs(page)
     const originalUrl = page.url()
 
@@ -51,7 +81,7 @@ for (const direction of ['back', 'forward'] as const) {
   test(`history ${direction} can explicitly bypass a document unload warning`, async ({
     page,
   }) => {
-    await prepareDocumentTraversal(page, direction)
+    await prepareDocumentTraversal(page, delta)
     await page.getByLabel('Ignore blockers').check()
     const dialogs = dismissUnloadDialogs(page)
 
@@ -59,23 +89,14 @@ for (const direction of ['back', 'forward'] as const) {
       .getByRole('button', { name: `History ${direction}`, exact: true })
       .click()
 
-    await expect(page).toHaveURL(/\/$/)
+    await expect(page).toHaveURL(/\/\?entry=\d$/)
     expect(dialogs).toEqual([])
   })
 
   test(`ignored same-document ${direction} preserves the next document unload warning`, async ({
     page,
   }) => {
-    await page.goto('/history-blocking')
-    await page.getByRole('link', { name: 'Add history entry' }).click()
-    await expect(page.getByText('Step 1', { exact: true })).toBeVisible()
-    if (direction === 'forward') {
-      await page
-        .getByRole('button', { name: 'History back', exact: true })
-        .click()
-      await expect(page.getByText('Step 0', { exact: true })).toBeVisible()
-    }
-    await page.getByLabel('Draft', { exact: true }).fill('Unsaved draft')
+    await prepareSameDocumentTraversal(page, delta)
     await page.getByLabel('Ignore blockers').check()
     const dialogs = dismissUnloadDialogs(page)
 
@@ -84,13 +105,16 @@ for (const direction of ['back', 'forward'] as const) {
       .click()
 
     await expect(
-      page.getByText(direction === 'back' ? 'Step 0' : 'Step 1', {
+      page.getByText(`Step ${delta < 0 ? 0 : delta}`, {
         exact: true,
       }),
     ).toBeVisible()
     await expect(page.getByLabel('Draft', { exact: true })).toHaveValue(
       'Unsaved draft',
     )
+    await expect(
+      page.getByText('Blocker status: idle', { exact: true }),
+    ).toBeVisible()
     expect(dialogs).toEqual([])
 
     await page.getByRole('link', { name: 'Leave document' }).click()
@@ -99,5 +123,55 @@ for (const direction of ['back', 'forward'] as const) {
     await expect(page.getByLabel('Draft', { exact: true })).toHaveValue(
       'Unsaved draft',
     )
+  })
+
+  test(`same-document ${direction} still checks blockers by default`, async ({
+    page,
+  }) => {
+    await prepareSameDocumentTraversal(page, delta)
+
+    await page
+      .getByRole('button', { name: `History ${direction}`, exact: true })
+      .click()
+
+    await expect(
+      page.getByText('Blocker status: blocked', { exact: true }),
+    ).toBeVisible()
+    await expect(
+      page.getByText(`Step ${delta < 0 ? -delta : 0}`, { exact: true }),
+    ).toBeVisible()
+    await expect(page.getByLabel('Draft', { exact: true })).toHaveValue(
+      'Unsaved draft',
+    )
+  })
+}
+
+for (const ignoreBlocker of [false, true]) {
+  test(`history go(0) ${ignoreBlocker ? 'can bypass' : 'preserves'} the reload warning`, async ({
+    page,
+  }) => {
+    await page.goto('/history-blocking')
+    await page.getByLabel('Draft', { exact: true }).fill('Unsaved draft')
+    await expect(
+      page.getByText('Unsaved changes', { exact: true }),
+    ).toBeVisible()
+    if (ignoreBlocker) {
+      await page.getByLabel('Ignore blockers').check()
+    }
+    const dialogs = dismissUnloadDialogs(page)
+
+    await page
+      .getByRole('button', { name: 'History go(0)', exact: true })
+      .click()
+
+    if (ignoreBlocker) {
+      await expect(page.getByLabel('Draft', { exact: true })).toHaveValue('')
+      expect(dialogs).toEqual([])
+    } else {
+      await expect.poll(() => dialogs).toEqual(['beforeunload'])
+      await expect(page.getByLabel('Draft', { exact: true })).toHaveValue(
+        'Unsaved draft',
+      )
+    }
   })
 }

--- a/e2e/react-router/basic-file-based/tests/history-blocking.spec.ts
+++ b/e2e/react-router/basic-file-based/tests/history-blocking.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test } from '@playwright/test'
+import type { Page } from '@playwright/test'
+
+async function prepareDocumentTraversal(
+  page: Page,
+  direction: 'back' | 'forward',
+) {
+  if (direction === 'back') {
+    await page.goto('/')
+    await page.goto('/history-blocking')
+  } else {
+    await page.goto('/history-blocking')
+    await page.goto('/')
+    await page.goBack()
+  }
+  await expect(
+    page.getByRole('heading', { name: 'History blocking' }),
+  ).toBeVisible()
+  await page.getByLabel('Draft', { exact: true }).fill('Unsaved draft')
+  await expect(page.getByText('Unsaved changes', { exact: true })).toBeVisible()
+}
+
+function dismissUnloadDialogs(page: Page) {
+  const dialogs: Array<string> = []
+  page.on('dialog', async (dialog) => {
+    dialogs.push(dialog.type())
+    await dialog.dismiss()
+  })
+  return dialogs
+}
+
+for (const direction of ['back', 'forward'] as const) {
+  test(`history ${direction} to another document warns before losing edits`, async ({
+    page,
+  }) => {
+    await prepareDocumentTraversal(page, direction)
+    const dialogs = dismissUnloadDialogs(page)
+    const originalUrl = page.url()
+
+    await page
+      .getByRole('button', { name: `History ${direction}`, exact: true })
+      .click()
+
+    await expect.poll(() => dialogs).toEqual(['beforeunload'])
+    await expect(page).toHaveURL(originalUrl)
+    await expect(page.getByLabel('Draft', { exact: true })).toHaveValue(
+      'Unsaved draft',
+    )
+  })
+
+  test(`history ${direction} can explicitly bypass a document unload warning`, async ({
+    page,
+  }) => {
+    await prepareDocumentTraversal(page, direction)
+    await page.getByLabel('Ignore blockers').check()
+    const dialogs = dismissUnloadDialogs(page)
+
+    await page
+      .getByRole('button', { name: `History ${direction}`, exact: true })
+      .click()
+
+    await expect(page).toHaveURL(/\/$/)
+    expect(dialogs).toEqual([])
+  })
+
+  test(`ignored same-document ${direction} preserves the next document unload warning`, async ({
+    page,
+  }) => {
+    await page.goto('/history-blocking')
+    await page.getByRole('link', { name: 'Add history entry' }).click()
+    await expect(page.getByText('Step 1', { exact: true })).toBeVisible()
+    if (direction === 'forward') {
+      await page
+        .getByRole('button', { name: 'History back', exact: true })
+        .click()
+      await expect(page.getByText('Step 0', { exact: true })).toBeVisible()
+    }
+    await page.getByLabel('Draft', { exact: true }).fill('Unsaved draft')
+    await page.getByLabel('Ignore blockers').check()
+    const dialogs = dismissUnloadDialogs(page)
+
+    await page
+      .getByRole('button', { name: `History ${direction}`, exact: true })
+      .click()
+
+    await expect(
+      page.getByText(direction === 'back' ? 'Step 0' : 'Step 1', {
+        exact: true,
+      }),
+    ).toBeVisible()
+    await expect(page.getByLabel('Draft', { exact: true })).toHaveValue(
+      'Unsaved draft',
+    )
+    expect(dialogs).toEqual([])
+
+    await page.getByRole('link', { name: 'Leave document' }).click()
+
+    await expect.poll(() => dialogs).toEqual(['beforeunload'])
+    await expect(page.getByLabel('Draft', { exact: true })).toHaveValue(
+      'Unsaved draft',
+    )
+  })
+}

--- a/e2e/react-router/basic-file-based/tests/history-blocking.spec.ts
+++ b/e2e/react-router/basic-file-based/tests/history-blocking.spec.ts
@@ -129,6 +129,7 @@ for (const [direction, delta] of [
     page,
   }) => {
     await prepareSameDocumentTraversal(page, delta)
+    const originalUrl = page.url()
 
     await page
       .getByRole('button', { name: `History ${direction}`, exact: true })
@@ -143,6 +144,14 @@ for (const [direction, delta] of [
     await expect(page.getByLabel('Draft', { exact: true })).toHaveValue(
       'Unsaved draft',
     )
+    await page.getByRole('button', { name: 'Stay here' }).click()
+    await expect(
+      page.getByText('Blocker status: idle', { exact: true }),
+    ).toBeVisible()
+    await expect(page).toHaveURL(originalUrl)
+    await expect(
+      page.getByText(`Step ${delta < 0 ? -delta : 0}`, { exact: true }),
+    ).toBeVisible()
   })
 }
 

--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -101,7 +101,7 @@ export function createHistory(opts: {
   getLength: () => number
   pushState: (path: string, state: any) => void
   replaceState: (path: string, state: any) => void
-  go: (n: number) => void
+  go: (n: number, ignoreBlocker: boolean) => void
   back: (ignoreBlocker: boolean) => void
   forward: (ignoreBlocker: boolean) => void
   createHref: (path: string) => string
@@ -204,7 +204,7 @@ export function createHistory(opts: {
     go: (index, navigateOpts) => {
       tryNavigation({
         task: () => {
-          opts.go(index)
+          opts.go(index, navigateOpts?.ignoreBlocker ?? false)
           handleIndexChange({ type: 'GO', index })
         },
         navigateOpts,
@@ -500,8 +500,12 @@ export function createBrowserHistory(opts?: {
       }
       win.history.forward()
     },
-    go: (n) => {
+    go: (n, ignoreBlocker) => {
       nextPopIsGo = true
+      if (ignoreBlocker) {
+        skipBlockerNextPop = true
+        ignoreNextBeforeUnload = true
+      }
       win.history.go(n)
     },
     createHref: (href) => createHref(href),

--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -394,6 +394,10 @@ export function createBrowserHistory(opts?: {
   }
 
   const onPushPopEvent = async () => {
+    // Same-document traversals do not fire beforeunload, so consume their
+    // exemption here instead of carrying it into a later document navigation.
+    ignoreNextBeforeUnload = false
+
     if (ignoreNextPop) {
       ignoreNextPop = false
       return
@@ -483,13 +487,17 @@ export function createBrowserHistory(opts?: {
     pushState: (href, state) => queueHistoryAction(true, href, state),
     replaceState: (href, state) => queueHistoryAction(false, href, state),
     back: (ignoreBlocker) => {
-      if (ignoreBlocker) skipBlockerNextPop = true
-      ignoreNextBeforeUnload = true
+      if (ignoreBlocker) {
+        skipBlockerNextPop = true
+        ignoreNextBeforeUnload = true
+      }
       return win.history.back()
     },
     forward: (ignoreBlocker) => {
-      if (ignoreBlocker) skipBlockerNextPop = true
-      ignoreNextBeforeUnload = true
+      if (ignoreBlocker) {
+        skipBlockerNextPop = true
+        ignoreNextBeforeUnload = true
+      }
       win.history.forward()
     },
     go: (n) => {

--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -322,6 +322,9 @@ export function createBrowserHistory(opts?: {
 
   let nextPopIsGo = false
   let ignoreNextPop = false
+  // TODO: An ignored traversal past a history boundary emits neither popstate
+  // nor beforeunload, leaving these bypasses active for a later navigation.
+  // The History API provides no completion signal for such no-op traversals.
   let skipBlockerNextPop = false
   let ignoreNextBeforeUnload = false
 
@@ -434,7 +437,7 @@ export function createBrowserHistory(opts?: {
           })
           if (isBlocked) {
             ignoreNextPop = true
-            win.history.go(1)
+            win.history.go(-delta)
             history.notify(notify)
             return
           }


### PR DESCRIPTION
## 🎯 Changes

Handle blockers consistently across `history.back()`, `history.forward()`, and `history.go()`:

- Preserve native unload warnings during back/forward navigation unless explicitly bypassed.
- Forward the existing `ignoreBlocker` option for `go()` so it bypasses navigation blockers and native unload warnings, including `go(0)` reloads.
- Clear the unload bypass after same-document traversal so later document navigation still warns about unsaved changes.
- Reverse blocked traversal by its actual distance, restoring the original browser URL after forward navigation or multi-entry jumps.

Fixes #4867. The option-forwarding change overlaps with #7832; this PR also handles document unload warnings and tests the combined behavior in a real browser. The rollback correction overlaps with #7908.

The regression fixture uses `useBlocker`, public `router.history` methods, and ordinary links. Tests assert the displayed route step, draft contents, public blocker status, and real native dialogs without mocking browser events or changing router internals. Coverage includes both directions, one- and two-entry jumps, default blocking, explicit bypasses, subsequent unload warnings, reloads, and dismissing the app blocker to restore the original URL and displayed step.

Validation:

- Without the `go()` fix (keeping the back/forward fix): **9 failed, 17 passed**. The failures cover ignored same-document traversal, document traversal, and reloads.
- Before the rollback correction, four dismissal cases failed: `forward()`, `go(1)`, `go(-2)`, and `go(2)` left the browser at the wrong URL.
- With this patch: **56 browser tests passed** (26 history-blocking cases and 30 existing navigation/blocker cases).
- Affected ESLint, type, and unit suites passed.

Known limitation: an ignored traversal beyond a history boundary can leave its bypass active for a later navigation. This is documented beside the bypass flags in the source. Resolving it requires a separate decision about unload bypass behavior when the browser cannot identify a valid traversal destination.

Commands used `CI=1 NX_DAEMON=false NX_NO_CLOUD=true`:

```sh
pnpm nx run tanstack-router-e2e-react-basic-file-based:test:e2e --outputStyle=stream --skipRemoteCache -- tests/history-blocking.spec.ts tests/app.spec.ts
pnpm test:eslint --base=e16faec455237f4e4acbe4bec034378209c26765 --outputStyle=stream --skipRemoteCache
pnpm test:types --base=e16faec455237f4e4acbe4bec034378209c26765 --outputStyle=stream --skipRemoteCache
pnpm test:unit --base=e16faec455237f4e4acbe4bec034378209c26765 --outputStyle=stream --skipRemoteCache -- --reporter=verbose
```

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved unsaved-changes warnings during back, forward, and history traversal navigation.
  - The “Ignore blockers” option now bypasses warnings only for the requested navigation.
  - Subsequent navigation correctly restores unload warnings after an ignored same-document history change.
  - Blocked back, forward, and multi-step navigation now restores the original history entry.
  - Reload navigation now respects blocker settings.

- **Tests**
  - Added coverage for multi-step history navigation, blocked document changes, reloads, bypass behavior, and draft preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->