### PR TITLE
perf(solid-router): move server link shortcut before client setup

### DIFF
--- a/.changeset/silent-cycles-like.md
+++ b/.changeset/silent-cycles-like.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/solid-router': patch
+---
+
+Move the server shortcut for external and blocked links ahead of hydration, preloading, and active-state setup.

--- a/packages/solid-router/src/link.tsx
+++ b/packages/solid-router/src/link.tsx
@@ -47,11 +47,6 @@ export function useLinkProps<
   options: UseLinkPropsOptions<TRouter, TFrom, TTo, TMaskFrom, TMaskTo>,
 ): Solid.ComponentProps<'a'> {
   const router = useRouter()
-  const shouldHydrateHash = !isServer && !!router.options.ssr
-  const hasHydrated = useHydrated()
-
-  let hasRenderFetched = false
-
   const [local, rest] = Solid.splitProps(
     Solid.mergeProps(
       {
@@ -189,6 +184,46 @@ export function useLinkProps<
     return _href && getUrlScheme(_href) ? _href : undefined
   })
 
+  // SSR has no reactive destination changes or internal event handlers.
+  // Keep this guard inline so browser builds drop the entire shortcut.
+  if (isServer ?? router.isServer) {
+    const external = externalLink()
+    if (
+      external !== undefined &&
+      local.activeProps === STATIC_ACTIVE_PROPS_GET &&
+      local.inactiveProps === STATIC_INACTIVE_PROPS_GET &&
+      local.class === undefined &&
+      local.style === undefined
+    ) {
+      const disabled = local.disabled || external === null
+      return Solid.mergeProps(
+        propsSafeToSpread,
+        Solid.splitProps(local, [
+          'target',
+          'onClick',
+          'onBlur',
+          'onFocus',
+          'onMouseEnter',
+          'onMouseLeave',
+          'onMouseOut',
+          'onMouseOver',
+          'onTouchStart',
+        ])[0],
+        {
+          ref: options.ref,
+          href: external ?? undefined,
+          disabled,
+          ...(disabled && STATIC_DISABLED_PROPS),
+        },
+      ) as any
+    }
+  }
+
+  const shouldHydrateHash = !isServer && !!router.options.ssr
+  const hasHydrated = useHydrated()
+
+  let hasRenderFetched = false
+
   const preload = Solid.createMemo(() => {
     if (
       options.reloadDocument ||
@@ -301,41 +336,6 @@ export function useLinkProps<
       hasRenderFetched = true
     }
   })
-
-  // SSR has no reactive destination changes or internal event handlers.
-  // Keep this guard inline so browser builds drop the entire shortcut.
-  if (isServer ?? router.isServer) {
-    const external = externalLink()
-    if (
-      external !== undefined &&
-      local.activeProps === STATIC_ACTIVE_PROPS_GET &&
-      local.inactiveProps === STATIC_INACTIVE_PROPS_GET &&
-      local.class === undefined &&
-      local.style === undefined
-    ) {
-      const disabled = local.disabled || external === null
-      return Solid.mergeProps(
-        propsSafeToSpread,
-        Solid.splitProps(local, [
-          'target',
-          'onClick',
-          'onBlur',
-          'onFocus',
-          'onMouseEnter',
-          'onMouseLeave',
-          'onMouseOut',
-          'onMouseOver',
-          'onTouchStart',
-        ])[0],
-        {
-          ref: mergeRefs(setRef, options.ref),
-          href: external ?? undefined,
-          disabled,
-          ...(disabled && STATIC_DISABLED_PROPS),
-        },
-      ) as any
-    }
-  }
 
   // The click handler
   const handleClick = (e: MouseEvent) => {


### PR DESCRIPTION
## 🎯 Changes

Follow-up to #8308. Move the existing Solid Link server shortcut ahead of hydration, preloading, intersection-observer setup, active-state calculation, and internal ref allocation. The shortcut passes the caller's ref directly.

This applies to external and blocked links with default styling. URL classification and the shortcut's eligibility conditions stay the same.

Validation: Solid Router unit tests, type checks, and lint through Nx.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [ ] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved server-rendered handling for external and blocked links.
  - These links now render without unnecessary hydration, preloading, active-state behavior, or client-side event handling.
  - Preserves expected link behavior while reducing client-side setup for links that cannot be handled by the router.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->