### PR TITLE
perf(router-core): index cache membership checks per commit

### DIFF
--- a/.changeset/lucky-lies-tell.md
+++ b/.changeset/lucky-lies-tell.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+Reduce cache maintenance work during navigation by indexing incoming match IDs once per commit.

--- a/packages/router-core/src/load-client.ts
+++ b/packages/router-core/src/load-client.ts
@@ -1607,19 +1607,17 @@ export function commitMatches(
   const cached = new Map<string, AnyRouteMatch>()
   if (process.env.NODE_ENV === 'production' || !tx[6 /* refresh */]) {
     const now = Date.now()
+    // The rendered prefix and settled descendants supersede older generations.
+    // Unsettled matches beyond a fallback must not evict a newer preload.
+    const superseded = new Set<string>()
+    for (let index = 0; index < matches.length; index++) {
+      const match = matches[index]!
+      if (index < cut || match.status === 'success') {
+        superseded.add(match.id)
+      }
+    }
     for (const match of [...previous, ...previousCached.values()]) {
-      // Rendered-prefix ids and settled successes anywhere in the lane are
-      // authoritative: retaining an older same-id generation would shadow them
-      // at the next planning pass. Unsettled beyond-boundary matches are not —
-      // they must not evict a newer same-id preload.
-      if (
-        match.status !== 'success' ||
-        matches.some(
-          (candidate, index) =>
-            candidate.id === match.id &&
-            (index < cut || candidate.status === 'success'),
-        )
-      ) {
+      if (match.status !== 'success' || superseded.has(match.id)) {
         continue
       }
       const work = match as WorkMatch

--- a/packages/router-core/tests/cache-commit.bench.ts
+++ b/packages/router-core/tests/cache-commit.bench.ts
@@ -5,12 +5,17 @@ import type { LoaderFlight, LoadTransaction } from '../src/load-client'
 
 type Match = AnyRouteMatch & { _flight?: LoaderFlight }
 
+const workloads = [0, 4, 10, 100, 1000, 5000].flatMap((size) => [
+  [size, 4],
+  [size, 16],
+])
+
 // Run each family separately with -t to keep GC from other workloads out of
 // short operations. This measures commit/cache maintenance, not navigation.
 for (const family of ['snapshots', 'mixed flights', 'preload flights']) {
-  describe.each([0, 4, 10, 100, 1000, 5000])(
-    `${family}: %i cached matches`,
-    (size) => {
+  describe.each(workloads)(
+    `${family}: %i cached matches, %i active matches`,
+    (size, activeCount) => {
       for (const retainedFraction of [1, 0.5, 0]) {
         const retainedCount = Math.floor(size * retainedFraction)
         let aborts = 0
@@ -47,7 +52,7 @@ for (const family of ['snapshots', 'mixed flights', 'preload flights']) {
         const departing = entries.filter(
           (entry) => !entry.retained && entry.flight,
         )
-        const matches = Array.from({ length: 4 }, (_, index) => ({
+        const matches = Array.from({ length: activeCount }, (_, index) => ({
           id: `active-${index}`,
           routeId: 'retained',
           status: 'success',

--- a/packages/router-core/tests/cache-commit.test.ts
+++ b/packages/router-core/tests/cache-commit.test.ts
@@ -67,6 +67,45 @@ function setup(
 }
 
 describe('commit cache ownership', () => {
+  test.each(['error', 'notFound', 'pending', 'global not found'] as const)(
+    'only supersedes the rendered prefix and settled descendants at a %s boundary',
+    (boundaryKind) => {
+      const cached = [
+        'prefix',
+        'boundary',
+        'settled',
+        'pending',
+        'failed',
+        'unrelated',
+      ].map((id) => match(id, resource()))
+      const next = cached.slice(0, -1).map((entry) => match(entry.id))
+      if (boundaryKind === 'global not found') {
+        next[1]!._notFound = true
+      } else {
+        next[1]!.status = boundaryKind
+      }
+      next[3]!.status = 'pending'
+      next[4]!.status = 'error'
+      const { router, commit } = setup([], cached, next)
+
+      commit()
+
+      expect([...router._cache.keys()]).toEqual([
+        'pending',
+        'failed',
+        'unrelated',
+      ])
+      for (const [index, entry] of cached.entries()) {
+        if (index < 3) {
+          expect(entry._flight).toBeUndefined()
+        } else {
+          expect(router._cache.get(entry.id)).toBe(entry)
+          expect(entry._flight?.[1].signal.aborted).toBe(false)
+        }
+      }
+    },
+  )
+
   test('retains cached identities and releases the committed owner cloned into cache', () => {
     const retainedFlight = resource()
     const departedFlight = resource()


### PR DESCRIPTION
## 🎯 Changes

Build the set of incoming match IDs that supersede cached entries once per navigation commit. This replaces a repeated scan of incoming matches for every cached entry, reducing cache maintenance work for large caches and deep route branches while preserving the existing eviction rules.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced cache-maintenance work during navigation, improving efficiency for routes with many active matches.
  * Cache retention continues to preserve pending, failed, and unrelated route data while correctly releasing superseded entries.
* **Bug Fixes**
  * Improved cache ownership handling at error, not-found, and pending route boundaries without changing expected navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->