### PR TITLE
docs(start): describe key search entry pages

### DIFF
--- a/docs/start/framework/react/getting-started.md
+++ b/docs/start/framework/react/getting-started.md
@@ -3,6 +3,7 @@ id: getting-started
 title: Getting Started
 redirect_from:
   - /framework/react/quick-start
+description: Create a TanStack Start application with TanStack Builder, the CLI, or a working example, then run it locally and start adding routes.
 ---
 
 ## Start a new project

--- a/docs/start/framework/react/guide/authentication-overview.md
+++ b/docs/start/framework/react/guide/authentication-overview.md
@@ -1,6 +1,7 @@
 ---
 id: authentication-overview
 title: Authentication
+description: Compare authentication options for TanStack Start and plan session management, route protection, and server-side authorization.
 ---
 
 ## Authentication vs Authorization

--- a/docs/start/framework/react/guide/authentication.md
+++ b/docs/start/framework/react/guide/authentication.md
@@ -1,6 +1,7 @@
 ---
 id: authentication
 title: Authentication
+description: Explore authentication patterns in TanStack Start, including sessions, login and logout, protected routes, and role-based access.
 ---
 
 This guide covers authentication patterns and shows how to implement your own authentication system with TanStack Start.

--- a/docs/start/framework/react/guide/databases.md
+++ b/docs/start/framework/react/guide/databases.md
@@ -1,6 +1,7 @@
 ---
 id: databases
 title: Databases
+description: Connect a database to TanStack Start through server functions and server routes, and compare supported database providers.
 ---
 
 Databases are at the core of any dynamic application, providing the necessary infrastructure to store, retrieve, and manage data. TanStack Start makes it easy to integrate with a variety of databases, offering a flexible approach to managing your application's data layer.

--- a/docs/start/framework/react/guide/hosting.md
+++ b/docs/start/framework/react/guide/hosting.md
@@ -1,6 +1,7 @@
 ---
 id: hosting
 title: Hosting
+description: Deploy TanStack Start with Vite or Rsbuild using hosting guides for Cloudflare, Netlify, Railway, Vercel, Node.js, and other runtimes.
 ---
 
 Hosting is the process of deploying your application to the internet so that users can access it. This is a critical part of any web development project, ensuring your application is available to the world. TanStack Start supports Vite and Rsbuild, giving you flexible build outputs for different hosting providers and runtimes.

--- a/docs/start/framework/react/guide/seo.md
+++ b/docs/start/framework/react/guide/seo.md
@@ -1,6 +1,7 @@
 ---
 id: seo
 title: SEO
+description: Configure SEO in TanStack Start with page metadata, canonical URLs, structured data, server rendering, sitemaps, and robots.txt.
 ---
 
 > [!NOTE]

--- a/docs/start/framework/react/migrate-from-next-js.md
+++ b/docs/start/framework/react/migrate-from-next-js.md
@@ -1,6 +1,7 @@
 ---
 id: migrate-from-next-js
 title: Migrate from Next.js
+description: Move a basic Next.js App Router project to TanStack Start, including dependencies, build configuration, the root route, and page routes.
 ---
 
 This guide provides a step-by-step process to migrate a project from the Next.js App Router to **TanStack Start**. We respect the powerful features of Next.js and aim to make this transition as smooth as possible.

--- a/docs/start/framework/react/overview.md
+++ b/docs/start/framework/react/overview.md
@@ -1,6 +1,7 @@
 ---
 id: overview
 title: TanStack Start Overview
+description: Build full-stack React applications with TanStack Start, including server rendering, streaming, server functions, and type-safe routing.
 ---
 
 > [!NOTE]

--- a/docs/start/framework/solid/guide/authentication.md
+++ b/docs/start/framework/solid/guide/authentication.md
@@ -1,6 +1,7 @@
 ---
 id: authentication
 title: Authentication
+description: Explore authentication patterns in TanStack Start, including sessions, login and logout, protected routes, and role-based access.
 ---
 
 This guide covers authentication patterns and shows how to implement your own authentication system with TanStack Start.


### PR DESCRIPTION
## 🎯 Changes

Add explicit search descriptions to Start's overview, getting-started, Next.js migration, SEO, authentication, database, and hosting guides. These describe what each page covers instead of relying on a leading release notice, image caption, or generic opening sentence.

Nine source files change. Solid pages that reference React source inherit the descriptions, and the independent Solid authentication guide receives its own description. Document bodies are unchanged.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

Parsed all nine descriptions with the site's frontmatter reader and verified the document bodies stayed unchanged. Prettier passed. Ran `pnpm test:eslint`, `pnpm test:types`, and `pnpm test:unit` for the uncommitted changes; Nx found no affected package tasks.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added and refined page summaries across the React and Solid documentation.
  - Improved discoverability of guides covering authentication, databases, hosting, SEO, migration, and framework overviews.
  - Updated descriptions to highlight topics such as sessions, protected routes, deployment options, metadata, server rendering, and database providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->