### PR TITLE
feat(start): add configurable lazy server-function codec

### DIFF
--- a/.changeset/curvy-dolls-kiss.md
+++ b/.changeset/curvy-dolls-kiss.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/start-plugin-core': minor
+'@tanstack/start-client-core': minor
+'@tanstack/router-core': patch
+---
+
+Add `serverFns.transport: 'bundled' | 'lazy'` to the Start bundler plugins. Bundled keeps the codec in the initial bundle; lazy loads Seroval and response decoding on invocation and overlaps payload-free requests with that download.

--- a/benchmarks/bundle-size/scenarios/react-start-minimal/rsbuild.config.ts
+++ b/benchmarks/bundle-size/scenarios/react-start-minimal/rsbuild.config.ts
@@ -16,7 +16,10 @@ const startOptions = clientOutput
 
 export default defineConfig({
   logLevel: 'silent',
-  plugins: [pluginReact(), tanstackStart(startOptions)],
+  plugins: [
+    pluginReact(),
+    tanstackStart({ ...startOptions, serverFns: { transport: 'lazy' } }),
+  ],
   output: {
     distPath: {
       root: outDir,

--- a/benchmarks/bundle-size/scenarios/react-start-minimal/vite.config.ts
+++ b/benchmarks/bundle-size/scenarios/react-start-minimal/vite.config.ts
@@ -3,5 +3,5 @@ import viteReact from '@vitejs/plugin-react'
 import { tanstackStart } from '@tanstack/react-start/plugin/vite'
 
 export default defineConfig({
-  plugins: [tanstackStart(), viteReact()],
+  plugins: [tanstackStart({ serverFns: { transport: 'lazy' } }), viteReact()],
 })

--- a/benchmarks/bundle-size/scenarios/solid-start-minimal/vite.config.ts
+++ b/benchmarks/bundle-size/scenarios/solid-start-minimal/vite.config.ts
@@ -3,5 +3,8 @@ import solid from 'vite-plugin-solid'
 import { tanstackStart } from '@tanstack/solid-start/plugin/vite'
 
 export default defineConfig({
-  plugins: [tanstackStart(), solid({ ssr: true })],
+  plugins: [
+    tanstackStart({ serverFns: { transport: 'lazy' } }),
+    solid({ ssr: true }),
+  ],
 })

--- a/benchmarks/bundle-size/scenarios/vue-start-minimal/vite.config.ts
+++ b/benchmarks/bundle-size/scenarios/vue-start-minimal/vite.config.ts
@@ -4,5 +4,9 @@ import vueJsx from '@vitejs/plugin-vue-jsx'
 import { tanstackStart } from '@tanstack/vue-start/plugin/vite'
 
 export default defineConfig({
-  plugins: [tanstackStart(), vue(), vueJsx()],
+  plugins: [
+    tanstackStart({ serverFns: { transport: 'lazy' } }),
+    vue(),
+    vueJsx(),
+  ],
 })

--- a/docs/start/framework/react/guide/server-functions.md
+++ b/docs/start/framework/react/guide/server-functions.md
@@ -24,6 +24,35 @@ Server functions provide server capabilities (database access, environment varia
 > [!NOTE]
 > Server functions are meant to be called by your TanStack Start application. They are easy to use from your app code, and Start handles serialization across the client/server boundary. If you need an endpoint that can be called from outside your Start app, use [server routes](./server-routes) instead.
 
+## Transport Loading
+
+Configure client transport loading in your Start bundler plugin:
+
+```ts
+import { tanstackStart } from '@tanstack/react-start/plugin/vite'
+
+export default {
+  plugins: [
+    tanstackStart({
+      serverFns: {
+        transport: 'lazy', // 'bundled' by default
+      },
+    }),
+  ],
+}
+```
+
+The same `serverFns.transport` option is available in the Rsbuild plugin. This is a build-time choice: bundled builds remove the lazy loader and its waiting logic.
+
+- **`bundled`** includes Seroval and server-function response decoding in the initial JavaScript bundle. Use it when server functions are needed on the first render. It does not introduce a separate lazy transport chunk.
+- **`lazy`** loads the serialization and response-decoding code when the first browser server-function call starts. Calls without data or middleware context can send their request while this code downloads. Calls with data or context wait for it to serialize the request. FormData without middleware context can also be sent immediately.
+
+Lazy loading applies to the codec as a whole, including framed streaming responses. It starts at invocation, without waiting for response headers. Subsequent calls reuse the loaded codec. SPA mode uses the same default, `bundled`; choose `lazy` explicitly when its first-call tradeoff fits your application.
+
+Custom `serializationAdapters` configured with `createStart` work in both modes. Lazy mode passes the configured adapters to the codec, which creates their Seroval plugins on first use for request encoding and response decoding. Adapter definitions and their dependencies remain in your application's import graph; choosing lazy transport does not defer those imports or the code needed for SSR hydration.
+
+The lazy codec avoids importing the application entry, allowing its content-hashed URL to survive unrelated application changes. Browser caching still depends on your asset cache headers. Other application imports of Seroval or serialization plugins, and custom chunking rules, can change the chunk graph and reduce the saving or cache stability.
+
 ## Same-Origin Requests
 
 Server functions are same-origin RPC endpoints for your application. Browser requests to server functions should come from the same origin, verified with Fetch Metadata (`Sec-Fetch-Site`), `Origin`, or `Referer` headers. Use server routes for public APIs or endpoints that intentionally support cross-origin requests.

--- a/e2e/react-start/basic/package.json
+++ b/e2e/react-start/basic/package.json
@@ -92,6 +92,14 @@
         {
           "toolchain": "rsbuild",
           "mode": "preview"
+        },
+        {
+          "toolchain": "vite",
+          "mode": "ssr",
+          "name": "lazy-transport",
+          "env": {
+            "E2E_SERVER_FN_TRANSPORT": "lazy"
+          }
         }
       ]
     }

--- a/e2e/react-start/basic/start-mode-config.ts
+++ b/e2e/react-start/basic/start-mode-config.ts
@@ -15,6 +15,12 @@ const rsbuildClientOutput: 'module' | 'iife' | undefined = (() => {
 
 export function getStartModeConfig() {
   return {
+    serverFns: {
+      transport:
+        process.env.E2E_SERVER_FN_TRANSPORT === 'lazy'
+          ? ('lazy' as const)
+          : ('bundled' as const),
+    },
     spa: isSpaMode
       ? {
           enabled: true,

--- a/e2e/react-start/basic/tests/server-fn-transport.spec.ts
+++ b/e2e/react-start/basic/tests/server-fn-transport.spec.ts
@@ -1,0 +1,45 @@
+import { expect } from '@playwright/test'
+import { test } from '@tanstack/router-e2e-utils'
+
+test('lazy codec stays deferred and overlaps concurrent payload-free RPCs', async ({
+  page,
+}) => {
+  test.skip(process.env.E2E_SERVER_FN_TRANSPORT !== 'lazy')
+  let release!: () => void
+  const gate = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const requests: Array<string> = []
+  page.on('request', (request) => {
+    requests.push(request.url())
+  })
+  await page.route('**/serverFnCodec-*.js', async (route) => {
+    await gate
+    await route.continue()
+  })
+  await page.goto('/raw-stream/client-call')
+  await expect(page.getByTestId('test1-btn')).toBeVisible()
+  await page.waitForTimeout(1000)
+  const codecRequests = () =>
+    requests.filter((url) => /\/serverFnCodec-[^/]+\.js/.test(url))
+  expect(codecRequests()).toHaveLength(0)
+  try {
+    const rpc = page.waitForRequest(
+      (request) => request.headers()['x-tsr-serverfn'] === 'true',
+    )
+    await page.getByTestId('test1-btn').click()
+    await page.getByTestId('test2-btn').click()
+    await rpc
+    await expect.poll(() => codecRequests().length).toBe(1)
+    await expect(page.getByTestId('test1-result')).toBeHidden()
+  } finally {
+    release()
+  }
+  await expect(page.getByTestId('test1-result')).toContainText(
+    'chunk1chunk2chunk3',
+  )
+  await expect(page.getByTestId('test2-result')).toContainText(
+    'stream1-astream1-b',
+  )
+  expect(codecRequests()).toHaveLength(1)
+})

--- a/e2e/react-start/rsc/package.json
+++ b/e2e/react-start/rsc/package.json
@@ -27,6 +27,14 @@
           "toolchain": "rsbuild",
           "mode": "ssr",
           "shards": 6
+        },
+        {
+          "toolchain": "vite",
+          "mode": "ssr",
+          "name": "lazy-transport",
+          "env": {
+            "E2E_SERVER_FN_TRANSPORT": "lazy"
+          }
         }
       ]
     }

--- a/e2e/react-start/rsc/vite.config.ts
+++ b/e2e/react-start/rsc/vite.config.ts
@@ -15,6 +15,10 @@ export default defineConfig({
   },
   plugins: [
     tanstackStart({
+      serverFns: {
+        transport:
+          process.env.E2E_SERVER_FN_TRANSPORT === 'lazy' ? 'lazy' : 'bundled',
+      },
       rsc: {
         enabled: true,
       },

--- a/packages/router-core/src/index.ts
+++ b/packages/router-core/src/index.ts
@@ -473,10 +473,11 @@ export type {
 } from './ssr/serializer/transformer'
 
 export {
-  createSerializationAdapter,
   makeSerovalPlugin,
   makeSsrSerovalPlugin,
 } from './ssr/serializer/transformer'
+
+export { createSerializationAdapter } from './ssr/serializer/serializationAdapter'
 
 export { defaultSerovalPlugins } from './ssr/serializer/seroval-plugins'
 

--- a/packages/router-core/src/ssr/serializer/serializationAdapter.ts
+++ b/packages/router-core/src/ssr/serializer/serializationAdapter.ts
@@ -1,0 +1,25 @@
+import type {
+  AnySerializationAdapter,
+  CreateSerializationAdapterOptions,
+  SerializationAdapter,
+} from './transformer'
+
+/**
+ * Create a strongly-typed serialization adapter for SSR hydration.
+ * Use to register custom types with the router serializer.
+ */
+export function createSerializationAdapter<
+  TInput = unknown,
+  TOutput = unknown,
+  const TExtendsAdapters extends
+    | ReadonlyArray<AnySerializationAdapter>
+    | never = never,
+>(
+  opts: CreateSerializationAdapterOptions<TInput, TOutput, TExtendsAdapters>,
+): SerializationAdapter<TInput, TOutput, TExtendsAdapters> {
+  return opts as unknown as SerializationAdapter<
+    TInput,
+    TOutput,
+    TExtendsAdapters
+  >
+}

--- a/packages/router-core/src/ssr/serializer/transformer.ts
+++ b/packages/router-core/src/ssr/serializer/transformer.ts
@@ -37,26 +37,6 @@ export type UnionizeSerializationAdaptersInput<
   TAdapters extends ReadonlyArray<AnySerializationAdapter>,
 > = TAdapters[number]['~types']['input']
 
-/**
- * Create a strongly-typed serialization adapter for SSR hydration.
- * Use to register custom types with the router serializer.
- */
-export function createSerializationAdapter<
-  TInput = unknown,
-  TOutput = unknown,
-  const TExtendsAdapters extends
-    | ReadonlyArray<AnySerializationAdapter>
-    | never = never,
->(
-  opts: CreateSerializationAdapterOptions<TInput, TOutput, TExtendsAdapters>,
-): SerializationAdapter<TInput, TOutput, TExtendsAdapters> {
-  return opts as unknown as SerializationAdapter<
-    TInput,
-    TOutput,
-    TExtendsAdapters
-  >
-}
-
 export interface CreateSerializationAdapterOptions<
   TInput,
   TOutput,

--- a/packages/start-client-core/package.json
+++ b/packages/start-client-core/package.json
@@ -78,7 +78,13 @@
         "default": "./dist/esm/hydration/runtime.js"
       }
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./client-rpc/codec-stub": {
+      "import": {
+        "types": "./dist/esm/client-rpc/serverFnCodec.stub.d.ts",
+        "default": "./dist/esm/client-rpc/serverFnCodec.stub.js"
+      }
+    }
   },
   "imports": {
     "#tanstack-start-entry": {
@@ -92,6 +98,10 @@
     "#tanstack-start-plugin-adapters": {
       "types": "./src/start-entry.d.ts",
       "default": "./dist/esm/empty-plugin-adapters.js"
+    },
+    "#tanstack-start-server-fn-codec": {
+      "types": "./src/client-rpc/serverFnCodec.ts",
+      "default": "./dist/esm/client-rpc/serverFnCodec.js"
     }
   },
   "sideEffects": false,

--- a/packages/start-client-core/src/client-rpc/frame-decoder.ts
+++ b/packages/start-client-core/src/client-rpc/frame-decoder.ts
@@ -6,7 +6,7 @@
  * - Raw streams (binary data as ReadableStream<Uint8Array>)
  */
 
-import { FRAME_HEADER_SIZE, FrameType } from '../constants'
+import { FRAME_HEADER_SIZE, FrameType } from '../framed-protocol'
 
 /** Cached TextDecoder for frame decoding */
 const textDecoder = new TextDecoder()

--- a/packages/start-client-core/src/client-rpc/postProcessContext.ts
+++ b/packages/start-client-core/src/client-rpc/postProcessContext.ts
@@ -1,0 +1,51 @@
+/**
+ * Current async post-processing context for deserialization.
+ *
+ * Some deserializers need to perform async work after synchronous deserialization
+ * (e.g., decoding RSC payloads, fetching remote data). This context allows them
+ * to register promises that must complete before the deserialized value is used.
+ *
+ * This uses a synchronous execution context pattern:
+ * - Each call to `fromCrossJSON` is synchronous
+ * - Within that synchronous execution, all `fromSerializable` calls happen
+ * - We set the context before `fromCrossJSON`, clear it after
+ * - For streaming chunks, we set/clear context around each `onMessage` call
+ *
+ * Even with concurrent server function calls, each individual deserialization
+ * is atomic (synchronous), so promises are correctly scoped to their call.
+ */
+let currentPostProcessContext: Array<Promise<unknown>> | null = null
+
+/**
+ * Set the current post-processing context for async deserialization work.
+ * Called before deserialization starts.
+ *
+ * @param ctx - Array to collect async work promises, or null to clear
+ */
+export function setPostProcessContext(
+  ctx: Array<Promise<unknown>> | null,
+): void {
+  currentPostProcessContext = ctx
+}
+
+/**
+ * Get the current post-processing context.
+ * Returns null if no deserialization is in progress.
+ */
+export function getPostProcessContext(): Array<Promise<unknown>> | null {
+  return currentPostProcessContext
+}
+
+/**
+ * Track an async post-processing promise in the current deserialization context.
+ * Called by deserializers that need to perform async work after sync deserialization.
+ *
+ * If no context is active (e.g., on server), this is a no-op.
+ *
+ * @param promise - The async work promise to track
+ */
+export function trackPostProcessPromise(promise: Promise<unknown>): void {
+  if (currentPostProcessContext) {
+    currentPostProcessContext.push(promise)
+  }
+}

--- a/packages/start-client-core/src/client-rpc/serverFnCodec.stub.ts
+++ b/packages/start-client-core/src/client-rpc/serverFnCodec.stub.ts
@@ -1,0 +1,7 @@
+import type { ServerFnCodec } from './serverFnCodecLoader'
+
+// Lazy builds alias the bundled imports here: Vite can otherwise promote the
+// codec to an initial chunk before eliminating the bundled-only branches.
+// These bindings are only referenced in branches removed by the transport flag.
+export const serialize: ServerFnCodec['serialize'] = undefined!
+export const deserialize: ServerFnCodec['deserialize'] = undefined!

--- a/packages/start-client-core/src/client-rpc/serverFnCodec.ts
+++ b/packages/start-client-core/src/client-rpc/serverFnCodec.ts
@@ -1,0 +1,216 @@
+import { createRawStreamDeserializePlugin } from '@tanstack/router-core'
+import { fromCrossJSON, toJSONAsync } from 'seroval'
+import { createSerovalPlugins } from '../createSerovalPlugins'
+import { validateFramedProtocolVersion } from '../framed-protocol'
+import { TSS_CONTENT_TYPE_FRAMED } from '../framed-content-type'
+import { createFrameDecoder } from './frame-decoder'
+import { setPostProcessContext as setBundledPostProcessContext } from './postProcessContext'
+import type { AnySerializationAdapter } from '@tanstack/router-core'
+import type { Plugin } from 'seroval'
+
+let serovalPlugins: Array<Plugin<any, any>> | undefined
+function getPlugins(
+  adapters: ReadonlyArray<AnySerializationAdapter> | undefined,
+) {
+  return (serovalPlugins ??= createSerovalPlugins(adapters))
+}
+
+export async function serialize(
+  data: unknown,
+  adapters: ReadonlyArray<AnySerializationAdapter> | undefined,
+) {
+  return JSON.stringify(
+    await toJSONAsync(data, { plugins: getPlugins(adapters) }),
+  )
+}
+
+export async function deserialize(
+  response: Response,
+  contentType: string,
+  adapters: ReadonlyArray<AnySerializationAdapter> | undefined,
+  framed?: boolean,
+  setPostProcessContext?: typeof setBundledPostProcessContext,
+) {
+  const setContext =
+    process.env.TSS_SERVER_FN_TRANSPORT === 'lazy'
+      ? setPostProcessContext!
+      : setBundledPostProcessContext
+  const plugins = getPlugins(adapters)
+  let result
+
+  // If it's a framed response (contains RawStream), use frame decoder
+  if (
+    process.env.TSS_SERVER_FN_TRANSPORT === 'lazy'
+      ? framed
+      : contentType.includes(TSS_CONTENT_TYPE_FRAMED)
+  ) {
+    // Validate protocol version compatibility
+    validateFramedProtocolVersion(contentType)
+
+    if (!response.body) {
+      throw new Error('No response body for framed response')
+    }
+
+    const { getStream, chunks } = createFrameDecoder(response.body)
+
+    // Create deserialize plugin that wires up the raw streams
+    const rawStreamPlugin = createRawStreamDeserializePlugin(getStream)
+    const framedPlugins = [rawStreamPlugin, ...plugins]
+
+    const refs = new Map()
+    result = await processFramedResponse(
+      {
+        jsonStream: chunks,
+        onMessage: (msg: any) =>
+          fromCrossJSON(msg, { refs, plugins: framedPlugins }),
+        onError(msg, error) {
+          console.error(msg, error)
+        },
+      },
+      process.env.TSS_SERVER_FN_TRANSPORT === 'lazy'
+        ? setPostProcessContext
+        : undefined,
+    )
+  }
+  // If it's a JSON response, it can be simpler
+  else if (contentType.includes('application/json')) {
+    const jsonPayload = await response.json()
+    // Track async post-processing work for this deserialization
+    const postProcessPromises: Array<Promise<unknown>> = []
+    setContext(postProcessPromises)
+    try {
+      result = fromCrossJSON(jsonPayload, { plugins })
+    } finally {
+      setContext(null)
+    }
+    // Await any async post-processing before returning
+    await awaitPostProcessPromises(postProcessPromises)
+  }
+
+  if (result instanceof Error) {
+    throw result
+  }
+
+  return result
+}
+
+/**
+ * Processes a framed response where each JSON chunk is a complete JSON string
+ * (already decoded by frame decoder).
+ *
+ * Uses per-chunk post-processing context to ensure async deserialization work
+ * completes before the next chunk is processed. This prevents issues when
+ * streaming values require async post-processing (e.g., RSC decoding).
+ */
+async function processFramedResponse(
+  {
+    jsonStream,
+    onMessage,
+    onError,
+  }: {
+    jsonStream: ReadableStream<string>
+    onMessage: (msg: any) => any
+    onError?: (msg: string, error?: any) => void
+  },
+  setPostProcessContext?: typeof setBundledPostProcessContext,
+) {
+  const setContext =
+    process.env.TSS_SERVER_FN_TRANSPORT === 'lazy'
+      ? setPostProcessContext!
+      : setBundledPostProcessContext
+  const reader = jsonStream.getReader()
+
+  // Read first JSON frame - this is the main result
+  const { value: firstValue, done: firstDone } = await reader.read()
+  if (firstDone || !firstValue) {
+    throw new Error('Stream ended before first object')
+  }
+
+  // Each frame is a complete JSON string
+  const firstObject = JSON.parse(firstValue)
+
+  // Process remaining frames for streaming refs like RawStream.
+  // Keep draining until the server closes the stream.
+  // Each chunk gets its own post-processing context to properly scope async work.
+  let drainCancelled = false as boolean
+  const drain = (async () => {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      while (true) {
+        const { value, done } = await reader.read()
+        if (done) {
+          break
+        }
+        if (value) {
+          try {
+            // Set up post-processing context for this chunk
+            const chunkPostProcessPromises: Array<Promise<unknown>> = []
+            setContext(chunkPostProcessPromises)
+            try {
+              onMessage(JSON.parse(value))
+            } finally {
+              setContext(null)
+            }
+            // Await any async post-processing from this chunk before processing next.
+            // This ensures values requiring async work are ready before their
+            // containing Promise/Stream resolves/emits to consumers.
+            await awaitPostProcessPromises(chunkPostProcessPromises)
+          } catch (e) {
+            onError?.(`Invalid JSON: ${value}`, e)
+          }
+        }
+      }
+    } catch (err) {
+      if (!drainCancelled) {
+        onError?.('Stream processing error:', err)
+      }
+    }
+  })()
+
+  // Process first object with its own post-processing context
+  let result: any
+  const initialPostProcessPromises: Array<Promise<unknown>> = []
+  setContext(initialPostProcessPromises)
+  try {
+    result = onMessage(firstObject)
+  } catch (err) {
+    setContext(null)
+    drainCancelled = true
+    reader.cancel().catch(() => {})
+    throw err
+  }
+  setContext(null)
+
+  // Await initial post-processing promises before returning result
+  await awaitPostProcessPromises(initialPostProcessPromises)
+
+  // If the initial decode fails async, stop draining to avoid holding
+  // onto the response body and raw stream buffers unnecessarily.
+  Promise.resolve(result).catch(() => {
+    drainCancelled = true
+    reader.cancel().catch(() => {})
+  })
+
+  // Detach reader once draining completes.
+  drain.finally(() => {
+    try {
+      reader.releaseLock()
+    } catch {
+      // Ignore
+    }
+  })
+
+  return result
+}
+
+/**
+ * Helper to await all post-processing promises.
+ * Uses Promise.allSettled to ensure all promises complete even if some reject.
+ */
+async function awaitPostProcessPromises(
+  promises: Array<Promise<unknown>>,
+): Promise<void> {
+  if (promises.length > 0) {
+    await Promise.allSettled(promises)
+  }
+}

--- a/packages/start-client-core/src/client-rpc/serverFnCodecLoader.lazy.ts
+++ b/packages/start-client-core/src/client-rpc/serverFnCodecLoader.lazy.ts
@@ -1,0 +1,10 @@
+import type { ServerFnCodec } from './serverFnCodecLoader'
+
+let pending: Promise<ServerFnCodec> | undefined
+
+export function loadServerFnCodec(): Promise<ServerFnCodec> {
+  return (pending ??= import('./serverFnCodec').catch((error) => {
+    pending = undefined
+    throw error
+  }))
+}

--- a/packages/start-client-core/src/client-rpc/serverFnCodecLoader.ts
+++ b/packages/start-client-core/src/client-rpc/serverFnCodecLoader.ts
@@ -1,0 +1,3 @@
+import type * as codec from './serverFnCodec'
+
+export type ServerFnCodec = typeof codec

--- a/packages/start-client-core/src/client-rpc/serverFnFetcher.ts
+++ b/packages/start-client-core/src/client-rpc/serverFnFetcher.ts
@@ -1,239 +1,155 @@
 import {
-  createRawStreamDeserializePlugin,
   encode,
   invariant,
   isNotFound,
   parseRedirect,
 } from '@tanstack/router-core'
-import { fromCrossJSON, toJSONAsync } from 'seroval'
-import { getDefaultSerovalPlugins } from '../getDefaultSerovalPlugins'
 import {
-  TSS_CONTENT_TYPE_FRAMED,
+  deserialize as deserializeBundled,
+  serialize as serializeBundled,
+} from '#tanstack-start-server-fn-codec'
+import { TSS_CONTENT_TYPE_FRAMED } from '../framed-content-type'
+import { getStartOptions } from '../getStartOptions'
+import {
   TSS_FORMDATA_CONTEXT,
   X_TSS_RAW_RESPONSE,
   X_TSS_SERIALIZED,
-  validateFramedProtocolVersion,
 } from '../constants'
-import { createFrameDecoder } from './frame-decoder'
-import type { FunctionMiddlewareClientFnOptions } from '../createMiddleware'
-import type { Plugin as SerovalPlugin } from 'seroval'
+import { loadServerFnCodec } from './serverFnCodecLoader.lazy'
+import { setPostProcessContext } from './postProcessContext'
+import type { ServerFnCodec } from './serverFnCodecLoader'
 
-let serovalPlugins: Array<SerovalPlugin<any, any>> | null = null
-
-/**
- * Current async post-processing context for deserialization.
- *
- * Some deserializers need to perform async work after synchronous deserialization
- * (e.g., decoding RSC payloads, fetching remote data). This context allows them
- * to register promises that must complete before the deserialized value is used.
- *
- * This uses a synchronous execution context pattern:
- * - Each call to `fromCrossJSON` is synchronous
- * - Within that synchronous execution, all `fromSerializable` calls happen
- * - We set the context before `fromCrossJSON`, clear it after
- * - For streaming chunks, we set/clear context around each `onMessage` call
- *
- * Even with concurrent server function calls, each individual deserialization
- * is atomic (synchronous), so promises are correctly scoped to their call.
- */
-let currentPostProcessContext: Array<Promise<unknown>> | null = null
-
-/**
- * Set the current post-processing context for async deserialization work.
- * Called before deserialization starts.
- *
- * @param ctx - Array to collect async work promises, or null to clear
- */
-export function setPostProcessContext(
-  ctx: Array<Promise<unknown>> | null,
-): void {
-  currentPostProcessContext = ctx
-}
-
-/**
- * Get the current post-processing context.
- * Returns null if no deserialization is in progress.
- */
-export function getPostProcessContext(): Array<Promise<unknown>> | null {
-  return currentPostProcessContext
-}
-
-/**
- * Track an async post-processing promise in the current deserialization context.
- * Called by deserializers that need to perform async work after sync deserialization.
- *
- * If no context is active (e.g., on server), this is a no-op.
- *
- * @param promise - The async work promise to track
- */
-export function trackPostProcessPromise(promise: Promise<unknown>): void {
-  if (currentPostProcessContext) {
-    currentPostProcessContext.push(promise)
-  }
-}
-
-/**
- * Helper to await all post-processing promises.
- * Uses Promise.allSettled to ensure all promises complete even if some reject.
- */
-async function awaitPostProcessPromises(
-  promises: Array<Promise<unknown>>,
-): Promise<void> {
-  if (promises.length > 0) {
-    await Promise.allSettled(promises)
-  }
-}
-
-/**
- * Checks if an object has at least one own enumerable property.
- * More efficient than Object.keys(obj).length > 0 as it short-circuits on first property.
- */
 const hop = Object.prototype.hasOwnProperty
 function hasOwnProperties(obj: object): boolean {
-  for (const _ in obj) {
-    if (hop.call(obj, _)) {
+  for (const key in obj) {
+    if (hop.call(obj, key)) {
       return true
     }
   }
   return false
 }
-// caller =>
-//   serverFnFetcher =>
-//     client =>
-//       server =>
-//         fn =>
-//       seroval =>
-//     client middleware =>
-//   serverFnFetcher =>
-// caller
+
+// Cancel only this caller's wait; other requests still share the codec import.
+function waitForCodec(
+  codec: Promise<ServerFnCodec>,
+  signal: AbortSignal | undefined,
+): Promise<ServerFnCodec> {
+  signal?.throwIfAborted()
+  if (!signal) {
+    return codec
+  }
+  return new Promise((resolve, reject) => {
+    const onAbort = () => reject(signal.reason)
+    signal.addEventListener('abort', onAbort, { once: true })
+    codec.then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort)
+        resolve(value)
+      },
+      (error) => {
+        signal.removeEventListener('abort', onAbort)
+        reject(error)
+      },
+    )
+  })
+}
 
 export async function serverFnFetcher(
   url: string,
   args: Array<any>,
   handler: (url: string, requestInit: RequestInit) => Promise<Response>,
 ) {
-  if (!serovalPlugins) {
-    serovalPlugins = getDefaultSerovalPlugins()
-  }
-  const _first = args[0]
-
-  const first = _first as FunctionMiddlewareClientFnOptions<any, any, any> & {
+  const first = args[0] as {
+    method: string
+    data?: unknown
+    context?: Record<string, unknown>
+    signal?: AbortSignal
+    fetch?: typeof handler
     headers?: HeadersInit
   }
+  if (process.env.TSS_SERVER_FN_TRANSPORT === 'lazy') {
+    first.signal?.throwIfAborted()
+  }
+  const isFormData = first.data instanceof FormData
+  if (first.method === 'GET' && isFormData) {
+    throw new Error('FormData is not supported with GET requests')
+  }
 
-  // Use custom fetch if provided, otherwise fall back to the passed handler (global fetch)
+  // Begin loading before fetch so responses can overlap the codec download.
+  const codec =
+    process.env.TSS_SERVER_FN_TRANSPORT === 'lazy'
+      ? loadServerFnCodec()
+      : undefined
+  if (process.env.TSS_SERVER_FN_TRANSPORT === 'lazy') {
+    // Observe an early import failure while the RPC is still in flight.
+    void codec!.catch(() => {})
+  }
+  const adapters = getStartOptions()?.serializationAdapters
   const fetchImpl = first.fetch ?? handler
-
-  const type = first.data instanceof FormData ? 'formData' : 'payload'
-
-  // Arrange the headers
   const headers = first.headers ? new Headers(first.headers) : new Headers()
   headers.set('x-tsr-serverFn', 'true')
-
-  if (type === 'payload') {
+  if (!isFormData) {
     headers.set(
       'accept',
       `${TSS_CONTENT_TYPE_FRAMED}, application/x-ndjson, application/json`,
     )
   }
 
-  // If the method is GET, we need to move the payload to the query string
-  if (first.method === 'GET') {
-    if (type === 'formData') {
-      throw new Error('FormData is not supported with GET requests')
-    }
-    const serializedPayload = await serializePayload(first)
-    if (serializedPayload !== undefined) {
-      const encodedPayload = encode({
-        payload: serializedPayload,
-      })
-      if (url.includes('?')) {
-        url += `&${encodedPayload}`
-      } else {
-        url += `?${encodedPayload}`
+  let body: BodyInit | undefined
+  const hasContext = first.context && hasOwnProperties(first.context)
+  if (first.method === 'POST' && isFormData) {
+    body = first.data as FormData
+    if (hasContext) {
+      const serialize =
+        process.env.TSS_SERVER_FN_TRANSPORT === 'lazy'
+          ? (await waitForCodec(codec!, first.signal)).serialize
+          : serializeBundled
+      if (process.env.TSS_SERVER_FN_TRANSPORT === 'lazy') {
+        first.signal?.throwIfAborted()
       }
+      const context = await serialize(first.context, adapters)
+      if (process.env.TSS_SERVER_FN_TRANSPORT === 'lazy') {
+        first.signal?.throwIfAborted()
+      }
+      body.set(TSS_FORMDATA_CONTEXT, context)
     }
-  }
-
-  let body = undefined
-  if (first.method === 'POST') {
-    body = await getFetchBody(first)
-    if (typeof body === 'string') {
+  } else if (
+    (first.method === 'GET' || first.method === 'POST') &&
+    (first.data !== undefined || hasContext)
+  ) {
+    const payload: { data?: unknown; context?: unknown } = {}
+    if (first.data !== undefined) {
+      payload.data = first.data
+    }
+    if (hasContext) {
+      payload.context = first.context
+    }
+    const serialize =
+      process.env.TSS_SERVER_FN_TRANSPORT === 'lazy'
+        ? (await waitForCodec(codec!, first.signal)).serialize
+        : serializeBundled
+    if (process.env.TSS_SERVER_FN_TRANSPORT === 'lazy') {
+      first.signal?.throwIfAborted()
+    }
+    const serialized = await serialize(payload, adapters)
+    if (first.method === 'GET') {
+      url += (url.includes('?') ? '&' : '?') + encode({ payload: serialized })
+    } else {
+      body = serialized
       headers.set('content-type', 'application/json')
     }
   }
-
-  return await getResponse(async () =>
-    fetchImpl(url, {
+  if (process.env.TSS_SERVER_FN_TRANSPORT === 'lazy') {
+    first.signal?.throwIfAborted()
+  }
+  let response: Response
+  try {
+    response = await fetchImpl(url, {
       method: first.method,
       headers,
       signal: first.signal,
       body,
-    }),
-  )
-}
-
-async function serializePayload(
-  opts: FunctionMiddlewareClientFnOptions<any, any, any>,
-): Promise<string | undefined> {
-  let payloadAvailable = false
-  const payloadToSerialize: any = {}
-  if (opts.data !== undefined) {
-    payloadAvailable = true
-    payloadToSerialize['data'] = opts.data
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  if (opts.context && hasOwnProperties(opts.context)) {
-    payloadAvailable = true
-    payloadToSerialize['context'] = opts.context
-  }
-
-  if (payloadAvailable) {
-    return serialize(payloadToSerialize)
-  }
-  return undefined
-}
-
-async function serialize(data: any) {
-  return JSON.stringify(
-    await Promise.resolve(toJSONAsync(data, { plugins: serovalPlugins! })),
-  )
-}
-
-async function getFetchBody(
-  opts: FunctionMiddlewareClientFnOptions<any, any, any>,
-): Promise<FormData | string | undefined> {
-  if (opts.data instanceof FormData) {
-    let serializedContext = undefined
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (opts.context && hasOwnProperties(opts.context)) {
-      serializedContext = await serialize(opts.context)
-    }
-    if (serializedContext !== undefined) {
-      opts.data.set(TSS_FORMDATA_CONTEXT, serializedContext)
-    }
-    return opts.data
-  }
-  const serializedBody = await serializePayload(opts)
-  if (serializedBody) {
-    return serializedBody
-  }
-  return undefined
-}
-
-/**
- * Retrieves a response from a given function and manages potential errors
- * and special response types including redirects and not found errors.
- *
- * @param fn - The function to execute for obtaining the response.
- * @returns The processed response from the function.
- * @throws If the response is invalid or an error occurs during processing.
- */
-async function getResponse(fn: () => Promise<Response>) {
-  let response: Response
-  try {
-    response = await fn() // client => server => fn => server => client
+    })
   } catch (error) {
     if (error instanceof Response) {
       response = error
@@ -262,58 +178,32 @@ async function getResponse(fn: () => Promise<Response>) {
   // If the response is serialized by the start server, we need to process it
   // differently than a normal response.
   if (serializedByStart) {
-    let result
-
-    // If it's a framed response (contains RawStream), use frame decoder
-    if (contentType.includes(TSS_CONTENT_TYPE_FRAMED)) {
-      // Validate protocol version compatibility
-      validateFramedProtocolVersion(contentType)
-
-      if (!response.body) {
-        throw new Error('No response body for framed response')
-      }
-
-      const { getStream, chunks } = createFrameDecoder(response.body)
-
-      // Create deserialize plugin that wires up the raw streams
-      const rawStreamPlugin = createRawStreamDeserializePlugin(getStream)
-      const plugins = [rawStreamPlugin, ...(serovalPlugins || [])]
-
-      const refs = new Map()
-      result = await processFramedResponse({
-        jsonStream: chunks,
-        onMessage: (msg: any) => fromCrossJSON(msg, { refs, plugins }),
-        onError(msg, error) {
-          console.error(msg, error)
-        },
-      })
-    }
-    // If it's a JSON response, it can be simpler
-    else if (contentType.includes('application/json')) {
-      const jsonPayload = await response.json()
-      // Track async post-processing work for this deserialization
-      const postProcessPromises: Array<Promise<unknown>> = []
-      setPostProcessContext(postProcessPromises)
+    let deserialize: ServerFnCodec['deserialize'] | undefined
+    if (process.env.TSS_SERVER_FN_TRANSPORT === 'lazy') {
       try {
-        result = fromCrossJSON(jsonPayload, { plugins: serovalPlugins! })
-      } finally {
-        setPostProcessContext(null)
+        deserialize = (await waitForCodec(codec!, first.signal)).deserialize
+        first.signal?.throwIfAborted()
+      } catch (error) {
+        // The RPC may already have completed. Release its body without resending it.
+        void response.body?.cancel().catch(() => {})
+        throw error
       }
-      // Await any async post-processing before returning
-      await awaitPostProcessPromises(postProcessPromises)
     }
-
+    const result = await (process.env.TSS_SERVER_FN_TRANSPORT === 'lazy'
+      ? deserialize!(
+          response,
+          contentType,
+          adapters,
+          contentType.includes(TSS_CONTENT_TYPE_FRAMED),
+          setPostProcessContext,
+        )
+      : deserializeBundled(response, contentType, adapters))
     if (!result) {
       if (process.env.NODE_ENV !== 'production') {
         throw new Error('Invariant failed: expected result to be resolved')
       }
-
       invariant()
     }
-    if (result instanceof Error) {
-      throw result
-    }
-
     return result
   }
 
@@ -338,104 +228,4 @@ async function getResponse(fn: () => Promise<Response>) {
 
   // Or return the response itself
   return response
-}
-
-/**
- * Processes a framed response where each JSON chunk is a complete JSON string
- * (already decoded by frame decoder).
- *
- * Uses per-chunk post-processing context to ensure async deserialization work
- * completes before the next chunk is processed. This prevents issues when
- * streaming values require async post-processing (e.g., RSC decoding).
- */
-async function processFramedResponse({
-  jsonStream,
-  onMessage,
-  onError,
-}: {
-  jsonStream: ReadableStream<string>
-  onMessage: (msg: any) => any
-  onError?: (msg: string, error?: any) => void
-}) {
-  const reader = jsonStream.getReader()
-
-  // Read first JSON frame - this is the main result
-  const { value: firstValue, done: firstDone } = await reader.read()
-  if (firstDone || !firstValue) {
-    throw new Error('Stream ended before first object')
-  }
-
-  // Each frame is a complete JSON string
-  const firstObject = JSON.parse(firstValue)
-
-  // Process remaining frames for streaming refs like RawStream.
-  // Keep draining until the server closes the stream.
-  // Each chunk gets its own post-processing context to properly scope async work.
-  let drainCancelled = false as boolean
-  const drain = (async () => {
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      while (true) {
-        const { value, done } = await reader.read()
-        if (done) break
-        if (value) {
-          try {
-            // Set up post-processing context for this chunk
-            const chunkPostProcessPromises: Array<Promise<unknown>> = []
-            setPostProcessContext(chunkPostProcessPromises)
-            try {
-              onMessage(JSON.parse(value))
-            } finally {
-              setPostProcessContext(null)
-            }
-            // Await any async post-processing from this chunk before processing next.
-            // This ensures values requiring async work are ready before their
-            // containing Promise/Stream resolves/emits to consumers.
-            await awaitPostProcessPromises(chunkPostProcessPromises)
-          } catch (e) {
-            onError?.(`Invalid JSON: ${value}`, e)
-          }
-        }
-      }
-    } catch (err) {
-      if (!drainCancelled) {
-        onError?.('Stream processing error:', err)
-      }
-    }
-  })()
-
-  // Process first object with its own post-processing context
-  let result: any
-  const initialPostProcessPromises: Array<Promise<unknown>> = []
-  setPostProcessContext(initialPostProcessPromises)
-  try {
-    result = onMessage(firstObject)
-  } catch (err) {
-    setPostProcessContext(null)
-    drainCancelled = true
-    reader.cancel().catch(() => {})
-    throw err
-  }
-  setPostProcessContext(null)
-
-  // Await initial post-processing promises before returning result
-  await awaitPostProcessPromises(initialPostProcessPromises)
-
-  // If the initial decode fails async, stop draining to avoid holding
-  // onto the response body and raw stream buffers unnecessarily.
-  Promise.resolve(result).catch(() => {
-    drainCancelled = true
-    reader.cancel().catch(() => {})
-  })
-
-  // Detach reader once draining completes.
-  drain.finally(() => {
-    try {
-      reader.releaseLock()
-    } catch {
-      // Ignore
-    }
-  })
-
-  return result
 }

--- a/packages/start-client-core/src/constants.ts
+++ b/packages/start-client-core/src/constants.ts
@@ -8,65 +8,6 @@ export const X_TSS_SERIALIZED = 'x-tss-serialized'
 export const X_TSS_RAW_RESPONSE = 'x-tss-raw'
 export const X_TSS_CONTEXT = 'x-tss-context'
 
-/** Content-Type for multiplexed framed responses (RawStream support) */
-export const TSS_CONTENT_TYPE_FRAMED = 'application/x-tss-framed'
-
-/**
- * Frame types for binary multiplexing protocol.
- */
-export const FrameType = {
-  /** Seroval JSON chunk (NDJSON line) */
-  JSON: 0,
-  /** Raw stream data chunk */
-  CHUNK: 1,
-  /** Raw stream end (EOF) */
-  END: 2,
-  /** Raw stream error */
-  ERROR: 3,
-} as const
-
-export type FrameType = (typeof FrameType)[keyof typeof FrameType]
-
-/** Header size in bytes: type(1) + streamId(4) + length(4) */
-export const FRAME_HEADER_SIZE = 9
-
-/** Current protocol version for framed responses */
-export const TSS_FRAMED_PROTOCOL_VERSION = 1
-
-/** Full Content-Type header value with version parameter */
-export const TSS_CONTENT_TYPE_FRAMED_VERSIONED = `${TSS_CONTENT_TYPE_FRAMED}; v=${TSS_FRAMED_PROTOCOL_VERSION}`
-
-/**
- * Parses the version parameter from a framed Content-Type header.
- * Returns undefined if no version parameter is present.
- */
-const FRAMED_VERSION_REGEX = /;\s*v=(\d+)/
-export function parseFramedProtocolVersion(
-  contentType: string,
-): number | undefined {
-  // Match "v=<number>" in the content-type parameters
-  const match = contentType.match(FRAMED_VERSION_REGEX)
-  return match ? parseInt(match[1]!, 10) : undefined
-}
-
-/**
- * Validates that the server's protocol version is compatible with this client.
- * Throws an error if versions are incompatible.
- */
-export function validateFramedProtocolVersion(contentType: string): void {
-  const serverVersion = parseFramedProtocolVersion(contentType)
-  if (serverVersion === undefined) {
-    // No version specified - assume compatible (backwards compat)
-    return
-  }
-  if (serverVersion !== TSS_FRAMED_PROTOCOL_VERSION) {
-    throw new Error(
-      `Incompatible framed protocol version: server=${serverVersion}, client=${TSS_FRAMED_PROTOCOL_VERSION}. ` +
-        `Please ensure client and server are using compatible versions.`,
-    )
-  }
-}
-
 /**
  * Minimal metadata about a server function, available to client middleware.
  * Only contains the function ID since name/filename may expose server internals.
@@ -86,5 +27,3 @@ export interface ServerFnMeta extends ClientFnMeta {
   /** The source file path relative to the project root (e.g., "src/routes/api.ts") */
   filename: string
 }
-
-export {}

--- a/packages/start-client-core/src/createSerovalPlugins.ts
+++ b/packages/start-client-core/src/createSerovalPlugins.ts
@@ -1,0 +1,15 @@
+import {
+  makeSerovalPlugin,
+  defaultSerovalPlugins as routerDefaultSerovalPlugins,
+} from '@tanstack/router-core'
+import type { AnySerializationAdapter } from '@tanstack/router-core'
+import type { Plugin } from 'seroval'
+
+export function createSerovalPlugins(
+  adapters: ReadonlyArray<AnySerializationAdapter> | undefined,
+): Array<Plugin<any, any>> {
+  return [
+    ...(adapters?.map(makeSerovalPlugin) ?? []),
+    ...routerDefaultSerovalPlugins,
+  ]
+}

--- a/packages/start-client-core/src/framed-content-type.ts
+++ b/packages/start-client-core/src/framed-content-type.ts
@@ -1,0 +1,8 @@
+/** Shared with the dispatcher without importing the framed decoder protocol. */
+export const TSS_CONTENT_TYPE_FRAMED = 'application/x-tss-framed'
+
+/** Current protocol version for framed responses. */
+export const TSS_FRAMED_PROTOCOL_VERSION = 1
+
+/** Header construction stays outside the optional decoder protocol module. */
+export const TSS_CONTENT_TYPE_FRAMED_VERSIONED = `${TSS_CONTENT_TYPE_FRAMED}; v=${TSS_FRAMED_PROTOCOL_VERSION}`

--- a/packages/start-client-core/src/framed-protocol.ts
+++ b/packages/start-client-core/src/framed-protocol.ts
@@ -1,0 +1,51 @@
+import { TSS_FRAMED_PROTOCOL_VERSION } from './framed-content-type'
+
+/**
+ * Frame types for binary multiplexing protocol.
+ */
+export const FrameType = {
+  /** Seroval JSON chunk (NDJSON line) */
+  JSON: 0,
+  /** Raw stream data chunk */
+  CHUNK: 1,
+  /** Raw stream end (EOF) */
+  END: 2,
+  /** Raw stream error */
+  ERROR: 3,
+} as const
+
+export type FrameType = (typeof FrameType)[keyof typeof FrameType]
+
+/** Header size in bytes: type(1) + streamId(4) + length(4) */
+export const FRAME_HEADER_SIZE = 9
+
+/**
+ * Parses the version parameter from a framed Content-Type header.
+ * Returns undefined if no version parameter is present.
+ */
+const FRAMED_VERSION_REGEX = /;\s*v=(\d+)/
+export function parseFramedProtocolVersion(
+  contentType: string,
+): number | undefined {
+  // Match "v=<number>" in the content-type parameters
+  const match = contentType.match(FRAMED_VERSION_REGEX)
+  return match ? parseInt(match[1]!, 10) : undefined
+}
+
+/**
+ * Validates that the server's protocol version is compatible with this client.
+ * Throws an error if versions are incompatible.
+ */
+export function validateFramedProtocolVersion(contentType: string): void {
+  const serverVersion = parseFramedProtocolVersion(contentType)
+  if (serverVersion === undefined) {
+    // No version specified - assume compatible (backwards compat)
+    return
+  }
+  if (serverVersion !== TSS_FRAMED_PROTOCOL_VERSION) {
+    throw new Error(
+      `Incompatible framed protocol version: server=${serverVersion}, client=${TSS_FRAMED_PROTOCOL_VERSION}. ` +
+        `Please ensure client and server are using compatible versions.`,
+    )
+  }
+}

--- a/packages/start-client-core/src/getDefaultSerovalPlugins.ts
+++ b/packages/start-client-core/src/getDefaultSerovalPlugins.ts
@@ -1,18 +1,6 @@
-import {
-  makeSerovalPlugin,
-  defaultSerovalPlugins as routerDefaultSerovalPlugins,
-} from '@tanstack/router-core'
 import { getStartOptions } from './getStartOptions'
-import type { AnySerializationAdapter } from '@tanstack/router-core'
-import type { Plugin } from 'seroval'
+import { createSerovalPlugins } from './createSerovalPlugins'
 
-export function getDefaultSerovalPlugins(): Array<Plugin<any, any>> {
-  const start = getStartOptions()
-  const adapters = start?.serializationAdapters as
-    | Array<AnySerializationAdapter>
-    | undefined
-  return [
-    ...(adapters?.map(makeSerovalPlugin) ?? []),
-    ...routerDefaultSerovalPlugins,
-  ]
+export function getDefaultSerovalPlugins() {
+  return createSerovalPlugins(getStartOptions()?.serializationAdapters)
 }

--- a/packages/start-client-core/src/index.tsx
+++ b/packages/start-client-core/src/index.tsx
@@ -99,21 +99,22 @@ export type {
 export {
   TSS_FORMDATA_CONTEXT,
   TSS_SERVER_FUNCTION,
-  TSS_CONTENT_TYPE_FRAMED,
-  TSS_CONTENT_TYPE_FRAMED_VERSIONED,
-  TSS_FRAMED_PROTOCOL_VERSION,
-  FrameType,
-  FRAME_HEADER_SIZE,
   X_TSS_SERIALIZED,
   X_TSS_RAW_RESPONSE,
   X_TSS_CONTEXT,
+} from './constants'
+export type { ClientFnMeta, ServerFnMeta } from './constants'
+export {
+  TSS_CONTENT_TYPE_FRAMED,
+  TSS_CONTENT_TYPE_FRAMED_VERSIONED,
+  TSS_FRAMED_PROTOCOL_VERSION,
+} from './framed-content-type'
+export {
+  FrameType,
+  FRAME_HEADER_SIZE,
   validateFramedProtocolVersion,
-} from './constants'
-export type {
-  FrameType as FrameTypeValue,
-  ClientFnMeta,
-  ServerFnMeta,
-} from './constants'
+} from './framed-protocol'
+export type { FrameType as FrameTypeValue } from './framed-protocol'
 
 export type * from './serverRoute'
 
@@ -132,4 +133,4 @@ export { getRouterInstance } from './getRouterInstance'
 export { getDefaultSerovalPlugins } from './getDefaultSerovalPlugins'
 export { getGlobalStartContext } from './getGlobalStartContext'
 export { safeObjectMerge, createNullProtoObject } from './safeObjectMerge'
-export { trackPostProcessPromise } from './client-rpc/serverFnFetcher'
+export { trackPostProcessPromise } from './client-rpc/postProcessContext'

--- a/packages/start-client-core/tests/frame-decoder.test.ts
+++ b/packages/start-client-core/tests/frame-decoder.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { createFrameDecoder } from '../src/client-rpc/frame-decoder'
-import { FRAME_HEADER_SIZE, FrameType } from '../src/constants'
+import { FRAME_HEADER_SIZE, FrameType } from '../src/framed-protocol'
 
 /**
  * Helper to encode a frame for testing

--- a/packages/start-client-core/tests/serverFnCodec.test.ts
+++ b/packages/start-client-core/tests/serverFnCodec.test.ts
@@ -1,0 +1,336 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fromJSON, toCrossJSONAsync, toCrossJSONStream } from 'seroval'
+import { createSerializationAdapter } from '@tanstack/router-core'
+import { createSerovalPlugins } from '../src/createSerovalPlugins'
+import { FRAME_HEADER_SIZE } from '../src/framed-protocol'
+import { TSS_CONTENT_TYPE_FRAMED_VERSIONED } from '../src/framed-content-type'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+async function getCodec() {
+  const codec = await import('../src/client-rpc/serverFnCodec')
+  const { setPostProcessContext } =
+    await import('../src/client-rpc/postProcessContext')
+  return {
+    serialize: codec.serialize,
+    deserialize(
+      response: Response,
+      contentType: string,
+      adapters: Parameters<typeof codec.deserialize>[2],
+    ) {
+      if (process.env.TSS_SERVER_FN_TRANSPORT !== 'lazy') {
+        return codec.deserialize(response, contentType, adapters)
+      }
+      return codec.deserialize(
+        response,
+        contentType,
+        adapters,
+        contentType.includes('application/x-tss-framed'),
+        setPostProcessContext,
+      )
+    },
+  }
+}
+
+describe.each(['bundled', 'lazy'] as const)(
+  '%s server function codec',
+  (mode) => {
+    afterEach(() => vi.unstubAllEnvs())
+    beforeEach(() => {
+      vi.stubEnv('TSS_SERVER_FN_TRANSPORT', mode)
+      vi.resetModules()
+    })
+
+    it('preserves rich request and response values', async () => {
+      const codec = await getCodec()
+      const value = {
+        date: new Date('2026-09-08'),
+        map: new Map([['key', 123n]]),
+        missing: undefined,
+      }
+      expect(
+        fromJSON(JSON.parse(await codec.serialize(value, undefined)), {
+          plugins: createSerovalPlugins(undefined),
+        }),
+      ).toEqual(value)
+      const encoded = await toCrossJSONAsync(value, {
+        plugins: createSerovalPlugins(undefined),
+      })
+      await expect(
+        codec.deserialize(
+          Response.json(encoded),
+          'application/json',
+          undefined,
+        ),
+      ).resolves.toEqual(value)
+    })
+
+    it('delivers the first framed value before its deferred promise', async () => {
+      const codec = await getCodec()
+      const later = deferred<string>()
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          toCrossJSONStream(
+            { value: 'first', later: later.promise },
+            {
+              plugins: createSerovalPlugins(undefined),
+              onParse(value) {
+                const payload = new TextEncoder().encode(JSON.stringify(value))
+                const frame = new Uint8Array(FRAME_HEADER_SIZE + payload.length)
+                new DataView(frame.buffer).setUint32(5, payload.length, false)
+                frame.set(payload, FRAME_HEADER_SIZE)
+                controller.enqueue(frame)
+              },
+              onDone() {
+                controller.close()
+              },
+              onError(error) {
+                controller.error(error)
+              },
+            },
+          )
+        },
+      })
+      const result = await codec.deserialize(
+        new Response(body),
+        TSS_CONTENT_TYPE_FRAMED_VERSIONED,
+        undefined,
+      )
+      expect(result.value).toBe('first')
+      expect(result.later).toBeInstanceOf(Promise)
+      later.resolve('second')
+      await expect(result.later).resolves.toBe('second')
+    })
+
+    it('preserves custom adapters and waits for their post-processing', async () => {
+      const codec = await getCodec()
+      const context = await import('../src/client-rpc/postProcessContext')
+      const { trackPostProcessPromise } = await import('../src/index')
+      const gate = deferred<void>()
+      class Value {
+        ready = false
+        constructor(public value: string) {}
+      }
+      const fromSerializable = vi.fn((value: string) => {
+        const result = new Value(value)
+        trackPostProcessPromise(
+          gate.promise.then(() => {
+            result.ready = true
+          }),
+        )
+        return result
+      })
+      const adapter = createSerializationAdapter({
+        key: 'test',
+        test: (value): value is Value => value instanceof Value,
+        toSerializable: (value) => value.value,
+        fromSerializable,
+      })
+      const wire = await toCrossJSONAsync(
+        { value: new Value('custom') },
+        { plugins: createSerovalPlugins([adapter]) },
+      )
+      let ready = false
+      const result = codec
+        .deserialize(Response.json(wire), 'application/json', [adapter])
+        .then((value) => {
+          ready = true
+          return value
+        })
+      await vi.waitFor(() => expect(fromSerializable).toHaveBeenCalledOnce())
+      expect(context.getPostProcessContext()).toBeNull()
+      expect(ready).toBe(false)
+      gate.resolve()
+      await expect(result).resolves.toEqual({
+        value: { value: 'custom', ready: true },
+      })
+    })
+
+    it('keeps concurrent adapter post-processing scoped to each response', async () => {
+      const codec = await getCodec()
+      const { trackPostProcessPromise } = await import('../src/index')
+      const { getPostProcessContext } =
+        await import('../src/client-rpc/postProcessContext')
+      const gates = { first: deferred<void>(), second: deferred<void>() }
+      class Value {
+        ready = false
+        constructor(public key: keyof typeof gates) {}
+      }
+      const decode = vi.fn((key: keyof typeof gates) => {
+        const value = new Value(key)
+        trackPostProcessPromise(
+          gates[key].promise.then(() => {
+            value.ready = true
+          }),
+        )
+        return value
+      })
+      const adapter = createSerializationAdapter({
+        key: 'concurrent',
+        test: (value): value is Value => value instanceof Value,
+        toSerializable: (value) => value.key,
+        fromSerializable: decode,
+      })
+      const wire = await Promise.all(
+        ['first', 'second'].map((key) =>
+          toCrossJSONAsync(
+            { value: new Value(key as keyof typeof gates) },
+            { plugins: createSerovalPlugins([adapter]) },
+          ),
+        ),
+      )
+      let firstReady = false
+      const first = codec
+        .deserialize(Response.json(wire[0]), 'application/json', [adapter])
+        .then((value) => {
+          firstReady = true
+          return value
+        })
+      const second = codec.deserialize(
+        Response.json(wire[1]),
+        'application/json',
+        [adapter],
+      )
+      await vi.waitFor(() => expect(decode).toHaveBeenCalledTimes(2))
+      expect(getPostProcessContext()).toBeNull()
+      gates.second.resolve()
+      await expect(second).resolves.toEqual({
+        value: { key: 'second', ready: true },
+      })
+      expect(firstReady).toBe(false)
+      gates.first.resolve()
+      await expect(first).resolves.toEqual({
+        value: { key: 'first', ready: true },
+      })
+    })
+
+    it('keeps later framed post-processing independent across concurrent responses', async () => {
+      const codec = await getCodec()
+      const { trackPostProcessPromise } = await import('../src/index')
+      const { getPostProcessContext } =
+        await import('../src/client-rpc/postProcessContext')
+      const gates = { a: deferred<void>(), b: deferred<void>() }
+      const decoded: Array<string> = []
+      class Value {
+        constructor(public label: string) {}
+      }
+      const adapter = createSerializationAdapter({
+        key: 'framed-context',
+        test: (value): value is Value => value instanceof Value,
+        toSerializable: (value) => value.label,
+        fromSerializable: (label) => {
+          decoded.push(label)
+          const gate = gates[label as keyof typeof gates]
+          if (gate) {
+            trackPostProcessPromise(gate.promise)
+          }
+          return new Value(label)
+        },
+      })
+      function response() {
+        const later = deferred<Value>()
+        const after = deferred<Value>()
+        const stream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            toCrossJSONStream(
+              { later: later.promise, after: after.promise },
+              {
+                plugins: createSerovalPlugins([adapter]),
+                onParse(value) {
+                  const payload = new TextEncoder().encode(
+                    JSON.stringify(value),
+                  )
+                  const frame = new Uint8Array(
+                    FRAME_HEADER_SIZE + payload.length,
+                  )
+                  new DataView(frame.buffer).setUint32(5, payload.length, false)
+                  frame.set(payload, FRAME_HEADER_SIZE)
+                  controller.enqueue(frame)
+                },
+                onDone() {
+                  controller.close()
+                },
+                onError(error) {
+                  controller.error(error)
+                },
+              },
+            )
+          },
+        })
+        return {
+          later,
+          after,
+          result: codec.deserialize(
+            new Response(stream),
+            TSS_CONTENT_TYPE_FRAMED_VERSIONED,
+            [adapter],
+          ),
+        }
+      }
+      const a = response()
+      const b = response()
+      const [first, second] = await Promise.all([a.result, b.result])
+      a.later.resolve(new Value('a'))
+      b.later.resolve(new Value('b'))
+      await vi.waitFor(() => expect(decoded).toHaveLength(2))
+      a.after.resolve(new Value('after-a'))
+      b.after.resolve(new Value('after-b'))
+      gates.b.resolve()
+      await expect(second.after).resolves.toEqual(new Value('after-b'))
+      expect(decoded).not.toContain('after-a')
+      expect(getPostProcessContext()).toBeNull()
+      gates.a.resolve()
+      await expect(first.after).resolves.toEqual(new Value('after-a'))
+      expect(getPostProcessContext()).toBeNull()
+    })
+
+    it('clears the public context when an adapter throws', async () => {
+      const codec = await getCodec()
+      const { getPostProcessContext } =
+        await import('../src/client-rpc/postProcessContext')
+      class Value {}
+      const adapter = createSerializationAdapter({
+        key: 'throwing',
+        test: (value): value is Value => value instanceof Value,
+        toSerializable: () => null,
+        fromSerializable: () => {
+          throw new Error('adapter failed')
+        },
+      })
+      const wire = await toCrossJSONAsync(new Value(), {
+        plugins: createSerovalPlugins([adapter]),
+      })
+      await expect(
+        codec.deserialize(Response.json(wire), 'application/json', [adapter]),
+      ).rejects.toThrow('adapter failed')
+      expect(getPostProcessContext()).toBeNull()
+    })
+
+    it('rejects incompatible framed responses before consuming their body', async () => {
+      const codec = await getCodec()
+      await expect(
+        codec.deserialize(
+          new Response('invalid'),
+          'application/x-tss-framed; v=999',
+          undefined,
+        ),
+      ).rejects.toThrow('Incompatible framed protocol version')
+    })
+
+    it('propagates serialized errors', async () => {
+      const codec = await getCodec()
+      const wire = await toCrossJSONAsync(new Error('expected'), {
+        plugins: createSerovalPlugins(undefined),
+      })
+      await expect(
+        codec.deserialize(Response.json(wire), 'application/json', undefined),
+      ).rejects.toThrow('expected')
+    })
+  },
+)

--- a/packages/start-client-core/tests/serverFnCodecLoader.test.ts
+++ b/packages/start-client-core/tests/serverFnCodecLoader.test.ts
@@ -1,0 +1,45 @@
+import { expect, it, vi } from 'vitest'
+
+it('shares the real codec import across concurrent and later calls', async () => {
+  vi.resetModules()
+  const { loadServerFnCodec } =
+    await import('../src/client-rpc/serverFnCodecLoader.lazy')
+  const first = loadServerFnCodec()
+  expect(loadServerFnCodec()).toBe(first)
+  const codec = await first
+  expect(codec.serialize).toBeTypeOf('function')
+  expect(codec.deserialize).toBeTypeOf('function')
+  expect(await loadServerFnCodec()).toBe(codec)
+})
+
+it('clears a failed import so a later call can retry and share the new promise', async () => {
+  vi.resetModules()
+  const failure = new Error('temporary chunk fetch failure')
+  vi.doMock('../src/client-rpc/serverFnCodec', () => {
+    throw failure
+  })
+  try {
+    const { loadServerFnCodec } =
+      await import('../src/client-rpc/serverFnCodecLoader.lazy')
+    const first = loadServerFnCodec()
+    expect(loadServerFnCodec()).toBe(first)
+    // Vitest wraps errors thrown by mock module factories.
+    await expect(first).rejects.toHaveProperty('cause', failure)
+
+    // Simulate a retryable chunk-fetch failure becoming available. Keep the
+    // same loader closure; resetting it would conceal a stuck pending promise.
+    vi.doMock('../src/client-rpc/serverFnCodec', () => ({
+      serialize: vi.fn(),
+      deserialize: vi.fn(),
+    }))
+    const retry = loadServerFnCodec()
+    expect(retry).not.toBe(first)
+    expect(loadServerFnCodec()).toBe(retry)
+    const codec = await retry
+    expect(codec.serialize).toBeTypeOf('function')
+    expect(await loadServerFnCodec()).toBe(codec)
+  } finally {
+    vi.doUnmock('../src/client-rpc/serverFnCodec')
+    vi.resetModules()
+  }
+})

--- a/packages/start-client-core/tests/serverFnFetcher.test.ts
+++ b/packages/start-client-core/tests/serverFnFetcher.test.ts
@@ -1,0 +1,429 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { serverFnFetcher } from '../src/client-rpc/serverFnFetcher'
+import {
+  TSS_FORMDATA_CONTEXT,
+  X_TSS_RAW_RESPONSE,
+  X_TSS_SERIALIZED,
+} from '../src/constants'
+import type { ServerFnCodec } from '../src/client-rpc/serverFnCodecLoader'
+
+const mocks = vi.hoisted(() => ({
+  load: vi.fn(),
+  options: vi.fn(),
+  serialize: vi.fn(),
+  deserialize: vi.fn(),
+}))
+vi.mock('#tanstack-start-server-fn-codec', () => ({
+  serialize: mocks.serialize,
+  deserialize: mocks.deserialize,
+}))
+vi.mock('../src/client-rpc/serverFnCodecLoader.lazy', () => ({
+  loadServerFnCodec: mocks.load,
+}))
+vi.mock('../src/getStartOptions', () => ({ getStartOptions: mocks.options }))
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+function response() {
+  return Response.json(
+    { value: 'ok' },
+    { headers: { [X_TSS_SERIALIZED]: 'true' } },
+  )
+}
+
+describe('server function codec loading', () => {
+  let codec: ServerFnCodec
+  afterEach(() => {
+    expect(mocks.serialize).not.toHaveBeenCalled()
+    expect(mocks.deserialize).not.toHaveBeenCalled()
+    vi.unstubAllEnvs()
+  })
+  beforeEach(() => {
+    vi.stubEnv('TSS_SERVER_FN_TRANSPORT', 'lazy')
+    vi.clearAllMocks()
+    mocks.options.mockReturnValue(undefined)
+    codec = {
+      serialize: vi.fn(async (value) => JSON.stringify(value)),
+      deserialize: vi.fn(async (res) => res.json()),
+    }
+    mocks.load.mockResolvedValue(codec)
+  })
+
+  it.each(['GET', 'POST'])(
+    'dispatches a payload-free %s while the codec is loading',
+    async (method) => {
+      const loading = deferred<ServerFnCodec>()
+      mocks.load.mockReturnValue(loading.promise)
+      const fetch = vi.fn(async () => response())
+      const result = serverFnFetcher('/fn', [{ method, context: {} }], fetch)
+      expect(fetch).toHaveBeenCalledOnce()
+      expect(codec.deserialize).not.toHaveBeenCalled()
+      loading.resolve(codec)
+      await expect(result).resolves.toEqual({ value: 'ok' })
+    },
+  )
+
+  it.each(['GET', 'POST'])(
+    'waits for codec and serialization before dispatching a %s payload',
+    async (method) => {
+      const loading = deferred<ServerFnCodec>()
+      const encoding = deferred<string>()
+      mocks.load.mockReturnValue(loading.promise)
+      vi.mocked(codec.serialize).mockReturnValue(encoding.promise)
+      const fetch = vi.fn(async () => response())
+      const result = serverFnFetcher(
+        '/fn?existing=1',
+        [{ method, data: null, context: { token: 'context' } }],
+        fetch,
+      )
+      expect(fetch).not.toHaveBeenCalled()
+      loading.resolve(codec)
+      await Promise.resolve()
+      expect(codec.serialize).toHaveBeenCalledWith(
+        { data: null, context: { token: 'context' } },
+        undefined,
+      )
+      expect(fetch).not.toHaveBeenCalled()
+      encoding.resolve('encoded')
+      await result
+      expect(fetch).toHaveBeenCalledOnce()
+      const [url, init] = fetch.mock.calls[0] as unknown as [
+        string,
+        RequestInit,
+      ]
+      if (method === 'GET') {
+        expect(url).toBe('/fn?existing=1&payload=encoded')
+        expect(init.body).toBeUndefined()
+      } else {
+        expect(init.body).toBe('encoded')
+        expect(new Headers(init.headers).get('content-type')).toBe(
+          'application/json',
+        )
+      }
+    },
+  )
+
+  it.each([false, 0, ''])('serializes defined falsy data %j', async (data) => {
+    await serverFnFetcher('/fn', [{ method: 'POST', data }], async () =>
+      response(),
+    )
+    expect(codec.serialize).toHaveBeenCalledWith({ data }, undefined)
+  })
+
+  it('does not load or fetch with an already-aborted signal', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const fetch = vi.fn()
+    await expect(
+      serverFnFetcher(
+        '/fn',
+        [{ method: 'GET', signal: controller.signal }],
+        fetch,
+      ),
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    expect(mocks.load).not.toHaveBeenCalled()
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('serializes middleware context even when there is no data', async () => {
+    const loading = deferred<ServerFnCodec>()
+    mocks.load.mockReturnValue(loading.promise)
+    const fetch = vi.fn(async () => response())
+    const result = serverFnFetcher(
+      '/fn',
+      [{ method: 'GET', context: { user: 1 } }],
+      fetch,
+    )
+    expect(fetch).not.toHaveBeenCalled()
+    loading.resolve(codec)
+    await result
+    expect(codec.serialize).toHaveBeenCalledWith(
+      { context: { user: 1 } },
+      undefined,
+    )
+  })
+
+  it('dispatches FormData without serialization when context is empty', async () => {
+    const loading = deferred<ServerFnCodec>()
+    mocks.load.mockReturnValue(loading.promise)
+    const data = new FormData()
+    data.set('name', 'value')
+    const fetch = vi.fn(async () => response())
+    const result = serverFnFetcher(
+      '/fn',
+      [{ method: 'POST', data, context: {} }],
+      fetch,
+    )
+    expect(fetch).toHaveBeenCalledWith(
+      '/fn',
+      expect.objectContaining({ body: data }),
+    )
+    expect(codec.serialize).not.toHaveBeenCalled()
+    loading.resolve(codec)
+    await result
+  })
+
+  it('waits for serialized context before sending FormData', async () => {
+    const loading = deferred<ServerFnCodec>()
+    mocks.load.mockReturnValue(loading.promise)
+    const data = new FormData()
+    const fetch = vi.fn(async () => response())
+    const result = serverFnFetcher(
+      '/fn',
+      [{ method: 'POST', data, context: { user: 1 } }],
+      fetch,
+    )
+    expect(fetch).not.toHaveBeenCalled()
+    expect(data.has(TSS_FORMDATA_CONTEXT)).toBe(false)
+    loading.resolve(codec)
+    await result
+    expect(data.get(TSS_FORMDATA_CONTEXT)).toBe('{"user":1}')
+    expect(codec.serialize).toHaveBeenCalledWith({ user: 1 }, undefined)
+  })
+
+  it('rejects GET FormData before loading the codec or sending a request', async () => {
+    const fetch = vi.fn()
+    await expect(
+      serverFnFetcher('/fn', [{ method: 'GET', data: new FormData() }], fetch),
+    ).rejects.toThrow('FormData is not supported')
+    expect(mocks.load).not.toHaveBeenCalled()
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('does not dispatch after an abort during codec loading', async () => {
+    const loading = deferred<ServerFnCodec>()
+    mocks.load.mockReturnValue(loading.promise)
+    const controller = new AbortController()
+    const fetch = vi.fn()
+    const result = serverFnFetcher(
+      '/fn',
+      [{ method: 'POST', data: 1, signal: controller.signal }],
+      fetch,
+    )
+    controller.abort()
+    await expect(result).rejects.toMatchObject({ name: 'AbortError' })
+    expect(fetch).not.toHaveBeenCalled()
+    expect(codec.serialize).not.toHaveBeenCalled()
+    const other = serverFnFetcher('/fn', [{ method: 'GET' }], async () =>
+      response(),
+    )
+    loading.resolve(codec)
+    await expect(other).resolves.toEqual({ value: 'ok' })
+  })
+
+  it('observes early import failures and cancels the response without replaying the RPC', async () => {
+    const loading = deferred<ServerFnCodec>()
+    const rpc = deferred<Response>()
+    mocks.load.mockReturnValue(loading.promise)
+    const fetch = vi.fn(() => rpc.promise)
+    const result = serverFnFetcher('/fn', [{ method: 'POST' }], fetch)
+    const error = new Error('chunk unavailable')
+    loading.reject(error)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    const cancel = vi.fn()
+    rpc.resolve(
+      new Response(new ReadableStream({ cancel }), {
+        headers: {
+          'content-type': 'application/json',
+          [X_TSS_SERIALIZED]: 'true',
+        },
+      }),
+    )
+    await expect(result).rejects.toBe(error)
+    expect(cancel).toHaveBeenCalledOnce()
+    expect(fetch).toHaveBeenCalledOnce()
+  })
+
+  it('aborts after headers without waiting for the shared codec import', async () => {
+    const loading = deferred<ServerFnCodec>()
+    mocks.load.mockReturnValue(loading.promise)
+    const controller = new AbortController()
+    const cancel = vi.fn()
+    const res = new Response(new ReadableStream({ cancel }), {
+      headers: {
+        'content-type': 'application/json',
+        [X_TSS_SERIALIZED]: 'true',
+      },
+    })
+    const result = serverFnFetcher(
+      '/fn',
+      [{ method: 'GET', signal: controller.signal }],
+      async () => res,
+    )
+    await Promise.resolve()
+    controller.abort()
+    await expect(result).rejects.toMatchObject({ name: 'AbortError' })
+    expect(cancel).toHaveBeenCalledOnce()
+    expect(codec.deserialize).not.toHaveBeenCalled()
+    loading.resolve(codec)
+  })
+
+  it('does not encode or send a payload when the import fails', async () => {
+    const error = new Error('chunk unavailable')
+    mocks.load.mockReturnValue(Promise.reject(error))
+    const fetch = vi.fn()
+    await expect(
+      serverFnFetcher('/fn', [{ method: 'POST', data: 1 }], fetch),
+    ).rejects.toBe(error)
+    expect(codec.serialize).not.toHaveBeenCalled()
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns raw responses without waiting for the codec', async () => {
+    mocks.load.mockReturnValue(new Promise(() => {}))
+    const raw = new Response('raw', {
+      headers: { [X_TSS_RAW_RESPONSE]: 'true' },
+    })
+    await expect(
+      serverFnFetcher('/fn', [{ method: 'GET' }], async () => raw),
+    ).resolves.toBe(raw)
+  })
+
+  it('preserves custom fetch, headers, signal, adapters, and thrown Responses', async () => {
+    const adapters = []
+    mocks.options.mockReturnValue({ serializationAdapters: adapters })
+    const controller = new AbortController()
+    const headers = new Headers({ authorization: 'test' })
+    const custom = vi.fn(async () => {
+      throw response()
+    })
+    const fallback = vi.fn()
+    await expect(
+      serverFnFetcher(
+        '/fn',
+        [{ method: 'GET', fetch: custom, headers, signal: controller.signal }],
+        fallback,
+      ),
+    ).resolves.toEqual({ value: 'ok' })
+    expect(fallback).not.toHaveBeenCalled()
+    expect(headers.has('x-tsr-serverFn')).toBe(false)
+    expect(custom).toHaveBeenCalledWith(
+      '/fn',
+      expect.objectContaining({ signal: controller.signal }),
+    )
+    expect(codec.deserialize).toHaveBeenCalledWith(
+      expect.any(Response),
+      'application/json',
+      adapters,
+      false,
+      expect.any(Function),
+    )
+  })
+})
+
+describe('bundled codec specialization', () => {
+  afterEach(() => vi.unstubAllEnvs())
+  it.each([
+    { method: 'GET' },
+    { method: 'POST', data: { value: 'payload' } },
+    { method: 'POST', data: new FormData(), context: { value: 'context' } },
+  ])(
+    'calls static codec functions without invoking the loader for $method',
+    async (options) => {
+      vi.stubEnv('TSS_SERVER_FN_TRANSPORT', 'bundled')
+      vi.clearAllMocks()
+      mocks.options.mockReturnValue(undefined)
+      mocks.load.mockImplementation(() => {
+        throw new Error('bundled must not load the lazy codec')
+      })
+      mocks.serialize.mockImplementation(async (value) => JSON.stringify(value))
+      mocks.deserialize.mockImplementation(async (res) => res.json())
+      const fetch = vi.fn(async () => response())
+      await expect(serverFnFetcher('/fn', [options], fetch)).resolves.toEqual({
+        value: 'ok',
+      })
+      expect(fetch).toHaveBeenCalledOnce()
+      expect(mocks.load).not.toHaveBeenCalled()
+      expect(mocks.deserialize).toHaveBeenCalledOnce()
+    },
+  )
+})
+
+describe.each(['bundled', 'lazy'] as const)(
+  '%s synchronous fetch exceptions',
+  (mode) => {
+    afterEach(() => {
+      vi.unstubAllEnvs()
+      vi.restoreAllMocks()
+    })
+    beforeEach(() => {
+      vi.stubEnv('TSS_SERVER_FN_TRANSPORT', mode)
+      vi.clearAllMocks()
+      mocks.options.mockReturnValue(undefined)
+      mocks.deserialize.mockImplementation(async (res) => res.json())
+      mocks.load.mockResolvedValue({
+        serialize: mocks.serialize,
+        deserialize: mocks.deserialize,
+      })
+    })
+    it('decodes a synchronously thrown Response', async () => {
+      await expect(
+        serverFnFetcher('/fn', [{ method: 'GET' }], () => {
+          throw response()
+        }),
+      ).resolves.toEqual({ value: 'ok' })
+      expect(mocks.deserialize).toHaveBeenCalledOnce()
+    })
+    it('preserves a synchronously thrown Error and observes a later codec failure', async () => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+      const loading = deferred<ServerFnCodec>()
+      mocks.load.mockReturnValue(loading.promise)
+      const error = new Error('fetch failed')
+      await expect(
+        serverFnFetcher('/fn', [{ method: 'GET' }], () => {
+          throw error
+        }),
+      ).rejects.toBe(error)
+      if (mode === 'lazy') {
+        loading.reject(new Error('later import failure'))
+        await Promise.resolve()
+      }
+      expect(mocks.deserialize).not.toHaveBeenCalled()
+    })
+  },
+)
+
+describe('lazy abort during serialization', () => {
+  afterEach(() => vi.unstubAllEnvs())
+  it.each(['GET', 'POST', 'FormData'])(
+    'does not dispatch or mutate context after aborting %s encoding',
+    async (method) => {
+      vi.stubEnv('TSS_SERVER_FN_TRANSPORT', 'lazy')
+      vi.clearAllMocks()
+      mocks.options.mockReturnValue(undefined)
+      const encoding = deferred<string>()
+      const serialize = vi.fn(() => encoding.promise)
+      mocks.load.mockResolvedValue({ serialize, deserialize: vi.fn() })
+      const controller = new AbortController()
+      const form = new FormData()
+      const fetch = vi.fn(async () => response())
+      const result = serverFnFetcher(
+        '/fn',
+        [
+          {
+            method: method === 'GET' ? 'GET' : 'POST',
+            data: method === 'FormData' ? form : { value: 'payload' },
+            context: { value: 'context' },
+            signal: controller.signal,
+          },
+        ],
+        fetch,
+      )
+      await vi.waitFor(() => expect(serialize).toHaveBeenCalledOnce())
+      const reason = new Error('cancel encoding')
+      controller.abort(reason)
+      encoding.resolve('encoded')
+      await expect(result).rejects.toBe(reason)
+      expect(fetch).not.toHaveBeenCalled()
+      expect(form.has(TSS_FORMDATA_CONTEXT)).toBe(false)
+    },
+  )
+})

--- a/packages/start-client-core/vite.config.ts
+++ b/packages/start-client-core/vite.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url'
 import { defineConfig, mergeConfig } from 'vitest/config'
 import { tanstackViteConfig } from '@tanstack/vite-config'
 import packageJson from './package.json'
@@ -12,6 +13,11 @@ export default defineConfig(({ command }) =>
             }
           : undefined,
       test: {
+        alias: {
+          '#tanstack-start-server-fn-codec': fileURLToPath(
+            new URL('./src/client-rpc/serverFnCodec.ts', import.meta.url),
+          ),
+        },
         typecheck: { enabled: true },
         name: packageJson.name,
         watch: false,
@@ -25,6 +31,7 @@ export default defineConfig(({ command }) =>
         './src/index.tsx',
         './src/client/index.ts',
         './src/client-rpc/index.ts',
+        './src/client-rpc/serverFnCodec.stub.ts',
         './src/hydration/constants.ts',
         './src/hydration.ts',
         './src/hydration/runtime.ts',
@@ -37,6 +44,7 @@ export default defineConfig(({ command }) =>
         '#tanstack-start-entry',
         '#tanstack-router-entry',
         '#tanstack-start-plugin-adapters',
+        '#tanstack-start-server-fn-codec',
       ],
     }),
   ),

--- a/packages/start-plugin-core/src/rsbuild/planning.ts
+++ b/packages/start-plugin-core/src/rsbuild/planning.ts
@@ -1,6 +1,7 @@
 import { createRequire } from 'node:module'
 import { join } from 'pathe'
 import { mergeRsbuildConfig } from '@rsbuild/core'
+import { createServerFnTransportAliases } from '../server-fn-transport'
 import { ENTRY_POINTS } from '../constants'
 import type { EnvironmentConfig } from '@rsbuild/core'
 import type { ResolvedStartEntryPlan } from '../planning'
@@ -97,6 +98,7 @@ export function createRsbuildEnvironmentPlan(opts: {
   serverOutputDirectory: string
   publicBase: string
   serverFnProviderEnv: string
+  serverFnTransport?: 'bundled' | 'lazy'
   environmentOverrides?: RsbuildEnvironmentOverrides
   scriptFormat?: ScriptFormat
   rsc?: boolean | undefined
@@ -104,6 +106,7 @@ export function createRsbuildEnvironmentPlan(opts: {
 }): RsbuildEnvironmentPlanResult {
   const alias = {
     ...opts.entryAliases.alias,
+    ...createServerFnTransportAliases(opts.serverFnTransport),
     ...(opts.rsc
       ? {
           'react-server-dom-rspack/server$': resolveFromRoot(

--- a/packages/start-plugin-core/src/rsbuild/plugin.ts
+++ b/packages/start-plugin-core/src/rsbuild/plugin.ts
@@ -172,6 +172,7 @@ export function tanStackStartRsbuild(
           serverOutputDirectory: resolvedStartConfig.outputDirectories.server,
           publicBase: resolvedStartConfig.basePaths.publicBase,
           serverFnProviderEnv,
+          serverFnTransport: startConfig.serverFns.transport,
           environmentOverrides: corePluginOpts.rsbuild?.environments,
           scriptFormat,
           rsc: rscOpts,
@@ -202,6 +203,12 @@ export function tanStackStartRsbuild(
                 }
               : {}),
             define: {
+              'process.env.TSS_SERVER_FN_TRANSPORT': JSON.stringify(
+                startConfig.serverFns.transport,
+              ),
+              'import.meta.env.TSS_SERVER_FN_TRANSPORT': JSON.stringify(
+                startConfig.serverFns.transport,
+              ),
               'process.env.TSS_SERVER_FN_BASE': JSON.stringify(serverFnBase),
               'import.meta.env.TSS_SERVER_FN_BASE':
                 JSON.stringify(serverFnBase),

--- a/packages/start-plugin-core/src/rsbuild/plugin.ts
+++ b/packages/start-plugin-core/src/rsbuild/plugin.ts
@@ -18,6 +18,7 @@ import {
   createRsbuildResolvedEntryAliases,
   resolveRsbuildOutputDirectory,
 } from './planning'
+import { applyServerFnCodecSplitting } from './server-fn-transport'
 import { registerStartCompilerTransforms } from './start-compiler-host'
 import { registerImportProtection } from './import-protection'
 import {
@@ -292,6 +293,19 @@ export function tanStackStartRsbuild(
             alias: environmentPlan.alias,
           },
         })
+      })
+
+      api.modifyRspackConfig({
+        order: 'post',
+        handler(config, { environment, isDev }) {
+          if (
+            !isDev &&
+            environment.name === RSBUILD_ENVIRONMENT_NAMES.client &&
+            getConfig().startConfig.serverFns.transport === 'lazy'
+          ) {
+            applyServerFnCodecSplitting(config)
+          }
+        },
       })
 
       // ---------------------------------------------------------------

--- a/packages/start-plugin-core/src/rsbuild/server-fn-transport.ts
+++ b/packages/start-plugin-core/src/rsbuild/server-fn-transport.ts
@@ -1,0 +1,71 @@
+import type { Rspack } from '@rsbuild/core'
+
+const codecModule =
+  /[\\/]start-client-core[\\/](?:src|dist[\\/]esm)[\\/]client-rpc[\\/]serverFnCodec\.[jt]s$/
+
+function createServerFnCodecVendorGroup(): Rspack.OptimizationSplitChunksCacheGroup {
+  const graphs = new WeakMap<
+    Rspack.Compilation['chunkGraph'],
+    WeakMap<Rspack.Chunk, boolean>
+  >()
+  return {
+    // Preserve the default vendor group, except dependencies used only by
+    // the codec: extracting those adds a request and prevents concatenation.
+    test(module, { chunkGraph }) {
+      if (!/[\\/]node_modules[\\/]/.test(module.nameForCondition() ?? '')) {
+        return false
+      }
+      let onlyChunk: Rspack.Chunk | undefined
+      for (const chunk of chunkGraph.getModuleChunksIterable(module)) {
+        if (onlyChunk || chunk.canBeInitial()) {
+          return true
+        }
+        onlyChunk = chunk
+      }
+      if (!onlyChunk) {
+        return true
+      }
+      let codecChunks = graphs.get(chunkGraph)
+      if (!codecChunks) {
+        codecChunks = new WeakMap()
+        graphs.set(chunkGraph, codecChunks)
+      }
+      let isCodec = codecChunks.get(onlyChunk)
+      if (isCodec === undefined) {
+        isCodec = false
+        for (const member of chunkGraph.getChunkModulesIterable(onlyChunk)) {
+          if (codecModule.test(member.nameForCondition() ?? '')) {
+            isCodec = true
+            break
+          }
+        }
+        codecChunks.set(onlyChunk, isCodec)
+      }
+      return !isCodec
+    },
+    idHint: 'vendors',
+    priority: -10,
+    reuseExistingChunk: true,
+  }
+}
+
+/** Apply after preset resolution; user tools.rspack callbacks still run later. */
+export function applyServerFnCodecSplitting(
+  config: Rspack.Configuration,
+): void {
+  const splitChunks = config.optimization?.splitChunks
+  if (
+    !splitChunks ||
+    (splitChunks.cacheGroups &&
+      Object.prototype.hasOwnProperty.call(
+        splitChunks.cacheGroups,
+        'defaultVendors',
+      ))
+  ) {
+    return
+  }
+  splitChunks.cacheGroups = {
+    ...splitChunks.cacheGroups,
+    defaultVendors: createServerFnCodecVendorGroup(),
+  }
+}

--- a/packages/start-plugin-core/src/schema.ts
+++ b/packages/start-plugin-core/src/schema.ts
@@ -247,6 +247,7 @@ export const tanstackStartOptionsObjectSchema = z.object({
   serverFns: z
     .object({
       base: z.string().optional().default('/_serverFn'),
+      transport: z.enum(['bundled', 'lazy']).optional().default('bundled'),
       disableCsrfMiddlewareWarning: z.boolean().optional().default(false),
       generateFunctionId: z
         .custom<

--- a/packages/start-plugin-core/src/server-fn-transport.ts
+++ b/packages/start-plugin-core/src/server-fn-transport.ts
@@ -1,0 +1,10 @@
+export function createServerFnTransportAliases(
+  transport: 'bundled' | 'lazy' = 'bundled',
+): Partial<Record<'#tanstack-start-server-fn-codec', string>> {
+  return transport === 'lazy'
+    ? {
+        '#tanstack-start-server-fn-codec':
+          '@tanstack/start-client-core/client-rpc/codec-stub',
+      }
+    : {}
+}

--- a/packages/start-plugin-core/src/vite/planning.ts
+++ b/packages/start-plugin-core/src/vite/planning.ts
@@ -7,6 +7,7 @@ import {
   START_ENVIRONMENT_NAMES,
 } from '../constants'
 import { getBundlerOptions } from '../utils'
+import { createServerFnTransportAliases } from '../server-fn-transport'
 import type { CompileStartFrameworkOptions } from '../types'
 import type { ResolvedStartEntryPlan } from '../planning'
 import type * as vite from 'vite'
@@ -49,6 +50,7 @@ export function createViteConfigPlan(opts: {
   clientOutputDirectory: string
   serverOutputDirectory: string
   serverFnProviderEnv: string
+  serverFnTransport?: 'bundled' | 'lazy'
   optimizeDepsExclude: Array<string>
   noExternal: Array<string>
 }) {
@@ -131,6 +133,7 @@ export function createViteConfigPlan(opts: {
       ],
       alias: {
         ...opts.entryAliases.alias,
+        ...createServerFnTransportAliases(opts.serverFnTransport),
       },
     },
   } satisfies Pick<vite.UserConfig, 'environments' | 'resolve'>
@@ -140,6 +143,7 @@ export function createViteDefineConfig(opts: {
   command: 'serve' | 'build'
   mode: string | undefined
   serverFnBase: string
+  serverFnTransport?: 'bundled' | 'lazy'
   routerBasepath: string
   spaEnabled: boolean | undefined
   devSsrStylesEnabled: boolean
@@ -150,6 +154,10 @@ export function createViteDefineConfig(opts: {
 }) {
   return {
     ...defineReplaceEnv('TSS_SERVER_FN_BASE', opts.serverFnBase),
+    ...defineReplaceEnv(
+      'TSS_SERVER_FN_TRANSPORT',
+      opts.serverFnTransport ?? 'bundled',
+    ),
     ...defineReplaceEnv('TSS_ROUTER_BASEPATH', opts.routerBasepath),
     ...(opts.command === 'serve'
       ? defineReplaceEnv('TSS_SHELL', opts.spaEnabled ? 'true' : 'false')

--- a/packages/start-plugin-core/src/vite/plugin.ts
+++ b/packages/start-plugin-core/src/vite/plugin.ts
@@ -166,6 +166,7 @@ export function tanStackStartVite(
           clientOutputDirectory: resolvedStartConfig.outputDirectories.client,
           serverOutputDirectory: resolvedStartConfig.outputDirectories.server,
           serverFnProviderEnv,
+          serverFnTransport: startConfig.serverFns.transport,
           optimizeDepsExclude: crawlFrameworkPkgsResult.optimizeDeps.exclude,
           noExternal: crawlFrameworkPkgsResult.ssr.noExternal.sort(),
         })
@@ -180,6 +181,7 @@ export function tanStackStartVite(
             command,
             mode: viteConfig.mode,
             serverFnBase: TSS_SERVER_FN_BASE,
+            serverFnTransport: startConfig.serverFns.transport,
             routerBasepath,
             spaEnabled: startConfig.spa?.enabled,
             devSsrStylesEnabled: startConfig.dev.ssrStyles.enabled,

--- a/packages/start-plugin-core/tests/rsbuild/server-fn-transport.test.ts
+++ b/packages/start-plugin-core/tests/rsbuild/server-fn-transport.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test, vi } from 'vitest'
+import { applyServerFnCodecSplitting } from '../../src/rsbuild/server-fn-transport'
+import type { Rspack } from '@rsbuild/core'
+
+function moduleAt(path: string | null) {
+  return { nameForCondition: () => path } as Rspack.Module
+}
+
+function chunk(initial = false) {
+  return { canBeInitial: () => initial } as Rspack.Chunk
+}
+
+function graph(chunks: Array<Rspack.Chunk>, members: Array<Rspack.Module>) {
+  const getChunkModulesIterable = vi.fn(() => members)
+  return {
+    chunkGraph: {
+      getModuleChunksIterable: () => chunks,
+      getChunkModulesIterable,
+    } as unknown as Rspack.Compilation['chunkGraph'],
+    moduleGraph: {} as Rspack.Compilation['moduleGraph'],
+    getChunkModulesIterable,
+  }
+}
+
+function vendorTest() {
+  const config: Rspack.Configuration = {
+    optimization: { splitChunks: {} },
+  }
+  applyServerFnCodecSplitting(config)
+  const splitChunks = config.optimization!.splitChunks!
+  if (!splitChunks) {
+    throw new Error('Expected chunk splitting')
+  }
+  const group = splitChunks.cacheGroups!.defaultVendors
+  if (!group || typeof group.test !== 'function') {
+    throw new Error('Expected vendor filter')
+  }
+  return group.test
+}
+
+const vendor = moduleAt('/app/node_modules/seroval/dist/index.js')
+const codec = moduleAt(
+  '/app/node_modules/@tanstack/start-client-core/dist/esm/client-rpc/serverFnCodec.js',
+)
+
+describe('codec vendor splitting', () => {
+  test.each([
+    '/repo/packages/start-client-core/src/client-rpc/serverFnCodec.ts',
+    '/repo/packages/start-client-core/dist/esm/client-rpc/serverFnCodec.js',
+    '/app/node_modules/@tanstack/start-client-core/dist/esm/client-rpc/serverFnCodec.js',
+    '/app/node_modules/.pnpm/@tanstack+start-client-core@1.0.0/node_modules/@tanstack/start-client-core/dist/esm/client-rpc/serverFnCodec.js',
+    'C:\\app\\node_modules\\@tanstack\\start-client-core\\dist\\esm\\client-rpc\\serverFnCodec.js',
+  ])('keeps exclusive dependencies with codec at %s', (path) => {
+    expect(
+      vendorTest()(vendor, graph([chunk()], [moduleAt(path), vendor])),
+    ).toBe(false)
+  })
+
+  test('recognizes a Windows vendor path', () => {
+    expect(
+      vendorTest()(
+        moduleAt('C:\\app\\node_modules\\seroval\\dist\\index.js'),
+        graph([chunk()], [codec]),
+      ),
+    ).toBe(false)
+  })
+
+  test.each([
+    '/app/src/vendor.ts',
+    '/app/not_node_modules/seroval/index.js',
+    null,
+  ])('does not treat %s as a vendor', (path) => {
+    expect(vendorTest()(moduleAt(path), graph([chunk()], []))).toBe(false)
+  })
+
+  test('leaves unrelated async vendors eligible for extraction', () => {
+    expect(vendorTest()(vendor, graph([chunk()], [vendor]))).toBe(true)
+  })
+
+  test('does not mistake the initial codec loader for the codec', () => {
+    const loader = moduleAt(
+      '/repo/packages/start-client-core/dist/esm/client-rpc/serverFnCodecLoader.lazy.js',
+    )
+    expect(vendorTest()(vendor, graph([chunk()], [loader]))).toBe(true)
+  })
+
+  test('preserves a vendor shared with another async chunk', () => {
+    expect(
+      vendorTest()(vendor, graph([chunk(), chunk()], [codec, vendor])),
+    ).toBe(true)
+  })
+
+  test('preserves initial vendors and vendors shared with an initial chunk', () => {
+    const filter = vendorTest()
+    expect(filter(vendor, graph([chunk(true)], [codec, vendor]))).toBe(true)
+    expect(filter(vendor, graph([chunk(), chunk(true)], [codec, vendor]))).toBe(
+      true,
+    )
+  })
+
+  test('leaves chunkless vendors alone', () => {
+    expect(vendorTest()(vendor, graph([], []))).toBe(true)
+  })
+
+  test('scans each chunk once, scoped to its compilation graph', () => {
+    const filter = vendorTest()
+    const sharedChunk = chunk()
+    const first = graph([sharedChunk], [codec, vendor])
+    for (let i = 0; i < 100; i++) {
+      expect(filter(vendor, first)).toBe(false)
+    }
+    expect(first.getChunkModulesIterable).toHaveBeenCalledOnce()
+
+    const nextCompilation = graph([sharedChunk], [vendor])
+    expect(filter(vendor, nextCompilation)).toBe(true)
+    expect(nextCompilation.getChunkModulesIterable).toHaveBeenCalledOnce()
+  })
+})
+
+describe('resolved split configuration', () => {
+  test.each<Rspack.Configuration>([
+    {},
+    { optimization: {} },
+    { optimization: { splitChunks: false } },
+  ])('preserves absent or disabled splitting', (config) => {
+    const before = structuredClone(config)
+    applyServerFnCodecSplitting(config)
+    expect(config).toEqual(before)
+  })
+
+  test.each([false as const, { test: /custom/ }, { test: () => true }])(
+    'preserves explicit defaultVendors: %s',
+    (defaultVendors) => {
+      const splitChunks = { cacheGroups: { defaultVendors } }
+      applyServerFnCodecSplitting({ optimization: { splitChunks } })
+      expect(splitChunks.cacheGroups.defaultVendors).toBe(defaultVendors)
+    },
+  )
+
+  test('preserves an explicitly undefined vendor group from JavaScript config', () => {
+    const cacheGroups: NonNullable<
+      Rspack.OptimizationSplitChunksOptions['cacheGroups']
+    > = {}
+    Object.defineProperty(cacheGroups, 'defaultVendors', {
+      value: undefined,
+      enumerable: true,
+    })
+    applyServerFnCodecSplitting({
+      optimization: { splitChunks: { cacheGroups } },
+    })
+    expect(cacheGroups.defaultVendors).toBeUndefined()
+  })
+
+  test('preserves preset/custom groups and inherited chunk names', () => {
+    const vendors = { test: /node_modules/, name: 'vendor', priority: 0 }
+    const custom = { test: /editor/, name: 'editor' }
+    const splitChunks: Rspack.OptimizationSplitChunksOptions = {
+      name: 'custom-name',
+      cacheGroups: { vendors, custom },
+    }
+    applyServerFnCodecSplitting({ optimization: { splitChunks } })
+    expect(splitChunks.name).toBe('custom-name')
+    expect(splitChunks.cacheGroups!.vendors).toBe(vendors)
+    expect(splitChunks.cacheGroups!.custom).toBe(custom)
+    expect(splitChunks.cacheGroups!.defaultVendors).toEqual({
+      idHint: 'vendors',
+      test: expect.any(Function),
+      priority: -10,
+      reuseExistingChunk: true,
+    })
+  })
+
+  test('does not replace a previously installed group', () => {
+    const splitChunks: Rspack.OptimizationSplitChunksOptions = {}
+    const config = { optimization: { splitChunks } }
+    applyServerFnCodecSplitting(config)
+    const group = splitChunks.cacheGroups!.defaultVendors
+    applyServerFnCodecSplitting(config)
+    expect(splitChunks.cacheGroups!.defaultVendors).toBe(group)
+  })
+})

--- a/packages/start-plugin-core/tests/server-fn-transport.test.ts
+++ b/packages/start-plugin-core/tests/server-fn-transport.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from 'vitest'
+import { parseStartConfig as parseVite } from '../src/vite/schema'
+import { parseStartConfig as parseRsbuild } from '../src/rsbuild/schema'
+import { createServerFnTransportAliases } from '../src/server-fn-transport'
+import {
+  createViteConfigPlan,
+  createViteDefineConfig,
+  createViteResolvedEntryAliases,
+} from '../src/vite/planning'
+import {
+  createRsbuildEnvironmentPlan,
+  createRsbuildResolvedEntryAliases,
+} from '../src/rsbuild/planning'
+
+describe.each([
+  ['vite', parseVite],
+  ['rsbuild', parseRsbuild],
+] as const)('%s server function transport', (_, parse) => {
+  test('defaults to bundled, including SPA mode', () => {
+    expect(
+      parse({}, { framework: 'react' }, process.cwd()).serverFns.transport,
+    ).toBe('bundled')
+    expect(
+      parse({ spa: { enabled: true } }, { framework: 'react' }, process.cwd())
+        .serverFns.transport,
+    ).toBe('bundled')
+  })
+  test('accepts lazy as an explicit build choice', () => {
+    expect(
+      parse(
+        { serverFns: { transport: 'lazy' } },
+        { framework: 'react' },
+        process.cwd(),
+      ).serverFns.transport,
+    ).toBe('lazy')
+  })
+  test('rejects invalid transport values', () => {
+    expect(() =>
+      parse(
+        { serverFns: { transport: 'preload' as 'lazy' } },
+        { framework: 'react' },
+        process.cwd(),
+      ),
+    ).toThrow()
+  })
+})
+
+test('only lazy mode aliases the static codec imports', () => {
+  expect(createServerFnTransportAliases('bundled')).toEqual({})
+  expect(createServerFnTransportAliases('lazy')).toEqual({
+    '#tanstack-start-server-fn-codec':
+      '@tanstack/start-client-core/client-rpc/codec-stub',
+  })
+})
+
+test.each(['bundled', 'lazy'] as const)(
+  'forwards %s into both bundler plans',
+  (serverFnTransport) => {
+    const entryPaths = {
+      client: '/app/client.ts',
+      server: '/app/server.ts',
+      start: '/app/start.ts',
+      router: '/app/router.ts',
+    }
+    const common = {
+      clientOutputDirectory: '/app/dist/client',
+      serverOutputDirectory: '/app/dist/server',
+      serverFnProviderEnv: 'ssr',
+      serverFnTransport,
+    }
+    const vite = createViteConfigPlan({
+      ...common,
+      viteConfig: {},
+      command: 'build',
+      framework: 'react',
+      entryAliases: createViteResolvedEntryAliases({ entryPaths }),
+      optimizeDepsExclude: [],
+      noExternal: [],
+    })
+    const rsbuild = createRsbuildEnvironmentPlan({
+      ...common,
+      root: '/app',
+      publicBase: '/',
+      entryAliases: createRsbuildResolvedEntryAliases({ entryPaths }),
+    })
+    const expected =
+      serverFnTransport === 'lazy'
+        ? '@tanstack/start-client-core/client-rpc/codec-stub'
+        : undefined
+    expect(vite.resolve.alias['#tanstack-start-server-fn-codec']).toBe(expected)
+    expect(rsbuild.alias['#tanstack-start-server-fn-codec']).toBe(expected)
+  },
+)
+
+test.each(['bundled', 'lazy'] as const)(
+  'defines %s at build time',
+  (serverFnTransport) => {
+    const definitions = createViteDefineConfig({
+      command: 'build',
+      mode: 'production',
+      serverFnBase: '/_serverFn',
+      serverFnTransport,
+      routerBasepath: '/',
+      spaEnabled: false,
+      devSsrStylesEnabled: false,
+      devSsrStylesBasepath: '/',
+      inlineCssEnabled: false,
+      staticNodeEnv: true,
+      disableCsrfMiddlewareWarning: false,
+    })
+    expect(definitions['process.env.TSS_SERVER_FN_TRANSPORT']).toBe(
+      JSON.stringify(serverFnTransport),
+    )
+    expect(definitions['import.meta.env.TSS_SERVER_FN_TRANSPORT']).toBe(
+      JSON.stringify(serverFnTransport),
+    )
+  },
+)


### PR DESCRIPTION
## 🎯 Changes

Add an opt-in lazy server-function codec, deferring Seroval, its plugins, and framed decoding for streaming/RSC until the first browser call.

```ts
tanstackStart({ serverFns: { transport: 'lazy' } })
```

Available in the **Vite and Rsbuild plugins**:

- **`bundled` (default, including SPA):** codec stays in the initial bundle; no separate transport load. Prefer this for first-render server functions.
- **`lazy`:** import starts at invocation, alongside payload-free RPCs. Data or middleware context requires the codec before dispatch; FormData without context can dispatch immediately. Later calls reuse the import.

### Bundle results

Gzip-byte deltas against `main` at `9871c06258`, using otherwise identical minimal fixtures. “Total” includes deferred chunks.

| Fixture | Mode | Initial Δ | Total Δ |
| --- | --- | ---: | ---: |
| React / Vite | bundled | −26 B | −27 B |
| React / Vite | lazy | **−9,321 B** | +81 B |
| React / Rsbuild | bundled | +82 B | +82 B |
| React / Rsbuild | lazy | **−12,184 B** | +554 B |
| React / Rsbuild IIFE | lazy | **−12,199 B** | +535 B |

Solid/Vue lazy minimal save ~9.3 KB initial gzip. Router-only scenarios are unchanged. Existing Start minimal benchmarks select lazy; other scenarios retain bundled. Rsbuild keeps codec-exclusive dependencies together while preserving shared dependencies and explicit user chunk settings.

### Tradeoffs

- **Cold-call latency:** with artificial 100 ms script/RPC delays, payload-free calls added ~2 ms; payload/context calls added ~108 ms. With a 100 ms script delay and fast RPC, both added ~100 ms. Warm differences were small/noisy.
- **Adapters:** `serializationAdapters` and async post-processing work in both modes. Adapter code remains initial. Ordinary adapters preserve the saving; directly importing Seroval reduced measured savings to ~2.7 KB (Vite) / ~2.6 KB (Rsbuild).
- **Caching:** codec hashes survived unrelated app edits in tested Vite/Rsbuild/RSC builds. Other Seroval imports, custom chunking, dependency changes, and cache headers can affect this.

<details>
<summary>Implementation and validation</summary>

Compile-time flags remove unused mode branches. A lazy-only alias prevents Vite from retaining the bundled codec import; its stub is eliminated. Imports are shared, failed imports clear the cached promise, and cancellation affects only the caller. Adapters share the existing post-processing context.

Passed: package unit/type/lint/export checks, 18 bundle scenarios, 85 production browser tests, and 12 adapter browser builds. Rsbuild validation also covers shared Seroval, custom splitting settings, and streaming. E2E configuration uses a separate variable from the internal transport flag.

Timing experiments covered 576 cold calls plus warm calls and cached reloads, with 8 paired repetitions per case/profile. These use synthetic delays, without bandwidth/CPU throttling. The query-only SPA case is excluded for a hydration mismatch reproduced in the pre-prototype build.

Experiment reports, harness/results, and the microbenchmark remain local and are excluded from this PR.

</details>

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [ ] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<details>
<summary>Automated release summary</summary>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable server-function transport modes: `bundled` (default) and `lazy`.
  - Lazy mode loads serialization and response decoding on demand, allowing eligible requests to start while required code downloads.
  - Added support across Vite and Rsbuild, including streaming responses and custom serialization adapters.

- **Documentation**
  - Documented transport modes, loading behavior, streaming interactions, SPA mode, and adapter considerations.

- **Tests**
  - Added coverage for lazy loading, concurrent requests, aborts, streaming, adapters, and protocol compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

</details>
