### PR TITLE
docs(start): redirect obsolete Solid tutorial path

### DIFF
--- a/docs/start/framework/solid/guide/reading-writing-file.md
+++ b/docs/start/framework/solid/guide/reading-writing-file.md
@@ -1,5 +1,0 @@
----
-ref: docs/start/framework/react/guide/reading-writing-file.md
-replace:
-  { '@tanstack/react-start': '@tanstack/solid-start', 'React': 'SolidJS' }
----

--- a/docs/start/framework/solid/tutorial/reading-writing-file.md
+++ b/docs/start/framework/solid/tutorial/reading-writing-file.md
@@ -1,6 +1,8 @@
 ---
 id: reading-and-writing-file
 title: Building a Full Stack DevJokes App with TanStack Start
+redirect_from:
+  - /framework/solid/guide/reading-writing-file
 ---
 
 This tutorial will guide you through building a complete full-stack application using TanStack Start. You'll create a DevJokes app where users can view and add developer-themed jokes, demonstrating key concepts of TanStack Start including server functions, file-based data storage, and Solid components.


### PR DESCRIPTION
## 🎯 Changes

Remove the obsolete Solid `guide/reading-writing-file` stub, which references a nonexistent React guide and currently returns 404. Declare that old URL in the working Solid tutorial's `redirect_from` metadata so the documentation resolver permanently redirects it to `tutorial/reading-writing-file` and the source manifest emits only the tutorial URL.

Validation: the site's real manifest collector and redirect resolver checked all 81 remaining source paths, excluded the obsolete path, and resolved its alias to the tutorial. Required lint, types, and unit commands passed with no affected code tasks. Rechecked all 82 current live sitemap targets: 81 returned 200 with matching canonicals and document headings, including eight initially transient 500 responses that passed on serial retry. The obsolete path still returns 404 before deployment. The local HTTP preview's manifest was empty, so it was not used as proof of the deployed redirect. Live 308 and sitemap removal remain post-merge checks.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the SolidJS file reading and writing guide.
  - Added a redirect so the legacy guide URL continues to lead readers to the appropriate tutorial.
  - Simplified documentation maintenance for the SolidJS guide while preserving access to existing documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->