### PR TITLE
fix(react-router,router-core): hydrate Link active state against the server location

### DIFF
--- a/.changeset/quiet-links-hydrate.md
+++ b/.changeset/quiet-links-hydrate.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/router-core': patch
+'@tanstack/react-router': patch
+---
+
+Fix `<Link>` hydrating with the wrong active state (`data-status`, `aria-current`, active class) when a navigation starts before a Suspense boundary containing the link has hydrated. `hydrate()` now records the location the server rendered with, and links resolve their `href` and active state against it while hydrating, then follow the live location once hydrated.

--- a/.changeset/quiet-links-hydrate.md
+++ b/.changeset/quiet-links-hydrate.md
@@ -1,6 +1,8 @@
 ---
 '@tanstack/router-core': patch
 '@tanstack/react-router': patch
+'@tanstack/solid-router': patch
+'@tanstack/vue-router': patch
 ---
 
-Fix `<Link>` hydrating with the wrong active state (`data-status`, `aria-current`, active class) when a navigation starts before a Suspense boundary containing the link has hydrated. `hydrate()` now records the location the server rendered with, and links resolve their `href` and active state against it while hydrating, then follow the live location once hydrated.
+Fix `<Link>` hydrating with the wrong active state (`data-status`, `aria-current`, active class) when a navigation starts before the component containing the link has hydrated. `hydrate()` now records the location the server rendered with, and links resolve their `href` and active state against it while hydrating, then follow the live location once hydrated. Affects React, Solid and Vue: none of the three rectifies the mismatched attributes, so the stale state persisted on the element.

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -423,7 +423,7 @@ export function useLinkProps<
   // the comparator only sees the location, not whether this link's output moved.
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const selectLinkState = React.useCallback(
-    (location: ParsedLocation): LinkState => {
+    (liveLocation: ParsedLocation): LinkState => {
       const directExternalLink = resolveExternalLink(
         to,
         router.protocolAllowlist,
@@ -432,6 +432,14 @@ export function useLinkProps<
         return [directExternalLink ?? undefined]
       }
 
+      // React runs this selector as `getServerSnapshot` while a boundary is
+      // hydrating, so it must reproduce the server output; `stores.location`
+      // already holds the destination while the loader is in flight. The
+      // `isHydrated` flip re-runs the selection against the live location.
+      const location =
+        isHydrated || !router._hydrationLocation
+          ? liveLocation
+          : router._hydrationLocation
       const next = router.buildLocation({
         _fromLocation: location,
         ..._options,

--- a/packages/react-router/tests/issue-8233-link-hydration-active-state.test.tsx
+++ b/packages/react-router/tests/issue-8233-link-hydration-active-state.test.tsx
@@ -1,0 +1,305 @@
+import * as React from 'react'
+import { act } from '@testing-library/react'
+import { hydrateRoot } from 'react-dom/client'
+import { renderToString } from 'react-dom/server'
+import { afterEach, expect, test, vi } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import { dehydrateSsrMatchId } from '../../router-core/src/ssr/ssr-match-id'
+import { hydrate } from '../src/ssr/client'
+import {
+  Link,
+  Outlet,
+  RouterProvider,
+  createControlledPromise,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+import type { MockInstance } from 'vitest'
+import type { AnyRouter, RouteComponent } from '../src'
+
+const testCleanups: Array<() => void | Promise<void>> = []
+
+afterEach(async () => {
+  while (testCleanups.length) {
+    await testCleanups.pop()!()
+  }
+  vi.restoreAllMocks()
+  window.$_TSR = undefined
+  document.body.innerHTML = ''
+})
+
+function Home() {
+  return (
+    <main>
+      <Link to="/about" data-testid="content-link">
+        about
+      </Link>
+    </main>
+  )
+}
+
+function Footer() {
+  return (
+    <footer>
+      <Link to="/about" data-testid="footer-link">
+        about
+      </Link>
+    </footer>
+  )
+}
+
+function makeRouteTree(opts: {
+  Home: RouteComponent
+  Footer?: RouteComponent
+  aboutLoader?: () => Promise<void>
+  homeSsr?: false
+  homeLoader?: () => Promise<void>
+}) {
+  const { Home: HomeComponent, Footer: FooterComponent } = opts
+  const rootRoute = createRootRoute({
+    component: () => (
+      <>
+        <nav>
+          <Link to="/about" data-testid="header-link">
+            About
+          </Link>
+        </nav>
+        <Outlet />
+        {FooterComponent ? (
+          <React.Suspense fallback={null}>
+            <FooterComponent />
+          </React.Suspense>
+        ) : null}
+      </>
+    ),
+  })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    ssr: opts.homeSsr,
+    loader: opts.homeLoader,
+    component: HomeComponent,
+  })
+  const aboutRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/about',
+    loader: opts.aboutLoader,
+    component: () => <div>About</div>,
+  })
+  return rootRoute.addChildren([indexRoute, aboutRoute])
+}
+
+async function renderServer(serverRouter: AnyRouter) {
+  serverRouter.isServer = true
+  await serverRouter.load()
+  const html = renderToString(<RouterProvider router={serverRouter} />)
+  expect(html).not.toContain('data-status')
+  return html
+}
+
+async function hydrateClient(
+  serverRouter: AnyRouter,
+  clientRouter: AnyRouter,
+  serverHtml: string,
+) {
+  window.$_TSR = {
+    router: {
+      manifest: { routes: {} },
+      dehydratedData: {},
+      matches: serverRouter.stores.matches.get().map((match) => ({
+        i: dehydrateSsrMatchId(match.id),
+        u: match.updatedAt,
+        s: match.status,
+        l: match.loaderData,
+        e: match.error,
+        ssr: match.ssr,
+      })),
+    },
+    h: vi.fn(),
+    e: vi.fn(),
+    c: vi.fn(),
+    p: vi.fn(),
+    buffer: [],
+    initialized: false,
+  }
+  await hydrate(clientRouter)
+
+  const container = document.createElement('div')
+  container.innerHTML = serverHtml
+  document.body.appendChild(container)
+  const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+  let root!: ReturnType<typeof hydrateRoot>
+  await act(async () => {
+    root = hydrateRoot(container, <RouterProvider router={clientRouter} />)
+    testCleanups.push(async () => {
+      await act(() => root.unmount())
+    })
+    await Promise.resolve()
+  })
+  return { container, consoleError }
+}
+
+function hydrationMismatches(consoleError: MockInstance<typeof console.error>) {
+  return consoleError.mock.calls.filter((call) =>
+    call.map(String).join(' ').includes("didn't match"),
+  )
+}
+
+test('a Link inside a late-hydrating boundary hydrates against the server location when a navigation is pending', async () => {
+  const aboutLoader = createControlledPromise<void>()
+  const serverRouter = createRouter({
+    routeTree: makeRouteTree({ Home, aboutLoader: () => aboutLoader }),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+  const serverHtml = await renderServer(serverRouter)
+
+  // The route content is a lazy chunk so its Suspense boundary hydrates after
+  // the shell, leaving a window in which the header link is interactive.
+  const chunk = createControlledPromise<{ default: typeof Home }>()
+  const clientRouter = createRouter({
+    routeTree: makeRouteTree({
+      Home: React.lazy(() => chunk),
+      aboutLoader: () => aboutLoader,
+    }),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+  const { container, consoleError } = await hydrateClient(
+    serverRouter,
+    clientRouter,
+    serverHtml,
+  )
+
+  // Shell is hydrated, route content is still a dehydrated boundary.
+  const headerLink = container.querySelector('[data-testid="header-link"]')!
+  const contentLink = container.querySelector('[data-testid="content-link"]')!
+  expect(headerLink).not.toHaveAttribute('data-status')
+  expect(contentLink).not.toHaveAttribute('data-status')
+
+  let navigation!: Promise<void>
+  await act(async () => {
+    navigation = clientRouter.navigate({ to: '/about' })
+    await Promise.resolve()
+  })
+  expect(clientRouter.state.location.pathname).toBe('/about')
+  expect(clientRouter.state.resolvedLocation?.pathname).toBe('/')
+  expect(clientRouter.state.status).toBe('pending')
+  expect(headerLink).toHaveAttribute('data-status', 'active')
+
+  // Now the route content hydrates while the navigation is still pending.
+  await act(async () => {
+    chunk.resolve({ default: Home })
+    await chunk
+  })
+
+  expect(hydrationMismatches(consoleError)).toEqual([])
+  // After hydration the link follows the live location like the header link.
+  expect(contentLink).toHaveAttribute('data-status', 'active')
+
+  await act(async () => {
+    aboutLoader.resolve()
+    await navigation
+  })
+  expect(container).toHaveTextContent('About')
+})
+
+test('a Link inside a boundary that hydrates after a navigation committed still matches the server HTML', async () => {
+  const serverRouter = createRouter({
+    routeTree: makeRouteTree({ Home, Footer }),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+  const serverHtml = await renderServer(serverRouter)
+
+  // The footer lives in the root layout and is a lazy chunk, so its server
+  // HTML survives the navigation and only hydrates once the chunk arrives.
+  const chunk = createControlledPromise<{ default: typeof Footer }>()
+  const clientRouter = createRouter({
+    routeTree: makeRouteTree({ Home, Footer: React.lazy(() => chunk) }),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+  const { container, consoleError } = await hydrateClient(
+    serverRouter,
+    clientRouter,
+    serverHtml,
+  )
+  const footerLink = container.querySelector('[data-testid="footer-link"]')!
+  expect(footerLink).not.toHaveAttribute('data-status')
+
+  await act(async () => {
+    await clientRouter.navigate({ to: '/about' })
+  })
+  expect(clientRouter.state.resolvedLocation?.pathname).toBe('/about')
+  expect(container).toHaveTextContent('About')
+  expect(footerLink).not.toHaveAttribute('data-status')
+
+  await act(async () => {
+    chunk.resolve({ default: Footer })
+    await chunk
+  })
+
+  expect(hydrationMismatches(consoleError)).toEqual([])
+  expect(footerLink).toHaveAttribute('data-status', 'active')
+})
+
+test('a Link inside a boundary that hydrates while the initial client load is still pending matches the server HTML', async () => {
+  // An `ssr: false` route leaves `resolvedLocation` unset until its client
+  // load commits, so the server-rendered location has to come from `hydrate()`.
+  const homeLoader = createControlledPromise<void>()
+  const aboutLoader = createControlledPromise<void>()
+  const serverRouter = createRouter({
+    routeTree: makeRouteTree({
+      Home,
+      Footer,
+      homeSsr: false,
+      homeLoader: () => homeLoader,
+      aboutLoader: () => aboutLoader,
+    }),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+  const serverHtml = await renderServer(serverRouter)
+  expect(serverHtml).not.toContain('data-testid="content-link"')
+
+  const chunk = createControlledPromise<{ default: typeof Footer }>()
+  const clientRouter = createRouter({
+    routeTree: makeRouteTree({
+      Home,
+      Footer: React.lazy(() => chunk),
+      homeSsr: false,
+      homeLoader: () => homeLoader,
+      aboutLoader: () => aboutLoader,
+    }),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+  const { container, consoleError } = await hydrateClient(
+    serverRouter,
+    clientRouter,
+    serverHtml,
+  )
+  const footerLink = container.querySelector('[data-testid="footer-link"]')!
+  expect(footerLink).not.toHaveAttribute('data-status')
+  expect(clientRouter.state.status).toBe('pending')
+  expect(clientRouter.state.resolvedLocation).toBeUndefined()
+
+  let navigation!: Promise<void>
+  await act(async () => {
+    navigation = clientRouter.navigate({ to: '/about' })
+    await Promise.resolve()
+  })
+  expect(clientRouter.state.location.pathname).toBe('/about')
+  expect(clientRouter.state.resolvedLocation).toBeUndefined()
+
+  await act(async () => {
+    chunk.resolve({ default: Footer })
+    await chunk
+  })
+
+  expect(hydrationMismatches(consoleError)).toEqual([])
+  expect(footerLink).toHaveAttribute('data-status', 'active')
+
+  await act(async () => {
+    aboutLoader.resolve()
+    await navigation
+  })
+  expect(container).toHaveTextContent('About')
+})

--- a/packages/router-core/src/load-client.ts
+++ b/packages/router-core/src/load-client.ts
@@ -2240,6 +2240,8 @@ export async function hydrate(router: AnyRouter): Promise<void> {
     router.updateLatestLocation()
     location = router.latestLocation
     router.stores.location.set(location)
+    // Deferred boundaries hydrate against this, not the live location.
+    router._hydrationLocation = location
     candidates = router.matchRoutes(location, {
       _controller: controller,
     })

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1149,6 +1149,12 @@ export class RouterCore<
   origin!: string
   latestLocation!: ParsedLocation<FullSearchSchema<TRouteTree>>
   _pendingLocation?: ParsedLocation<FullSearchSchema<TRouteTree>>
+  /**
+   * The location the server rendered with, captured by `hydrate`. Boundaries
+   * that hydrate after a navigation started still render against it, because
+   * `stores.location` already holds the destination while the loader runs.
+   */
+  _hydrationLocation?: ParsedLocation<FullSearchSchema<TRouteTree>>
   basepath!: string
   routeTree!: TRouteTree
   routesById!: RoutesById<TRouteTree>

--- a/packages/solid-router/src/link.tsx
+++ b/packages/solid-router/src/link.tsx
@@ -130,7 +130,13 @@ export function useLinkProps<
   ])
 
   const currentLocation = Solid.createMemo(
-    () => router.stores.location.get(),
+    () => {
+      const live = router.stores.location.get()
+      // A boundary that hydrates after a navigation started must still resolve
+      // against the location the server rendered with; `stores.location`
+      // already holds the destination while the loader is in flight.
+      return hasHydrated() ? live : (router._hydrationLocation ?? live)
+    },
     undefined,
     { equals: (prev, next) => prev.href === next.href },
   )

--- a/packages/solid-router/tests/issue-8233-link-hydration-active-state.test.tsx
+++ b/packages/solid-router/tests/issue-8233-link-hydration-active-state.test.tsx
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import * as Solid from 'solid-js'
+import { hydrate as solidHydrate } from 'solid-js/web'
+import { hydrate as hydrateRouter } from '@tanstack/router-core/ssr/client'
+import { dehydrateSsrMatchId } from '../../router-core/src/ssr/ssr-match-id'
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  useLinkProps,
+} from '../src'
+import type { AnyRouteMatch } from '@tanstack/router-core'
+import type { TsrSsrGlobal } from '@tanstack/router-core/ssr/client'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  window.$_TSR = undefined
+  delete (globalThis as any)._$HY
+  document.body.innerHTML = ''
+})
+
+function bootstrap(matches: Array<AnyRouteMatch>): void {
+  window.$_TSR = {
+    router: {
+      manifest: undefined,
+      matches: matches.map((match) => ({
+        i: dehydrateSsrMatchId(match.id),
+        s: 'success' as const,
+        ssr: true as const,
+        u: Date.now(),
+      })),
+    },
+    h: vi.fn(),
+    e: vi.fn(),
+    c: vi.fn(),
+    p: vi.fn(),
+    buffer: [],
+  } as unknown as TsrSsrGlobal
+}
+
+describe('issue #8233: link active state during hydration', () => {
+  test('resolves against the location the server rendered with', async () => {
+    // Solid runs a component body once, so this is the hydrating render.
+    let hydratingRender: {
+      hydrating: boolean
+      home: string | null
+      about: string | null
+    }
+    let read: () => { home: string | null; about: string | null }
+
+    function Links() {
+      const home = useLinkProps({ to: '/' }) as Record<string, string>
+      const about = useLinkProps({ to: '/about' }) as Record<string, string>
+      read = () => ({
+        home: home['data-status'] ?? null,
+        about: about['data-status'] ?? null,
+      })
+      hydratingRender = {
+        hydrating: Solid.sharedConfig.context !== undefined,
+        ...read(),
+      }
+      return null
+    }
+
+    const rootRoute = createRootRoute({ component: Outlet })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: Links,
+    })
+    const aboutRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/about',
+      component: () => null,
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, aboutRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+    bootstrap(router.matchRoutes(router.state.location))
+    await hydrateRouter(router)
+
+    // What `loadClientRoute` publishes synchronously when a shell link is
+    // clicked while this boundary has not hydrated yet.
+    const pending = router.buildLocation({ to: '/about' })
+    router.batch(() => {
+      router.stores.status.set('pending')
+      router.stores.location.set(pending as any)
+    })
+
+    // What `generateHydrationScript()` installs in a real app.
+    ;(globalThis as any)._$HY = {
+      events: [],
+      completed: new WeakSet(),
+      r: {},
+      fe() {},
+      done: false,
+    }
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    solidHydrate(() => <RouterProvider router={router} />, container)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // The hydrating render has to reproduce the server output: `/` was the
+    // rendered location, so the home link is active and the about link is not.
+    expect(hydratingRender!).toEqual({
+      hydrating: true,
+      home: 'active',
+      about: null,
+    })
+
+    // Once hydrated, the live (pending) location takes over.
+    expect(read!()).toEqual({ home: null, about: 'active' })
+  })
+})

--- a/packages/vue-router/src/link.tsx
+++ b/packages/vue-router/src/link.tsx
@@ -192,11 +192,28 @@ function useLinkPropsImpl(
     })
   }
 
+  // `vnode.el` is already assigned while an instance hydrates and is null for
+  // a fresh client mount, which is the distinction needed here: only a
+  // hydrating render has to reproduce the server output.
+  const hydrating = Vue.ref(Vue.getCurrentInstance()?.vnode.el != null)
+  Vue.onMounted(() => {
+    hydrating.value = false
+  })
+
+  // A boundary that hydrates after a navigation started must still resolve
+  // against the location the server rendered with; `stores.location` already
+  // holds the destination while the loader is in flight.
+  const renderLocation = Vue.computed(() =>
+    hydrating.value
+      ? (router._hydrationLocation ?? currentLocation.value)
+      : currentLocation.value,
+  )
+
   const next = Vue.computed(() => {
     // Rebuild when inherited search/hash or the current route context changes.
 
     const options = getOptions()
-    const opts = { _fromLocation: currentLocation.value, ...options }
+    const opts = { _fromLocation: renderLocation.value, ...options }
     return router.buildLocation(opts)
   })
 
@@ -233,7 +250,7 @@ function useLinkPropsImpl(
       return false
     }
     return getIsActive(
-      currentLocation.value,
+      renderLocation.value,
       next.value,
       options.activeOptions,
       router,

--- a/packages/vue-router/tests/issue-8233-link-hydration-active-state.test.tsx
+++ b/packages/vue-router/tests/issue-8233-link-hydration-active-state.test.tsx
@@ -1,0 +1,128 @@
+import * as Vue from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { hydrate as hydrateRouter } from '@tanstack/router-core/ssr/client'
+import {
+  Link,
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+import { dehydrateToBootstrap } from './ssr-test-utils'
+import type { TsrSsrGlobal } from '@tanstack/router-core/ssr/client'
+
+declare global {
+  interface Window {
+    $_TSR?: TsrSsrGlobal
+  }
+}
+
+const testCleanups: Array<() => void | Promise<void>> = []
+
+afterEach(async () => {
+  while (testCleanups.length) {
+    await testCleanups.pop()!()
+  }
+  vi.restoreAllMocks()
+  window.$_TSR = undefined
+  document.body.innerHTML = ''
+})
+
+function status(container: Element, testId: string) {
+  return (
+    container
+      .querySelector(`[data-testid="${testId}"]`)
+      ?.getAttribute('data-status') ?? null
+  )
+}
+
+describe('issue #8233: link active state during hydration', () => {
+  test('resolves against the location the server rendered with', async () => {
+    const makeRouteTree = () => {
+      const rootRoute = createRootRoute({ component: Outlet })
+      const indexRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/',
+        component: () => (
+          <p>
+            <Link to="/" data-testid="home">
+              Home
+            </Link>
+            <Link to="/about" data-testid="about">
+              About
+            </Link>
+          </p>
+        ),
+      })
+      const aboutRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/about',
+        component: () => <div>About</div>,
+      })
+      return rootRoute.addChildren([indexRoute, aboutRoute])
+    }
+
+    const serverRouter = createRouter({
+      routeTree: makeRouteTree(),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+    serverRouter.isServer = true
+    testCleanups.push(() => serverRouter.serverSsr?.cleanup())
+    window.$_TSR = await dehydrateToBootstrap(serverRouter)
+
+    const serverHtml = await renderToString(
+      Vue.createSSRApp(
+        Vue.defineComponent({
+          setup: () => () => <RouterProvider router={serverRouter} />,
+        }),
+      ),
+    )
+
+    const clientRouter = createRouter({
+      routeTree: makeRouteTree(),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+    await hydrateRouter(clientRouter)
+
+    // What `loadClientRoute` publishes synchronously when a shell link is
+    // clicked while this boundary has not hydrated yet.
+    const pending = clientRouter.buildLocation({ to: '/about' })
+    clientRouter.batch(() => {
+      clientRouter.stores.status.set('pending')
+      clientRouter.stores.location.set(pending as any)
+    })
+
+    const container = document.createElement('div')
+    container.innerHTML = serverHtml
+    document.body.appendChild(container)
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const clientApp = Vue.createSSRApp(
+      Vue.defineComponent({
+        setup: () => () => <RouterProvider router={clientRouter} />,
+      }),
+    )
+    clientApp.mount(container)
+    testCleanups.push(() => {
+      clientApp.unmount()
+      container.remove()
+    })
+
+    // The hydrating render has to reproduce the server output: `/` was the
+    // rendered location, so the home link is active and the about link is not.
+    expect(status(container, 'home')).toBe('active')
+    expect(status(container, 'about')).toBe(null)
+    expect(
+      [consoleError.mock.calls, consoleWarn.mock.calls].flat(2).join(' '),
+    ).not.toMatch(/hydration|mismatch/i)
+
+    // Once hydrated, the live (pending) location takes over.
+    await Vue.nextTick()
+    expect(status(container, 'home')).toBe(null)
+    expect(status(container, 'about')).toBe('active')
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Fixes [#8233.](https://github.com/TanStack/router/issues/8233)

`useLinkProps` derives its `href` and active state from `useStore(router.stores.location, …)`. `@tanstack/react-store` passes the same live `source.get()` as both `getSnapshot` and `getServerSnapshot`, so React reads the *current* location while a boundary is hydrating. A navigation that starts after the shell hydrates but before the route content does publishes its destination to `stores.location` synchronously (`loadClientRoute`), so every `<Link>` in the not-yet-hydrated content that points at the pending destination hydrates as active against HTML the server rendered as inactive.

- `router-core`: `hydrate()` records the location it claims the SSR payload with on `router._hydrationLocation` (internal field, no public API change).
- `react-router`: `selectLinkState` resolves against that location until `useHydrated()` flips, then re-derives against the live location. This also fixes `href` for relative links, which the server builds from the SSR location while the client was building it from the pending one.

Active state is deliberately not suppressed while hydrating: the server renders `data-status="active"` for the current page's links, so suppressing it would create the mismatch in the opposite direction. The tests assert both directions.

`resolvedLocation` is not a usable source here. It moves to the destination once the navigation commits, and it stays `undefined` until the initial client load commits when a route sets `ssr: false`. Both cases have a test that fails with `resolvedLocation` and passes with the captured hydration location.

### Behaviour

Unchanged when no navigation is in flight, because both locations are then equal, and unchanged in CSR, where `_hydrationLocation` is `undefined` and `useHydrated()` is already `true` on the first render. Applications that hydrate without calling `hydrate()` keep today's behaviour.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

- `pnpm nx run-many --target=test:unit --projects=@tanstack/react-router,@tanstack/router-core` — `router-core` 121 files / 1809 passed / 4 expected fail, `react-router` 90 files / 1126 passed / 1 skipped, no type errors
- `pnpm nx run-many --target=test:eslint --projects=@tanstack/react-router,@tanstack/router-core` — 0 errors (the pre-existing 26 and 100 warnings are unchanged)
- `pnpm nx run-many --target=test:types --projects=@tanstack/react-router,@tanstack/router-core` — passes on TS 5.6, 5.7, 5.8, 5.9, 6.0 and 7.0

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Fixed `<Link>` hydration so active states, URLs, `data-status`, `aria-current`, and active classes match the server-rendered location.
* Prevented hydration mismatches when navigation begins before content inside a Suspense boundary finishes hydrating.
* Links now transition to the current client location after hydration completes.
* Improved redirect and URL handling, including safer treatment of external, malformed, and potentially dangerous destinations.
* Prevented duplicate `beforeunload` prompts during document navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->