### PR TITLE
perf(history): avoid temporary arrays in memory history

### DIFF
--- a/.changeset/history-forward-entries.md
+++ b/.changeset/history-forward-entries.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/history': patch
+---
+
+Avoid temporary arrays when replacing forward memory-history entries.

--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -663,13 +663,13 @@ export function createMemoryHistory(
     getLength: () => entries.length,
     pushState: (path, state) => {
       // Removes all subsequent entries after the current index to start a new branch
+      index = index < entries.length - 1 ? index + 1 : entries.length
+      states[index] = state
+      entries[index] = path
       if (index < entries.length - 1) {
-        entries.splice(index + 1)
-        states.splice(index + 1)
+        entries.length = index + 1
+        states.length = index + 1
       }
-      states.push(state)
-      entries.push(path)
-      index = Math.max(entries.length - 1, 0)
     },
     replaceState: (path, state) => {
       states[index] = state

--- a/packages/history/tests/createMemoryHistory.test.ts
+++ b/packages/history/tests/createMemoryHistory.test.ts
@@ -70,6 +70,38 @@ describe('createMemoryHistory', () => {
     expect(history.location.pathname).toBe('/b')
   })
 
+  test('discards forward entries and their state when pushing a new branch', () => {
+    const initialEntries = ['/']
+    const history = createMemoryHistory({ initialEntries })
+    history.push('/kept', { marker: 'kept' })
+    const keptState = history.location.state
+    history.push('/discarded-first', { marker: 'discarded-first' })
+    history.push('/discarded-last', { marker: 'discarded-last' })
+    history.go(-2)
+    history.push('/new', { marker: 'new' })
+
+    expect(initialEntries).toEqual(['/', '/kept', '/new'])
+    expect(history.length).toBe(3)
+    expect(history.location.pathname).toBe('/new')
+    expect(history.location.state).toMatchObject({
+      __TSR_index: 2,
+      marker: 'new',
+    })
+    const newState = history.location.state
+
+    history.forward()
+    expect(history.location.pathname).toBe('/new')
+    expect(history.location.state).toBe(newState)
+
+    history.back()
+    expect(history.location.pathname).toBe('/kept')
+    expect(history.location.state).toBe(keptState)
+
+    history.forward()
+    expect(history.location.pathname).toBe('/new')
+    expect(history.location.state).toBe(newState)
+  })
+
   test('length', () => {
     const history = createMemoryHistory()
     expect(history.length).toBe(1)


### PR DESCRIPTION
## 🎯 Changes

Write the next memory-history URL and state directly at the destination index, then truncate any remaining forward entries. This avoids the two unused arrays returned by `splice` when a push creates a new branch. Backward/forward navigation and retained state stay unchanged.

### Performance

Local Node.js 24.12.0 comparison of `6494e75362` and `ea0bcb8690`. Allocation rows are medians of three heap-sampling profiles with a 4,096-byte sampling interval; history setup is outside the measurement window.

| Workload | Before | After | Change |
| --- | ---: | ---: | ---: |
| 100,000 one-entry branches, sampled allocation bytes | 174,676,312 | 163,961,904 | -6.1% |
| 4,096 pushes discarding 64 forward entries each, sampled allocation bytes | 9,232,904 | 4,443,224 | -51.9% |
| Standalone memory-history bundle, gzip | 1,225 bytes | 1,220 bytes | -5 bytes |

These allocation estimates include objects collected by GC; they are not retained-heap measurements. The standalone bundle uses Vite 8.0.14, minified ESM, `es2022`, and gzip level 9. Browser-history-only output is byte-identical.

Longer ordinary-push measurements were effectively unchanged: median elapsed time was 80.392 ms before and 80.315 ms after; CPU time was 100.221 ms before and 100.421 ms after, across nine counterbalanced samples of 150,000 pushes. This PR claims allocation savings, not a stable navigation-speed improvement.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory-history behavior when navigating back and creating a new entry, correctly removing forward entries while preserving the active history.
  * Back and forward navigation now maintains the expected entries and state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->