### PR TITLE
fix(router-core): omit defaulted search params for retain-then-strip Links

### DIFF
--- a/.changeset/retain-strip-link-defaults.md
+++ b/.changeset/retain-strip-link-defaults.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+Fix `retainSearchParams` before `stripSearchParams` so Link hrefs omit default search params instead of keeping them and breaking active matching.

--- a/packages/react-router/tests/link.test.tsx
+++ b/packages/react-router/tests/link.test.tsx
@@ -6293,6 +6293,65 @@ describe('search middleware', () => {
     expect(postsLink).toHaveAttribute('data-status', 'active')
   })
 
+  test('retainSearchParams before stripSearchParams omits defaults from Link href and stays active', async () => {
+    // Regression for https://github.com/TanStack/router/issues/8309
+    const defaults = { myParam: 'foo' }
+    const rootRoute = createRootRoute({
+      validateSearch: z.object({
+        myParam: z.string().default('foo'),
+      }),
+      search: {
+        middlewares: [retainSearchParams(true), stripSearchParams(defaults)],
+      },
+      component: () => {
+        const { myParam } = rootRoute.useSearch()
+        return (
+          <>
+            <div data-testid="search-value">{myParam}</div>
+            <Link data-testid="home-link" to="/">
+              Home
+            </Link>
+            <Link data-testid="about-link" to="/about">
+              About
+            </Link>
+            <Outlet />
+          </>
+        )
+      },
+    })
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component: () => <h1>Index</h1>,
+    })
+    const aboutRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/about',
+      component: () => <h1>About</h1>,
+    })
+
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, aboutRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    render(<RouterProvider router={router} />)
+
+    expect(await screen.findByTestId('search-value')).toHaveTextContent('foo')
+    expect(router.state.location.search).toEqual({})
+
+    const homeLink = await screen.findByTestId('home-link')
+    const homeHref = homeLink.getAttribute('href')
+    expect(homeHref).toBe('/')
+    expect(getSearchParamsFromURI(homeHref!).size).toBe(0)
+    expect(homeLink).toHaveAttribute('data-status', 'active')
+
+    const aboutLink = await screen.findByTestId('about-link')
+    const aboutHref = aboutLink.getAttribute('href')
+    expect(aboutHref).toBe('/about')
+    expect(getSearchParamsFromURI(aboutHref!).size).toBe(0)
+  })
+
   describe('reloadDocument', () => {
     test('link to /posts with params', async () => {
       const rootRoute = createRootRoute()

--- a/packages/router-core/src/searchMiddleware.ts
+++ b/packages/router-core/src/searchMiddleware.ts
@@ -132,6 +132,16 @@ export function stripSearchParams<
             if (meta) {
               ;(meta.removed ||= new Map()).set(key, value)
             }
+          } else if (
+            meta &&
+            !(key in result) &&
+            hasOwn.call(search as object, key) &&
+            deepEqual((search as Record<string, unknown>)[key], value)
+          ) {
+            // next() dropped this key (e.g. Link with no search prop returns {}).
+            // Still mark the default as removed so outer retainSearchParams does
+            // not put the defaulted value back into the built href.
+            ;(meta.removed ||= new Map()).set(key, value)
           }
         },
       )

--- a/packages/router-core/tests/build-location.test.ts
+++ b/packages/router-core/tests/build-location.test.ts
@@ -475,6 +475,76 @@ describe('buildLocation - search params', () => {
     expect(location.search).toEqual({})
   })
 
+  test('retainSearchParams(true) before stripSearchParams should omit defaulted params when search is unset', async () => {
+    // Regression for https://github.com/TanStack/router/issues/8309
+    // Link builds locations without a search option; fromSearch still includes
+    // validated defaults. retain then strip must not put those defaults in the href.
+    const defaults = { myParam: 'foo' }
+    const rootRoute = new BaseRootRoute({
+      validateSearch: (search: Record<string, unknown>) => ({
+        myParam:
+          search.myParam === undefined ? defaults.myParam : search.myParam,
+      }),
+      search: {
+        middlewares: [retainSearchParams(true), stripSearchParams(defaults)],
+      },
+    })
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute]),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    await router.load()
+
+    expect(router.state.location.search).toEqual({})
+    expect(router.state.matches.at(-1)?.search).toEqual(defaults)
+
+    const location = router.buildLocation({ to: '/' } as any)
+
+    expect(location.search).toEqual({})
+    expect(location.href).toBe('/')
+  })
+
+  test('retainSearchParams(true) before stripSearchParams should still retain non-default params when search is unset', async () => {
+    const defaults = { myParam: 'foo' }
+    const rootRoute = new BaseRootRoute({
+      validateSearch: (search: Record<string, unknown>) => ({
+        myParam:
+          search.myParam === undefined
+            ? defaults.myParam
+            : String(search.myParam),
+      }),
+      search: {
+        middlewares: [retainSearchParams(true), stripSearchParams(defaults)],
+      },
+    })
+    const indexRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+    })
+    const aboutRoute = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/about',
+    })
+
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([indexRoute, aboutRoute]),
+      history: createMemoryHistory({ initialEntries: ['/?myParam=bar'] }),
+    })
+
+    await router.load()
+
+    const location = router.buildLocation({ to: '/about' } as any)
+
+    expect(location.search).toEqual({ myParam: 'bar' })
+    expect(location.href).toBe('/about?myParam=bar')
+  })
+
   test('retainSearchParams should not restore params explicitly removed by stripSearchParams', async () => {
     const rootRoute = new BaseRootRoute({})
     const indexRoute = new BaseRoute({


### PR DESCRIPTION
## Changes

Fixes #8309.

When `retainSearchParams` is listed before `stripSearchParams`, Links that do not pass a `search` prop were still building hrefs like `/?myParam=foo` even though the browser URL correctly omitted the default. That mismatch also prevented the Link from showing as active.

Root cause: `buildLocation` without a `search` option ends the middleware chain with `{}`. Object-form `stripSearchParams` only recorded removals for keys still present on that result, so an outer `retainSearchParams` put the validated defaults from `fromSearch` back into the href.

This patch marks default-valued keys as removed when they were present on the incoming search but dropped by `next()`, matching how array-form strip already behaves. Non-default retained params are unchanged.

Regressions cover:
- `buildLocation` with retain-then-strip and no `search` option
- retaining non-default values in that same order
- Link href omission + `data-status="active"`

## Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed link generation so default search parameters are omitted when search-parameter retention and stripping are used together.
  - Corrected active-link matching when default search values are validated but not included in the URL.
  - Preserved non-default search values during navigation.

- **Tests**
  - Added coverage for generated links, active states, and navigation behavior involving default search parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->