### PR TITLE
test(start): cover prerender crawl request and output boundaries

### DIFF
--- a/e2e/react-start/basic/build-tests/README.md
+++ b/e2e/react-start/basic/build-tests/README.md
@@ -1,0 +1,22 @@
+# Build integration tests
+
+These Node.js tests exercise production builds and inspect their network and
+filesystem effects. They run separately from the browser tests in `tests/`.
+
+Run the suite from the repository root:
+
+```sh
+pnpm nx run tanstack-react-start-e2e-basic:test:build
+```
+
+The target participates in `pnpm test:build`, `pnpm test:ci`, and affected PR
+checks. Nx builds workspace dependencies first; each test owns its application
+build, so the target does not depend on the normal application `build` target.
+No Playwright browser or application web server is required.
+
+The crawl test starts a local HTTP listener before building to detect requests
+to another origin. It enables prerendering through `E2E_PRERENDER_CRAWL_ORIGIN`
+and writes to a temporary directory under the fixture's `node_modules`, keeping
+server dependencies resolvable and generated files outside the TypeScript check.
+The suite allows 120 seconds per test, including the build and type check; the
+build process has a shorter 100-second timeout to leave time for cleanup.

--- a/e2e/react-start/basic/build-tests/prerender-crawl.test.ts
+++ b/e2e/react-start/basic/build-tests/prerender-crawl.test.ts
@@ -1,19 +1,12 @@
+import assert from 'node:assert/strict'
 import { execFile } from 'node:child_process'
 import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
 import { createServer } from 'node:http'
 import { join } from 'node:path'
+import { test } from 'node:test'
 import { promisify } from 'node:util'
-import { expect, test } from '@playwright/test'
 
-// Exercise the public production build once, rather than rebuilding in every
-// browser/application mode. Both cases share one crawler invocation.
-test('prerender crawling keeps network requests and output files inside their boundaries', async () => {
-  test.skip(
-    (process.env.E2E_TOOLCHAIN ?? 'vite') !== 'vite' ||
-      (process.env.MODE ?? 'ssr') !== 'ssr',
-    'This test runs its own Vite prerender build',
-  )
-  test.setTimeout(120_000)
+test('prerender crawling keeps network requests and output files inside their boundaries', async (t) => {
   // Keep external package resolution available to the built SSR entry, while
   // excluding these temporary build artifacts from the app type check.
   const temporary = await mkdtemp(
@@ -48,35 +41,30 @@ test('prerender crawling keeps network requests and output files inside their bo
       maxBuffer: 10 * 1024 * 1024,
     })
 
-    await test.info().attach('prerender-build', {
-      body: build.stdout + build.stderr,
-      contentType: 'text/plain',
-    })
+    t.diagnostic(build.stdout + build.stderr)
     const clientDir = join(outDir, 'client')
     const seed = await readFile(
       join(clientDir, 'crawl-boundaries/seed/index.html'),
       'utf8',
     )
-    expect(seed).toContain(`/../../crawl-boundaries/escaped`)
-    expect(seed).toContain(`//127.0.0.1:${address.port}/external`)
-    expect(seed).toContain(`/%2F%2F127.0.0.1:${address.port}/encoded`)
-    expect(
-      await readFile(
-        join(clientDir, 'crawl-boundaries/safe/index.html'),
-        'utf8',
-      ),
-    ).toContain('crawl-boundaries:safe')
-    expect(requests).toEqual([])
+    assert.ok(seed.includes(`/../../crawl-boundaries/escaped`))
+    assert.ok(seed.includes(`//127.0.0.1:${address.port}/external`))
+    assert.ok(seed.includes(`/%2F%2F127.0.0.1:${address.port}/encoded`))
+    const safe = await readFile(
+      join(clientDir, 'crawl-boundaries/safe/index.html'),
+      'utf8',
+    )
+    assert.ok(safe.includes('crawl-boundaries:safe'))
+    assert.deepEqual(requests, [])
 
     const htmlFiles = (await readdir(temporary, { recursive: true })).filter(
       (file) => file.endsWith('.html'),
     )
-    expect(htmlFiles.length).toBeGreaterThanOrEqual(2)
+    assert.ok(htmlFiles.length >= 2)
     for (const file of htmlFiles) {
-      expect(file.split('\\').join('/')).toMatch(/^output\/client\//)
-      expect(await readFile(join(temporary, file), 'utf8')).not.toContain(
-        'external-crawl-content',
-      )
+      assert.match(file.split('\\').join('/'), /^output\/client\//)
+      const html = await readFile(join(temporary, file), 'utf8')
+      assert.ok(!html.includes('external-crawl-content'))
     }
   } finally {
     await new Promise<void>((resolve, reject) =>

--- a/e2e/react-start/basic/package.json
+++ b/e2e/react-start/basic/package.json
@@ -14,6 +14,7 @@
     "preview": "vite preview",
     "preview:rsbuild": "rsbuild preview",
     "start": "node server.js",
+    "test:build": "node --test --test-timeout=120000 build-tests/*.test.ts",
     "test:e2e:startDummyServer": "node -e 'import(\"./tests/setup/global.setup.ts\").then(m => m.default())' & node -e 'import(\"./tests/setup/waitForDummyServer.ts\").then(m => m.default())'",
     "test:e2e:stopDummyServer": "node -e 'import(\"./tests/setup/global.teardown.ts\").then(m => m.default())'",
     "test:e2e:local": "playwright test --project=chromium"
@@ -51,6 +52,20 @@
     "zod": "^4.4.3"
   },
   "nx": {
+    "targets": {
+      "test:build": {
+        "dependsOn": [
+          "^build"
+        ],
+        "inputs": [
+          "default",
+          "^buildProduction",
+          "dependentTaskOutputs"
+        ],
+        "outputs": [],
+        "parallelism": false
+      }
+    },
     "metadata": {
       "playwrightModes": [
         {

--- a/e2e/react-start/basic/src/routeTree.gen.ts
+++ b/e2e/react-start/basic/src/routeTree.gen.ts
@@ -29,6 +29,7 @@ import { Route as TypeOnlyReexportRouteImport } from './routes/type-only-reexpor
 import { Route as UsersRouteImport } from './routes/users'
 import { Route as LayoutLayout2RouteImport } from './routes/_layout/_layout-2'
 import { Route as ApiUsersRouteImport } from './routes/api.users'
+import { Route as CrawlBoundariesSplatRouteImport } from './routes/crawl-boundaries.$'
 import { Route as Issue6221DashboardRouteImport } from './routes/issue-6221.dashboard'
 import { Route as MultiCookieRedirectIndexRouteImport } from './routes/multi-cookie-redirect/index'
 import { Route as MultiCookieRedirectTargetRouteImport } from './routes/multi-cookie-redirect/target'
@@ -179,6 +180,11 @@ const LayoutLayout2Route = LayoutLayout2RouteImport.update({
 const ApiUsersRoute = ApiUsersRouteImport.update({
   id: '/api/users',
   path: '/api/users',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CrawlBoundariesSplatRoute = CrawlBoundariesSplatRouteImport.update({
+  id: '/crawl-boundaries/$',
+  path: '/crawl-boundaries/$',
   getParentRoute: () => rootRouteImport,
 } as any)
 const Issue6221DashboardRoute = Issue6221DashboardRouteImport.update({
@@ -480,6 +486,7 @@ export interface FileRoutesByFullPath {
   '/not-found/parent-boundary': typeof NotFoundParentBoundaryRouteRouteWithChildren
   '/specialChars/malformed': typeof SpecialCharsMalformedRouteRouteWithChildren
   '/api/users': typeof ApiUsersRouteWithChildren
+  '/crawl-boundaries/$': typeof CrawlBoundariesSplatRoute
   '/issue-6221/dashboard': typeof Issue6221DashboardRoute
   '/multi-cookie-redirect/target': typeof MultiCookieRedirectTargetRoute
   '/not-found/via-beforeLoad': typeof NotFoundViaBeforeLoadRoute
@@ -545,6 +552,7 @@ export interface FileRoutesByTo {
   '/type-only-reexport': typeof TypeOnlyReexportRoute
   '/specialChars/malformed': typeof SpecialCharsMalformedRouteRouteWithChildren
   '/api/users': typeof ApiUsersRouteWithChildren
+  '/crawl-boundaries/$': typeof CrawlBoundariesSplatRoute
   '/issue-6221/dashboard': typeof Issue6221DashboardRoute
   '/multi-cookie-redirect/target': typeof MultiCookieRedirectTargetRoute
   '/not-found/via-beforeLoad': typeof NotFoundViaBeforeLoadRoute
@@ -618,6 +626,7 @@ export interface FileRoutesById {
   '/specialChars/malformed': typeof SpecialCharsMalformedRouteRouteWithChildren
   '/_layout/_layout-2': typeof LayoutLayout2RouteWithChildren
   '/api/users': typeof ApiUsersRouteWithChildren
+  '/crawl-boundaries/$': typeof CrawlBoundariesSplatRoute
   '/issue-6221/dashboard': typeof Issue6221DashboardRoute
   '/multi-cookie-redirect/target': typeof MultiCookieRedirectTargetRoute
   '/not-found/via-beforeLoad': typeof NotFoundViaBeforeLoadRoute
@@ -692,6 +701,7 @@ export interface FileRouteTypes {
     | '/not-found/parent-boundary'
     | '/specialChars/malformed'
     | '/api/users'
+    | '/crawl-boundaries/$'
     | '/issue-6221/dashboard'
     | '/multi-cookie-redirect/target'
     | '/not-found/via-beforeLoad'
@@ -757,6 +767,7 @@ export interface FileRouteTypes {
     | '/type-only-reexport'
     | '/specialChars/malformed'
     | '/api/users'
+    | '/crawl-boundaries/$'
     | '/issue-6221/dashboard'
     | '/multi-cookie-redirect/target'
     | '/not-found/via-beforeLoad'
@@ -829,6 +840,7 @@ export interface FileRouteTypes {
     | '/specialChars/malformed'
     | '/_layout/_layout-2'
     | '/api/users'
+    | '/crawl-boundaries/$'
     | '/issue-6221/dashboard'
     | '/multi-cookie-redirect/target'
     | '/not-found/via-beforeLoad'
@@ -900,6 +912,7 @@ export interface RootRouteChildren {
   TypeOnlyReexportRoute: typeof TypeOnlyReexportRoute
   UsersRoute: typeof UsersRouteWithChildren
   ApiUsersRoute: typeof ApiUsersRouteWithChildren
+  CrawlBoundariesSplatRoute: typeof CrawlBoundariesSplatRoute
   Issue6221DashboardRoute: typeof Issue6221DashboardRoute
   MultiCookieRedirectTargetRoute: typeof MultiCookieRedirectTargetRoute
   RedirectTargetRoute: typeof RedirectTargetRouteWithChildren
@@ -1050,6 +1063,13 @@ declare module '@tanstack/react-router' {
       path: '/api/users'
       fullPath: '/api/users'
       preLoaderRoute: typeof ApiUsersRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/crawl-boundaries/$': {
+      id: '/crawl-boundaries/$'
+      path: '/crawl-boundaries/$'
+      fullPath: '/crawl-boundaries/$'
+      preLoaderRoute: typeof CrawlBoundariesSplatRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/issue-6221/dashboard': {
@@ -1688,6 +1708,7 @@ const rootRouteChildren: RootRouteChildren = {
   TypeOnlyReexportRoute: TypeOnlyReexportRoute,
   UsersRoute: UsersRouteWithChildren,
   ApiUsersRoute: ApiUsersRouteWithChildren,
+  CrawlBoundariesSplatRoute: CrawlBoundariesSplatRoute,
   Issue6221DashboardRoute: Issue6221DashboardRoute,
   MultiCookieRedirectTargetRoute: MultiCookieRedirectTargetRoute,
   RedirectTargetRoute: RedirectTargetRouteWithChildren,

--- a/e2e/react-start/basic/src/routes/crawl-boundaries.$.ts
+++ b/e2e/react-start/basic/src/routes/crawl-boundaries.$.ts
@@ -1,0 +1,28 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/crawl-boundaries/$')({
+  server: {
+    handlers: {
+      GET: ({ request }) => {
+        const page = new URL(request.url).pathname
+          .split('/')
+          .filter(Boolean)
+          .at(-1)
+        const origin = process.env.E2E_PRERENDER_CRAWL_ORIGIN
+        const links =
+          page === 'seed' && origin
+            ? `<a href="/crawl-boundaries/safe">safe</a>
+             <a href="/../../crawl-boundaries/escaped">traversal</a>
+             <a href="//${new URL(origin).host}/external">external</a>
+             <a href="/%2F%2F${new URL(origin).host}/encoded">encoded</a>`
+            : ''
+        return new Response(
+          `<html><body>crawl-boundaries:${page}${links}</body></html>`,
+          {
+            headers: { 'content-type': 'text/html' },
+          },
+        )
+      },
+    },
+  },
+})

--- a/e2e/react-start/basic/start-mode-config.ts
+++ b/e2e/react-start/basic/start-mode-config.ts
@@ -14,6 +14,20 @@ const rsbuildClientOutput: 'module' | 'iife' | undefined = (() => {
 })()
 
 export function getStartModeConfig() {
+  if (process.env.E2E_PRERENDER_CRAWL_ORIGIN) {
+    return {
+      pages: [{ path: '/crawl-boundaries/seed' }],
+      prerender: {
+        enabled: true,
+        autoStaticPathsDiscovery: false,
+        crawlLinks: true,
+        concurrency: 1,
+        retryCount: 0,
+        failOnError: false,
+      },
+    }
+  }
+
   return {
     spa: isSpaMode
       ? {

--- a/e2e/react-start/basic/tests/prerender-crawl.spec.ts
+++ b/e2e/react-start/basic/tests/prerender-crawl.spec.ts
@@ -1,0 +1,87 @@
+import { execFile } from 'node:child_process'
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import { expect, test } from '@playwright/test'
+
+// Exercise the public production build once, rather than rebuilding in every
+// browser/application mode. Both cases share one crawler invocation.
+test('prerender crawling keeps network requests and output files inside their boundaries', async () => {
+  test.skip(
+    (process.env.E2E_TOOLCHAIN ?? 'vite') !== 'vite' ||
+      (process.env.MODE ?? 'ssr') !== 'ssr',
+    'This test runs its own Vite prerender build',
+  )
+  test.setTimeout(120_000)
+  // Keep external package resolution available to the built SSR entry, while
+  // excluding these temporary build artifacts from the app type check.
+  const temporary = await mkdtemp(
+    join(process.cwd(), 'node_modules/.prerender-crawl-'),
+  )
+  const outDir = join(temporary, 'output')
+  const requests: Array<string | undefined> = []
+  const external = createServer((request, response) => {
+    requests.push(request.url)
+    response.writeHead(200, { 'content-type': 'text/html' })
+    response.end('<html>external-crawl-content</html>')
+  })
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      external.once('error', reject)
+      external.listen(0, '127.0.0.1', resolve)
+    })
+    const address = external.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Expected a listening HTTP server')
+    }
+    const origin = `http://127.0.0.1:${address.port}`
+    const build = await promisify(execFile)('pnpm', ['build:vite'], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        E2E_DIST_DIR: outDir,
+        E2E_PRERENDER_CRAWL_ORIGIN: origin,
+      },
+      timeout: 100_000,
+      maxBuffer: 10 * 1024 * 1024,
+    })
+
+    await test.info().attach('prerender-build', {
+      body: build.stdout + build.stderr,
+      contentType: 'text/plain',
+    })
+    const clientDir = join(outDir, 'client')
+    const seed = await readFile(
+      join(clientDir, 'crawl-boundaries/seed/index.html'),
+      'utf8',
+    )
+    expect(seed).toContain(`/../../crawl-boundaries/escaped`)
+    expect(seed).toContain(`//127.0.0.1:${address.port}/external`)
+    expect(seed).toContain(`/%2F%2F127.0.0.1:${address.port}/encoded`)
+    expect(
+      await readFile(
+        join(clientDir, 'crawl-boundaries/safe/index.html'),
+        'utf8',
+      ),
+    ).toContain('crawl-boundaries:safe')
+    expect(requests).toEqual([])
+
+    const htmlFiles = (await readdir(temporary, { recursive: true })).filter(
+      (file) => file.endsWith('.html'),
+    )
+    expect(htmlFiles.length).toBeGreaterThanOrEqual(2)
+    for (const file of htmlFiles) {
+      expect(file.split('\\').join('/')).toMatch(/^output\/client\//)
+      expect(await readFile(join(temporary, file), 'utf8')).not.toContain(
+        'external-crawl-content',
+      )
+    }
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      external.close((error) => (error ? reject(error) : resolve())),
+    )
+    await rm(temporary, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## 🎯 Changes

Add a real prerender-build regression test for crawl-discovered traversal and protocol-relative links, including encoded protocol-relative input. A fixture page supplies these links alongside a normal link. The test verifies that normal crawling works, a separate local HTTP server receives no requests, and every generated HTML file stays inside the client output directory.

The cases share one build and HTTP listener. The test uses the public build command and file-route handlers, with temporary output and listener cleanup. Changes are limited to the e2e fixture, its generated route tree, and tests.

Validation: the new build test passes with application TypeScript checks; changed source/test files pass ESLint, and all 21 existing prerender unit tests pass.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [ ] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added prerender crawl handling for dynamic crawl-boundary routes.
  - Supports safe traversal of relative, external, and encoded URLs without generating pages outside the client output.
  - Added build-time configuration for controlled prerender crawling.

- **Tests**
  - Added end-to-end coverage verifying generated pages, URL handling, output boundaries, and external request isolation.
  - Added a dedicated build test command with extended timeout support.

- **Documentation**
  - Documented the React Start build integration test suite, including setup, execution, and CI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->