### PR TITLE
docs(start): add tested TanStack Query integration guide

### DIFF
--- a/docs/router/guide/external-data-loading.md
+++ b/docs/router/guide/external-data-loading.md
@@ -6,6 +6,8 @@ title: External Data Loading
 > [!IMPORTANT]
 > This guide is geared towards external state management libraries and their integration with TanStack Router for data fetching, ssr, hydration/dehydration and streaming. If you haven't read the standard [Data Loading](./data-loading.md) guide, please do so first.
 
+For a full-stack React application, follow [TanStack Query with Start](/start/latest/docs/framework/react/guide/tanstack-query) for request-scoped SSR, hydration, and mutation invalidation with a tested example.
+
 ## To **Store** or to **Coordinate**?
 
 While Router is very capable of storing and managing most data needs out of the box, sometimes you just might want something more robust!

--- a/docs/start/config.json
+++ b/docs/start/config.json
@@ -324,6 +324,10 @@
             {
               "label": "Databases",
               "to": "framework/react/guide/databases"
+            },
+            {
+              "label": "TanStack Query",
+              "to": "framework/react/guide/tanstack-query"
             }
           ]
         },

--- a/docs/start/framework/react/guide/tanstack-query.md
+++ b/docs/start/framework/react/guide/tanstack-query.md
@@ -1,0 +1,152 @@
+---
+id: tanstack-query
+title: TanStack Query
+description: Use TanStack Query with TanStack Start for request-isolated SSR, hydration, route preloading, streaming, and mutation invalidation.
+---
+
+TanStack Start uses Router loaders to coordinate navigation. TanStack Query can own the fetched data, freshness, and mutation state. Use them together when your application needs a query cache across routes, background updates, or mutation-driven invalidation.
+
+The [React Query example](../examples/start-basic-react-query) includes a `/preferences` page that reads and updates a display name stored in a cookie. Its [tests](https://github.com/TanStack/router/blob/main/examples/react/start-basic-react-query/tests/preferences.spec.ts) check server-rendered data, isolation between requests, hydration without a duplicate read, and invalidation after a server function. The preference cookie is not an authentication mechanism.
+
+## Install and create a QueryClient per router
+
+Install `@tanstack/react-query` and `@tanstack/react-router-ssr-query`. The example uses Query 5.102 or newer, including `queryClient.query`. See the [integration reference](/router/latest/docs/integrations/query) for its options.
+
+```tsx title="src/router.tsx"
+import { QueryClient } from '@tanstack/react-query'
+import { createRouter } from '@tanstack/react-router'
+import { setupRouterSsrQueryIntegration } from '@tanstack/react-router-ssr-query'
+import { routeTree } from './routeTree.gen'
+
+export function getRouter() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { staleTime: 30_000 } },
+  })
+  const router = createRouter({
+    routeTree,
+    context: { queryClient },
+    defaultPreload: 'intent',
+    defaultPreloadStaleTime: 0,
+  })
+
+  setupRouterSsrQueryIntegration({ router, queryClient })
+  return router
+}
+```
+
+Create the client inside `getRouter`, not at module scope. Start creates a router for each SSR request. A process-wide QueryClient could reuse one reader's cached data in another reader's HTML. The browser then keeps the client attached to its router during navigation.
+
+Declare `queryClient: QueryClient` in the root route's `createRootRouteWithContext` type so child loaders can access it. The integration supplies the Query provider and handles SSR dehydration, hydration, and streaming. Do not add a second QueryClient or independently dehydrate the same cache. If you already own the provider wrapper, use the integration's `wrapQueryClient: false` option.
+
+`defaultPreloadStaleTime: 0` lets Query decide whether a preload needs data. The example's 30-second Query `staleTime` prevents an immediate repeat read when the browser receives fresh SSR data. Choose the freshness window for your application, rather than treating 30 seconds as a universal setting.
+
+## Share query options between the loader and component
+
+Keep a query's key and function together. Privileged reads belong in a server function, because a normal route loader can also run in the browser during navigation.
+
+```tsx title="src/utils/preferences.ts"
+import { queryOptions } from '@tanstack/react-query'
+import { createServerFn } from '@tanstack/react-start'
+import { getCookie, setResponseHeader } from '@tanstack/react-start/server'
+
+export const getReaderName = createServerFn({ method: 'GET' }).handler(() => {
+  setResponseHeader('Cache-Control', 'private, no-store')
+  return getCookie('reader-name') || 'Guest'
+})
+
+export const readerNameOptions = queryOptions({
+  queryKey: ['reader-name'],
+  queryFn: () => getReaderName(),
+})
+```
+
+The route awaits the query for content that must appear in the initial HTML:
+
+```tsx title="src/routes/preferences.tsx"
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { createFileRoute } from '@tanstack/react-router'
+import { readerNameOptions } from '../utils/preferences'
+
+export const Route = createFileRoute('/preferences')({
+  loader: async ({ context }) => {
+    await context.queryClient.query(readerNameOptions)
+  },
+  headers: () => ({ 'Cache-Control': 'private, no-store' }),
+  component: Preferences,
+})
+
+function Preferences() {
+  const { data: name } = useSuspenseQuery(readerNameOptions)
+  return <p>Hello, {name}</p>
+}
+```
+
+Both calls use the same query key and options. The loader populates the request's cache; the component reads it; the integration transfers it to the browser. The component does not need to call the server function again in an effect.
+
+For a parameterized resource, include its identity in the key, such as `['post', postId]`. If search values affect the result, validate them and include them in both `loaderDeps` and the query key. Keep secrets out of keys and serialized query data.
+
+## Await critical data and stream secondary data
+
+Await queries that determine the page's main content, title, authorization, redirects, or whether it exists. Return title and description data from the loader when a route's `head` needs them, as the example's post route does.
+
+Secondary content can begin loading without blocking the loader, then render inside a Suspense boundary. Keep that query under the SSR integration so its result can stream to the browser. Handle the imperative query promise's rejection as well as the component's error boundary; a fire-and-forget promise should not become an unhandled server rejection.
+
+The example's existing `/deferred` route shows a separate Suspense boundary. See [streaming and prefetching](/router/latest/docs/integrations/query#prefetching-and-streaming) for the integration's behavior. A plain `useQuery` that has no loader prefetch is not a guarantee that its data will be in the server-rendered HTML.
+
+## Invalidate Query after a server mutation
+
+The preference example validates the display name and writes its cookie inside a POST server function. The component calls that function through `useServerFn`, then invalidates the query that reads the cookie:
+
+```tsx
+const queryClient = useQueryClient()
+const save = useServerFn(saveReaderName)
+const mutation = useMutation({
+  mutationFn: (name: string) => save({ data: name }),
+  onSuccess: () =>
+    queryClient.invalidateQueries({ queryKey: readerNameOptions.queryKey }),
+})
+```
+
+Returning the invalidation promise keeps the mutation pending until its active query's refetch finishes. The form can use `mutation.isPending` and `mutation.isError` for feedback. The example also disables its JavaScript-dependent form until hydration and uses a POST method so a native submission cannot put form values in the URL.
+
+Invalidate the data's actual owner. `queryClient.invalidateQueries` refreshes Query data; `router.invalidate()` reloads Router-owned loader data and route context. Use both only when the mutation changes both, such as a login that changes root authentication context and private queries. Neither call purges your CDN or invalidates a database cache.
+
+If a mutation returns the complete updated resource, `setQueryData` can update that cache entry directly instead. Optimistic updates need cancellation, rollback on failure, and reconciliation with the server result. This example uses a confirmed write followed by invalidation, not an optimistic update.
+
+## Keep account data isolated beyond SSR
+
+Request-scoped QueryClients prevent cross-request cache sharing on the server. They do not authorize reads or automatically clear a browser cache when its account changes.
+
+For authenticated applications, authorize every private read and mutation on the server, including resource-level permissions. On sign-out or account switching, cancel and remove the previous account's private queries, then reload the relevant route context. Include account or tenant identity in keys when that is part of the resource's identity, but do not treat a key as an access-control check.
+
+The `/preferences` route and its server functions return `Cache-Control: private, no-store` because their output varies by cookie. Verify the final response through your hosting provider and CDN. Do not publicly cache personalized HTML merely because the QueryClient itself is isolated.
+
+## Diagnose extra requests
+
+Check when and where each request occurs. A background refresh after the freshness window, a reconnect, or a deliberate invalidation can be expected.
+
+| Symptom                                             | Check                                                                                         |
+| --------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| A read repeats immediately after hydration          | Query `staleTime`, hydration configuration, matching keys, and accidental extra QueryClients  |
+| Navigation loads different data than a direct visit | Search validation, `loaderDeps`, query keys, and server-only boundaries                       |
+| A mutation succeeds but old data stays visible      | Which cache owns the displayed value and which keys were invalidated                          |
+| A second account sees the first account's data      | Module-scoped server clients, browser cache cleanup, account keys, and shared HTTP caches     |
+| SSR contains only a loading state                   | Whether the loader awaited critical data and whether the component reads the prefetched query |
+
+Start with the same options object in the loader and component. Avoid adding manual hydration code or disabling all refetching to hide a duplicate request.
+
+## Run the example's checks
+
+From the repository root, install dependencies and build the framework packages as described in [Contributing](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md). Then:
+
+```sh
+cd examples/react/start-basic-react-query
+pnpm exec playwright install chromium
+pnpm test:e2e
+pnpm build
+QUERY_EXAMPLE_PRODUCTION=1 pnpm test:e2e
+```
+
+The tests send concurrent SSR requests with different preference cookies while using the same query key. Each HTML response must contain only its own reader's value. The browser test then requires zero additional reads during hydration, exactly one read after mutation invalidation, and no extra read after a reload hydrates fresh data.
+
+The post and user demos use JSONPlaceholder. The preference tests run without that external API.

--- a/docs/start/framework/react/guide/tanstack-query.md
+++ b/docs/start/framework/react/guide/tanstack-query.md
@@ -95,7 +95,7 @@ The example's existing `/deferred` route shows a separate Suspense boundary. See
 
 ## Invalidate Query after a server mutation
 
-The preference example validates the display name and writes its cookie inside a POST server function. The component calls that function through `useServerFn`, then invalidates the query that reads the cookie:
+The preference example validates the display name and writes its cookie inside a POST server function. Its `src/start.ts` enables Start's CSRF middleware for server-function requests. The component calls that function through `useServerFn`, then invalidates the query that reads the cookie:
 
 ```tsx
 const queryClient = useQueryClient()

--- a/examples/react/start-basic-react-query/README.md
+++ b/examples/react/start-basic-react-query/README.md
@@ -38,5 +38,18 @@ This example demonstrates how to use TanStack Query with TanStack Start for:
 
 - Server-side data fetching
 - Client-side caching and synchronization
-- Optimistic updates
-- Automatic refetching
+- Confirmed server mutations followed by query invalidation
+- Explicit freshness and automatic refetching
+
+## SSR and mutation checks
+
+Read the [Start + TanStack Query guide](https://tanstack.com/start/latest/docs/framework/react/guide/tanstack-query). The `/preferences` page stores a harmless display name in a cookie, so its tests need no account or external API. This cookie is not authentication. The other post/user examples use JSONPlaceholder.
+
+```sh
+pnpm exec playwright install chromium
+pnpm test:e2e
+pnpm build
+QUERY_EXAMPLE_PRODUCTION=1 pnpm test:e2e
+```
+
+The tests check concurrent SSR request isolation, no duplicate hydration read, one refetch after mutation invalidation, and persistence on reload. Query data is fresh for 30 seconds by default in this example; choose a window appropriate for your application.

--- a/examples/react/start-basic-react-query/package.json
+++ b/examples/react/start-basic-react-query/package.json
@@ -7,7 +7,8 @@
     "dev": "vite dev",
     "build": "vite build && tsc --noEmit",
     "preview": "vite preview",
-    "start": "pnpx srvx --prod -s ../client dist/server/server.js"
+    "start": "pnpx srvx --prod -s ../client dist/server/server.js",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.102.0",
@@ -30,6 +31,7 @@
     "tailwindcss": "^4.2.2",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
-    "vite": "^8.0.14"
+    "vite": "^8.0.14",
+    "@playwright/test": "^1.61.0"
   }
 }

--- a/examples/react/start-basic-react-query/playwright.config.ts
+++ b/examples/react/start-basic-react-query/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests',
+  use: { baseURL: 'http://localhost:3110', browserName: 'chromium' },
+  webServer: {
+    command:
+      process.env.QUERY_EXAMPLE_PRODUCTION === '1'
+        ? 'PORT=3110 pnpm start'
+        : 'pnpm dev --port 3110',
+    url: 'http://localhost:3110/preferences',
+    timeout: 120_000,
+  },
+})

--- a/examples/react/start-basic-react-query/src/routeTree.gen.ts
+++ b/examples/react/start-basic-react-query/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as PathlessLayoutRouteImport } from './routes/_pathlessLayout'
 import { Route as DeferredRouteImport } from './routes/deferred'
 import { Route as PostsRouteRouteImport } from './routes/posts.route'
+import { Route as PreferencesRouteImport } from './routes/preferences'
 import { Route as RedirectRouteImport } from './routes/redirect'
 import { Route as UsersRouteRouteImport } from './routes/users.route'
 import { Route as PathlessLayoutNestedLayoutRouteImport } from './routes/_pathlessLayout/_nested-layout'
@@ -43,6 +44,11 @@ const DeferredRoute = DeferredRouteImport.update({
 const PostsRouteRoute = PostsRouteRouteImport.update({
   id: '/posts',
   path: '/posts',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PreferencesRoute = PreferencesRouteImport.update({
+  id: '/preferences',
+  path: '/preferences',
   getParentRoute: () => rootRouteImport,
 } as any)
 const RedirectRoute = RedirectRouteImport.update({
@@ -113,6 +119,7 @@ export interface FileRoutesByFullPath {
   '/posts': typeof PostsRouteRouteWithChildren
   '/users': typeof UsersRouteRouteWithChildren
   '/deferred': typeof DeferredRoute
+  '/preferences': typeof PreferencesRoute
   '/redirect': typeof RedirectRoute
   '/api/users': typeof ApiUsersRouteWithChildren
   '/posts/$postId': typeof PostsPostIdRoute
@@ -127,6 +134,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/deferred': typeof DeferredRoute
+  '/preferences': typeof PreferencesRoute
   '/redirect': typeof RedirectRoute
   '/api/users': typeof ApiUsersRouteWithChildren
   '/posts/$postId': typeof PostsPostIdRoute
@@ -145,6 +153,7 @@ export interface FileRoutesById {
   '/users': typeof UsersRouteRouteWithChildren
   '/_pathlessLayout': typeof PathlessLayoutRouteWithChildren
   '/deferred': typeof DeferredRoute
+  '/preferences': typeof PreferencesRoute
   '/redirect': typeof RedirectRoute
   '/_pathlessLayout/_nested-layout': typeof PathlessLayoutNestedLayoutRouteWithChildren
   '/api/users': typeof ApiUsersRouteWithChildren
@@ -164,6 +173,7 @@ export interface FileRouteTypes {
     | '/posts'
     | '/users'
     | '/deferred'
+    | '/preferences'
     | '/redirect'
     | '/api/users'
     | '/posts/$postId'
@@ -178,6 +188,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/deferred'
+    | '/preferences'
     | '/redirect'
     | '/api/users'
     | '/posts/$postId'
@@ -195,6 +206,7 @@ export interface FileRouteTypes {
     | '/users'
     | '/_pathlessLayout'
     | '/deferred'
+    | '/preferences'
     | '/redirect'
     | '/_pathlessLayout/_nested-layout'
     | '/api/users'
@@ -214,6 +226,7 @@ export interface RootRouteChildren {
   UsersRouteRoute: typeof UsersRouteRouteWithChildren
   PathlessLayoutRoute: typeof PathlessLayoutRouteWithChildren
   DeferredRoute: typeof DeferredRoute
+  PreferencesRoute: typeof PreferencesRoute
   RedirectRoute: typeof RedirectRoute
   ApiUsersRoute: typeof ApiUsersRouteWithChildren
   PostsPostIdDeepRoute: typeof PostsPostIdDeepRoute
@@ -247,6 +260,13 @@ declare module '@tanstack/react-router' {
       path: '/posts'
       fullPath: '/posts'
       preLoaderRoute: typeof PostsRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/preferences': {
+      id: '/preferences'
+      path: '/preferences'
+      fullPath: '/preferences'
+      preLoaderRoute: typeof PreferencesRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/redirect': {
@@ -412,6 +432,7 @@ const rootRouteChildren: RootRouteChildren = {
   UsersRouteRoute: UsersRouteRouteWithChildren,
   PathlessLayoutRoute: PathlessLayoutRouteWithChildren,
   DeferredRoute: DeferredRoute,
+  PreferencesRoute: PreferencesRoute,
   RedirectRoute: RedirectRoute,
   ApiUsersRoute: ApiUsersRouteWithChildren,
   PostsPostIdDeepRoute: PostsPostIdDeepRoute,

--- a/examples/react/start-basic-react-query/src/routeTree.gen.ts
+++ b/examples/react/start-basic-react-query/src/routeTree.gen.ts
@@ -442,10 +442,11 @@ export const routeTree = rootRouteImport
   ._addFileTypes<FileRouteTypes>()
 
 import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
+import type { startInstance } from './start.ts'
 declare module '@tanstack/react-start' {
   interface Register {
     ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
+    config: Awaited<ReturnType<typeof startInstance.getOptions>>
   }
 }

--- a/examples/react/start-basic-react-query/src/router.tsx
+++ b/examples/react/start-basic-react-query/src/router.tsx
@@ -6,12 +6,15 @@ import { DefaultCatchBoundary } from './components/DefaultCatchBoundary'
 import { NotFound } from './components/NotFound'
 
 export function getRouter() {
-  const queryClient = new QueryClient()
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { staleTime: 30_000 } },
+  })
 
   const router = createRouter({
     routeTree,
     context: { queryClient },
     defaultPreload: 'intent',
+    defaultPreloadStaleTime: 0,
     defaultErrorComponent: DefaultCatchBoundary,
     defaultNotFoundComponent: () => <NotFound />,
   })

--- a/examples/react/start-basic-react-query/src/routes/__root.tsx
+++ b/examples/react/start-basic-react-query/src/routes/__root.tsx
@@ -83,6 +83,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
       </head>
       <body>
         <div className="p-2 flex gap-2 text-lg">
+          <Link to="/preferences">Preferences</Link>
           <Link
             to="/"
             activeProps={{

--- a/examples/react/start-basic-react-query/src/routes/preferences.tsx
+++ b/examples/react/start-basic-react-query/src/routes/preferences.tsx
@@ -1,0 +1,68 @@
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from '@tanstack/react-query'
+import { createFileRoute, useHydrated } from '@tanstack/react-router'
+import { useServerFn } from '@tanstack/react-start'
+import { readerNameOptions, saveReaderName } from '../utils/preferences'
+
+export const Route = createFileRoute('/preferences')({
+  loader: async ({ context }) => {
+    await context.queryClient.query(readerNameOptions)
+  },
+  headers: () => ({ 'Cache-Control': 'private, no-store' }),
+  head: () => ({ meta: [{ title: 'Reader preferences' }] }),
+  component: Preferences,
+})
+
+function Preferences() {
+  const { data: name } = useSuspenseQuery(readerNameOptions)
+  const queryClient = useQueryClient()
+  const save = useServerFn(saveReaderName)
+  const hydrated = useHydrated()
+  const mutation = useMutation({
+    mutationFn: (name: string) => save({ data: name }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: readerNameOptions.queryKey }),
+  })
+
+  return (
+    <main className="space-y-4 p-4">
+      <h1 className="text-2xl font-bold">Reader preferences</h1>
+      <p data-testid="reader-name">Hello, {name}</p>
+      <form
+        method="post"
+        onSubmit={(event) => {
+          event.preventDefault()
+          const value = new FormData(event.currentTarget).get('name')
+          if (typeof value === 'string') {
+            mutation.mutate(value)
+          }
+        }}
+      >
+        <fieldset
+          disabled={!hydrated || mutation.isPending}
+          className="flex gap-3"
+        >
+          <label>
+            Display name{' '}
+            <input
+              name="name"
+              defaultValue={name}
+              maxLength={40}
+              required
+              className="rounded border p-1"
+            />
+          </label>
+          <button type="submit" className="rounded border px-3">
+            {mutation.isPending ? 'Saving...' : 'Save name'}
+          </button>
+        </fieldset>
+        {mutation.isError ? (
+          <p role="alert">Could not save your name. Try again.</p>
+        ) : null}
+      </form>
+    </main>
+  )
+}

--- a/examples/react/start-basic-react-query/src/start.ts
+++ b/examples/react/start-basic-react-query/src/start.ts
@@ -1,0 +1,9 @@
+import { createCsrfMiddleware, createStart } from '@tanstack/react-start'
+
+export const startInstance = createStart(() => ({
+  requestMiddleware: [
+    createCsrfMiddleware({
+      filter: (ctx) => ctx.handlerType === 'serverFn',
+    }),
+  ],
+}))

--- a/examples/react/start-basic-react-query/src/utils/preferences.ts
+++ b/examples/react/start-basic-react-query/src/utils/preferences.ts
@@ -1,0 +1,34 @@
+import { queryOptions } from '@tanstack/react-query'
+import { createServerFn } from '@tanstack/react-start'
+import {
+  getCookie,
+  setCookie,
+  setResponseHeader,
+} from '@tanstack/react-start/server'
+
+export const getReaderName = createServerFn({ method: 'GET' }).handler(() => {
+  setResponseHeader('Cache-Control', 'private, no-store')
+  return getCookie('reader-name') || 'Guest'
+})
+
+export const saveReaderName = createServerFn({ method: 'POST' })
+  .validator((name: string) => {
+    if (typeof name !== 'string' || !name.trim() || name.length > 40) {
+      throw new Error('Enter a name between 1 and 40 characters')
+    }
+    return name.trim()
+  })
+  .handler(({ data }) => {
+    setResponseHeader('Cache-Control', 'private, no-store')
+    setCookie('reader-name', data, {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      path: '/',
+    })
+  })
+
+export const readerNameOptions = queryOptions({
+  queryKey: ['reader-name'],
+  queryFn: () => getReaderName(),
+})

--- a/examples/react/start-basic-react-query/tests/preferences.spec.ts
+++ b/examples/react/start-basic-react-query/tests/preferences.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test'
+
+test('concurrent SSR requests keep the same query key isolated by request', async ({
+  request,
+}) => {
+  const names = ['Lucia', 'Omar', 'Maya', 'Felix']
+  const responses = await Promise.all(
+    names.map((name) =>
+      request.get('/preferences', {
+        headers: { Cookie: `reader-name=${name}` },
+      }),
+    ),
+  )
+  for (const [index, response] of responses.entries()) {
+    expect(response.status()).toBe(200)
+    expect(response.headers()['cache-control']).toContain('no-store')
+    const html = await response.text()
+    expect(html).toContain(names[index])
+    for (const other of names.filter((_, otherIndex) => otherIndex !== index)) {
+      expect(html).not.toContain(other)
+    }
+  }
+})
+
+test('hydration reuses SSR data and mutation invalidation refetches once', async ({
+  page,
+}) => {
+  const reads: string[] = []
+  page.on('request', (request) => {
+    if (
+      request.method() === 'GET' &&
+      new URL(request.url()).pathname.startsWith('/_serverFn/')
+    ) {
+      reads.push(request.url())
+    }
+  })
+  await page.goto('/preferences')
+  await expect(page.getByTestId('reader-name')).toHaveText('Hello, Guest')
+  await expect(page.getByLabel('Display name')).toBeEnabled()
+  await page.waitForLoadState('networkidle')
+  expect(reads).toHaveLength(0)
+
+  await page.getByLabel('Display name').fill('Ada')
+  await page.getByRole('button', { name: 'Save name' }).click()
+  await expect(page.getByTestId('reader-name')).toHaveText('Hello, Ada')
+  await expect(page.getByRole('button', { name: 'Save name' })).toBeEnabled()
+  await page.waitForLoadState('networkidle')
+  expect(reads).toHaveLength(1)
+
+  await page.reload()
+  await expect(page.getByTestId('reader-name')).toHaveText('Hello, Ada')
+  await expect(page.getByLabel('Display name')).toBeEnabled()
+  await page.waitForLoadState('networkidle')
+  expect(reads).toHaveLength(1)
+})

--- a/examples/react/start-basic-react-query/tests/preferences.spec.ts
+++ b/examples/react/start-basic-react-query/tests/preferences.spec.ts
@@ -41,11 +41,23 @@ test('hydration reuses SSR data and mutation invalidation refetches once', async
   expect(reads).toHaveLength(0)
 
   await page.getByLabel('Display name').fill('Ada')
+  const mutation = page.waitForRequest((request) => request.method() === 'POST')
   await page.getByRole('button', { name: 'Save name' }).click()
   await expect(page.getByTestId('reader-name')).toHaveText('Hello, Ada')
   await expect(page.getByRole('button', { name: 'Save name' })).toBeEnabled()
   await page.waitForLoadState('networkidle')
   expect(reads).toHaveLength(1)
+
+  const savedRequest = await mutation
+  const headers = await savedRequest.allHeaders()
+  delete headers['content-length']
+  headers.origin = 'https://untrusted.example'
+  headers['sec-fetch-site'] = 'cross-site'
+  const denied = await page.request.post(savedRequest.url(), {
+    headers,
+    data: savedRequest.postData() ?? '',
+  })
+  expect(denied.status()).toBe(403)
 
   await page.reload()
   await expect(page.getByTestId('reader-name')).toHaveText('Hello, Ada')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10025,6 +10025,9 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.61.0
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))


### PR DESCRIPTION
## 🎯 Changes

Add a TanStack Start + Query guide covering request-scoped QueryClients, SSR hydration, preloading, streaming, and mutation invalidation. Link it from the Start navigation and Router data-loading guide.

Extend the existing React Query example with a cookie-backed preference page. Its browser checks verify concurrent SSR request isolation, no duplicate hydration reads, and exactly one refetch after mutation invalidation. The preference cookie is a local demonstration, not authentication.

Validation: required ESLint, type, and unit checks passed. The example build passed. Both browser tests passed in development and production.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a changeset.
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guidance for integrating TanStack Query with TanStack Start, including SSR, hydration, streaming, preloading, and mutation invalidation.
  * Added a Preferences page to the React Query example for viewing and saving a reader name.
  * Added explicit query freshness settings and post-mutation refetching.

* **Documentation**
  * Added navigation for the integration guide and expanded example testing guidance.

* **Tests**
  * Added Playwright coverage for SSR isolation, hydration, persistence, query invalidation, and cross-site request protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->