### PR TITLE
perf(router-core): use fast-property records for SSR

### DIFF
--- a/.changeset/cold-mirrors-read.md
+++ b/.changeset/cold-mirrors-read.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+Reduce SSR Link rendering work by using fast-property null-prototype records on the server while preserving the existing client allocation path.

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -218,7 +218,9 @@ export function hasKeys(obj: Record<string, unknown>) {
   return false
 }
 
-export const createNull = () => Object.create(null)
+// SSR copies benefit from fast properties; client structural sharing does not.
+export const createNull = () =>
+  isServer ? Object.setPrototypeOf({}, null) : Object.create(null)
 export const nullReplaceEqualDeep: typeof replaceEqualDeep = (prev, next) =>
   replaceEqualDeep(prev, next, createNull)
 

--- a/packages/router-core/tests/null-records.bench.ts
+++ b/packages/router-core/tests/null-records.bench.ts
@@ -1,0 +1,82 @@
+import { afterAll, bench, describe, expect } from 'vitest'
+import { hasKeys } from '../src/utils'
+
+type RecordFactory = () => Record<string, unknown>
+
+const dictionary: RecordFactory = () => Object.create(null)
+const fast: RecordFactory = () => Object.setPrototypeOf({}, null)
+const iterations = 128
+const benchOptions = {
+  time: 500,
+  warmupTime: 100,
+  throws: true,
+}
+
+if (process.env.TSR_LINK_PERF === '1') {
+  for (const scenario of [
+    { name: 'empty records', size: 0, layouts: 1 },
+    { name: 'one field', size: 1, layouts: 1 },
+    { name: 'eight fields', size: 8, layouts: 1 },
+    { name: '64 fields', size: 64, layouts: 1 },
+    { name: '256 fields', size: 256, layouts: 1 },
+    { name: 'eight changing field names', size: 8, layouts: 32 },
+  ]) {
+    describe(`null records: ${scenario.name}`, () => {
+      for (const variant of [
+        {
+          name: 'dictionary source / dictionary target',
+          source: dictionary,
+          target: dictionary,
+        },
+        {
+          name: 'dictionary source / fast target',
+          source: dictionary,
+          target: fast,
+        },
+        {
+          name: 'fast source / dictionary target',
+          source: fast,
+          target: dictionary,
+        },
+        { name: 'fast source / fast target', source: fast, target: fast },
+      ]) {
+        const sources = Array.from(
+          { length: scenario.layouts },
+          (_, layout) => {
+            const source = variant.source()
+            for (let index = 0; index < scenario.size; index++) {
+              source[`field_${layout}_${index}`] = `value-${index}`
+            }
+            return source
+          },
+        )
+        const records: Array<Record<string, unknown>> = []
+        let nonempty = 0
+        function run() {
+          nonempty = 0
+          for (let index = 0; index < iterations; index++) {
+            const result = Object.assign(
+              variant.target(),
+              sources[index % sources.length],
+            )
+            records[index] = result
+            if (hasKeys(result)) {
+              nonempty++
+            }
+          }
+        }
+        function check() {
+          expect(nonempty).toBe(scenario.size ? iterations : 0)
+          for (let index = 0; index < records.length; index++) {
+            expect(Object.getPrototypeOf(records[index])).toBeNull()
+            expect(records[index]).toEqual(sources[index % sources.length])
+          }
+        }
+        run()
+        check()
+        bench(variant.name, run, benchOptions)
+        afterAll(check)
+      }
+    })
+  }
+}

--- a/packages/router-core/tests/null-records.test.ts
+++ b/packages/router-core/tests/null-records.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test, vi } from 'vitest'
+import { createNull } from '../src/utils'
+
+const environment = vi.hoisted(() => ({ server: false }))
+vi.mock('@tanstack/router-core/isServer', () => ({
+  get isServer() {
+    return environment.server
+  },
+}))
+
+describe.each([false, true])('null records (server: %s)', (server) => {
+  test('returns fresh extensible records without inherited properties', () => {
+    environment.server = server
+    const first = createNull()
+    const second = createNull()
+    expect(Object.getPrototypeOf(first)).toBeNull()
+    expect(Reflect.ownKeys(first)).toEqual([])
+    expect(Object.isExtensible(first)).toBe(true)
+    expect(first).not.toBe(second)
+    expect('constructor' in first).toBe(false)
+    expect('__proto__' in first).toBe(false)
+  })
+
+  test('copies special keys and symbols without invoking prototype setters', () => {
+    environment.server = server
+    const symbol = Symbol('param')
+    const source = JSON.parse(
+      '{"__proto__":{"polluted":true},"constructor":"value","id":"item"}',
+    )
+    source[symbol] = 'symbol value'
+    const result = Object.assign(createNull(), source)
+    expect(Object.getPrototypeOf(result)).toBeNull()
+    expect(Reflect.ownKeys(result)).toEqual(Reflect.ownKeys(source))
+    expect(Object.getOwnPropertyDescriptors(result)).toEqual(
+      Object.getOwnPropertyDescriptors(source),
+    )
+    expect(result.polluted).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Select Object.setPrototypeOf({}, null) in createNull only for the existing compile-time server branch. Keep client dictionary allocation and all direct allocation sites unchanged. Add null-prototype/special-key coverage for both branches and an opt-in 24-case small/large/dynamic record benchmark.

Against f38d8d0ede, six fresh paired SSR repetitions reduced CPU by 7.41% for shared params (95% CI -12.28% to -2.27%), 14.25% for unique params (-17.52% to -10.85%), and 9.24% for param updaters (-12.73% to -5.60%). Wall intervals also show speedups. Three unique-param allocation profiles averaged 1222705899 to 1125029176 bytes over 300 batches (-8.0%).

All 18 client bundle fixtures are byte-identical in raw/gzip/initial-gzip/Brotli. Rejected blanket client expansion because canonical CPU regressed about 21.5%; removed the separate parameter-target hunk after attribution found no demonstrated incremental speedup. Fast properties are not a universal dictionary optimization.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [ ] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [ ] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Reduced server-side rendering work for links, improving SSR efficiency while preserving existing client-side behavior.

- **Security and Reliability**
  - Improved handling of special object keys during rendering to prevent unintended prototype-related side effects.
  - Ensured generated link data remains isolated and safely extensible.

- **Tests**
  - Added coverage and performance benchmarks for server-rendered link data handling across different environments and record sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->