### PR TITLE
docs: remove duplicate Router and Start page headings

### DIFF
--- a/docs/router/how-to/share-search-params-across-routes.md
+++ b/docs/router/how-to/share-search-params-across-routes.md
@@ -2,8 +2,6 @@
 title: Share Search Parameters Across Routes
 ---
 
-# How to Share Search Parameters Across Routes
-
 Search parameters automatically inherit from parent routes in TanStack Router. When a parent route validates search parameters, child routes can access them via `Route.useSearch()` alongside their own parameters.
 
 ## How Parameter Inheritance Works

--- a/docs/start/framework/react/guide/cdn-asset-urls.md
+++ b/docs/start/framework/react/guide/cdn-asset-urls.md
@@ -3,8 +3,6 @@ id: cdn-asset-urls
 title: CDN Asset URLs
 ---
 
-# CDN Asset URLs
-
 > **Experimental:** `transformAssets` is experimental and subject to change.
 
 Use this guide when you need TanStack Start to rewrite manifest-managed asset URLs at runtime. The most common use case is serving JavaScript and CSS from a CDN whose origin is known only when the server starts, or varies per request.

--- a/docs/start/framework/react/guide/client-entry-point.md
+++ b/docs/start/framework/react/guide/client-entry-point.md
@@ -3,8 +3,6 @@ id: client-entry-point
 title: Client Entry Point
 ---
 
-# Client Entry Point
-
 > [!NOTE]
 > The client entry point is **optional** out of the box. If not provided, TanStack Start will automatically handle the client entry point for you using the below as a default.
 

--- a/docs/start/framework/react/guide/early-hints.md
+++ b/docs/start/framework/react/guide/early-hints.md
@@ -3,8 +3,6 @@ id: early-hints
 title: Early Hints
 ---
 
-# Early Hints
-
 > **Experimental:** Early Hints are experimental and subject to change.
 
 HTTP `103 Early Hints` lets your server tell the browser about important resources before the final HTML response is ready. TanStack Start can collect route assets and route `head().links`, then call your server entry so your runtime can send `103` responses.

--- a/docs/start/framework/react/guide/server-entry-point.md
+++ b/docs/start/framework/react/guide/server-entry-point.md
@@ -3,8 +3,6 @@ id: server-entry-point
 title: Server Entry Point
 ---
 
-# Server Entry Point
-
 > [!NOTE]
 > The server entry point is **optional** out of the box. If not provided, TanStack Start will automatically handle the server entry point for you using the below as a default.
 

--- a/docs/start/framework/solid/guide/client-entry-point.md
+++ b/docs/start/framework/solid/guide/client-entry-point.md
@@ -3,8 +3,6 @@ id: client-entry-point
 title: Client Entry Point
 ---
 
-# Client Entry Point
-
 > [!NOTE]
 > The client entry point is **optional** out of the box. If not provided, TanStack Start will automatically handle the client entry point for you using the below as a default.
 


### PR DESCRIPTION
## 🎯 Changes

Remove redundant Markdown H1s from five Start guides and one Router guide so each page uses the title rendered from frontmatter.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [ ] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
