### PR TITLE
fix(router-core): dedupe canonical head links so child routes override parents

### DIFF
--- a/.changeset/dedupe-canonical-head-links.md
+++ b/.changeset/dedupe-canonical-head-links.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+Dedupe `<link rel="canonical">` across nested routes so a child route's canonical link overrides its parent's, matching how `meta` tags are deduped. Other link rels (`stylesheet`, `preload`, `icon`, …) are still allowed to repeat.

--- a/docs/router/guide/document-head-management.md
+++ b/docs/router/guide/document-head-management.md
@@ -61,7 +61,7 @@ Out of the box, TanStack Router will dedupe `title` and `meta` tags, preferring 
 
 - `title` tags defined in nested routes will override a `title` tag defined in a parent route (but you can compose them together, which is covered in a future section of this guide)
 - `meta` tags with the same `name` or `property` will be overridden by the last occurrence of that tag found in nested routes
-- `link` tags with `rel="canonical"` are deduped the same way — the last occurrence in nested routes overrides the parent's canonical link. Other `link` rels such as `stylesheet`, `preload`, and `icon` are not deduped, since multiple of them are valid.
+- `link` tags with `rel="canonical"` are deduped the same way — the last occurrence in nested routes overrides the parent's canonical link. Other `link` rels such as `stylesheet`, `preload`, and `icon` are not deduped by `rel`; distinct links remain repeatable, while identical tags are still deduped.
 
 ### `<HeadContent />`
 

--- a/docs/router/guide/document-head-management.md
+++ b/docs/router/guide/document-head-management.md
@@ -61,6 +61,7 @@ Out of the box, TanStack Router will dedupe `title` and `meta` tags, preferring 
 
 - `title` tags defined in nested routes will override a `title` tag defined in a parent route (but you can compose them together, which is covered in a future section of this guide)
 - `meta` tags with the same `name` or `property` will be overridden by the last occurrence of that tag found in nested routes
+- `link` tags with `rel="canonical"` are deduped the same way — the last occurrence in nested routes overrides the parent's canonical link. Other `link` rels such as `stylesheet`, `preload`, and `icon` are not deduped, since multiple of them are valid.
 
 ### `<HeadContent />`
 

--- a/packages/router-core/src/manifest.ts
+++ b/packages/router-core/src/manifest.ts
@@ -150,15 +150,21 @@ export type RouterManagedTag =
  * `alternate` legitimately repeat and must not be collapsed.
  */
 const UNIQUE_LINK_RELS = new Set<string>(['canonical'])
+const LINK_REL_TOKEN_SEPARATOR = /[\t\n\f\r ]+/
 
 function uniqueLinkRelKey(tag: RouterManagedTag): string | undefined {
   if (tag.tag !== 'link') {
     return undefined
   }
   const rel = tag.attrs?.rel
-  return typeof rel === 'string' && UNIQUE_LINK_RELS.has(rel)
-    ? `link:${rel}`
-    : undefined
+  const uniqueRel =
+    typeof rel === 'string'
+      ? rel
+          .toLowerCase()
+          .split(LINK_REL_TOKEN_SEPARATOR)
+          .find((token) => UNIQUE_LINK_RELS.has(token))
+      : undefined
+  return uniqueRel === undefined ? undefined : `link:${uniqueRel}`
 }
 
 export function appendUniqueUserTags(

--- a/packages/router-core/src/manifest.ts
+++ b/packages/router-core/src/manifest.ts
@@ -142,6 +142,25 @@ export type RouterManagedTag =
   | RouterManagedScriptTag
   | RouterManagedStyleTag
 
+/**
+ * `<link>` rels that are unique by nature: at most one such tag is valid in the
+ * document. For these, a child route's tag must override its parent's rather
+ * than being concatenated, mirroring how meta tags dedupe by name/property.
+ * Deliberately narrow — rels like `stylesheet`, `preload`, `icon` and
+ * `alternate` legitimately repeat and must not be collapsed.
+ */
+const UNIQUE_LINK_RELS = new Set<string>(['canonical'])
+
+function uniqueLinkRelKey(tag: RouterManagedTag): string | undefined {
+  if (tag.tag !== 'link') {
+    return undefined
+  }
+  const rel = tag.attrs?.rel
+  return typeof rel === 'string' && UNIQUE_LINK_RELS.has(rel)
+    ? `link:${rel}`
+    : undefined
+}
+
 export function appendUniqueUserTags(
   target: Array<RouterManagedTag>,
   tags: Array<RouterManagedTag>,
@@ -155,15 +174,32 @@ export function appendUniqueUserTags(
     return
   }
 
+  // Tags arrive parent-first, so the last occurrence of a unique-by-nature
+  // link rel is the deepest (child) match and is the one that should win.
+  const lastUniqueRelIndex = new Map<string, number>()
+  tags.forEach((tag, index) => {
+    const relKey = uniqueLinkRelKey(tag)
+    if (relKey !== undefined) {
+      lastUniqueRelIndex.set(relKey, index)
+    }
+  })
+
   const seen = new Set<string>()
-  for (const tag of tags) {
+  tags.forEach((tag, index) => {
+    const relKey = uniqueLinkRelKey(tag)
+    if (relKey !== undefined) {
+      if (lastUniqueRelIndex.get(relKey) === index) {
+        target.push(tag)
+      }
+      return
+    }
     const key = JSON.stringify(tag)
     if (seen.has(key)) {
-      continue
+      return
     }
     seen.add(key)
     target.push(tag)
-  }
+  })
 }
 
 export type ManifestCssLink =

--- a/packages/router-core/tests/manifest.test.ts
+++ b/packages/router-core/tests/manifest.test.ts
@@ -114,4 +114,78 @@ describe('appendUniqueUserTags', () => {
 
     expect(target).toEqual([tag, tag])
   })
+
+  it('keeps only the last canonical link so a child route overrides its parent (#6719)', () => {
+    const parentCanonical: RouterManagedTag = {
+      tag: 'link',
+      attrs: {
+        rel: 'canonical',
+        href: 'https://example.com/',
+      },
+    }
+    const childCanonical: RouterManagedTag = {
+      tag: 'link',
+      attrs: {
+        rel: 'canonical',
+        href: 'https://example.com/blog',
+      },
+    }
+    const target: Array<RouterManagedTag> = []
+
+    // Matches are ordered parent-first, so the child's canonical is appended last.
+    appendUniqueUserTags(target, [parentCanonical, childCanonical])
+
+    expect(target).toEqual([childCanonical])
+  })
+
+  it('does not deduplicate non-unique link rels such as stylesheet by rel (#6719)', () => {
+    const firstStylesheet: RouterManagedTag = {
+      tag: 'link',
+      attrs: {
+        rel: 'stylesheet',
+        href: '/a.css',
+      },
+    }
+    const secondStylesheet: RouterManagedTag = {
+      tag: 'link',
+      attrs: {
+        rel: 'stylesheet',
+        href: '/b.css',
+      },
+    }
+    const target: Array<RouterManagedTag> = []
+
+    appendUniqueUserTags(target, [firstStylesheet, secondStylesheet])
+
+    expect(target).toEqual([firstStylesheet, secondStylesheet])
+  })
+
+  it('overrides canonical while preserving repeatable links in the same call (#6719)', () => {
+    const stylesheet: RouterManagedTag = {
+      tag: 'link',
+      attrs: { rel: 'stylesheet', href: '/app.css' },
+    }
+    const parentCanonical: RouterManagedTag = {
+      tag: 'link',
+      attrs: { rel: 'canonical', href: 'https://example.com/' },
+    }
+    const preload: RouterManagedTag = {
+      tag: 'link',
+      attrs: { rel: 'preload', href: '/font.woff2', as: 'font' },
+    }
+    const childCanonical: RouterManagedTag = {
+      tag: 'link',
+      attrs: { rel: 'canonical', href: 'https://example.com/blog' },
+    }
+    const target: Array<RouterManagedTag> = []
+
+    appendUniqueUserTags(target, [
+      stylesheet,
+      parentCanonical,
+      preload,
+      childCanonical,
+    ])
+
+    expect(target).toEqual([stylesheet, preload, childCanonical])
+  })
 })

--- a/packages/router-core/tests/manifest.test.ts
+++ b/packages/router-core/tests/manifest.test.ts
@@ -188,4 +188,58 @@ describe('appendUniqueUserTags', () => {
 
     expect(target).toEqual([stylesheet, preload, childCanonical])
   })
+
+  it('identifies canonical in case-insensitive rel token lists (#6719)', () => {
+    const parentCanonical: RouterManagedTag = {
+      tag: 'link',
+      attrs: { rel: 'CANONICAL', href: 'https://example.com/' },
+    }
+    const childCanonical: RouterManagedTag = {
+      tag: 'link',
+      attrs: {
+        rel: 'alternate canonical',
+        href: 'https://example.com/blog',
+      },
+    }
+    const target: Array<RouterManagedTag> = []
+
+    appendUniqueUserTags(target, [parentCanonical, childCanonical])
+
+    expect(target).toEqual([childCanonical])
+  })
+
+  it('does not split rel tokens on non-HTML whitespace (#6719)', () => {
+    const canonical: RouterManagedTag = {
+      tag: 'link',
+      attrs: { rel: 'canonical', href: 'https://example.com/' },
+    }
+    const nonCanonical: RouterManagedTag = {
+      tag: 'link',
+      attrs: {
+        rel: 'alternate\u00a0canonical',
+        href: 'https://example.com/blog',
+      },
+    }
+    const target: Array<RouterManagedTag> = []
+
+    appendUniqueUserTags(target, [canonical, nonCanonical])
+
+    expect(target).toEqual([canonical, nonCanonical])
+  })
+
+  it('does not trim non-HTML whitespace from rel values (#6719)', () => {
+    const canonical: RouterManagedTag = {
+      tag: 'link',
+      attrs: { rel: 'canonical', href: 'https://example.com/' },
+    }
+    const nonCanonical: RouterManagedTag = {
+      tag: 'link',
+      attrs: { rel: '\u00a0canonical', href: 'https://example.com/blog' },
+    }
+    const target: Array<RouterManagedTag> = []
+
+    appendUniqueUserTags(target, [canonical, nonCanonical])
+
+    expect(target).toEqual([canonical, nonCanonical])
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Fixes #6719.

`head.links` from every matched route were concatenated and deduped only by exact `JSON.stringify` equality, so a `<link rel="canonical">` defined on a child route could **not** override a parent's — both ended up in the rendered `<head>`. Two different canonical URLs is invalid HTML and actively harmful for SEO. This is inconsistent with `meta` tags, which already dedupe by `name`/`property` with the child winning.

The dedup happens in one shared place, `appendUniqueUserTags` (`packages/router-core/src/manifest.ts`), so all three framework adapters (react/solid/vue) inherit the fix:

- A small `UNIQUE_LINK_RELS` set marks rels that are unique by nature (currently just `canonical`).
- For those, only the **last** occurrence is kept. Links are collected parent-first, so "last" is the deepest child match — the one that should win, matching `meta` semantics.
- Repeatable rels (`stylesheet`, `preload`, `icon`, `alternate`, …) are left exactly as before.

Manifest-managed stylesheet/preload links are pushed directly and never routed through `appendUniqueUserTags`, so asset emission is unaffected.

Docs (`docs/router/guide/document-head-management.md`) and a changeset are included.

## Test verification (RED → GREEN)

New unit tests in `packages/router-core/tests/manifest.test.ts`. Run against the unmodified base (fix reverted, tests kept) — **RED**:

```
FAIL  tests/manifest.test.ts > appendUniqueUserTags > keeps only the last canonical link so a child route overrides its parent (#6719)
AssertionError: expected [ …(2) ] to deeply equal [ { tag: 'link', attrs: { …(2) } } ]
+   { attrs: { href: "https://example.com/",     rel: "canonical" }, tag: "link" },   // parent leaked through
    { attrs: { href: "https://example.com/blog", rel: "canonical" }, tag: "link" }
 Tests  1 failed | 15 passed (16)
```

With the fix — **GREEN**:

```
Test Files  2 passed (2)
     Tests  17 passed (17)
Type Errors  no errors
```

Full local suite for the affected packages (`@tanstack/router-core`, `@tanstack/react-router`, `@tanstack/solid-router`, `@tanstack/vue-router`) — build, eslint, types and unit — is green on both the base branch and this branch (1123 unit tests passing, no new failures):

```
Test Files  89 passed (89)
     Tests  1123 passed | 1 skipped (1124)
ALL LOCAL CI TARGETS GREEN
```

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Canonical links in nested routes are now deduplicated automatically.
  * A child route’s canonical link overrides the canonical link inherited from its parent.
  * Repeatable links, including stylesheets, preloads, and icons, continue to be supported without rel-based deduplication.

* **Documentation**
  * Clarified document head management guidance for canonical-link behavior and repeatable links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review follow-up

Canonical `rel` matching is case-insensitive and uses HTML ASCII-whitespace tokenization. Regression tests cover token lists plus Unicode-whitespace boundaries. Repeatable rels are not deduped by rel; distinct links repeat while identical tags retain existing exact-tag deduplication.

Focused result after review fixes: 20 tests passed.