### PR TITLE
fix(router-core): handle constructor search fields without throwing

### DIFF
--- a/.changeset/green-areas-shine.md
+++ b/.changeset/green-areas-shine.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/router-core': patch
+---
+
+Prevent constructor fields in search parameters from crashing router initialization or client navigation, including null values and objects that shadow hasOwnProperty.

--- a/packages/router-core/src/utils.ts
+++ b/packages/router-core/src/utils.ts
@@ -337,13 +337,13 @@ export function isPlainObject(o: any) {
   }
 
   // If has modified prototype
-  const prot = ctor.prototype
+  const prot = ctor?.prototype
   if (!hasObjectPrototype(prot)) {
     return false
   }
 
   // If constructor does not have an Object-specific method
-  if (!prot.hasOwnProperty('isPrototypeOf')) {
+  if (!hasOwn.call(prot, 'isPrototypeOf')) {
     return false
   }
 

--- a/packages/router-core/tests/search-constructor.test.ts
+++ b/packages/router-core/tests/search-constructor.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test, vi } from 'vitest'
+import { createMemoryHistory } from '@tanstack/history'
+import { BaseRootRoute, BaseRoute } from '../src'
+import { createTestRouter } from './routerTestUtils'
+
+describe('search parameters with constructor data', () => {
+  test.each([
+    ['null', null],
+    ['zero', 0],
+    ['string', 'model'],
+    ['object', { prototype: { hasOwnProperty: null } }],
+  ])('initializes and loads with a %s constructor field', async (_, value) => {
+    const rootRoute = new BaseRootRoute({})
+    const loader = vi.fn(() => 'loaded')
+    const validateSearch = vi.fn(() => ({}))
+    const route = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      validateSearch,
+      loader,
+    })
+    const history = createMemoryHistory({
+      initialEntries: [
+        `/?constructor=${encodeURIComponent(JSON.stringify(value))}`,
+      ],
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([route]),
+      history,
+      isServer: false,
+      search: { strict: true },
+    })
+
+    await router.load()
+
+    expect(loader).toHaveBeenCalledOnce()
+    expect(validateSearch).toHaveBeenCalled()
+    expect(router.state.matches.at(-1)?.loaderData).toBe('loaded')
+  })
+
+  test('preserves constructor data during client navigation', async () => {
+    const rootRoute = new BaseRootRoute({})
+    const route = new BaseRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      validateSearch: (search: Record<string, unknown>) => search,
+    })
+    const router = createTestRouter({
+      routeTree: rootRoute.addChildren([route]),
+      history: createMemoryHistory(),
+      isServer: false,
+    })
+    await router.load()
+
+    await router.navigate({ to: '/', search: { constructor: null } })
+
+    expect(router.state.location.search.constructor).toBeNull()
+    expect(router.state.location.href).toBe('/?constructor=null')
+    await router.navigate({ to: '/', search: { constructor: 'model' } })
+    expect(router.state.location.search.constructor).toBe('model')
+  })
+})


### PR DESCRIPTION
## 🎯 Changes

Visiting `/?constructor=null` with the default search parser throws during client router initialization, before `validateSearch` can run, even with `search.strict: true`. Client navigation with the same search value also throws. A JSON `constructor` object whose `prototype.hasOwnProperty` is not callable triggers a similar failure.

`isPlainObject` reads the input's `constructor` field as constructor metadata. Guard the nullable prototype access and use the existing `hasOwn` helper instead of calling a method on that metadata.

Add regression coverage for initial loading with strict search validation and for preserving `constructor` search values during client navigation. The failing inputs were reproduced with `@tanstack/react-router@1.170.35` in a production browser bundle; with the fix, the route renders and subsequent navigation works.

### Validation

- Before the fix, three of the five new regression cases fail; all five pass with the fix.
- Router Core unit tests, all six configured TypeScript checks, lint, and build pass locally. The production browser reproduction also initializes and navigates successfully after the fix.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed router initialization and navigation crashes when search parameters include a `constructor` field.
  - Search parameters with `null`, numeric, text, or object values are now safely encoded, parsed, and preserved in the URL and router state.
  - Improved handling of search parameter objects with missing constructors or custom `hasOwnProperty` values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->