### PR TITLE
fix(start): reject non-ok JSON server function responses

### DIFF
--- a/.changeset/quiet-rivers-reject.md
+++ b/.changeset/quiet-rivers-reject.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/start-client-core': patch
+---
+
+Reject non-OK JSON server function responses that were not serialized by TanStack Start.

--- a/packages/start-client-core/src/client-rpc/serverFnFetcher.ts
+++ b/packages/start-client-core/src/client-rpc/serverFnFetcher.ts
@@ -328,6 +328,9 @@ async function getResponse(fn: () => Promise<Response>) {
     if (isNotFound(jsonPayload)) {
       throw jsonPayload
     }
+    if (!response.ok) {
+      throw new Error(JSON.stringify(jsonPayload))
+    }
     return jsonPayload
   }
 

--- a/packages/start-client-core/tests/serverFnFetcher.test.ts
+++ b/packages/start-client-core/tests/serverFnFetcher.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest'
+import { serverFnFetcher } from '../src/client-rpc/serverFnFetcher'
+
+vi.mock('../src/getDefaultSerovalPlugins', () => ({
+  getDefaultSerovalPlugins: () => [],
+}))
+
+describe('serverFnFetcher', () => {
+  it('rejects non-ok JSON responses that were not serialized by Start', async () => {
+    const body = {
+      status: 500,
+      unhandled: true,
+      message: 'HTTPError',
+    }
+
+    const result = serverFnFetcher('/_serverFn/test', [{ method: 'GET' }], () =>
+      Promise.resolve(Response.json(body, { status: 500 })),
+    )
+
+    await expect(result).rejects.toThrow(JSON.stringify(body))
+  })
+
+  it('returns ok JSON responses that were not serialized by Start', async () => {
+    const body = { result: 'ok' }
+
+    const result = serverFnFetcher('/_serverFn/test', [{ method: 'GET' }], () =>
+      Promise.resolve(Response.json(body)),
+    )
+
+    await expect(result).resolves.toEqual(body)
+  })
+})


### PR DESCRIPTION
Written by an AI agent on behalf of @dvd233, who has reviewed this pull request.

## 🎯 Changes

Reject non-OK JSON server-function responses that were not serialized by TanStack Start, instead of returning the parsed error body as a successful result.

Redirect and not-found handling remain unchanged, and successful plain JSON responses still resolve normally. Focused regression coverage exercises both the failing 500 response and the successful control case.

Fixes #8280.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
