### PR TITLE
docs(start): record verified Query recipe versions

### DIFF
--- a/docs/start/framework/react/guide/tanstack-query.md
+++ b/docs/start/framework/react/guide/tanstack-query.md
@@ -1,6 +1,12 @@
 ---
 id: tanstack-query
 title: TanStack Query
+updated: "2026-09-11"
+testedWith:
+  "@tanstack/react-start": "1.168.52"
+  "@tanstack/react-query": "5.102.0"
+  react: "19.2.3"
+  vite: "8.0.14"
 description: Use TanStack Query with TanStack Start for request-isolated SSR, hydration, route preloading, streaming, and mutation invalidation.
 ---
 

--- a/docs/start/framework/react/guide/tanstack-query.md
+++ b/docs/start/framework/react/guide/tanstack-query.md
@@ -1,12 +1,12 @@
 ---
 id: tanstack-query
 title: TanStack Query
-updated: "2026-09-11"
+updated: '2026-09-11'
 testedWith:
-  "@tanstack/react-start": "1.168.52"
-  "@tanstack/react-query": "5.102.0"
-  react: "19.2.3"
-  vite: "8.0.14"
+  '@tanstack/react-start': '1.168.52'
+  '@tanstack/react-query': '5.102.0'
+  react: '19.2.3'
+  vite: '8.0.14'
 description: Use TanStack Query with TanStack Start for request-isolated SSR, hydration, route preloading, streaming, and mutation invalidation.
 ---
 


### PR DESCRIPTION
## 🎯 Changes

Record the TanStack Query guide's actual content update date and the exact package versions used to verify its runnable preference example. The date comes from content commit e047e3f7ca9c21ab5dd02f384c497a6077f3f001 on September 11, rather than the metadata edit date.

Installed versions: react-start 1.168.52, react-query 5.102.0, React 19.2.3, Vite 8.0.14. Development and production Playwright tests passed (two each), covering request isolation, hydration reuse, and mutation invalidation. The example build and repository lint, type, and unit checks passed. The site freshness renderer is being implemented separately; these fields add source facts without changing guide prose.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a changeset.
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the TanStack Query guide with its latest revision date.
  - Added the tested dependency versions used by the example, including React, Vite, and TanStack packages.
  - Documented the pinned versions for `@tanstack/react-start`, `@tanstack/react-query`, React, and Vite to clarify the example’s tested environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->