### PR TITLE
docs(start): fix tutorial and ISR guide links

### DIFF
--- a/docs/start/framework/react/guide/isr.md
+++ b/docs/start/framework/react/guide/isr.md
@@ -492,5 +492,5 @@ Track key metrics:
 - [Static Prerendering](./static-prerendering.md) - Build-time page generation
 - [Hosting](./hosting.md) - CDN deployment configurations
 - [Server Functions](./server-functions.md) - Creating dynamic data endpoints
-- [Data Loading](../../../../router/guide/data-loading.md) - Client-side cache control
+- [Data Loading](/router/latest/docs/guide/data-loading) - Client-side cache control
 - [Middleware](./middleware.md) - Request/response customization

--- a/docs/start/framework/react/tutorial/reading-writing-file.md
+++ b/docs/start/framework/react/tutorial/reading-writing-file.md
@@ -152,7 +152,7 @@ export type JokesData = Joke[]
 
 ### Step 1.3: Create Server Functions to Read the File
 
-Let's create a new file `src/serverActions/jokesActions.ts` to create a server function to perform a read-write operation. We will be creating a server function using [`createServerFn`](https://tanstack.com/start/latest/docs/framework/react/server-functions).
+Let's create a new file `src/serverActions/jokesActions.ts` to create a server function to perform a read-write operation. We will be creating a server function using [`createServerFn`](https://tanstack.com/start/latest/docs/framework/react/guide/server-functions).
 
 ```tsx
 // src/serverActions/jokesActions.ts

--- a/docs/start/framework/solid/tutorial/reading-writing-file.md
+++ b/docs/start/framework/solid/tutorial/reading-writing-file.md
@@ -152,7 +152,7 @@ export type JokesData = Joke[]
 
 ### Step 1.3: Create Server Functions to Read the File
 
-Let's create a new file `src/serverActions/jokesActions.ts` to create a server function to perform a read-write operation. We will be creating a server function using [`createServerFn`](https://tanstack.com/start/latest/docs/framework/solid/server-functions).
+Let's create a new file `src/serverActions/jokesActions.ts` to create a server function to perform a read-write operation. We will be creating a server function using [`createServerFn`](https://tanstack.com/start/latest/docs/framework/solid/guide/server-functions).
 
 ```tsx
 // src/serverActions/jokesActions.ts


### PR DESCRIPTION
## 🎯 Changes

Fix the file tutorial links to `createServerFn` in React and Solid, and point the ISR guide's data-loading link at the Router guide. The old URLs led to a generic docs page instead of the referenced guide.

This includes the original tutorial fix from #7683, with its commit and authorship preserved. All three destinations were checked against source and the live website. The authentication links are covered separately by #7705.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

Ran `pnpm test:eslint`, `pnpm test:types`, and `pnpm test:unit` against `origin/main`. Nx found no affected package tasks for these documentation-only changes. Prettier passed for all three changed files. Live destination checks returned the intended pages with HTTP 200.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated related-resource links in the React ISR guide.
  * Corrected `createServerFn` links in the React and Solid file-reading tutorials.
  * Improved navigation to the relevant Router and framework-specific server-function documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->