### PR TITLE
feat(start): add route sitemap metadata and streamed output

### DIFF
--- a/.changeset/open-taxes-thank.md
+++ b/.changeset/open-taxes-thank.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/start-client-core': minor
+'@tanstack/start-plugin-core': minor
+---
+
+Add route-level sitemap metadata and stream sitemap output while preserving page overrides and pages.json.

--- a/docs/start/framework/react/guide/static-prerendering.md
+++ b/docs/start/framework/react/guide/static-prerendering.md
@@ -141,7 +141,7 @@ export default defineConfig({
 
 <!-- ::end:tabs -->
 
-By default, Start builds route options used by `prerenderParams` separately from the final server bundle so they can be used at build time without being deployed. Set `prerender.separateRouteOptionsBundle` to `false` if your deployment adapter does not support the extra build environment or if you prefer to keep those route options in the server bundle.
+By default, Start builds route options used by `prerenderParams` and `sitemap` separately from the final server bundle so they can be used at build time without being deployed. Set `prerender.separateRouteOptionsBundle` to `false` if your deployment adapter does not support the extra build environment or if you prefer to keep those route options in the server bundle.
 
 ## Automatic Static Route Discovery
 
@@ -157,7 +157,7 @@ Note: Dynamic routes can still be prerendered if they are linked from other page
 
 ## Dynamic Route Prerendering
 
-Dynamic routes can declare `prerenderParams` to generate specific parameter values at build time. Each returned entry creates one page from the route path and can override prerender options for that page.
+Dynamic routes can declare `prerenderParams` to generate specific parameter values at build time. Each returned entry creates one page from the route path and can override sitemap or prerender options for that page.
 
 ```tsx
 // src/routes/posts/$postId.tsx
@@ -167,6 +167,7 @@ export const Route = createFileRoute('/posts/$postId')({
   validateSearch: (search: Record<string, unknown>): { ref?: string } => ({
     ...(typeof search.ref === 'string' ? { ref: search.ref } : {}),
   }),
+  sitemap: { changefreq: 'weekly' },
   prerender: { retryCount: 2, crawlLinks: false },
   prerenderParams: async () => {
     const posts = await fetchPosts()
@@ -174,6 +175,7 @@ export const Route = createFileRoute('/posts/$postId')({
     return posts.map((post) => ({
       params: { postId: post.id },
       search: { ref: 'sitemap' },
+      sitemap: { lastmod: post.updatedAt, priority: 0.8 },
       prerender: { retryCount: 3 },
     }))
   },
@@ -193,7 +195,9 @@ Route-level `prerender` options provide defaults for entries returned by that ro
 
 Callbacks may return an array, a synchronous iterable, or an asynchronous iterable, directly or through a promise. Iterables are consumed as pages are queued, so an async generator can discover pages incrementally. Use the supplied `signal` to cancel pending data requests when discovery stops.
 
-Code that is only referenced by `prerenderParams` is removed from the client route bundle, so these options can import server-only data sources used to discover pages at build time.
+Code that is only referenced by `prerenderParams` or `sitemap` is removed from the client route bundle, so these options can import server-only data sources used to discover pages at build time.
+
+Route-level `sitemap` metadata provides defaults for generated pages. Each entry's `sitemap` options override those defaults, and explicit plugin `pages` options take precedence over both. Static pages also receive defaults from their matching route. Use `sitemap.exclude: true` to generate HTML without adding the page to the sitemap. The route option does not enable sitemap output; configure the top-level `sitemap` option in your Start plugin.
 
 ## Crawling Links
 

--- a/docs/start/framework/solid/guide/static-prerendering.md
+++ b/docs/start/framework/solid/guide/static-prerendering.md
@@ -145,7 +145,7 @@ export default defineConfig({
 
 <!-- ::end:tabs -->
 
-By default, Start builds route options used by `prerenderParams` separately from the final server bundle so they can be used at build time without being deployed. Set `prerender.separateRouteOptionsBundle` to `false` if your deployment adapter does not support the extra build environment or if you prefer to keep those route options in the server bundle.
+By default, Start builds route options used by `prerenderParams` and `sitemap` separately from the final server bundle so they can be used at build time without being deployed. Set `prerender.separateRouteOptionsBundle` to `false` if your deployment adapter does not support the extra build environment or if you prefer to keep those route options in the server bundle.
 
 ## Automatic Static Route Discovery
 
@@ -161,7 +161,7 @@ Note: Dynamic routes can still be prerendered if they are linked from other page
 
 ## Dynamic Route Prerendering
 
-Dynamic routes can declare `prerenderParams` to generate specific parameter values at build time. Each returned entry creates one page from the route path and can override prerender options for that page.
+Dynamic routes can declare `prerenderParams` to generate specific parameter values at build time. Each returned entry creates one page from the route path and can override sitemap or prerender options for that page.
 
 ```tsx
 // src/routes/posts/$postId.tsx
@@ -171,6 +171,7 @@ export const Route = createFileRoute('/posts/$postId')({
   validateSearch: (search: Record<string, unknown>): { ref?: string } => ({
     ...(typeof search.ref === 'string' ? { ref: search.ref } : {}),
   }),
+  sitemap: { changefreq: 'weekly' },
   prerender: { retryCount: 2, crawlLinks: false },
   prerenderParams: async () => {
     const posts = await fetchPosts()
@@ -178,6 +179,7 @@ export const Route = createFileRoute('/posts/$postId')({
     return posts.map((post) => ({
       params: { postId: post.id },
       search: { ref: 'sitemap' },
+      sitemap: { lastmod: post.updatedAt, priority: 0.8 },
       prerender: { retryCount: 3 },
     }))
   },
@@ -197,7 +199,9 @@ Route-level `prerender` options provide defaults for entries returned by that ro
 
 Callbacks may return an array, a synchronous iterable, or an asynchronous iterable, directly or through a promise. Iterables are consumed as pages are queued, so an async generator can discover pages incrementally. Use the supplied `signal` to cancel pending data requests when discovery stops.
 
-Code that is only referenced by `prerenderParams` is removed from the client route bundle, so these options can import server-only data sources used to discover pages at build time.
+Code that is only referenced by `prerenderParams` or `sitemap` is removed from the client route bundle, so these options can import server-only data sources used to discover pages at build time.
+
+Route-level `sitemap` metadata provides defaults for generated pages. Each entry's `sitemap` options override those defaults, and explicit plugin `pages` options take precedence over both. Static pages also receive defaults from their matching route. Use `sitemap.exclude: true` to generate HTML without adding the page to the sitemap. The route option does not enable sitemap output; configure the top-level `sitemap` option in your Start plugin.
 
 ## Crawling Links
 

--- a/e2e/react-start/basic/src/routes/prerender-params.$slug.tsx
+++ b/e2e/react-start/basic/src/routes/prerender-params.$slug.tsx
@@ -26,34 +26,65 @@ export const Route = createFileRoute('/prerender-params/$slug')({
     page: z.number().optional(),
     tag: z.string().optional(),
   }),
+  sitemap: {
+    changefreq: 'weekly',
+  },
   *prerenderParams() {
     yield {
       params: { slug: 'hello-world' },
+      sitemap: {
+        lastmod: '2026-05-05',
+        priority: 0.8,
+      },
     }
     yield {
       params: { slug: '대한민국' },
+      sitemap: {
+        priority: 0.6,
+      },
     }
     yield {
       params: { slug: 'reserved?hash#plus+' },
+      sitemap: {
+        exclude: true,
+      },
     }
     yield {
       params: { slug: 'with-query' },
       search: { page: 2, tag: 'router start' },
+      sitemap: {
+        priority: 0.4,
+      },
     }
     yield {
       params: { slug: getServerOnlyPrerenderSlug() },
+      sitemap: {
+        exclude: true,
+      },
     }
     yield {
       params: { slug: topLevelPrerenderLiteral },
+      sitemap: {
+        exclude: true,
+      },
     }
     yield {
       params: { slug: topLevelPrerenderImportedMarker },
+      sitemap: {
+        exclude: true,
+      },
     }
     yield {
       params: { slug: topLevelPrerenderImportedCall },
+      sitemap: {
+        exclude: true,
+      },
     }
     yield {
       params: { slug: topLevelPrerenderSideEffect },
+      sitemap: {
+        exclude: true,
+      },
     }
   },
   component: RouteComponent,

--- a/e2e/react-start/basic/tests/prerendering.spec.ts
+++ b/e2e/react-start/basic/tests/prerendering.spec.ts
@@ -195,5 +195,30 @@ test.describe('Prerender Static Path Discovery', () => {
         expect(outputContainsMarker(serverDistDir, marker)).toBe(false)
       }
     })
+
+    test('should include route sitemap options from prerenderParams', () => {
+      const sitemapPath = join(distDir, 'sitemap.xml')
+
+      expect(existsSync(sitemapPath)).toBe(true)
+
+      const sitemap = readFileSync(sitemapPath, 'utf-8')
+      expect(sitemap).toContain(
+        '<loc>https://example.com/prerender-params/hello-world</loc>',
+      )
+      expect(sitemap).toContain('<lastmod>2026-05-05</lastmod>')
+      expect(sitemap).toContain('<priority>0.8</priority>')
+      expect(sitemap).toContain('<changefreq>weekly</changefreq>')
+      expect(sitemap).toContain(
+        '<loc>https://example.com/prerender-params/대한민국</loc>',
+      )
+      expect(sitemap).toContain('<priority>0.6</priority>')
+      expect(sitemap).toContain(
+        '<loc>https://example.com/prerender-params/with-query?page=2&amp;tag=router+start</loc>',
+      )
+      expect(sitemap).toContain('<priority>0.4</priority>')
+      expect(sitemap).not.toContain(
+        '<loc>https://example.com/prerender-params/server-only-slug</loc>',
+      )
+    })
   })
 })

--- a/e2e/solid-start/basic/src/routes/prerender-params.$slug.tsx
+++ b/e2e/solid-start/basic/src/routes/prerender-params.$slug.tsx
@@ -7,22 +7,41 @@ export const Route = createFileRoute('/prerender-params/$slug')({
     page: z.number().optional(),
     tag: z.string().optional(),
   }),
+  sitemap: {
+    changefreq: 'weekly',
+  },
   *prerenderParams() {
     yield {
       params: { slug: 'hello-world' },
+      sitemap: {
+        lastmod: '2026-05-05',
+        priority: 0.8,
+      },
     }
     yield {
       params: { slug: '대한민국' },
+      sitemap: {
+        priority: 0.6,
+      },
     }
     yield {
       params: { slug: 'reserved?hash#plus+' },
+      sitemap: {
+        exclude: true,
+      },
     }
     yield {
       params: { slug: 'with-query' },
       search: { page: 2, tag: 'router start' },
+      sitemap: {
+        priority: 0.4,
+      },
     }
     yield {
       params: { slug: getServerOnlyPrerenderSlug() },
+      sitemap: {
+        exclude: true,
+      },
     }
   },
   component: RouteComponent,

--- a/e2e/solid-start/basic/tests/prerendering.spec.ts
+++ b/e2e/solid-start/basic/tests/prerendering.spec.ts
@@ -140,5 +140,30 @@ test.describe('Prerender Static Path Discovery', () => {
         }),
       ).toBe(false)
     })
+
+    test('should include route sitemap options from prerenderParams', () => {
+      const sitemapPath = join(distDir, 'sitemap.xml')
+
+      expect(existsSync(sitemapPath)).toBe(true)
+
+      const sitemap = readFileSync(sitemapPath, 'utf-8')
+      expect(sitemap).toContain(
+        '<loc>https://example.com/prerender-params/hello-world</loc>',
+      )
+      expect(sitemap).toContain('<lastmod>2026-05-05</lastmod>')
+      expect(sitemap).toContain('<priority>0.8</priority>')
+      expect(sitemap).toContain('<changefreq>weekly</changefreq>')
+      expect(sitemap).toContain(
+        '<loc>https://example.com/prerender-params/대한민국</loc>',
+      )
+      expect(sitemap).toContain('<priority>0.6</priority>')
+      expect(sitemap).toContain(
+        '<loc>https://example.com/prerender-params/with-query?page=2&amp;tag=router+start</loc>',
+      )
+      expect(sitemap).toContain('<priority>0.4</priority>')
+      expect(sitemap).not.toContain(
+        '<loc>https://example.com/prerender-params/server-only-slug</loc>',
+      )
+    })
   })
 })

--- a/e2e/vue-start/basic/src/routes/prerender-params.$slug.tsx
+++ b/e2e/vue-start/basic/src/routes/prerender-params.$slug.tsx
@@ -7,22 +7,41 @@ export const Route = createFileRoute('/prerender-params/$slug')({
     page: z.number().optional(),
     tag: z.string().optional(),
   }),
+  sitemap: {
+    changefreq: 'weekly',
+  },
   *prerenderParams() {
     yield {
       params: { slug: 'hello-world' },
+      sitemap: {
+        lastmod: '2026-05-05',
+        priority: 0.8,
+      },
     }
     yield {
       params: { slug: '대한민국' },
+      sitemap: {
+        priority: 0.6,
+      },
     }
     yield {
       params: { slug: 'reserved?hash#plus+' },
+      sitemap: {
+        exclude: true,
+      },
     }
     yield {
       params: { slug: 'with-query' },
       search: { page: 2, tag: 'router start' },
+      sitemap: {
+        priority: 0.4,
+      },
     }
     yield {
       params: { slug: getServerOnlyPrerenderSlug() },
+      sitemap: {
+        exclude: true,
+      },
     }
   },
   component: RouteComponent,

--- a/e2e/vue-start/basic/tests/prerendering.spec.ts
+++ b/e2e/vue-start/basic/tests/prerendering.spec.ts
@@ -140,5 +140,30 @@ test.describe('Prerender Static Path Discovery', () => {
         }),
       ).toBe(false)
     })
+
+    test('should include route sitemap options from prerenderParams', () => {
+      const sitemapPath = join(distDir, 'sitemap.xml')
+
+      expect(existsSync(sitemapPath)).toBe(true)
+
+      const sitemap = readFileSync(sitemapPath, 'utf-8')
+      expect(sitemap).toContain(
+        '<loc>https://example.com/prerender-params/hello-world</loc>',
+      )
+      expect(sitemap).toContain('<lastmod>2026-05-05</lastmod>')
+      expect(sitemap).toContain('<priority>0.8</priority>')
+      expect(sitemap).toContain('<changefreq>weekly</changefreq>')
+      expect(sitemap).toContain(
+        '<loc>https://example.com/prerender-params/대한민국</loc>',
+      )
+      expect(sitemap).toContain('<priority>0.6</priority>')
+      expect(sitemap).toContain(
+        '<loc>https://example.com/prerender-params/with-query?page=2&amp;tag=router+start</loc>',
+      )
+      expect(sitemap).toContain('<priority>0.4</priority>')
+      expect(sitemap).not.toContain(
+        '<loc>https://example.com/prerender-params/server-only-slug</loc>',
+      )
+    })
   })
 })

--- a/packages/start-client-core/src/prerenderParams.ts
+++ b/packages/start-client-core/src/prerenderParams.ts
@@ -37,6 +37,7 @@ declare module '@tanstack/router-core' {
         >
       >
     >
+    sitemap?: RouteSitemapOptions
   }
   /* eslint-enable unused-imports/no-unused-vars */
 }
@@ -59,8 +60,40 @@ type PrerenderParamsSearch<TSearch> = unknown extends TSearch
 
 export type PrerenderParamsEntry<TParams, TSearch = {}> = {
   params: TParams
+  sitemap?: RouteSitemapOptions
   prerender?: RoutePrerenderOptions
 } & PrerenderParamsSearch<TSearch>
+
+export interface RouteSitemapOptions {
+  exclude?: boolean
+  priority?: number
+  changefreq?:
+    | 'always'
+    | 'hourly'
+    | 'daily'
+    | 'weekly'
+    | 'monthly'
+    | 'yearly'
+    | 'never'
+  lastmod?: string | Date
+  alternateRefs?: Array<{
+    href: string
+    hreflang: string
+  }>
+  images?: Array<{
+    loc: string
+    caption?: string
+    title?: string
+  }>
+  news?: {
+    publication: {
+      name: string
+      language: string
+    }
+    publicationDate: string | Date
+    title: string
+  }
+}
 
 export interface RoutePrerenderOptions {
   enabled?: boolean
@@ -74,6 +107,7 @@ export interface RoutePrerenderOptions {
   onSuccess?: (opts: {
     page: {
       path: string
+      sitemap?: RouteSitemapOptions
       fromCrawl?: boolean
     }
     html: string

--- a/packages/start-client-core/src/tests/prerenderParams.test-d.ts
+++ b/packages/start-client-core/src/tests/prerenderParams.test-d.ts
@@ -1,5 +1,9 @@
 import { expectTypeOf, test } from 'vitest'
-import type {} from '../prerenderParams'
+import type {
+  PrerenderParamsEntry,
+  RoutePrerenderOptions,
+  RouteSitemapOptions,
+} from '../prerenderParams'
 import type { AnyRoute, FileBaseRouteOptions } from '@tanstack/router-core'
 
 type ParentRoute = Omit<AnyRoute, 'types'> & {
@@ -9,6 +13,46 @@ type ParentRoute = Omit<AnyRoute, 'types'> & {
     }
   }
 }
+
+test('sitemap metadata is available on entries and onSuccess pages', () => {
+  const sitemap = {
+    priority: 0,
+    exclude: false,
+    lastmod: new Date(),
+    alternateRefs: [{ href: 'https://example.com/fr', hreflang: 'fr' }],
+    images: [
+      {
+        loc: 'https://example.com/image.png',
+        title: 'Image',
+        caption: 'Caption',
+      },
+    ],
+    news: {
+      publication: { name: 'News', language: 'en' },
+      publicationDate: new Date(),
+      title: 'Title',
+    },
+  } satisfies RouteSitemapOptions
+  const entry = {
+    params: { slug: 'post' },
+    sitemap,
+  } satisfies PrerenderParamsEntry<{ slug: string }>
+  expectTypeOf(entry.sitemap.lastmod).toEqualTypeOf<Date>()
+  const options = {
+    onSuccess: ({ page }) => {
+      expectTypeOf(page.sitemap).toEqualTypeOf<
+        RouteSitemapOptions | undefined
+      >()
+    },
+  } satisfies RoutePrerenderOptions
+  expectTypeOf(options.onSuccess).toBeFunction()
+
+  const invalid = {
+    // @ts-expect-error changefreq must be a sitemap frequency
+    changefreq: 'sometimes',
+  } satisfies RouteSitemapOptions
+  expectTypeOf(invalid.changefreq).toEqualTypeOf<'sometimes'>()
+})
 
 test('prerenderParams uses route path and all params', () => {
   const options = {
@@ -26,6 +70,10 @@ test('prerenderParams uses route path and all params', () => {
         },
       ]
     },
+    sitemap: {
+      priority: 0.7,
+      changefreq: 'weekly',
+    },
   } satisfies FileBaseRouteOptions<
     unknown,
     ParentRoute,
@@ -34,6 +82,8 @@ test('prerenderParams uses route path and all params', () => {
     undefined,
     { slug: string }
   >
+
+  expectTypeOf(options.sitemap.changefreq).toEqualTypeOf<'weekly'>()
 
   type Entry = Awaited<
     ReturnType<NonNullable<typeof options.prerenderParams>>

--- a/packages/start-plugin-core/src/build-sitemap.ts
+++ b/packages/start-plugin-core/src/build-sitemap.ts
@@ -1,9 +1,9 @@
-import { writeFileSync } from 'node:fs'
+import { mkdir, open } from 'node:fs/promises'
 import path from 'node:path'
 import { create } from 'xmlbuilder2'
 import { createLogger } from './utils'
-import type { TanStackStartOutputConfig } from './schema'
-import type { XMLBuilder } from 'xmlbuilder2/lib/interfaces'
+import type { Page, TanStackStartOutputConfig } from './schema'
+import type { FileHandle } from 'node:fs/promises'
 
 export type SitemapUrl = {
   loc: string
@@ -40,89 +40,74 @@ export type SitemapData = {
   urls: Array<SitemapUrl>
 }
 
-function buildSitemapJson(
-  pages: TanStackStartOutputConfig['pages'],
-  host: string,
-): SitemapData {
-  const slash = checkSlash(host)
+function pageToXml(input: Page, host: string): string {
+  const item: SitemapUrl = {
+    ...input.sitemap,
+    loc: `${host}${host.endsWith('/') ? '' : '/'}${input.path.replace(/^\/+/g, '')}`,
+    lastmod: new Date(input.sitemap?.lastmod ?? Date.now())
+      .toISOString()
+      .split('T')[0]!,
+  }
+  const sitemap = create().ele('urlset', namespaces)
+  const page = sitemap.ele('url')
+  page.ele('loc').txt(item.loc)
+  page.ele('lastmod').txt(item.lastmod)
 
-  const urls: Array<SitemapUrl> = pages
-    .filter((page) => {
-      return page.sitemap?.exclude !== true
-    })
-    .map((page) => ({
-      loc: `${host}${slash}${page.path.replace(/^\/+/g, '')}`,
-      lastmod: page.sitemap?.lastmod
-        ? new Date(page.sitemap.lastmod).toISOString().split('T')[0]!
-        : new Date().toISOString().split('T')[0]!,
-      priority: page.sitemap?.priority,
-      changefreq: page.sitemap?.changefreq,
-      alternateRefs: page.sitemap?.alternateRefs,
-      images: page.sitemap?.images,
-      news: page.sitemap?.news,
-    }))
+  if (item.priority !== undefined) {
+    page.ele('priority').txt(item.priority.toString())
+  }
+  if (item.changefreq) {
+    page.ele('changefreq').txt(item.changefreq)
+  }
 
-  return { urls }
-}
-
-function jsonToXml(sitemapData: SitemapData): string {
-  const sitemap = createXml('urlset')
-
-  for (const item of sitemapData.urls) {
-    const page = sitemap.ele('url')
-    page.ele('loc').txt(item.loc)
-    page.ele('lastmod').txt(item.lastmod)
-
-    if (item.priority !== undefined) {
-      page.ele('priority').txt(item.priority.toString())
-    }
-    if (item.changefreq) {
-      page.ele('changefreq').txt(item.changefreq)
-    }
-
-    // Add alternate references
-    if (item.alternateRefs?.length) {
-      for (const ref of item.alternateRefs) {
-        const alternateRef = page.ele('xhtml:link')
-        alternateRef.att('rel', 'alternate')
-        alternateRef.att('href', ref.href)
-        if (ref.hreflang) {
-          alternateRef.att('hreflang', ref.hreflang)
-        }
+  // Add alternate references
+  if (item.alternateRefs?.length) {
+    for (const ref of item.alternateRefs) {
+      const alternateRef = page.ele('xhtml:link')
+      alternateRef.att('rel', 'alternate')
+      alternateRef.att('href', ref.href)
+      if (ref.hreflang) {
+        alternateRef.att('hreflang', ref.hreflang)
       }
-    }
-
-    // Add images
-    if (item.images?.length) {
-      for (const image of item.images) {
-        const imageElement = page.ele('image:image')
-        imageElement.ele('image:loc').txt(image.loc)
-        if (image.title) {
-          imageElement.ele('image:title').txt(image.title)
-        }
-        if (image.caption) {
-          imageElement.ele('image:caption').txt(image.caption)
-        }
-      }
-    }
-
-    // Add news
-    if (item.news) {
-      const newsElement = page.ele('news:news')
-      const publication = newsElement.ele('news:publication')
-      publication.ele('news:name').txt(item.news.publication.name)
-      publication.ele('news:language').txt(item.news.publication.language)
-      newsElement
-        .ele('news:publication_date')
-        .txt(new Date(item.news.publicationDate).toISOString().split('T')[0]!)
-      newsElement.ele('news:title').txt(item.news.title)
     }
   }
 
-  return sitemap.end({ prettyPrint: true })
+  // Add images
+  if (item.images?.length) {
+    for (const image of item.images) {
+      const imageElement = page.ele('image:image')
+      imageElement.ele('image:loc').txt(image.loc)
+      if (image.title) {
+        imageElement.ele('image:title').txt(image.title)
+      }
+      if (image.caption) {
+        imageElement.ele('image:caption').txt(image.caption)
+      }
+    }
+  }
+
+  // Add news
+  if (item.news) {
+    const newsElement = page.ele('news:news')
+    const publication = newsElement.ele('news:publication')
+    publication.ele('news:name').txt(item.news.publication.name)
+    publication.ele('news:language').txt(item.news.publication.language)
+    newsElement
+      .ele('news:publication_date')
+      .txt(new Date(item.news.publicationDate).toISOString().split('T')[0]!)
+    newsElement.ele('news:title').txt(item.news.title)
+  }
+  return page.toString({ prettyPrint: true })
 }
 
-export function buildSitemap({
+const namespaces = {
+  xmlns: 'http://www.sitemaps.org/schemas/sitemap/0.9',
+  'xmlns:xhtml': 'http://www.w3.org/1999/xhtml',
+  'xmlns:image': 'http://www.google.com/schemas/sitemap-image/1.1',
+  'xmlns:news': 'http://www.google.com/schemas/sitemap-news/0.9',
+}
+
+export function createSitemapWriter({
   startConfig,
   publicDir,
 }: {
@@ -130,85 +115,122 @@ export function buildSitemap({
   publicDir: string
 }) {
   const logger = createLogger('sitemap')
-
-  let sitemapOptions = startConfig.sitemap
-
-  if (!sitemapOptions && startConfig.pages.length) {
-    sitemapOptions = { enabled: true, outputPath: 'sitemap.xml' }
-  }
-
-  if (!sitemapOptions?.enabled) {
+  const { sitemap } = startConfig
+  if (!sitemap?.enabled) {
     throw new Error('Sitemap is not enabled')
   }
-
-  const { host, outputPath } = sitemapOptions
-
+  const { host, outputPath } = sitemap
   if (!host) {
-    if (!startConfig.sitemap) {
-      logger.info(
-        'Hint: Pages found, but no sitemap host has been set. To enable sitemap generation, set the `sitemap.host` option.',
-      )
-      return
-    }
     throw new Error(
       'Sitemap host is not set and required to build the sitemap.',
     )
   }
-
   if (!outputPath) {
     throw new Error('Sitemap output path is not set')
   }
+  const sitemapHost = host
 
-  const { pages } = startConfig
-
-  if (!pages.length) {
-    logger.info('No pages were found to build the sitemap. Skipping...')
-    return
-  }
-
-  logger.info('Building Sitemap...')
-
-  // Build the sitemap data
-  const sitemapData = buildSitemapJson(pages, host)
-
-  // Generate output paths
   const xmlOutputPath = path.join(publicDir, outputPath)
   const pagesOutputPath = path.join(publicDir, 'pages.json')
+  let xmlFile: FileHandle | undefined
+  let pagesFile: FileHandle | undefined
+  let queue = Promise.resolve()
+  let closing: Promise<void> | undefined
+  let hasPages = false
 
-  try {
-    // Write XML sitemap
-    logger.info(`Writing sitemap XML at ${xmlOutputPath}`)
-    writeFileSync(xmlOutputPath, jsonToXml(sitemapData))
+  function write(page: Page): Promise<void> {
+    const pending = closing
+      ? Promise.reject(new Error('Sitemap writer is closed'))
+      : queue.then(async () => {
+          const json = JSON.stringify(page)
+          const xml =
+            page.sitemap?.exclude === true ? '' : pageToXml(page, sitemapHost)
+          if (!hasPages) {
+            await mkdir(path.dirname(xmlOutputPath), { recursive: true })
+            await mkdir(publicDir, { recursive: true })
+            xmlFile = await open(xmlOutputPath, 'w')
+            pagesFile = await open(pagesOutputPath, 'w')
+            const root = create({ version: '1.0', encoding: 'UTF-8' })
+              .ele('urlset', namespaces)
+              .com('This file was automatically generated by TanStack Start.')
+              .end({ prettyPrint: true })
+            await xmlFile.writeFile(root.replace('</urlset>', ''), 'utf8')
+            await pagesFile.writeFile('{"pages":[\n', 'utf8')
+          }
+          if (xml) {
+            await xmlFile!.writeFile(`${xml}\n`, 'utf8')
+          }
+          await pagesFile!.writeFile(`${hasPages ? ',\n' : ''}${json}`, 'utf8')
+          hasPages = true
+        })
+    // Requests can run concurrently; observe failures immediately while keeping
+    // the rejected queue available to subsequent writes and close().
+    void pending.catch(() => {})
+    if (!closing) {
+      queue = pending
+    }
+    return pending
+  }
 
-    // Write pages data for runtime use
-    logger.info(`Writing pages data at ${pagesOutputPath}`)
-    writeFileSync(
-      pagesOutputPath,
-      JSON.stringify(
-        {
-          pages,
-          host,
-          lastBuilt: new Date().toISOString(),
-        },
-        null,
-        2,
-      ),
-    )
-  } catch (e) {
-    logger.error(`Unable to write sitemap files`, e)
+  function close(): Promise<void> {
+    if (closing) {
+      return closing
+    }
+    closing = (async () => {
+      try {
+        await queue
+        if (hasPages) {
+          await xmlFile!.writeFile('</urlset>\n', 'utf8')
+          await pagesFile!.writeFile(
+            `\n],"host":${JSON.stringify(host)},"lastBuilt":${JSON.stringify(new Date().toISOString())}}\n`,
+            'utf8',
+          )
+          logger.info(`Wrote sitemap XML at ${xmlOutputPath}`)
+        } else {
+          logger.info('No pages were found to build the sitemap. Skipping...')
+        }
+      } finally {
+        await closeFiles()
+      }
+    })()
+    void closing.catch(() => {})
+    return closing
+  }
+
+  return { write, close }
+
+  async function closeFiles() {
+    const results = await Promise.allSettled([
+      xmlFile?.close(),
+      pagesFile?.close(),
+    ])
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        throw result.reason
+      }
+    }
   }
 }
 
-function createXml(elementName: 'urlset' | 'sitemapindex'): XMLBuilder {
-  return create({ version: '1.0', encoding: 'UTF-8' })
-    .ele(elementName, {
-      xmlns: 'https://www.sitemaps.org/schemas/sitemap/0.9',
-      'xmlns:xhtml': 'http://www.w3.org/1999/xhtml',
-    })
-    .com(`This file was automatically generated by TanStack Start.`)
-}
-
-function checkSlash(host: string): string {
-  const finalChar = host.slice(-1)
-  return finalChar === '/' ? '' : '/'
+export async function buildSitemap({
+  startConfig,
+  publicDir,
+}: {
+  startConfig: TanStackStartOutputConfig
+  publicDir: string
+}) {
+  if (!startConfig.sitemap && startConfig.pages.length) {
+    createLogger('sitemap').info(
+      'Hint: Pages found, but no sitemap host has been set. To enable sitemap generation, set the `sitemap.host` option.',
+    )
+    return
+  }
+  const writer = createSitemapWriter({ startConfig, publicDir })
+  try {
+    for (const page of startConfig.pages) {
+      await writer.write(page)
+    }
+  } finally {
+    await writer.close()
+  }
 }

--- a/packages/start-plugin-core/src/post-build.ts
+++ b/packages/start-plugin-core/src/post-build.ts
@@ -1,6 +1,6 @@
 import { HEADERS } from '@tanstack/start-server-core/constants'
-import { buildSitemap } from './build-sitemap'
-import type { Page, TanStackStartOutputConfig } from './schema'
+import { createSitemapWriter } from './build-sitemap'
+import type { TanStackStartOutputConfig } from './schema'
 import type { PrerenderPageSink } from './prerender'
 
 export interface StartPostBuildAdapter {
@@ -66,23 +66,21 @@ export async function postBuild({
     })
   }
 
-  if (startConfig.prerender.enabled) {
-    const pages: Array<Page> = []
-    await adapter.prerender(
-      { ...startConfig },
-      {
-        pageSink: (page) => {
-          pages.push(page)
-        },
-      },
-    )
-    startConfig.pages = pages
-  }
-
-  if (startConfig.sitemap?.enabled) {
-    await buildSitemap({
-      startConfig,
-      publicDir: adapter.getClientOutputDirectory(),
-    })
+  const sitemap = startConfig.sitemap?.enabled
+    ? createSitemapWriter({
+        startConfig,
+        publicDir: adapter.getClientOutputDirectory(),
+      })
+    : undefined
+  try {
+    if (startConfig.prerender.enabled) {
+      await adapter.prerender({ ...startConfig }, { pageSink: sitemap?.write })
+    } else if (sitemap) {
+      for (const page of startConfig.pages) {
+        await sitemap.write(page)
+      }
+    }
+  } finally {
+    await sitemap?.close()
   }
 }

--- a/packages/start-plugin-core/src/prerender-params-runner.ts
+++ b/packages/start-plugin-core/src/prerender-params-runner.ts
@@ -1,7 +1,10 @@
 import { defaultStringifySearch, interpolatePath } from '@tanstack/router-core'
 import { collectPrerenderRouteOptions } from './prerender-route-options'
 import type { Page } from './schema'
-import type { RoutePrerenderOptions } from '@tanstack/start-client-core'
+import type {
+  RoutePrerenderOptions,
+  RouteSitemapOptions,
+} from '@tanstack/start-client-core'
 import type { AnyRoute } from '@tanstack/router-core'
 
 interface PrerenderParamsLogger {
@@ -11,6 +14,7 @@ interface PrerenderParamsLogger {
 interface PrerenderParamsEntry {
   params: Record<string, unknown>
   search?: Record<string, unknown>
+  sitemap?: RouteSitemapOptions
   prerender?: RoutePrerenderOptions
 }
 
@@ -33,7 +37,7 @@ export async function runPrerenderParams({
   signal,
   onPage,
 }: RunPrerenderParamsOptions): Promise<void> {
-  const { routeOptions, dynamicRoutes } =
+  const { routeOptions, dynamicRoutes, sitemapRoutes } =
     collectPrerenderRouteOptions(routeTree)
 
   // Explicit pages may receive route-level defaults and gap-fills from
@@ -42,6 +46,22 @@ export async function runPrerenderParams({
   const explicitByPath = new Map<string, Page>()
   for (const page of pages) {
     explicitByPath.set(page.path, page)
+  }
+
+  for (const route of sitemapRoutes) {
+    if (isDynamicPath(route.path)) {
+      continue
+    }
+    const page = explicitByPath.get(route.path)
+    if (page) {
+      explicitByPath.set(route.path, {
+        ...page,
+        sitemap: mergeOptions(
+          routeOptions.get(route.routePath)?.sitemap,
+          page.sitemap,
+        ),
+      })
+    }
   }
 
   const seen = new Set<string>(explicitByPath.keys())
@@ -131,7 +151,8 @@ export async function runPrerenderParams({
             )
           }
 
-          const { params, search, prerender } = entry as PrerenderParamsEntry
+          const { params, search, prerender, sitemap } =
+            entry as PrerenderParamsEntry
 
           const { interpolatedPath, isMissingParams, usedParams } =
             interpolatePath({ path: route.path, params })
@@ -151,6 +172,7 @@ export async function runPrerenderParams({
             path:
               interpolatedPath + (search ? defaultStringifySearch(search) : ''),
             prerender: mergeOptions(options.prerender, prerender),
+            sitemap: mergeOptions(options.sitemap, sitemap),
           }
 
           if (filter && !filter(page)) {
@@ -235,10 +257,11 @@ function merge(base: Page, override: Partial<Page>): Page {
     ...base,
     ...override,
     prerender: mergeOptions(base.prerender, override.prerender),
+    sitemap: mergeOptions(base.sitemap, override.sitemap),
   }
 }
 
-function mergeOptions<T extends RoutePrerenderOptions>(
+function mergeOptions<T extends RoutePrerenderOptions | RouteSitemapOptions>(
   base: T | undefined,
   override: T | undefined,
 ) {

--- a/packages/start-plugin-core/src/prerender-route-options.ts
+++ b/packages/start-plugin-core/src/prerender-route-options.ts
@@ -3,6 +3,7 @@ import type {
   PrerenderParamsEntry,
   PrerenderParamsResult,
   RoutePrerenderOptions,
+  RouteSitemapOptions,
 } from '@tanstack/start-client-core'
 
 export interface PrerenderRouteMetadata {
@@ -20,22 +21,25 @@ export interface PrerenderRouteOptions {
         PrerenderParamsResult<PrerenderParamsEntry<Record<string, unknown>>>
       >
   prerender?: RoutePrerenderOptions
+  sitemap?: RouteSitemapOptions
 }
 
 export function collectPrerenderRouteOptions(routeTree: AnyRoute | undefined): {
   routeOptions: Map<string, PrerenderRouteOptions>
   dynamicRoutes: Array<PrerenderRouteMetadata>
+  sitemapRoutes: Array<PrerenderRouteMetadata>
 } {
   const routeOptions = new Map<string, PrerenderRouteOptions>()
   const dynamicRoutes: Array<PrerenderRouteMetadata> = []
+  const sitemapRoutes: Array<PrerenderRouteMetadata> = []
 
   if (!routeTree) {
-    return { routeOptions, dynamicRoutes }
+    return { routeOptions, dynamicRoutes, sitemapRoutes }
   }
 
   visit(routeTree)
 
-  return { routeOptions, dynamicRoutes }
+  return { routeOptions, dynamicRoutes, sitemapRoutes }
 
   function visit(route: AnyRoute) {
     const options = route.options as PrerenderRouteOptions & {
@@ -53,9 +57,17 @@ export function collectPrerenderRouteOptions(routeTree: AnyRoute | undefined): {
 
       if (options.prerenderParams) {
         dynamicRoutes.push(metadata)
+      }
+
+      if (options.sitemap) {
+        sitemapRoutes.push(metadata)
+      }
+
+      if (options.prerenderParams || options.sitemap) {
         routeOptions.set(routePath, {
           prerenderParams: options.prerenderParams,
           prerender: options.prerender,
+          sitemap: options.sitemap,
         })
       }
     }

--- a/packages/start-plugin-core/src/start-router-plugin/constants.ts
+++ b/packages/start-plugin-core/src/start-router-plugin/constants.ts
@@ -5,6 +5,11 @@ export const CLIENT_ROUTE_OPTION_DELETE_NODES = [
   'headers',
   'prerenderParams',
   'prerender',
+  'sitemap',
 ]
 
-export const SERVER_ROUTE_OPTION_DELETE_NODES = ['prerenderParams', 'prerender']
+export const SERVER_ROUTE_OPTION_DELETE_NODES = [
+  'prerenderParams',
+  'prerender',
+  'sitemap',
+]

--- a/packages/start-plugin-core/tests/build-sitemap.test.ts
+++ b/packages/start-plugin-core/tests/build-sitemap.test.ts
@@ -1,0 +1,213 @@
+import * as fs from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { create } from 'xmlbuilder2'
+import { buildSitemap, createSitemapWriter } from '../src/build-sitemap'
+import type { Page, TanStackStartOutputConfig } from '../src/schema'
+
+vi.mock('node:fs/promises', async (importOriginal) => ({
+  ...(await importOriginal<typeof fs>()),
+}))
+
+describe('streaming sitemap output', () => {
+  let publicDir: string
+
+  beforeEach(async () => {
+    publicDir = await fs.mkdtemp(join(tmpdir(), 'tss-sitemap-'))
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await fs.rm(publicDir, { recursive: true, force: true })
+  })
+
+  function config(pages: Array<Page> = []): TanStackStartOutputConfig {
+    return {
+      pages,
+      sitemap: {
+        enabled: true,
+        host: 'https://example.com',
+        outputPath: 'nested/maps/sitemap.xml',
+      },
+    } as TanStackStartOutputConfig
+  }
+
+  it('escapes and preserves metadata, priority zero, namespaces, and page order', async () => {
+    const pages: Array<Page> = [
+      {
+        path: '/news?q=one&tag=two',
+        sitemap: {
+          priority: 0,
+          changefreq: 'weekly',
+          lastmod: new Date('2026-05-05T12:00:00Z'),
+          alternateRefs: [
+            { href: 'https://example.com/fr?q=1&x="2"', hreflang: 'fr' },
+          ],
+          images: [
+            {
+              loc: 'https://example.com/image?a=1&b=2',
+              title: 'A < B',
+              caption: '"Quoted" & more',
+            },
+          ],
+          news: {
+            publication: { name: 'News & Stories', language: 'en' },
+            publicationDate: '2026-05-04',
+            title: 'A < B & C',
+          },
+        },
+      },
+      { path: '/second', sitemap: { priority: 0.8 } },
+      {
+        path: '/excluded',
+        sitemap: { exclude: true },
+        prerender: { enabled: false },
+      },
+    ]
+    const writer = createSitemapWriter({ startConfig: config(), publicDir })
+    try {
+      await Promise.all(pages.map(writer.write))
+    } finally {
+      await writer.close()
+    }
+
+    const xml = await fs.readFile(
+      join(publicDir, 'nested/maps/sitemap.xml'),
+      'utf8',
+    )
+    const root = create(xml).root().node as unknown as Element
+    expect(root.namespaceURI).toBe(
+      'http://www.sitemaps.org/schemas/sitemap/0.9',
+    )
+    expect(root.getAttribute('xmlns:image')).toBe(
+      'http://www.google.com/schemas/sitemap-image/1.1',
+    )
+    expect(root.getAttribute('xmlns:news')).toBe(
+      'http://www.google.com/schemas/sitemap-news/0.9',
+    )
+    expect(root.getAttribute('xmlns:xhtml')).toBe(
+      'http://www.w3.org/1999/xhtml',
+    )
+    const urls = root.getElementsByTagName('url')
+    expect(urls.length).toBe(2)
+    const text = (name: string) =>
+      urls[0]!.getElementsByTagName(name)[0]!.textContent
+    expect({
+      loc: text('loc'),
+      lastmod: text('lastmod'),
+      priority: text('priority'),
+      changefreq: text('changefreq'),
+      imageLoc: text('image:loc'),
+      imageTitle: text('image:title'),
+      imageCaption: text('image:caption'),
+      publicationName: text('news:name'),
+      publicationLanguage: text('news:language'),
+      publicationDate: text('news:publication_date'),
+      newsTitle: text('news:title'),
+    }).toEqual({
+      loc: 'https://example.com/news?q=one&tag=two',
+      lastmod: '2026-05-05',
+      priority: '0',
+      changefreq: 'weekly',
+      imageLoc: 'https://example.com/image?a=1&b=2',
+      imageTitle: 'A < B',
+      imageCaption: '"Quoted" & more',
+      publicationName: 'News & Stories',
+      publicationLanguage: 'en',
+      publicationDate: '2026-05-04',
+      newsTitle: 'A < B & C',
+    })
+    const alternate = urls[0]!.getElementsByTagName('xhtml:link')[0]!
+    expect(alternate.getAttribute('href')).toBe(
+      'https://example.com/fr?q=1&x="2"',
+    )
+    expect(alternate.getAttribute('hreflang')).toBe('fr')
+    expect(alternate.getAttribute('rel')).toBe('alternate')
+    expect(urls[1]!.getElementsByTagName('loc')[0]!.textContent).toBe(
+      'https://example.com/second',
+    )
+    const json = JSON.parse(
+      await fs.readFile(join(publicDir, 'pages.json'), 'utf8'),
+    )
+    expect(json.pages).toEqual(JSON.parse(JSON.stringify(pages)))
+    expect(json.host).toBe('https://example.com')
+    expect(Number.isNaN(Date.parse(json.lastBuilt))).toBe(false)
+  })
+
+  it('closes once after queued writes and rejects late writes', async () => {
+    const writer = createSitemapWriter({ startConfig: config(), publicDir })
+    const written = writer.write({ path: '/first' })
+    const closed = writer.close()
+    expect(writer.close()).toBe(closed)
+    await expect(writer.write({ path: '/late' })).rejects.toThrow('closed')
+    await written
+    await closed
+    await writer.close()
+    const json = JSON.parse(
+      await fs.readFile(join(publicDir, 'pages.json'), 'utf8'),
+    )
+    expect(json.pages).toEqual([{ path: '/first' }])
+  })
+
+  it('rejects initialization failure and closes a file opened before that failure', async () => {
+    await fs.mkdir(join(publicDir, 'pages.json'))
+    const open = fs.open
+    const closes: Array<ReturnType<typeof vi.spyOn>> = []
+    vi.spyOn(fs, 'open').mockImplementation(async (...args) => {
+      const handle = await open(...args)
+      closes.push(vi.spyOn(handle, 'close'))
+      return handle
+    })
+    const writer = createSitemapWriter({ startConfig: config(), publicDir })
+    await expect(writer.write({ path: '/first' })).rejects.toThrow()
+    await expect(writer.close()).rejects.toThrow()
+    expect(closes).toHaveLength(1)
+    expect(closes[0]).toHaveBeenCalledOnce()
+    await expect(writer.close()).rejects.toThrow()
+    expect(closes[0]).toHaveBeenCalledOnce()
+  })
+
+  it('propagates write failure through buildSitemap and closes both outputs', async () => {
+    const open = fs.open
+    const closes: Array<ReturnType<typeof vi.spyOn>> = []
+    vi.spyOn(fs, 'open').mockImplementation(async (...args) => {
+      const handle = await open(...args)
+      closes.push(vi.spyOn(handle, 'close'))
+      vi.spyOn(handle, 'writeFile').mockRejectedValue(new Error('disk full'))
+      return handle
+    })
+    await expect(
+      buildSitemap({ startConfig: config([{ path: '/first' }]), publicDir }),
+    ).rejects.toThrow('disk full')
+    expect(closes).toHaveLength(2)
+    for (const close of closes) {
+      expect(close).toHaveBeenCalledOnce()
+    }
+  })
+
+  it('observes serialization rejection even before close is awaited', async () => {
+    const writer = createSitemapWriter({ startConfig: config(), publicDir })
+    writer.write({ path: '/invalid', sitemap: { lastmod: 'invalid date' } })
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    await expect(writer.close()).rejects.toThrow('Invalid time value')
+    await expect(fs.access(join(publicDir, 'pages.json'))).rejects.toThrow()
+  })
+
+  it('creates no output for an empty sitemap and retains disabled wrapper validation', async () => {
+    await buildSitemap({ startConfig: config(), publicDir })
+    await expect(fs.access(join(publicDir, 'pages.json'))).rejects.toThrow()
+    await expect(
+      buildSitemap({
+        startConfig: {
+          ...config(),
+          sitemap: { ...config().sitemap!, enabled: false },
+        },
+        publicDir,
+      }),
+    ).rejects.toThrow('not enabled')
+    await expect(
+      fs.access(join(publicDir, 'nested/maps/sitemap.xml')),
+    ).rejects.toThrow()
+  })
+})

--- a/packages/start-plugin-core/tests/post-build.test.ts
+++ b/packages/start-plugin-core/tests/post-build.test.ts
@@ -1,0 +1,225 @@
+import { access, mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { create } from 'xmlbuilder2'
+import { postBuild } from '../src/post-build'
+import { prerender } from '../src/prerender'
+import type { StartPostBuildAdapter } from '../src/post-build'
+import type { TanStackStartOutputConfig } from '../src/schema'
+
+describe('postBuild sitemap output', () => {
+  let publicDir: string
+
+  beforeEach(async () => {
+    publicDir = await mkdtemp(join(tmpdir(), 'tss-post-build-'))
+    delete globalThis.TSS_PRERENDABLE_PATHS
+    globalThis.TSS_PRERENDER_ROUTE_TREE = async () => undefined
+  })
+
+  afterEach(async () => {
+    delete globalThis.TSS_PRERENDER_ROUTE_TREE
+    delete globalThis.TSS_PRERENDABLE_PATHS
+    await rm(publicDir, { recursive: true, force: true })
+  })
+
+  function config(): TanStackStartOutputConfig {
+    return {
+      router: { basepath: '' },
+      spa: { enabled: false, prerender: { outputPath: '/_shell' } },
+      prerender: {
+        enabled: true,
+        autoStaticPathsDiscovery: false,
+        concurrency: 1,
+        crawlLinks: false,
+        retryCount: 0,
+        failOnError: false,
+      },
+      sitemap: {
+        enabled: true,
+        host: 'https://example.com',
+        outputPath: 'sitemap.xml',
+      },
+      pages: [],
+    } as unknown as TanStackStartOutputConfig
+  }
+
+  it('streams successful and disabled pages, excluding filtered and failed pages', async () => {
+    const startConfig = config()
+    startConfig.pages = [
+      {
+        path: '/success',
+        prerender: {
+          onSuccess: () => ({
+            sitemap: { priority: 0, lastmod: '2026-05-05' },
+          }),
+        },
+      },
+      {
+        path: '/disabled',
+        prerender: { enabled: false },
+        sitemap: { changefreq: 'weekly' },
+      },
+      { path: '/filtered' },
+      { path: '/excluded', sitemap: { exclude: true } },
+      { path: '/failed' },
+    ]
+    startConfig.prerender!.filter = (page) => page.path !== '/filtered'
+    const request = vi.fn(
+      async (url: string) =>
+        new Response('<html>rendered</html>', {
+          status: url === '/failed/' ? 500 : 200,
+          headers: { 'content-type': 'text/html' },
+        }),
+    )
+    const close = vi.fn(async () => {})
+    const adapter: StartPostBuildAdapter = {
+      getClientOutputDirectory: () => publicDir,
+      prerender: (options, sinks) =>
+        prerender({
+          startConfig: options,
+          pageSink: sinks?.pageSink,
+          handler: {
+            getClientOutputDirectory: () => publicDir,
+            request,
+            close,
+          },
+        }),
+    }
+    await postBuild({ startConfig, adapter })
+
+    expect(request.mock.calls.map(([url]) => url)).toEqual([
+      '/success/',
+      '/excluded/',
+      '/failed/',
+    ])
+    expect(close).toHaveBeenCalledOnce()
+    const xml = create(
+      await readFile(join(publicDir, 'sitemap.xml'), 'utf8'),
+    ).end({ format: 'object' }) as any
+    expect(xml.urlset.url.map((url: any) => url.loc)).toEqual([
+      'https://example.com/success',
+      'https://example.com/disabled',
+    ])
+    expect(xml.urlset.url[0]).toMatchObject({
+      priority: '0',
+      lastmod: '2026-05-05',
+    })
+    expect(xml.urlset.url[1].changefreq).toBe('weekly')
+    const json = JSON.parse(
+      await readFile(join(publicDir, 'pages.json'), 'utf8'),
+    )
+    expect(json.pages.map((page: any) => page.path)).toEqual([
+      '/success',
+      '/disabled',
+      '/excluded',
+    ])
+    expect(json.pages[0].sitemap).toEqual({
+      priority: 0,
+      lastmod: '2026-05-05',
+    })
+    expect(json.pages[1]).toMatchObject({
+      prerender: { enabled: false },
+      sitemap: { changefreq: 'weekly' },
+    })
+    expect(json.pages[2].sitemap).toEqual({ exclude: true })
+    await expect(
+      access(join(publicDir, 'success/index.html')),
+    ).resolves.toBeUndefined()
+    await expect(
+      access(join(publicDir, 'excluded/index.html')),
+    ).resolves.toBeUndefined()
+    await expect(
+      access(join(publicDir, 'disabled/index.html')),
+    ).rejects.toThrow()
+    await expect(access(join(publicDir, 'failed/index.html'))).rejects.toThrow()
+  })
+
+  it('awaits explicit page writes when prerendering is disabled', async () => {
+    const startConfig = config()
+    startConfig.prerender!.enabled = false
+    startConfig.pages = [
+      { path: '/second' },
+      { path: '/first', sitemap: { priority: 0 } },
+    ]
+    const render = vi.fn()
+    await postBuild({
+      startConfig,
+      adapter: { getClientOutputDirectory: () => publicDir, prerender: render },
+    })
+    expect(render).not.toHaveBeenCalled()
+    const json = JSON.parse(
+      await readFile(join(publicDir, 'pages.json'), 'utf8'),
+    )
+    expect(json.pages).toEqual(startConfig.pages)
+  })
+
+  it('creates no sitemap files when disabled while still prerendering', async () => {
+    const startConfig = config()
+    startConfig.sitemap!.enabled = false
+    startConfig.pages = [{ path: '/success' }]
+    const outputDirectory = vi.fn(() => publicDir)
+    await postBuild({
+      startConfig,
+      adapter: {
+        getClientOutputDirectory: outputDirectory,
+        prerender: (options, sinks) =>
+          prerender({
+            startConfig: options,
+            pageSink: sinks?.pageSink,
+            handler: {
+              getClientOutputDirectory: () => publicDir,
+              request: async () =>
+                new Response('<html>rendered</html>', {
+                  headers: { 'content-type': 'text/html' },
+                }),
+            },
+          }),
+      },
+    })
+    expect(outputDirectory).not.toHaveBeenCalled()
+    await expect(
+      access(join(publicDir, 'success/index.html')),
+    ).resolves.toBeUndefined()
+    await expect(access(join(publicDir, 'sitemap.xml'))).rejects.toThrow()
+    await expect(access(join(publicDir, 'pages.json'))).rejects.toThrow()
+  })
+
+  it('closes output after a fatal prerender error', async () => {
+    const startConfig = config()
+    startConfig.pages = [{ path: '/success' }, { path: '/failed' }]
+    startConfig.prerender!.failOnError = true
+    const close = vi.fn(async () => {})
+    await expect(
+      postBuild({
+        startConfig,
+        adapter: {
+          getClientOutputDirectory: () => publicDir,
+          prerender: (options, sinks) =>
+            prerender({
+              startConfig: options,
+              pageSink: sinks?.pageSink,
+              handler: {
+                getClientOutputDirectory: () => publicDir,
+                request: async (url) =>
+                  new Response('<html>rendered</html>', {
+                    status: url === '/failed/' ? 500 : 200,
+                    headers: { 'content-type': 'text/html' },
+                  }),
+                close,
+              },
+            }),
+        },
+      }),
+    ).rejects.toThrow('Failed to fetch')
+    expect(close).toHaveBeenCalledOnce()
+    const xml = create(
+      await readFile(join(publicDir, 'sitemap.xml'), 'utf8'),
+    ).end({ format: 'object' }) as any
+    expect(xml.urlset.url.loc).toBe('https://example.com/success')
+    const json = JSON.parse(
+      await readFile(join(publicDir, 'pages.json'), 'utf8'),
+    )
+    expect(json.pages.map((page: any) => page.path)).toEqual(['/success'])
+  })
+})

--- a/packages/start-plugin-core/tests/prerender-params-runner.test.ts
+++ b/packages/start-plugin-core/tests/prerender-params-runner.test.ts
@@ -24,6 +24,105 @@ function createRouteTree(optionsById: Record<string, any>) {
 }
 
 describe('collectPrerenderParams', () => {
+  it('uses static route sitemap defaults without overwriting explicit false or zero', async () => {
+    const routeTree = createRouteTree({
+      '/about': {
+        sitemap: { priority: 0.8, exclude: true, changefreq: 'weekly' },
+      },
+    })
+    const pages = await collectPrerenderParams({
+      routeTree,
+      pages: [{ path: '/about', sitemap: { priority: 0, exclude: false } }],
+      logger,
+    })
+    expect(pages).toEqual([
+      {
+        path: '/about',
+        sitemap: { priority: 0, exclude: false, changefreq: 'weekly' },
+      },
+    ])
+  })
+
+  it('merges route, generated-entry, and explicit sitemap metadata in precedence order', async () => {
+    const images = [
+      { loc: 'https://example.com/image.png', title: 'Image & caption' },
+    ]
+    const routeTree = createRouteTree({
+      '/posts/$slug': {
+        sitemap: { priority: 0.8, exclude: true, changefreq: 'weekly', images },
+        prerenderParams: () => [
+          {
+            params: { slug: 'generated' },
+            sitemap: { priority: 0, exclude: false, lastmod: '2026-05-05' },
+          },
+          {
+            params: { slug: 'explicit' },
+            sitemap: { priority: 0.4, exclude: true, lastmod: '2026-05-05' },
+          },
+        ],
+      },
+    })
+    const pages = await collectPrerenderParams({
+      routeTree,
+      pages: [
+        {
+          path: '/posts/explicit',
+          sitemap: { priority: 0, exclude: false, lastmod: '2026-05-06' },
+        },
+      ],
+      logger,
+    })
+    expect(pages).toEqual([
+      {
+        path: '/posts/generated',
+        prerender: undefined,
+        sitemap: {
+          priority: 0,
+          exclude: false,
+          lastmod: '2026-05-05',
+          changefreq: 'weekly',
+          images,
+        },
+      },
+      {
+        path: '/posts/explicit',
+        prerender: undefined,
+        sitemap: {
+          priority: 0,
+          exclude: false,
+          lastmod: '2026-05-06',
+          changefreq: 'weekly',
+          images,
+        },
+      },
+    ])
+  })
+
+  it('makes generated sitemap metadata available to the page filter', async () => {
+    const routeTree = createRouteTree({
+      '/posts/$slug': {
+        sitemap: { changefreq: 'daily' },
+        prerenderParams: () => [
+          { params: { slug: 'keep' }, sitemap: { priority: 0.5 } },
+          { params: { slug: 'drop' }, sitemap: { priority: 0 } },
+        ],
+      },
+    })
+    const pages = await collectPrerenderParams({
+      routeTree,
+      pages: [],
+      logger,
+      filter: (page) => page.sitemap?.priority !== 0,
+    })
+    expect(pages).toEqual([
+      {
+        path: '/posts/keep',
+        prerender: undefined,
+        sitemap: { changefreq: 'daily', priority: 0.5 },
+      },
+    ])
+  })
+
   it('expands dynamic route params into pages', async () => {
     const routeTree = createRouteTree({
       '/posts/$slug': {

--- a/packages/start-plugin-core/tests/start-router-plugin-constants.test.ts
+++ b/packages/start-plugin-core/tests/start-router-plugin-constants.test.ts
@@ -12,6 +12,7 @@ describe('client route option stripping', () => {
       'headers',
       'prerenderParams',
       'prerender',
+      'sitemap',
     ])
   })
 
@@ -19,6 +20,7 @@ describe('client route option stripping', () => {
     expect(SERVER_ROUTE_OPTION_DELETE_NODES).toEqual([
       'prerenderParams',
       'prerender',
+      'sitemap',
     ])
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Add route-level and per-entry sitemap metadata, with streamed sitemap and `pages.json` output.

Built on #8293. Split from #7346, based on @nikuscs's work.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).
