### PR TITLE
fix(start-server-core): return 400 for invalid JSON server function payloads

### DIFF
--- a/.changeset/clear-json-payload-400.md
+++ b/.changeset/clear-json-payload-400.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/start-server-core': patch
+---
+
+Return 400 for invalid JSON on server function GET payloads and JSON request bodies.

--- a/packages/start-server-core/src/server-functions-handler.ts
+++ b/packages/start-server-core/src/server-functions-handler.ts
@@ -139,9 +139,21 @@ export const handleServerAction = async ({
             throw new Error('Payload too large')
           }
           // If there's a payload, we should try to parse it
-          const payload: any = payloadParam
-            ? parsePayload(JSON.parse(payloadParam))
-            : {}
+          let payload: any = {}
+          if (payloadParam) {
+            let parsedJson: unknown
+            try {
+              parsedJson = JSON.parse(payloadParam)
+            } catch (error) {
+              if (error instanceof SyntaxError) {
+                throw new Response('Invalid server function payload', {
+                  status: 400,
+                })
+              }
+              throw error
+            }
+            payload = parsePayload(parsedJson)
+          }
           payload.context = safeObjectMerge(payload.context, context)
           payload.method = methodUpper
           // Send it through!
@@ -150,7 +162,16 @@ export const handleServerAction = async ({
 
         let jsonPayload
         if (contentType?.includes('application/json')) {
-          jsonPayload = await request.json()
+          try {
+            jsonPayload = await request.json()
+          } catch (error) {
+            if (error instanceof SyntaxError) {
+              throw new Response('Invalid server function payload', {
+                status: 400,
+              })
+            }
+            throw error
+          }
         }
 
         const payload = jsonPayload ? parsePayload(jsonPayload) : {}

--- a/packages/start-server-core/tests/server-functions-handler-invalid-json.test.ts
+++ b/packages/start-server-core/tests/server-functions-handler-invalid-json.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { runWithStartContext } from '@tanstack/start-storage-context'
+
+const action = vi.fn()
+
+vi.mock('../src/getServerFnById', () => ({
+  getServerFnById: vi.fn(async () => action),
+}))
+
+const { handleServerAction } = await import('../src/server-functions-handler')
+
+const SERVER_FN_ID = 'test-server-fn'
+
+function invoke(request: Request) {
+  return runWithStartContext(
+    {
+      getRouter: () => ({}) as any,
+      request,
+      startOptions: {},
+      contextAfterGlobalMiddlewares: {},
+      executedRequestMiddlewares: new Set(),
+      handlerType: 'serverFn',
+    },
+    () =>
+      handleServerAction({
+        request,
+        context: {},
+        serverFnId: SERVER_FN_ID,
+      }),
+  )
+}
+
+beforeEach(() => {
+  action.mockReset()
+  action.mockImplementation(async () => ({ result: { ok: true } }))
+})
+
+describe('handleServerAction invalid JSON payloads', () => {
+  test('returns 400 for a malformed GET payload instead of an unhandled 500', async () => {
+    Object.assign(action, { method: 'GET' })
+
+    const request = new Request(
+      `http://localhost/_serverFn/${SERVER_FN_ID}?payload=%7Bgarbage%7D`,
+      {
+        method: 'GET',
+        headers: { 'x-tsr-serverFn': 'true' },
+      },
+    )
+
+    const result = await invoke(request)
+
+    expect(result).toBeInstanceOf(Response)
+    const response = result as Response
+    expect(response.status).toBe(400)
+    await expect(response.text()).resolves.toBe(
+      'Invalid server function payload',
+    )
+    expect(action).not.toHaveBeenCalled()
+  })
+
+  test('returns 400 for a malformed JSON POST body instead of an unhandled 500', async () => {
+    Object.assign(action, { method: 'POST' })
+
+    const request = new Request(`http://localhost/_serverFn/${SERVER_FN_ID}`, {
+      method: 'POST',
+      headers: {
+        'x-tsr-serverFn': 'true',
+        'Content-Type': 'application/json',
+      },
+      body: '{garbage}',
+    })
+
+    const result = await invoke(request)
+
+    expect(result).toBeInstanceOf(Response)
+    const response = result as Response
+    expect(response.status).toBe(400)
+    await expect(response.text()).resolves.toBe(
+      'Invalid server function payload',
+    )
+    expect(action).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

A server function request with malformed JSON currently 500s. GET `JSON.parse(payloadParam)` and POST `request.json()` throw `SyntaxError`, the handler logs `Server Fn Error!`, and the client sees an unhandled 500. That's a bad request, not a server fault — crawlers replaying `/_serverFn/...` URLs with garbage payloads show up in production monitoring as 500s.

`handleServerAction` already returns a thrown `Response` from its outer catch, so both parse sites now throw `new Response('Invalid server function payload', { status: 400 })` on `SyntaxError` and rethrow anything else. seroval/`fromJSON` still 500s; this only covers invalid JSON.

This is the malformed-JSON case from #8237. The missing `x-tsr-serverFn` path is already in #8220, so this PR does not close that issue.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid JSON in server function GET payloads and request bodies now returns a clear `400` response instead of an unhandled `500` error.
  - Server functions are no longer invoked when their request payload contains malformed JSON.

- **Tests**
  - Added coverage for malformed JSON in both GET and POST server function requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->