### PR TITLE
docs(start): troubleshoot server and client execution boundaries

### DIFF
--- a/docs/start/framework/react/guide/environment-functions.md
+++ b/docs/start/framework/react/guide/environment-functions.md
@@ -121,3 +121,37 @@ Environment functions are tree-shaken based on the environment for each bundle p
 Functions created using `createIsomorphicFn()` are tree-shaken. All codes inside `.client()` are not included in server bundle, and vice-versa.
 
 On the server, functions created using `createClientOnlyFn()` are replaced with a function that throws an `Error` on the server. The reverse is true for `createServerOnlyFn` functions on the client.
+
+## Troubleshooting
+
+### A loader works on refresh but throws during navigation
+
+If a loader throws `createServerOnlyFn() functions can only be called on the server!` after clicking a link, check whether it calls a server-only helper directly. Route loaders also run in the browser during client navigation. `createServerOnlyFn` guards a local function, it does not send a request to the server.
+
+Wrap the server work in `createServerFn` and call that function from the loader:
+
+```tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { createServerFn, createServerOnlyFn } from '@tanstack/react-start'
+
+const readOnlyOnServer = createServerOnlyFn(() => 'Read on the server')
+const readThroughRpc = createServerFn().handler(() => readOnlyOnServer())
+
+export const Route = createFileRoute('/example')({
+  loader: () => readThroughRpc(),
+})
+```
+
+The server function runs directly during SSR and makes a request to the server when called in the browser. Test both a direct page request and navigation from another route. A successful refresh alone does not exercise the browser loader.
+
+The [execution-boundary tests](https://github.com/TanStack/router/blob/main/e2e/react-start/basic/tests/environment-functions.spec.ts) include the failing direct call and the working server-function version. See [Server Functions](./server-functions.md) for validation and middleware when the function accepts user input.
+
+### Browser code throws `window is not defined` on the server
+
+This means browser-only code ran during server execution. Use the stack trace to find the first application or dependency module that reads `window`, `document`, or another browser API.
+
+For a browser-only component, render it inside `ClientOnly` from `@tanstack/react-router` with a useful fallback. The Start compiler removes its children from the server bundle, which lets the bundler remove imports used only by those children. The [ClientOnly example](https://github.com/TanStack/router/blob/main/e2e/react-start/basic/src/routes/client-only.tsx) covers a component that reads `window` at module scope, and its [tests](https://github.com/TanStack/router/blob/main/e2e/react-start/basic/tests/client-only.spec.ts) check the server fallback and hydrated content.
+
+A browser API used elsewhere, such as a route loader or server function, still needs the correct execution boundary. Move component side effects into an effect or event handler. For logic that needs different server and browser implementations, use `createIsomorphicFn` with both implementations. Wrapping a function in `createClientOnlyFn` does not defer its call until the browser, calling that wrapper on the server throws the client-only guard error instead.
+
+If the stack points into build tooling or the error persists in a minimal app with the correct boundary, include that app and the installed Start and bundler versions in a [bug report](https://github.com/TanStack/router/issues/new/choose). A compiler or dependency bug needs a reproducible fix, not a blanket change to rendering mode.

--- a/e2e/react-start/basic/src/routeTree.gen.ts
+++ b/e2e/react-start/basic/src/routeTree.gen.ts
@@ -15,6 +15,8 @@ import { Route as AsyncScriptsRouteImport } from './routes/async-scripts'
 import { Route as AuthDocsRouteImport } from './routes/auth-docs'
 import { Route as ClientOnlyRouteImport } from './routes/client-only'
 import { Route as DeferredRouteImport } from './routes/deferred'
+import { Route as ExecutionLocalRouteImport } from './routes/execution-local'
+import { Route as ExecutionRpcRouteImport } from './routes/execution-rpc'
 import { Route as InlineScriptsRouteImport } from './routes/inline-scripts'
 import { Route as LinksRouteImport } from './routes/links'
 import { Route as NotFoundRouteRouteImport } from './routes/not-found/route'
@@ -111,6 +113,16 @@ const ClientOnlyRoute = ClientOnlyRouteImport.update({
 const DeferredRoute = DeferredRouteImport.update({
   id: '/deferred',
   path: '/deferred',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ExecutionLocalRoute = ExecutionLocalRouteImport.update({
+  id: '/execution-local',
+  path: '/execution-local',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ExecutionRpcRoute = ExecutionRpcRouteImport.update({
+  id: '/execution-rpc',
+  path: '/execution-rpc',
   getParentRoute: () => rootRouteImport,
 } as any)
 const InlineScriptsRoute = InlineScriptsRouteImport.update({
@@ -479,6 +491,8 @@ export interface FileRoutesByFullPath {
   '/auth-docs': typeof AuthDocsRouteWithChildren
   '/client-only': typeof ClientOnlyRoute
   '/deferred': typeof DeferredRoute
+  '/execution-local': typeof ExecutionLocalRoute
+  '/execution-rpc': typeof ExecutionRpcRoute
   '/inline-scripts': typeof InlineScriptsRoute
   '/links': typeof LinksRoute
   '/plain-ts-type-assertion': typeof PlainTsTypeAssertionRoute
@@ -551,6 +565,8 @@ export interface FileRoutesByTo {
   '/auth-docs': typeof AuthDocsRouteWithChildren
   '/client-only': typeof ClientOnlyRoute
   '/deferred': typeof DeferredRoute
+  '/execution-local': typeof ExecutionLocalRoute
+  '/execution-rpc': typeof ExecutionRpcRoute
   '/inline-scripts': typeof InlineScriptsRoute
   '/links': typeof LinksRoute
   '/plain-ts-type-assertion': typeof PlainTsTypeAssertionRoute
@@ -620,6 +636,8 @@ export interface FileRoutesById {
   '/auth-docs': typeof AuthDocsRouteWithChildren
   '/client-only': typeof ClientOnlyRoute
   '/deferred': typeof DeferredRoute
+  '/execution-local': typeof ExecutionLocalRoute
+  '/execution-rpc': typeof ExecutionRpcRoute
   '/inline-scripts': typeof InlineScriptsRoute
   '/links': typeof LinksRoute
   '/plain-ts-type-assertion': typeof PlainTsTypeAssertionRoute
@@ -697,6 +715,8 @@ export interface FileRouteTypes {
     | '/auth-docs'
     | '/client-only'
     | '/deferred'
+    | '/execution-local'
+    | '/execution-rpc'
     | '/inline-scripts'
     | '/links'
     | '/plain-ts-type-assertion'
@@ -769,6 +789,8 @@ export interface FileRouteTypes {
     | '/auth-docs'
     | '/client-only'
     | '/deferred'
+    | '/execution-local'
+    | '/execution-rpc'
     | '/inline-scripts'
     | '/links'
     | '/plain-ts-type-assertion'
@@ -837,6 +859,8 @@ export interface FileRouteTypes {
     | '/auth-docs'
     | '/client-only'
     | '/deferred'
+    | '/execution-local'
+    | '/execution-rpc'
     | '/inline-scripts'
     | '/links'
     | '/plain-ts-type-assertion'
@@ -914,6 +938,8 @@ export interface RootRouteChildren {
   AuthDocsRoute: typeof AuthDocsRouteWithChildren
   ClientOnlyRoute: typeof ClientOnlyRoute
   DeferredRoute: typeof DeferredRoute
+  ExecutionLocalRoute: typeof ExecutionLocalRoute
+  ExecutionRpcRoute: typeof ExecutionRpcRoute
   InlineScriptsRoute: typeof InlineScriptsRoute
   LinksRoute: typeof LinksRoute
   PlainTsTypeAssertionRoute: typeof PlainTsTypeAssertionRoute
@@ -977,6 +1003,20 @@ declare module '@tanstack/react-router' {
       path: '/deferred'
       fullPath: '/deferred'
       preLoaderRoute: typeof DeferredRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/execution-local': {
+      id: '/execution-local'
+      path: '/execution-local'
+      fullPath: '/execution-local'
+      preLoaderRoute: typeof ExecutionLocalRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/execution-rpc': {
+      id: '/execution-rpc'
+      path: '/execution-rpc'
+      fullPath: '/execution-rpc'
+      preLoaderRoute: typeof ExecutionRpcRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/inline-scripts': {
@@ -1729,6 +1769,8 @@ const rootRouteChildren: RootRouteChildren = {
   AuthDocsRoute: AuthDocsRouteWithChildren,
   ClientOnlyRoute: ClientOnlyRoute,
   DeferredRoute: DeferredRoute,
+  ExecutionLocalRoute: ExecutionLocalRoute,
+  ExecutionRpcRoute: ExecutionRpcRoute,
   InlineScriptsRoute: InlineScriptsRoute,
   LinksRoute: LinksRoute,
   PlainTsTypeAssertionRoute: PlainTsTypeAssertionRoute,

--- a/e2e/react-start/basic/src/routes/__root.tsx
+++ b/e2e/react-start/basic/src/routes/__root.tsx
@@ -197,6 +197,9 @@ function RootDocument({ children }: { children: React.ReactNode }) {
           >
             Client Only
           </Link>{' '}
+          <Link to="/execution-rpc" preload={false}>
+            Server function loader
+          </Link>{' '}
           <Link
             to="/raw-stream"
             activeProps={{

--- a/e2e/react-start/basic/src/routes/execution-local.tsx
+++ b/e2e/react-start/basic/src/routes/execution-local.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { readOnlyOnServer } from '~/utils/execution-functions'
+
+// This intentionally fails during browser navigation. It is the negative case
+// for the environment-functions troubleshooting guide.
+export const Route = createFileRoute('/execution-local')({
+  loader: () => readOnlyOnServer(),
+  component: Result,
+  errorComponent: ({ error }) => (
+    <p role="alert">{error instanceof Error ? error.message : String(error)}</p>
+  ),
+})
+
+function Result() {
+  return <p data-testid="execution-result">{Route.useLoaderData()}</p>
+}

--- a/e2e/react-start/basic/src/routes/execution-rpc.tsx
+++ b/e2e/react-start/basic/src/routes/execution-rpc.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { readThroughRpc } from '~/utils/execution-functions'
+
+export const Route = createFileRoute('/execution-rpc')({
+  loader: () => readThroughRpc(),
+  component: Result,
+})
+
+function Result() {
+  return (
+    <>
+      <p data-testid="execution-result">{Route.useLoaderData()}</p>
+      <Link to="/execution-local" preload={false}>
+        Call the server-only helper directly
+      </Link>
+    </>
+  )
+}

--- a/e2e/react-start/basic/src/utils/execution-functions.ts
+++ b/e2e/react-start/basic/src/utils/execution-functions.ts
@@ -1,0 +1,5 @@
+import { createServerFn, createServerOnlyFn } from '@tanstack/react-start'
+
+export const readOnlyOnServer = createServerOnlyFn(() => 'Read on the server')
+
+export const readThroughRpc = createServerFn().handler(() => readOnlyOnServer())

--- a/e2e/react-start/basic/tests/client-only.spec.ts
+++ b/e2e/react-start/basic/tests/client-only.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from '@playwright/test'
 import { test } from '@tanstack/router-e2e-utils'
+import { isSpaMode } from './utils/isSpaMode'
 
 /**
  * These tests verify the <ClientOnly> compiler optimization.
@@ -15,7 +16,15 @@ import { test } from '@tanstack/router-e2e-utils'
 
 test('ClientOnly renders fallback on server, then client content after hydration', async ({
   page,
+  request,
 }) => {
+  const response = await request.get('/client-only')
+  expect(response.status()).toBe(200)
+  const html = await response.text()
+  expect(html).not.toContain('data-testid="window-size"')
+  if (!isSpaMode) {
+    expect(html).toContain('Loading window size...')
+  }
   // Navigate directly to the client-only route
   // If the compiler optimization isn't working, this would crash the server
   // because WindowSize.tsx accesses `window` at module scope

--- a/e2e/react-start/basic/tests/environment-functions.spec.ts
+++ b/e2e/react-start/basic/tests/environment-functions.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from '@playwright/test'
+import { isSpaMode } from './utils/isSpaMode'
+
+const guardError =
+  'createServerOnlyFn() functions can only be called on the server!'
+
+test('a server-only loader works on the server but rejects client navigation', async ({
+  page,
+  request,
+}) => {
+  const direct = await request.get('/execution-local')
+  expect(direct.status()).toBe(200)
+  if (!isSpaMode) {
+    expect(await direct.text()).toContain('Read on the server')
+  }
+  await page.goto('/execution-rpc')
+  await expect(page.getByTestId('execution-result')).toHaveText(
+    'Read on the server',
+  )
+  await page
+    .getByRole('link', { name: 'Call the server-only helper directly' })
+    .click()
+  await expect(page.getByRole('alert')).toHaveText(guardError)
+})
+
+test('a server function preserves the loader result on direct requests and navigation', async ({
+  page,
+  request,
+}) => {
+  const direct = await request.get('/execution-rpc')
+  expect(direct.status()).toBe(200)
+  if (!isSpaMode) {
+    expect(await direct.text()).toContain('Read on the server')
+  }
+  await page.goto('/')
+  await page
+    .getByRole('link', { name: 'Server function loader', exact: true })
+    .click()
+  await expect(page.getByTestId('execution-result')).toHaveText(
+    'Read on the server',
+  )
+  await page.reload()
+  await expect(page.getByTestId('execution-result')).toHaveText(
+    'Read on the server',
+  )
+})


### PR DESCRIPTION
## 🎯 Changes

Explain why a loader that calls `createServerOnlyFn` can work on refresh and fail during client navigation, and show the `createServerFn` fix. Add guidance for browser APIs reached during server execution, including the current `ClientOnly` compiler behavior.

The basic Start fixture includes failing and working loader routes. Browser tests exercise both paths, and the existing `ClientOnly` test now checks raw server HTML before hydration.

Validation: production Vite SSR suite, 140 passed and 3 skipped; focused Vite SPA tests, 5 passed; required lint, types, and unit checks passed. Focused Rsbuild SSR and SPA tests also passed, 5 in each mode.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added guidance for handling server-only and browser-only code across rendering boundaries.
  - Added example routes demonstrating server-only loaders and server functions.
  - Added navigation for the server-function example.

- **Bug Fixes**
  - Improved coverage for client-only rendering and server-function behavior across direct requests, navigation, and reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->