### PR TITLE
test(start): cover namespace env-only functions in application builds

### DIFF
--- a/e2e/react-start/server-functions/src/routes/env-only.tsx
+++ b/e2e/react-start/server-functions/src/routes/env-only.tsx
@@ -4,37 +4,57 @@ import {
   createServerFn,
   createServerOnlyFn,
 } from '@tanstack/react-start'
+import * as Start from '@tanstack/react-start'
 import { useState } from 'react'
 
 const serverEcho = createServerOnlyFn((input: string) => 'server got: ' + input)
 const clientEcho = createClientOnlyFn((input: string) => 'client got: ' + input)
 
-const testOnServer = createServerFn().handler(() => {
-  const serverOnServer = serverEcho('hello')
-  let clientOnServer: string
-  try {
-    clientOnServer = clientEcho('hello')
-  } catch (e) {
-    clientOnServer =
-      'clientEcho threw an error: ' +
-      (e instanceof Error ? e.message : String(e))
-  }
-  return { serverOnServer, clientOnServer }
-})
+const namespaceServerEcho = Start.createServerOnlyFn(
+  (input: string) => 'server got: ' + input + ' (NAMESPACE_SERVER_ONLY_BODY)',
+)
+const namespaceClientEcho = Start.createClientOnlyFn(
+  (input: string) => 'client got: ' + input + ' (NAMESPACE_CLIENT_ONLY_BODY)',
+)
+
+const testOnServer = createServerFn()
+  .inputValidator((namespace: boolean) => namespace)
+  .handler(({ data: namespace }) => {
+    const serverOnServer = (namespace ? namespaceServerEcho : serverEcho)(
+      'hello',
+    )
+    let clientOnServer: string
+    try {
+      clientOnServer = (namespace ? namespaceClientEcho : clientEcho)('hello')
+    } catch (e) {
+      clientOnServer =
+        'clientEcho threw an error: ' +
+        (e instanceof Error ? e.message : String(e))
+    }
+    return { serverOnServer, clientOnServer }
+  })
 
 export const Route = createFileRoute('/env-only')({
+  validateSearch: (search): { namespace?: boolean } => ({
+    namespace: search.namespace === true,
+  }),
   component: RouteComponent,
 })
 
 function RouteComponent() {
+  const namespace = Route.useSearch().namespace ?? false
   const [results, setResults] = useState<Partial<Record<string, string>>>()
 
   async function handleClick() {
-    const { serverOnServer, clientOnServer } = await testOnServer()
-    const clientOnClient = clientEcho('hello')
+    const { serverOnServer, clientOnServer } = await testOnServer({
+      data: namespace,
+    })
+    const clientOnClient = (namespace ? namespaceClientEcho : clientEcho)(
+      'hello',
+    )
     let serverOnClient: string
     try {
-      serverOnClient = serverEcho('hello')
+      serverOnClient = (namespace ? namespaceServerEcho : serverEcho)('hello')
     } catch (e) {
       serverOnClient =
         'serverEcho threw an error: ' +

--- a/e2e/react-start/server-functions/tests/env-only-build.spec.ts
+++ b/e2e/react-start/server-functions/tests/env-only-build.spec.ts
@@ -1,0 +1,26 @@
+import { readFile, readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import { expect, test } from '@playwright/test'
+
+test('namespace env-only function bodies are excluded from the opposite build', async () => {
+  const outDir = process.env.E2E_DIST_DIR ?? 'dist'
+
+  for (const [environment, included, excluded] of [
+    ['client', 'NAMESPACE_CLIENT_ONLY_BODY', 'NAMESPACE_SERVER_ONLY_BODY'],
+    ['server', 'NAMESPACE_SERVER_ONLY_BODY', 'NAMESPACE_CLIENT_ONLY_BODY'],
+  ] as const) {
+    const directory = join(outDir, environment)
+    const files = (await readdir(directory, { recursive: true })).filter(
+      (file) => /\.[cm]?js$/.test(file),
+    )
+    expect(files.length).toBeGreaterThan(0)
+    const code = (
+      await Promise.all(
+        files.map((file) => readFile(join(directory, file), 'utf8')),
+      )
+    ).join('\n')
+
+    expect(code).toContain(included)
+    expect(code).not.toContain(excluded)
+  }
+})

--- a/e2e/react-start/server-functions/tests/server-functions.spec.ts
+++ b/e2e/react-start/server-functions/tests/server-functions.spec.ts
@@ -127,30 +127,32 @@ test('isomorphic functions can have different implementations on client and serv
   )
 })
 
-test('env-only functions can only be called on the server or client respectively', async ({
-  page,
-}) => {
-  await page.goto('/env-only')
+for (const namespace of [false, true]) {
+  test(`env-only functions respect their environment (namespace: ${namespace})`, async ({
+    page,
+  }) => {
+    await page.goto(`/env-only?namespace=${namespace}`)
 
-  await page.waitForLoadState('networkidle')
+    await page.waitForLoadState('networkidle')
 
-  await page.getByTestId('test-env-only-results-btn').click()
-  await page.waitForLoadState('networkidle')
+    await page.getByTestId('test-env-only-results-btn').click()
+    await page.waitForLoadState('networkidle')
 
-  await expect(page.getByTestId('server-on-server')).toContainText(
-    'server got: hello',
-  )
-  await expect(page.getByTestId('server-on-client')).toContainText(
-    'serverEcho threw an error: createServerOnlyFn() functions can only be called on the server!',
-  )
+    await expect(page.getByTestId('server-on-server')).toHaveText(
+      `server got: hello${namespace ? ' (NAMESPACE_SERVER_ONLY_BODY)' : ''}`,
+    )
+    await expect(page.getByTestId('server-on-client')).toHaveText(
+      'serverEcho threw an error: createServerOnlyFn() functions can only be called on the server!',
+    )
 
-  await expect(page.getByTestId('client-on-server')).toContainText(
-    'clientEcho threw an error: createClientOnlyFn() functions can only be called on the client!',
-  )
-  await expect(page.getByTestId('client-on-client')).toContainText(
-    'client got: hello',
-  )
-})
+    await expect(page.getByTestId('client-on-server')).toHaveText(
+      'clientEcho threw an error: createClientOnlyFn() functions can only be called on the client!',
+    )
+    await expect(page.getByTestId('client-on-client')).toHaveText(
+      `client got: hello${namespace ? ' (NAMESPACE_CLIENT_ONLY_BODY)' : ''}`,
+    )
+  })
+}
 
 test('Server function can return null for GET and POST calls', async ({
   page,

--- a/e2e/solid-start/server-functions/src/routes/env-only.tsx
+++ b/e2e/solid-start/server-functions/src/routes/env-only.tsx
@@ -4,37 +4,58 @@ import {
   createServerFn,
   createServerOnlyFn,
 } from '@tanstack/solid-start'
+import * as Start from '@tanstack/solid-start'
 import { createSignal } from 'solid-js'
 
 const serverEcho = createServerOnlyFn((input: string) => 'server got: ' + input)
 const clientEcho = createClientOnlyFn((input: string) => 'client got: ' + input)
 
-const testOnServer = createServerFn().handler(() => {
-  const serverOnServer = serverEcho('hello')
-  let clientOnServer: string
-  try {
-    clientOnServer = clientEcho('hello')
-  } catch (e) {
-    clientOnServer =
-      'clientEcho threw an error: ' +
-      (e instanceof Error ? e.message : String(e))
-  }
-  return { serverOnServer, clientOnServer }
-})
+const namespaceServerEcho = Start.createServerOnlyFn(
+  (input: string) => 'server got: ' + input + ' (NAMESPACE_SERVER_ONLY_BODY)',
+)
+const namespaceClientEcho = Start.createClientOnlyFn(
+  (input: string) => 'client got: ' + input + ' (NAMESPACE_CLIENT_ONLY_BODY)',
+)
+
+const testOnServer = createServerFn()
+  .inputValidator((namespace: boolean) => namespace)
+  .handler(({ data: namespace }) => {
+    const serverOnServer = (namespace ? namespaceServerEcho : serverEcho)(
+      'hello',
+    )
+    let clientOnServer: string
+    try {
+      clientOnServer = (namespace ? namespaceClientEcho : clientEcho)('hello')
+    } catch (e) {
+      clientOnServer =
+        'clientEcho threw an error: ' +
+        (e instanceof Error ? e.message : String(e))
+    }
+    return { serverOnServer, clientOnServer }
+  })
 
 export const Route = createFileRoute('/env-only')({
+  validateSearch: (search): { namespace?: boolean } => ({
+    namespace: search.namespace === true,
+  }),
   component: RouteComponent,
 })
 
 function RouteComponent() {
+  const search = Route.useSearch()
   const [results, setResults] = createSignal<Partial<Record<string, string>>>()
 
   async function handleClick() {
-    const { serverOnServer, clientOnServer } = await testOnServer()
-    const clientOnClient = clientEcho('hello')
+    const namespace = search().namespace ?? false
+    const { serverOnServer, clientOnServer } = await testOnServer({
+      data: namespace,
+    })
+    const clientOnClient = (namespace ? namespaceClientEcho : clientEcho)(
+      'hello',
+    )
     let serverOnClient: string
     try {
-      serverOnClient = serverEcho('hello')
+      serverOnClient = (namespace ? namespaceServerEcho : serverEcho)('hello')
     } catch (e) {
       serverOnClient =
         'serverEcho threw an error: ' +

--- a/e2e/solid-start/server-functions/tests/env-only-build.spec.ts
+++ b/e2e/solid-start/server-functions/tests/env-only-build.spec.ts
@@ -1,0 +1,26 @@
+import { readFile, readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import { expect, test } from '@playwright/test'
+
+test('namespace env-only function bodies are excluded from the opposite build', async () => {
+  const outDir = process.env.E2E_DIST_DIR ?? 'dist'
+
+  for (const [environment, included, excluded] of [
+    ['client', 'NAMESPACE_CLIENT_ONLY_BODY', 'NAMESPACE_SERVER_ONLY_BODY'],
+    ['server', 'NAMESPACE_SERVER_ONLY_BODY', 'NAMESPACE_CLIENT_ONLY_BODY'],
+  ] as const) {
+    const directory = join(outDir, environment)
+    const files = (await readdir(directory, { recursive: true })).filter(
+      (file) => /\.[cm]?js$/.test(file),
+    )
+    expect(files.length).toBeGreaterThan(0)
+    const code = (
+      await Promise.all(
+        files.map((file) => readFile(join(directory, file), 'utf8')),
+      )
+    ).join('\n')
+
+    expect(code).toContain(included)
+    expect(code).not.toContain(excluded)
+  }
+})

--- a/e2e/solid-start/server-functions/tests/server-functions.spec.ts
+++ b/e2e/solid-start/server-functions/tests/server-functions.spec.ts
@@ -117,30 +117,32 @@ test('isomorphic functions can have different implementations on client and serv
   )
 })
 
-test('env-only functions can only be called on the server or client respectively', async ({
-  page,
-}) => {
-  await page.goto('/env-only')
+for (const namespace of [false, true]) {
+  test(`env-only functions respect their environment (namespace: ${namespace})`, async ({
+    page,
+  }) => {
+    await page.goto(`/env-only?namespace=${namespace}`)
 
-  await page.waitForLoadState('networkidle')
+    await page.waitForLoadState('networkidle')
 
-  await page.getByTestId('test-env-only-results-btn').click()
-  await page.waitForLoadState('networkidle')
+    await page.getByTestId('test-env-only-results-btn').click()
+    await page.waitForLoadState('networkidle')
 
-  await expect(page.getByTestId('server-on-server')).toContainText(
-    'server got: hello',
-  )
-  await expect(page.getByTestId('server-on-client')).toContainText(
-    'serverEcho threw an error: createServerOnlyFn() functions can only be called on the server!',
-  )
+    await expect(page.getByTestId('server-on-server')).toHaveText(
+      `server got: hello${namespace ? ' (NAMESPACE_SERVER_ONLY_BODY)' : ''}`,
+    )
+    await expect(page.getByTestId('server-on-client')).toHaveText(
+      'serverEcho threw an error: createServerOnlyFn() functions can only be called on the server!',
+    )
 
-  await expect(page.getByTestId('client-on-server')).toContainText(
-    'clientEcho threw an error: createClientOnlyFn() functions can only be called on the client!',
-  )
-  await expect(page.getByTestId('client-on-client')).toContainText(
-    'client got: hello',
-  )
-})
+    await expect(page.getByTestId('client-on-server')).toHaveText(
+      'clientEcho threw an error: createClientOnlyFn() functions can only be called on the client!',
+    )
+    await expect(page.getByTestId('client-on-client')).toHaveText(
+      `client got: hello${namespace ? ' (NAMESPACE_CLIENT_ONLY_BODY)' : ''}`,
+    )
+  })
+}
 
 test('Server function can return null for GET and POST calls', async ({
   page,


### PR DESCRIPTION
## 🎯 Changes

Extend the React and Solid env-only fixtures with namespace imports from their public Start entrypoints. Browser tests exercise allowed calls and wrong-environment errors, and build tests verify that each environment contains its own function body while excluding the other environment's body. The existing named-import cases remain covered.

Validation: three tests pass for React/Vite, React/Rsbuild, and Solid/Vite (nine total), including application type checks; changed files pass ESLint, and all 44 compiler unit tests pass.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [ ] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for namespace-scoped server-only and client-only functions in React and Solid applications.
  * Routes can now select the appropriate function implementations using a `namespace` search parameter.

* **Bug Fixes**
  * Improved build isolation so server-only code is excluded from client builds and client-only code is excluded from server builds.

* **Tests**
  * Added coverage for namespace behavior and environment-specific build output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->