### PR TITLE
feat(router-core): add loadModule option for lazy chunks

### DIFF
--- a/.changeset/load-module-option.md
+++ b/.changeset/load-module-option.md
@@ -1,0 +1,8 @@
+---
+'@tanstack/router-core': minor
+'@tanstack/react-router': minor
+'@tanstack/solid-router': minor
+'@tanstack/vue-router': minor
+---
+
+Add a `loadModule` router option so bundlers can intercept lazy chunk `import()` calls (for example to attach custom headers).

--- a/docs/router/api/router/RouterOptionsType.md
+++ b/docs/router/api/router/RouterOptionsType.md
@@ -75,10 +75,16 @@ const router = createRouter({
     if (!response.ok) {
       throw new TypeError(`Failed to fetch dynamically imported module: ${url}`)
     }
-    return import(/* @vite-ignore */ url)
+    const source = await response.text()
+    const objectUrl = URL.createObjectURL(
+      new Blob([source], { type: 'text/javascript' }),
+    )
+    return import(/* @vite-ignore */ objectUrl)
   },
 })
 ```
+
+`import(url)` after `fetch(url)` would be a second request and would not send those headers. Evaluating `response` through an object URL loads that file as a single module; relative imports inside the chunk resolve against the blob URL, not the original module graph.
 
 ### `defaultPreloadDelay` property
 

--- a/docs/router/api/router/RouterOptionsType.md
+++ b/docs/router/api/router/RouterOptionsType.md
@@ -54,6 +54,32 @@ The `RouterOptions` type accepts an object with the following properties and met
 - If `'viewport'`, routes will be preloaded by default when they are within the viewport of the browser.
 - If `'render'`, routes will be preloaded by default as soon as they are rendered in the DOM.
 
+### `loadModule` method
+
+- Type: `(url: string) => Promise<unknown>`
+- Optional
+- Defaults to native `import()`
+- Called to load a lazy route chunk by URL. Bundlers can rewrite dynamic `import()` calls to this function (or to `globalThis.__TANSTACK_ROUTER_LOAD_MODULE__`) so applications can intercept chunk requests — for example to attach custom headers or credentials.
+- `getLoadModule`, `setLoadModule`, and `defaultLoadModule` are also exported from `@tanstack/router-core` (and the framework router packages) for use outside `createRouter`.
+
+```tsx
+import { createRouter } from '@tanstack/react-router'
+
+const router = createRouter({
+  routeTree,
+  loadModule: async (url) => {
+    const response = await fetch(url, {
+      credentials: 'same-origin',
+      headers: { Authorization: 'Bearer token' },
+    })
+    if (!response.ok) {
+      throw new TypeError(`Failed to fetch dynamically imported module: ${url}`)
+    }
+    return import(/* @vite-ignore */ url)
+  },
+})
+```
+
 ### `defaultPreloadDelay` property
 
 - Type: `number`

--- a/packages/react-router/src/index.tsx
+++ b/packages/react-router/src/index.tsx
@@ -24,6 +24,9 @@ export {
   retainSearchParams,
   stripSearchParams,
   createSerializationAdapter,
+  defaultLoadModule,
+  getLoadModule,
+  setLoadModule,
 } from '@tanstack/router-core'
 
 export type {
@@ -205,6 +208,7 @@ export type {
   RouterContextOptions,
   ControllablePromise,
   InjectedHtmlEntry,
+  LoadModuleFn,
   RouterOptions,
   RouterState,
   ListenerFn,

--- a/packages/router-core/src/index.ts
+++ b/packages/router-core/src/index.ts
@@ -244,9 +244,13 @@ export {
   getInitialRouterState,
   getMatchedRoutes,
   trailingSlashOptions,
+  defaultLoadModule,
+  getLoadModule,
+  setLoadModule,
 } from './router'
 
 export type {
+  LoadModuleFn,
   ViewTransitionOptions,
   TrailingSlashOption,
   Register,

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -161,6 +161,30 @@ export interface RouterOptionsExtensions extends DefaultRouterOptionsExtensions 
 
 export type SSROption = boolean | 'data-only'
 
+export type LoadModuleFn = (url: string) => Promise<unknown>
+
+const LOAD_MODULE_GLOBAL = '__TANSTACK_ROUTER_LOAD_MODULE__'
+
+export function defaultLoadModule(url: string): Promise<unknown> {
+  return import(/* @vite-ignore */ url)
+}
+
+export function getLoadModule(): LoadModuleFn {
+  const loadModule = (globalThis as Record<string, unknown>)[LOAD_MODULE_GLOBAL]
+  return typeof loadModule === 'function'
+    ? (loadModule as LoadModuleFn)
+    : defaultLoadModule
+}
+
+export function setLoadModule(loadModule: LoadModuleFn | undefined): void {
+  ;(globalThis as Record<string, unknown>)[LOAD_MODULE_GLOBAL] =
+    loadModule ?? defaultLoadModule
+}
+
+if (!(globalThis as Record<string, unknown>)[LOAD_MODULE_GLOBAL]) {
+  setLoadModule(defaultLoadModule)
+}
+
 export interface RouterOptions<
   TRouteTree extends AnyRoute,
   TTrailingSlashOption extends TrailingSlashOption,
@@ -205,6 +229,12 @@ export interface RouterOptions<
    * @link [Guide](https://tanstack.com/router/latest/docs/framework/react/guide/preloading)
    */
   defaultPreload?: false | 'intent' | 'viewport' | 'render'
+  /**
+   * Load a lazy route chunk by URL. Bundlers can rewrite dynamic `import()`
+   * calls to this function so apps can intercept chunk requests (for example
+   * to attach headers). Defaults to native `import()`.
+   */
+  loadModule?: LoadModuleFn
   /**
    * The delay in milliseconds that a route must be hovered over or touched before it is preloaded.
    *
@@ -1093,6 +1123,7 @@ export class RouterCore<
       ...prevOptions,
       ...newOptions,
     }
+    setLoadModule(this.options.loadModule)
 
     this.isServer = this.options.isServer ?? typeof document === 'undefined'
 

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -232,7 +232,9 @@ export interface RouterOptions<
   /**
    * Load a lazy route chunk by URL. Bundlers can rewrite dynamic `import()`
    * calls to this function so apps can intercept chunk requests (for example
-   * to attach headers). Defaults to native `import()`.
+   * to attach headers). Defaults to native `import()`. If you `fetch` the
+   * module, evaluate `response` (e.g. via an object URL) instead of calling
+   * `import(url)` again — that would be a second request without your headers.
    */
   loadModule?: LoadModuleFn
   /**

--- a/packages/router-core/tests/load-module.test.ts
+++ b/packages/router-core/tests/load-module.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import { BaseRootRoute } from '../src'
+import {
+  defaultLoadModule,
+  getLoadModule,
+  setLoadModule,
+} from '../src/router'
+import { createTestRouter } from './routerTestUtils'
+
+afterEach(() => {
+  setLoadModule(undefined)
+})
+
+describe('loadModule', () => {
+  test('defaults to defaultLoadModule', () => {
+    expect(getLoadModule()).toBe(defaultLoadModule)
+  })
+
+  test('createRouter installs options.loadModule', () => {
+    const loadModule = async (url: string) => ({ default: url })
+    const router = createTestRouter({
+      routeTree: new BaseRootRoute({}),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+      loadModule,
+    })
+
+    expect(router.options.loadModule).toBe(loadModule)
+    expect(getLoadModule()).toBe(loadModule)
+  })
+
+  test('setLoadModule(undefined) restores the default', () => {
+    const loadModule = async (url: string) => ({ default: url })
+    setLoadModule(loadModule)
+    expect(getLoadModule()).toBe(loadModule)
+    setLoadModule(undefined)
+    expect(getLoadModule()).toBe(defaultLoadModule)
+  })
+})

--- a/packages/solid-router/src/index.tsx
+++ b/packages/solid-router/src/index.tsx
@@ -22,6 +22,9 @@ export {
   retainSearchParams,
   stripSearchParams,
   createSerializationAdapter,
+  defaultLoadModule,
+  getLoadModule,
+  setLoadModule,
 } from '@tanstack/router-core'
 
 export type {
@@ -176,6 +179,7 @@ export type {
   MatchRouteOptions,
   RouteMask,
   RouterContextOptions,
+  LoadModuleFn,
   RouterOptions,
   RouterConstructorOptions,
   ControllablePromise,

--- a/packages/vue-router/src/index.tsx
+++ b/packages/vue-router/src/index.tsx
@@ -22,6 +22,9 @@ export {
   retainSearchParams,
   stripSearchParams,
   createSerializationAdapter,
+  defaultLoadModule,
+  getLoadModule,
+  setLoadModule,
 } from '@tanstack/router-core'
 
 export type {
@@ -200,6 +203,7 @@ export type {
   RouterContextOptions,
   ControllablePromise,
   InjectedHtmlEntry,
+  LoadModuleFn,
   RouterOptions,
   RouterState,
   ListenerFn,


### PR DESCRIPTION
## Summary

Adds a `loadModule` option on the router so applications (and bundlers) can intercept lazy route chunk loads by URL.

Native `import()` cannot attach request headers or credentials. With this hook, a bundler can rewrite dynamic `import(specifier)` to `getLoadModule()(new URL(specifier, import.meta.url).href)` (or `globalThis.__TANSTACK_ROUTER_LOAD_MODULE__`), and the app can implement that function with `fetch`.

If you `fetch` the module, evaluate the **response body** (for example via an object URL). Calling `import(url)` after `fetch(url)` is a second request and will not send those headers.

Default remains native `import()`. `getLoadModule`, `setLoadModule`, and `defaultLoadModule` are exported from `@tanstack/router-core` and re-exported from the React, Solid, and Vue router packages.

## Example

```ts
const router = createRouter({
  routeTree,
  loadModule: async (url) => {
    const response = await fetch(url, {
      credentials: 'same-origin',
      headers: { Authorization: 'Bearer token' },
    })
    if (!response.ok) {
      throw new TypeError(`Failed to fetch dynamically imported module: ${url}`)
    }
    const source = await response.text()
    const objectUrl = URL.createObjectURL(
      new Blob([source], { type: 'text/javascript' }),
    )
    return import(/* @vite-ignore */ objectUrl)
  },
})
```

Evaluating through an object URL loads that file as a single module; relative imports inside the chunk resolve against the blob URL, not the original module graph.

## Test plan

- [x] `packages/router-core` unit tests for default / install / restore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable lazy route-module loading through a new `loadModule` router option.
  - Added runtime helpers for setting, retrieving, and restoring the module loader.
  - Exposed the new loading utilities and type across React, Solid, and Vue Router packages.
  - Supports custom chunk fetching, including use cases requiring custom request headers.

- **Documentation**
  - Expanded guidance for custom loaders, including blob-based module evaluation and relative import behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->