### PR TITLE
docs(router): clarify when Start helps with data loading

### DIFF
--- a/docs/router/guide/external-data-loading.md
+++ b/docs/router/guide/external-data-loading.md
@@ -6,7 +6,7 @@ title: External Data Loading
 > [!IMPORTANT]
 > This guide is geared towards external state management libraries and their integration with TanStack Router for data fetching, ssr, hydration/dehydration and streaming. If you haven't read the standard [Data Loading](./data-loading.md) guide, please do so first.
 
-For a full-stack React application, follow [TanStack Query with Start](/start/latest/docs/framework/react/guide/tanstack-query) for request-scoped SSR, hydration, and mutation invalidation with a tested example.
+Router can coordinate loaders and an existing API without Start. If you also want an integrated server runtime and typed server functions for your React application, follow [TanStack Query with Start](/start/latest/docs/framework/react/guide/tanstack-query) for request-scoped SSR, hydration, and mutation invalidation with a tested example.
 
 ## To **Store** or to **Coordinate**?
 


### PR DESCRIPTION
## 🎯 Changes

Clarify that Router can coordinate loaders with an existing API without adopting Start. Keep the existing contextual Start Query link for readers who want an integrated server runtime and typed server functions.

This completes the selection guidance alongside the previously added Query and Form recipe links. No additional global navigation or duplicate links. Repository lint, type, and unit checks passed.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a changeset.
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the Router can coordinate data loaders with an existing API without requiring Start.
  * Updated guidance to reference the TanStack Query with Start guide for integrated server runtimes and typed server functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->