### PR TITLE
perf(router-core): reduce empty location pipeline work

### DIFF
--- a/.changeset/slick-forks-beam.md
+++ b/.changeset/slick-forks-beam.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+Reduce location-building overhead for object-form path params and empty search middleware pipelines.

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -2809,13 +2809,13 @@ function applySearchMiddleware(
   destRoutes: ReadonlyArray<AnyRoute>,
   includeValidateSearch: boolean | undefined,
 ) {
-  const middlewares = [] as Array<SearchMiddleware<any>>
+  let middlewares: Array<SearchMiddleware<any>> | undefined
 
   for (const route of destRoutes) {
     const routeOptions = route.options
     if ('search' in routeOptions) {
       if (routeOptions.search?.middlewares) {
-        middlewares.push(...routeOptions.search.middlewares)
+        ;(middlewares ||= []).push(...routeOptions.search.middlewares)
       }
     }
     // TODO remove preSearchFilters and postSearchFilters in v2
@@ -2837,7 +2837,7 @@ function applySearchMiddleware(
             )
           : result
       }
-      middlewares.push(legacyMiddleware)
+      ;(middlewares ||= []).push(legacyMiddleware)
     }
 
     const routeValidateSearch = routeOptions.validateSearch
@@ -2861,9 +2861,17 @@ function applySearchMiddleware(
         return result
       }
 
-      middlewares.push(validate)
+      ;(middlewares ||= []).push(validate)
     }
   }
+
+  if (!middlewares?.length) {
+    if (!dest.search) {
+      return !isServer && !hasKeys(search) ? search : {}
+    }
+    return dest.search === true ? search : functionalUpdate(dest.search, search)
+  }
+  const middlewareList = middlewares
 
   const applyNext = (
     index: number,
@@ -2871,7 +2879,7 @@ function applySearchMiddleware(
     meta?: SearchMiddlewareMeta,
   ): any => {
     // no more middlewares left, return the current search
-    if (index >= middlewares.length) {
+    if (index >= middlewareList.length) {
       if (!dest.search) {
         return {}
       }
@@ -2896,7 +2904,11 @@ function applySearchMiddleware(
       return applyNext(index + 1, newSearch, meta)
     }
 
-    return (middlewares[index]! as any)({ search: currentSearch, next, meta })
+    return (middlewareList[index]! as any)({
+      search: currentSearch,
+      next,
+      meta,
+    })
   }
 
   return applyNext(0, search)
@@ -2932,8 +2944,11 @@ function resolveNextParams(
   if ((spec ?? true) === true) {
     return base
   }
+  if (typeof spec !== 'function') {
+    return Object.assign(Object.create(null), base, spec)
+  }
   const next = Object.assign(Object.create(null), base)
-  return Object.assign(next, functionalUpdate(spec as any, next))
+  return Object.assign(next, spec(next))
 }
 
 function extractStrictParams(

--- a/packages/router-core/tests/build-location.test.ts
+++ b/packages/router-core/tests/build-location.test.ts
@@ -234,6 +234,25 @@ describe('buildLocation - params function receives parsed params', () => {
 })
 
 describe('buildLocation - search params', () => {
+  test('preserves structural sharing when clearing an already empty search', () => {
+    const rootRoute = new BaseRootRoute({})
+    const route = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([route]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    const inherited = router.buildLocation({ to: '/', search: true })
+    const cleared = router.buildLocation({ to: '/' })
+
+    expect(cleared.search).toBe(inherited.search)
+    expect(cleared.search).toEqual({})
+    expect(cleared.searchStr).toBe('')
+  })
+
   test('only applies route validation when requested', async () => {
     const events: Array<string> = []
     const validateSearch = vi.fn((search: Record<string, unknown>) => {
@@ -1653,6 +1672,32 @@ describe('buildLocation - basepath', () => {
 })
 
 describe('buildLocation - params edge cases', () => {
+  test('copies static param getters once without mutating inherited params', () => {
+    const rootRoute = new BaseRootRoute({})
+    const userRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/users/$userId',
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([userRoute]),
+      history: createMemoryHistory({ initialEntries: ['/users/123'] }),
+    })
+    const getUserId = vi.fn(() => '456')
+    const params = {
+      get userId() {
+        return getUserId()
+      },
+    }
+
+    expect(
+      router.buildLocation({ to: '/users/$userId', params }).pathname,
+    ).toBe('/users/456')
+    expect(getUserId).toHaveBeenCalledOnce()
+    expect(
+      router.buildLocation({ to: '/users/$userId', params: true }).pathname,
+    ).toBe('/users/123')
+  })
+
   test('params: true should preserve current params', async () => {
     const rootRoute = new BaseRootRoute({})
     const userRoute = new BaseRoute({


### PR DESCRIPTION
Combine object-form parameter merges into one native call. Allocate a search middleware pipeline only when it is needed, and reuse the existing empty client search value. Preserve callback and structural-sharing behavior.

React Link rendering benchmark, measured separately for this commit and its parent using exact production builds:
- Workload: benchmarks/client-nav/scenarios/links/react/speed.bench.ts (200 persistent Links, eight navigations per measured batch).
- Apple M4, Node 24.20.0, Vitest 4.1.4, NODE_ENV=production.
- 4 fresh parent processes and 8 fresh processes for this commit, each with warmupIterations=50 and time=10000 ms; counterbalanced run order.
- Parent mean times (ms): 4.4180, 4.0844, 4.1333, 4.2867.
- This commit mean times (ms): 3.9412, 3.8998, 3.8950, 4.2674, 4.0423, 3.8793, 3.9043, 4.1120.
- Median run means: 4.2100 -> 3.9228 ms.
- Incremental effect: 6.82% less time; throughput change +7.32%.
- Largest within-run RME for this revision: 1.22%.

Incremental minimal/full React gzip impact: +44/+49 bytes. Benchmark sources and commit implementation trees are unchanged.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [ ] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [ ] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved navigation location-building efficiency for object-form path parameters.
  * Reduced overhead when no search middleware is configured.

* **Bug Fixes**
  * Preserved shared empty search state when clearing an already-empty search.
  * Corrected static parameter handling to avoid repeated getter evaluation.
  * Preserved existing paths when retaining current route parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->