### PR TITLE
test(router-core): cover SSR URL encoding regressions

### DIFF
--- a/packages/router-core/tests/server-url-encoding.test.ts
+++ b/packages/router-core/tests/server-url-encoding.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from 'vitest'
+import { BaseRootRoute, BaseRoute } from '../src'
+import { createTestRouter, loadServerResponse } from './routerTestUtils'
+
+const asciiControls = [...Array.from({ length: 32 }, (_, code) => code), 127]
+const staticPaths = ['/', '/admin', '/profile'] as const
+const parameterCases = [
+  '{{app_name}}',
+  '<test>',
+  '"quoted"',
+  "apostrophe's",
+  'back`tick',
+  'file name',
+  'a\\b',
+  'a%b',
+  '대한민국',
+  '😀',
+  ...asciiControls.map((code) => `a${String.fromCharCode(code)}b`),
+].map((value) => ({ value, path: `/params/${encodeURIComponent(value)}` }))
+const encodedControls = [
+  ...asciiControls.map(
+    (code) => `%${code.toString(16).padStart(2, '0').toUpperCase()}`,
+  ),
+  '%0D%0A',
+]
+
+describe.each([false, true])('SSR URL encoding (rewrite: %s)', (rewrite) => {
+  function setupRouter() {
+    const loaderCalls: Array<string> = []
+    const rootRoute = new BaseRootRoute()
+    const staticRoutes = staticPaths.map(
+      (path) =>
+        new BaseRoute({
+          getParentRoute: () => rootRoute,
+          path,
+          loader: () => {
+            loaderCalls.push(path)
+            return path
+          },
+        }),
+    )
+    const paramRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/params/$value',
+      loader: ({ params }) => params.value,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([...staticRoutes, paramRoute]),
+      isServer: true,
+      rewrite: rewrite
+        ? { input: ({ url }) => url, output: ({ url }) => url }
+        : undefined,
+    })
+    return { router, paramRoute, loaderCalls }
+  }
+
+  test.each(parameterCases)(
+    'serves and rebuilds $path without redirecting',
+    async ({ value, path }) => {
+      const { router, paramRoute } = setupRouter()
+
+      const response = await loadServerResponse(router, path)
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('Location')).toBeNull()
+      const match = router.state.matches.find(
+        (item) => item.routeId === paramRoute.id,
+      )
+      expect(match?.params).toEqual({ value })
+      expect(match?.loaderData).toBe(value)
+      expect(
+        router.buildLocation({ to: '/params/$value', params: { value } })
+          .publicHref,
+      ).toBe(path)
+    },
+  )
+
+  test.each(staticPaths)('loads the ordinary route %s', async (path) => {
+    const { router, loaderCalls } = setupRouter()
+
+    const response = await loadServerResponse(router, path)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Location')).toBeNull()
+    expect(loaderCalls).toEqual([path])
+  })
+
+  test.each(encodedControls)(
+    'preserves %s when resolving routes and canonicalizing trailing slashes',
+    async (encoded) => {
+      for (const variant of new Set([encoded, encoded.toLowerCase()])) {
+        for (const path of [
+          `/${variant}admin`,
+          `/assets/..${variant}/profile`,
+          `/assets/..${variant}/`,
+        ]) {
+          const normalizedPath = path.replace(variant, encoded)
+          const { router, loaderCalls } = setupRouter()
+
+          const response = await loadServerResponse(router, path)
+
+          expect(loaderCalls, path).toEqual([])
+          expect(router.state.location.pathname, path).toBe(normalizedPath)
+          if (path.endsWith('/')) {
+            const destination = normalizedPath.slice(0, -1)
+            expect(response.status, path).toBe(307)
+            expect(response.headers.get('Location'), path).toBe(destination)
+
+            // Removing the trailing slash must preserve the encoded segment
+            // and end at a 404, rather than redirecting again or loading '/'.
+            const followUp = setupRouter()
+            const finalResponse = await loadServerResponse(
+              followUp.router,
+              destination,
+            )
+            expect(finalResponse.status, path).toBe(404)
+            expect(finalResponse.headers.get('Location'), path).toBeNull()
+            expect(followUp.loaderCalls, path).toEqual([])
+            expect(followUp.router.state.location.pathname, path).toBe(
+              destination,
+            )
+          } else {
+            expect(response.status, path).toBe(404)
+            expect(response.headers.get('Location'), path).toBeNull()
+          }
+        }
+      }
+    },
+  )
+})


### PR DESCRIPTION
## 🎯 Changes

Adds SSR request-handler regression tests for encoded path parameters, extending the coverage from #7695. They assert HTTP 200 without a redirect, correctly decoded parameters and loader data, and a stable rebuilt URL for braces, angle brackets, quotes, backticks, spaces, backslashes, percent signs, Unicode, and all ASCII controls.

Also verifies that percent-encoded controls remain part of the path when matching routes. Ordinary routes provide positive loader checks; altered paths must return 404 without running those loaders. Trailing-slash redirects must preserve the encoded segment and terminate at a 404. Both groups run with ordinary routing and identity input/output rewrites.

Validation:

- `pnpm nx run @tanstack/router-core:test:unit -- tests/server-url-encoding.test.ts`: all 160 new tests pass.
- `pnpm nx run @tanstack/router-core:test:unit`: 122 files pass, with 1,969 passing tests and 4 existing expected failures.
- `pnpm nx run @tanstack/router-core:test:types`: passes on TypeScript 5.6, 5.7, 5.8, 5.9, 6.0, and 7.0.
- `pnpm nx run @tanstack/router-core:test:eslint -- tests/server-url-encoding.test.ts`: passes with existing source warnings only.
- Prettier and `git diff --check` pass.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for server-rendered URL encoding across parameterized and static routes.
  * Verified handling of special characters, Unicode, emoji, and encoded control characters.
  * Confirmed consistent routing behavior with rewrites enabled or disabled, including redirects, route parameters, loader results, and canonical URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->