### PR TITLE
docs(start): distinguish authentication page titles

### DIFF
--- a/docs/start/config.json
+++ b/docs/start/config.json
@@ -310,7 +310,7 @@
           "label": "react",
           "children": [
             {
-              "label": "Authentication Overview",
+              "label": "Choose Authentication",
               "to": "framework/react/guide/authentication-overview"
             },
             {
@@ -318,7 +318,7 @@
               "to": "framework/react/guide/authentication-server-primitives"
             },
             {
-              "label": "Authentication",
+              "label": "Implement Authentication",
               "to": "framework/react/guide/authentication"
             },
             {
@@ -331,7 +331,7 @@
           "label": "solid",
           "children": [
             {
-              "label": "Authentication Overview",
+              "label": "Choose Authentication",
               "to": "framework/solid/guide/authentication-overview"
             },
             {
@@ -339,7 +339,7 @@
               "to": "framework/solid/guide/authentication-server-primitives"
             },
             {
-              "label": "Authentication",
+              "label": "Implement Authentication",
               "to": "framework/solid/guide/authentication"
             },
             {

--- a/docs/start/framework/react/guide/authentication-overview.md
+++ b/docs/start/framework/react/guide/authentication-overview.md
@@ -1,8 +1,10 @@
 ---
 id: authentication-overview
-title: Authentication
-description: Compare authentication options for TanStack Start and plan session management, route protection, and server-side authorization.
+title: Choose Authentication for React Apps
+description: Compare hosted services, auth libraries, and custom authentication for React apps built with TanStack Start. Choose an approach before implementing sessions and authorization.
 ---
+
+Choose how your React app will handle identity, sessions, and permissions. This page compares approaches and providers. Once you have chosen an approach, use [Implement Authentication in React](./authentication.md) for the application workflow.
 
 ## Authentication vs Authorization
 

--- a/docs/start/framework/react/guide/authentication.md
+++ b/docs/start/framework/react/guide/authentication.md
@@ -1,12 +1,12 @@
 ---
 id: authentication
-title: Authentication
-description: Explore authentication patterns in TanStack Start, including sessions, login and logout, protected routes, and role-based access.
+title: Implement Authentication in React
+description: Implement sessions, sign-in, sign-out, protected routes, and server-side authorization in a TanStack Start React app.
 ---
 
-This guide covers authentication patterns and shows how to implement your own authentication system with TanStack Start.
+Implement the authentication workflow in your React app, from sessions and sign-in to protected routes and authorization.
 
-> **📋 Before You Start:** Check our [Authentication Overview](./authentication-overview.md) for all available options including partner solutions and hosted services.
+To compare libraries and hosted services, read [Choose Authentication for React Apps](./authentication-overview.md).
 
 ## Authentication Approaches
 

--- a/docs/start/framework/solid/guide/authentication.md
+++ b/docs/start/framework/solid/guide/authentication.md
@@ -1,12 +1,12 @@
 ---
 id: authentication
-title: Authentication
-description: Explore authentication patterns in TanStack Start, including sessions, login and logout, protected routes, and role-based access.
+title: Implement Authentication in SolidJS
+description: Implement sessions, sign-in, sign-out, protected routes, and server-side authorization in a TanStack Start SolidJS app.
 ---
 
-This guide covers authentication patterns and shows how to implement your own authentication system with TanStack Start.
+Implement the authentication workflow in your SolidJS app, from sessions and sign-in to protected routes and authorization.
 
-> **📋 Before You Start:** Check our [Authentication Overview](./authentication-overview.md) for all available options including partner solutions and hosted services.
+To compare libraries and hosted services, read [Choose Authentication for SolidJS Apps](./authentication-overview.md).
 
 ## Authentication Approaches
 


### PR DESCRIPTION
## 🎯 Changes

Differentiate the authentication overview and implementation pages for React and Solid. Each URL now has a distinct title, H1, and description, and the introductions and navigation labels distinguish choosing an approach from implementing it. Preserve all existing URLs and guide content, with clear cross-links between the two jobs.

Validation: all four pages returned 200 in the local docs renderer, with four distinct titles, H1s, and descriptions. Required lint, type, and unit commands completed successfully with no affected code tasks. The Solid overview continues to reuse the React source through its existing replacement mapping.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a changeset.
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication navigation labels for React and Solid guides to clarify the distinction between choosing an authentication approach and implementing it.
  * Revised React and Solid authentication documentation titles, descriptions, and introductions to better explain available options and implementation workflows.
  * Added guidance linking authentication overview content with implementation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->