### PR TITLE
docs(start): correct authentication server function examples

### DIFF
--- a/docs/start/framework/react/guide/authentication.md
+++ b/docs/start/framework/react/guide/authentication.md
@@ -502,17 +502,18 @@ describe('Authentication Flow', () => {
 
 ### Loading States
 
-Call the function returned by `useServerFn` with `{ data }`. Track pending state in the component, handle invalid credentials, and refresh route context after a successful login. This form uses the `loginFn` from the server-functions example above.
+Call the function returned by `useServerFn` with `{ data }`. Track pending state in the component, handle invalid credentials, and refresh route context after a successful login. This form uses the `loginFn` from the server-functions example above. It requires JavaScript, so the fields stay disabled until hydration; `method="post"` also prevents credentials appearing in a native GET submission.
 
 ```tsx
 // components/LoginForm.tsx
 import { useState } from 'react'
 import type { FormEvent } from 'react'
-import { useRouter } from '@tanstack/react-router'
+import { useHydrated, useRouter } from '@tanstack/react-router'
 import { useServerFn } from '@tanstack/react-start'
 import { loginFn } from '../server/auth'
 
 export function LoginForm() {
+  const hydrated = useHydrated()
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
   const login = useServerFn(loginFn)
@@ -544,23 +545,25 @@ export function LoginForm() {
   }
 
   return (
-    <form onSubmit={handleSubmit}>
-      <label>
-        Email
-        <input name="email" type="email" autoComplete="username" required />
-      </label>
-      <label>
-        Password
-        <input
-          name="password"
-          type="password"
-          autoComplete="current-password"
-          required
-        />
-      </label>
-      <button type="submit" disabled={isLoading}>
-        {isLoading ? 'Logging in...' : 'Login'}
-      </button>
+    <form method="post" onSubmit={handleSubmit}>
+      <fieldset disabled={!hydrated || isLoading}>
+        <label>
+          Email
+          <input name="email" type="email" autoComplete="username" required />
+        </label>
+        <label>
+          Password
+          <input
+            name="password"
+            type="password"
+            autoComplete="current-password"
+            required
+          />
+        </label>
+        <button type="submit" disabled={isLoading}>
+          {isLoading ? 'Logging in...' : 'Login'}
+        </button>
+      </fieldset>
       <p role="alert">{error}</p>
     </form>
   )

--- a/docs/start/framework/react/guide/authentication.md
+++ b/docs/start/framework/react/guide/authentication.md
@@ -140,6 +140,7 @@ import type { ReactNode } from 'react'
 import { getCurrentUserFn } from '../server/auth'
 
 export const Route = createRootRoute({
+  headers: () => ({ 'Cache-Control': 'private, no-store' }),
   beforeLoad: async () => ({ user: await getCurrentUserFn() }),
   component: Outlet,
   shellComponent: RootDocument,
@@ -159,6 +160,8 @@ function RootDocument({ children }: { children: ReactNode }) {
   )
 }
 ```
+
+The root includes session-specific data, so its responses use `Cache-Control: private, no-store`. Keep that policy on child routes that render this data, and do not override it with public caching at your CDN.
 
 Read that state from a descendant component:
 

--- a/docs/start/framework/react/guide/authentication.md
+++ b/docs/start/framework/react/guide/authentication.md
@@ -87,7 +87,8 @@ export const getCurrentUserFn = createServerFn({ method: 'GET' }).handler(
       return null
     }
 
-    return await getUserById(userId)
+    const user = await getUserById(userId)
+    return user ? { id: user.id, email: user.email, role: user.role } : null
   },
 )
 ```
@@ -123,46 +124,55 @@ export function useAppSession() {
 
 ### 3. Authentication Context
 
-Share authentication state across your application:
+Load the current user in your root route's `beforeLoad` so the initial server render and child routes receive the same authentication state. `useServerFn` returns a callable function, not an object with `data`, `isLoading`, or `refetch`. You can call a server function directly from `beforeLoad`.
+
+Merge this pattern into your existing root route, keeping its metadata and document shell:
 
 ```tsx
-// contexts/auth.tsx
-import { createContext, useContext, ReactNode } from 'react'
-import { useServerFn } from '@tanstack/react-start'
+// routes/__root.tsx
+import {
+  createRootRoute,
+  HeadContent,
+  Outlet,
+  Scripts,
+} from '@tanstack/react-router'
+import type { ReactNode } from 'react'
 import { getCurrentUserFn } from '../server/auth'
 
-type User = {
-  id: string
-  email: string
-  role: string
-}
+export const Route = createRootRoute({
+  beforeLoad: async () => ({ user: await getCurrentUserFn() }),
+  component: Outlet,
+  shellComponent: RootDocument,
+})
 
-type AuthContextType = {
-  user: User | null
-  isLoading: boolean
-  refetch: () => void
-}
-
-const AuthContext = createContext<AuthContextType | undefined>(undefined)
-
-export function AuthProvider({ children }: { children: ReactNode }) {
-  const { data: user, isLoading, refetch } = useServerFn(getCurrentUserFn)
-
+function RootDocument({ children }: { children: ReactNode }) {
   return (
-    <AuthContext.Provider value={{ user, isLoading, refetch }}>
-      {children}
-    </AuthContext.Provider>
+    <html>
+      <head>
+        <HeadContent />
+      </head>
+      <body>
+        {children}
+        <Scripts />
+      </body>
+    </html>
   )
 }
+```
 
-export function useAuth() {
-  const context = useContext(AuthContext)
-  if (!context) {
-    throw new Error('useAuth must be used within AuthProvider')
-  }
-  return context
+Read that state from a descendant component:
+
+```tsx
+// components/AuthStatus.tsx
+import { Route } from '../routes/__root'
+
+export function AuthStatus() {
+  const { user } = Route.useRouteContext()
+  return <span>{user ? user.email : 'Signed out'}</span>
 }
 ```
+
+After login or logout changes the session, call `await router.invalidate()` to reload the current user and rerun route guards. Keep private-data authorization in the server function itself, even when a route already checks the user.
 
 ### 4. Route Protection
 
@@ -489,17 +499,42 @@ describe('Authentication Flow', () => {
 
 ### Loading States
 
-```tsx
-function LoginForm() {
-  const [isLoading, setIsLoading] = useState(false)
-  const loginMutation = useServerFn(loginFn)
+Call the function returned by `useServerFn` with `{ data }`. Track pending state in the component, handle invalid credentials, and refresh route context after a successful login. This form uses the `loginFn` from the server-functions example above.
 
-  const handleSubmit = async (data: LoginData) => {
+```tsx
+// components/LoginForm.tsx
+import { useState } from 'react'
+import type { FormEvent } from 'react'
+import { useRouter } from '@tanstack/react-router'
+import { useServerFn } from '@tanstack/react-start'
+import { loginFn } from '../server/auth'
+
+export function LoginForm() {
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+  const login = useServerFn(loginFn)
+  const router = useRouter()
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const formData = new FormData(event.currentTarget)
+    const email = formData.get('email')
+    const password = formData.get('password')
+    if (typeof email !== 'string' || typeof password !== 'string') {
+      return
+    }
+
     setIsLoading(true)
+    setError('')
     try {
-      await loginMutation.mutate(data)
-    } catch (error) {
-      // Handle error
+      const result = await login({ data: { email, password } })
+      if (result?.error) {
+        setError(result.error)
+        return
+      }
+      await router.invalidate()
+    } catch {
+      setError('Login failed. Please try again.')
     } finally {
       setIsLoading(false)
     }
@@ -507,10 +542,23 @@ function LoginForm() {
 
   return (
     <form onSubmit={handleSubmit}>
-      {/* Form fields */}
-      <button disabled={isLoading}>
+      <label>
+        Email
+        <input name="email" type="email" autoComplete="username" required />
+      </label>
+      <label>
+        Password
+        <input
+          name="password"
+          type="password"
+          autoComplete="current-password"
+          required
+        />
+      </label>
+      <button type="submit" disabled={isLoading}>
         {isLoading ? 'Logging in...' : 'Login'}
       </button>
+      <p role="alert">{error}</p>
     </form>
   )
 }

--- a/docs/start/framework/solid/guide/authentication.md
+++ b/docs/start/framework/solid/guide/authentication.md
@@ -502,16 +502,17 @@ describe('Authentication Flow', () => {
 
 ### Loading States
 
-Call the function returned by `useServerFn` with `{ data }`. Track pending state in the component, handle invalid credentials, and refresh route context after a successful login. This form uses the `loginFn` from the server-functions example above.
+Call the function returned by `useServerFn` with `{ data }`. Track pending state in the component, handle invalid credentials, and refresh route context after a successful login. This form uses the `loginFn` from the server-functions example above. It requires JavaScript, so the fields stay disabled until hydration; `method="post"` also prevents credentials appearing in a native GET submission.
 
 ```tsx
 // components/LoginForm.tsx
 import { createSignal } from 'solid-js'
-import { useRouter } from '@tanstack/solid-router'
+import { useHydrated, useRouter } from '@tanstack/solid-router'
 import { useServerFn } from '@tanstack/solid-start'
 import { loginFn } from '../server/auth'
 
 export function LoginForm() {
+  const hydrated = useHydrated()
   const [isLoading, setIsLoading] = createSignal(false)
   const [error, setError] = createSignal('')
   const login = useServerFn(loginFn)
@@ -545,23 +546,25 @@ export function LoginForm() {
   }
 
   return (
-    <form onSubmit={handleSubmit}>
-      <label>
-        Email
-        <input name="email" type="email" autocomplete="username" required />
-      </label>
-      <label>
-        Password
-        <input
-          name="password"
-          type="password"
-          autocomplete="current-password"
-          required
-        />
-      </label>
-      <button type="submit" disabled={isLoading()}>
-        {isLoading() ? 'Logging in...' : 'Login'}
-      </button>
+    <form method="post" onSubmit={handleSubmit}>
+      <fieldset disabled={!hydrated() || isLoading()}>
+        <label>
+          Email
+          <input name="email" type="email" autocomplete="username" required />
+        </label>
+        <label>
+          Password
+          <input
+            name="password"
+            type="password"
+            autocomplete="current-password"
+            required
+          />
+        </label>
+        <button type="submit" disabled={isLoading()}>
+          {isLoading() ? 'Logging in...' : 'Login'}
+        </button>
+      </fieldset>
       <p role="alert">{error()}</p>
     </form>
   )

--- a/docs/start/framework/solid/guide/authentication.md
+++ b/docs/start/framework/solid/guide/authentication.md
@@ -87,7 +87,8 @@ export const getCurrentUserFn = createServerFn({ method: 'GET' }).handler(
       return null
     }
 
-    return await getUserById(userId)
+    const user = await getUserById(userId)
+    return user ? { id: user.id, email: user.email, role: user.role } : null
   },
 )
 ```
@@ -123,46 +124,55 @@ export function useAppSession() {
 
 ### 3. Authentication Context
 
-Share authentication state across your application:
+Load the current user in your root route's `beforeLoad` so the initial server render and child routes receive the same authentication state. `useServerFn` returns a callable function, not an object with `data`, `isLoading`, or `refetch`. You can call a server function directly from `beforeLoad`.
+
+Merge this pattern into your existing root route, keeping its metadata and document shell:
 
 ```tsx
-// contexts/auth.tsx
-import { createContext, useContext } from 'solid-js'
-import { useServerFn } from '@tanstack/solid-start'
+// routes/__root.tsx
+import {
+  createRootRoute,
+  HeadContent,
+  Outlet,
+  Scripts,
+} from '@tanstack/solid-router'
+import type { JSX } from 'solid-js'
 import { getCurrentUserFn } from '../server/auth'
 
-type User = {
-  id: string
-  email: string
-  role: string
-}
+export const Route = createRootRoute({
+  beforeLoad: async () => ({ user: await getCurrentUserFn() }),
+  component: Outlet,
+  shellComponent: RootDocument,
+})
 
-type AuthContextType = {
-  user: User | null
-  isLoading: boolean
-  refetch: () => void
-}
-
-const AuthContext = createContext<AuthContextType | undefined>(undefined)
-
-export function AuthProvider(props) {
-  const { data: user, isLoading, refetch } = useServerFn(getCurrentUserFn)
-
+function RootDocument({ children }: { children: JSX.Element }) {
   return (
-    <AuthContext.Provider value={{ user, isLoading, refetch }}>
-      {props.children}
-    </AuthContext.Provider>
+    <html>
+      <head>
+        <HeadContent />
+      </head>
+      <body>
+        {children}
+        <Scripts />
+      </body>
+    </html>
   )
 }
+```
 
-export function useAuth() {
-  const context = useContext(AuthContext)
-  if (!context) {
-    throw new Error('useAuth must be used within AuthProvider')
-  }
-  return context
+Read that state from a descendant component:
+
+```tsx
+// components/AuthStatus.tsx
+import { Route } from '../routes/__root'
+
+export function AuthStatus() {
+  const context = Route.useRouteContext()
+  return <span>{context().user?.email ?? 'Signed out'}</span>
 }
 ```
+
+After login or logout changes the session, call `await router.invalidate()` to reload the current user and rerun route guards. Keep private-data authorization in the server function itself, even when a route already checks the user.
 
 ### 4. Route Protection
 
@@ -489,17 +499,43 @@ describe('Authentication Flow', () => {
 
 ### Loading States
 
-```tsx
-function LoginForm() {
-  const [isLoading, setIsLoading] = createSignal(false)
-  const loginMutation = useServerFn(loginFn)
+Call the function returned by `useServerFn` with `{ data }`. Track pending state in the component, handle invalid credentials, and refresh route context after a successful login. This form uses the `loginFn` from the server-functions example above.
 
-  const handleSubmit = async (data: LoginData) => {
+```tsx
+// components/LoginForm.tsx
+import { createSignal } from 'solid-js'
+import { useRouter } from '@tanstack/solid-router'
+import { useServerFn } from '@tanstack/solid-start'
+import { loginFn } from '../server/auth'
+
+export function LoginForm() {
+  const [isLoading, setIsLoading] = createSignal(false)
+  const [error, setError] = createSignal('')
+  const login = useServerFn(loginFn)
+  const router = useRouter()
+
+  const handleSubmit = async (
+    event: SubmitEvent & { currentTarget: HTMLFormElement },
+  ) => {
+    event.preventDefault()
+    const formData = new FormData(event.currentTarget)
+    const email = formData.get('email')
+    const password = formData.get('password')
+    if (typeof email !== 'string' || typeof password !== 'string') {
+      return
+    }
+
     setIsLoading(true)
+    setError('')
     try {
-      await loginMutation.mutate(data)
-    } catch (error) {
-      // Handle error
+      const result = await login({ data: { email, password } })
+      if (result?.error) {
+        setError(result.error)
+        return
+      }
+      await router.invalidate()
+    } catch {
+      setError('Login failed. Please try again.')
     } finally {
       setIsLoading(false)
     }
@@ -507,10 +543,23 @@ function LoginForm() {
 
   return (
     <form onSubmit={handleSubmit}>
-      {/* Form fields */}
-      <button disabled={isLoading()}>
+      <label>
+        Email
+        <input name="email" type="email" autocomplete="username" required />
+      </label>
+      <label>
+        Password
+        <input
+          name="password"
+          type="password"
+          autocomplete="current-password"
+          required
+        />
+      </label>
+      <button type="submit" disabled={isLoading()}>
         {isLoading() ? 'Logging in...' : 'Login'}
       </button>
+      <p role="alert">{error()}</p>
     </form>
   )
 }

--- a/docs/start/framework/solid/guide/authentication.md
+++ b/docs/start/framework/solid/guide/authentication.md
@@ -140,6 +140,7 @@ import type { JSX } from 'solid-js'
 import { getCurrentUserFn } from '../server/auth'
 
 export const Route = createRootRoute({
+  headers: () => ({ 'Cache-Control': 'private, no-store' }),
   beforeLoad: async () => ({ user: await getCurrentUserFn() }),
   component: Outlet,
   shellComponent: RootDocument,
@@ -159,6 +160,8 @@ function RootDocument({ children }: { children: JSX.Element }) {
   )
 }
 ```
+
+The root includes session-specific data, so its responses use `Cache-Control: private, no-store`. Keep that policy on child routes that render this data, and do not override it with public caching at your CDN.
 
 Read that state from a descendant component:
 

--- a/e2e/react-start/basic/src/routeTree.gen.ts
+++ b/e2e/react-start/basic/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as LayoutRouteImport } from './routes/_layout'
 import { Route as AsyncScriptsRouteImport } from './routes/async-scripts'
+import { Route as AuthDocsRouteImport } from './routes/auth-docs'
 import { Route as ClientOnlyRouteImport } from './routes/client-only'
 import { Route as DeferredRouteImport } from './routes/deferred'
 import { Route as InlineScriptsRouteImport } from './routes/inline-scripts'
@@ -29,6 +30,7 @@ import { Route as TypeOnlyReexportRouteImport } from './routes/type-only-reexpor
 import { Route as UsersRouteImport } from './routes/users'
 import { Route as LayoutLayout2RouteImport } from './routes/_layout/_layout-2'
 import { Route as ApiUsersRouteImport } from './routes/api.users'
+import { Route as AuthDocsPrivateRouteImport } from './routes/auth-docs.private'
 import { Route as Issue6221DashboardRouteImport } from './routes/issue-6221.dashboard'
 import { Route as MultiCookieRedirectIndexRouteImport } from './routes/multi-cookie-redirect/index'
 import { Route as MultiCookieRedirectTargetRouteImport } from './routes/multi-cookie-redirect/target'
@@ -94,6 +96,11 @@ const LayoutRoute = LayoutRouteImport.update({
 const AsyncScriptsRoute = AsyncScriptsRouteImport.update({
   id: '/async-scripts',
   path: '/async-scripts',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AuthDocsRoute = AuthDocsRouteImport.update({
+  id: '/auth-docs',
+  path: '/auth-docs',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ClientOnlyRoute = ClientOnlyRouteImport.update({
@@ -180,6 +187,11 @@ const ApiUsersRoute = ApiUsersRouteImport.update({
   id: '/api/users',
   path: '/api/users',
   getParentRoute: () => rootRouteImport,
+} as any)
+const AuthDocsPrivateRoute = AuthDocsPrivateRouteImport.update({
+  id: '/private',
+  path: '/private',
+  getParentRoute: () => AuthDocsRoute,
 } as any)
 const Issue6221DashboardRoute = Issue6221DashboardRouteImport.update({
   id: '/issue-6221/dashboard',
@@ -464,6 +476,7 @@ export interface FileRoutesByFullPath {
   '/search-params': typeof SearchParamsRouteRouteWithChildren
   '/specialChars': typeof SpecialCharsRouteRouteWithChildren
   '/async-scripts': typeof AsyncScriptsRoute
+  '/auth-docs': typeof AuthDocsRouteWithChildren
   '/client-only': typeof ClientOnlyRoute
   '/deferred': typeof DeferredRoute
   '/inline-scripts': typeof InlineScriptsRoute
@@ -480,6 +493,7 @@ export interface FileRoutesByFullPath {
   '/not-found/parent-boundary': typeof NotFoundParentBoundaryRouteRouteWithChildren
   '/specialChars/malformed': typeof SpecialCharsMalformedRouteRouteWithChildren
   '/api/users': typeof ApiUsersRouteWithChildren
+  '/auth-docs/private': typeof AuthDocsPrivateRoute
   '/issue-6221/dashboard': typeof Issue6221DashboardRoute
   '/multi-cookie-redirect/target': typeof MultiCookieRedirectTargetRoute
   '/not-found/via-beforeLoad': typeof NotFoundViaBeforeLoadRoute
@@ -534,6 +548,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/specialChars': typeof SpecialCharsRouteRouteWithChildren
   '/async-scripts': typeof AsyncScriptsRoute
+  '/auth-docs': typeof AuthDocsRouteWithChildren
   '/client-only': typeof ClientOnlyRoute
   '/deferred': typeof DeferredRoute
   '/inline-scripts': typeof InlineScriptsRoute
@@ -545,6 +560,7 @@ export interface FileRoutesByTo {
   '/type-only-reexport': typeof TypeOnlyReexportRoute
   '/specialChars/malformed': typeof SpecialCharsMalformedRouteRouteWithChildren
   '/api/users': typeof ApiUsersRouteWithChildren
+  '/auth-docs/private': typeof AuthDocsPrivateRoute
   '/issue-6221/dashboard': typeof Issue6221DashboardRoute
   '/multi-cookie-redirect/target': typeof MultiCookieRedirectTargetRoute
   '/not-found/via-beforeLoad': typeof NotFoundViaBeforeLoadRoute
@@ -601,6 +617,7 @@ export interface FileRoutesById {
   '/specialChars': typeof SpecialCharsRouteRouteWithChildren
   '/_layout': typeof LayoutRouteWithChildren
   '/async-scripts': typeof AsyncScriptsRoute
+  '/auth-docs': typeof AuthDocsRouteWithChildren
   '/client-only': typeof ClientOnlyRoute
   '/deferred': typeof DeferredRoute
   '/inline-scripts': typeof InlineScriptsRoute
@@ -618,6 +635,7 @@ export interface FileRoutesById {
   '/specialChars/malformed': typeof SpecialCharsMalformedRouteRouteWithChildren
   '/_layout/_layout-2': typeof LayoutLayout2RouteWithChildren
   '/api/users': typeof ApiUsersRouteWithChildren
+  '/auth-docs/private': typeof AuthDocsPrivateRoute
   '/issue-6221/dashboard': typeof Issue6221DashboardRoute
   '/multi-cookie-redirect/target': typeof MultiCookieRedirectTargetRoute
   '/not-found/via-beforeLoad': typeof NotFoundViaBeforeLoadRoute
@@ -676,6 +694,7 @@ export interface FileRouteTypes {
     | '/search-params'
     | '/specialChars'
     | '/async-scripts'
+    | '/auth-docs'
     | '/client-only'
     | '/deferred'
     | '/inline-scripts'
@@ -692,6 +711,7 @@ export interface FileRouteTypes {
     | '/not-found/parent-boundary'
     | '/specialChars/malformed'
     | '/api/users'
+    | '/auth-docs/private'
     | '/issue-6221/dashboard'
     | '/multi-cookie-redirect/target'
     | '/not-found/via-beforeLoad'
@@ -746,6 +766,7 @@ export interface FileRouteTypes {
     | '/'
     | '/specialChars'
     | '/async-scripts'
+    | '/auth-docs'
     | '/client-only'
     | '/deferred'
     | '/inline-scripts'
@@ -757,6 +778,7 @@ export interface FileRouteTypes {
     | '/type-only-reexport'
     | '/specialChars/malformed'
     | '/api/users'
+    | '/auth-docs/private'
     | '/issue-6221/dashboard'
     | '/multi-cookie-redirect/target'
     | '/not-found/via-beforeLoad'
@@ -812,6 +834,7 @@ export interface FileRouteTypes {
     | '/specialChars'
     | '/_layout'
     | '/async-scripts'
+    | '/auth-docs'
     | '/client-only'
     | '/deferred'
     | '/inline-scripts'
@@ -829,6 +852,7 @@ export interface FileRouteTypes {
     | '/specialChars/malformed'
     | '/_layout/_layout-2'
     | '/api/users'
+    | '/auth-docs/private'
     | '/issue-6221/dashboard'
     | '/multi-cookie-redirect/target'
     | '/not-found/via-beforeLoad'
@@ -887,6 +911,7 @@ export interface RootRouteChildren {
   SpecialCharsRouteRoute: typeof SpecialCharsRouteRouteWithChildren
   LayoutRoute: typeof LayoutRouteWithChildren
   AsyncScriptsRoute: typeof AsyncScriptsRoute
+  AuthDocsRoute: typeof AuthDocsRouteWithChildren
   ClientOnlyRoute: typeof ClientOnlyRoute
   DeferredRoute: typeof DeferredRoute
   InlineScriptsRoute: typeof InlineScriptsRoute
@@ -931,6 +956,13 @@ declare module '@tanstack/react-router' {
       path: '/async-scripts'
       fullPath: '/async-scripts'
       preLoaderRoute: typeof AsyncScriptsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auth-docs': {
+      id: '/auth-docs'
+      path: '/auth-docs'
+      fullPath: '/auth-docs'
+      preLoaderRoute: typeof AuthDocsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/client-only': {
@@ -1051,6 +1083,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/api/users'
       preLoaderRoute: typeof ApiUsersRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/auth-docs/private': {
+      id: '/auth-docs/private'
+      path: '/private'
+      fullPath: '/auth-docs/private'
+      preLoaderRoute: typeof AuthDocsPrivateRouteImport
+      parentRoute: typeof AuthDocsRoute
     }
     '/issue-6221/dashboard': {
       id: '/issue-6221/dashboard'
@@ -1570,6 +1609,18 @@ const LayoutRouteChildren: LayoutRouteChildren = {
 const LayoutRouteWithChildren =
   LayoutRoute._addFileChildren(LayoutRouteChildren)
 
+interface AuthDocsRouteChildren {
+  AuthDocsPrivateRoute: typeof AuthDocsPrivateRoute
+}
+
+const AuthDocsRouteChildren: AuthDocsRouteChildren = {
+  AuthDocsPrivateRoute: AuthDocsPrivateRoute,
+}
+
+const AuthDocsRouteWithChildren = AuthDocsRoute._addFileChildren(
+  AuthDocsRouteChildren,
+)
+
 interface PostsRouteChildren {
   PostsPostIdRoute: typeof PostsPostIdRoute
   PostsIndexRoute: typeof PostsIndexRoute
@@ -1675,6 +1726,7 @@ const rootRouteChildren: RootRouteChildren = {
   SpecialCharsRouteRoute: SpecialCharsRouteRouteWithChildren,
   LayoutRoute: LayoutRouteWithChildren,
   AsyncScriptsRoute: AsyncScriptsRoute,
+  AuthDocsRoute: AuthDocsRouteWithChildren,
   ClientOnlyRoute: ClientOnlyRoute,
   DeferredRoute: DeferredRoute,
   InlineScriptsRoute: InlineScriptsRoute,

--- a/e2e/react-start/basic/src/routes/auth-docs.private.tsx
+++ b/e2e/react-start/basic/src/routes/auth-docs.private.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+import { getPrivateDataFn } from '../utils/auth-docs'
+
+export const Route = createFileRoute('/auth-docs/private')({
+  beforeLoad: ({ context }) => {
+    if (!context.user) {
+      throw redirect({ to: '/auth-docs' })
+    }
+  },
+  loader: () => getPrivateDataFn(),
+  component: PrivatePage,
+})
+
+function PrivatePage() {
+  const message = Route.useLoaderData()
+  return <p data-testid="auth-docs-private-page">{message}</p>
+}

--- a/e2e/react-start/basic/src/routes/auth-docs.tsx
+++ b/e2e/react-start/basic/src/routes/auth-docs.tsx
@@ -11,6 +11,7 @@ import {
 
 export const Route = createFileRoute('/auth-docs')({
   beforeLoad: async () => ({ user: await getCurrentUserFn() }),
+  headers: () => ({ 'Cache-Control': 'private, no-store' }),
   component: AuthDocs,
 })
 

--- a/e2e/react-start/basic/src/routes/auth-docs.tsx
+++ b/e2e/react-start/basic/src/routes/auth-docs.tsx
@@ -1,4 +1,9 @@
-import { createFileRoute, Outlet, useRouter } from '@tanstack/react-router'
+import {
+  createFileRoute,
+  Outlet,
+  useHydrated,
+  useRouter,
+} from '@tanstack/react-router'
 import { useServerFn } from '@tanstack/react-start'
 import { useState } from 'react'
 import type { FormEvent } from 'react'
@@ -16,6 +21,7 @@ export const Route = createFileRoute('/auth-docs')({
 })
 
 function AuthDocs() {
+  const hydrated = useHydrated()
   const { user } = Route.useRouteContext()
   const router = useRouter()
   const login = useServerFn(loginFn)
@@ -52,18 +58,20 @@ function AuthDocs() {
   return (
     <div>
       <p data-testid="auth-docs-user">{user?.email ?? 'Signed out'}</p>
-      <form onSubmit={handleSubmit}>
-        <label>
-          Email
-          <input name="email" type="email" required />
-        </label>
-        <label>
-          Password
-          <input name="password" type="password" required />
-        </label>
-        <button type="submit" disabled={isLoading}>
-          {isLoading ? 'Logging in...' : 'Login'}
-        </button>
+      <form method="post" onSubmit={handleSubmit}>
+        <fieldset disabled={!hydrated || isLoading}>
+          <label>
+            Email
+            <input name="email" type="email" required />
+          </label>
+          <label>
+            Password
+            <input name="password" type="password" required />
+          </label>
+          <button type="submit" disabled={isLoading}>
+            {isLoading ? 'Logging in...' : 'Login'}
+          </button>
+        </fieldset>
         <p role="alert">{error}</p>
       </form>
       <button

--- a/e2e/react-start/basic/src/routes/auth-docs.tsx
+++ b/e2e/react-start/basic/src/routes/auth-docs.tsx
@@ -1,0 +1,91 @@
+import { createFileRoute, Outlet, useRouter } from '@tanstack/react-router'
+import { useServerFn } from '@tanstack/react-start'
+import { useState } from 'react'
+import type { FormEvent } from 'react'
+import {
+  getCurrentUserFn,
+  getPrivateDataFn,
+  loginFn,
+  logoutFn,
+} from '../utils/auth-docs'
+
+export const Route = createFileRoute('/auth-docs')({
+  beforeLoad: async () => ({ user: await getCurrentUserFn() }),
+  component: AuthDocs,
+})
+
+function AuthDocs() {
+  const { user } = Route.useRouteContext()
+  const router = useRouter()
+  const login = useServerFn(loginFn)
+  const logout = useServerFn(logoutFn)
+  const getPrivateData = useServerFn(getPrivateDataFn)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [privateResult, setPrivateResult] = useState('')
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const formData = new FormData(event.currentTarget)
+    const email = formData.get('email')
+    const password = formData.get('password')
+    if (typeof email !== 'string' || typeof password !== 'string') {
+      return
+    }
+    setIsLoading(true)
+    setError('')
+    try {
+      const result = await login({ data: { email, password } })
+      if (result?.error) {
+        setError(result.error)
+        return
+      }
+      await router.invalidate()
+    } catch {
+      setError('Login failed. Please try again.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div>
+      <p data-testid="auth-docs-user">{user?.email ?? 'Signed out'}</p>
+      <form onSubmit={handleSubmit}>
+        <label>
+          Email
+          <input name="email" type="email" required />
+        </label>
+        <label>
+          Password
+          <input name="password" type="password" required />
+        </label>
+        <button type="submit" disabled={isLoading}>
+          {isLoading ? 'Logging in...' : 'Login'}
+        </button>
+        <p role="alert">{error}</p>
+      </form>
+      <button
+        onClick={async () => {
+          await logout()
+          await router.invalidate()
+        }}
+      >
+        Logout
+      </button>
+      <button
+        onClick={async () => {
+          try {
+            setPrivateResult(await getPrivateData())
+          } catch {
+            setPrivateResult('Access denied')
+          }
+        }}
+      >
+        Request private data directly
+      </button>
+      <p data-testid="auth-docs-private-result">{privateResult}</p>
+      <Outlet />
+    </div>
+  )
+}

--- a/e2e/react-start/basic/src/utils/auth-docs.ts
+++ b/e2e/react-start/basic/src/utils/auth-docs.ts
@@ -1,0 +1,48 @@
+import { createServerFn } from '@tanstack/react-start'
+import { redirect } from '@tanstack/react-router'
+import { useSession } from '@tanstack/react-start/server'
+
+function getSession() {
+  return useSession<{ email?: string }>({
+    name: 'auth-docs-test',
+    password: 'authentication-docs-browser-test-secret-only-2026',
+  })
+}
+
+export const getCurrentUserFn = createServerFn({ method: 'GET' }).handler(
+  async () => {
+    const session = await getSession()
+    return session.data.email ? { email: session.data.email } : null
+  },
+)
+
+export const loginFn = createServerFn({ method: 'POST' })
+  .validator((data: { email: string; password: string }) => data)
+  .handler(async ({ data }) => {
+    // Fixed credentials belong only to this browser-test fixture.
+    if (
+      data.email !== 'reader@example.com' ||
+      data.password !== 'test-password'
+    ) {
+      return { error: 'Invalid credentials' }
+    }
+    const session = await getSession()
+    await session.update({ email: data.email })
+    throw redirect({ to: '/auth-docs/private' })
+  })
+
+export const logoutFn = createServerFn({ method: 'POST' }).handler(async () => {
+  const session = await getSession()
+  await session.clear()
+  throw redirect({ to: '/auth-docs' })
+})
+
+export const getPrivateDataFn = createServerFn({ method: 'GET' }).handler(
+  async () => {
+    const session = await getSession()
+    if (!session.data.email) {
+      throw new Error('Unauthorized')
+    }
+    return 'Private account data'
+  },
+)

--- a/e2e/react-start/basic/tests/auth-docs.spec.ts
+++ b/e2e/react-start/basic/tests/auth-docs.spec.ts
@@ -47,3 +47,25 @@ test('authentication docs pattern handles login, logout, route context, and serv
   await page.goto('/auth-docs/private')
   await expect(page).toHaveURL(/\/auth-docs$/)
 })
+
+test('the authentication form cannot submit credentials before hydration', async ({
+  browser,
+  baseURL,
+}) => {
+  const context = await browser.newContext({
+    javaScriptEnabled: false,
+    baseURL,
+  })
+  const page = await context.newPage()
+  try {
+    await page.goto('/auth-docs')
+    await expect(page.locator('form')).toHaveAttribute('method', 'post')
+    await expect(page.getByLabel('Email', { exact: true })).toBeDisabled()
+    await expect(page.getByLabel('Password', { exact: true })).toBeDisabled()
+    await expect(
+      page.getByRole('button', { name: 'Login', exact: true }),
+    ).toBeDisabled()
+  } finally {
+    await context.close()
+  }
+})

--- a/e2e/react-start/basic/tests/auth-docs.spec.ts
+++ b/e2e/react-start/basic/tests/auth-docs.spec.ts
@@ -30,7 +30,8 @@ test('authentication docs pattern handles login, logout, route context, and serv
     'Private account data',
   )
 
-  await page.reload()
+  const response = await page.reload()
+  expect(response?.headers()['cache-control']).toBe('private, no-store')
   await expect(page.getByTestId('auth-docs-user')).toHaveText(
     'reader@example.com',
   )

--- a/e2e/react-start/basic/tests/auth-docs.spec.ts
+++ b/e2e/react-start/basic/tests/auth-docs.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@playwright/test'
+
+test('authentication docs pattern handles login, logout, route context, and server authorization', async ({
+  page,
+}) => {
+  await page.goto('/auth-docs/private')
+  await expect(page).toHaveURL(/\/auth-docs$/)
+  await expect(page.getByTestId('auth-docs-user')).toHaveText('Signed out')
+
+  await page
+    .getByRole('button', { name: 'Request private data directly' })
+    .click()
+  await expect(page.getByTestId('auth-docs-private-result')).toHaveText(
+    'Access denied',
+  )
+
+  await page.getByLabel('Email', { exact: true }).fill('reader@example.com')
+  await page.getByLabel('Password', { exact: true }).fill('wrong-password')
+  await page.getByRole('button', { name: 'Login', exact: true }).click()
+  await expect(page.getByRole('alert')).toHaveText('Invalid credentials')
+  await expect(page.getByTestId('auth-docs-user')).toHaveText('Signed out')
+
+  await page.getByLabel('Password', { exact: true }).fill('test-password')
+  await page.getByRole('button', { name: 'Login', exact: true }).click()
+  await expect(page).toHaveURL(/\/auth-docs\/private$/)
+  await expect(page.getByTestId('auth-docs-user')).toHaveText(
+    'reader@example.com',
+  )
+  await expect(page.getByTestId('auth-docs-private-page')).toHaveText(
+    'Private account data',
+  )
+
+  await page.reload()
+  await expect(page.getByTestId('auth-docs-user')).toHaveText(
+    'reader@example.com',
+  )
+  await page.getByRole('button', { name: 'Logout', exact: true }).click()
+  await expect(page).toHaveURL(/\/auth-docs$/)
+  await expect(page.getByTestId('auth-docs-user')).toHaveText('Signed out')
+  await page
+    .getByRole('button', { name: 'Request private data directly' })
+    .click()
+  await expect(page.getByTestId('auth-docs-private-result')).toHaveText(
+    'Access denied',
+  )
+  await page.goto('/auth-docs/private')
+  await expect(page).toHaveURL(/\/auth-docs$/)
+})

--- a/e2e/react-start/basic/tests/auth-docs.spec.ts
+++ b/e2e/react-start/basic/tests/auth-docs.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { isSpaMode } from './utils/isSpaMode'
 
 test('authentication docs pattern handles login, logout, route context, and server authorization', async ({
   page,
@@ -31,7 +32,14 @@ test('authentication docs pattern handles login, logout, route context, and serv
   )
 
   const response = await page.reload()
-  expect(response?.headers()['cache-control']).toBe('private, no-store')
+  expect(response?.status()).toBe(200)
+  if (isSpaMode) {
+    // The shared SPA shell must not contain authenticated account data.
+    expect(await response?.text()).not.toContain('reader@example.com')
+    expect(await response?.text()).not.toContain('Private account data')
+  } else {
+    expect(response?.headers()['cache-control']).toBe('private, no-store')
+  }
   await expect(page.getByTestId('auth-docs-user')).toHaveText(
     'reader@example.com',
   )
@@ -59,12 +67,22 @@ test('the authentication form cannot submit credentials before hydration', async
   const page = await context.newPage()
   try {
     await page.goto('/auth-docs')
-    await expect(page.locator('form')).toHaveAttribute('method', 'post')
-    await expect(page.getByLabel('Email', { exact: true })).toBeDisabled()
-    await expect(page.getByLabel('Password', { exact: true })).toBeDisabled()
-    await expect(
-      page.getByRole('button', { name: 'Login', exact: true }),
-    ).toBeDisabled()
+    if (isSpaMode) {
+      // Without JavaScript, the SPA shell cannot render credential controls.
+      await expect(page.locator('form')).toHaveCount(0)
+      await expect(page.getByLabel('Email', { exact: true })).toHaveCount(0)
+      await expect(page.getByLabel('Password', { exact: true })).toHaveCount(0)
+      await expect(
+        page.getByRole('button', { name: 'Login', exact: true }),
+      ).toHaveCount(0)
+    } else {
+      await expect(page.locator('form')).toHaveAttribute('method', 'post')
+      await expect(page.getByLabel('Email', { exact: true })).toBeDisabled()
+      await expect(page.getByLabel('Password', { exact: true })).toBeDisabled()
+      await expect(
+        page.getByRole('button', { name: 'Login', exact: true }),
+      ).toBeDisabled()
+    }
   } finally {
     await context.close()
   }


### PR DESCRIPTION
## 🎯 Changes

The React and Solid authentication guides treat `useServerFn` as a query or mutation object. It returns a callable function. Replace the broken auth provider with server-loaded route context, and fix the login forms to submit `{ data }`, show pending and error states, and invalidate route context after the session changes.

The current-user example now returns only the fields needed by the UI. The guide keeps server-side authorization separate from route guards.

Add a regression to the active React Start browser-test app. It checks invalid credentials, successful login, session persistence after reload, logout, protected-route rejection, and a direct private-server-function call without a route guard.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

Validation:
- `pnpm nx run tanstack-react-start-e2e-basic:test:e2e--vite-ssr --args=auth-docs.spec.ts`: passed the browser flow against the built app.
- The active React test app passed `tsc --noEmit`.
- Extracted and typechecked the exact root-route, auth-status, and login-form snippets for both React and Solid against the built workspace packages. Solid browser behavior was not separately tested.
- Required affected eslint, types, and unit commands passed with no package tasks. The browser test was run separately because these commands exclude the e2e app.
- Prettier and `git diff --check` passed.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authentication examples covering login, logout, session state, protected routes, and private data access.
  * Added protected demo pages with signed-in and signed-out states, error handling, and access control.
  * Added private, non-cacheable session responses to help protect authentication data.

* **Documentation**
  * Updated React and Solid authentication guidance with route context, direct server-function calls, loading states, hydration handling, and session refresh guidance.

* **Tests**
  * Added end-to-end coverage for authentication, redirects, invalid credentials, session persistence, private data access, cache headers, and logout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->