### PR TITLE
test(start): cover transformed script URL escaping in SSR

### DIFF
--- a/e2e/react-start/transform-asset-urls/src/server.ts
+++ b/e2e/react-start/transform-asset-urls/src/server.ts
@@ -83,4 +83,18 @@ const handler = createStartHandler(
     : defaultStreamHandler,
 )
 
-export default createServerEntry({ fetch: handler })
+export default createServerEntry({
+  fetch(request, options) {
+    const scriptUrl = request.headers.get('x-test-script-url')
+    if (scriptUrl) {
+      return createStartHandler({
+        handler: defaultStreamHandler,
+        transformAssets: ({ kind, url }) => ({
+          href: kind === 'script' ? scriptUrl : url,
+        }),
+      })(request, options)
+    }
+
+    return handler(request, options)
+  },
+})

--- a/e2e/react-start/transform-asset-urls/tests/script-url-escaping.spec.ts
+++ b/e2e/react-start/transform-asset-urls/tests/script-url-escaping.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from '@playwright/test'
+
+for (const [name, scriptUrl] of [
+  [
+    'closing script tag',
+    '</script><script>document.documentElement.setAttribute("data-asset-url-executed","yes")</script><script type="module">/*',
+  ],
+  [
+    'quoted attribute',
+    '"><script>document.documentElement.setAttribute("data-asset-url-executed","yes")</script><script src="',
+  ],
+] as const) {
+  test(`transformed script URLs preserve a ${name} as attribute text`, async ({
+    page,
+  }) => {
+    await page.setExtraHTTPHeaders({ 'x-test-script-url': scriptUrl })
+    // The URLs deliberately do not identify loadable modules. Keep the page's
+    // real inline scripts enabled so an accidentally injected script would run.
+    await page.route('**/*', (route) => {
+      if (route.request().resourceType() === 'script') {
+        return route.abort()
+      }
+      return route.continue()
+    })
+
+    const response = await page.goto('/')
+    expect(response?.status()).toBe(200)
+    await expect(page.getByTestId('home-heading')).toHaveText('Welcome Home')
+
+    const sources = await page
+      .locator('script[src]')
+      .evaluateAll((scripts) =>
+        scripts.map((script) => script.getAttribute('src')),
+      )
+    expect(sources).toContain(scriptUrl)
+    await expect(page.locator('html')).not.toHaveAttribute(
+      'data-asset-url-executed',
+      'yes',
+    )
+    expect(
+      await page.locator('script:not([src])').allTextContents(),
+    ).not.toContain(
+      'document.documentElement.setAttribute("data-asset-url-executed","yes")',
+    )
+  })
+}


### PR DESCRIPTION
## 🎯 Changes

Add browser regression tests for transformed script URLs containing closing script tags or quoted attributes. The fixture configures the public `createStartHandler` API and tests the actual SSR response: URL text must remain in the script's `src` attribute, the page must render, and injected inline JavaScript must not execute.

Validation: all 12 asset-transform application tests pass, including the two new cases; the build includes TypeScript checking. Changed files pass ESLint, and all 19 asset-transform unit tests pass.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [ ] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of transformed script asset URLs containing special characters.
  - Prevented potentially unsafe URL content from being interpreted as executable HTML or JavaScript.

- **Tests**
  - Added end-to-end coverage for script URLs attempting to escape script tags or HTML attributes.
  - Verified URLs remain intact and injected code does not execute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->