### PR TITLE
fix(history): normalize memory history hrefs

### DIFF
--- a/.changeset/happy-turkeys-write.md
+++ b/.changeset/happy-turkeys-write.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/history': patch
+---
+
+Normalize memory history hrefs consistently with browser and server history, including protocol-relative paths and control characters.

--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -684,7 +684,7 @@ export function createMemoryHistory(
     go: (n) => {
       index = Math.min(Math.max(index + n, 0), entries.length - 1)
     },
-    createHref: (path) => path,
+    createHref: normalizeHref,
     getBlockers: _getBlockers,
     setBlockers: _setBlockers,
   })

--- a/packages/history/tests/createMemoryHistory.test.ts
+++ b/packages/history/tests/createMemoryHistory.test.ts
@@ -2,6 +2,35 @@ import { describe, expect, test, vi } from 'vitest'
 import { createMemoryHistory } from '../src'
 
 describe('createMemoryHistory', () => {
+  test.each([
+    ['//example.com/path', '/example.com/path'],
+    ['/\\example.com/path', '/example.com/path'],
+    ['\\/example.com/path', '/example.com/path'],
+    ['\\\\example.com/path', '/example.com/path'],
+    [' \t/\r\\example.com/path', '/example.com/path'],
+    ['/\t/example.com/path', '/example.com/path'],
+    ['/a\tb?q=a\nb#section\r', '/ab?q=ab#section'],
+    ['/a\u0000b?q=a\u0001b#section\u007f', '/a%00b?q=a%01b#section%7F'],
+    ['/', '/'],
+    ['/posts/123?sort=new#comments', '/posts/123?sort=new#comments'],
+    ['/caf%C3%A9?q=%2F#//section', '/caf%C3%A9?q=%2F#//section'],
+    ['/a//b?q=//value#\\/section', '/a//b?q=//value#\\/section'],
+    ['/%2Fexample.com/path', '/%2Fexample.com/path'],
+  ])('creates href %j consistent with navigation', (href, expected) => {
+    const history = createMemoryHistory()
+    const location = history.location
+    const createdHref = history.createHref(href)
+
+    expect(createdHref).toBe(expected)
+    expect(history.location).toBe(location)
+    expect(new URL(createdHref, 'https://app.example').origin).toBe(
+      'https://app.example',
+    )
+
+    history.push(href)
+    expect(history.location.href).toBe(createdHref)
+  })
+
   test('exposes the current blocker registry after registration and removal', () => {
     const history = createMemoryHistory()
     const first = { blockerFn: vi.fn(() => true) }


### PR DESCRIPTION
## 🎯 Changes

Memory history normalizes locations through `parseHref`, but its `createHref` currently returns the input unchanged. For example, pushing `//example.com/path` produces the location `/example.com/path`, while formatting the same input produces a protocol-relative link.

Use `normalizeHref` in memory history's `createHref` so generated hrefs match navigation and the browser/server history implementations. Add 13 regression cases covering protocol-relative prefixes, slash/backslash variants, control characters, and preservation of ordinary and encoded paths. Include a patch changeset for `@tanstack/history`.

Follow-up to #8308 and #8354.

Validation:
- Confirmed eight new cases fail before the fix; all 118 history tests pass afterward.
- `pnpm test:eslint --outputStyle=stream --skipRemoteCache`
- `pnpm test:types --outputStyle=stream --skipRemoteCache`
- `pnpm test:unit --outputStyle=stream --skipRemoteCache`
- Prettier and `git diff --check`.
- React basic example browser smoke test, including a native anchor check against the built memory-history implementation.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [ ] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Memory history links are now normalized consistently with browser and server history.
  * Protocol-relative paths and control characters are handled correctly when generating links.
  * Generated links now resolve to the application’s origin and remain consistent after navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->