### PR TITLE
fix(router-core): stop forcing history.scrollRestoration to 'manual'

### DIFF
--- a/.changeset/scroll-restoration-browser-default.md
+++ b/.changeset/scroll-restoration-browser-default.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+Stop forcing `history.scrollRestoration = 'manual'` when scroll restoration is enabled. The browser's native restoration runs before first paint, so forcing manual mode broke iOS Safari swipe-back previews and made Chrome paint at the top and snap down on hard refresh; the router's own restoration still runs afterwards and still restores individual scroll containers.

--- a/packages/router-core/src/scroll-restoration.ts
+++ b/packages/router-core/src/scroll-restoration.ts
@@ -201,8 +201,6 @@ export function setupScrollRestoration(router: AnyRouter, force?: boolean) {
     scroll.restoration = true
     ignoreScroll = false
 
-    history.scrollRestoration = 'manual'
-
     document.addEventListener(
       'scroll',
       (event) => {

--- a/packages/router-core/tests/scroll-restoration.test.ts
+++ b/packages/router-core/tests/scroll-restoration.test.ts
@@ -70,7 +70,10 @@ describe('setupScrollRestoration', () => {
 
     expect(router._scroll.restoring).toBe(true)
     expect(router._scroll.restoration).toBe(true)
-    expect(window.history.scrollRestoration).toBe('manual')
+    // The browser's own restoration stays on: it handles the window before
+    // first paint (Safari swipe-back previews, hard refresh); the router only
+    // corrects afterwards and restores individual scroll containers.
+    expect(window.history.scrollRestoration).toBe('auto')
     expect(
       windowAddEventListener.mock.calls.some(([event]) => event === 'pagehide'),
     ).toBe(true)


### PR DESCRIPTION
## 🎯 Changes

Fixes #7956 (follow-up to #7815).

`setupScrollRestoration` still set `history.scrollRestoration = 'manual'` whenever `scrollRestoration: true`. Forcing manual mode turns off the browser's native pre-paint restore, which is what iOS Safari's swipe-back preview and Chrome's hard refresh rely on: Safari repainted at the wrong offset after the gesture, and Chrome painted at the top and snapped down a frame later. The router's own restore runs post-paint in the `onRendered` subscriber; it still runs, still corrects the window position and still restores individual scroll containers, none of which depend on manual mode.

This PR removes the assignment and leaves `history.scrollRestoration` on the browser default. As discussed in the issue it is a plain removal rather than an option: no case was found where `'manual'` restores better than native restore plus the router's corrector, so an opt-in would only preserve the regression path.

- `packages/router-core/src/scroll-restoration.ts`: drop the `history.scrollRestoration = 'manual'` assignment.
- `packages/router-core/tests/scroll-restoration.test.ts`: the setup test now asserts that `scrollRestoration` stays `'auto'`, with a comment explaining why.
- Changeset for `@tanstack/router-core` (patch).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll restoration during browser navigation and hard refreshes.
  * Preserved the browser’s native scroll restoration before the page’s first paint, improving swipe-back previews and preventing visible scroll jumps.
  * Continued restoring scroll positions for individual containers after navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->