### PR TITLE
perf(history): use lightweight history for server rendering

### DIFF
--- a/.changeset/sad-pans-design.md
+++ b/.changeset/sad-pans-design.md
@@ -1,0 +1,7 @@
+---
+'@tanstack/start-server-core': patch
+'@tanstack/router-core': patch
+'@tanstack/history': patch
+---
+
+Use lightweight request history for SSR and make server navigation a no-op. Use redirect() to issue HTTP redirects. Server hrefs use the same normalization as browser history to handle protocol-relative URLs and control characters.

--- a/docs/router/guide/history-types.md
+++ b/docs/router/guide/history-types.md
@@ -9,6 +9,7 @@ If you don't create a history instance, a browser-oriented instance of this API 
 - `createBrowserHistory`: The default history type.
 - `createHashHistory`: A history type that uses a hash to track history.
 - `createMemoryHistory`: A history type that keeps the history in memory.
+- `createServerHistory`: A history type with a fixed request URL and no-op navigation, used by the SSR request handlers.
 
 Once you have a history instance, you can pass it to the `Router` constructor:
 

--- a/docs/router/guide/ssr.md
+++ b/docs/router/guide/ssr.md
@@ -60,7 +60,9 @@ To implement non-streaming SSR with TanStack Router, you will need the following
 
 ### Automatic Server History
 
-On the client, Router defaults to using an instance of `createBrowserHistory`, which is the preferred type of history to use on the client. On the server, however, you will want to use an instance of `createMemoryHistory` instead. This is because `createBrowserHistory` uses the `window` object, which does not exist on the server. This is handled automatically for you in the RouterServer component.
+On the client, Router defaults to using an instance of `createBrowserHistory`. On the server, the Router SSR request handler and TanStack Start automatically create a lightweight history containing only the request URL. This history does not keep a navigation stack or respond to `push`, `replace`, `go`, `back`, or `forward` calls.
+
+Server-side calls to `router.navigate()` and `router.commitLocation()` are also no-ops: their promises resolve without changing the request location or running another load. To redirect a request, use the dedicated [redirect API](../api/router/redirectFunction.md), such as `throw redirect({ to: '/login' })` in `beforeLoad` or a loader.
 
 ### Automatic Loader Dehydration/Hydration
 

--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -690,6 +690,58 @@ export function createMemoryHistory(
   })
 }
 
+const noop = () => {}
+
+class ServerHistory implements RouterHistory {
+  declare private _subscribers?: RouterHistory['subscribers']
+
+  constructor(public location: HistoryLocation) {}
+
+  get length() {
+    return 1
+  }
+
+  // Preserve the history interface without allocating a Set for each request.
+  get subscribers() {
+    return (this._subscribers ??= new Set())
+  }
+
+  subscribe() {
+    return noop
+  }
+
+  push() {}
+  replace() {}
+  go() {}
+  back() {}
+  forward() {}
+
+  canGoBack() {
+    return false
+  }
+
+  createHref(href: string) {
+    return normalizeHref(href)
+  }
+
+  block() {
+    return noop
+  }
+
+  flush() {}
+  destroy() {}
+  notify() {}
+
+  _getBlockers(): Array<NavigationBlocker> {
+    return []
+  }
+}
+
+/** A fixed request location; server navigation is a no-op. */
+export function createServerHistory(href: string): RouterHistory {
+  return new ServerHistory(parseHref(href, undefined))
+}
+
 export function parseHref(
   href: string,
   state: ParsedHistoryState | undefined,

--- a/packages/history/tests/createServerHistory.test.ts
+++ b/packages/history/tests/createServerHistory.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test, vi } from 'vitest'
+import {
+  createBrowserHistory,
+  createMemoryHistory,
+  createServerHistory,
+} from '../src'
+
+describe('server history', () => {
+  test.each([
+    '/',
+    '/posts/123?sort=new#comments',
+    '/caf%C3%A9?q=%2F#//section',
+    '//example.com/path',
+    '/\\example.com/path',
+    '/path\nname?value=\u0000',
+  ])('parses and sanitizes %j like memory history', (href) => {
+    const history = createServerHistory(href)
+    const memory = createMemoryHistory({ initialEntries: [href] })
+    expect(history.location).toEqual({
+      ...memory.location,
+      state: {
+        key: expect.any(String),
+        __TSR_key: expect.any(String),
+        __TSR_index: 0,
+      },
+    })
+    expect(history.location.state.key).toBe(history.location.state.__TSR_key)
+  })
+
+  test.each([
+    '//evil.example/path',
+    '/\\evil.example/path',
+    '\\/evil.example/path',
+    '\\\\evil.example/path',
+    ' \t/\r\\evil.example/path',
+    '/\t/evil.example/path',
+    '/a\tb?q=a\nb#section\r',
+    '/a\u0000b?q=a\u0001b#section\u007f',
+    '/',
+    '/posts/123?sort=new#comments',
+    '/caf%C3%A9?q=%2F#//section',
+    '/a//b?q=//value#\\/section',
+    '/%2Fevil.example/path',
+  ])('normalizes href %j like browser history', (href) => {
+    const history = createServerHistory('/request')
+    const browser = createBrowserHistory()
+    try {
+      expect(history.createHref(href)).toBe(browser.createHref(href))
+      expect(history.location.href).toBe('/request')
+    } finally {
+      browser.destroy()
+    }
+  })
+
+  test('ignores navigation, subscriptions, and blockers', () => {
+    const history = createServerHistory('/request?q=1')
+    const location = history.location
+    const subscriber = vi.fn()
+    const blockerFn = vi.fn(() => true)
+    const unsubscribe = history.subscribe(subscriber)
+    const unblock = history.block({ blockerFn })
+
+    history.push('/pushed', { value: 1 })
+    history.replace('/replaced', { value: 2 })
+    history.go(-1)
+    history.back()
+    history.forward()
+    history.notify({ type: 'PUSH' })
+    history.flush()
+    history.destroy()
+    unsubscribe()
+    unblock()
+
+    expect(history.location).toBe(location)
+    expect(history.length).toBe(1)
+    expect(history.canGoBack()).toBe(false)
+    expect(history.subscribers.size).toBe(0)
+    expect(history._getBlockers()).toEqual([])
+    expect(subscriber).not.toHaveBeenCalled()
+    expect(blockerFn).not.toHaveBeenCalled()
+  })
+
+  test('isolates state and exposed collections between requests', () => {
+    const first = createServerHistory('/first')
+    const second = createServerHistory('/second')
+    first.location.state.__TSR_index = 10
+    first.subscribers.add(vi.fn())
+    first._getBlockers().push({ blockerFn: () => true })
+
+    expect(second.location.pathname).toBe('/second')
+    expect(second.location.state.__TSR_index).toBe(0)
+    expect(second.subscribers.size).toBe(0)
+    expect(second._getBlockers()).toEqual([])
+  })
+})

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -2185,6 +2185,10 @@ export class RouterCore<
     ignoreBlocker,
     ...next
   }) => {
+    if (isServer ?? this.isServer) {
+      return
+    }
+
     const nextLocation = next.maskedLocation ?? next
     if (nextLocation.external && !(isServer ?? this.isServer)) {
       return documentNavigation(this, nextLocation.publicHref, {
@@ -2287,6 +2291,10 @@ export class RouterCore<
     ignoreBlocker,
     ...rest
   }: BuildNextOptions & CommitLocationOptions = {}): Promise<void> => {
+    if (isServer ?? this.isServer) {
+      return Promise.resolve()
+    }
+
     const location = this.buildLocation({
       ...(rest as any),
       _includeValidateSearch: true,
@@ -2330,6 +2338,10 @@ export class RouterCore<
     publicHref,
     ...rest
   }) => {
+    if (isServer ?? this.isServer) {
+      return
+    }
+
     const hrefScheme = href ? getUrlScheme(href) : undefined
 
     if (hrefScheme || reloadDocument) {

--- a/packages/router-core/src/ssr/createRequestHandler.ts
+++ b/packages/router-core/src/ssr/createRequestHandler.ts
@@ -1,4 +1,4 @@
-import { createMemoryHistory } from '@tanstack/history'
+import { createServerHistory } from '@tanstack/history'
 import { _getRenderedMatches } from '../load-client'
 import { mergeHeaders } from './headers'
 import {
@@ -118,9 +118,7 @@ export function createRequestHandler<TRouter extends AnyRouter>({
       const href = url.href.replace(url.origin, '')
 
       // Create a history for the router
-      const history = createMemoryHistory({
-        initialEntries: [href],
-      })
+      const history = createServerHistory(href)
 
       // Update the router with the history and context
       router.update({

--- a/packages/router-core/tests/document-navigation.test.ts
+++ b/packages/router-core/tests/document-navigation.test.ts
@@ -177,13 +177,13 @@ describe('document navigation', () => {
     expect(windowLocation.replace).not.toHaveBeenCalled()
   })
 
-  test('keeps server commits in memory history', async () => {
+  test('ignores server navigation to an external output', async () => {
     const { router, history } = setupRouter({ isServer: true })
     vi.stubGlobal('window', undefined)
 
     await router.navigate({ to: '/admin' })
 
-    expect(history.location.href).toBe(externalHref)
+    expect(history.location.href).toBe('/')
   })
 
   test.each([

--- a/packages/router-core/tests/server-history.test.ts
+++ b/packages/router-core/tests/server-history.test.ts
@@ -1,0 +1,112 @@
+import { createMemoryHistory, createServerHistory } from '@tanstack/history'
+import { expect, test, vi } from 'vitest'
+import { BaseRootRoute, BaseRoute, redirect } from '../src'
+import { createTestRouter, loadServerResponse } from './routerTestUtils'
+
+test.each([false, true])(
+  'router navigation respects isServer=%s with memory history',
+  async (isServer) => {
+    const root = new BaseRootRoute()
+    const targetLoader = vi.fn(() => 'target')
+    const router = createTestRouter({
+      isServer,
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+      routeTree: root.addChildren([
+        new BaseRoute({ getParentRoute: () => root, path: '/' }),
+        new BaseRoute({
+          getParentRoute: () => root,
+          path: '/target',
+          loader: targetLoader,
+        }),
+      ]),
+    })
+    await router.load()
+    const load = vi.spyOn(router, 'load')
+
+    await router.navigate({ to: '/target' })
+    expect(router.history.length).toBe(isServer ? 1 : 2)
+    expect(router.state.location.pathname).toBe(isServer ? '/' : '/target')
+    await router.navigate({ to: '/', replace: true })
+    expect(router.history.length).toBe(isServer ? 1 : 2)
+    expect(router.history.location.pathname).toBe('/')
+    expect(targetLoader).toHaveBeenCalledTimes(isServer ? 0 : 1)
+    expect(load).toHaveBeenCalledTimes(isServer ? 0 : 2)
+  },
+)
+
+test('server navigation entry points resolve without building or loading', async () => {
+  const router = createTestRouter({
+    isServer: true,
+    history: createServerHistory('/'),
+    routeTree: new BaseRootRoute(),
+  })
+  const location = router.buildLocation({ to: '/' })
+  const build = vi.spyOn(router, 'buildLocation')
+  const load = vi.spyOn(router, 'load')
+  await router.navigate({ to: '/' })
+  await router.navigate({ href: 'https://example.com', reloadDocument: true })
+  await router.navigate({ to: '/', reloadDocument: true, replace: true })
+  await router.buildAndCommitLocation({ to: '/' })
+  await router.commitLocation(location)
+
+  expect(build).not.toHaveBeenCalled()
+  expect(load).not.toHaveBeenCalled()
+  expect(router._pendingLocation).toBeUndefined()
+  expect(router._commitPromise).toBeUndefined()
+})
+
+test.each(['beforeLoad', 'loader'] as const)(
+  'navigation during %s leaves the request load intact',
+  async (hook) => {
+    const targetLoader = vi.fn()
+    const root = new BaseRootRoute()
+    const router = createTestRouter({
+      isServer: true,
+      routeTree: root.addChildren([
+        new BaseRoute({
+          getParentRoute: () => root,
+          path: '/',
+          [hook]: async ({
+            navigate,
+          }: {
+            navigate: (opts: { to: string }) => Promise<void>
+          }) => {
+            await navigate({ to: '/target' })
+            return { value: 'request data' }
+          },
+        }),
+        new BaseRoute({
+          getParentRoute: () => root,
+          path: '/target',
+          loader: targetLoader,
+        }),
+      ]),
+    })
+    const load = vi.spyOn(router, 'load')
+    const response = await loadServerResponse(router, '/')
+
+    expect(response.status).toBe(200)
+    expect(load).toHaveBeenCalledTimes(1)
+    expect(targetLoader).not.toHaveBeenCalled()
+    expect(router.state.location.pathname).toBe('/')
+    expect(router.history.location.pathname).toBe('/')
+    expect(router.state.matches.at(-1)?.status).toBe('success')
+    router.history.push('/target')
+    expect(router.history.location.pathname).toBe('/')
+  },
+)
+
+test('server redirects still produce HTTP redirect responses', async () => {
+  const router = createTestRouter({
+    isServer: true,
+    routeTree: new BaseRootRoute({
+      beforeLoad: () => {
+        throw redirect({ href: '/login', statusCode: 307 })
+      },
+    }),
+  })
+  const response = await loadServerResponse(router, '/')
+  expect(response.status).toBe(307)
+  expect(response.headers.get('Location')).toBe('/login')
+  expect(router.history.location.pathname).toBe('/')
+})

--- a/packages/start-server-core/src/createStartHandler.ts
+++ b/packages/start-server-core/src/createStartHandler.ts
@@ -1,4 +1,4 @@
-import { createMemoryHistory } from '@tanstack/history'
+import { createServerHistory } from '@tanstack/history'
 import {
   createCsrfMiddleware,
   createNullProtoObject,
@@ -551,9 +551,7 @@ export function createStartHandler<TRegister = Register>(
           isShell = request.headers.get(HEADERS.TSS_SHELL) === 'true'
         }
 
-        const history = createMemoryHistory({
-          initialEntries: [href],
-        })
+        const history = createServerHistory(href)
 
         router.update({
           history,

--- a/packages/start-server-core/tests/createStartHandler.test.ts
+++ b/packages/start-server-core/tests/createStartHandler.test.ts
@@ -553,6 +553,31 @@ describe('createStartHandler redirect safety', () => {
   )
 })
 
+it('keeps the request URL when server code attempts navigation', async () => {
+  const loader = vi.fn(async () => {
+    const router = startMocks.router!
+    router.history.push('/pushed')
+    router.history.replace('/replaced')
+    await router.navigate({ to: '/navigated' })
+    return 'request data'
+  })
+  const router = makeRouterWithRouteWork({ loader })
+  startMocks.router = router
+  const load = vi.spyOn(router, 'load')
+  const handler = createStartHandler(({ router: loadedRouter }) => {
+    expect(loadedRouter.state.location.pathname).toBe('/work')
+    expect(loadedRouter.history.location.pathname).toBe('/work')
+    expect(loadedRouter.history.length).toBe(1)
+    return new Response(loadedRouter.state.matches.at(-1)?.loaderData as string)
+  })
+  const response = await handler(new Request('http://localhost/work'), {})
+
+  expect(response.status).toBe(200)
+  expect(await response.text()).toBe('request data')
+  expect(loader).toHaveBeenCalledTimes(1)
+  expect(load).toHaveBeenCalledTimes(1)
+})
+
 describe('createStartHandler SSR cleanup ownership', () => {
   it('preserves serverFn stream cleanup ownership through early return', async () => {
     startMocks.requestMiddleware = []


### PR DESCRIPTION
## 🎯 Changes

SSR handlers currently allocate a full memory history for each request, including a navigation stack and per-instance callbacks. Add `createServerHistory` to `@tanstack/history` and use it in Router and Start SSR handlers. It keeps one request location, shares methods, and uses the same href normalization as browser history.

Server calls to `navigate`, `buildAndCommitLocation`, and `commitLocation` now resolve without changing the location or starting another load. HTTP redirects continue to use `redirect()`. These guards use the existing `isServer` flag, preserving client navigation behavior.

Includes regression coverage for href normalization, request isolation, no-op server navigation, HTTP redirects, and client push/replace behavior, plus SSR documentation updates.

Previously validated locally: 3,405 tests passed across history, Router Core, and Start server, along with their type, lint, and package build checks. No additional checks were run when opening this PR.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lightweight server-side history for SSR requests, preserving the request URL without maintaining navigation history.
  * Added `createServerHistory` for server request handlers.
  * Server-side navigation is now safely ignored; redirects continue to produce HTTP redirect responses.
  * Server href normalization now matches browser history, including protocol-relative URLs and control characters.

* **Documentation**
  * Updated SSR and history guides with server-history behavior and redirect guidance.

* **Bug Fixes**
  * Prevented server-side navigation during route loading from changing URLs or triggering unintended loaders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->