### PR TITLE
fix(router): preserve Link state prop behavior

### DIFF
--- a/.changeset/forty-loops-sing.md
+++ b/.changeset/forty-loops-sing.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/solid-router': patch
+---
+
+Keep Solid Link's computed `href`, `target`, and `disabled` values authoritative when active or inactive state props contain routing options, while preserving state-prop refs, event handlers, and class/style merging.

--- a/.changeset/loud-times-tie.md
+++ b/.changeset/loud-times-tie.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+Collect shared pathname-cache keys during interpolation instead of parsing templates twice, and share dynamic-segment handling to reduce bundle size.

--- a/.changeset/loud-weeks-boil.md
+++ b/.changeset/loud-weeks-boil.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/react-router': patch
+'@tanstack/solid-router': patch
+'@tanstack/vue-router': patch
+---
+
+Allow active and inactive Link props to override base element props in React and Solid while preserving class/style merging. Keep React's `href`, `target`, and `disabled` values controlled by routing options. Preserve Vue object and nested-array class bindings, including reactive updates and server rendering, without mutating cached bindings during VNode normalization.

--- a/.changeset/lucky-candies-smoke.md
+++ b/.changeset/lucky-candies-smoke.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+Simplify path interpolation into ordered segment-type blocks with shared prefix/value/suffix assembly. Preserve one-pass parsing and optional metadata collection, and reuse the public result object instead of allocating and clearing a missing-parameter callback.

--- a/.changeset/mean-mice-design.md
+++ b/.changeset/mean-mice-design.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+Reuse pathname interpolation across Links with bounded router-scoped caches. Keep parameter callbacks and navigation state independent of the cache.

--- a/.changeset/six-adults-open.md
+++ b/.changeset/six-adults-open.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/solid-router': patch
+'@tanstack/vue-router': patch
+---
+
+Reduce Link bundle size by sharing exact/fuzzy active-path checks and resolving only the selected active or inactive props. Avoid unnecessary class/style allocations while preserving reactive style updates, server rendering, and each framework's prop-override behavior.

--- a/.changeset/spotty-bats-jog.md
+++ b/.changeset/spotty-bats-jog.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/router-core': patch
+'@tanstack/react-router': patch
+---
+
+Reduce the bundle cost of shared Link pathname interpolation while preserving its rendering performance. Reuse one interpolation pass for pathname and optional metadata, keep the bounded cache on the router, and simplify React Link active-state and prop merging.

--- a/benchmarks/client-nav/README.md
+++ b/benchmarks/client-nav/README.md
@@ -143,15 +143,20 @@ those separate workloads.
 
 - **Client:** 200 persistent measured Links, four control Links, and eight
   completed navigations per timed batch. The existing client harness checks
-  hrefs and active state during its untimed warm-up lap.
+  hrefs and active state during its untimed warm-up lap. Control navigations
+  replace the history entry, keeping history size constant. Post-measurement
+  assertions also check that the measured anchors stayed mounted.
 - **SSR:** four fresh-router requests per timed batch, each rendering 200
   measured Links through `RouterProvider` and `renderToString`. Router creation,
   `router.load()`, rendering, and history cleanup are included. This isolates
   Router SSR Link work, not Start HTTP handling, dehydration, or streaming.
   HTML assertions run outside the timed batch.
-- Both use the same code-based workload definitions, production JSX/library
-  builds, 50 warm-up iterations, and three-second measurement windows. The
-  client and server bundles assert their resolved `isServer` environment.
+- Both use the same code-based workload definitions and production JSX/library
+  builds. The regular Vitest entry points use at least 100 warm-up iterations,
+  one second of warm-up time, and five-second measurement windows. The client
+  and server bundles assert their resolved `isServer` environment. React and
+  React DOM remain external so comparisons can share the same renderer runtime.
+  These bundles are Node-hosted (jsdom for client mode), not browser deployments.
 
 Run the gate tests and typecheck separately:
 
@@ -166,3 +171,44 @@ Vitest processes. Report the actual refs, per-case means and relative margins
 of error; rerun noisy or borderline results with `-t` rather than interpreting
 a small difference as a proven speedup. Client and SSR times have different
 batch units and should not be compared directly.
+
+### Stable paired comparisons
+
+For regression decisions, prefer the paired runner over a whole-file Vitest
+run. It starts a fresh process for every case and repetition, avoiding JIT
+feedback from earlier cases. Inside each process, both revisions share the
+same production React installation but have separate router/app modules and
+router instances. Initialization order alternates between repetitions.
+
+```bash
+# Build the baseline using these same benchmark sources in its own checkout.
+# --baseline points to that checkout's link-performance/dist directory.
+TSR_LINK_PERF=1 pnpm nx run @benchmarks/react-link-performance:test:perf:stable -- \
+  --baseline /path/to/baseline/benchmarks/client-nav/link-performance/dist \
+  --outputJson /tmp/paired-links.json
+
+# Narrow a comparison, or increase independent process repetitions.
+TSR_LINK_PERF=1 pnpm nx run @benchmarks/react-link-performance:test:perf:stable -- \
+  --baseline /path/to/baseline/benchmarks/client-nav/link-performance/dist \
+  --mode ssr -t "middleware|unique-params" --repeats 6 \
+  --outputJson /tmp/paired-links-ssr.json
+```
+
+The runner requires Node with `process.threadCpuUsage` (Node 24 works).
+It fixes V8 random/hash seeds, warms each variant for at least two seconds
+and 100 batches, then alternates ABBA/BAAB blocks calibrated to roughly 500 ms.
+Both variants do exactly the same number of batches per block. It records
+main-thread CPU time, wall time, and whole-process CPU time; GC during
+measurement is not disabled or discarded.
+
+The default is four independent process repetitions. Reported 95% intervals
+use their paired log-ratios, not the many correlated batches as independent
+samples. A faster/slower verdict requires CPU and wall intervals to agree.
+Intervals overlapping zero or disagreeing metrics are inconclusive; narrow
+intervals entirely inside +/-2% are reported separately.
+
+An A/A calibration uses the current `dist` directory as `--baseline`. Its
+intervals should contain zero before trusting similarly sized A/B differences.
+Shared-machine contention can still make small changes unresolved. Do not
+interpret a point estimate alone, or an inconclusive result, as proof that
+a workload is unchanged.

--- a/benchmarks/client-nav/README.md
+++ b/benchmarks/client-nav/README.md
@@ -115,3 +115,54 @@ Typecheck benchmark sources (baseline + scenarios):
 ```bash
 CI=1 NX_DAEMON=false pnpm nx run @benchmarks/client-nav:test:types --outputStyle=stream --skipRemoteCache
 ```
+
+## Opt-in React Link performance suite
+
+`link-performance/` contains additional client-navigation and SSR workloads for
+focused Link work. They are **not included** in the regular client-nav/SSR
+aggregate projects or their CodSpeed build dependencies. Benchmark discovery
+also requires `TSR_LINK_PERF=1`; without it, no extended benchmark files or app
+bundles are imported.
+
+```bash
+TSR_LINK_PERF=1 CI=1 NX_DAEMON=false pnpm nx run @benchmarks/react-link-performance:test:perf:client --outputStyle=stream --skipRemoteCache -- --run
+TSR_LINK_PERF=1 CI=1 NX_DAEMON=false pnpm nx run @benchmarks/react-link-performance:test:perf:ssr --outputStyle=stream --skipRemoteCache -- --run
+
+# Select a feature and save the normal Vitest JSON report.
+TSR_LINK_PERF=1 CI=1 NX_DAEMON=false pnpm nx run @benchmarks/react-link-performance:test:perf:client --outputStyle=stream --skipRemoteCache -- --run -t "updater|optional|splat" --outputJson /tmp/link-perf.json
+```
+
+The cases cover repeated versus unique destination params, updater functions,
+relative/inherited values, search middleware chains, param stringification,
+optional and splat segments, encoding, masks, basepath/rewrites, and active
+props with structured search. These exercise different costs: cache hits and
+misses, parameter cloning, callbacks, middleware traversal, URI encoding,
+building masked/public locations, active-state comparisons, and prop merging.
+Existing preload, mount, and route-tree-scale scenarios remain responsible for
+those separate workloads.
+
+- **Client:** 200 persistent measured Links, four control Links, and eight
+  completed navigations per timed batch. The existing client harness checks
+  hrefs and active state during its untimed warm-up lap.
+- **SSR:** four fresh-router requests per timed batch, each rendering 200
+  measured Links through `RouterProvider` and `renderToString`. Router creation,
+  `router.load()`, rendering, and history cleanup are included. This isolates
+  Router SSR Link work, not Start HTTP handling, dehydration, or streaming.
+  HTML assertions run outside the timed batch.
+- Both use the same code-based workload definitions, production JSX/library
+  builds, 50 warm-up iterations, and three-second measurement windows. The
+  client and server bundles assert their resolved `isServer` environment.
+
+Run the gate tests and typecheck separately:
+
+```bash
+CI=1 NX_DAEMON=false pnpm nx run @benchmarks/react-link-performance:test:unit --outputStyle=stream --skipRemoteCache
+CI=1 NX_DAEMON=false pnpm nx run @benchmarks/react-link-performance:test:types --outputStyle=stream --skipRemoteCache
+```
+
+For before/after comparisons, use identical benchmark files and dependencies
+on both refs, build each ref through its Nx targets, and alternate fresh
+Vitest processes. Report the actual refs, per-case means and relative margins
+of error; rerun noisy or borderline results with `-t` rather than interpreting
+a small difference as a proven speedup. Client and SSR times have different
+batch units and should not be compared directly.

--- a/benchmarks/client-nav/link-performance/cases.ts
+++ b/benchmarks/client-nav/link-performance/cases.ts
@@ -1,0 +1,360 @@
+export const LINK_CASES = [
+  {
+    id: 'shared-params',
+    label: 'Shared string params',
+    description: '200 persistent Links reuse 40 string parameter values.',
+  },
+  {
+    id: 'unique-params',
+    label: 'Unique string params',
+    description: '200 distinct parameter values exceed the 128-result cache.',
+  },
+  {
+    id: 'param-updaters',
+    label: 'Parameter updaters',
+    description: 'Parameter functions derive destinations from current params.',
+  },
+  {
+    id: 'location-updaters',
+    label: 'Search, hash and state updaters',
+    description:
+      'Functions derive search, hash and history state from the source.',
+  },
+  {
+    id: 'relative',
+    label: 'Relative targets',
+    description: 'Parent and child targets inherit current params and search.',
+  },
+  {
+    id: 'middleware',
+    label: 'Search middleware chain',
+    description:
+      'Retain a tenant, strip a default page and normalize a filter.',
+  },
+  {
+    id: 'numeric-params',
+    label: 'Numeric params',
+    description: 'Parse numbers, update them numerically and stringify them.',
+  },
+  {
+    id: 'optional-params',
+    label: 'Optional segments',
+    description: 'Set, inherit and explicitly clear an optional path segment.',
+  },
+  {
+    id: 'splats',
+    label: 'Splat params',
+    description: 'Empty, multi-segment and encoded splat values.',
+  },
+  {
+    id: 'encoding',
+    label: 'Allowed path characters',
+    description: 'Preserve allowed @, : and + while encoding other characters.',
+  },
+  {
+    id: 'masks',
+    label: 'Explicit route masks',
+    description:
+      'Build a different public path and search for each destination.',
+  },
+  {
+    id: 'rewrites',
+    label: 'Basepath and rewrites',
+    description: 'Compose /app with input/output locale path rewrites.',
+  },
+  {
+    id: 'active',
+    label: 'Active props and structured search',
+    description:
+      'Exact, fuzzy and search matching with props and render children.',
+  },
+] as const
+
+export type LinkCaseId = (typeof LINK_CASES)[number]['id']
+
+export const LINK_COUNT = 200
+export const NAVIGATION_STATES = [1, 2, 3, 0] as const
+export const LOCALES = ['en', 'fr', 'de', 'es'] as const
+
+export interface Filter {
+  tag: string
+  flags: { open: boolean }
+  tags: Array<string>
+}
+
+export interface LinkSearch {
+  page?: number
+  tenant?: string
+  filter?: Filter
+}
+
+export function sourceFilter(index: number): Filter {
+  return {
+    tag: `group-${index}`,
+    flags: { open: index % 2 === 0 },
+    tags: ['links', `state-${index}`],
+  }
+}
+
+export function sourceSearch(
+  caseId: LinkCaseId,
+  stateIndex: number,
+): Partial<LinkSearch> {
+  switch (caseId) {
+    case 'location-updaters':
+    case 'relative':
+    case 'middleware':
+    case 'active':
+      return {
+        page: stateIndex + 1,
+        tenant: `tenant-${stateIndex}`,
+        filter: sourceFilter(stateIndex),
+      }
+    case 'rewrites':
+      return { tenant: LOCALES[stateIndex] }
+    default:
+      return {}
+  }
+}
+
+export function optionalCategory(stateIndex: number) {
+  return stateIndex % 2 === 0 ? `category-${stateIndex}` : undefined
+}
+
+export function splatValue(index: number) {
+  switch (index % 4) {
+    case 0:
+      return ''
+    case 1:
+      return `folder/sub/file-${index % 40}`
+    case 2:
+      return 'a b/100%/caf\u00e9?#'
+    default:
+      return 'literal%2F/\u{1f680}'
+  }
+}
+
+export function encodedValue(index: number) {
+  return `user-${index % 40}@mail.test:tag+value /?#% caf\u00e9`
+}
+
+function url(pathname: string, search: Partial<LinkSearch> = {}, hash = '') {
+  const result = new URL(pathname, 'http://localhost')
+  for (const [key, value] of Object.entries<LinkSearch[keyof LinkSearch]>(
+    search,
+  )) {
+    if (value !== undefined) {
+      result.searchParams.set(
+        key,
+        typeof value === 'object' ? JSON.stringify(value) : String(value),
+      )
+    }
+  }
+  result.hash = hash
+  return result.pathname + result.search + result.hash
+}
+
+function sourcePath(caseId: LinkCaseId, stateIndex: number) {
+  switch (caseId) {
+    case 'relative':
+      return `/teams/team-${stateIndex}/item-${stateIndex}`
+    case 'numeric-params':
+      return `/numbers/${stateIndex}`
+    case 'optional-params': {
+      const category = optionalCategory(stateIndex)
+      return `/optional/${category ? `${category}/` : ''}item-${stateIndex}`
+    }
+    case 'splats':
+      return `/files/source/state-${stateIndex}`
+    case 'encoding':
+      return `/encoded/source-${stateIndex}`
+    case 'active':
+      return `/items/item-${stateIndex}/details`
+    default:
+      return `/items/item-${stateIndex}`
+  }
+}
+
+export function getSourceUrl(caseId: LinkCaseId, stateIndex: number): string {
+  if (!Number.isInteger(stateIndex) || stateIndex < 0 || stateIndex > 3) {
+    throw new Error(`Invalid Link performance state: ${stateIndex}`)
+  }
+  const pathname = sourcePath(caseId, stateIndex)
+  if (caseId === 'rewrites') {
+    return `/app/${LOCALES[stateIndex]}${pathname}`
+  }
+  return url(
+    pathname,
+    sourceSearch(caseId, stateIndex),
+    caseId === 'location-updaters' ? `source-${stateIndex}` : '',
+  )
+}
+
+// These expectations use fixture values and platform encoding, not router APIs.
+function expectedHref(caseId: LinkCaseId, stateIndex: number, index: number) {
+  const itemId = `item-${index % 40}`
+  switch (caseId) {
+    case 'shared-params':
+      return `/items/${itemId}`
+    case 'unique-params':
+      return `/items/item-${index}`
+    case 'param-updaters':
+      return `/items/item-${stateIndex}-related-${index % 40}`
+    case 'location-updaters':
+      return url(
+        `/items/item-${stateIndex}`,
+        {
+          ...sourceSearch(caseId, stateIndex),
+          page: stateIndex + 2 + (index % 5),
+        },
+        `source-${stateIndex}-link-${index % 5}`,
+      )
+    case 'relative':
+      return url(
+        index % 2 === 0
+          ? `/teams/team-${stateIndex}`
+          : `/teams/team-${stateIndex}/item-${stateIndex}/details`,
+        sourceSearch(caseId, stateIndex),
+      )
+    case 'middleware':
+      return url(`/filtered/${itemId}`, {
+        tenant: `tenant-${stateIndex}`,
+        page: index % 2 === 0 ? undefined : 2,
+        filter: { ...sourceFilter(index % 4), tag: `LABEL-${index % 40}` },
+      })
+    case 'numeric-params':
+      return `/numbers/${stateIndex + (index % 40)}`
+    case 'optional-params': {
+      const category =
+        index % 3 === 0
+          ? 'fixed'
+          : index % 3 === 1
+            ? optionalCategory(stateIndex)
+            : undefined
+      return `/optional/${category ? `${category}/` : ''}${itemId}`
+    }
+    case 'splats': {
+      const value = splatValue(index)
+      return `/files${value ? `/${value.split('/').map(encodeURIComponent).join('/')}` : ''}`
+    }
+    case 'encoding': {
+      const value = encodeURIComponent(encodedValue(index))
+        .replaceAll('%40', '@')
+        .replaceAll('%3A', ':')
+        .replaceAll('%2B', '+')
+      return `/encoded/${value}`
+    }
+    case 'masks':
+      return url(`/public/display-${index % 40}`, {
+        tenant: `mask-${index % 4}`,
+      })
+    case 'rewrites':
+      return url(`/app/${LOCALES[index % 4]}/items/${itemId}`, {
+        page: (index % 3) + 1,
+      })
+    case 'active': {
+      const item = Math.floor(index / 5)
+      const variant = index % 5
+      const search =
+        variant < 3
+          ? { filter: sourceFilter(item % 4) }
+          : {
+              ...sourceSearch('active', item % 4),
+              ...(variant === 4 ? { filter: undefined } : {}),
+            }
+      return url(`/items/item-${item}${variant < 2 ? '' : '/details'}`, search)
+    }
+  }
+}
+
+function assertUrl(
+  actualHref: string | null,
+  expectedHref: string,
+  label: string,
+) {
+  if (actualHref === null) {
+    throw new Error(`${label}: missing href`)
+  }
+  const actual = new URL(actualHref, 'http://localhost')
+  const expected = new URL(expectedHref, 'http://localhost')
+  // Query ordering and the platform's '+' versus '%20' are immaterial here.
+  const query = (value: URL) =>
+    JSON.stringify([...value.searchParams.entries()].sort())
+  if (
+    actual.origin !== expected.origin ||
+    actual.pathname !== expected.pathname ||
+    actual.hash !== expected.hash ||
+    query(actual) !== query(expected)
+  ) {
+    throw new Error(
+      `${label}: expected ${expectedHref}, received ${actualHref}`,
+    )
+  }
+}
+
+export function assertScenario(
+  caseId: LinkCaseId,
+  stateIndex: number,
+  root: ParentNode,
+): void {
+  const source = root.querySelector('[data-testid="source-path"]')
+  if (source?.textContent !== sourcePath(caseId, stateIndex)) {
+    throw new Error(
+      `${caseId}/${stateIndex}: unexpected source path ${source?.textContent}`,
+    )
+  }
+  const links = root.querySelectorAll<HTMLAnchorElement>('a[data-perf-link]')
+  if (links.length !== LINK_COUNT) {
+    throw new Error(
+      `${caseId}: expected ${LINK_COUNT} Links, got ${links.length}`,
+    )
+  }
+  for (const [index, link] of links.entries()) {
+    const label = `${caseId}/${stateIndex}/link-${index}`
+    if (link.getAttribute('data-perf-link') !== String(index)) {
+      throw new Error(`${label}: unexpected Link order`)
+    }
+    assertUrl(
+      link.getAttribute('href'),
+      expectedHref(caseId, stateIndex, index),
+      label,
+    )
+    let active: boolean | undefined
+    if (caseId === 'shared-params') {
+      active = index % 40 === stateIndex
+    } else if (caseId === 'unique-params') {
+      active = index === stateIndex
+    } else if (caseId === 'active') {
+      active =
+        Math.floor(index / 5) === stateIndex && [0, 2, 3].includes(index % 5)
+      if (
+        link.textContent !== `${index}:${active ? 'active' : 'inactive'}` ||
+        link.getAttribute('title') !== (active ? 'active' : 'inactive') ||
+        !link.classList.contains(active ? 'perf-active' : 'perf-inactive') ||
+        link.style.color !== (active ? 'green' : 'gray') ||
+        link.style.opacity !== '0.8'
+      ) {
+        throw new Error(
+          `${label}: active props or render children are incorrect`,
+        )
+      }
+    }
+    if (
+      active !== undefined &&
+      (link.getAttribute('data-status') === 'active') !== active
+    ) {
+      throw new Error(`${label}: expected active=${active}`)
+    }
+  }
+  for (let state = 0; state < 4; state++) {
+    const control = root.querySelector(`[data-testid="go-state-${state}"]`)
+    if (!control || control.hasAttribute('data-perf-link')) {
+      throw new Error(`${caseId}: missing or measured control Link ${state}`)
+    }
+    assertUrl(
+      control.getAttribute('href'),
+      getSourceUrl(caseId, state),
+      `${caseId}/control-${state}`,
+    )
+  }
+}

--- a/benchmarks/client-nav/link-performance/client.bench.ts
+++ b/benchmarks/client-nav/link-performance/client.bench.ts
@@ -1,12 +1,6 @@
 import { afterEach, beforeEach, bench, describe } from 'vitest'
-import { createScenarioSetup } from '../scenarios/harness'
-import { benchOptions, ticksPerIteration } from '../scenarios/links/shared'
-import {
-  LINK_CASES,
-  NAVIGATION_STATES,
-  assertScenario,
-  getSourceUrl,
-} from './cases'
+import { LINK_CASES } from './cases'
+import { createClientScenario, samplingOptions } from './scenario'
 import type * as App from './src/client'
 
 const appModulePath = './dist/client/app.js'
@@ -17,41 +11,21 @@ if (app.serverEnvironment !== false) {
 
 for (const { id, label } of LINK_CASES) {
   describe(label, () => {
-    let mounted: ReturnType<typeof app.mountTestApp> | undefined
-    const test = createScenarioSetup({
-      frameworkLabel: 'React',
-      mount: (container, history) => {
-        mounted = app.mountTestApp(container, history, id)
-        return mounted
-      },
-      initialUrl: getSourceUrl(id, 0),
-      steps: NAVIGATION_STATES.map((state) => `go-state-${state}`),
-      assertAfterStep: (index, container) => {
-        assertScenario(id, NAVIGATION_STATES[index]!, container)
-        if (!mounted) {
-          throw new Error('Link benchmark app was not mounted')
-        }
-        mounted.assertStateUpdates()
-      },
+    const scenario = createClientScenario(app, id)
+    function finish() {
+      try {
+        scenario.check()
+      } finally {
+        scenario.teardown()
+      }
+    }
+    beforeEach(scenario.setup)
+    afterEach(finish)
+
+    bench(`client Links: ${id}`, scenario.batch, {
+      ...samplingOptions,
+      setup: scenario.setup,
+      teardown: finish,
     })
-
-    beforeEach(test.before)
-    afterEach(test.after)
-
-    bench(
-      `client Links: ${id}`,
-      async () => {
-        for (let index = 0; index < ticksPerIteration; index++) {
-          await test.tick()
-        }
-        await test.finishBatch()
-      },
-      {
-        ...benchOptions,
-        time: 3_000,
-        setup: test.before,
-        teardown: test.after,
-      },
-    )
   })
 }

--- a/benchmarks/client-nav/link-performance/client.bench.ts
+++ b/benchmarks/client-nav/link-performance/client.bench.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, bench, describe } from 'vitest'
+import { createScenarioSetup } from '../scenarios/harness'
+import { benchOptions, ticksPerIteration } from '../scenarios/links/shared'
+import {
+  LINK_CASES,
+  NAVIGATION_STATES,
+  assertScenario,
+  getSourceUrl,
+} from './cases'
+import type * as App from './src/client'
+
+const appModulePath = './dist/client/app.js'
+const app: typeof App = await import(/* @vite-ignore */ appModulePath)
+if (app.serverEnvironment !== false) {
+  throw new Error('Link client benchmarks must use the production client build')
+}
+
+for (const { id, label } of LINK_CASES) {
+  describe(label, () => {
+    let mounted: ReturnType<typeof app.mountTestApp> | undefined
+    const test = createScenarioSetup({
+      frameworkLabel: 'React',
+      mount: (container, history) => {
+        mounted = app.mountTestApp(container, history, id)
+        return mounted
+      },
+      initialUrl: getSourceUrl(id, 0),
+      steps: NAVIGATION_STATES.map((state) => `go-state-${state}`),
+      assertAfterStep: (index, container) => {
+        assertScenario(id, NAVIGATION_STATES[index]!, container)
+        if (!mounted) {
+          throw new Error('Link benchmark app was not mounted')
+        }
+        mounted.assertStateUpdates()
+      },
+    })
+
+    beforeEach(test.before)
+    afterEach(test.after)
+
+    bench(
+      `client Links: ${id}`,
+      async () => {
+        for (let index = 0; index < ticksPerIteration; index++) {
+          await test.tick()
+        }
+        await test.finishBatch()
+      },
+      {
+        ...benchOptions,
+        time: 3_000,
+        setup: test.before,
+        teardown: test.after,
+      },
+    )
+  })
+}

--- a/benchmarks/client-nav/link-performance/config.test.ts
+++ b/benchmarks/client-nav/link-performance/config.test.ts
@@ -31,6 +31,27 @@ describe.each(['client', 'ssr'] as const)(
       )
       expect(config.build?.ssr).toBe(target === 'ssr')
       expect(config.build?.outDir).toBe(`./dist/${target}`)
+      expect(config.build?.rolldownOptions?.platform).toBe('node')
+      expect(config.build?.rolldownOptions?.external).toEqual([
+        'node:module',
+        'module',
+        /^react(?:\/|$)/,
+        /^react-dom(?:\/|$)/,
+      ])
+    })
+
+    test('does not retransform built bundles in the test environment', () => {
+      vi.stubEnv('VITEST', 'true')
+      const config = createLinkPerformanceConfig(target)
+      expect(config.ssr?.noExternal).toBeUndefined()
+      expect(config.test?.server?.deps?.external).toEqual([
+        /\/link-performance\/dist\//,
+      ])
+    })
+
+    test('bundles router dependencies when building app snapshots', () => {
+      vi.stubEnv('VITEST', undefined)
+      expect(createLinkPerformanceConfig(target).ssr?.noExternal).toBe(true)
     })
   },
 )

--- a/benchmarks/client-nav/link-performance/config.test.ts
+++ b/benchmarks/client-nav/link-performance/config.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { createLinkPerformanceConfig } from './config'
+
+afterEach(() => vi.unstubAllEnvs())
+
+describe.each(['client', 'ssr'] as const)(
+  '%s opt-in configuration',
+  (target) => {
+    test.each([undefined, '', '0', 'false'])(
+      'does not discover benchmarks with TSR_LINK_PERF=%s',
+      (value) => {
+        vi.stubEnv('TSR_LINK_PERF', value)
+        const config = createLinkPerformanceConfig(target)
+        expect(config.test?.benchmark?.include).toEqual([])
+        expect(config.test?.passWithNoTests).toBe(true)
+      },
+    )
+
+    test('discovers only the requested suite when explicitly enabled', () => {
+      vi.stubEnv('TSR_LINK_PERF', '1')
+      const config = createLinkPerformanceConfig(target)
+      expect(config.test?.benchmark?.include).toEqual([`${target}.bench.ts`])
+      expect(config.test?.passWithNoTests).toBe(false)
+    })
+
+    test('builds production code for the correct environment', () => {
+      const config = createLinkPerformanceConfig(target)
+      expect(config.define?.['process.env.NODE_ENV']).toBe('"production"')
+      expect(config.resolve?.conditions).toContain(
+        target === 'ssr' ? 'node' : 'browser',
+      )
+      expect(config.build?.ssr).toBe(target === 'ssr')
+      expect(config.build?.outDir).toBe(`./dist/${target}`)
+    })
+  },
+)

--- a/benchmarks/client-nav/link-performance/config.ts
+++ b/benchmarks/client-nav/link-performance/config.ts
@@ -25,7 +25,7 @@ export function createLinkPerformanceConfig(
       conditions: [server ? 'node' : 'browser', 'production'],
     },
     ssr: {
-      noExternal: true,
+      noExternal: process.env.VITEST ? undefined : true,
       resolve: {
         conditions: ['node', 'production'],
       },
@@ -41,6 +41,13 @@ export function createLinkPerformanceConfig(
         fileName: 'app',
       },
       rolldownOptions: {
+        platform: 'node',
+        external: [
+          'node:module',
+          'module',
+          /^react(?:\/|$)/,
+          /^react-dom(?:\/|$)/,
+        ],
         output: { entryFileNames: 'app.js' },
       },
     },
@@ -49,6 +56,11 @@ export function createLinkPerformanceConfig(
       watch: false,
       environment: server ? 'node' : 'jsdom',
       setupFiles: server ? [] : ['../vitest.setup.ts'],
+      server: {
+        deps: {
+          external: [/\/link-performance\/dist\//],
+        },
+      },
       include: [],
       passWithNoTests: !enabled,
       benchmark: {

--- a/benchmarks/client-nav/link-performance/config.ts
+++ b/benchmarks/client-nav/link-performance/config.ts
@@ -1,0 +1,59 @@
+import { fileURLToPath } from 'node:url'
+import react from '@vitejs/plugin-react'
+import codspeedPlugin from '@codspeed/vitest-plugin'
+import type { UserConfig } from 'vite'
+
+const root = fileURLToPath(new URL('.', import.meta.url))
+
+export function createLinkPerformanceConfig(
+  target: 'client' | 'ssr',
+): UserConfig {
+  const server = target === 'ssr'
+  const enabled = process.env.TSR_LINK_PERF === '1'
+
+  return {
+    root,
+    define: {
+      'process.env.NODE_ENV': JSON.stringify('production'),
+    },
+    plugins: [
+      !!(process.env.VITEST && process.env.WITH_INSTRUMENTATION) &&
+        codspeedPlugin(),
+      react(),
+    ],
+    resolve: {
+      conditions: [server ? 'node' : 'browser', 'production'],
+    },
+    ssr: {
+      noExternal: true,
+      resolve: {
+        conditions: ['node', 'production'],
+      },
+    },
+    build: {
+      outDir: `./dist/${target}`,
+      emptyOutDir: true,
+      minify: false,
+      ssr: server,
+      lib: {
+        entry: `${root}src/${target}.tsx`,
+        formats: ['es'],
+        fileName: 'app',
+      },
+      rolldownOptions: {
+        output: { entryFileNames: 'app.js' },
+      },
+    },
+    test: {
+      name: `react-link-performance-${target}`,
+      watch: false,
+      environment: server ? 'node' : 'jsdom',
+      setupFiles: server ? [] : ['../vitest.setup.ts'],
+      include: [],
+      passWithNoTests: !enabled,
+      benchmark: {
+        include: enabled ? [`${target}.bench.ts`] : [],
+      },
+    },
+  }
+}

--- a/benchmarks/client-nav/link-performance/project.json
+++ b/benchmarks/client-nav/link-performance/project.json
@@ -1,0 +1,74 @@
+{
+  "name": "@benchmarks/react-link-performance",
+  "projectType": "application",
+  "tags": ["optional-benchmark"],
+  "targets": {
+    "build:client": {
+      "executor": "nx:run-commands",
+      "cache": false,
+      "dependsOn": [
+        {
+          "projects": ["@tanstack/react-router"],
+          "target": "build"
+        }
+      ],
+      "options": {
+        "command": "NODE_ENV=production vite build --config ./link-performance/vite.client.config.ts",
+        "cwd": "benchmarks/client-nav"
+      }
+    },
+    "build:ssr": {
+      "executor": "nx:run-commands",
+      "cache": false,
+      "dependsOn": [
+        {
+          "projects": ["@tanstack/react-router"],
+          "target": "build"
+        }
+      ],
+      "options": {
+        "command": "NODE_ENV=production vite build --config ./link-performance/vite.ssr.config.ts",
+        "cwd": "benchmarks/client-nav"
+      }
+    },
+    "test:perf:client": {
+      "executor": "nx:run-commands",
+      "cache": false,
+      "dependsOn": ["build:client"],
+      "options": {
+        "command": "NODE_ENV=production vitest bench --config ./link-performance/vite.client.config.ts",
+        "cwd": "benchmarks/client-nav"
+      }
+    },
+    "test:perf:ssr": {
+      "executor": "nx:run-commands",
+      "cache": false,
+      "dependsOn": ["build:ssr"],
+      "options": {
+        "command": "NODE_ENV=production vitest bench --config ./link-performance/vite.ssr.config.ts",
+        "cwd": "benchmarks/client-nav"
+      }
+    },
+    "test:unit": {
+      "executor": "nx:run-commands",
+      "dependsOn": [],
+      "options": {
+        "command": "vitest run --config ./link-performance/vitest.config.ts",
+        "cwd": "benchmarks/client-nav"
+      }
+    },
+    "test:types": {
+      "executor": "nx:run-commands",
+      "dependsOn": [
+        {
+          "projects": ["@tanstack/react-router"],
+          "target": "build"
+        }
+      ],
+      "options": {
+        "command": "tsc -p ./link-performance/tsconfig.json --noEmit",
+        "cwd": "benchmarks/client-nav"
+      }
+    }
+  }
+}

--- a/benchmarks/client-nav/link-performance/project.json
+++ b/benchmarks/client-nav/link-performance/project.json
@@ -49,6 +49,14 @@
         "cwd": "benchmarks/client-nav"
       }
     },
+    "test:perf:stable": {
+      "executor": "nx:run-commands",
+      "cache": false,
+      "dependsOn": ["build:client", "build:ssr"],
+      "options": {
+        "command": "NODE_ENV=production node --import=@swc-node/register/esm-register benchmarks/client-nav/link-performance/stable-runner.ts"
+      }
+    },
     "test:unit": {
       "executor": "nx:run-commands",
       "dependsOn": [],

--- a/benchmarks/client-nav/link-performance/scenario.ts
+++ b/benchmarks/client-nav/link-performance/scenario.ts
@@ -1,0 +1,114 @@
+import { JSDOM } from 'jsdom'
+import { createScenarioSetup } from '../scenarios/harness'
+import { ticksPerIteration } from '../scenarios/links/shared'
+import { NAVIGATION_STATES, assertScenario, getSourceUrl } from './cases'
+import type { LinkCaseId } from './cases'
+import type * as ClientApp from './src/client'
+import type * as SsrApp from './src/ssr'
+
+export interface LinkScenario {
+  setup: () => Promise<void>
+  batch: () => Promise<void>
+  check: () => void
+  teardown: () => void
+}
+
+export const samplingOptions = {
+  warmupIterations: 100,
+  warmupTime: 1_000,
+  time: 5_000,
+  throws: true,
+}
+
+export function createClientScenario(
+  app: typeof ClientApp,
+  id: LinkCaseId,
+): LinkScenario {
+  let mounted: ReturnType<typeof app.mountTestApp> | undefined
+  let container: HTMLElement | undefined
+  let anchors: Array<Element> = []
+  const test = createScenarioSetup({
+    frameworkLabel: 'React',
+    mount: (element, history) => {
+      container = element
+      mounted = app.mountTestApp(element, history, id)
+      return mounted
+    },
+    initialUrl: getSourceUrl(id, 0),
+    steps: NAVIGATION_STATES.map((state) => `go-state-${state}`),
+    assertAfterStep: (index, element) => {
+      assertScenario(id, NAVIGATION_STATES[index]!, element)
+      if (!mounted) {
+        throw new Error('Link benchmark app was not mounted')
+      }
+      mounted.assertStateUpdates()
+    },
+  })
+
+  return {
+    async setup() {
+      await test.before()
+      if (!container) {
+        throw new Error('Link benchmark container was not created')
+      }
+      anchors = [...container.querySelectorAll('a[data-perf-link]')]
+    },
+    async batch() {
+      for (let index = 0; index < ticksPerIteration; index++) {
+        await test.tick()
+      }
+      await test.finishBatch()
+    },
+    check() {
+      if (!container || !mounted) {
+        throw new Error('Link benchmark app was not mounted')
+      }
+      assertScenario(id, 0, container)
+      mounted.assertStateUpdates()
+      if (mounted.router.history.length !== 1) {
+        throw new Error('Link benchmark history must remain bounded')
+      }
+      const current = container.querySelectorAll('a[data-perf-link]')
+      if (anchors.some((anchor, index) => current[index] !== anchor)) {
+        throw new Error('Measured Links must stay mounted across navigations')
+      }
+    },
+    teardown: test.after,
+  }
+}
+
+export function createSsrScenario(
+  app: typeof SsrApp,
+  id: LinkCaseId,
+): LinkScenario {
+  let html = ''
+  let state = 0
+  function check() {
+    const dom = new JSDOM(html)
+    try {
+      assertScenario(id, state, dom.window.document)
+    } finally {
+      dom.window.close()
+    }
+  }
+
+  return {
+    async setup() {
+      for (const nextState of NAVIGATION_STATES) {
+        state = nextState
+        html = await app.renderScenario(id, state, true)
+        check()
+      }
+    },
+    async batch() {
+      for (const nextState of NAVIGATION_STATES) {
+        state = nextState
+        html = await app.renderScenario(id, state)
+      }
+    },
+    check,
+    teardown() {
+      html = ''
+    },
+  }
+}

--- a/benchmarks/client-nav/link-performance/src/client.tsx
+++ b/benchmarks/client-nav/link-performance/src/client.tsx
@@ -1,0 +1,29 @@
+import { RouterProvider } from '@tanstack/react-router'
+import { isServer } from '@tanstack/router-core/isServer'
+import { createRoot } from 'react-dom/client'
+import { assertStateUpdates, createLinkRouter } from './workload'
+import type { LinkRouter } from './workload'
+import type { RouterHistory } from '@tanstack/history'
+import type { LinkCaseId } from '../cases'
+
+export const serverEnvironment: boolean | undefined = isServer
+
+export function mountTestApp(
+  container: HTMLElement,
+  history: RouterHistory,
+  caseId: LinkCaseId,
+): {
+  router: LinkRouter
+  unmount: () => void
+  assertStateUpdates: () => void
+} {
+  const router = createLinkRouter(caseId, history, false)
+  const root = createRoot(container)
+  root.render(<RouterProvider router={router} />)
+
+  return {
+    router,
+    unmount: () => root.unmount(),
+    assertStateUpdates: () => assertStateUpdates(router),
+  }
+}

--- a/benchmarks/client-nav/link-performance/src/ssr.tsx
+++ b/benchmarks/client-nav/link-performance/src/ssr.tsx
@@ -1,0 +1,29 @@
+import { RouterProvider, createMemoryHistory } from '@tanstack/react-router'
+import { isServer } from '@tanstack/router-core/isServer'
+import { renderToString } from 'react-dom/server'
+import { getSourceUrl } from '../cases'
+import { assertStateUpdates, createLinkRouter } from './workload'
+import type { LinkCaseId } from '../cases'
+
+export const serverEnvironment: boolean | undefined = isServer
+
+export async function renderScenario(
+  caseId: LinkCaseId,
+  stateIndex: number,
+  verify = false,
+) {
+  const history = createMemoryHistory({
+    initialEntries: [getSourceUrl(caseId, stateIndex)],
+  })
+  const router = createLinkRouter(caseId, history, true)
+  try {
+    await router.load()
+    const html = renderToString(<RouterProvider router={router} />)
+    if (verify) {
+      assertStateUpdates(router)
+    }
+    return html
+  } finally {
+    history.destroy()
+  }
+}

--- a/benchmarks/client-nav/link-performance/src/workload.tsx
+++ b/benchmarks/client-nav/link-performance/src/workload.tsx
@@ -1,0 +1,505 @@
+import {
+  Link,
+  Outlet,
+  createRootRouteWithContext,
+  createRoute,
+  createRouter,
+  linkOptions,
+  retainSearchParams,
+  stripSearchParams,
+  useLocation,
+} from '@tanstack/react-router'
+import {
+  LINK_COUNT,
+  LOCALES,
+  encodedValue,
+  optionalCategory,
+  sourceFilter,
+  sourceSearch,
+  splatValue,
+} from '../cases'
+import type { RouterHistory } from '@tanstack/history'
+import type { SearchSchemaInput } from '@tanstack/react-router'
+import type { Filter, LinkCaseId, LinkSearch } from '../cases'
+
+interface StateUpdates {
+  calls: number
+  verifiedCalls: number
+  input: number
+  output: number
+  offset: number
+}
+
+interface WorkloadContext {
+  caseId: LinkCaseId
+  stateUpdates: StateUpdates
+}
+
+function isFilter(value: unknown): value is Filter {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'tag' in value &&
+    typeof value.tag === 'string' &&
+    'flags' in value &&
+    typeof value.flags === 'object' &&
+    value.flags !== null &&
+    'open' in value.flags &&
+    typeof value.flags.open === 'boolean' &&
+    'tags' in value &&
+    Array.isArray(value.tags) &&
+    value.tags.every((tag: unknown) => typeof tag === 'string')
+  )
+}
+
+const rootRoute = createRootRouteWithContext<WorkloadContext>()({
+  validateSearch: (
+    search: Record<string, unknown> & SearchSchemaInput,
+  ): LinkSearch => ({
+    page: typeof search.page === 'number' ? search.page : undefined,
+    tenant: typeof search.tenant === 'string' ? search.tenant : undefined,
+    filter: isFilter(search.filter) ? search.filter : undefined,
+  }),
+  component: RootLayout,
+})
+
+const itemsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: 'items/$itemId',
+})
+const detailsRoute = createRoute({
+  getParentRoute: () => itemsRoute,
+  path: 'details',
+})
+const teamRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: 'teams/$teamId',
+})
+const teamItemRoute = createRoute({
+  getParentRoute: () => teamRoute,
+  path: '$itemId',
+})
+const teamDetailsRoute = createRoute({
+  getParentRoute: () => teamItemRoute,
+  path: 'details',
+})
+const filteredRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: 'filtered/$itemId',
+  search: {
+    middlewares: [
+      retainSearchParams<LinkSearch>(['tenant']),
+      stripSearchParams<LinkSearch>({ page: 1 }),
+      ({ search, next }) => {
+        const result = next(search)
+        return {
+          ...result,
+          filter: result.filter
+            ? { ...result.filter, tag: result.filter.tag.trim().toUpperCase() }
+            : undefined,
+        }
+      },
+    ],
+  },
+})
+const numericRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: 'numbers/$number',
+  params: {
+    parse: ({ number }) => {
+      const value = Number(number)
+      if (!Number.isFinite(value)) {
+        throw new Error(`Invalid number: ${number}`)
+      }
+      return { number: value }
+    },
+    stringify: ({ number }) => ({ number: String(number) }),
+  },
+})
+const optionalRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: 'optional/{-$category}/$itemId',
+})
+const splatRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: 'files/$',
+})
+const encodedRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: 'encoded/$value',
+})
+const publicRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: 'public/$itemId',
+})
+
+const routeTree = rootRoute.addChildren([
+  itemsRoute.addChildren([detailsRoute]),
+  teamRoute.addChildren([teamItemRoute.addChildren([teamDetailsRoute])]),
+  filteredRoute,
+  numericRoute,
+  optionalRoute,
+  splatRoute,
+  encodedRoute,
+  publicRoute,
+])
+
+const localeRewrite = {
+  input: ({ url }: { url: URL }) => {
+    const match = /^\/(en|fr|de|es)(\/.*)$/.exec(url.pathname)
+    if (match) {
+      url.pathname = match[2]!
+      url.searchParams.set('tenant', match[1]!)
+    }
+    return url
+  },
+  output: ({ url }: { url: URL }) => {
+    const locale = url.searchParams.get('tenant')
+    if (locale) {
+      url.searchParams.delete('tenant')
+      url.pathname = `/${locale}${url.pathname}`
+    }
+    return url
+  },
+}
+
+export function createLinkRouter(
+  caseId: LinkCaseId,
+  history: RouterHistory,
+  isServer: boolean,
+) {
+  const context: WorkloadContext = {
+    caseId,
+    stateUpdates: {
+      calls: 0,
+      verifiedCalls: 0,
+      input: 0,
+      output: 0,
+      offset: 0,
+    },
+  }
+  return createRouter({
+    routeTree,
+    history,
+    isServer,
+    context,
+    scrollRestoration: false,
+    defaultPreload: false,
+    trailingSlash: 'never',
+    pathParamsAllowedCharacters:
+      caseId === 'encoding' ? ['@', ':', '+'] : undefined,
+    ...(caseId === 'rewrites'
+      ? { basepath: '/app', rewrite: localeRewrite }
+      : {}),
+  })
+}
+
+export type LinkRouter = ReturnType<typeof createLinkRouter>
+
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: LinkRouter
+  }
+}
+
+declare module '@tanstack/history' {
+  interface HistoryState {
+    linkPerfState?: number
+  }
+}
+
+// Call alongside DOM assertions, outside the timed loop, after each sample.
+export function assertStateUpdates(router: LinkRouter): void {
+  const { caseId, stateUpdates } = router.options.context
+  if (caseId !== 'location-updaters') {
+    return
+  }
+  const input = router.state.location.state.linkPerfState ?? 0
+  if (
+    stateUpdates.calls - stateUpdates.verifiedCalls < LINK_COUNT ||
+    stateUpdates.input !== input ||
+    stateUpdates.output !== input + stateUpdates.offset ||
+    stateUpdates.offset < 1 ||
+    stateUpdates.offset > 40
+  ) {
+    throw new Error(
+      'Link history-state updaters did not run with current state',
+    )
+  }
+  stateUpdates.verifiedCalls = stateUpdates.calls
+}
+
+function sourceOptions(caseId: LinkCaseId, stateIndex: number) {
+  const itemId = `item-${stateIndex}`
+  const common = {
+    search: sourceSearch(caseId, stateIndex),
+    hash: caseId === 'location-updaters' ? `source-${stateIndex}` : '',
+    state: { linkPerfState: stateIndex + 10 },
+  }
+  switch (caseId) {
+    case 'relative':
+      return linkOptions({
+        ...common,
+        to: '/teams/$teamId/$itemId',
+        params: { teamId: `team-${stateIndex}`, itemId },
+      })
+    case 'numeric-params':
+      return linkOptions({
+        ...common,
+        to: '/numbers/$number',
+        params: { number: stateIndex },
+      })
+    case 'optional-params':
+      return linkOptions({
+        ...common,
+        to: '/optional/{-$category}/$itemId',
+        params: { category: optionalCategory(stateIndex), itemId },
+      })
+    case 'splats':
+      return linkOptions({
+        ...common,
+        to: '/files/$',
+        params: { _splat: `source/state-${stateIndex}` },
+      })
+    case 'encoding':
+      return linkOptions({
+        ...common,
+        to: '/encoded/$value',
+        params: { value: `source-${stateIndex}` },
+      })
+    case 'active':
+      return linkOptions({
+        ...common,
+        to: '/items/$itemId/details',
+        params: { itemId },
+      })
+    default:
+      return linkOptions({
+        ...common,
+        to: '/items/$itemId',
+        params: { itemId },
+      })
+  }
+}
+
+const indexes = Array.from({ length: LINK_COUNT }, (_, index) => index)
+const controls = [0, 1, 2, 3] as const
+
+function SourcePath() {
+  const pathname = useLocation({ select: (location) => location.pathname })
+  return <span data-testid="source-path">{pathname}</span>
+}
+
+function RootLayout() {
+  const context = rootRoute.useRouteContext()
+  return (
+    <>
+      <nav>
+        {controls.map((stateIndex) => (
+          <Link
+            key={stateIndex}
+            {...sourceOptions(context.caseId, stateIndex)}
+            preload={false}
+            resetScroll={false}
+            hashScrollIntoView={false}
+            data-testid={`go-state-${stateIndex}`}
+          >
+            State {stateIndex}
+          </Link>
+        ))}
+      </nav>
+      <SourcePath />
+      <section aria-label="Measured Links">
+        {indexes.map((index) => measuredLink(context, index))}
+      </section>
+      <Outlet />
+    </>
+  )
+}
+
+function measuredLink(
+  { caseId, stateUpdates }: WorkloadContext,
+  index: number,
+) {
+  const common = {
+    key: index,
+    'data-perf-link': index,
+    preload: false,
+    children: `Link ${index}`,
+  } as const
+  const itemId = `item-${index % 40}`
+  switch (caseId) {
+    case 'shared-params':
+    case 'unique-params':
+      return (
+        <Link
+          {...common}
+          to="/items/$itemId"
+          params={{
+            itemId: caseId === 'unique-params' ? `item-${index}` : itemId,
+          }}
+        />
+      )
+    case 'param-updaters':
+      return (
+        <Link
+          {...common}
+          from="/items/$itemId"
+          to="."
+          params={(previous) => ({
+            itemId: `${previous.itemId}-related-${index % 40}`,
+          })}
+        />
+      )
+    case 'location-updaters':
+      return (
+        <Link
+          {...common}
+          from="/items/$itemId"
+          to="."
+          params
+          search={(previous) => ({
+            ...previous,
+            page: (previous.page ?? 1) + 1 + (index % 5),
+          })}
+          hash={(previous) => `${previous}-link-${index % 5}`}
+          state={(previous) => {
+            const input = previous.linkPerfState ?? 0
+            const offset = (index % 40) + 1
+            const output = input + offset
+            stateUpdates.calls++
+            stateUpdates.input = input
+            stateUpdates.output = output
+            stateUpdates.offset = offset
+            return { ...previous, linkPerfState: output }
+          }}
+        />
+      )
+    case 'relative':
+      return (
+        <Link
+          {...common}
+          from="/teams/$teamId/$itemId"
+          to={index % 2 === 0 ? '..' : './details'}
+          params
+          search
+        />
+      )
+    case 'middleware':
+      return (
+        <Link
+          {...common}
+          to="/filtered/$itemId"
+          params={{ itemId }}
+          search={{
+            page: index % 2 === 0 ? 1 : 2,
+            filter: {
+              ...sourceFilter(index % 4),
+              tag: ` label-${index % 40} `,
+            },
+          }}
+        />
+      )
+    case 'numeric-params':
+      return (
+        <Link
+          {...common}
+          from="/numbers/$number"
+          to="."
+          params={(previous) => ({ number: previous.number + (index % 40) })}
+        />
+      )
+    case 'optional-params':
+      return (
+        <Link
+          {...common}
+          from="/optional/{-$category}/$itemId"
+          to="."
+          params={
+            index % 3 === 0
+              ? { itemId, category: 'fixed' }
+              : index % 3 === 1
+                ? { itemId }
+                : { itemId, category: undefined }
+          }
+        />
+      )
+    case 'splats':
+      return (
+        <Link
+          {...common}
+          to="/files/$"
+          params={{ _splat: splatValue(index) }}
+        />
+      )
+    case 'encoding':
+      return (
+        <Link
+          {...common}
+          to="/encoded/$value"
+          params={{ value: encodedValue(index) }}
+        />
+      )
+    case 'masks':
+      return (
+        <Link
+          {...common}
+          to="/items/$itemId"
+          params={{ itemId }}
+          search={{ page: 2 }}
+          mask={{
+            to: '/public/$itemId',
+            params: { itemId: `display-${index % 40}` },
+            search: { tenant: `mask-${index % 4}` },
+          }}
+        />
+      )
+    case 'rewrites':
+      return (
+        <Link
+          {...common}
+          to="/items/$itemId"
+          params={{ itemId }}
+          search={{ tenant: LOCALES[index % 4], page: (index % 3) + 1 }}
+        />
+      )
+    case 'active': {
+      const item = Math.floor(index / 5)
+      const variant = index % 5
+      return (
+        <Link
+          {...common}
+          to={variant < 2 ? '/items/$itemId' : '/items/$itemId/details'}
+          params={{ itemId: `item-${item}` }}
+          search={
+            variant < 3
+              ? { filter: sourceFilter(item % 4) }
+              : {
+                  ...sourceSearch('active', item % 4),
+                  ...(variant === 4 ? { filter: undefined } : {}),
+                }
+          }
+          activeOptions={{
+            exact: variant === 1 || variant === 2 || variant === 3,
+            includeSearch: variant !== 2,
+            explicitUndefined: variant === 4,
+          }}
+          className="perf-link"
+          style={{ color: 'black', opacity: 0.8 }}
+          activeProps={() => ({
+            className: 'perf-active',
+            title: 'active',
+            style: { color: 'green' },
+          })}
+          inactiveProps={() => ({
+            className: 'perf-inactive',
+            title: 'inactive',
+            style: { color: 'gray' },
+          })}
+        >
+          {({ isActive }) => `${index}:${isActive ? 'active' : 'inactive'}`}
+        </Link>
+      )
+    }
+  }
+}

--- a/benchmarks/client-nav/link-performance/src/workload.tsx
+++ b/benchmarks/client-nav/link-performance/src/workload.tsx
@@ -299,6 +299,7 @@ function RootLayout() {
           <Link
             key={stateIndex}
             {...sourceOptions(context.caseId, stateIndex)}
+            replace
             preload={false}
             resetScroll={false}
             hashScrollIntoView={false}

--- a/benchmarks/client-nav/link-performance/ssr.bench.ts
+++ b/benchmarks/client-nav/link-performance/ssr.bench.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, bench, describe } from 'vitest'
-import { JSDOM } from 'jsdom'
-import { benchOptions } from '../scenarios/links/shared'
-import { LINK_CASES, NAVIGATION_STATES, assertScenario } from './cases'
+import { LINK_CASES } from './cases'
+import { createSsrScenario, samplingOptions } from './scenario'
 import type * as App from './src/ssr'
 
 const appUrl = new URL('./dist/ssr/app.js', import.meta.url).href
@@ -12,43 +11,21 @@ if (app.serverEnvironment !== true) {
 
 for (const { id, label } of LINK_CASES) {
   describe(label, () => {
-    let html = ''
-    let state = 0
-
-    function assertHtml() {
-      const dom = new JSDOM(html)
+    const scenario = createSsrScenario(app, id)
+    function finish() {
       try {
-        assertScenario(id, state, dom.window.document)
+        scenario.check()
       } finally {
-        dom.window.close()
+        scenario.teardown()
       }
     }
+    beforeEach(scenario.setup)
+    afterEach(finish)
 
-    async function prepare() {
-      for (const nextState of NAVIGATION_STATES) {
-        state = nextState
-        html = await app.renderScenario(id, state, true)
-        assertHtml()
-      }
-    }
-
-    beforeEach(prepare)
-    afterEach(assertHtml)
-
-    bench(
-      `SSR Links: ${id}`,
-      async () => {
-        for (const nextState of NAVIGATION_STATES) {
-          state = nextState
-          html = await app.renderScenario(id, state)
-        }
-      },
-      {
-        ...benchOptions,
-        time: 3_000,
-        setup: prepare,
-        teardown: assertHtml,
-      },
-    )
+    bench(`SSR Links: ${id}`, scenario.batch, {
+      ...samplingOptions,
+      setup: scenario.setup,
+      teardown: finish,
+    })
   })
 }

--- a/benchmarks/client-nav/link-performance/ssr.bench.ts
+++ b/benchmarks/client-nav/link-performance/ssr.bench.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, bench, describe } from 'vitest'
+import { JSDOM } from 'jsdom'
+import { benchOptions } from '../scenarios/links/shared'
+import { LINK_CASES, NAVIGATION_STATES, assertScenario } from './cases'
+import type * as App from './src/ssr'
+
+const appUrl = new URL('./dist/ssr/app.js', import.meta.url).href
+const app: typeof App = await import(/* @vite-ignore */ appUrl)
+if (app.serverEnvironment !== true) {
+  throw new Error('Link SSR benchmarks must use the production server build')
+}
+
+for (const { id, label } of LINK_CASES) {
+  describe(label, () => {
+    let html = ''
+    let state = 0
+
+    function assertHtml() {
+      const dom = new JSDOM(html)
+      try {
+        assertScenario(id, state, dom.window.document)
+      } finally {
+        dom.window.close()
+      }
+    }
+
+    async function prepare() {
+      for (const nextState of NAVIGATION_STATES) {
+        state = nextState
+        html = await app.renderScenario(id, state, true)
+        assertHtml()
+      }
+    }
+
+    beforeEach(prepare)
+    afterEach(assertHtml)
+
+    bench(
+      `SSR Links: ${id}`,
+      async () => {
+        for (const nextState of NAVIGATION_STATES) {
+          state = nextState
+          html = await app.renderScenario(id, state)
+        }
+      },
+      {
+        ...benchOptions,
+        time: 3_000,
+        setup: prepare,
+        teardown: assertHtml,
+      },
+    )
+  })
+}

--- a/benchmarks/client-nav/link-performance/stable-runner.ts
+++ b/benchmarks/client-nav/link-performance/stable-runner.ts
@@ -1,0 +1,274 @@
+import { fork } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { parseArgs } from 'node:util'
+import { LINK_CASES } from './cases'
+import { classify, mean, summarizeRatios } from './statistics'
+import type { LinkCaseId } from './cases'
+import type {
+  BlockSample,
+  Mode,
+  Variant,
+  WorkerRequest,
+  WorkerResponse,
+} from './worker-protocol'
+
+const projectRoot = fileURLToPath(new URL('.', import.meta.url))
+const workspaceRoot = resolve(projectRoot, '../../..')
+
+function startWorker() {
+  const child = fork(
+    fileURLToPath(new URL('./stable-worker.ts', import.meta.url)),
+    {
+      cwd: workspaceRoot,
+      env: { ...process.env, NODE_ENV: 'production' },
+      execArgv: [
+        '--import=@swc-node/register/esm-register',
+        '--random-seed=42',
+        '--hash-seed=42',
+      ],
+      stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
+    },
+  )
+  let stderr = ''
+  child.stderr?.on('data', (data: Buffer) => {
+    stderr = (stderr + data.toString()).slice(-4_096)
+  })
+
+  function request(message: WorkerRequest): Promise<WorkerResponse> {
+    return new Promise((resolveResponse, reject) => {
+      const timeout = setTimeout(() => {
+        finish(
+          new Error(`Sampling worker timed out: ${message.kind}\n${stderr}`),
+        )
+      }, 60_000)
+      const onExit = (code: number | null) =>
+        finish(new Error(`Sampling worker exited (${code})\n${stderr}`))
+      const onError = (error: Error) => finish(error)
+      const onMessage = (response: WorkerResponse) => {
+        if (response.kind === 'error') {
+          finish(new Error(response.message))
+        } else {
+          finish(undefined, response)
+        }
+      }
+      function finish(error?: Error, response?: WorkerResponse) {
+        clearTimeout(timeout)
+        child.off('message', onMessage)
+        child.off('error', onError)
+        child.off('exit', onExit)
+        if (error) {
+          reject(error)
+        } else if (response) {
+          resolveResponse(response)
+        }
+      }
+      child.once('message', onMessage)
+      child.once('error', onError)
+      child.once('exit', onExit)
+      child.send(message, (error) => {
+        if (error) {
+          finish(error)
+        }
+      })
+    })
+  }
+
+  return {
+    request,
+    kill: () => child.kill(),
+  }
+}
+
+async function sampleReplica(
+  mode: Mode,
+  caseId: LinkCaseId,
+  baseline: string,
+  current: string,
+  replica: number,
+) {
+  const worker = startWorker()
+  const samples: Array<Array<BlockSample>> = [[], []]
+  const ratios: Array<{ cpu: number; wall: number }> = []
+  try {
+    const starts: Array<number> = []
+    // Balance module initialization and which variant finishes warming last.
+    const startupOrder: Array<Variant> = replica % 2 ? [1, 0] : [0, 1]
+    for (const index of startupOrder) {
+      const ready = await worker.request({
+        kind: 'init',
+        mode,
+        caseId,
+        bundle: index === 0 ? baseline : current,
+        variant: index,
+      })
+      if (ready.kind !== 'ready') {
+        throw new Error('Expected a ready sampling worker')
+      }
+      starts[index] = ready.batchMs
+    }
+    const iterations = Math.max(1, Math.ceil(500 / Math.min(...starts)))
+    for (let round = 0; round < 2; round++) {
+      const block: Array<Array<BlockSample>> = [[], []]
+      const order: Array<Variant> =
+        (round + replica) % 2 ? [1, 0, 0, 1] : [0, 1, 1, 0]
+      for (const index of order) {
+        const result = await worker.request({
+          kind: 'measure',
+          iterations,
+          variant: index,
+        })
+        if (result.kind !== 'sample') {
+          throw new Error('Expected a block measurement')
+        }
+        samples[index]!.push(result.sample)
+        block[index]!.push(result.sample)
+      }
+      ratios.push({
+        cpu:
+          mean(block[1]!.map((s) => s.cpuMs)) /
+          mean(block[0]!.map((s) => s.cpuMs)),
+        wall:
+          mean(block[1]!.map((s) => s.wallMs)) /
+          mean(block[0]!.map((s) => s.wallMs)),
+      })
+    }
+    const response = await worker.request({ kind: 'stop' })
+    if (response.kind !== 'stopped') {
+      throw new Error('Expected successful post-measurement assertions')
+    }
+    return {
+      iterations,
+      baseline: samples[0]!,
+      current: samples[1]!,
+      cpuRatio: Math.exp(mean(ratios.map((r) => Math.log(r.cpu)))),
+      wallRatio: Math.exp(mean(ratios.map((r) => Math.log(r.wall)))),
+    }
+  } finally {
+    worker.kill()
+  }
+}
+
+async function main() {
+  if (process.env.TSR_LINK_PERF !== '1') {
+    console.log('Link performance sampling is disabled; set TSR_LINK_PERF=1.')
+    return
+  }
+  const { values } = parseArgs({
+    options: {
+      baseline: { type: 'string' },
+      current: { type: 'string', default: resolve(projectRoot, 'dist') },
+      mode: { type: 'string', default: 'all' },
+      repeats: { type: 'string', default: '4' },
+      outputJson: { type: 'string' },
+      testNamePattern: { type: 'string', short: 't' },
+    },
+  })
+  if (!values.baseline || !values.outputJson) {
+    throw new Error(
+      'Specify --baseline <dist directory> and --outputJson <file>',
+    )
+  }
+  const repeats = Number(values.repeats)
+  if (!Number.isInteger(repeats) || repeats < 3 || repeats > 11) {
+    throw new Error('--repeats must be an integer between 3 and 11')
+  }
+  if (!['all', 'client', 'ssr'].includes(values.mode)) {
+    throw new Error('--mode must be all, client, or ssr')
+  }
+  const modes: Array<Mode> =
+    values.mode === 'all'
+      ? ['client', 'ssr']
+      : values.mode === 'client'
+        ? ['client']
+        : ['ssr']
+  const pattern = values.testNamePattern
+    ? new RegExp(values.testNamePattern)
+    : undefined
+  const cases = LINK_CASES.filter(
+    (c) => !pattern || pattern.test(`${c.label} ${c.id}`),
+  )
+  if (!cases.length) {
+    throw new Error('No Link workloads match the requested pattern')
+  }
+  const report: {
+    protocol: string
+    node: string
+    complete: boolean
+    results: Array<{
+      mode: Mode
+      caseId: LinkCaseId
+      baselineSha256: string
+      currentSha256: string
+      replicas: Array<Awaited<ReturnType<typeof sampleReplica>>>
+      cpu: ReturnType<typeof summarizeRatios>
+      wall: ReturnType<typeof summarizeRatios>
+      verdict: ReturnType<typeof classify>
+    }>
+  } = {
+    protocol:
+      'fresh process per case/replica; shared React runtime; separately loaded router variants; 2 ABBA/BAAB rounds; ~500ms calibrated fixed-work blocks; >=2s/100 batches warmup; main-thread CPU and wall time; fixed V8 random/hash seeds',
+    node: process.version,
+    complete: false,
+    results: [],
+  }
+  const output = resolve(values.outputJson)
+  mkdirSync(dirname(output), { recursive: true })
+  mkdirSync(resolve(projectRoot, 'dist'), { recursive: true })
+  const staging = mkdtempSync(resolve(projectRoot, 'dist/comparison-'))
+  try {
+    for (const mode of modes) {
+      const baselineInput = resolve(values.baseline, mode, 'app.js')
+      const currentInput = resolve(values.current, mode, 'app.js')
+      // Both snapshots resolve React from the same package installation.
+      const baseline = resolve(staging, `baseline-${mode}.mjs`)
+      const current = resolve(staging, `current-${mode}.mjs`)
+      copyFileSync(baselineInput, baseline)
+      copyFileSync(currentInput, current)
+      const digest = (file: string) =>
+        createHash('sha256').update(readFileSync(file)).digest('hex')
+      const baselineSha256 = digest(baseline)
+      const currentSha256 = digest(current)
+      for (const { id } of cases) {
+        const replicas = []
+        for (let replica = 0; replica < repeats; replica++) {
+          replicas.push(
+            await sampleReplica(mode, id, baseline, current, replica),
+          )
+        }
+        const cpu = summarizeRatios(replicas.map((r) => r.cpuRatio))
+        const wall = summarizeRatios(replicas.map((r) => r.wallRatio))
+        const verdict = classify(cpu, wall)
+        report.results.push({
+          mode,
+          caseId: id,
+          baselineSha256,
+          currentSha256,
+          replicas,
+          cpu,
+          wall,
+          verdict,
+        })
+        writeFileSync(output, JSON.stringify(report, null, 2))
+        console.log(
+          `${mode} ${id}: CPU ${cpu.changePercent.toFixed(2)}% [${cpu.low95.toFixed(2)}, ${cpu.high95.toFixed(2)}], wall ${wall.changePercent.toFixed(2)}% [${wall.low95.toFixed(2)}, ${wall.high95.toFixed(2)}] ${verdict}`,
+        )
+      }
+    }
+    report.complete = true
+    writeFileSync(output, JSON.stringify(report, null, 2))
+  } finally {
+    rmSync(staging, { recursive: true })
+  }
+}
+
+await main()

--- a/benchmarks/client-nav/link-performance/stable-worker.ts
+++ b/benchmarks/client-nav/link-performance/stable-worker.ts
@@ -1,0 +1,112 @@
+import { pathToFileURL } from 'node:url'
+import { createClientScenario, createSsrScenario } from './scenario'
+import type { LinkScenario } from './scenario'
+import type { WorkerRequest, WorkerResponse } from './worker-protocol'
+import type * as ClientApp from './src/client'
+import type * as SsrApp from './src/ssr'
+
+const scenarios: Array<LinkScenario> = []
+const creationOrder: Array<LinkScenario> = []
+let closeWindow = () => {}
+
+function reply(response: WorkerResponse) {
+  if (!process.send) {
+    throw new Error('The Link sampling worker requires an IPC parent')
+  }
+  process.send(response)
+}
+
+async function handle(request: WorkerRequest) {
+  if (request.kind === 'init') {
+    if (typeof process.threadCpuUsage !== 'function') {
+      throw new Error(
+        'Stable sampling requires Node.js with process.threadCpuUsage',
+      )
+    }
+    if (scenarios[request.variant]) {
+      throw new Error('A worker must only initialize each variant once')
+    }
+    let scenario: LinkScenario
+    const bundleUrl = pathToFileURL(request.bundle)
+    bundleUrl.searchParams.set('linkPerfVariant', String(request.variant))
+    if (request.mode === 'client') {
+      const { window } = await import('../jsdom')
+      closeWindow = () => window.close()
+      const app: typeof ClientApp = await import(bundleUrl.href)
+      if (app.serverEnvironment !== false) {
+        throw new Error('Expected a production client bundle')
+      }
+      scenario = createClientScenario(app, request.caseId)
+    } else {
+      const app: typeof SsrApp = await import(bundleUrl.href)
+      if (app.serverEnvironment !== true) {
+        throw new Error('Expected a production SSR bundle')
+      }
+      scenario = createSsrScenario(app, request.caseId)
+    }
+    scenarios[request.variant] = scenario
+    creationOrder.push(scenario)
+    await scenario.setup()
+    const start = performance.now()
+    let iterations = 0
+    do {
+      await scenario.batch()
+      iterations++
+    } while (iterations < 100 || performance.now() - start < 2_000)
+    reply({
+      kind: 'ready',
+      batchMs: (performance.now() - start) / iterations,
+    })
+    return
+  }
+  if (request.kind === 'measure') {
+    const scenario = scenarios[request.variant]
+    if (!scenario) {
+      throw new Error('The sampling worker has not been initialized')
+    }
+    if (!Number.isInteger(request.iterations) || request.iterations < 1) {
+      throw new Error('Expected a positive batch count')
+    }
+    const cpuStart = process.threadCpuUsage()
+    const processStart = process.cpuUsage()
+    const start = performance.now()
+    for (let index = 0; index < request.iterations; index++) {
+      await scenario.batch()
+    }
+    const wallMs = performance.now() - start
+    const cpu = process.threadCpuUsage(cpuStart)
+    const processCpu = process.cpuUsage(processStart)
+    reply({
+      kind: 'sample',
+      sample: {
+        iterations: request.iterations,
+        wallMs: wallMs / request.iterations,
+        cpuMs: (cpu.user + cpu.system) / 1_000 / request.iterations,
+        processCpuMs:
+          (processCpu.user + processCpu.system) / 1_000 / request.iterations,
+      },
+    })
+    return
+  }
+  try {
+    for (const scenario of creationOrder) {
+      scenario.check()
+    }
+  } finally {
+    for (const scenario of creationOrder.reverse()) {
+      scenario.teardown()
+    }
+    closeWindow()
+  }
+  reply({ kind: 'stopped' })
+}
+
+process.on('message', (request: WorkerRequest) => {
+  void handle(request).catch((error: unknown) => {
+    reply({
+      kind: 'error',
+      message:
+        error instanceof Error ? error.stack || error.message : String(error),
+    })
+  })
+})

--- a/benchmarks/client-nav/link-performance/statistics.test.ts
+++ b/benchmarks/client-nav/link-performance/statistics.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from 'vitest'
+import { classify, mean, summarizeRatios } from './statistics'
+
+test('summarizes multiplicative paired changes across process replicas', () => {
+  const result = summarizeRatios([0.9, 0.9, 0.9, 0.9])
+  expect(result.changePercent).toBeCloseTo(-10)
+  expect(result.low95).toBeCloseTo(-10)
+  expect(result.high95).toBeCloseTo(-10)
+  expect(result.replicas).toBe(4)
+})
+
+test('does not turn opposite noisy runs into a conclusive result', () => {
+  const result = summarizeRatios([0.9, 1.1, 0.95, 1.05])
+  expect(result.low95).toBeLessThan(0)
+  expect(result.high95).toBeGreaterThan(0)
+  expect(classify(result, result)).toBe('inconclusive')
+})
+
+test('requires CPU and wall time to corroborate a direction', () => {
+  const slower = summarizeRatios([1.08, 1.09, 1.08, 1.09])
+  const faster = summarizeRatios([0.9, 0.91, 0.9, 0.91])
+  expect(classify(slower, slower)).toBe('slower')
+  expect(classify(faster, faster)).toBe('faster')
+  expect(classify(slower, faster)).toBe('inconclusive')
+  expect(classify(summarizeRatios([1, 1, 1]), summarizeRatios([1, 1, 1]))).toBe(
+    'within-2%',
+  )
+})
+
+test('rejects incomplete or invalid sampling data', () => {
+  expect(() => summarizeRatios([1])).toThrow()
+  expect(() => summarizeRatios([0, 1])).toThrow()
+  expect(() => summarizeRatios([NaN, 1])).toThrow()
+  expect(() => mean([])).toThrow()
+  expect(() => mean([Infinity])).toThrow()
+})

--- a/benchmarks/client-nav/link-performance/statistics.ts
+++ b/benchmarks/client-nav/link-performance/statistics.ts
@@ -1,0 +1,57 @@
+const critical95 = [
+  12.7062, 4.3027, 3.1824, 2.7764, 2.5706, 2.4469, 2.3646, 2.306, 2.2622,
+  2.2281,
+]
+
+export function mean(values: ReadonlyArray<number>) {
+  if (!values.length || values.some((value) => !Number.isFinite(value))) {
+    throw new Error('Expected finite, nonempty samples')
+  }
+  return values.reduce((sum, value) => sum + value, 0) / values.length
+}
+
+export function summarizeRatios(ratios: ReadonlyArray<number>) {
+  if (
+    ratios.length < 2 ||
+    ratios.length > 11 ||
+    ratios.some((value) => value <= 0)
+  ) {
+    throw new Error('Expected 2-11 independent positive process-replica ratios')
+  }
+  const logs = ratios.map(Math.log)
+  const center = mean(logs)
+  const variance =
+    logs.reduce((sum, value) => sum + (value - center) ** 2, 0) /
+    (logs.length - 1)
+  // Replicas, not the many correlated batches inside a worker, are the samples.
+  const margin =
+    critical95[logs.length - 2]! * Math.sqrt(variance / logs.length)
+  const percent = (value: number) => (Math.exp(value) - 1) * 100
+  return {
+    changePercent: percent(center),
+    low95: percent(center - margin),
+    high95: percent(center + margin),
+    replicas: ratios.length,
+  }
+}
+
+export function classify(
+  cpu: ReturnType<typeof summarizeRatios>,
+  wall: ReturnType<typeof summarizeRatios>,
+) {
+  if (cpu.low95 > 0 && wall.low95 > 0) {
+    return 'slower'
+  }
+  if (cpu.high95 < 0 && wall.high95 < 0) {
+    return 'faster'
+  }
+  if (
+    cpu.low95 >= -2 &&
+    cpu.high95 <= 2 &&
+    wall.low95 >= -2 &&
+    wall.high95 <= 2
+  ) {
+    return 'within-2%'
+  }
+  return 'inconclusive'
+}

--- a/benchmarks/client-nav/link-performance/tsconfig.json
+++ b/benchmarks/client-nav/link-performance/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
+    "types": ["node", "vite/client", "vitest/globals"]
+  },
+  "include": [
+    "./**/*.ts",
+    "./**/*.tsx",
+    "../scenarios/harness.ts",
+    "../setup-helpers.ts",
+    "../vitest.setup.ts"
+  ]
+}

--- a/benchmarks/client-nav/link-performance/vite.client.config.ts
+++ b/benchmarks/client-nav/link-performance/vite.client.config.ts
@@ -1,0 +1,3 @@
+import { createLinkPerformanceConfig } from './config'
+
+export default createLinkPerformanceConfig('client')

--- a/benchmarks/client-nav/link-performance/vite.ssr.config.ts
+++ b/benchmarks/client-nav/link-performance/vite.ssr.config.ts
@@ -1,0 +1,3 @@
+import { createLinkPerformanceConfig } from './config'
+
+export default createLinkPerformanceConfig('ssr')

--- a/benchmarks/client-nav/link-performance/vitest.config.ts
+++ b/benchmarks/client-nav/link-performance/vitest.config.ts
@@ -1,0 +1,11 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  root: fileURLToPath(new URL('.', import.meta.url)),
+  test: {
+    watch: false,
+    environment: 'node',
+    include: ['config.test.ts'],
+  },
+})

--- a/benchmarks/client-nav/link-performance/vitest.config.ts
+++ b/benchmarks/client-nav/link-performance/vitest.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   test: {
     watch: false,
     environment: 'node',
-    include: ['config.test.ts'],
+    include: ['*.test.ts'],
   },
 })

--- a/benchmarks/client-nav/link-performance/worker-protocol.ts
+++ b/benchmarks/client-nav/link-performance/worker-protocol.ts
@@ -1,0 +1,28 @@
+import type { LinkCaseId } from './cases'
+
+export type Mode = 'client' | 'ssr'
+export type Variant = 0 | 1
+
+export type WorkerRequest =
+  | {
+      kind: 'init'
+      mode: Mode
+      caseId: LinkCaseId
+      bundle: string
+      variant: Variant
+    }
+  | { kind: 'measure'; iterations: number; variant: Variant }
+  | { kind: 'stop' }
+
+export interface BlockSample {
+  wallMs: number
+  cpuMs: number
+  processCpuMs: number
+  iterations: number
+}
+
+export type WorkerResponse =
+  | { kind: 'ready'; batchMs: number }
+  | { kind: 'sample'; sample: BlockSample }
+  | { kind: 'stopped' }
+  | { kind: 'error'; message: string }

--- a/benchmarks/ssr/README.md
+++ b/benchmarks/ssr/README.md
@@ -98,3 +98,19 @@ Use `react`, `solid`, or `vue` for `<framework>`. The baseline projects use `@be
 - Server-function loops must include `sec-fetch-site: same-origin` so the default CSRF middleware accepts the request.
 - Loops that expect non-200 responses pass a custom `validateResponse` to `runRequestLoop`.
 - Bench loops must build deterministic requests from the seeded random helper and consume response bodies through `runRequestLoop` or `runSsrRequestLoop`.
+
+## Optional React Link workloads
+
+The [opt-in Link suite](../client-nav/README.md#opt-in-react-link-performance-suite)
+adds focused standalone React Router SSR coverage for params/updaters,
+inheritance, search middlewares, optional/splat segments, encoding, masks,
+rewrites, and active props. Each timed batch creates four fresh routers and
+renders their Links to HTML; it does not measure Start HTTP/streaming overhead.
+
+```bash
+TSR_LINK_PERF=1 CI=1 NX_DAEMON=false pnpm nx run @benchmarks/react-link-performance:test:perf:ssr --outputStyle=stream --skipRemoteCache -- --run
+```
+
+These cases are excluded from this directory's aggregate projects and normal
+CodSpeed dependency graph. The flag must be explicitly enabled when invoking
+the dedicated target.

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -94,28 +94,16 @@ function resolveIsActive(
   activeOptions: ActiveOptions | undefined,
   basepath: string,
   isHydrated: boolean,
-  isExternal: boolean,
 ): boolean {
-  if (isExternal) {
+  const currentPath = removeTrailingSlash(location.pathname, basepath)
+  const nextPath = removeTrailingSlash(next.pathname, basepath)
+  if (
+    currentPath !== nextPath &&
+    (activeOptions?.exact ||
+      !currentPath.startsWith(nextPath) ||
+      currentPath[nextPath.length] !== '/')
+  ) {
     return false
-  }
-  if (activeOptions?.exact) {
-    const testExact = exactPathTest(location.pathname, next.pathname, basepath)
-    if (!testExact) {
-      return false
-    }
-  } else {
-    const currentPathSplit = removeTrailingSlash(location.pathname, basepath)
-    const nextPathSplit = removeTrailingSlash(next.pathname, basepath)
-
-    const pathIsFuzzyEqual =
-      currentPathSplit.startsWith(nextPathSplit) &&
-      (currentPathSplit.length === nextPathSplit.length ||
-        currentPathSplit[nextPathSplit.length] === '/')
-
-    if (!pathIsFuzzyEqual) {
-      return false
-    }
   }
 
   if (activeOptions?.includeSearch ?? true) {
@@ -523,14 +511,14 @@ export function useLinkProps<
       return [
         hrefOption?.href,
         externalLink,
-        resolveIsActive(
-          location,
-          next,
-          stableActiveOptions,
-          router.basepath,
-          isHydrated,
-          externalLink !== undefined,
-        ),
+        !externalLink &&
+          resolveIsActive(
+            location,
+            next,
+            stableActiveOptions,
+            router.basepath,
+            isHydrated,
+          ),
       ]
     },
     [stableActiveOptions, disabled, isHydrated, _options, router, to],
@@ -543,18 +531,10 @@ export function useLinkProps<
     compareLinkState,
   )
 
-  const resolvedProps: React.HTMLAttributes<HTMLAnchorElement> = isActive
-    ? (functionalUpdate(activeProps as any, {}) ?? STATIC_ACTIVE_OBJECT)
-    : (functionalUpdate(inactiveProps, {}) ?? STATIC_EMPTY_OBJECT)
-  const stateClassName = resolvedProps.className
-  const resolvedClassName = className
-    ? stateClassName
-      ? `${className} ${stateClassName}`
-      : className
-    : stateClassName
-  const stateStyle = resolvedProps.style
-  const resolvedStyle =
-    style && stateStyle ? { ...style, ...stateStyle } : style || stateStyle
+  const resolvedProps: React.HTMLAttributes<HTMLAnchorElement> =
+    functionalUpdate(isActive ? activeProps : inactiveProps, {}) ??
+    (isActive ? STATIC_ACTIVE_OBJECT : STATIC_EMPTY_OBJECT)
+  const { className: stateClassName, style: stateStyle } = resolvedProps
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const hasRenderFetched = React.useRef(false)
@@ -704,8 +684,12 @@ export function useLinkProps<
     onTouchStart: composeHandlers(onTouchStart, handleTouchStart),
     disabled: !!disabled,
     target,
-    ...(resolvedStyle && { style: resolvedStyle }),
-    ...(resolvedClassName && { className: resolvedClassName }),
+    ...(style && {
+      style: stateStyle ? { ...style, ...stateStyle } : style,
+    }),
+    ...(className && {
+      className: className + (stateClassName ? ' ' + stateClassName : ''),
+    }),
     ...(disabled && STATIC_DISABLED_PROPS),
     ...(isActive && STATIC_ACTIVE_PROPS),
   }

--- a/packages/react-router/src/link.tsx
+++ b/packages/react-router/src/link.tsx
@@ -427,10 +427,11 @@ export function useLinkProps<
 
     return {
       ...propsSafeToSpread,
+      ref: innerRef as React.ComponentPropsWithRef<'a'>['ref'],
       ...resolvedActiveProps,
       ...resolvedInactiveProps,
+      // State props can override element props, but not routing options.
       href: hrefOption?.href,
-      ref: innerRef as React.ComponentPropsWithRef<'a'>['ref'],
       disabled: !!disabled,
       target,
       ...(resolvedStyle && { style: resolvedStyle }),
@@ -673,8 +674,6 @@ export function useLinkProps<
 
   return {
     ...propsSafeToSpread,
-    ...resolvedProps,
-    href,
     ref: innerRef as React.ComponentPropsWithRef<'a'>['ref'],
     onClick: composeHandlers(onClick, handleClick),
     onBlur: composeHandlers(onBlur, handleLeave),
@@ -682,6 +681,9 @@ export function useLinkProps<
     onMouseEnter: composeHandlers(onMouseEnter, enqueuePreload),
     onMouseLeave: composeHandlers(onMouseLeave, handleLeave),
     onTouchStart: composeHandlers(onTouchStart, handleTouchStart),
+    ...resolvedProps,
+    // State props can override element props, but not routing options.
+    href,
     disabled: !!disabled,
     target,
     ...(style && {

--- a/packages/react-router/tests/link-destination.test.tsx
+++ b/packages/react-router/tests/link-destination.test.tsx
@@ -1,0 +1,290 @@
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import {
+  Link,
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  defaultStringifySearch,
+  retainSearchParams,
+} from '../src'
+
+describe('Link destination updates', () => {
+  beforeEach(() => vi.stubEnv('NODE_ENV', 'production'))
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllEnvs()
+  })
+
+  function setupFixedLink(
+    params = { id: 'fixed' },
+    stringify?: (params: Record<string, unknown>) => { id: string },
+  ) {
+    const rootRoute = createRootRoute({
+      component: () => (
+        <>
+          <Link
+            to="/target/$id"
+            params={params}
+            search={{}}
+            hash="details"
+            activeOptions={{ includeSearch: false }}
+            data-testid="fixed-link"
+          >
+            Target
+          </Link>
+          <Outlet />
+        </>
+      ),
+    })
+    const itemsRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/items/$source',
+    })
+    const targetRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/target/$id',
+      params: { stringify },
+    })
+    const routeTree = rootRoute.addChildren([itemsRoute, targetRoute])
+    const router = createRouter<typeof routeTree, 'always' | 'never'>({
+      routeTree,
+      history: createMemoryHistory({ initialEntries: ['/items/one'] }),
+    })
+    return { router, rootRoute }
+  }
+
+  test('preserves a fixed destination when unrelated location inputs change', async () => {
+    const { router } = setupFixedLink()
+    render(<RouterProvider router={router} />)
+
+    const link = await screen.findByTestId('fixed-link')
+    expect(link).toHaveAttribute('href', '/target/fixed#details')
+    expect(link).not.toHaveAttribute('data-status')
+
+    await act(() =>
+      router.navigate({
+        to: '/items/$source',
+        params: { source: 'two' },
+        search: { tab: 'other' },
+        hash: 'other',
+      }),
+    )
+
+    expect(link).toHaveAttribute('href', '/target/fixed#details')
+    expect(link).not.toHaveAttribute('data-status')
+
+    await act(() =>
+      router.navigate({
+        to: '/target/$id',
+        params: { id: 'fixed' },
+      }),
+    )
+    expect(link).toHaveAttribute('data-status', 'active')
+    expect(link).toHaveAttribute('href', '/target/fixed#details')
+  })
+
+  test('updates the destination when router options change', async () => {
+    const { router } = setupFixedLink()
+    render(<RouterProvider router={router} />)
+
+    const link = await screen.findByTestId('fixed-link')
+    expect(link).toHaveAttribute('href', '/target/fixed#details')
+
+    router.update({ trailingSlash: 'always' })
+    await act(() =>
+      router.navigate({ to: '/items/$source', params: { source: 'two' } }),
+    )
+    expect(link).toHaveAttribute('href', '/target/fixed/#details')
+
+    router.update({ trailingSlash: 'never' })
+    await act(() =>
+      router.navigate({ to: '/items/$source', params: { source: 'three' } }),
+    )
+    expect(link).toHaveAttribute('href', '/target/fixed#details')
+  })
+
+  test('evaluates param stringifiers before reusing pathnames', async () => {
+    const stringify = vi.fn((params: Record<string, unknown>) => ({
+      id: `${params.source}-${params.id}`,
+    }))
+    const { router } = setupFixedLink({ id: 'fixed' }, stringify)
+    render(<RouterProvider router={router} />)
+
+    const link = await screen.findByTestId('fixed-link')
+    expect(link).toHaveAttribute('href', '/target/one-fixed#details')
+
+    await act(() =>
+      router.navigate({ to: '/items/$source', params: { source: 'two' } }),
+    )
+    expect(link).toHaveAttribute('href', '/target/two-fixed#details')
+
+    stringify.mockClear()
+    await act(() =>
+      router.navigate({ to: '/items/$source', params: { source: 'one' } }),
+    )
+    expect(link).toHaveAttribute('href', '/target/one-fixed#details')
+    expect(stringify).toHaveBeenCalled()
+  })
+
+  test('updates when ancestor search middleware is added and removed', async () => {
+    const { router, rootRoute } = setupFixedLink()
+    render(<RouterProvider router={router} />)
+
+    const link = await screen.findByTestId('fixed-link')
+    expect(link).toHaveAttribute('href', '/target/fixed#details')
+
+    rootRoute.update({
+      search: { middlewares: [retainSearchParams(true)] },
+    })
+    await act(() =>
+      router.navigate({
+        to: '/items/$source',
+        params: { source: 'two' },
+        search: { retained: 'value' },
+      }),
+    )
+    expect(link).toHaveAttribute('href', '/target/fixed?retained=value#details')
+
+    rootRoute.update({ search: undefined })
+    await act(() =>
+      router.navigate({
+        to: '/items/$source',
+        params: { source: 'three' },
+        search: { retained: 'value' },
+      }),
+    )
+    expect(link).toHaveAttribute('href', '/target/fixed#details')
+  })
+
+  test('continues evaluating a custom search serializer', async () => {
+    const { router } = setupFixedLink()
+    let language = 'en'
+    router.update({
+      stringifySearch: (search) =>
+        defaultStringifySearch({ ...search, language }),
+    })
+    render(<RouterProvider router={router} />)
+
+    const link = await screen.findByTestId('fixed-link')
+    expect(link).toHaveAttribute('href', '/target/fixed?language=en#details')
+
+    language = 'fr'
+    await act(() =>
+      router.navigate({ to: '/items/$source', params: { source: 'two' } }),
+    )
+    expect(link).toHaveAttribute('href', '/target/fixed?language=fr#details')
+  })
+
+  test('reads accessor-backed params after navigation', async () => {
+    let id = 'one'
+    const { router } = setupFixedLink({
+      get id() {
+        return id
+      },
+    })
+    render(<RouterProvider router={router} />)
+
+    const link = await screen.findByTestId('fixed-link')
+    expect(link).toHaveAttribute('href', '/target/one#details')
+
+    id = 'two'
+    await act(() =>
+      router.navigate({ to: '/items/$source', params: { source: 'two' } }),
+    )
+    expect(link).toHaveAttribute('href', '/target/two#details')
+  })
+
+  test('updates when an existing params object changes', async () => {
+    const params = { id: 'one' }
+    const { router } = setupFixedLink(params)
+    render(<RouterProvider router={router} />)
+
+    const link = await screen.findByTestId('fixed-link')
+    expect(link).toHaveAttribute('href', '/target/one#details')
+
+    params.id = 'two'
+    await act(() =>
+      router.navigate({ to: '/items/$source', params: { source: 'two' } }),
+    )
+    expect(link).toHaveAttribute('href', '/target/two#details')
+  })
+
+  test('updates fixed params and hash when Link props change', async () => {
+    const rootRoute = createRootRoute({
+      component: function Root() {
+        const [value, setValue] = React.useState('one')
+        return (
+          <>
+            <button onClick={() => setValue('two')}>Change target</button>
+            <Link
+              to="/items/$id"
+              params={{ id: value }}
+              hash={value}
+              data-testid="changing-link"
+            >
+              Item
+            </Link>
+            <Outlet />
+          </>
+        )
+      },
+    })
+    const itemsRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/items/$id',
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([itemsRoute]),
+      history: createMemoryHistory({ initialEntries: ['/items/one'] }),
+    })
+    render(<RouterProvider router={router} />)
+
+    const link = await screen.findByTestId('changing-link')
+    expect(link).toHaveAttribute('href', '/items/one#one')
+    expect(link).toHaveAttribute('data-status', 'active')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Change target' }))
+
+    expect(link).toHaveAttribute('href', '/items/two#two')
+    expect(link).not.toHaveAttribute('data-status')
+  })
+
+  test('updates inherited params and active state together', async () => {
+    const rootRoute = createRootRoute({
+      component: () => (
+        <>
+          <Link to="/items/$id" params={{}} data-testid="inherited-link">
+            {({ isActive }) => (isActive ? 'Current item' : 'Another item')}
+          </Link>
+          <Outlet />
+        </>
+      ),
+    })
+    const itemsRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/items/$id',
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([itemsRoute]),
+      history: createMemoryHistory({ initialEntries: ['/items/one'] }),
+    })
+    render(<RouterProvider router={router} />)
+
+    const link = await screen.findByTestId('inherited-link')
+    expect(link).toHaveAttribute('href', '/items/one')
+    expect(link).toHaveTextContent('Current item')
+
+    await act(() =>
+      router.navigate({ to: '/items/$id', params: { id: 'two' } }),
+    )
+
+    expect(link).toHaveAttribute('href', '/items/two')
+    expect(link).toHaveAttribute('data-status', 'active')
+    expect(link).toHaveTextContent('Current item')
+  })
+})

--- a/packages/react-router/tests/link-state-props.test.tsx
+++ b/packages/react-router/tests/link-state-props.test.tsx
@@ -1,31 +1,56 @@
-import React from 'react'
-import { cleanup, render } from '@testing-library/react'
-import { afterEach, expect, test } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { afterEach, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import {
   Link,
   RouterContextProvider,
+  RouterProvider,
   createMemoryHistory,
   createRootRoute,
   createRoute,
   createRouter,
+  useLinkProps,
 } from '../src'
 
-afterEach(cleanup)
+const disposers: Array<() => void> = []
+afterEach(() => {
+  cleanup()
+  for (const dispose of disposers.splice(0)) {
+    dispose()
+  }
+})
 
-test.each([false, true])(
-  'active links preserve styling while disabled changes (masked=%s)',
-  async (masked) => {
+test.each([
+  { active: true, masked: false, server: false },
+  { active: true, masked: true, server: false },
+  { active: false, masked: false, server: false },
+  { active: false, masked: true, server: false },
+  { active: true, masked: false, server: true },
+  { active: true, masked: true, server: true },
+  { active: false, masked: false, server: true },
+  { active: false, masked: true, server: true },
+])(
+  'state props preserve routing while disabled changes (active: $active, masked: $masked, server: $server)',
+  async ({ active, masked, server }) => {
     const root = createRootRoute()
     const router = createRouter({
       routeTree: root.addChildren([
         createRoute({ getParentRoute: () => root, path: '/active' }),
+        createRoute({ getParentRoute: () => root, path: '/inactive' }),
       ]),
-      history: createMemoryHistory({ initialEntries: ['/active'] }),
+      history: createMemoryHistory({
+        initialEntries: [active ? '/active' : '/inactive'],
+      }),
+      isServer: server,
     })
+    disposers.push(router.history.destroy)
     await router.load()
-    const activeProps = {
-      className: 'active-state',
+    const stateProps = {
+      className: 'state-class',
       href: 'javascript:active()',
+      target: '_self',
+      disabled: false,
     }
     const content = (disabled: boolean) => (
       <RouterContextProvider router={router}>
@@ -33,18 +58,37 @@ test.each([false, true])(
           to="/active"
           mask={masked ? { to: '/masked' } : undefined}
           disabled={disabled}
-          activeProps={activeProps}
+          target="_blank"
+          activeProps={stateProps}
+          inactiveProps={stateProps}
         >
           Target
         </Link>
       </RouterContextProvider>
     )
-    const view = render(content(false))
+    const view = server ? undefined : render(content(false))
     for (const disabled of [false, true, false]) {
-      view.rerender(content(disabled))
-      const anchor = view.getByText('Target')
-      expect(anchor).toHaveClass('active-state')
-      expect(anchor).toHaveAttribute('aria-current', 'page')
+      let anchor: HTMLElement
+      if (view) {
+        view.rerender(content(disabled))
+        anchor = view.getByText('Target')
+      } else {
+        const container = document.createElement('div')
+        container.innerHTML = renderToString(content(disabled))
+        const link = container.querySelector('a')
+        expect(link).not.toBeNull()
+        if (!link) {
+          throw new Error('Expected the server-rendered Link')
+        }
+        anchor = link
+      }
+      expect(anchor).toHaveClass('state-class')
+      expect(anchor).toHaveAttribute('target', '_blank')
+      if (active) {
+        expect(anchor).toHaveAttribute('aria-current', 'page')
+      } else {
+        expect(anchor).not.toHaveAttribute('aria-current')
+      }
       if (disabled) {
         expect(anchor).not.toHaveAttribute('href')
         expect(anchor).toHaveAttribute('aria-disabled', 'true')
@@ -52,6 +96,85 @@ test.each([false, true])(
         expect(anchor).toHaveAttribute('href', masked ? '/masked' : '/active')
         expect(anchor).not.toHaveAttribute('aria-disabled')
       }
+    }
+  },
+)
+
+test.each([
+  { active: true, server: false },
+  { active: false, server: false },
+  { active: true, server: true },
+  { active: false, server: true },
+])(
+  'selected state props override base props (active: $active, server: $server)',
+  async ({ active, server }) => {
+    const baseClick = vi.fn()
+    const selectedClick = vi.fn((event: React.MouseEvent) =>
+      event.preventDefault(),
+    )
+    const unusedClick = vi.fn()
+    const stateRef = React.createRef<HTMLAnchorElement>()
+    let resolvedRef: React.Ref<HTMLAnchorElement> | undefined
+    const stateProps = {
+      ref: stateRef,
+      title: 'state title',
+      onClick: selectedClick,
+      className: 'state-class',
+      style: { color: 'blue' },
+    }
+    const history = createMemoryHistory({ initialEntries: ['/target'] })
+    disposers.push(history.destroy)
+    function TestLink() {
+      const props = useLinkProps({
+        to: active ? '/target' : '/',
+        target: '_blank',
+        title: 'base title',
+        onClick: baseClick,
+        className: 'base',
+        style: { color: 'red', marginTop: 2 },
+        activeProps: active ? stateProps : { onClick: unusedClick },
+        inactiveProps: active ? { onClick: unusedClick } : stateProps,
+        preload: false,
+      })
+      resolvedRef = props.ref
+      return <a {...props}>Override</a>
+    }
+    const root = createRootRoute({ component: TestLink })
+    const router = createRouter({
+      routeTree: root.addChildren([
+        createRoute({ getParentRoute: () => root, path: '/' }),
+        createRoute({ getParentRoute: () => root, path: '/target' }),
+      ]),
+      history,
+      isServer: server,
+      scrollRestoration: false,
+    })
+
+    let link: HTMLElement
+    if (server) {
+      await router.load()
+      const container = document.createElement('div')
+      container.innerHTML = renderToString(<RouterProvider router={router} />)
+      const anchor = container.querySelector('a')
+      expect(anchor).not.toBeNull()
+      if (!anchor) {
+        throw new Error('Expected the server-rendered Link')
+      }
+      link = anchor
+    } else {
+      render(<RouterProvider router={router} />)
+      link = await screen.findByRole('link', { name: 'Override' })
+    }
+
+    expect(resolvedRef).toBe(stateRef)
+    expect(link).toHaveAttribute('title', 'state title')
+    expect(link).toHaveClass('base', 'state-class')
+    expect(link.style).toMatchObject({ color: 'blue', marginTop: '2px' })
+    if (!server) {
+      fireEvent.click(link)
+      expect(selectedClick).toHaveBeenCalledOnce()
+      expect(baseClick).not.toHaveBeenCalled()
+      expect(unusedClick).not.toHaveBeenCalled()
     }
   },
 )

--- a/packages/router-core/src/path.ts
+++ b/packages/router-core/src/path.ts
@@ -1,6 +1,5 @@
 import { isServer } from '@tanstack/router-core/isServer'
 import { last } from './utils'
-import { createSieveCache } from './sieve-cache'
 import {
   SEGMENT_TYPE_OPTIONAL_PARAM,
   SEGMENT_TYPE_PATHNAME,
@@ -222,62 +221,6 @@ interface InterpolatePathOptions {
    * For testing only, in development mode we use the router.isServer value
    */
   server?: boolean
-  /** @internal Collect parameter names during the first interpolation. */
-  _keys?: Array<string>
-}
-
-/** @internal */
-export function createPathInterpolator() {
-  type Plan = [keys: Array<string>, paths: SieveCache<string, string>]
-  const plans = createSieveCache<string, Plan>(32)
-  let previousPlan: Plan | undefined
-  let previousPath: string | undefined
-  let previousDecoder: InterpolatePathOptions['decoder']
-
-  return (options: InterpolatePathOptions): string => {
-    const { path, params, decoder } = options
-    if (!path?.includes('$')) {
-      return path || '/'
-    }
-
-    if (decoder !== previousDecoder) {
-      previousDecoder = decoder
-      previousPlan = undefined
-      plans.clear()
-    }
-
-    let plan = previousPath === path ? previousPlan : plans.get(path)
-    let interpolated: string | undefined
-    if (!plan) {
-      const keys: Array<string> = []
-      interpolated = interpolatePath({
-        ...options,
-        _keys: keys,
-      }).interpolatedPath
-      plan = [keys, createSieveCache<string, string>(128)]
-      plans.set(path, plan)
-    }
-    previousPlan = plan
-    previousPath = path
-
-    const [keys, paths] = plan
-    let key = ''
-    for (const name of keys) {
-      const value = params[name]
-      if (typeof value !== 'string') {
-        return interpolated ?? interpolatePath(options).interpolatedPath
-      }
-      key = keys.length === 1 ? value : key + `${value.length}:${value}`
-    }
-
-    const cached = paths.get(key)
-    if (cached !== undefined) {
-      return cached
-    }
-    interpolated ??= interpolatePath(options).interpolatedPath
-    paths.set(key, interpolated)
-    return interpolated
-  }
 }
 
 type InterPolatePathResult = {
@@ -288,11 +231,12 @@ type InterPolatePathResult = {
 
 function encodeParam(
   key: string,
-  params: InterpolatePathOptions['params'],
+  value: unknown,
   decoder: InterpolatePathOptions['decoder'],
-): any {
-  const value = params[key]
-  if (typeof value !== 'string') return value
+): string {
+  if (typeof value !== 'string') {
+    return '' + (value ?? undefined)
+  }
 
   if (key === '_splat') {
     // Early return if value only contains URL-safe characters (performance optimization)
@@ -318,17 +262,41 @@ function encodeParam(
 export function interpolatePath(
   options: InterpolatePathOptions,
 ): InterPolatePathResult {
-  const { path, params, decoder } = options
-  // Tracking if any params are missing in the `params` object
-  // when interpolating the path
-  let isMissingParams = false
+  const { path, params, decoder, server } = options
   const usedParams: Record<string, unknown> = Object.create(null)
+  let isMissingParams = false
+  const interpolatedPath = interpolatePathname(
+    path || '/',
+    params,
+    decoder,
+    usedParams,
+    undefined,
+    server,
+    () => {
+      isMissingParams = true
+    },
+  )
+  return { interpolatedPath, usedParams, isMissingParams }
+}
 
-  if (!path?.includes('$')) {
-    return { interpolatedPath: path || '/', usedParams, isMissingParams }
+/**
+ * @internal
+ * Optional metadata is collected in the same pass as the pathname.
+ */
+export function interpolatePathname(
+  path: string,
+  params: Record<string, unknown>,
+  decoder: InterpolatePathOptions['decoder'],
+  usedParams?: Record<string, unknown>,
+  keys?: Array<string>,
+  server?: boolean,
+  onMissing?: () => void,
+): string {
+  if (!path.includes('$')) {
+    return path
   }
 
-  if (isServer ?? options.server) {
+  if (isServer ?? server) {
     // Fast path for common templates like `/posts/$id` or `/files/$`.
     // Braced segments (`{...}`) are more complex (prefix/suffix/optional) and are
     // handled by the general parser below.
@@ -339,67 +307,67 @@ export function interpolatePath(
 
       while (cursor < length) {
         // Skip slashes between segments. '/' code is 47
-        while (cursor < length && path.charCodeAt(cursor) === 47) cursor++
-        if (cursor >= length) break
+        while (cursor < length && path.charCodeAt(cursor) === 47) {
+          cursor++
+        }
+        if (cursor >= length) {
+          break
+        }
 
         const start = cursor
         let end = path.indexOf('/', cursor)
-        if (end === -1) end = length
+        if (end === -1) {
+          end = length
+        }
         cursor = end
 
         const part = path.substring(start, end)
-        if (!part) continue
 
         // `$id` or `$` (splat). '$' code is 36
         if (part.charCodeAt(0) === 36) {
-          if (part.length === 1) {
-            options._keys?.push('_splat')
-            const splat = params._splat
-            usedParams._splat = splat
-            // TODO: Deprecate *
-            usedParams['*'] = splat
-
-            if (!splat) {
-              isMissingParams = true
-              continue
+          const splat = part.length === 1
+          const key = splat ? '_splat' : part.substring(1)
+          const value = params[key]
+          keys?.push(key)
+          if (onMissing && !(splat ? value : key in params)) {
+            onMissing()
+            onMissing = undefined
+          }
+          if (usedParams) {
+            usedParams[key] = value
+            if (splat) {
+              // TODO: Deprecate *
+              usedParams['*'] = value
             }
-
-            const value = encodeParam('_splat', params, decoder)
-            joined += '/' + value
-          } else {
-            const key = part.substring(1)
-            options._keys?.push(key)
-            if (!isMissingParams && !(key in params)) {
-              isMissingParams = true
-            }
-            usedParams[key] = params[key]
-
-            const value = encodeParam(key, params, decoder) ?? 'undefined'
-            joined += '/' + value
+          }
+          if (!splat || value) {
+            joined += '/' + encodeParam(key, value, decoder)
           }
         } else {
           joined += '/' + part
         }
       }
 
-      if (path.endsWith('/')) joined += '/'
+      if (path.endsWith('/')) {
+        joined += '/'
+      }
 
-      const interpolatedPath = joined || '/'
-      return { usedParams, interpolatedPath, isMissingParams }
+      return joined || '/'
     }
   }
 
-  const length = path.length
   let cursor = 0
   let segment
   let joined = ''
-  while (cursor < length) {
+  while (cursor < path.length) {
     const start = cursor
     segment = parseSegment(path, start, segment)
     const end = segment[5]
     cursor = end + 1
 
-    if (start === end) continue
+    if (start === end) {
+      continue
+    }
 
     const kind = segment[0]
 
@@ -411,43 +379,38 @@ export function interpolatePath(
     const splat = kind === SEGMENT_TYPE_WILDCARD
     const optional = kind === SEGMENT_TYPE_OPTIONAL_PARAM
     const key = splat ? '_splat' : path.substring(segment[2], segment[3])
-    options._keys?.push(key)
-    if (!splat && !optional && !isMissingParams && !(key in params)) {
-      isMissingParams = true
-    }
     const valueRaw = params[key]
+    keys?.push(key)
+    if (onMissing && !(splat ? valueRaw : optional || key in params)) {
+      onMissing()
+      onMissing = undefined
+    }
     if (optional && valueRaw == null) {
       continue
     }
-    usedParams[key] = valueRaw
+    if (usedParams) {
+      usedParams[key] = valueRaw
+      if (splat) {
+        // TODO: Deprecate *
+        usedParams['*'] = valueRaw
+      }
+    }
 
     const prefix = path.substring(start, segment[1])
     const suffix = path.substring(segment[4], end)
-    if (splat) {
-      // TODO: Deprecate *
-      usedParams['*'] = valueRaw
-      if (!valueRaw) {
-        isMissingParams = true
-        // Missing splats retain their prefix/suffix, but not an empty segment.
-        if (prefix || suffix) {
-          joined += '/' + prefix + suffix
-        }
-        continue
-      }
+    const emptySplat = splat && !valueRaw
+    if (emptySplat && !prefix && !suffix) {
+      continue
     }
-    const value = encodeParam(key, params, decoder)
-    joined +=
-      '/' +
-      prefix +
-      (splat ? value : (value ?? (optional ? '' : 'undefined'))) +
-      suffix
+    const value = emptySplat ? '' : encodeParam(key, valueRaw, decoder)
+    joined += '/' + prefix + value + suffix
   }
 
-  if (path.endsWith('/')) joined += '/'
+  if (path.endsWith('/')) {
+    joined += '/'
+  }
 
-  const interpolatedPath = joined || '/'
-
-  return { usedParams, interpolatedPath, isMissingParams }
+  return joined || '/'
 }
 
 function encodePathParam(

--- a/packages/router-core/src/path.ts
+++ b/packages/router-core/src/path.ts
@@ -240,7 +240,9 @@ function encodeParam(
 
   if (key === '_splat') {
     // Early return if value only contains URL-safe characters (performance optimization)
-    if (/^[a-zA-Z0-9\-._~!/]*$/.test(value)) return value
+    if (!value || /^[a-zA-Z0-9\-._~!/]*$/.test(value)) {
+      return value
+    }
     // the splat/catch-all routes shouldn't have the '/' encoded out
     // Use encodeURIComponent for each segment to properly encode spaces,
     // plus signs, and other special characters that encodeURI leaves unencoded
@@ -263,20 +265,21 @@ export function interpolatePath(
   options: InterpolatePathOptions,
 ): InterPolatePathResult {
   const { path, params, decoder, server } = options
-  const usedParams: Record<string, unknown> = Object.create(null)
-  let isMissingParams = false
-  const interpolatedPath = interpolatePathname(
-    path || '/',
+  const result: InterPolatePathResult = {
+    interpolatedPath: path || '/',
+    usedParams: Object.create(null),
+    isMissingParams: false,
+  }
+  result.interpolatedPath = interpolatePathname(
+    result.interpolatedPath,
     params,
     decoder,
-    usedParams,
+    result.usedParams,
     undefined,
     server,
-    () => {
-      isMissingParams = true
-    },
+    result,
   )
-  return { interpolatedPath, usedParams, isMissingParams }
+  return result
 }
 
 /**
@@ -290,7 +293,7 @@ export function interpolatePathname(
   usedParams?: Record<string, unknown>,
   keys?: Array<string>,
   server?: boolean,
-  onMissing?: () => void,
+  metadata?: { isMissingParams: boolean },
 ): string {
   if (!path.includes('$')) {
     return path
@@ -329,9 +332,8 @@ export function interpolatePathname(
           const key = splat ? '_splat' : part.substring(1)
           const value = params[key]
           keys?.push(key)
-          if (onMissing && !(splat ? value : key in params)) {
-            onMissing()
-            onMissing = undefined
+          if (metadata && (splat ? !value : !(key in params))) {
+            metadata.isMissingParams = true
           }
           if (usedParams) {
             usedParams[key] = value
@@ -376,34 +378,50 @@ export function interpolatePathname(
       continue
     }
 
-    const splat = kind === SEGMENT_TYPE_WILDCARD
-    const optional = kind === SEGMENT_TYPE_OPTIONAL_PARAM
-    const key = splat ? '_splat' : path.substring(segment[2], segment[3])
-    const valueRaw = params[key]
+    const prefixEnd = segment[1]
+    const suffixStart = segment[4]
+    const key =
+      kind === SEGMENT_TYPE_WILDCARD
+        ? '_splat'
+        : path.substring(segment[2], segment[3])
+    let paramValue = params[key]
     keys?.push(key)
-    if (onMissing && !(splat ? valueRaw : optional || key in params)) {
-      onMissing()
-      onMissing = undefined
-    }
-    if (optional && valueRaw == null) {
-      continue
-    }
-    if (usedParams) {
-      usedParams[key] = valueRaw
-      if (splat) {
+
+    if (kind === SEGMENT_TYPE_WILDCARD) {
+      if (usedParams) {
+        usedParams[key] = paramValue
         // TODO: Deprecate *
-        usedParams['*'] = valueRaw
+        usedParams['*'] = paramValue
+      }
+      if (!paramValue) {
+        if (metadata) {
+          metadata.isMissingParams = true
+        }
+        // A missing wildcard keeps its affixes, but omits a bare segment.
+        if (prefixEnd === start && suffixStart === end) {
+          continue
+        }
+        paramValue = ''
+      }
+    } else {
+      // Named parameters: $id or {-$id}.
+      if (kind === SEGMENT_TYPE_OPTIONAL_PARAM) {
+        if (paramValue == null) {
+          continue
+        }
+      } else if (metadata && !(key in params)) {
+        metadata.isMissingParams = true
+      }
+      if (usedParams) {
+        usedParams[key] = paramValue
       }
     }
 
-    const prefix = path.substring(start, segment[1])
-    const suffix = path.substring(segment[4], end)
-    const emptySplat = splat && !valueRaw
-    if (emptySplat && !prefix && !suffix) {
-      continue
-    }
-    const value = emptySplat ? '' : encodeParam(key, valueRaw, decoder)
-    joined += '/' + prefix + value + suffix
+    joined +=
+      '/' +
+      path.substring(start, prefixEnd) +
+      encodeParam(key, paramValue, decoder) +
+      path.substring(suffixStart, end)
   }
 
   if (path.endsWith('/')) {

--- a/packages/router-core/src/path.ts
+++ b/packages/router-core/src/path.ts
@@ -3,7 +3,6 @@ import { last } from './utils'
 import { createSieveCache } from './sieve-cache'
 import {
   SEGMENT_TYPE_OPTIONAL_PARAM,
-  SEGMENT_TYPE_PARAM,
   SEGMENT_TYPE_PATHNAME,
   SEGMENT_TYPE_WILDCARD,
   parseSegment,
@@ -223,26 +222,22 @@ interface InterpolatePathOptions {
    * For testing only, in development mode we use the router.isServer value
    */
   server?: boolean
+  /** @internal Collect parameter names during the first interpolation. */
+  _keys?: Array<string>
 }
 
 /** @internal */
 export function createPathInterpolator() {
-  type Plan = {
-    path: string
-    keys: Array<string>
-    paths: SieveCache<string, string>
-  }
+  type Plan = [keys: Array<string>, paths: SieveCache<string, string>]
   const plans = createSieveCache<string, Plan>(32)
   let previousPlan: Plan | undefined
+  let previousPath: string | undefined
   let previousDecoder: InterpolatePathOptions['decoder']
 
   return (options: InterpolatePathOptions): string => {
     const { path, params, decoder } = options
-    if (!path || path === '/') {
-      return '/'
-    }
-    if (!path.includes('$')) {
-      return path
+    if (!path?.includes('$')) {
+      return path || '/'
     }
 
     if (decoder !== previousDecoder) {
@@ -251,43 +246,36 @@ export function createPathInterpolator() {
       plans.clear()
     }
 
-    let plan = previousPlan?.path === path ? previousPlan : plans.get(path)
+    let plan = previousPath === path ? previousPlan : plans.get(path)
+    let interpolated: string | undefined
     if (!plan) {
       const keys: Array<string> = []
-      let cursor = 0
-      let segment
-      while (cursor < path.length) {
-        segment = parseSegment(path, cursor, segment)
-        cursor = segment[5] + 1
-        if (
-          segment[0] === SEGMENT_TYPE_PARAM ||
-          segment[0] === SEGMENT_TYPE_OPTIONAL_PARAM
-        ) {
-          keys.push(path.substring(segment[2], segment[3]))
-        } else if (segment[0] === SEGMENT_TYPE_WILDCARD) {
-          keys.push('_splat')
-        }
-      }
-      plan = { path, keys, paths: createSieveCache<string, string>(128) }
+      interpolated = interpolatePath({
+        ...options,
+        _keys: keys,
+      }).interpolatedPath
+      plan = [keys, createSieveCache<string, string>(128)]
       plans.set(path, plan)
     }
     previousPlan = plan
+    previousPath = path
 
+    const [keys, paths] = plan
     let key = ''
-    for (const name of plan.keys) {
+    for (const name of keys) {
       const value = params[name]
       if (typeof value !== 'string') {
-        return interpolatePath(options).interpolatedPath
+        return interpolated ?? interpolatePath(options).interpolatedPath
       }
-      key = plan.keys.length === 1 ? value : key + `${value.length}:${value}`
+      key = keys.length === 1 ? value : key + `${value.length}:${value}`
     }
 
-    const cached = plan.paths.get(key)
+    const cached = paths.get(key)
     if (cached !== undefined) {
       return cached
     }
-    const interpolated = interpolatePath(options).interpolatedPath
-    plan.paths.set(key, interpolated)
+    interpolated ??= interpolatePath(options).interpolatedPath
+    paths.set(key, interpolated)
     return interpolated
   }
 }
@@ -327,26 +315,20 @@ function encodeParam(
  * - Encodes params safely (configurable allowed characters)
  * - Supports `{-$optional}` segments, `{prefix{$id}suffix}` and `{$}` wildcards
  */
-export function interpolatePath({
-  path,
-  params,
-  decoder,
-  // `server` is marked @internal and stripped from .d.ts by `stripInternal`.
-  // We avoid destructuring it in the function signature so the emitted
-  // declaration doesn't reference a property that no longer exists.
-  ...rest
-}: InterpolatePathOptions): InterPolatePathResult {
+export function interpolatePath(
+  options: InterpolatePathOptions,
+): InterPolatePathResult {
+  const { path, params, decoder } = options
   // Tracking if any params are missing in the `params` object
   // when interpolating the path
   let isMissingParams = false
   const usedParams: Record<string, unknown> = Object.create(null)
 
-  if (!path || path === '/')
-    return { interpolatedPath: '/', usedParams, isMissingParams }
-  if (!path.includes('$'))
-    return { interpolatedPath: path, usedParams, isMissingParams }
+  if (!path?.includes('$')) {
+    return { interpolatedPath: path || '/', usedParams, isMissingParams }
+  }
 
-  if (isServer ?? rest.server) {
+  if (isServer ?? options.server) {
     // Fast path for common templates like `/posts/$id` or `/files/$`.
     // Braced segments (`{...}`) are more complex (prefix/suffix/optional) and are
     // handled by the general parser below.
@@ -371,6 +353,7 @@ export function interpolatePath({
         // `$id` or `$` (splat). '$' code is 36
         if (part.charCodeAt(0) === 36) {
           if (part.length === 1) {
+            options._keys?.push('_splat')
             const splat = params._splat
             usedParams._splat = splat
             // TODO: Deprecate *
@@ -385,6 +368,7 @@ export function interpolatePath({
             joined += '/' + value
           } else {
             const key = part.substring(1)
+            options._keys?.push(key)
             if (!isMissingParams && !(key in params)) {
               isMissingParams = true
             }
@@ -424,60 +408,39 @@ export function interpolatePath({
       continue
     }
 
-    if (kind === SEGMENT_TYPE_WILDCARD) {
-      const splat = params._splat
-      usedParams._splat = splat
+    const splat = kind === SEGMENT_TYPE_WILDCARD
+    const optional = kind === SEGMENT_TYPE_OPTIONAL_PARAM
+    const key = splat ? '_splat' : path.substring(segment[2], segment[3])
+    options._keys?.push(key)
+    if (!splat && !optional && !isMissingParams && !(key in params)) {
+      isMissingParams = true
+    }
+    const valueRaw = params[key]
+    if (optional && valueRaw == null) {
+      continue
+    }
+    usedParams[key] = valueRaw
+
+    const prefix = path.substring(start, segment[1])
+    const suffix = path.substring(segment[4], end)
+    if (splat) {
       // TODO: Deprecate *
-      usedParams['*'] = splat
-
-      const prefix = path.substring(start, segment[1])
-      const suffix = path.substring(segment[4], end)
-
-      // Check if _splat parameter is missing. _splat could be missing if undefined or an empty string or some other falsy value.
-      if (!splat) {
+      usedParams['*'] = valueRaw
+      if (!valueRaw) {
         isMissingParams = true
-        // For missing splat parameters, just return the prefix and suffix without the wildcard
-        // If there is a prefix or suffix, return them joined, otherwise omit the segment
+        // Missing splats retain their prefix/suffix, but not an empty segment.
         if (prefix || suffix) {
           joined += '/' + prefix + suffix
         }
         continue
       }
-
-      const value = encodeParam('_splat', params, decoder)
-      joined += '/' + prefix + value + suffix
-      continue
     }
-
-    if (kind === SEGMENT_TYPE_PARAM) {
-      const key = path.substring(segment[2], segment[3])
-      if (!isMissingParams && !(key in params)) {
-        isMissingParams = true
-      }
-      usedParams[key] = params[key]
-
-      const prefix = path.substring(start, segment[1])
-      const suffix = path.substring(segment[4], end)
-      const value = encodeParam(key, params, decoder) ?? 'undefined'
-      joined += '/' + prefix + value + suffix
-      continue
-    }
-
-    if (kind === SEGMENT_TYPE_OPTIONAL_PARAM) {
-      const key = path.substring(segment[2], segment[3])
-      const valueRaw = params[key]
-
-      // Check if optional parameter is missing or undefined
-      if (valueRaw == null) continue
-
-      usedParams[key] = valueRaw
-
-      const prefix = path.substring(start, segment[1])
-      const suffix = path.substring(segment[4], end)
-      const value = encodeParam(key, params, decoder) ?? ''
-      joined += '/' + prefix + value + suffix
-      continue
-    }
+    const value = encodeParam(key, params, decoder)
+    joined +=
+      '/' +
+      prefix +
+      (splat ? value : (value ?? (optional ? '' : 'undefined'))) +
+      suffix
   }
 
   if (path.endsWith('/')) joined += '/'

--- a/packages/router-core/src/path.ts
+++ b/packages/router-core/src/path.ts
@@ -1,5 +1,6 @@
 import { isServer } from '@tanstack/router-core/isServer'
 import { last } from './utils'
+import { createSieveCache } from './sieve-cache'
 import {
   SEGMENT_TYPE_OPTIONAL_PARAM,
   SEGMENT_TYPE_PARAM,
@@ -222,6 +223,73 @@ interface InterpolatePathOptions {
    * For testing only, in development mode we use the router.isServer value
    */
   server?: boolean
+}
+
+/** @internal */
+export function createPathInterpolator() {
+  type Plan = {
+    path: string
+    keys: Array<string>
+    paths: SieveCache<string, string>
+  }
+  const plans = createSieveCache<string, Plan>(32)
+  let previousPlan: Plan | undefined
+  let previousDecoder: InterpolatePathOptions['decoder']
+
+  return (options: InterpolatePathOptions): string => {
+    const { path, params, decoder } = options
+    if (!path || path === '/') {
+      return '/'
+    }
+    if (!path.includes('$')) {
+      return path
+    }
+
+    if (decoder !== previousDecoder) {
+      previousDecoder = decoder
+      previousPlan = undefined
+      plans.clear()
+    }
+
+    let plan = previousPlan?.path === path ? previousPlan : plans.get(path)
+    if (!plan) {
+      const keys: Array<string> = []
+      let cursor = 0
+      let segment
+      while (cursor < path.length) {
+        segment = parseSegment(path, cursor, segment)
+        cursor = segment[5] + 1
+        if (
+          segment[0] === SEGMENT_TYPE_PARAM ||
+          segment[0] === SEGMENT_TYPE_OPTIONAL_PARAM
+        ) {
+          keys.push(path.substring(segment[2], segment[3]))
+        } else if (segment[0] === SEGMENT_TYPE_WILDCARD) {
+          keys.push('_splat')
+        }
+      }
+      plan = { path, keys, paths: createSieveCache<string, string>(128) }
+      plans.set(path, plan)
+    }
+    previousPlan = plan
+
+    let key = ''
+    for (const name of plan.keys) {
+      const value = params[name]
+      if (typeof value !== 'string') {
+        return interpolatePath(options).interpolatedPath
+      }
+      key = plan.keys.length === 1 ? value : key + `${value.length}:${value}`
+    }
+
+    const cached = plan.paths.get(key)
+    if (cached !== undefined) {
+      return cached
+    }
+    const interpolated = interpolatePath(options).interpolatedPath
+    plan.paths.set(key, interpolated)
+    return interpolated
+  }
 }
 
 type InterPolatePathResult = {

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -2,6 +2,7 @@ import { createBrowserHistory, parseHref } from '@tanstack/history'
 import { isServer, loadServerRoute } from '@tanstack/router-core/isServer'
 import {
   DEFAULT_PROTOCOL_ALLOWLIST,
+  createNull,
   decodePath,
   deepEqual,
   encodePathLikeUrl,
@@ -24,8 +25,7 @@ import {
 } from './new-process-route-tree'
 import {
   compileDecodeCharMap,
-  createPathInterpolator,
-  interpolatePath,
+  interpolatePathname,
   resolvePath,
   trimPath,
   trimPathRight,
@@ -993,6 +993,12 @@ type LightweightRouteMatchCacheEntry = [
   result: LightweightRouteMatchResult,
 ]
 
+type InterpolationPlan = [
+  keys: Array<string>,
+  paths: SieveCache<string, string>,
+  decoder: ((encoded: string) => string) | undefined,
+]
+
 export type CreateRouterFn = <
   TRouteTree extends AnyRoute,
   TTrailingSlashOption extends TrailingSlashOption = 'never',
@@ -1133,7 +1139,7 @@ export class RouterCore<
   routesByPath!: RoutesByPath<TRouteTree>
   processedTree!: ProcessedTree<TRouteTree, any, any>
   resolvePathCache!: SieveCache<string, string>
-  private interpolatePath = createPathInterpolator()
+  private pathCache = createSieveCache<string, InterpolationPlan>(32)
   private routeBranchCache = new WeakMap<AnyRoute, ReadonlyArray<AnyRoute>>()
   private lightweightCache = new WeakMap<
     ParsedLocation,
@@ -1640,12 +1646,23 @@ export class RouterCore<
         searchError ??= cause
       }
       // Match identity must only use the raw params captured from the URL.
-      const { interpolatedPath, usedParams } = interpolatePath({
-        path: route.fullPath,
-        params: rawParams,
-        decoder: this.pathParamsDecoder,
-        server: this.isServer,
-      })
+      const usedParams: Record<string, unknown> = createNull()
+      const interpolatedPath =
+        isServer === undefined
+          ? interpolatePathname(
+              route.fullPath,
+              rawParams,
+              this.pathParamsDecoder,
+              usedParams,
+              undefined,
+              this.isServer,
+            )
+          : interpolatePathname(
+              route.fullPath,
+              rawParams,
+              this.pathParamsDecoder,
+              usedParams,
+            )
 
       // Seed planning from the accepted same-ID cache generation first, then
       // from the committed generation for this route. Presentation stores are
@@ -1856,6 +1873,71 @@ export class RouterCore<
     return result
   }
 
+  private interpolatePath(
+    path: string,
+    params: Record<string, unknown>,
+  ): string {
+    const decoder = this.pathParamsDecoder
+    let plan = this.pathCache.get(path)
+    let interpolated: string | undefined
+    if (!plan || plan[2] !== decoder) {
+      const keys: Array<string> = []
+      interpolated =
+        isServer === undefined
+          ? interpolatePathname(
+              path,
+              params,
+              decoder,
+              undefined,
+              keys,
+              this.isServer,
+            )
+          : interpolatePathname(path, params, decoder, undefined, keys)
+      plan = [keys, createSieveCache<string, string>(128), decoder]
+      this.pathCache.set(path, plan)
+    }
+    const [keys, paths] = plan
+    let key = ''
+    for (const name of keys) {
+      const value = params[name]
+      if (typeof value !== 'string') {
+        return (
+          interpolated ||
+          (isServer === undefined
+            ? interpolatePathname(
+                path,
+                params,
+                decoder,
+                undefined,
+                undefined,
+                this.isServer,
+              )
+            : interpolatePathname(path, params, decoder))
+        )
+      }
+      key = keys.length === 1 ? value : key + value.length + ':' + value
+    }
+    const cached = paths.get(key)
+    if (cached) {
+      return cached
+    }
+    paths.set(
+      key,
+      (interpolated ||=
+        isServer === undefined
+          ? interpolatePathname(
+              path,
+              params,
+              decoder,
+              undefined,
+              undefined,
+              this.isServer,
+            )
+          : interpolatePathname(path, params, decoder)),
+    )
+    return interpolated
+  }
+
   /**
    * Build the next ParsedLocation from navigation options without committing.
    * Resolves `to`/`from`, params/search/hash/state, applies search validation
@@ -1966,7 +2048,7 @@ export class RouterCore<
             route.options.params?.stringify ?? route.options.stringifyParams
           if (fn) {
             if (nextParams === fromParams) {
-              nextParams = Object.assign(Object.create(null), nextParams)
+              nextParams = Object.assign(createNull(), nextParams)
             }
             try {
               Object.assign(nextParams, fn(nextParams))
@@ -1985,12 +2067,9 @@ export class RouterCore<
         ? // Keep path params uninterpolated for matchRoute/template matching.
           nextTo
         : decodePath(
-            this.interpolatePath({
-              path: nextTo,
-              params: nextParams,
-              decoder: this.pathParamsDecoder,
-              server: this.isServer,
-            }),
+            nextTo.includes('$')
+              ? this.interpolatePath(nextTo, nextParams)
+              : nextTo,
           ).path
 
       if (
@@ -2127,7 +2206,7 @@ export class RouterCore<
         this.processedTree,
       )
       if (match) {
-        const params = Object.assign(Object.create(null), match.rawParams)
+        const params = Object.assign(createNull(), match.rawParams)
         const { from: _from, params: maskParams, ...maskProps } = match.route
 
         // If mask has a params function, call it with the matched params as context

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -24,6 +24,7 @@ import {
 } from './new-process-route-tree'
 import {
   compileDecodeCharMap,
+  createPathInterpolator,
   interpolatePath,
   resolvePath,
   trimPath,
@@ -1132,6 +1133,7 @@ export class RouterCore<
   routesByPath!: RoutesByPath<TRouteTree>
   processedTree!: ProcessedTree<TRouteTree, any, any>
   resolvePathCache!: SieveCache<string, string>
+  private interpolatePath = createPathInterpolator()
   private routeBranchCache = new WeakMap<AnyRoute, ReadonlyArray<AnyRoute>>()
   private lightweightCache = new WeakMap<
     ParsedLocation,
@@ -1983,12 +1985,12 @@ export class RouterCore<
         ? // Keep path params uninterpolated for matchRoute/template matching.
           nextTo
         : decodePath(
-            interpolatePath({
+            this.interpolatePath({
               path: nextTo,
               params: nextParams,
               decoder: this.pathParamsDecoder,
               server: this.isServer,
-            }).interpolatedPath,
+            }),
           ).path
 
       if (

--- a/packages/router-core/tests/build-location.test.ts
+++ b/packages/router-core/tests/build-location.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test, vi } from 'vitest'
 import { createMemoryHistory } from '@tanstack/history'
+import { isServer as serverEnvironment } from '@tanstack/router-core/isServer'
+import * as pathUtils from '../src/path'
 import {
   BaseRootRoute,
   BaseRoute,
@@ -22,6 +24,73 @@ test('_getUserHistoryState removes volatile router bookkeeping but keeps mask pa
       user: 'state',
     } as any),
   ).toEqual({ user: 'state', __tempLocation: {}, __tempKey: 'temp-key' })
+})
+
+test.each([false, true])(
+  'forwards the development server override when router.isServer is %s',
+  (isServer) => {
+    expect(serverEnvironment).toBeUndefined()
+    const rootRoute = new BaseRootRoute({})
+    const route = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/items/$id',
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([route]),
+      history: createMemoryHistory({ initialEntries: ['/items/one'] }),
+      isServer,
+    })
+    const interpolate = vi.spyOn(pathUtils, 'interpolatePathname')
+    try {
+      const matches = router.matchRoutes('/items/one', {})
+      expect(matches.at(-1)?.pathname).toBe('/items/one')
+      const call = interpolate.mock.calls.find(
+        ([path]) => path === '/items/$id',
+      )
+      expect(call).toHaveLength(6)
+      expect(call?.[5]).toBe(isServer)
+    } finally {
+      interpolate.mockRestore()
+    }
+  },
+)
+
+test('keeps interpolation caches router-local and follows decoder changes', () => {
+  const rootRoute = new BaseRootRoute({})
+  const route = new BaseRoute({
+    getParentRoute: () => rootRoute,
+    path: '/items/$id',
+  })
+  const routeTree = rootRoute.addChildren([route])
+  const makeRouter = () =>
+    createTestRouter({
+      routeTree,
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+  const router = makeRouter()
+  const decoder = vi.fn(pathUtils.compileDecodeCharMap(['@']))
+  router.pathParamsDecoder = decoder
+
+  expect(
+    router.buildLocation({ to: '/items/$id', params: { id: '@one' } }).href,
+  ).toBe('/items/@one')
+  decoder.mockClear()
+  expect(
+    router.buildLocation({ to: '/items/$id', params: { id: '@one' } }).href,
+  ).toBe('/items/@one')
+  expect(decoder).not.toHaveBeenCalled()
+
+  const other = makeRouter()
+  other.pathParamsDecoder = decoder
+  expect(
+    other.buildLocation({ to: '/items/$id', params: { id: '@one' } }).href,
+  ).toBe('/items/@one')
+  expect(decoder).toHaveBeenCalledOnce()
+
+  router.pathParamsDecoder = pathUtils.compileDecodeCharMap(['+'])
+  expect(
+    router.buildLocation({ to: '/items/$id', params: { id: '@one' } }).href,
+  ).toBe('/items/%40one')
 })
 
 describe('buildLocation - params function receives parsed params', () => {

--- a/packages/router-core/tests/path-interpolation.bench.ts
+++ b/packages/router-core/tests/path-interpolation.bench.ts
@@ -1,0 +1,102 @@
+import { bench, describe, expect } from 'vitest'
+import {
+  compileDecodeCharMap,
+  createPathInterpolator,
+  interpolatePath,
+} from '../src/path'
+
+type Options = Parameters<ReturnType<typeof createPathInterpolator>>[0]
+
+const scenarios: Array<{ name: string; inputs: Array<Options> }> = [
+  {
+    name: 'single-param shared hits',
+    inputs: Array.from({ length: 200 }, (_, index) => ({
+      path: '/items/$id',
+      params: { id: `item ${Math.floor(index / 5)}`, unrelated: index },
+    })),
+  },
+  {
+    name: 'multi-param shared hits',
+    inputs: Array.from({ length: 200 }, (_, index) => ({
+      path: '/orgs/$orgId/items/$id',
+      params: {
+        orgId: `org:${Math.floor(index / 5) % 4}`,
+        id: `item/${Math.floor(index / 5)}`,
+      },
+    })),
+  },
+  {
+    name: 'result eviction',
+    inputs: Array.from({ length: 256 }, (_, index) => ({
+      path: '/items/$id',
+      params: { id: `item ${index}` },
+    })),
+  },
+  {
+    name: 'template eviction',
+    inputs: Array.from({ length: 64 }, (_, index) => ({
+      path: `/section-${index}/$id`,
+      params: { id: 'item one' },
+    })),
+  },
+  {
+    name: 'mixed optional and splat params',
+    inputs: Array.from({ length: 200 }, (_, index) => {
+      switch (index % 5) {
+        case 0:
+          return { path: '/posts/{-$category}', params: {} }
+        case 1:
+          return {
+            path: '/posts/{-$category}',
+            params: { category: `news-${index % 10}` },
+          }
+        case 2:
+          return { path: '/users/$id', params: { id: index } }
+        case 3:
+          return { path: '/files/$', params: { _splat: `docs/${index % 20}` } }
+        default:
+          return { path: '/about', params: {} }
+      }
+    }),
+  },
+]
+
+const decoder = compileDecodeCharMap(['@', '+'])
+for (const { inputs } of scenarios) {
+  for (const input of inputs) {
+    input.decoder = decoder
+    input.server = false
+  }
+}
+
+describe.each(scenarios)('$name', ({ inputs }) => {
+  const interpolate = createPathInterpolator()
+  let checksum = 0
+  const expected = inputs.reduce((sum, input) => {
+    const result = interpolatePath(input).interpolatedPath
+    expect(interpolate(input)).toBe(result)
+    return sum + result.length
+  }, 0)
+  for (const input of inputs) {
+    expect(interpolate(input)).toBe(interpolatePath(input).interpolatedPath)
+  }
+
+  bench(
+    'shared interpolation batch',
+    () => {
+      let length = 0
+      for (const input of inputs) {
+        length += interpolate(input).length
+      }
+      checksum = length
+    },
+    {
+      time: 1500,
+      warmupTime: 500,
+      throws: true,
+      teardown: () => {
+        expect(checksum).toBe(expected)
+      },
+    },
+  )
+})

--- a/packages/router-core/tests/path-interpolation.bench.ts
+++ b/packages/router-core/tests/path-interpolation.bench.ts
@@ -1,11 +1,10 @@
 import { bench, describe, expect } from 'vitest'
-import {
-  compileDecodeCharMap,
-  createPathInterpolator,
-  interpolatePath,
-} from '../src/path'
+import { createMemoryHistory } from '@tanstack/history'
+import { BaseRootRoute } from '../src'
+import { compileDecodeCharMap, interpolatePath } from '../src/path'
+import { createTestRouter } from './routerTestUtils'
 
-type Options = Parameters<ReturnType<typeof createPathInterpolator>>[0]
+type Options = Parameters<typeof interpolatePath>[0]
 
 const scenarios: Array<{ name: string; inputs: Array<Options> }> = [
   {
@@ -59,6 +58,26 @@ const scenarios: Array<{ name: string; inputs: Array<Options> }> = [
       }
     }),
   },
+  {
+    name: 'missing required and splat params',
+    inputs: Array.from({ length: 200 }, (_, index) => {
+      switch (index % 5) {
+        case 0:
+          return { path: '/$first/$second', params: { second: 'two' } }
+        case 1:
+          return {
+            path: '/$first/$second',
+            params: { first: undefined, second: 'two' },
+          }
+        case 2:
+          return { path: '/$first/{-$second}', params: {} }
+        case 3:
+          return { path: '/files/$', params: {} }
+        default:
+          return { path: '/files/prefix{$}suffix', params: { _splat: '' } }
+      }
+    }),
+  },
 ]
 
 const decoder = compileDecodeCharMap(['@', '+'])
@@ -76,23 +95,41 @@ scenarios.push(
 )
 
 describe.each(scenarios)('$name', ({ inputs }) => {
-  const interpolate = createPathInterpolator()
+  const router = createTestRouter({
+    routeTree: new BaseRootRoute({}),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+    isServer: inputs[0]?.server,
+    scrollRestoration: false,
+  })
+  router.pathParamsDecoder = decoder
+  router.history.destroy()
+  const interpolate = router['interpolatePath']
+  const calls = inputs
+    .filter((input) => input.path?.includes('$'))
+    .map((input) => ({
+      args:
+        interpolate.length === 1 ? [input] : [input.path || '/', input.params],
+      expected: interpolatePath(input).interpolatedPath,
+    }))
   let checksum = 0
-  const expected = inputs.reduce((sum, input) => {
-    const result = interpolatePath(input).interpolatedPath
-    expect(interpolate(input)).toBe(result)
-    return sum + result.length
+  const expected = inputs.reduce(
+    (sum, input) => sum + interpolatePath(input).interpolatedPath.length,
+    0,
+  )
+  const cachedExpected = calls.reduce((sum, call) => {
+    expect(Reflect.apply(interpolate, router, call.args)).toBe(call.expected)
+    return sum + call.expected.length
   }, 0)
-  for (const input of inputs) {
-    expect(interpolate(input)).toBe(interpolatePath(input).interpolatedPath)
+  for (const call of calls) {
+    expect(Reflect.apply(interpolate, router, call.args)).toBe(call.expected)
   }
 
   bench(
     'shared interpolation batch',
     () => {
       let length = 0
-      for (const input of inputs) {
-        length += interpolate(input).length
+      for (const call of calls) {
+        length += Reflect.apply(interpolate, router, call.args).length
       }
       checksum = length
     },
@@ -101,7 +138,7 @@ describe.each(scenarios)('$name', ({ inputs }) => {
       warmupTime: 500,
       throws: true,
       teardown: () => {
-        expect(checksum).toBe(expected)
+        expect(checksum).toBe(cachedExpected)
       },
     },
   )

--- a/packages/router-core/tests/path-interpolation.bench.ts
+++ b/packages/router-core/tests/path-interpolation.bench.ts
@@ -68,6 +68,12 @@ for (const { inputs } of scenarios) {
     input.server = false
   }
 }
+scenarios.push(
+  ...scenarios.map(({ name, inputs }) => ({
+    name: `server ${name}`,
+    inputs: inputs.map((input) => ({ ...input, server: true })),
+  })),
+)
 
 describe.each(scenarios)('$name', ({ inputs }) => {
   const interpolate = createPathInterpolator()
@@ -87,6 +93,25 @@ describe.each(scenarios)('$name', ({ inputs }) => {
       let length = 0
       for (const input of inputs) {
         length += interpolate(input).length
+      }
+      checksum = length
+    },
+    {
+      time: 1500,
+      warmupTime: 500,
+      throws: true,
+      teardown: () => {
+        expect(checksum).toBe(expected)
+      },
+    },
+  )
+
+  bench(
+    'uncached interpolation batch',
+    () => {
+      let length = 0
+      for (const input of inputs) {
+        length += interpolatePath(input).interpolatedPath.length
       }
       checksum = length
     },

--- a/packages/router-core/tests/path-interpolation.bench.ts
+++ b/packages/router-core/tests/path-interpolation.bench.ts
@@ -1,7 +1,11 @@
 import { bench, describe, expect } from 'vitest'
 import { createMemoryHistory } from '@tanstack/history'
 import { BaseRootRoute } from '../src'
-import { compileDecodeCharMap, interpolatePath } from '../src/path'
+import {
+  compileDecodeCharMap,
+  interpolatePath,
+  interpolatePathname,
+} from '../src/path'
 import { createTestRouter } from './routerTestUtils'
 
 type Options = Parameters<typeof interpolatePath>[0]
@@ -78,6 +82,17 @@ const scenarios: Array<{ name: string; inputs: Array<Options> }> = [
       }
     }),
   },
+  {
+    name: 'affixed mixed segments',
+    inputs: Array.from({ length: 200 }, (_, index) => ({
+      path: '/root/prefix{$id}suffix/{-$language}/files/{$}.txt',
+      params: {
+        id: `item ${index % 40}`,
+        language: index % 2 ? 'en' : undefined,
+        _splat: index % 3 ? `docs/file ${index % 20}` : '',
+      },
+    })),
+  },
 ]
 
 const decoder = compileDecodeCharMap(['@', '+'])
@@ -139,6 +154,32 @@ describe.each(scenarios)('$name', ({ inputs }) => {
       throws: true,
       teardown: () => {
         expect(checksum).toBe(cachedExpected)
+      },
+    },
+  )
+
+  bench(
+    'pathname-only interpolation batch',
+    () => {
+      let length = 0
+      for (const input of inputs) {
+        length += interpolatePathname(
+          input.path || '/',
+          input.params,
+          input.decoder,
+          undefined,
+          undefined,
+          input.server,
+        ).length
+      }
+      checksum = length
+    },
+    {
+      time: 1500,
+      warmupTime: 500,
+      throws: true,
+      teardown: () => {
+        expect(checksum).toBe(expected)
       },
     },
   )

--- a/packages/router-core/tests/path.test.ts
+++ b/packages/router-core/tests/path.test.ts
@@ -3,6 +3,7 @@ import {
   compileDecodeCharMap,
   exactPathTest,
   interpolatePath,
+  interpolatePathname,
   removeTrailingSlash,
   resolvePath,
   trimPathLeft,
@@ -186,6 +187,58 @@ describe.each([false, true])(
         }).usedParams,
       ).toEqual({ _splat: 'docs/guide', '*': 'docs/guide' })
     })
+
+    it.each([
+      {
+        params: { id: 'one two', _splat: 'docs/file name' },
+        path: '/root/prefixone%20twosuffix/files/docs/file%20name.txt',
+        used: {
+          id: 'one two',
+          _splat: 'docs/file name',
+          '*': 'docs/file name',
+        },
+        missing: false,
+      },
+      {
+        params: { id: '', language: '', _splat: '' },
+        path: '/root/prefixsuffix//files/.txt',
+        used: { id: '', language: '', _splat: '', '*': '' },
+        missing: true,
+      },
+      {
+        params: {},
+        path: '/root/prefixundefinedsuffix/files/.txt',
+        used: { id: undefined, _splat: undefined, '*': undefined },
+        missing: true,
+      },
+    ])(
+      'keeps mixed segment metadata in one pass for $params',
+      ({ params, path, used, missing }) => {
+        const template = '/root/prefix{$id}suffix/{-$language}/files/{$}.txt'
+        const usedParams: Record<string, unknown> = Object.create(null)
+        const keys: Array<string> = []
+        const metadata = { isMissingParams: false }
+        expect(
+          interpolatePathname(
+            template,
+            params,
+            undefined,
+            usedParams,
+            keys,
+            server,
+            metadata,
+          ),
+        ).toBe(path)
+        expect(keys).toEqual(['id', 'language', '_splat'])
+        expect(usedParams).toEqual(used)
+        expect(metadata.isMissingParams).toBe(missing)
+        expect(interpolatePath({ path: template, params, server })).toEqual({
+          interpolatedPath: path,
+          usedParams: used,
+          isMissingParams: missing,
+        })
+      },
+    )
 
     it.each([
       {

--- a/packages/router-core/tests/path.test.ts
+++ b/packages/router-core/tests/path.test.ts
@@ -118,6 +118,60 @@ describe.each([false, true])(
         '/users/123',
       )
     })
+
+    it('tracks optional params that were absent when the template was first used', () => {
+      const interpolate = createPathInterpolator()
+      const path = '/posts/{-$category}/$id'
+      const inputs = [
+        { id: 'one' },
+        { id: 'one', category: 'news' },
+        { id: 'one', category: undefined },
+        { id: 'one', category: '' },
+        { id: 'one', category: 'updates' },
+      ]
+
+      for (const params of [...inputs, ...inputs]) {
+        const options = { path, params, server }
+        expect(interpolate(options)).toBe(
+          interpolatePath(options).interpolatedPath,
+        )
+      }
+    })
+
+    it('uses the canonical splat value instead of its legacy alias', () => {
+      const interpolate = createPathInterpolator()
+      const decoder = vi.fn(compileDecodeCharMap(['@']))
+      const options = {
+        path: '/files/$',
+        params: { _splat: 'docs/@guide', '*': 'ignored' },
+        decoder,
+        server,
+      }
+
+      expect(interpolate(options)).toBe('/files/docs/@guide')
+      decoder.mockClear()
+      expect(
+        interpolate({
+          ...options,
+          params: { _splat: 'docs/@guide', '*': 'changed' },
+        }),
+      ).toBe('/files/docs/@guide')
+      expect(decoder).not.toHaveBeenCalled()
+    })
+
+    it('keeps public usedParams unchanged for missing optionals and splats', () => {
+      expect(
+        interpolatePath({ path: '/posts/{-$category}', params: {}, server })
+          .usedParams,
+      ).toEqual({})
+      expect(
+        interpolatePath({
+          path: '/files/$',
+          params: { _splat: 'docs/guide' },
+          server,
+        }).usedParams,
+      ).toEqual({ _splat: 'docs/guide', '*': 'docs/guide' })
+    })
   },
 )
 

--- a/packages/router-core/tests/path.test.ts
+++ b/packages/router-core/tests/path.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   compileDecodeCharMap,
-  createPathInterpolator,
   exactPathTest,
   interpolatePath,
   removeTrailingSlash,
@@ -17,6 +16,7 @@ import {
   processRouteTree,
 } from '../src/new-process-route-tree'
 import { createSieveCache } from '../src/sieve-cache'
+import { createTestPathInterpolator as createPathInterpolator } from './routerTestUtils'
 import type { SegmentKind } from '../src/new-process-route-tree'
 
 describe.each([false, true])(
@@ -91,6 +91,20 @@ describe.each([false, true])(
         interpolate({ ...options, decoder: compileDecodeCharMap(['+']) }),
       ).toBe('/users/%40+')
       expect(interpolate(options)).toBe('/users/%40%2B')
+    })
+
+    it('refreshes each cached template when its decoder changes', () => {
+      const interpolate = createPathInterpolator()
+      const allowAt = compileDecodeCharMap(['@'])
+      const allowPlus = compileDecodeCharMap(['+'])
+      for (const decoder of [allowAt, allowPlus, undefined, allowAt]) {
+        for (const path of ['/users/$id', '/teams/$id']) {
+          const options = { path, params: { id: '@+' }, decoder, server }
+          expect(interpolate(options)).toBe(
+            interpolatePath(options).interpolatedPath,
+          )
+        }
+      }
     })
 
     it('does not confuse parameter boundaries in shared cache keys', () => {
@@ -172,6 +186,53 @@ describe.each([false, true])(
         }).usedParams,
       ).toEqual({ _splat: 'docs/guide', '*': 'docs/guide' })
     })
+
+    it.each([
+      {
+        path: '/$first/$second',
+        params: { second: 'two' },
+        pathname: '/undefined/two',
+        usedParams: { first: undefined, second: 'two' },
+        missing: true,
+      },
+      {
+        path: '/$first/$second',
+        params: { first: undefined, second: 'two' },
+        pathname: '/undefined/two',
+        usedParams: { first: undefined, second: 'two' },
+        missing: false,
+      },
+      {
+        path: '/{-$first}/$second',
+        params: { second: 'two' },
+        pathname: '/two',
+        usedParams: { second: 'two' },
+        missing: false,
+      },
+      {
+        path: '/$first/{-$second}',
+        params: {},
+        pathname: '/undefined',
+        usedParams: { first: undefined },
+        missing: true,
+      },
+      {
+        path: '/$first/prefix{$}suffix',
+        params: { first: 'one' },
+        pathname: '/one/prefixsuffix',
+        usedParams: { first: 'one', _splat: undefined, '*': undefined },
+        missing: true,
+      },
+    ])(
+      'preserves missing-param metadata for $path with $params',
+      ({ path, params, pathname, usedParams, missing }) => {
+        expect(interpolatePath({ path, params, server })).toEqual({
+          interpolatedPath: pathname,
+          usedParams,
+          isMissingParams: missing,
+        })
+      },
+    )
 
     it('tracks a splat that was empty when the template was first used', () => {
       const interpolate = createPathInterpolator()

--- a/packages/router-core/tests/path.test.ts
+++ b/packages/router-core/tests/path.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   compileDecodeCharMap,
+  createPathInterpolator,
   exactPathTest,
   interpolatePath,
   removeTrailingSlash,
@@ -17,6 +18,108 @@ import {
 } from '../src/new-process-route-tree'
 import { createSieveCache } from '../src/sieve-cache'
 import type { SegmentKind } from '../src/new-process-route-tree'
+
+describe.each([false, true])(
+  'shared pathname interpolation (server: %s)',
+  (server) => {
+    it.each([
+      { path: '/', params: {} },
+      { path: '/users/', params: {} },
+      { path: '/users/$id', params: { id: '123' } },
+      { path: '/users/$id', params: { id: 0 } },
+      { path: '/users/$id', params: {} },
+      { path: '/users/$id', params: { id: 'a/b?#@+' } },
+      { path: '/users/$id', params: { id: 'cafe\u0301' } },
+      { path: '/users/{$id}.json', params: { id: '123' } },
+      { path: '/posts/{-$category}', params: {} },
+      { path: '/posts/{-$category}', params: { category: undefined } },
+      { path: '/posts/{-$category}', params: { category: '' } },
+      { path: '/posts/{-$category}', params: { category: 'news' } },
+      {
+        path: '/posts/prefix{-$category}suffix',
+        params: { category: 'news' },
+      },
+      { path: '/files/$', params: { _splat: 'a b/c+d' } },
+      { path: '/files/prefix{$}suffix', params: { _splat: 'a/b' } },
+      { path: '/files/$', params: { _splat: '' } },
+      { path: '/$id/$id/', params: { id: '123' } },
+    ])('matches interpolation for $path with $params', ({ path, params }) => {
+      const interpolate = createPathInterpolator()
+      const options = { path, params, server }
+      const expected = interpolatePath(options).interpolatedPath
+
+      expect(interpolate(options)).toBe(expected)
+      expect(interpolate({ ...options, params: { ...params } })).toBe(expected)
+    })
+
+    it('shares results across equivalent params without retaining unrelated params', () => {
+      const interpolate = createPathInterpolator()
+      const decoder = vi.fn(compileDecodeCharMap(['@']))
+      const options = {
+        path: '/users/$id',
+        params: { id: '@one', unrelated: 'first' },
+        decoder,
+        server,
+      }
+      expect(interpolate(options)).toBe('/users/@one')
+      expect(decoder).toHaveBeenCalledOnce()
+
+      expect(
+        interpolate({
+          ...options,
+          params: { id: '@one', unrelated: 'second' },
+        }),
+      ).toBe('/users/@one')
+      expect(decoder).toHaveBeenCalledOnce()
+
+      const anotherRouter = createPathInterpolator()
+      expect(anotherRouter(options)).toBe('/users/@one')
+      expect(decoder).toHaveBeenCalledTimes(2)
+    })
+
+    it('invalidates results when allowed-character decoding changes', () => {
+      const interpolate = createPathInterpolator()
+      const options = {
+        path: '/users/$id',
+        params: { id: '@+' },
+        server,
+      }
+      expect(
+        interpolate({ ...options, decoder: compileDecodeCharMap(['@']) }),
+      ).toBe('/users/@%2B')
+      expect(
+        interpolate({ ...options, decoder: compileDecodeCharMap(['+']) }),
+      ).toBe('/users/%40+')
+      expect(interpolate(options)).toBe('/users/%40%2B')
+    })
+
+    it('does not confuse parameter boundaries in shared cache keys', () => {
+      const interpolate = createPathInterpolator()
+      const options = { path: '/$first/$second', server }
+      const first = { first: 'a:b', second: 'c' }
+      const second = { first: 'a', second: 'b:c' }
+
+      expect(interpolate({ ...options, params: first })).toBe('/a%3Ab/c')
+      expect(interpolate({ ...options, params: second })).toBe('/a/b%3Ac')
+      expect(interpolate({ ...options, params: first })).toBe('/a%3Ab/c')
+    })
+
+    it('keeps templates separate when parameter values are equal', () => {
+      const interpolate = createPathInterpolator()
+      const params = { id: '123' }
+
+      expect(interpolate({ path: '/users/$id', params, server })).toBe(
+        '/users/123',
+      )
+      expect(interpolate({ path: '/posts/$id', params, server })).toBe(
+        '/posts/123',
+      )
+      expect(interpolate({ path: '/users/$id', params, server })).toBe(
+        '/users/123',
+      )
+    })
+  },
+)
 
 describe.each([{ basepath: '/' }, { basepath: '/app' }, { basepath: '/app/' }])(
   'removeTrailingSlash with basepath $basepath',

--- a/packages/router-core/tests/path.test.ts
+++ b/packages/router-core/tests/path.test.ts
@@ -172,6 +172,38 @@ describe.each([false, true])(
         }).usedParams,
       ).toEqual({ _splat: 'docs/guide', '*': 'docs/guide' })
     })
+
+    it('tracks a splat that was empty when the template was first used', () => {
+      const interpolate = createPathInterpolator()
+      for (const _splat of ['', 'docs/guide', '', 'docs/reference']) {
+        const options = {
+          path: '/files/prefix{$}suffix',
+          params: { _splat },
+          server,
+        }
+        expect(interpolate(options)).toBe(
+          interpolatePath(options).interpolatedPath,
+        )
+      }
+    })
+
+    it('does not retain incomplete metadata when the first interpolation throws', () => {
+      const interpolate = createPathInterpolator()
+      const options = { path: '/$first/$second', server }
+
+      expect(() =>
+        interpolate({
+          ...options,
+          params: { first: '\uD800', second: 'one' },
+        }),
+      ).toThrow(URIError)
+
+      for (const second of ['two', 'three', 'two']) {
+        expect(
+          interpolate({ ...options, params: { first: 'valid', second } }),
+        ).toBe(`/valid/${second}`)
+      }
+    })
   },
 )
 

--- a/packages/router-core/tests/routerTestUtils.ts
+++ b/packages/router-core/tests/routerTestUtils.ts
@@ -1,11 +1,14 @@
 import { batch, createAtom } from '@tanstack/store'
+import { createMemoryHistory } from '@tanstack/history'
 import { isServer } from '@tanstack/router-core/isServer'
 import {
   RouterCore,
+  BaseRootRoute,
   createNonReactiveMutableStore,
   createNonReactiveReadonlyStore,
 } from '../src'
 import { createRequestHandler } from '../src/ssr/createRequestHandler'
+import type { interpolatePath } from '../src/path'
 import type { RouterHistory } from '@tanstack/history'
 import type {
   AnyRouter,
@@ -47,6 +50,31 @@ export function createTestRouter<
   >,
 ) {
   return new RouterCore(options, getStoreConfig)
+}
+
+export function createTestPathInterpolator() {
+  const router = createTestRouter({
+    routeTree: new BaseRootRoute({}),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+    scrollRestoration: false,
+  })
+  router.history.destroy()
+  const interpolate = router['interpolatePath']
+
+  return (options: Parameters<typeof interpolatePath>[0]): string => {
+    router.isServer = options.server ?? false
+    router.pathParamsDecoder = options.decoder
+    // Support both sides of the factory-to-method benchmark comparison.
+    const args =
+      interpolate.length === 1
+        ? [options]
+        : [options.path || '/', options.params]
+    const result = Reflect.apply(interpolate, router, args)
+    if (typeof result !== 'string') {
+      throw new Error('Expected an interpolated pathname')
+    }
+    return result
+  }
 }
 
 /** Materialize the request-local server result as the HTTP response users see. */

--- a/packages/solid-router/src/link.tsx
+++ b/packages/solid-router/src/link.tsx
@@ -433,8 +433,8 @@ export function useLinkProps<
       : stateClass
 
     return {
-      ...stateProps,
       ...base,
+      ...stateProps,
       ...(style && hasKeys(style) ? { style } : undefined),
       ...(className ? { class: className } : undefined),
       ...(active && STATIC_ACTIVE_ATTRIBUTES),

--- a/packages/solid-router/src/link.tsx
+++ b/packages/solid-router/src/link.tsx
@@ -4,7 +4,6 @@ import { mergeRefs } from '@solid-primitives/refs'
 
 import {
   deepEqual,
-  exactPathTest,
   functionalUpdate,
   hasKeys,
   isAbsoluteUrl,
@@ -204,29 +203,15 @@ export function useLinkProps<
     const current = currentLocation()
     const nextLocation = next()
 
-    if (activeOptions?.exact) {
-      const testExact = exactPathTest(
-        current.pathname,
-        nextLocation.pathname,
-        router.basepath,
-      )
-      if (!testExact) {
-        return false
-      }
-    } else {
-      const currentPath = removeTrailingSlash(current.pathname, router.basepath)
-      const nextPath = removeTrailingSlash(
-        nextLocation.pathname,
-        router.basepath,
-      )
-
-      const pathIsFuzzyEqual =
-        currentPath.startsWith(nextPath) &&
-        (currentPath.length === nextPath.length ||
-          currentPath[nextPath.length] === '/')
-      if (!pathIsFuzzyEqual) {
-        return false
-      }
+    const currentPath = removeTrailingSlash(current.pathname, router.basepath)
+    const nextPath = removeTrailingSlash(nextLocation.pathname, router.basepath)
+    if (
+      currentPath !== nextPath &&
+      (activeOptions?.exact ||
+        !currentPath.startsWith(nextPath) ||
+        currentPath[nextPath.length] !== '/')
+    ) {
+      return false
     }
 
     if (activeOptions?.includeSearch ?? true) {
@@ -431,26 +416,26 @@ export function useLinkProps<
       }
     }
 
-    const activeProps: ResolvedLinkStateProps = active
-      ? (functionalUpdate(local.activeProps as any, {}) ?? EMPTY_OBJECT)
-      : EMPTY_OBJECT
-    const inactiveProps: ResolvedLinkStateProps = active
-      ? EMPTY_OBJECT
-      : functionalUpdate(local.inactiveProps, {})
-    const style = {
-      ...local.style,
-      ...activeProps.style,
-      ...inactiveProps.style,
-    }
-    const className = [local.class, activeProps.class, inactiveProps.class]
-      .filter(Boolean)
-      .join(' ')
+    const stateProps: ResolvedLinkStateProps =
+      functionalUpdate(active ? local.activeProps : local.inactiveProps, {}) ??
+      EMPTY_OBJECT
+    const baseStyle = local.style
+    const stateStyle = stateProps.style
+    // Snapshot reactive style properties so in-place updates remain observable.
+    const style =
+      baseStyle || stateStyle ? { ...baseStyle, ...stateStyle } : undefined
+    const baseClass = local.class
+    const stateClass = stateProps.class
+    const className = baseClass
+      ? stateClass
+        ? `${baseClass} ${stateClass}`
+        : baseClass
+      : stateClass
 
     return {
-      ...activeProps,
-      ...inactiveProps,
+      ...stateProps,
       ...base,
-      ...(hasKeys(style) ? { style } : undefined),
+      ...(style && hasKeys(style) ? { style } : undefined),
       ...(className ? { class: className } : undefined),
       ...(active && STATIC_ACTIVE_ATTRIBUTES),
     } as ResolvedLinkStateProps

--- a/packages/solid-router/src/link.tsx
+++ b/packages/solid-router/src/link.tsx
@@ -435,6 +435,10 @@ export function useLinkProps<
     return {
       ...base,
       ...stateProps,
+      // State props can override element props, but not routing options.
+      href: base.href,
+      disabled: base.disabled,
+      target: base.target,
       ...(style && hasKeys(style) ? { style } : undefined),
       ...(className ? { class: className } : undefined),
       ...(active && STATIC_ACTIVE_ATTRIBUTES),

--- a/packages/solid-router/tests/link-style.test.tsx
+++ b/packages/solid-router/tests/link-style.test.tsx
@@ -1,0 +1,166 @@
+import * as Solid from 'solid-js'
+import { createStore } from 'solid-js/store'
+import { afterEach, expect, test, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@solidjs/testing-library'
+import {
+  Link,
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+
+const disposers: Array<() => void> = []
+afterEach(() => {
+  cleanup()
+  for (const dispose of disposers.splice(0)) {
+    dispose()
+  }
+})
+
+function renderLinks(Links: Solid.Component) {
+  const history = createMemoryHistory({ initialEntries: ['/target'] })
+  disposers.push(history.destroy)
+  const root = createRootRoute({
+    component: () => (
+      <>
+        <Links />
+        <Outlet />
+      </>
+    ),
+  })
+  const router = createRouter({
+    routeTree: root.addChildren([
+      createRoute({ getParentRoute: () => root, path: '/' }),
+      createRoute({ getParentRoute: () => root, path: '/target' }),
+    ]),
+    history,
+    scrollRestoration: false,
+    defaultPreload: false,
+  })
+  render(() => <RouterProvider router={router} />)
+  return router
+}
+
+test('tracks additions to an initially empty state-only style store', async () => {
+  const [style, setStyle] = createStore<Solid.JSX.CSSProperties>({})
+  renderLinks(() => (
+    <Link to="/target" activeProps={() => ({ style })}>
+      Reactive
+    </Link>
+  ))
+  const link = await screen.findByRole('link', { name: 'Reactive' })
+  expect(link.style.color).toBe('')
+  setStyle('color', 'red')
+  await waitFor(() => expect(link.style.color).toBe('red'))
+  setStyle('color', undefined)
+  await waitFor(() => expect(link.style.color).toBe(''))
+})
+
+test('merges only the selected state and tracks reactive style properties', async () => {
+  const [base, setBase] = createStore<Solid.JSX.CSSProperties>({
+    color: 'red',
+    'margin-top': '2px',
+  })
+  const [stateStyle, setStateStyle] = createStore<Solid.JSX.CSSProperties>({
+    'background-color': 'white',
+  })
+  const [stateClass, setStateClass] = Solid.createSignal('selected')
+  const active = vi.fn(() => ({
+    class: stateClass(),
+    style: stateStyle,
+    title: 'selected',
+    href: '/state-href',
+  }))
+  const inactive = vi.fn(() => ({
+    class: 'idle',
+    style: { color: 'gray' },
+    title: 'idle',
+  }))
+  const router = renderLinks(() => (
+    <Link
+      to="/target"
+      class="base"
+      style={base}
+      activeProps={active}
+      inactiveProps={inactive}
+    >
+      Styled
+    </Link>
+  ))
+  const link = await screen.findByRole('link', { name: 'Styled' })
+  expect(link).toHaveClass('base', 'selected')
+  expect(link.style).toMatchObject({
+    color: 'red',
+    marginTop: '2px',
+    backgroundColor: 'white',
+  })
+  expect(link).toHaveAttribute('href', '/target')
+  expect(inactive).not.toHaveBeenCalled()
+
+  setBase('color', 'blue')
+  setStateStyle('background-color', 'black')
+  setStateClass('updated')
+  await waitFor(() => {
+    expect(link).toHaveClass('base', 'updated')
+    expect(link.style).toMatchObject({
+      color: 'blue',
+      backgroundColor: 'black',
+    })
+  })
+
+  await router.navigate({ to: '/' })
+  await waitFor(() => {
+    expect(link).toHaveClass('base', 'idle')
+    expect(link).toHaveAttribute('title', 'idle')
+    expect(link.style).toMatchObject({ color: 'gray', marginTop: '2px' })
+    expect(link.style.backgroundColor).toBe('')
+  })
+  active.mockClear()
+  inactive.mockClear()
+  setBase('margin-top', '3px')
+  await waitFor(() => expect(link.style).toMatchObject({ marginTop: '3px' }))
+  expect(active).not.toHaveBeenCalled()
+  expect(inactive).toHaveBeenCalled()
+
+  await router.navigate({ to: '/target' })
+  await waitFor(() => {
+    expect(link).toHaveClass('base', 'updated')
+    expect(link.style).toMatchObject({
+      color: 'blue',
+      backgroundColor: 'black',
+    })
+  })
+})
+
+test('switches between default and custom state props without stale attributes', async () => {
+  const [custom, setCustom] = Solid.createSignal(false)
+  const router = renderLinks(() => (
+    <Link
+      to="/target"
+      activeProps={
+        custom() ? { title: 'custom', style: { color: 'red' } } : undefined
+      }
+    >
+      Defaults
+    </Link>
+  ))
+  const link = await screen.findByRole('link', { name: 'Defaults' })
+  expect(link).toHaveClass('active')
+  setCustom(true)
+  await waitFor(() => {
+    expect(link).not.toHaveClass('active')
+    expect(link).toHaveAttribute('title', 'custom')
+    expect(link.style).toMatchObject({ color: 'red' })
+  })
+  setCustom(false)
+  await waitFor(() => {
+    expect(link).toHaveClass('active')
+    expect(link).not.toHaveAttribute('title')
+    expect(link.style.color).toBe('')
+  })
+  await router.navigate({ to: '/' })
+  await waitFor(() => expect(link).not.toHaveClass('active'))
+})

--- a/packages/solid-router/tests/link-style.test.tsx
+++ b/packages/solid-router/tests/link-style.test.tsx
@@ -1,7 +1,13 @@
 import * as Solid from 'solid-js'
 import { createStore } from 'solid-js/store'
 import { afterEach, expect, test, vi } from 'vitest'
-import { cleanup, render, screen, waitFor } from '@solidjs/testing-library'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@solidjs/testing-library'
 import {
   Link,
   Outlet,
@@ -44,6 +50,47 @@ function renderLinks(Links: Solid.Component) {
   return router
 }
 
+test.each([true, false])(
+  'selected state props override base props (active: %s)',
+  async (active) => {
+    const baseClick = vi.fn()
+    const selectedClick = vi.fn((event: MouseEvent) => event.preventDefault())
+    const unusedClick = vi.fn()
+    const selectedRef = vi.fn()
+    const stateProps = {
+      ref: selectedRef,
+      title: 'state title',
+      onClick: selectedClick,
+      class: 'state-class',
+      style: { color: 'blue' },
+    }
+    renderLinks(() => (
+      <Link
+        to={active ? '/target' : '/'}
+        target="_blank"
+        title="base title"
+        onClick={baseClick}
+        class="base"
+        style={{ color: 'red', 'margin-top': '2px' }}
+        activeProps={active ? stateProps : { onClick: unusedClick }}
+        inactiveProps={active ? { onClick: unusedClick } : stateProps}
+      >
+        Override
+      </Link>
+    ))
+    const link = await screen.findByRole('link', { name: 'Override' })
+    expect(selectedRef).toHaveBeenCalledOnce()
+    expect(selectedRef.mock.calls[0]?.[0]).toBe(link)
+    expect(link).toHaveAttribute('title', 'state title')
+    expect(link).toHaveClass('base', 'state-class')
+    expect(link.style).toMatchObject({ color: 'blue', marginTop: '2px' })
+    fireEvent.click(link)
+    expect(selectedClick).toHaveBeenCalledOnce()
+    expect(baseClick).not.toHaveBeenCalled()
+    expect(unusedClick).not.toHaveBeenCalled()
+  },
+)
+
 test('tracks additions to an initially empty state-only style store', async () => {
   const [style, setStyle] = createStore<Solid.JSX.CSSProperties>({})
   renderLinks(() => (
@@ -72,7 +119,6 @@ test('merges only the selected state and tracks reactive style properties', asyn
     class: stateClass(),
     style: stateStyle,
     title: 'selected',
-    href: '/state-href',
   }))
   const inactive = vi.fn(() => ({
     class: 'idle',

--- a/packages/solid-router/tests/link-style.test.tsx
+++ b/packages/solid-router/tests/link-style.test.tsx
@@ -51,7 +51,7 @@ function renderLinks(Links: Solid.Component) {
 }
 
 test.each([true, false])(
-  'selected state props override base props (active: %s)',
+  'selected state props override element props but not routing options (active: %s)',
   async (active) => {
     const baseClick = vi.fn()
     const selectedClick = vi.fn((event: MouseEvent) => event.preventDefault())
@@ -63,6 +63,9 @@ test.each([true, false])(
       onClick: selectedClick,
       class: 'state-class',
       style: { color: 'blue' },
+      href: '/state-href',
+      target: '_self',
+      disabled: true,
     }
     renderLinks(() => (
       <Link
@@ -82,6 +85,9 @@ test.each([true, false])(
     expect(selectedRef).toHaveBeenCalledOnce()
     expect(selectedRef.mock.calls[0]?.[0]).toBe(link)
     expect(link).toHaveAttribute('title', 'state title')
+    expect(link).toHaveAttribute('href', active ? '/target' : '/')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).not.toHaveAttribute('disabled')
     expect(link).toHaveClass('base', 'state-class')
     expect(link.style).toMatchObject({ color: 'blue', marginTop: '2px' })
     fireEvent.click(link)

--- a/packages/solid-router/tests/server/link-style.test.tsx
+++ b/packages/solid-router/tests/server/link-style.test.tsx
@@ -1,0 +1,75 @@
+import { JSDOM } from 'jsdom'
+import { expect, test, vi } from 'vitest'
+import { Link, createRootRoute, createRoute, createRouter } from '../../src'
+import {
+  RouterServer,
+  createRequestHandler,
+  renderRouterToString,
+} from '../../src/ssr/server'
+
+test('preserves selected state props and styling during SSR', async () => {
+  const active = vi.fn(() => ({
+    class: 'selected',
+    style: { color: 'blue' },
+    title: 'selected',
+  }))
+  const unused = vi.fn(() => ({ class: 'unused' }))
+  const root = createRootRoute({
+    component: () => (
+      <>
+        <Link
+          to="/"
+          class="base"
+          style={{ color: 'red', 'margin-top': '2px' }}
+          activeProps={active}
+          inactiveProps={unused}
+        >
+          Active
+        </Link>
+        <Link
+          to="/other"
+          activeProps={unused}
+          inactiveProps={{ class: 'idle', 'data-state': 'idle' }}
+        >
+          Inactive
+        </Link>
+        <Link to="/">Default</Link>
+        <Link to="/" activeProps={{}}>
+          Empty
+        </Link>
+      </>
+    ),
+  })
+  const routeTree = root.addChildren([
+    createRoute({ getParentRoute: () => root, path: '/' }),
+    createRoute({ getParentRoute: () => root, path: '/other' }),
+  ])
+  const handler = createRequestHandler({
+    request: new Request('http://localhost/'),
+    createRouter: () => createRouter({ routeTree, isServer: true }),
+  })
+  const response = await handler(({ router, responseHeaders }) =>
+    renderRouterToString({
+      router,
+      responseHeaders,
+      children: () => <RouterServer router={router} />,
+    }),
+  )
+  const dom = new JSDOM(await response.text())
+  try {
+    const links = dom.window.document.querySelectorAll('a')
+    expect(links).toHaveLength(4)
+    expect([...links[0]!.classList]).toEqual(['base', 'selected'])
+    expect(links[0]!.style.color).toBe('blue')
+    expect(links[0]!.style.marginTop).toBe('2px')
+    expect(links[0]!.getAttribute('title')).toBe('selected')
+    expect([...links[1]!.classList]).toEqual(['idle'])
+    expect(links[1]!.getAttribute('data-state')).toBe('idle')
+    expect([...links[2]!.classList]).toEqual(['active'])
+    expect([...links[3]!.classList]).toEqual([])
+    expect(active).toHaveBeenCalled()
+    expect(unused).not.toHaveBeenCalled()
+  } finally {
+    dom.window.close()
+  }
+})

--- a/packages/solid-router/tests/server/link-style.test.tsx
+++ b/packages/solid-router/tests/server/link-style.test.tsx
@@ -1,6 +1,12 @@
 import { JSDOM } from 'jsdom'
 import { expect, test, vi } from 'vitest'
-import { Link, createRootRoute, createRoute, createRouter } from '../../src'
+import {
+  Link,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  useLinkProps,
+} from '../../src'
 import {
   RouterServer,
   createRequestHandler,
@@ -8,37 +14,48 @@ import {
 } from '../../src/ssr/server'
 
 test('preserves selected state props and styling during SSR', async () => {
+  const activeRef = vi.fn()
+  const inactiveRef = vi.fn()
+  let resolvedActiveRef: unknown
+  let resolvedInactiveRef: unknown
   const active = vi.fn(() => ({
     class: 'selected',
     style: { color: 'blue' },
     title: 'selected',
+    ref: activeRef,
   }))
   const unused = vi.fn(() => ({ class: 'unused' }))
   const root = createRootRoute({
-    component: () => (
-      <>
-        <Link
-          to="/"
-          class="base"
-          style={{ color: 'red', 'margin-top': '2px' }}
-          activeProps={active}
-          inactiveProps={unused}
-        >
-          Active
-        </Link>
-        <Link
-          to="/other"
-          activeProps={unused}
-          inactiveProps={{ class: 'idle', 'data-state': 'idle' }}
-        >
-          Inactive
-        </Link>
-        <Link to="/">Default</Link>
-        <Link to="/" activeProps={{}}>
-          Empty
-        </Link>
-      </>
-    ),
+    component: () => {
+      const activeProps = useLinkProps({
+        to: '/',
+        class: 'base',
+        style: { color: 'red', 'margin-top': '2px' },
+        activeProps: active,
+        inactiveProps: unused,
+      })
+      const inactiveProps = useLinkProps({
+        to: '/other',
+        activeProps: unused,
+        inactiveProps: {
+          class: 'idle',
+          'data-state': 'idle',
+          ref: inactiveRef,
+        },
+      })
+      resolvedActiveRef = activeProps.ref
+      resolvedInactiveRef = inactiveProps.ref
+      return (
+        <>
+          <a {...activeProps}>Active</a>
+          <a {...inactiveProps}>Inactive</a>
+          <Link to="/">Default</Link>
+          <Link to="/" activeProps={{}}>
+            Empty
+          </Link>
+        </>
+      )
+    },
   })
   const routeTree = root.addChildren([
     createRoute({ getParentRoute: () => root, path: '/' }),
@@ -63,8 +80,10 @@ test('preserves selected state props and styling during SSR', async () => {
     expect(links[0]!.style.color).toBe('blue')
     expect(links[0]!.style.marginTop).toBe('2px')
     expect(links[0]!.getAttribute('title')).toBe('selected')
+    expect(resolvedActiveRef).toBe(activeRef)
     expect([...links[1]!.classList]).toEqual(['idle'])
     expect(links[1]!.getAttribute('data-state')).toBe('idle')
+    expect(resolvedInactiveRef).toBe(inactiveRef)
     expect([...links[2]!.classList]).toEqual(['active'])
     expect([...links[3]!.classList]).toEqual([])
     expect(active).toHaveBeenCalled()

--- a/packages/solid-router/tests/server/link-style.test.tsx
+++ b/packages/solid-router/tests/server/link-style.test.tsx
@@ -13,7 +13,7 @@ import {
   renderRouterToString,
 } from '../../src/ssr/server'
 
-test('preserves selected state props and styling during SSR', async () => {
+test('preserves routing options, selected state props, and styling during SSR', async () => {
   const activeRef = vi.fn()
   const inactiveRef = vi.fn()
   let resolvedActiveRef: unknown
@@ -23,12 +23,24 @@ test('preserves selected state props and styling during SSR', async () => {
     style: { color: 'blue' },
     title: 'selected',
     ref: activeRef,
+    href: '/state-active',
+    target: '_self',
+    disabled: true,
   }))
+  const inactive = {
+    class: 'idle',
+    'data-state': 'idle',
+    ref: inactiveRef,
+    href: '/state-inactive',
+    target: '_self',
+    disabled: true,
+  }
   const unused = vi.fn(() => ({ class: 'unused' }))
   const root = createRootRoute({
     component: () => {
       const activeProps = useLinkProps({
         to: '/',
+        target: '_blank',
         class: 'base',
         style: { color: 'red', 'margin-top': '2px' },
         activeProps: active,
@@ -36,12 +48,9 @@ test('preserves selected state props and styling during SSR', async () => {
       })
       const inactiveProps = useLinkProps({
         to: '/other',
+        target: '_blank',
         activeProps: unused,
-        inactiveProps: {
-          class: 'idle',
-          'data-state': 'idle',
-          ref: inactiveRef,
-        },
+        inactiveProps: inactive,
       })
       resolvedActiveRef = activeProps.ref
       resolvedInactiveRef = inactiveProps.ref
@@ -80,9 +89,15 @@ test('preserves selected state props and styling during SSR', async () => {
     expect(links[0]!.style.color).toBe('blue')
     expect(links[0]!.style.marginTop).toBe('2px')
     expect(links[0]!.getAttribute('title')).toBe('selected')
+    expect(links[0]!.getAttribute('href')).toBe('/')
+    expect(links[0]!.getAttribute('target')).toBe('_blank')
+    expect(links[0]!.hasAttribute('disabled')).toBe(false)
     expect(resolvedActiveRef).toBe(activeRef)
     expect([...links[1]!.classList]).toEqual(['idle'])
     expect(links[1]!.getAttribute('data-state')).toBe('idle')
+    expect(links[1]!.getAttribute('href')).toBe('/other')
+    expect(links[1]!.getAttribute('target')).toBe('_blank')
+    expect(links[1]!.hasAttribute('disabled')).toBe(false)
     expect(resolvedInactiveRef).toBe(inactiveRef)
     expect([...links[2]!.classList]).toEqual(['active'])
     expect([...links[3]!.classList]).toEqual([])

--- a/packages/vue-router/src/link.tsx
+++ b/packages/vue-router/src/link.tsx
@@ -1,7 +1,6 @@
 import * as Vue from 'vue'
 import {
   deepEqual,
-  exactPathTest,
   hasKeys,
   isAbsoluteUrl,
   isDangerousProtocol,
@@ -142,19 +141,14 @@ function useLinkPropsImpl(
       router,
     )
 
-    const {
-      resolvedActiveProps,
-      resolvedInactiveProps,
-      resolvedClassName,
-      resolvedStyle,
-    } = resolveStyleProps(options, isActive)
+    const { resolvedProps, resolvedClassName, resolvedStyle } =
+      resolveStyleProps(options, isActive)
 
     const result = combineResultProps({
       href,
       options,
       isActive,
-      resolvedActiveProps,
-      resolvedInactiveProps,
+      resolvedProps,
       resolvedClassName,
       resolvedStyle,
     })
@@ -411,20 +405,15 @@ function useLinkPropsImpl(
       return getExternalLinkProps(options, router, ref, staticEventHandlers)
     }
 
-    const {
-      resolvedActiveProps,
-      resolvedInactiveProps,
-      resolvedClassName,
-      resolvedStyle,
-    } = resolvedStyleProps.value
+    const { resolvedProps, resolvedClassName, resolvedStyle } =
+      resolvedStyleProps.value
     return combineResultProps({
       href: href.value,
       options,
       ref,
       staticEventHandlers,
       isActive: isActive.value,
-      resolvedActiveProps,
-      resolvedInactiveProps,
+      resolvedProps,
       resolvedClassName,
       resolvedStyle,
     })
@@ -435,58 +424,47 @@ function useLinkPropsImpl(
 }
 
 function resolveStyleProps(options: AnyLinkPropsOptions, isActive: boolean) {
-  const activeProps = options.activeProps || (() => ({ class: 'active' }))
-  const resolvedActiveProps: StyledProps = (isActive
-    ? typeof activeProps === 'function'
-      ? activeProps()
-      : activeProps
-    : {}) || { class: undefined, style: undefined }
+  const props =
+    (isActive ? options.activeProps : options.inactiveProps) ||
+    (isActive ? STATIC_ACTIVE_PROPS : EMPTY_OBJECT)
+  const resolvedProps: StyledProps =
+    (typeof props === 'function' ? props() : props) || EMPTY_OBJECT
+  const baseClass = options.class
+  const stateClass = resolvedProps.class
+  const resolvedClassName = baseClass
+    ? stateClass
+      ? `${baseClass} ${stateClass}`
+      : `${baseClass}`
+    : stateClass
+      ? `${stateClass}`
+      : undefined
 
-  const inactiveProps = options.inactiveProps || (() => ({}))
-
-  const resolvedInactiveProps: StyledProps = (isActive
-    ? {}
-    : typeof inactiveProps === 'function'
-      ? inactiveProps()
-      : inactiveProps) || { class: undefined, style: undefined }
-
-  const classes = [
-    options.class,
-    resolvedActiveProps?.class,
-    resolvedInactiveProps?.class,
-  ].filter(Boolean)
-  const resolvedClassName = classes.length ? classes.join(' ') : undefined
-
-  const result: Record<string, string | number> = {}
-
-  // Merge styles from all sources
-  if (options.style) {
-    Object.assign(result, options.style)
+  const baseStyle = options.style
+  const stateStyle = resolvedProps.style
+  let resolvedStyle: Record<string, string | number> | undefined
+  if (baseStyle || stateStyle) {
+    // Keep a snapshot of reactive styles rather than returning their proxy.
+    const style: Record<string, string | number> = {}
+    Object.assign(style, baseStyle, stateStyle)
+    if (hasKeys(style)) {
+      resolvedStyle = style
+    }
   }
-
-  if (resolvedActiveProps?.style) {
-    Object.assign(result, resolvedActiveProps.style)
-  }
-
-  if (resolvedInactiveProps?.style) {
-    Object.assign(result, resolvedInactiveProps.style)
-  }
-
-  const resolvedStyle = hasKeys(result) ? result : undefined
   return {
-    resolvedActiveProps,
-    resolvedInactiveProps,
+    resolvedProps,
     resolvedClassName,
     resolvedStyle,
   }
 }
 
+const STATIC_ACTIVE_PROPS = { class: 'active' }
+const EMPTY_OBJECT = {}
+
 function combineResultProps({
   href,
   options,
   isActive,
-  resolvedActiveProps,
-  resolvedInactiveProps,
+  resolvedProps,
   resolvedClassName,
   resolvedStyle,
   ref,
@@ -496,8 +474,7 @@ function combineResultProps({
   href: string | undefined
   options: AnyLinkPropsOptions
   isActive: boolean
-  resolvedActiveProps: StyledProps
-  resolvedInactiveProps: StyledProps
+  resolvedProps: StyledProps
   resolvedClassName?: string
   resolvedStyle?: Record<string, string | number>
   ref?: Vue.VNodeRef | undefined
@@ -530,15 +507,9 @@ function combineResultProps({
     result['aria-current'] = 'page'
   }
 
-  for (const key of Object.keys(resolvedActiveProps)) {
+  for (const key of Object.keys(resolvedProps)) {
     if (key !== 'class' && key !== 'style') {
-      result[key] = resolvedActiveProps[key]
-    }
-  }
-
-  for (const key of Object.keys(resolvedInactiveProps)) {
-    if (key !== 'class' && key !== 'style') {
-      result[key] = resolvedInactiveProps[key]
+      result[key] = resolvedProps[key]
     }
   }
   return result
@@ -673,26 +644,15 @@ function getIsActive(
   activeOptions: LinkOptions['activeOptions'],
   router: AnyRouter,
 ) {
-  if (activeOptions?.exact) {
-    const testExact = exactPathTest(
-      loc.pathname,
-      nextLoc.pathname,
-      router.basepath,
-    )
-    if (!testExact) {
-      return false
-    }
-  } else {
-    const currentPath = removeTrailingSlash(loc.pathname, router.basepath)
-    const nextPath = removeTrailingSlash(nextLoc.pathname, router.basepath)
-
-    const pathIsFuzzyEqual =
-      currentPath.startsWith(nextPath) &&
-      (currentPath.length === nextPath.length ||
-        currentPath[nextPath.length] === '/')
-    if (!pathIsFuzzyEqual) {
-      return false
-    }
+  const currentPath = removeTrailingSlash(loc.pathname, router.basepath)
+  const nextPath = removeTrailingSlash(nextLoc.pathname, router.basepath)
+  if (
+    currentPath !== nextPath &&
+    (activeOptions?.exact ||
+      !currentPath.startsWith(nextPath) ||
+      currentPath[nextPath.length] !== '/')
+  ) {
+    return false
   }
 
   if (activeOptions?.includeSearch ?? true) {

--- a/packages/vue-router/src/link.tsx
+++ b/packages/vue-router/src/link.tsx
@@ -141,15 +141,17 @@ function useLinkPropsImpl(
       router,
     )
 
-    const { resolvedProps, resolvedClassName, resolvedStyle } =
-      resolveStyleProps(options, isActive)
+    const { resolvedProps, resolvedClass, resolvedStyle } = resolveStyleProps(
+      options,
+      isActive,
+    )
 
     const result = combineResultProps({
       href,
       options,
       isActive,
       resolvedProps,
-      resolvedClassName,
+      resolvedClass,
       resolvedStyle,
     })
 
@@ -405,7 +407,7 @@ function useLinkPropsImpl(
       return getExternalLinkProps(options, router, ref, staticEventHandlers)
     }
 
-    const { resolvedProps, resolvedClassName, resolvedStyle } =
+    const { resolvedProps, resolvedClass, resolvedStyle } =
       resolvedStyleProps.value
     return combineResultProps({
       href: href.value,
@@ -414,7 +416,7 @@ function useLinkPropsImpl(
       staticEventHandlers,
       isActive: isActive.value,
       resolvedProps,
-      resolvedClassName,
+      resolvedClass,
       resolvedStyle,
     })
   })
@@ -431,12 +433,12 @@ function resolveStyleProps(options: AnyLinkPropsOptions, isActive: boolean) {
     (typeof props === 'function' ? props() : props) || EMPTY_OBJECT
   const baseClass = options.class
   const stateClass = resolvedProps.class
-  const resolvedClassName = baseClass
+  const resolvedClass = baseClass
     ? stateClass
-      ? `${baseClass} ${stateClass}`
-      : `${baseClass}`
+      ? [baseClass, stateClass]
+      : baseClass
     : stateClass
-      ? `${stateClass}`
+      ? stateClass
       : undefined
 
   const baseStyle = options.style
@@ -452,7 +454,7 @@ function resolveStyleProps(options: AnyLinkPropsOptions, isActive: boolean) {
   }
   return {
     resolvedProps,
-    resolvedClassName,
+    resolvedClass,
     resolvedStyle,
   }
 }
@@ -465,7 +467,7 @@ function combineResultProps({
   options,
   isActive,
   resolvedProps,
-  resolvedClassName,
+  resolvedClass,
   resolvedStyle,
   ref,
   staticEventHandlers,
@@ -475,7 +477,7 @@ function combineResultProps({
   options: AnyLinkPropsOptions
   isActive: boolean
   resolvedProps: StyledProps
-  resolvedClassName?: string
+  resolvedClass?: StyledProps['class']
   resolvedStyle?: Record<string, string | number>
   ref?: Vue.VNodeRef | undefined
   staticEventHandlers?: LinkEventHandlers
@@ -493,8 +495,8 @@ function combineResultProps({
     result.style = resolvedStyle
   }
 
-  if (resolvedClassName) {
-    result.class = resolvedClassName
+  if (resolvedClass) {
+    result.class = resolvedClass
   }
 
   if (options.disabled) {
@@ -898,8 +900,8 @@ const LinkImpl = Vue.defineComponent({
         )
       }
 
-      // Return the component with props and children
-      return Vue.h(Component, linkProps, slotContent)
+      // Vue normalizes class bindings in place; preserve the cached bindings.
+      return Vue.h(Component, { ...linkProps }, slotContent)
     }
   },
 })

--- a/packages/vue-router/tests/link-style-ssr.test.tsx
+++ b/packages/vue-router/tests/link-style-ssr.test.tsx
@@ -1,0 +1,78 @@
+import * as Vue from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import { expect, test, vi } from 'vitest'
+import {
+  Link,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+
+test('preserves selected state props and styling during SSR', async () => {
+  const active = vi.fn(() => ({
+    class: 'selected',
+    style: { color: 'blue' },
+    title: 'selected',
+  }))
+  const unused = vi.fn(() => ({ class: 'unused' }))
+  const root = createRootRoute({
+    component: () =>
+      Vue.h(Vue.Fragment, [
+        Vue.h(
+          Link,
+          {
+            to: '/',
+            class: 'base',
+            style: { color: 'red', marginTop: '2px' },
+            activeProps: active,
+            inactiveProps: unused,
+          },
+          () => 'Active',
+        ),
+        Vue.h(
+          Link,
+          {
+            to: '/other',
+            activeProps: unused,
+            inactiveProps: { class: 'idle', 'data-state': 'idle' },
+          },
+          () => 'Inactive',
+        ),
+        Vue.h(Link, { to: '/' }, () => 'Default'),
+        Vue.h(Link, { to: '/', activeProps: {} }, () => 'Empty'),
+      ]),
+  })
+  const history = createMemoryHistory({ initialEntries: ['/'] })
+  const router = createRouter({
+    routeTree: root.addChildren([
+      createRoute({ getParentRoute: () => root, path: '/' }),
+      createRoute({ getParentRoute: () => root, path: '/other' }),
+    ]),
+    history,
+    isServer: true,
+  })
+  try {
+    await router.load()
+    const html = await renderToString(
+      Vue.createSSRApp(() => Vue.h(RouterProvider, { router })),
+    )
+    const container = document.createElement('div')
+    container.innerHTML = html
+    const links = container.querySelectorAll('a')
+    expect(links).toHaveLength(4)
+    expect(links[0]!.className).toBe('base selected')
+    expect(links[0]!.style.color).toBe('blue')
+    expect(links[0]!.style.marginTop).toBe('2px')
+    expect(links[0]!.getAttribute('title')).toBe('selected')
+    expect(links[1]!.className).toBe('idle')
+    expect(links[1]!.getAttribute('data-state')).toBe('idle')
+    expect(links[2]!.className).toBe('active')
+    expect(links[3]!.className).toBe('')
+    expect(active).toHaveBeenCalledWith()
+    expect(unused).not.toHaveBeenCalled()
+  } finally {
+    history.destroy()
+  }
+})

--- a/packages/vue-router/tests/link-style-ssr.test.tsx
+++ b/packages/vue-router/tests/link-style-ssr.test.tsx
@@ -12,7 +12,7 @@ import {
 
 test('preserves selected state props and styling during SSR', async () => {
   const active = vi.fn(() => ({
-    class: 'selected',
+    class: ['selected', [{ 'active-object': true, hidden: false }]],
     style: { color: 'blue' },
     title: 'selected',
   }))
@@ -36,7 +36,7 @@ test('preserves selected state props and styling during SSR', async () => {
           {
             to: '/other',
             activeProps: unused,
-            inactiveProps: { class: 'idle', 'data-state': 'idle' },
+            inactiveProps: { class: { idle: true }, 'data-state': 'idle' },
           },
           () => 'Inactive',
         ),
@@ -62,7 +62,11 @@ test('preserves selected state props and styling during SSR', async () => {
     container.innerHTML = html
     const links = container.querySelectorAll('a')
     expect(links).toHaveLength(4)
-    expect(links[0]!.className).toBe('base selected')
+    expect([...links[0]!.classList]).toEqual([
+      'base',
+      'selected',
+      'active-object',
+    ])
     expect(links[0]!.style.color).toBe('blue')
     expect(links[0]!.style.marginTop).toBe('2px')
     expect(links[0]!.getAttribute('title')).toBe('selected')

--- a/packages/vue-router/tests/link-style.test.tsx
+++ b/packages/vue-router/tests/link-style.test.tsx
@@ -9,6 +9,7 @@ import {
   createRootRoute,
   createRoute,
   createRouter,
+  useLinkProps,
 } from '../src'
 
 const disposers: Array<() => void> = []
@@ -37,6 +38,85 @@ function renderLinks(Links: Vue.Component) {
   render(Vue.h(RouterProvider, { router }))
   return router
 }
+
+test('preserves object and nested-array class bindings across state updates', async () => {
+  const activeClass = Vue.reactive({ selected: true, removed: false })
+  const inactiveClass = Vue.reactive({ idle: true })
+  const router = renderLinks(() =>
+    Vue.h(
+      Link,
+      {
+        to: '/target',
+        class: ['base', { decorated: true }],
+        activeProps: () => ({
+          class: ['active-state', [undefined, activeClass, ['nested']]],
+        }),
+        inactiveProps: { class: inactiveClass },
+      },
+      () => 'Class bindings',
+    ),
+  )
+  const link = await screen.findByRole('link', { name: 'Class bindings' })
+  expect([...link.classList]).toEqual([
+    'base',
+    'decorated',
+    'active-state',
+    'selected',
+    'nested',
+  ])
+  activeClass.selected = false
+  activeClass.removed = true
+  await waitFor(() => {
+    expect(link).not.toHaveClass('selected')
+    expect(link).toHaveClass('removed', 'nested')
+  })
+  await router.navigate({ to: '/' })
+  await waitFor(() => {
+    expect([...link.classList]).toEqual(['base', 'decorated', 'idle'])
+  })
+  inactiveClass.idle = false
+  await waitFor(() =>
+    expect([...link.classList]).toEqual(['base', 'decorated']),
+  )
+})
+
+test.each([false, true])(
+  'useLinkProps retains class values rather than strings (with base: %s)',
+  async (withBase) => {
+    const baseClass = ['base', { decorated: true }]
+    const stateClass = { selected: true }
+    let binding: unknown
+    const HookLink = Vue.defineComponent({
+      setup() {
+        const props = useLinkProps({
+          to: '/target',
+          class: withBase ? baseClass : undefined,
+          activeProps: { class: stateClass },
+        })
+        return () => {
+          const resolved = Vue.unref(props)
+          binding = resolved.class
+          return Vue.h('a', { ...resolved }, 'Hook classes')
+        }
+      },
+    })
+    renderLinks(HookLink)
+    await screen.findByRole('link', { name: 'Hook classes' })
+    if (withBase) {
+      expect(binding).toEqual([baseClass, stateClass])
+    } else {
+      expect(binding).toBe(stateClass)
+    }
+  },
+)
+
+test('omits the class binding when neither source provides a class', async () => {
+  renderLinks(() =>
+    Vue.h(Link, { to: '/target', activeProps: {} }, () => 'No classes'),
+  )
+  const link = await screen.findByRole('link', { name: 'No classes' })
+  expect(link).not.toHaveAttribute('class')
+})
 
 test('tracks additions to an initially empty state-only style proxy', async () => {
   const style = Vue.reactive<Vue.CSSProperties>({})

--- a/packages/vue-router/tests/link-style.test.tsx
+++ b/packages/vue-router/tests/link-style.test.tsx
@@ -1,0 +1,162 @@
+import * as Vue from 'vue'
+import { afterEach, expect, test, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/vue'
+import {
+  Link,
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '../src'
+
+const disposers: Array<() => void> = []
+afterEach(() => {
+  cleanup()
+  for (const dispose of disposers.splice(0)) {
+    dispose()
+  }
+})
+
+function renderLinks(Links: Vue.Component) {
+  const history = createMemoryHistory({ initialEntries: ['/target'] })
+  disposers.push(history.destroy)
+  const root = createRootRoute({
+    component: () => Vue.h(Vue.Fragment, [Vue.h(Links), Vue.h(Outlet)]),
+  })
+  const router = createRouter({
+    routeTree: root.addChildren([
+      createRoute({ getParentRoute: () => root, path: '/' }),
+      createRoute({ getParentRoute: () => root, path: '/target' }),
+    ]),
+    history,
+    scrollRestoration: false,
+    defaultPreload: false,
+  })
+  render(Vue.h(RouterProvider, { router }))
+  return router
+}
+
+test('tracks additions to an initially empty state-only style proxy', async () => {
+  const style = Vue.reactive<Vue.CSSProperties>({})
+  renderLinks(() =>
+    Vue.h(
+      Link,
+      { to: '/target', activeProps: () => ({ style }) },
+      () => 'Reactive',
+    ),
+  )
+  const link = await screen.findByRole('link', { name: 'Reactive' })
+  expect(link.style.color).toBe('')
+  style.color = 'red'
+  await waitFor(() => expect(link.style.color).toBe('red'))
+  delete style.color
+  await waitFor(() => expect(link.style.color).toBe(''))
+})
+
+test('merges only the selected state and tracks reactive style properties', async () => {
+  const base = Vue.reactive({ color: 'red', marginTop: '2px' })
+  const stateStyle = Vue.reactive({ backgroundColor: 'white' })
+  const stateClass = Vue.ref('selected')
+  const active = vi.fn(() => ({
+    class: stateClass.value,
+    style: stateStyle,
+    title: 'selected',
+    href: '/state-href',
+  }))
+  const inactive = vi.fn(() => ({
+    class: 'idle',
+    style: { color: 'gray' },
+    title: 'idle',
+  }))
+  const router = renderLinks(() =>
+    Vue.h(
+      Link,
+      {
+        to: '/target',
+        class: ['base', { decorated: true }],
+        style: base,
+        activeProps: active,
+        inactiveProps: inactive,
+      },
+      () => 'Styled',
+    ),
+  )
+  const link = await screen.findByRole('link', { name: 'Styled' })
+  expect(link).toHaveClass('base', 'decorated', 'selected')
+  expect(link.style).toMatchObject({
+    color: 'red',
+    marginTop: '2px',
+    backgroundColor: 'white',
+  })
+  expect(link).toHaveAttribute('href', '/state-href')
+  expect(inactive).not.toHaveBeenCalled()
+
+  base.color = 'blue'
+  stateStyle.backgroundColor = 'black'
+  stateClass.value = 'updated'
+  await waitFor(() => {
+    expect(link).toHaveClass('base', 'decorated', 'updated')
+    expect(link.style).toMatchObject({
+      color: 'blue',
+      backgroundColor: 'black',
+    })
+  })
+
+  await router.navigate({ to: '/' })
+  await waitFor(() => {
+    expect(link).toHaveClass('base', 'idle')
+    expect(link).toHaveAttribute('title', 'idle')
+    expect(link).toHaveAttribute('href', '/target')
+    expect(link.style).toMatchObject({ color: 'gray', marginTop: '2px' })
+    expect(link.style.backgroundColor).toBe('')
+  })
+  active.mockClear()
+  inactive.mockClear()
+  base.marginTop = '3px'
+  await waitFor(() => expect(link.style).toMatchObject({ marginTop: '3px' }))
+  expect(active).not.toHaveBeenCalled()
+  expect(inactive).toHaveBeenCalled()
+
+  await router.navigate({ to: '/target' })
+  await waitFor(() => {
+    expect(link).toHaveClass('base', 'updated')
+    expect(link.style).toMatchObject({
+      color: 'blue',
+      backgroundColor: 'black',
+    })
+  })
+})
+
+test('switches between default and custom state props without stale attributes', async () => {
+  const custom = Vue.ref(false)
+  const router = renderLinks(() =>
+    Vue.h(
+      Link,
+      {
+        to: '/target',
+        activeProps: custom.value
+          ? { title: 'custom', style: { color: 'red' } }
+          : undefined,
+      },
+      () => 'Defaults',
+    ),
+  )
+  const link = await screen.findByRole('link', { name: 'Defaults' })
+  expect(link).toHaveClass('active')
+  custom.value = true
+  await waitFor(() => {
+    expect(link).not.toHaveClass('active')
+    expect(link).toHaveAttribute('title', 'custom')
+    expect(link.style).toMatchObject({ color: 'red' })
+  })
+  custom.value = false
+  await waitFor(() => {
+    expect(link).toHaveClass('active')
+    expect(link).not.toHaveAttribute('title')
+    expect(link.style.color).toBe('')
+  })
+  await router.navigate({ to: '/' })
+  await waitFor(() => expect(link).not.toHaveClass('active'))
+})


### PR DESCRIPTION
## 🎯 Changes

Allow state props to override base element props while keeping routing-owned values authoritative, preserving Vue class bindings and Solid computed routing props.

This is PR 5 of a stacked series and is based on `optimize-link-segment-interpolation`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated changesets.
- [ ] This change is docs/CI/dev-only.