### PR TITLE
perf(router,start): update Seroval to 1.6.7

### DIFF
--- a/.changeset/neat-corners-work.md
+++ b/.changeset/neat-corners-work.md
@@ -1,0 +1,9 @@
+---
+'@tanstack/router-core': patch
+'@tanstack/start-client-core': patch
+'@tanstack/start-server-core': patch
+'@tanstack/start-plugin-core': patch
+'@tanstack/start-static-server-functions': patch
+---
+
+Update Seroval to 1.6.6 for faster string and binary serialization.

--- a/.changeset/neat-corners-work.md
+++ b/.changeset/neat-corners-work.md
@@ -6,4 +6,4 @@
 '@tanstack/start-static-server-functions': patch
 ---
 
-Update Seroval to 1.6.6 for faster string and binary serialization.
+Update Seroval to 1.6.7 for faster string and binary serialization.

--- a/benchmarks/ssr/package.json
+++ b/benchmarks/ssr/package.json
@@ -19,7 +19,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "@vitejs/plugin-vue-jsx": "^5.1.5",
     "@types/react": "catalog:",
-    "seroval": "^1.6.6",
+    "seroval": "^1.6.7",
     "@typescript/native": "npm:typescript@^7.0.2",
     "jsdom": "29.1.1",
     "typescript": "npm:@typescript/typescript6@^6.0.2",

--- a/benchmarks/ssr/package.json
+++ b/benchmarks/ssr/package.json
@@ -19,7 +19,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "@vitejs/plugin-vue-jsx": "^5.1.5",
     "@types/react": "catalog:",
-    "seroval": "^1.6.2",
+    "seroval": "^1.6.6",
     "@typescript/native": "npm:typescript@^7.0.2",
     "jsdom": "29.1.1",
     "typescript": "npm:@typescript/typescript6@^6.0.2",

--- a/packages/router-core/package.json
+++ b/packages/router-core/package.json
@@ -184,7 +184,7 @@
   "dependencies": {
     "@tanstack/history": "workspace:*",
     "cookie-es": "^3.0.0",
-    "seroval": "^1.6.6",
+    "seroval": "^1.6.7",
     "seroval-plugins": "^1.6.2"
   },
   "devDependencies": {

--- a/packages/router-core/package.json
+++ b/packages/router-core/package.json
@@ -184,7 +184,7 @@
   "dependencies": {
     "@tanstack/history": "workspace:*",
     "cookie-es": "^3.0.0",
-    "seroval": "^1.6.2",
+    "seroval": "^1.6.6",
     "seroval-plugins": "^1.6.2"
   },
   "devDependencies": {

--- a/packages/start-client-core/package.json
+++ b/packages/start-client-core/package.json
@@ -109,7 +109,7 @@
     "@tanstack/router-core": "workspace:*",
     "@tanstack/start-fn-stubs": "workspace:*",
     "@tanstack/start-storage-context": "workspace:*",
-    "seroval": "^1.6.2"
+    "seroval": "^1.6.6"
   },
   "devDependencies": {
     "vite": "*",

--- a/packages/start-client-core/package.json
+++ b/packages/start-client-core/package.json
@@ -109,7 +109,7 @@
     "@tanstack/router-core": "workspace:*",
     "@tanstack/start-fn-stubs": "workspace:*",
     "@tanstack/start-storage-context": "workspace:*",
-    "seroval": "^1.6.6"
+    "seroval": "^1.6.7"
   },
   "devDependencies": {
     "vite": "*",

--- a/packages/start-plugin-core/package.json
+++ b/packages/start-plugin-core/package.json
@@ -98,7 +98,7 @@
     "lightningcss": "^1.33.0",
     "pathe": "catalog:",
     "picomatch": "^4.0.7",
-    "seroval": "^1.6.6",
+    "seroval": "^1.6.7",
     "source-map": "^0.7.6",
     "srvx": "^0.11.22",
     "tinyglobby": "catalog:",

--- a/packages/start-plugin-core/package.json
+++ b/packages/start-plugin-core/package.json
@@ -98,7 +98,7 @@
     "lightningcss": "^1.33.0",
     "pathe": "catalog:",
     "picomatch": "^4.0.7",
-    "seroval": "^1.6.2",
+    "seroval": "^1.6.6",
     "source-map": "^0.7.6",
     "srvx": "^0.11.22",
     "tinyglobby": "catalog:",

--- a/packages/start-server-core/package.json
+++ b/packages/start-server-core/package.json
@@ -105,7 +105,7 @@
     "@tanstack/start-storage-context": "workspace:*",
     "fetchdts": "^0.1.6",
     "h3-v2": "npm:h3@2.0.1-rc.20",
-    "seroval": "^1.6.6"
+    "seroval": "^1.6.7"
   },
   "devDependencies": {
     "@standard-schema/spec": "^1.0.0",

--- a/packages/start-server-core/package.json
+++ b/packages/start-server-core/package.json
@@ -105,7 +105,7 @@
     "@tanstack/start-storage-context": "workspace:*",
     "fetchdts": "^0.1.6",
     "h3-v2": "npm:h3@2.0.1-rc.20",
-    "seroval": "^1.6.2"
+    "seroval": "^1.6.6"
   },
   "devDependencies": {
     "@standard-schema/spec": "^1.0.0",

--- a/packages/start-static-server-functions/package.json
+++ b/packages/start-static-server-functions/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@tanstack/start-client-core": "workspace:*",
-    "seroval": "^1.6.6"
+    "seroval": "^1.6.7"
   },
   "devDependencies": {
     "vite": "*",

--- a/packages/start-static-server-functions/package.json
+++ b/packages/start-static-server-functions/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@tanstack/start-client-core": "workspace:*",
-    "seroval": "^1.6.2"
+    "seroval": "^1.6.6"
   },
   "devDependencies": {
     "vite": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -556,8 +556,8 @@ importers:
         specifier: 29.1.1
         version: 29.1.1(@noble/hashes@2.0.1)
       seroval:
-        specifier: ^1.6.2
-        version: 1.6.2
+        specifier: ^1.6.6
+        version: 1.6.6
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -14196,11 +14196,11 @@ importers:
         specifier: ^3.0.0
         version: 3.1.1
       seroval:
-        specifier: ^1.6.2
-        version: 1.6.2
+        specifier: ^1.6.6
+        version: 1.6.6
       seroval-plugins:
         specifier: ^1.6.2
-        version: 1.6.2(seroval@1.6.2)
+        version: 1.6.2(seroval@1.6.6)
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
@@ -14893,8 +14893,8 @@ importers:
         specifier: workspace:*
         version: link:../start-storage-context
       seroval:
-        specifier: ^1.6.2
-        version: 1.6.2
+        specifier: ^1.6.6
+        version: 1.6.6
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
@@ -14984,8 +14984,8 @@ importers:
         specifier: ^4.0.7
         version: 4.0.7
       seroval:
-        specifier: ^1.6.2
-        version: 1.6.2
+        specifier: ^1.6.6
+        version: 1.6.6
       source-map:
         specifier: ^0.7.6
         version: 0.7.6
@@ -15063,8 +15063,8 @@ importers:
         specifier: npm:h3@2.0.1-rc.20
         version: h3@2.0.1-rc.20(crossws@0.4.12(srvx@0.11.22))
       seroval:
-        specifier: ^1.6.2
-        version: 1.6.2
+        specifier: ^1.6.6
+        version: 1.6.6
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
@@ -15109,8 +15109,8 @@ importers:
         specifier: workspace:*
         version: link:../start-client-core
       seroval:
-        specifier: ^1.6.2
-        version: 1.6.2
+        specifier: ^1.6.6
+        version: 1.6.6
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
@@ -27534,8 +27534,8 @@ packages:
     resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
     engines: {node: '>=10'}
 
-  seroval@1.6.2:
-    resolution: {integrity: sha512-mPT+SD2TrlB6wvte1KkYOYUkubaTbd6pZ/6Kk3C9nxzrHmCZyhxOO7XGAeL7f+yLKZglzGtM9odUVvg/EhO+vQ==}
+  seroval@1.6.6:
+    resolution: {integrity: sha512-brjHfhA6vDMEAqfpJ8aCudGCQDFYdaQocpNOs59XSt1l2ulz2Cz+OB+jVPHn1mgx/tYo/6x3YZ7+yOtBzTsKYQ==}
     engines: {node: '>=10'}
 
   serve-index@1.9.1:
@@ -42732,13 +42732,13 @@ snapshots:
     dependencies:
       seroval: 1.5.4
 
-  seroval-plugins@1.6.2(seroval@1.6.2):
+  seroval-plugins@1.6.2(seroval@1.6.6):
     dependencies:
-      seroval: 1.6.2
+      seroval: 1.6.6
 
   seroval@1.5.4: {}
 
-  seroval@1.6.2: {}
+  seroval@1.6.6: {}
 
   serve-index@1.9.1(supports-color@10.2.2):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -556,8 +556,8 @@ importers:
         specifier: 29.1.1
         version: 29.1.1(@noble/hashes@2.0.1)
       seroval:
-        specifier: ^1.6.6
-        version: 1.6.6
+        specifier: ^1.6.7
+        version: 1.6.7
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -14196,11 +14196,11 @@ importers:
         specifier: ^3.0.0
         version: 3.1.1
       seroval:
-        specifier: ^1.6.6
-        version: 1.6.6
+        specifier: ^1.6.7
+        version: 1.6.7
       seroval-plugins:
         specifier: ^1.6.2
-        version: 1.6.2(seroval@1.6.6)
+        version: 1.6.2(seroval@1.6.7)
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
@@ -14893,8 +14893,8 @@ importers:
         specifier: workspace:*
         version: link:../start-storage-context
       seroval:
-        specifier: ^1.6.6
-        version: 1.6.6
+        specifier: ^1.6.7
+        version: 1.6.7
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
@@ -14984,8 +14984,8 @@ importers:
         specifier: ^4.0.7
         version: 4.0.7
       seroval:
-        specifier: ^1.6.6
-        version: 1.6.6
+        specifier: ^1.6.7
+        version: 1.6.7
       source-map:
         specifier: ^0.7.6
         version: 0.7.6
@@ -15063,8 +15063,8 @@ importers:
         specifier: npm:h3@2.0.1-rc.20
         version: h3@2.0.1-rc.20(crossws@0.4.12(srvx@0.11.22))
       seroval:
-        specifier: ^1.6.6
-        version: 1.6.6
+        specifier: ^1.6.7
+        version: 1.6.7
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
@@ -15109,8 +15109,8 @@ importers:
         specifier: workspace:*
         version: link:../start-client-core
       seroval:
-        specifier: ^1.6.6
-        version: 1.6.6
+        specifier: ^1.6.7
+        version: 1.6.7
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
@@ -27534,8 +27534,8 @@ packages:
     resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
     engines: {node: '>=10'}
 
-  seroval@1.6.6:
-    resolution: {integrity: sha512-brjHfhA6vDMEAqfpJ8aCudGCQDFYdaQocpNOs59XSt1l2ulz2Cz+OB+jVPHn1mgx/tYo/6x3YZ7+yOtBzTsKYQ==}
+  seroval@1.6.7:
+    resolution: {integrity: sha512-AeDcLh0yO2SFm9W71essgnSzLV9DI8ZH0x0knXn2DMnUZj728mpLbxjlbB6IqKCmqh8JA3cEqRyGoNkt584JcQ==}
     engines: {node: '>=10'}
 
   serve-index@1.9.1:
@@ -42732,13 +42732,13 @@ snapshots:
     dependencies:
       seroval: 1.5.4
 
-  seroval-plugins@1.6.2(seroval@1.6.6):
+  seroval-plugins@1.6.2(seroval@1.6.7):
     dependencies:
-      seroval: 1.6.6
+      seroval: 1.6.7
 
   seroval@1.5.4: {}
 
-  seroval@1.6.6: {}
+  seroval@1.6.7: {}
 
   serve-index@1.9.1(supports-color@10.2.2):
     dependencies:


### PR DESCRIPTION
Update Router and Start to Seroval 1.6.7 for faster string and binary serialization. Update the SSR benchmark dependency to the same version.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated serialization support to Seroval 1.6.7.
  * Improved handling of string and binary data across Router and Start applications.
* **Release**
  * Published a patch release covering the affected Router and Start packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->