### PR TITLE
perf(react-router): avoid redundant Link state prop allocations

### DIFF
--- a/.changeset/honest-nails-burn.md
+++ b/.changeset/honest-nails-burn.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-router': patch
+---
+
+React Links resolve state props without temporary class-name arrays or unnecessary style copies.

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -543,32 +543,18 @@ export function useLinkProps<
     compareLinkState,
   )
 
-  // Get the active props
-  const resolvedActiveProps: React.HTMLAttributes<HTMLAnchorElement> = isActive
+  const resolvedProps: React.HTMLAttributes<HTMLAnchorElement> = isActive
     ? (functionalUpdate(activeProps as any, {}) ?? STATIC_ACTIVE_OBJECT)
-    : STATIC_EMPTY_OBJECT
-
-  // Get the inactive props
-  const resolvedInactiveProps: React.HTMLAttributes<HTMLAnchorElement> =
-    isActive
-      ? STATIC_EMPTY_OBJECT
-      : (functionalUpdate(inactiveProps, {}) ?? STATIC_EMPTY_OBJECT)
-
-  const resolvedClassName = [
-    className,
-    resolvedActiveProps.className,
-    resolvedInactiveProps.className,
-  ]
-    .filter(Boolean)
-    .join(' ')
-
-  const resolvedStyle = (style ||
-    resolvedActiveProps.style ||
-    resolvedInactiveProps.style) && {
-    ...style,
-    ...resolvedActiveProps.style,
-    ...resolvedInactiveProps.style,
-  }
+    : (functionalUpdate(inactiveProps, {}) ?? STATIC_EMPTY_OBJECT)
+  const stateClassName = resolvedProps.className
+  const resolvedClassName = className
+    ? stateClassName
+      ? `${className} ${stateClassName}`
+      : className
+    : stateClassName
+  const stateStyle = resolvedProps.style
+  const resolvedStyle =
+    style && stateStyle ? { ...style, ...stateStyle } : style || stateStyle
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const hasRenderFetched = React.useRef(false)
@@ -707,8 +693,7 @@ export function useLinkProps<
 
   return {
     ...propsSafeToSpread,
-    ...resolvedActiveProps,
-    ...resolvedInactiveProps,
+    ...resolvedProps,
     href,
     ref: innerRef as React.ComponentPropsWithRef<'a'>['ref'],
     onClick: composeHandlers(onClick, handleClick),

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -8148,3 +8148,57 @@ describe('explicit-undefined params are not collapsed into an empty object', () 
     )
   })
 })
+
+test('reuses unmodified Link styles and merges active styles', async () => {
+  const baseStyle = { color: 'red', marginTop: 2 }
+  let renderedStyle: React.CSSProperties | undefined
+  function StyledLink() {
+    const props = useLinkProps({
+      to: '/target',
+      style: baseStyle,
+      className: 'base',
+      activeProps: () => ({
+        className: 'selected',
+        style: { color: 'blue' },
+      }),
+      inactiveProps: () => ({ className: 'unselected' }),
+    })
+    renderedStyle = props.style
+    return <a {...props}>Styled target</a>
+  }
+  const rootRoute = createRootRoute({
+    component: () => (
+      <>
+        <StyledLink />
+        <Outlet />
+      </>
+    ),
+  })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+  })
+  const targetRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/target',
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute, targetRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+  render(<RouterProvider router={router} />)
+
+  const link = await screen.findByRole('link', { name: 'Styled target' })
+  expect(renderedStyle).toBe(baseStyle)
+  expect(link).toHaveClass('base', 'unselected')
+
+  await act(() => router.navigate({ to: '/target' }))
+
+  expect(renderedStyle).toEqual({ color: 'blue', marginTop: 2 })
+  expect(link).toHaveClass('base', 'selected')
+
+  await act(() => router.navigate({ to: '/' }))
+
+  expect(renderedStyle).toBe(baseStyle)
+  expect(link).toHaveClass('base', 'unselected')
+})


### PR DESCRIPTION
Links resolve one state-prop bag instead of separate active and inactive bags. Class names do not need temporary arrays. Unchanged styles retain their original references. Callback behavior and prop precedence remain unchanged.

React Link rendering benchmark, measured separately for this commit and its parent using exact production builds:
- Workload: benchmarks/client-nav/scenarios/links/react/speed.bench.ts (200 persistent Links, eight navigations per measured batch).
- Apple M4, Node 24.20.0, Vitest 4.1.4, NODE_ENV=production.
- 8 fresh parent processes and 8 fresh processes for this commit, each with warmupIterations=50 and time=10000 ms; counterbalanced run order.
- Parent mean times (ms): 3.9412, 3.8998, 3.8950, 4.2674, 4.0423, 3.8793, 3.9043, 4.1120.
- This commit mean times (ms): 3.8767, 3.8900, 4.5507, 4.0116, 3.8297, 3.8582, 3.8879, 4.0157.
- Median run means: 3.9228 -> 3.8889 ms.
- Incremental effect: 0.86% less time; throughput change +0.87%.
- Largest within-run RME for this revision: 3.08%.
- The small difference is not a reliable speedup claim; it is close to process-to-process variation.

Incremental minimal/full React gzip impact: -12/-7 bytes. Benchmark sources and commit implementation trees are unchanged.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [ ] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [ ] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved React Link styling so active and inactive state properties resolve correctly during navigation.
  - Base class names and styles are now preserved while state-specific styling is merged as expected.
  - Returning to the original route correctly restores the link’s default appearance.

- **Tests**
  - Added coverage for style and class-name behavior across active and inactive navigation states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->