### PR TITLE
test(start): cover request-scoped RSC stylesheet isolation

### DIFF
--- a/e2e/react-start/rsc/src/routes/rsc-css-conditional.$branch.tsx
+++ b/e2e/react-start/rsc/src/routes/rsc-css-conditional.$branch.tsx
@@ -1,9 +1,12 @@
-import { ClientOnly, createFileRoute, Link } from '@tanstack/react-router'
+import { ClientOnly, Link, createFileRoute } from '@tanstack/react-router'
 import { getConditionalCssServerComponent } from '~/utils/conditionalCssServerComponent'
 import { pageStyles } from '~/utils/styles'
 
 export const Route = createFileRoute('/rsc-css-conditional/$branch')({
   loader: async ({ params: { branch } }) => {
+    if (branch === 'none') {
+      return { Server: null, branch: 'none' }
+    }
     const activeBranch = branch === 'violet' ? 'violet' : 'orange'
     const Server = await getConditionalCssServerComponent({
       data: { branch: activeBranch },

--- a/e2e/react-start/rsc/src/utils/conditionalOrange.module.css
+++ b/e2e/react-start/rsc/src/utils/conditionalOrange.module.css
@@ -1,4 +1,5 @@
 .panel {
+  --conditional-variant: orange;
   background: #ffedd5;
   border: 2px solid #f97316;
   border-radius: 10px;

--- a/e2e/react-start/rsc/tests/rsc-request-asset-isolation.spec.ts
+++ b/e2e/react-start/rsc/tests/rsc-request-asset-isolation.spec.ts
@@ -1,0 +1,45 @@
+import { readFile, readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import { expect, test } from '@playwright/test'
+
+test('RSC stylesheets stay scoped to each response for the same matched route', async ({
+  request,
+  page,
+}) => {
+  const clientDir = join(process.env.E2E_DIST_DIR ?? 'dist', 'client')
+  const cssFiles = (await readdir(clientDir, { recursive: true })).filter(
+    (file) => file.endsWith('.css'),
+  )
+  const stylesheets = await Promise.all(
+    cssFiles.map(async (file) => ({
+      href: '/' + file.split('\\').join('/'),
+      css: await readFile(join(clientDir, file), 'utf8'),
+    })),
+  )
+  const orange = stylesheets.filter(({ css }) =>
+    /--conditional-variant:\s*orange/.test(css),
+  )
+  expect(orange).toHaveLength(1)
+  const stylesheet = orange[0].href
+
+  for (const branch of ['orange', 'none', 'orange', 'none']) {
+    const response = await request.get(`/rsc-css-conditional/${branch}`)
+    expect(response.status()).toBe(200)
+    const html = await response.text()
+    const label = await page.evaluate((html) => {
+      const document = new DOMParser().parseFromString(html, 'text/html')
+      return document.querySelector(
+        '[data-testid="rsc-css-conditional-branch"]',
+      )?.textContent
+    }, html)
+    expect(label).toBe(`Active branch: ${branch}`)
+
+    // Check the complete SSR response, including hydration data: CSS can be
+    // replayed by the client even when it is absent from the initial head.
+    if (branch === 'orange') {
+      expect(html).toContain(stylesheet)
+    } else {
+      expect(html).not.toContain(stylesheet)
+    }
+  }
+})


### PR DESCRIPTION
## 🎯 Changes

Add a production SSR regression test that alternates RSC-rendering and non-RSC requests for the same matched route. The test identifies the fixture's stylesheet from the emitted CSS and checks the complete HTML response, including hydration data, so request-scoped assets cannot silently carry over to the next response.

The fixture adds a no-component variant and a CSS marker; no package implementation changes.

Validation: the new test and four existing conditional-CSS tests pass on both Vite and Rsbuild (ten total), with application type checks. Changed TypeScript files pass ESLint, and all nine SSR manifest unit tests pass.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [ ] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Conditional styling is now correctly isolated between responses, preventing styles from one branch from appearing on another.
  - Requests for the `none` branch now return without loading conditional server-rendered content.
  - Repeated navigation between styled and unstyled branches now consistently displays the correct content and styling.

- **Tests**
  - Added coverage to verify response status, branch rendering, and conditional stylesheet inclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->