### PR TITLE
perf(router-core): avoid empty query serializer allocations

### DIFF
--- a/.changeset/empty-states-relax.md
+++ b/.changeset/empty-states-relax.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+Avoid constructing a query serializer when search is empty or all values are undefined.

--- a/packages/router-core/src/qss.ts
+++ b/packages/router-core/src/qss.ts
@@ -26,16 +26,16 @@ export function encode(
   obj: Record<string, any>,
   stringify: (value: any) => string = String,
 ): string {
-  const result = new URLSearchParams()
+  let result: URLSearchParams | undefined
 
   for (const key in obj) {
     const val = obj[key]
     if (val !== undefined) {
-      result.set(key, stringify(val))
+      ;(result ||= new URLSearchParams()).set(key, stringify(val))
     }
   }
 
-  return result.toString()
+  return result ? result.toString() : ''
 }
 
 /**

--- a/packages/router-core/tests/qss.test.ts
+++ b/packages/router-core/tests/qss.test.ts
@@ -1,7 +1,74 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { decode, encode } from '../src/qss'
 
+afterEach(() => vi.unstubAllGlobals())
+
 describe('encode function', () => {
+  it.each([{}, { skipped: undefined }])(
+    'does not allocate a native serializer for %j',
+    (input) => {
+      const Original = URLSearchParams
+      const constructor = vi.fn(function () {
+        return new Original()
+      })
+      vi.stubGlobal('URLSearchParams', constructor)
+      expect(encode(input)).toBe('')
+      expect(constructor).not.toHaveBeenCalled()
+    },
+  )
+
+  it('keeps getter and serializer order, including inherited values', () => {
+    const calls: Array<string> = []
+    const input = Object.create({
+      get inherited() {
+        calls.push('get inherited')
+        return 'last'
+      },
+    })
+    Object.defineProperties(input, {
+      skipped: {
+        enumerable: true,
+        get() {
+          calls.push('get skipped')
+          return undefined
+        },
+      },
+      own: {
+        enumerable: true,
+        get() {
+          calls.push('get own')
+          return 'first'
+        },
+      },
+    })
+    expect(
+      encode(input, (value) => {
+        calls.push(`stringify ${value}`)
+        return value
+      }),
+    ).toBe('own=first&inherited=last')
+    expect(calls).toEqual([
+      'get skipped',
+      'get own',
+      'stringify first',
+      'get inherited',
+      'stringify last',
+    ])
+  })
+
+  it('preserves falsy values and empty serializer output', () => {
+    expect(encode({ zero: 0, false: false, null: null, empty: '' })).toBe(
+      'zero=0&false=false&null=null&empty=',
+    )
+    expect(encode({ value: 'present' }, () => '')).toBe('value=')
+  })
+
+  it('retains native set semantics for keys that normalize to the same string', () => {
+    expect(encode({ '\uD800': 'first', '\uD801': 'second' })).toBe(
+      '%EF%BF%BD=second',
+    )
+  })
+
   it('should encode an object into a query string without a prefix', () => {
     const obj = { token: 'foo', key: 'value' }
     const queryString = encode(obj)

--- a/packages/router-core/tests/searchParams.bench.ts
+++ b/packages/router-core/tests/searchParams.bench.ts
@@ -112,6 +112,14 @@ function stringifyBatch(search: Record<string, unknown>) {
 }
 
 describe('default search serialization', () => {
+  bench('empty object', () => {
+    stringifyBatch({})
+  })
+
+  bench('only undefined values', () => {
+    stringifyBatch({ first: undefined, second: undefined })
+  })
+
   bench('ordinary string values', () => {
     stringifyBatch(ordinaryStrings)
   })


### PR DESCRIPTION
Construct URLSearchParams only when the first non-undefined input is serialized. Preserve inherited enumeration, getter/callback order, falsy values, empty custom output and native set collision semantics. Add failing-before empty-allocation cases and focused empty-query benchmark cases.

Against d40fb30307, four balanced isolated-process pairs reduced client shared-param CPU 7.89% (95% CI -12.61% to -2.92%) and wall 7.36% (-12.77% to -1.61%). SSR shared-param CPU fell 15.65% (-18.07% to -13.15%) and wall 15.63% (-18.72% to -12.41%). Populated middleware search remained inconclusive: CPU -0.20% (-2.69% to +2.36%), wall +0.02% (-3.36% to +3.51%).

React Router minimal/full gzip +1/+7 bytes; deltas across all 18 fixtures range -3 to +7 bytes. Custom stringifySearch and middleware are still executed; no API or functionality removed.

## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [ ] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [ ] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Empty search parameters and parameters containing only undefined values now produce an empty query string consistently.
  - Search parameter serialization preserves falsy values, inherited values, and duplicate normalized keys correctly.

- **Performance**
  - Avoids unnecessary query-string serializer creation when no defined search values are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->