### PR TITLE
chore(deps): upgrade Rsbuild to 2.2.5

### DIFF
--- a/.changeset/rsbuild-watch-predicate.md
+++ b/.changeset/rsbuild-watch-predicate.md
@@ -3,4 +3,4 @@
 '@tanstack/solid-start': patch
 ---
 
-Support Rsbuild 2.2: preserve function-based Rspack watch exclusions when adding monorepo build-output exclusions, and leave string-valued Babel loader options intact in the Solid Start plugin.
+Support Rsbuild 2.2: preserve function-based Rspack watch exclusions and regular-expression flags when adding monorepo build-output exclusions, and leave string-valued Babel loader options intact in the Solid Start plugin.

--- a/.changeset/rsbuild-watch-predicate.md
+++ b/.changeset/rsbuild-watch-predicate.md
@@ -1,0 +1,6 @@
+---
+'@tanstack/start-plugin-core': patch
+'@tanstack/solid-start': patch
+---
+
+Support Rsbuild 2.2: preserve function-based Rspack watch exclusions when adding monorepo build-output exclusions, and leave string-valued Babel loader options intact in the Solid Start plugin.

--- a/packages/solid-start/package.json
+++ b/packages/solid-start/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "clean": "rimraf ./dist && rimraf ./coverage",
     "test": "pnpm test:build",
+    "test:unit": "vitest",
     "test:build": "publint --strict && attw --ignore-rules no-resolution --pack .",
     "build": "vite build && vite build -c vite.config.server-entry.ts"
   },

--- a/packages/solid-start/src/plugin/rsbuild.ts
+++ b/packages/solid-start/src/plugin/rsbuild.ts
@@ -51,6 +51,9 @@ export function tanstackStart(
           }
 
           rule.use(CHAIN_ID.USE.BABEL).tap((babelOptions) => {
+            if (typeof babelOptions === 'string') {
+              return babelOptions
+            }
             babelOptions.presets = (babelOptions.presets ?? []).map(
               (preset: unknown) => {
                 if (

--- a/packages/solid-start/tests/rsbuild.test.ts
+++ b/packages/solid-start/tests/rsbuild.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment node
+import { createRsbuild } from '@rsbuild/core'
+import { describe, expect, test, vi } from 'vitest'
+import { tanstackStart } from '../src/plugin/rsbuild'
+
+// Exercise the Solid-specific hook with Rsbuild's real chain, independently of
+// route generation and the core Start plugin's filesystem setup.
+vi.mock('@tanstack/start-plugin-core/rsbuild', () => ({
+  RSBUILD_ENVIRONMENT_NAMES: { server: 'server' },
+  tanStackStartRsbuild: () => ({ setup() {} }),
+}))
+
+async function configureBabel(
+  target: 'web' | 'node',
+  options: string | { presets: Array<unknown> },
+) {
+  const results: Array<unknown> = []
+  const rsbuild = await createRsbuild({
+    rsbuildConfig: {
+      source: { entry: { index: './src/index.ts' } },
+      output: { target },
+      plugins: [
+        {
+          name: 'test-babel-options',
+          setup(api) {
+            api.modifyBundlerChain((chain, { CHAIN_ID }) => {
+              for (const id of [
+                CHAIN_ID.RULE.JS,
+                CHAIN_ID.RULE.JS_DATA_URI,
+                'babel-js',
+              ]) {
+                chain.module
+                  .rule(id)
+                  .use(CHAIN_ID.USE.BABEL)
+                  .loader('babel-loader')
+                  .options(structuredClone(options))
+              }
+            })
+          },
+        },
+        tanstackStart(),
+        {
+          name: 'test-read-babel-options',
+          setup(api) {
+            api.modifyBundlerChain((chain, { CHAIN_ID }) => {
+              for (const id of [
+                CHAIN_ID.RULE.JS,
+                CHAIN_ID.RULE.JS_DATA_URI,
+                'babel-js',
+              ]) {
+                results.push(
+                  chain.module.rule(id).use(CHAIN_ID.USE.BABEL).get('options'),
+                )
+              }
+            })
+          },
+        },
+      ],
+    },
+  })
+  await rsbuild.initConfigs()
+  return results
+}
+
+describe('Solid Start Rsbuild Babel options', () => {
+  test.each(['web', 'node'] as const)(
+    'preserves string loader options for %s',
+    async (target) => {
+      const options = 'babelrc=true&configFile=./babel.config.json'
+      expect(await configureBabel(target, options)).toEqual([
+        options,
+        options,
+        options,
+      ])
+    },
+  )
+
+  test.each(['web', 'node'] as const)(
+    'retains Solid hydration and target selection for %s',
+    async (target) => {
+      const options = {
+        presets: [
+          ['babel-preset-solid', { custom: true, hydratable: false }],
+          ['another-preset', { untouched: true }],
+        ],
+      }
+      const expected = {
+        presets: [
+          [
+            'babel-preset-solid',
+            {
+              custom: true,
+              hydratable: true,
+              generate: target === 'node' ? 'ssr' : 'dom',
+            },
+          ],
+          ['another-preset', { untouched: true }],
+        ],
+      }
+      expect(await configureBabel(target, options)).toEqual([
+        expected,
+        expected,
+        expected,
+      ])
+    },
+  )
+})

--- a/packages/start-plugin-core/src/rsbuild/plugin.ts
+++ b/packages/start-plugin-core/src/rsbuild/plugin.ts
@@ -7,8 +7,9 @@ import {
   applyResolvedRouterBasepath,
   createStartConfigContext,
 } from '../config-context'
-import { escapeRegExp, normalizePath } from '../utils'
+import { normalizePath } from '../utils'
 import { createServerFnBasePath, normalizePublicBase } from '../planning'
+import { addWorkspaceWatchIgnored } from './watch-ignored'
 import { parseStartConfig, rsbuildClientOutputSchema } from './schema'
 import {
   RSBUILD_CLIENT_ASSETS_DIR,
@@ -444,27 +445,12 @@ export function tanStackStartRsbuild(
           const workspaceDistRealpaths = resolveWorkspacePackageDistRealpaths()
           if (workspaceDistRealpaths.length === 0) return
 
-          const workspaceDistIgnored = new RegExp(
-            workspaceDistRealpaths
-              .map((path) => `^${escapeRegExp(path)}(?:[\\\\/]|$)`)
-              .join('|'),
-          )
-          const ignored = config.watchOptions?.ignored
-
           config.watchOptions = {
             ...(config.watchOptions ?? {}),
-            ignored:
-              ignored == null
-                ? new RegExp(
-                    `${defaultRspackWatchIgnored.source}|${workspaceDistIgnored.source}`,
-                  )
-                : typeof ignored === 'string'
-                  ? [ignored, ...workspaceDistRealpaths]
-                  : Array.isArray(ignored)
-                    ? [...ignored, ...workspaceDistRealpaths]
-                    : new RegExp(
-                        `${ignored.source}|${workspaceDistIgnored.source}`,
-                      ),
+            ignored: addWorkspaceWatchIgnored(
+              config.watchOptions?.ignored,
+              workspaceDistRealpaths,
+            ),
           }
         })
       }
@@ -789,8 +775,6 @@ export function tanStackStartRsbuild(
     },
   }
 }
-
-const defaultRspackWatchIgnored = /[\\/](?:\.git|node_modules)[\\/]/
 
 function seedResolveModules(
   config: RspackConfig,

--- a/packages/start-plugin-core/src/rsbuild/watch-ignored.ts
+++ b/packages/start-plugin-core/src/rsbuild/watch-ignored.ts
@@ -1,0 +1,24 @@
+import { escapeRegExp } from '../utils'
+import type { Rspack } from '@rsbuild/core'
+
+type WatchIgnored = NonNullable<Rspack.Configuration['watchOptions']>['ignored']
+
+export function addWorkspaceWatchIgnored(
+  ignored: WatchIgnored,
+  directories: Array<string>,
+): WatchIgnored {
+  const workspace = new RegExp(
+    directories.map((path) => `^${escapeRegExp(path)}(?:[\\\\/]|$)`).join('|'),
+  )
+  if (typeof ignored === 'function') {
+    return (entry) => ignored(entry) || workspace.test(entry)
+  }
+  if (typeof ignored === 'string') {
+    return [ignored, ...directories]
+  }
+  if (Array.isArray(ignored)) {
+    return [...ignored, ...directories]
+  }
+  const original = ignored ?? /[\\/](?:\.git|node_modules)[\\/]/
+  return new RegExp(`${original.source}|${workspace.source}`)
+}

--- a/packages/start-plugin-core/src/rsbuild/watch-ignored.ts
+++ b/packages/start-plugin-core/src/rsbuild/watch-ignored.ts
@@ -20,5 +20,5 @@ export function addWorkspaceWatchIgnored(
     return [...ignored, ...directories]
   }
   const original = ignored ?? /[\\/](?:\.git|node_modules)[\\/]/
-  return new RegExp(`${original.source}|${workspace.source}`)
+  return new RegExp(`${original.source}|${workspace.source}`, original.flags)
 }

--- a/packages/start-plugin-core/tests/rsbuild/watch-ignored.test.ts
+++ b/packages/start-plugin-core/tests/rsbuild/watch-ignored.test.ts
@@ -2,6 +2,19 @@ import { describe, expect, test } from 'vitest'
 import { addWorkspaceWatchIgnored } from '../../src/rsbuild/watch-ignored'
 
 describe('workspace watch exclusions', () => {
+  test('preserves flags on an existing regular expression', () => {
+    const ignored = addWorkspaceWatchIgnored(/generated/iu, ['/repo/dist'])
+    expect(ignored).toBeInstanceOf(RegExp)
+    if (!(ignored instanceof RegExp)) {
+      throw new Error('Expected a watch expression')
+    }
+    expect(ignored.flags).toBe('iu')
+    expect(ignored.test('/app/GENERATED/route.ts')).toBe(true)
+    expect(ignored.test('/repo/dist/index.js')).toBe(true)
+    expect(ignored.test('/repo/dist-other/index.js')).toBe(false)
+    expect(ignored.test('/app/route.ts')).toBe(false)
+  })
+
   test('preserves an existing predicate and excludes only the workspace dist directory', () => {
     const ignored = addWorkspaceWatchIgnored(
       (entry) => entry.endsWith('.generated.ts'),

--- a/packages/start-plugin-core/tests/rsbuild/watch-ignored.test.ts
+++ b/packages/start-plugin-core/tests/rsbuild/watch-ignored.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'vitest'
+import { addWorkspaceWatchIgnored } from '../../src/rsbuild/watch-ignored'
+
+describe('workspace watch exclusions', () => {
+  test('preserves an existing predicate and excludes only the workspace dist directory', () => {
+    const ignored = addWorkspaceWatchIgnored(
+      (entry) => entry.endsWith('.generated.ts'),
+      ['/repo/packages/router/dist'],
+    )
+    expect(typeof ignored).toBe('function')
+    if (typeof ignored !== 'function') {
+      throw new Error('Expected a watch predicate')
+    }
+    expect(ignored('/app/route.generated.ts')).toBe(true)
+    expect(ignored('/repo/packages/router/dist/index.js')).toBe(true)
+    expect(ignored('/repo/packages/router/dist')).toBe(true)
+    expect(ignored('/repo/packages/router/dist-other/index.js')).toBe(false)
+    expect(ignored('/app/route.ts')).toBe(false)
+  })
+
+  test('retains default, regex, and glob exclusions', () => {
+    expect(addWorkspaceWatchIgnored(undefined, ['/repo/dist'])).toEqual(
+      /[\\/](?:\.git|node_modules)[\\/]|^\/repo\/dist(?:[\\/]|$)/,
+    )
+    expect(addWorkspaceWatchIgnored(/generated/, ['/repo/dist'])).toEqual(
+      /generated|^\/repo\/dist(?:[\\/]|$)/,
+    )
+    expect(addWorkspaceWatchIgnored('**/generated/**', ['/repo/dist'])).toEqual(
+      ['**/generated/**', '/repo/dist'],
+    )
+    expect(
+      addWorkspaceWatchIgnored(['**/generated/**'], ['/repo/dist']),
+    ).toEqual(['**/generated/**', '/repo/dist'])
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ catalogs:
       specifier: ^1.26.2
       version: 1.26.2
     '@rsbuild/core':
-      specifier: ^2.1.0
-      version: 2.1.1
+      specifier: ^2.2.5
+      version: 2.2.5
     '@tanstack/vite-config':
       specifier: 0.5.2
       version: 0.5.2
@@ -244,10 +244,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ^2.1.0
-        version: 2.1.1
+        version: 2.2.5
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.0.0(@rsbuild/core@2.2.5)(@rspack/core@2.2.3(@swc/helpers@0.5.23))
       '@tanstack/router-plugin':
         specifier: workspace:*
         version: link:../../packages/router-plugin
@@ -1468,10 +1468,10 @@ importers:
         version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.1.0
-        version: 2.1.1
+        version: 2.2.5
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.0.0(@rsbuild/core@2.2.5)(@rspack/core@2.2.3(@swc/helpers@0.5.23))
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -1523,10 +1523,10 @@ importers:
         version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.1.0
-        version: 2.1.1
+        version: 2.2.5
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.0.0(@rsbuild/core@2.2.5)(@rspack/core@2.2.3(@swc/helpers@0.5.23))
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -1752,10 +1752,10 @@ importers:
         version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.1.0
-        version: 2.1.1
+        version: 2.2.5
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.0.0(@rsbuild/core@2.2.5)(@rspack/core@2.2.3(@swc/helpers@0.5.23))
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -2179,10 +2179,10 @@ importers:
         version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.1.0
-        version: 2.1.1
+        version: 2.2.5
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.0.0(@rsbuild/core@2.2.5)(@rspack/core@2.2.3(@swc/helpers@0.5.23))
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -2359,10 +2359,10 @@ importers:
         version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.1.0
-        version: 2.1.1
+        version: 2.2.5
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.0.0(@rsbuild/core@2.2.5)(@rspack/core@2.2.3(@swc/helpers@0.5.23))
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -2417,10 +2417,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ^2.1.0
-        version: 2.1.1
+        version: 2.2.5
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.0.0(@rsbuild/core@2.2.5)(@rspack/core@2.2.3(@swc/helpers@0.5.23))
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -2622,10 +2622,10 @@ importers:
         version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.1.0
-        version: 2.1.1
+        version: 2.2.5
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.0.0(@rsbuild/core@2.2.5)(@rspack/core@2.2.3(@swc/helpers@0.5.23))
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -2738,10 +2738,10 @@ importers:
         version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.1.0
-        version: 2.1.1
+        version: 2.2.5
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.0.0(@rsbuild/core@2.2.5)(@rspack/core@2.2.3(@swc/helpers@0.5.23))
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -2983,10 +2983,10 @@ importers:
         version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.1.0
-        version: 2.1.1
+        version: 2.2.5
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.0.0(@rsbuild/core@2.2.5)(@rspack/core@2.2.3(@swc/helpers@0.5.23))
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -3029,10 +3029,10 @@ importers:
         version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.1.0
-        version: 2.1.1
+        version: 2.2.5
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.0.0(@rsbuild/core@2.2.5)(@rspack/core@2.2.3(@swc/helpers@0.5.23))
       '@tanstack/eslint-plugin-start':
         specifier: workspace:^
         version: link:../../../packages/eslint-plugin-start
@@ -3197,10 +3197,10 @@ importers:
         version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.1.0
-        version: 2.1.1
+        version: 2.2.5
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.0.0(@rsbuild/core@2.2.5)(@rspack/core@2.2.3(@swc/helpers@0.5.23))
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -3438,10 +3438,10 @@ importers:
         version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.1.0
-        version: 2.1.1
+        version: 2.2.5
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.0.0(@rsbuild/core@2.2.5)(@rspack/core@2.2.3(@swc/helpers@0.5.23))
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -4575,13 +4575,13 @@ importers:
         version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.1.0
-        version: 2.1.1
+        version: 2.2.5
       '@rsbuild/plugin-babel':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.1.1)(supports-color@10.2.2)
+        version: 1.1.2(@rsbuild/core@2.2.5)(supports-color@10.2.2)
       '@rsbuild/plugin-solid':
         specifier: ^1.1.1
-        version: 1.1.1(@babel/core@7.29.7(supports-color@10.2.2))(@rsbuild/core@2.1.1)(solid-js@1.9.12)(supports-color@10.2.2)
+        version: 1.1.1(@babel/core@7.29.7(supports-color@10.2.2))(@rsbuild/core@2.2.5)(solid-js@1.9.12)(supports-color@10.2.2)
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -4624,13 +4624,13 @@ importers:
         version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.1.0
-        version: 2.1.1
+        version: 2.2.5
       '@rsbuild/plugin-babel':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.1.1)(supports-color@10.2.2)
+        version: 1.1.2(@rsbuild/core@2.2.5)(supports-color@10.2.2)
       '@rsbuild/plugin-solid':
         specifier: ^1.1.1
-        version: 1.1.1(@babel/core@7.29.7(supports-color@10.2.2))(@rsbuild/core@2.1.1)(solid-js@1.9.12)(supports-color@10.2.2)
+        version: 1.1.1(@babel/core@7.29.7(supports-color@10.2.2))(@rsbuild/core@2.2.5)(solid-js@1.9.12)(supports-color@10.2.2)
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -4823,13 +4823,13 @@ importers:
         version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.1.0
-        version: 2.1.1
+        version: 2.2.5
       '@rsbuild/plugin-babel':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.1.1)(supports-color@10.2.2)
+        version: 1.1.2(@rsbuild/core@2.2.5)(supports-color@10.2.2)
       '@rsbuild/plugin-solid':
         specifier: ^1.1.1
-        version: 1.1.1(@babel/core@7.29.7(supports-color@10.2.2))(@rsbuild/core@2.1.1)(solid-js@1.9.12)(supports-color@10.2.2)
+        version: 1.1.1(@babel/core@7.29.7(supports-color@10.2.2))(@rsbuild/core@2.2.5)(solid-js@1.9.12)(supports-color@10.2.2)
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -5239,13 +5239,13 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ^2.1.0
-        version: 2.1.1
+        version: 2.2.5
       '@rsbuild/plugin-babel':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.1.1)(supports-color@10.2.2)
+        version: 1.1.2(@rsbuild/core@2.2.5)(supports-color@10.2.2)
       '@rsbuild/plugin-solid':
         specifier: ^1.1.1
-        version: 1.1.1(@babel/core@7.29.7(supports-color@10.2.2))(@rsbuild/core@2.1.1)(solid-js@1.9.12)(supports-color@10.2.2)
+        version: 1.1.1(@babel/core@7.29.7(supports-color@10.2.2))(@rsbuild/core@2.2.5)(solid-js@1.9.12)(supports-color@10.2.2)
       '@tanstack/router-e2e-utils':
         specifier: workspace:^
         version: link:../../e2e-utils
@@ -6478,16 +6478,16 @@ importers:
         version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.1.0
-        version: 2.1.1
+        version: 2.2.5
       '@rsbuild/plugin-babel':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.1.1)(supports-color@10.2.2)
+        version: 1.1.2(@rsbuild/core@2.2.5)(supports-color@10.2.2)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.7
-        version: 1.2.7(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.25)(vue@3.5.25(@typescript/typescript6@6.0.2))
+        version: 1.2.7(@rsbuild/core@2.2.5)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.25)(vue@3.5.25(@typescript/typescript6@6.0.2))
       '@rsbuild/plugin-vue-jsx':
         specifier: ^2.0.0
-        version: 2.0.0(@babel/core@7.29.7(supports-color@10.2.2))(@rsbuild/core@2.1.1)(supports-color@10.2.2)
+        version: 2.0.0(@babel/core@7.29.7(supports-color@10.2.2))(@rsbuild/core@2.2.5)(supports-color@10.2.2)
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -6536,16 +6536,16 @@ importers:
         version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.1.0
-        version: 2.1.1
+        version: 2.2.5
       '@rsbuild/plugin-babel':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.1.1)(supports-color@10.2.2)
+        version: 1.1.2(@rsbuild/core@2.2.5)(supports-color@10.2.2)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.7
-        version: 1.2.7(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.25)(vue@3.5.25(@typescript/typescript6@6.0.2))
+        version: 1.2.7(@rsbuild/core@2.2.5)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.25)(vue@3.5.25(@typescript/typescript6@6.0.2))
       '@rsbuild/plugin-vue-jsx':
         specifier: ^2.0.0
-        version: 2.0.0(@babel/core@7.29.7(supports-color@10.2.2))(@rsbuild/core@2.1.1)(supports-color@10.2.2)
+        version: 2.0.0(@babel/core@7.29.7(supports-color@10.2.2))(@rsbuild/core@2.2.5)(supports-color@10.2.2)
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -6762,16 +6762,16 @@ importers:
         version: 1.61.1
       '@rsbuild/core':
         specifier: ^2.1.0
-        version: 2.1.1
+        version: 2.2.5
       '@rsbuild/plugin-babel':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.1.1)(supports-color@10.2.2)
+        version: 1.1.2(@rsbuild/core@2.2.5)(supports-color@10.2.2)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.7
-        version: 1.2.7(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.25)(vue@3.5.25(@typescript/typescript6@6.0.2))
+        version: 1.2.7(@rsbuild/core@2.2.5)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.25)(vue@3.5.25(@typescript/typescript6@6.0.2))
       '@rsbuild/plugin-vue-jsx':
         specifier: ^2.0.0
-        version: 2.0.0(@babel/core@7.29.7(supports-color@10.2.2))(@rsbuild/core@2.1.1)(supports-color@10.2.2)
+        version: 2.0.0(@babel/core@7.29.7(supports-color@10.2.2))(@rsbuild/core@2.2.5)(supports-color@10.2.2)
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -8964,10 +8964,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ^2.1.0
-        version: 2.1.1
+        version: 2.2.5
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.0.0(@rsbuild/core@2.2.5)(@rspack/core@2.2.3(@swc/helpers@0.5.23))
       '@tanstack/router-plugin':
         specifier: workspace:*
         version: link:../../../packages/router-plugin
@@ -10082,13 +10082,13 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ^2.0.11
-        version: 2.0.14
+        version: 2.2.5
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.14)(@rspack/core@2.1.1(@swc/helpers@0.5.23))
+        version: 2.0.0(@rsbuild/core@2.2.5)(@rspack/core@2.2.3(@swc/helpers@0.5.23))
       '@rsbuild/plugin-tailwindcss':
         specifier: ^2.0.3
-        version: 2.0.3(@rsbuild/core@2.0.14)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.110.3)
+        version: 2.0.3(@rsbuild/core@2.2.5)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(webpack@5.110.3)
       '@types/node':
         specifier: 25.0.9
         version: 25.0.9
@@ -12187,13 +12187,13 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ^2.1.0
-        version: 2.1.1
+        version: 2.2.5
       '@rsbuild/plugin-babel':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.1.1)(supports-color@10.2.2)
+        version: 1.1.2(@rsbuild/core@2.2.5)(supports-color@10.2.2)
       '@rsbuild/plugin-solid':
         specifier: ^1.1.1
-        version: 1.1.1(@babel/core@7.29.7(supports-color@10.2.2))(@rsbuild/core@2.1.1)(solid-js@1.9.12)(supports-color@10.2.2)
+        version: 1.1.1(@babel/core@7.29.7(supports-color@10.2.2))(@rsbuild/core@2.2.5)(solid-js@1.9.12)(supports-color@10.2.2)
       '@tanstack/router-plugin':
         specifier: workspace:*
         version: link:../../../packages/router-plugin
@@ -13660,7 +13660,7 @@ importers:
     dependencies:
       nitropack:
         specifier: ^2.13.4
-        version: 2.13.4(@electric-sql/pglite@0.3.2)(@libsql/client@0.15.15)(@netlify/blobs@10.1.0)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(mysql2@3.15.3)(rolldown@1.0.2)(srvx@0.11.22)(supports-color@10.2.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))(webpack@5.110.3)
+        version: 2.13.4(@electric-sql/pglite@0.3.2)(@libsql/client@0.15.15)(@netlify/blobs@10.1.0)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(mysql2@3.15.3)(rolldown@1.0.2)(srvx@0.11.22)(supports-color@10.2.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))(webpack@5.110.3)
       pathe:
         specifier: 'catalog:'
         version: 2.0.3
@@ -13917,7 +13917,7 @@ importers:
         version: 1.26.2(@typescript/typescript6@6.0.2)(eslint@9.22.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(ts-api-utils@2.4.0(@typescript/typescript6@6.0.2))
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.1
+        version: 2.2.5
       '@tanstack/vite-config':
         specifier: 'catalog:'
         version: 0.5.2(@types/node@25.0.9)(@typescript/typescript6@6.0.2)(supports-color@10.2.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -14420,7 +14420,7 @@ importers:
         version: 5.0.0
       unplugin:
         specifier: ^3.3.0
-        version: 3.3.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.0.2)(rollup@4.63.1)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))(webpack@5.110.3)
+        version: 3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.0.2)(rollup@4.63.1)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))(webpack@5.110.3)
       vite:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
@@ -14436,7 +14436,7 @@ importers:
         version: 0.18.4
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.1
+        version: 2.2.5
       '@tanstack/vite-config':
         specifier: 'catalog:'
         version: 0.5.2(@types/node@25.0.9)(@typescript/typescript6@6.0.2)(rollup@4.63.1)(supports-color@10.2.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -14766,7 +14766,7 @@ importers:
         version: 1.26.2(@typescript/typescript6@6.0.2)(eslint@9.22.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(ts-api-utils@2.4.0(@typescript/typescript6@6.0.2))
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.1
+        version: 2.2.5
       '@tanstack/router-utils':
         specifier: workspace:*
         version: link:../router-utils
@@ -15016,7 +15016,7 @@ importers:
         version: 0.18.4
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.1
+        version: 2.2.5
       '@tanstack/vite-config':
         specifier: 'catalog:'
         version: 0.5.2(@types/node@25.0.9)(@typescript/typescript6@6.0.2)(supports-color@10.2.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))
@@ -15416,7 +15416,7 @@ importers:
         version: 0.18.4
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.1
+        version: 2.2.5
       '@tanstack/router-utils':
         specifier: workspace:*
         version: link:../router-utils
@@ -20475,18 +20475,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rsbuild/core@2.0.14':
-    resolution: {integrity: sha512-SSPer6vM+v82CV6JXIOzyyT++A1ECgsVvvUuveD5rfGxX/W58vWGnB+zWcYbMfYOjTntD+9ve6QGGh6kBjPx6A==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      core-js: '>= 3.0.0'
-    peerDependenciesMeta:
-      core-js:
-        optional: true
-
-  '@rsbuild/core@2.1.1':
-    resolution: {integrity: sha512-s6Cc+pHCJK9RP6Yk4LwsQWHxxxasrk5kmo9nkZK7j1iObp4w2PLivsUdP6HtkeoXuxcnK3QKH8/r49plNBjaQw==}
+  '@rsbuild/core@2.2.5':
+    resolution: {integrity: sha512-nf34ri1iZduYhHUr5Vc79L7Eml+IlN0nFIaF/g3OW4WR/gShxuf5wVXS69/H8FTHJYN4SdYlNcefSZQluEMKgA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -20548,13 +20538,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-arm64@2.0.8':
-    resolution: {integrity: sha512-vCgbgH7B7qom+uID+RCZsTCOYFb9wC4/4+1U6rMfytrXGVJ72eNQs2tbdjOl0lb18CT3N/n+VkWynUiLk84GwA==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-arm64@2.1.1':
-    resolution: {integrity: sha512-6K8jA3pZphBwLt5DU78wl0IzY1myHrqNSvFVCd9CHa+szlOwv2iMQpZdYdpupIBxwiZ39rrDyQKtoZw7lsAG8w==}
+  '@rspack/binding-darwin-arm64@2.2.3':
+    resolution: {integrity: sha512-MGLx4lMTY6XEtJi55S+fk83+683GeUDuoqzjixbq6ehHdr/l6nGiHhgvMtV5DYt9sCytUDzyrCkcJ0AWqJxnTA==}
     cpu: [arm64]
     os: [darwin]
 
@@ -20563,13 +20548,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@2.0.8':
-    resolution: {integrity: sha512-satPm2PD4B7jDTVlVAdvMVdUszwLvWUEnUDzLb77mvVkezKNDZmuhb+e8s+FfKs8hJpNbZ9VAejuA2rr8o985w==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@2.1.1':
-    resolution: {integrity: sha512-RdqtEfIbSe5ucLNVvMac1k88UwmL4Gil8uXqlEFcSZ3VC2jTOkecadd+B0RYqJ+PirSInrRmKm1cr0740zppOA==}
+  '@rspack/binding-darwin-x64@2.2.3':
+    resolution: {integrity: sha512-5B/c1YTYEz9m7TyqtGQgTmXMr9PoPewyqsyHB4N0AB7nxDhtgmki0GniP2Lqtx3LJzOvQMjwet+I2lmWxvxwCg==}
     cpu: [x64]
     os: [darwin]
 
@@ -20579,14 +20559,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-arm64-gnu@2.0.8':
-    resolution: {integrity: sha512-pSI+npPQE/uDtiboqvcOIRJbEV2+B+H1xffmko/gw50la92oTUW60kVULFwsb6L0+GVCzIcwX3yq60GtYIn+Ug==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rspack/binding-linux-arm64-gnu@2.1.1':
-    resolution: {integrity: sha512-ROKtqXoLpbZO1vYEcNxQg6COvRhdlJcoib1Z4pzG1nIyctEAUuFmnD7pIvJiVe6M7YuJNXW+1p0BhpptT2XEUQ==}
+  '@rspack/binding-linux-arm64-gnu@2.2.3':
+    resolution: {integrity: sha512-sU+jPGD2xz3BxFvsdBQVGce538YHqrSKMB4ZSfKhj6RSKjeGzpJ1BVl8+IndiQsfTgaUxi7N+r5cs/ezGy1TVQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -20597,26 +20571,20 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-arm64-musl@2.0.8':
-    resolution: {integrity: sha512-igjJ43yxWQ72GZqjDDZSSHax9/Vg+6rLMmOvFglTJUkQpB4Tyvu/YjW+WRjYj2xRw6blOjLxUSJWASvuSqqlvg==}
+  '@rspack/binding-linux-arm64-musl@2.2.3':
+    resolution: {integrity: sha512-EQuADbqWbVgNAh5ep/u/B7Z/8UUkZjMLzHAOKZJklBpe4Y8mnhFNjieX0xc9NadR+drj9tqmEANxzTOkFtVPyQ==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-arm64-musl@2.1.1':
-    resolution: {integrity: sha512-QdQpG9dK0GfPASjBd/8rUwDNW0ShfFfYJfcoGLNTM6A8EqmgvWwklXDiCVF5dXALbZIksAuRznIKnLDsUoXi9Q==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@rspack/binding-linux-riscv64-gnu@2.1.1':
-    resolution: {integrity: sha512-LGdYCAvblZp2qtHk9UseYftIRyaBzSWqEzd1toaS08sYESXERm+YBbrYKKiyq1yXiU1L7BkhMUxiWc3GCYmKcA==}
+  '@rspack/binding-linux-riscv64-gnu@2.2.3':
+    resolution: {integrity: sha512-F3x6Nu0RUSoLtiaMse3hYQ3Nf5A2de6vTWWDXj14Ll6BpGWXGn+U/eXT/nB199fFnDEYf+CJEa7d6fzcYdwdjA==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-riscv64-musl@2.1.1':
-    resolution: {integrity: sha512-87phiiPGFT1p4gy3Oz6YdNijCPXdjJy43LFdE8AFiZsV4ChFXQPqnVCF2aMRLybYa51A+9wGYlTvxt09yUQUww==}
+  '@rspack/binding-linux-riscv64-musl@2.2.3':
+    resolution: {integrity: sha512-O3HK7OnPvoBxZu4MX2j+t3gk4qiUsFYqj/29L3WgU1iQsdUSIN6PInW2JvbiLqyuzt09VltIEXTKayY8EysCpQ==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
@@ -20627,14 +20595,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-gnu@2.0.8':
-    resolution: {integrity: sha512-zrkoEOnqj1hOEBO5T2I/2Ts2HSJsYFh1qXwMpK4dMJFGGNWDfNeUa6/LF5uq3VINF3JUl7RL47AgrucoSZJXPA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rspack/binding-linux-x64-gnu@2.1.1':
-    resolution: {integrity: sha512-om0/PvZzxISsnyz3hdmI3xBi3Qsn6faRGrfp6WJpGHa5JYYaRVWz1MJ9fe+/cQE9ON9r32HpMOeuataCLv+Owg==}
+  '@rspack/binding-linux-x64-gnu@2.2.3':
+    resolution: {integrity: sha512-IzQGcw09WYn/IzwB1SQpg7FQ211MBr+fJB2/WoRrPS6CNdtlkDHZaI8z2oq+2Oc5Su21jgX75VlWFajirUx5Dw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -20645,14 +20607,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-musl@2.0.8':
-    resolution: {integrity: sha512-6CtDaGZjNDvJd9TBp7a9zABbrPORO21W96+3ZcGBn0YNUPUk4ARxIxrTTpeJ/1F41QDM8AYIkGDdqEYMqTYBsA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@rspack/binding-linux-x64-musl@2.1.1':
-    resolution: {integrity: sha512-YgAyTOM5ZWvWT0Exwcg7QkGUv9PsHT4yIsEyJbH+a99uAKliGMwkHIOP/aJgrCF8G+lTfigY2wyl9cWo4TA4aw==}
+  '@rspack/binding-linux-x64-musl@2.2.3':
+    resolution: {integrity: sha512-9OKSx2ickrR+PFal94XE6Hkj49AQ2HI3KuR9XeRkKOwSxjwrskV/Pn1wc2itDOHkm/QHP7k+MttsYb4FGuNIqw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -20661,12 +20617,8 @@ packages:
     resolution: {integrity: sha512-ANk73ZKtPrZf9gdtyRK2nQUfhi1uXoC5P2KF89pyVAE8+zcoLBnYtZGYpWa/cmNi5BcO5g4Z+v2l1UA3bUPLQQ==}
     cpu: [wasm32]
 
-  '@rspack/binding-wasm32-wasi@2.0.8':
-    resolution: {integrity: sha512-Yf4SiqTUroT5Ju+te0YAY2xxKOb35tECsO21v7hYyGa705wrgoAK/MmF7enOvs9GR1iZIqgiLD/wxsIxl8GjJw==}
-    cpu: [wasm32]
-
-  '@rspack/binding-wasm32-wasi@2.1.1':
-    resolution: {integrity: sha512-OicgaB3Dcd+KXsH/I3DkJG7XQyREJScg/jLkCtycFn9BhT0IVJvgi37F8QNJKl8Bp9YZIGehsqK9HpQWav6SLw==}
+  '@rspack/binding-wasm32-wasi@2.2.3':
+    resolution: {integrity: sha512-gici3jWJi0GDy9kbYh57LoA57H8A2EAD9cV2jFKp1YoJ2aX2U9lANh4L+xoKPTvVQYpRvleoA5jkAvyfeLQ5bw==}
     cpu: [wasm32]
 
   '@rspack/binding-win32-arm64-msvc@2.0.0':
@@ -20674,13 +20626,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-arm64-msvc@2.0.8':
-    resolution: {integrity: sha512-8NCuiQsAhXrwRBy57QZoypqrws/zLBkaQVGiB8hksr6v++8hNigNjqpQARLbd0iyMuHsQQ++8+auGk6xlDXmzw==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-arm64-msvc@2.1.1':
-    resolution: {integrity: sha512-fwL4P3SsC0r/vVGgnmexnc4vkvf+9vWMcGw5fdlPBJNR/zWlZRSXR5V6eXcHrpYVLhBsLYvZYE3NZa9paIUGxw==}
+  '@rspack/binding-win32-arm64-msvc@2.2.3':
+    resolution: {integrity: sha512-1MG66kcuqAGFs9ewiBc+/NJSTQr1jHrkZ2nCVMyhukl1o8embmFZa3BCibYgBYs5P7FRc6Sa+CDXcrfDZOLInQ==}
     cpu: [arm64]
     os: [win32]
 
@@ -20689,13 +20636,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@2.0.8':
-    resolution: {integrity: sha512-bxiekytbX7V9KFAra+HkwtNWC6pYfHEBBZFpiT0xUs3mCFOmAAFVBsBSQsoCP9AdCEXoMAvNdnrHNw3iov4OZw==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@2.1.1':
-    resolution: {integrity: sha512-j3BISXbjPyI57HeHxW9Jx+UP7RebNQ4t62uCbRP29caf9aghYJP+ZA5nJ2X7pol7N5Je2/V6WNahuNd0zQFDOA==}
+  '@rspack/binding-win32-ia32-msvc@2.2.3':
+    resolution: {integrity: sha512-CAigxxh9DYJmEwH9f6FRkSsmt0GhKVqKaFRVFFrF9WDL7gXP3hyE/h/cCeMdmlTzRt8Mht87AvnDX7PG3neMrA==}
     cpu: [ia32]
     os: [win32]
 
@@ -20704,24 +20646,16 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.0.8':
-    resolution: {integrity: sha512-7zPs8YCe/ZVJTwd+5lpB0CP0tkn2pONf/T1ycmVY76u21Nrwt8mXQGc/2yH2eWP4B7fikYBr3hGr7mpR2fajqQ==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rspack/binding-win32-x64-msvc@2.1.1':
-    resolution: {integrity: sha512-aPNNFuZT5iBM8+S9J4P5ywJbf3tUvZN3Ppe6mXJ8/jTVDUDhe0YVj3AgD/AuxnUvl+yHrLfQkN1nNwUfIcomfA==}
+  '@rspack/binding-win32-x64-msvc@2.2.3':
+    resolution: {integrity: sha512-qa5Wc34a+Uux5foZ1Z+9fPQceVRbgTunaIulHezVF/ZxvqKO4DkAC7tFl53shB0YRVBAPg8R78MGd8cByfoxLQ==}
     cpu: [x64]
     os: [win32]
 
   '@rspack/binding@2.0.0':
     resolution: {integrity: sha512-WA2f9eQpejkvf5Vrnf6wNCn1m8RT1p08NjgOZpKhsCzr0uBjWeRvGduawlrFFHZh/jPnWZTVaVdQ08FEAWbwGw==}
 
-  '@rspack/binding@2.0.8':
-    resolution: {integrity: sha512-3uZ+y8aQxq33ty2srMxg2Nu0XuBI6vVrG50rkDaXqwWqOohfgGUSfFuQK7EnSUNy4aFUQlCG6NHialQHJov0wg==}
-
-  '@rspack/binding@2.1.1':
-    resolution: {integrity: sha512-6062hZP33fn1w51ClpQnum19GGXl/3eS754xrRYbQ7wwBNZk94HVwfSyiqcNCtY/pB1lsFjnaTKiW/Q+jv0axQ==}
+  '@rspack/binding@2.2.3':
+    resolution: {integrity: sha512-532+T5N6yIdukChiL85H4NFN2vn9oi8wlLa1ByPNtpNYriE9s24fUhn0RiK7w/xACqnNpYmXCqLYCvjOzyCy+w==}
 
   '@rspack/core@2.0.0':
     resolution: {integrity: sha512-WD1mJM9LbZ7Z399Rbv9dE3BNEV0+3sE5OzDdzV8hOxUb3mX++ynK5n9kil8w60B6nGdcKeV9ly5aN4PgqiwWUg==}
@@ -20735,20 +20669,8 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rspack/core@2.0.8':
-    resolution: {integrity: sha512-+NLGJf8gZxihDmMFzjlly3toc2SMjeDmuvz0/Cai9AMdV4F+Pqcnt2BA9V4e3SY2jmhJQtPwgyyLtR1RiJO77g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
-      '@swc/helpers': ^0.5.23
-    peerDependenciesMeta:
-      '@module-federation/runtime-tools':
-        optional: true
-      '@swc/helpers':
-        optional: true
-
-  '@rspack/core@2.1.1':
-    resolution: {integrity: sha512-Rgz6xZcD0rm7ejZhYNi13qvW2dSnIQQt/7D3xbYoT5hOU838JbkF0P3SAMFGKE+FyLZswnyRpxGfnYHZQqDmJA==}
+  '@rspack/core@2.2.3':
+    resolution: {integrity: sha512-VHejw+PDd5B5v6VduFyjLSTIFaHBMNGPMKw+Y0zjkMqjYhDD1hjLOBC5frRKjTWcfYdk+Q73auWPp9k/H9PfIQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -29787,6 +29709,24 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@rspack/binding-linux-ppc64-gnu@2.2.3':
+    resolution: {integrity: sha512-kyXROzr519a5juBII9ysuc5ZD2apEZ0DJqL5PPCAOVHjzMfThEIBwnX3gicNCmp+kY0CCIOl2LagwbtFaOzoiA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-s390x-gnu@2.2.3':
+    resolution: {integrity: sha512-SIxfGdwBdAjwJ8pDlPTb8MPIZIv/i2lKHn4/ywuDpFOxlUA4Bo/OKqQOenHx2MFD2mN8jigBZQTF0KVe5YP1uQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
 snapshots:
 
   '@adobe/css-tools@4.4.1': {}
@@ -34826,21 +34766,14 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.63.1':
     optional: true
 
-  '@rsbuild/core@2.0.14':
+  '@rsbuild/core@2.2.5':
     dependencies:
-      '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.3(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/core@2.1.1':
-    dependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
-      '@swc/helpers': 0.5.23
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-
-  '@rsbuild/plugin-babel@1.1.2(@rsbuild/core@2.1.1)(supports-color@10.2.2)':
+  '@rsbuild/plugin-babel@1.1.2(@rsbuild/core@2.2.5)(supports-color@10.2.2)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
@@ -34849,65 +34782,56 @@ snapshots:
       '@types/babel__core': 7.20.5
       reduce-configs: 1.1.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.1
+      '@rsbuild/core': 2.2.5
     transitivePeerDependencies:
       - supports-color
 
-  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.14)(@rspack/core@2.1.1(@swc/helpers@0.5.23))':
+  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.2.5)(@rspack/core@2.2.3(@swc/helpers@0.5.23))':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.14
+      '@rsbuild/core': 2.2.5
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))':
+  '@rsbuild/plugin-solid@1.1.1(@babel/core@7.29.7(supports-color@10.2.2))(@rsbuild/core@2.2.5)(solid-js@1.9.12)(supports-color@10.2.2)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))(react-refresh@0.18.0)
-      react-refresh: 0.18.0
-    optionalDependencies:
-      '@rsbuild/core': 2.1.1
-    transitivePeerDependencies:
-      - '@rspack/core'
-
-  '@rsbuild/plugin-solid@1.1.1(@babel/core@7.29.7(supports-color@10.2.2))(@rsbuild/core@2.1.1)(solid-js@1.9.12)(supports-color@10.2.2)':
-    dependencies:
-      '@rsbuild/plugin-babel': 1.1.2(@rsbuild/core@2.1.1)(supports-color@10.2.2)
+      '@rsbuild/plugin-babel': 1.1.2(@rsbuild/core@2.2.5)(supports-color@10.2.2)
       babel-preset-solid: 1.9.10(@babel/core@7.29.7(supports-color@10.2.2))(solid-js@1.9.12)
       solid-refresh: 0.7.8(solid-js@1.9.12)
     optionalDependencies:
-      '@rsbuild/core': 2.1.1
+      '@rsbuild/core': 2.2.5
     transitivePeerDependencies:
       - '@babel/core'
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.0.14)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.110.3)':
+  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.2.5)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(webpack@5.110.3)':
     dependencies:
-      '@tailwindcss/webpack': 4.3.1(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.110.3)
+      '@tailwindcss/webpack': 4.3.1(@rspack/core@2.2.3(@swc/helpers@0.5.23))(webpack@5.110.3)
     optionalDependencies:
-      '@rsbuild/core': 2.0.14
+      '@rsbuild/core': 2.2.5
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-vue-jsx@2.0.0(@babel/core@7.29.7(supports-color@10.2.2))(@rsbuild/core@2.1.1)(supports-color@10.2.2)':
+  '@rsbuild/plugin-vue-jsx@2.0.0(@babel/core@7.29.7(supports-color@10.2.2))(@rsbuild/core@2.2.5)(supports-color@10.2.2)':
     dependencies:
-      '@rsbuild/plugin-babel': 1.1.2(@rsbuild/core@2.1.1)(supports-color@10.2.2)
+      '@rsbuild/plugin-babel': 1.1.2(@rsbuild/core@2.2.5)(supports-color@10.2.2)
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       babel-plugin-vue-jsx-hmr: 1.0.0(supports-color@10.2.2)
     optionalDependencies:
-      '@rsbuild/core': 2.1.1
+      '@rsbuild/core': 2.2.5
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  '@rsbuild/plugin-vue@1.2.7(@rsbuild/core@2.1.1)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.25)(vue@3.5.25(@typescript/typescript6@6.0.2))':
+  '@rsbuild/plugin-vue@1.2.7(@rsbuild/core@2.2.5)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.25)(vue@3.5.25(@typescript/typescript6@6.0.2))':
     dependencies:
-      rspack-vue-loader: 17.5.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.25)(vue@3.5.25(@typescript/typescript6@6.0.2))
+      rspack-vue-loader: 17.5.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.25)(vue@3.5.25(@typescript/typescript6@6.0.2))
     optionalDependencies:
-      '@rsbuild/core': 2.1.1
+      '@rsbuild/core': 2.2.5
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/compiler-sfc'
@@ -34916,61 +34840,43 @@ snapshots:
   '@rspack/binding-darwin-arm64@2.0.0':
     optional: true
 
-  '@rspack/binding-darwin-arm64@2.0.8':
-    optional: true
-
-  '@rspack/binding-darwin-arm64@2.1.1':
+  '@rspack/binding-darwin-arm64@2.2.3':
     optional: true
 
   '@rspack/binding-darwin-x64@2.0.0':
     optional: true
 
-  '@rspack/binding-darwin-x64@2.0.8':
-    optional: true
-
-  '@rspack/binding-darwin-x64@2.1.1':
+  '@rspack/binding-darwin-x64@2.2.3':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@2.0.0':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.0.8':
-    optional: true
-
-  '@rspack/binding-linux-arm64-gnu@2.1.1':
+  '@rspack/binding-linux-arm64-gnu@2.2.3':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@2.0.0':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@2.0.8':
+  '@rspack/binding-linux-arm64-musl@2.2.3':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@2.1.1':
+  '@rspack/binding-linux-riscv64-gnu@2.2.3':
     optional: true
 
-  '@rspack/binding-linux-riscv64-gnu@2.1.1':
-    optional: true
-
-  '@rspack/binding-linux-riscv64-musl@2.1.1':
+  '@rspack/binding-linux-riscv64-musl@2.2.3':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@2.0.0':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.0.8':
-    optional: true
-
-  '@rspack/binding-linux-x64-gnu@2.1.1':
+  '@rspack/binding-linux-x64-gnu@2.2.3':
     optional: true
 
   '@rspack/binding-linux-x64-musl@2.0.0':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@2.0.8':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@2.1.1':
+  '@rspack/binding-linux-x64-musl@2.2.3':
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.0.0':
@@ -34980,45 +34886,29 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rspack/binding-wasm32-wasi@2.0.8':
+  '@rspack/binding-wasm32-wasi@2.2.3':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    optional: true
-
-  '@rspack/binding-wasm32-wasi@2.1.1':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@2.0.0':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.0.8':
-    optional: true
-
-  '@rspack/binding-win32-arm64-msvc@2.1.1':
+  '@rspack/binding-win32-arm64-msvc@2.2.3':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.0.0':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.0.8':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc@2.1.1':
+  '@rspack/binding-win32-ia32-msvc@2.2.3':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@2.0.0':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@2.0.8':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@2.1.1':
+  '@rspack/binding-win32-x64-msvc@2.2.3':
     optional: true
 
   '@rspack/binding@2.0.0':
@@ -35034,33 +34924,22 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.0.0
       '@rspack/binding-win32-x64-msvc': 2.0.0
 
-  '@rspack/binding@2.0.8':
+  '@rspack/binding@2.2.3':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.0.8
-      '@rspack/binding-darwin-x64': 2.0.8
-      '@rspack/binding-linux-arm64-gnu': 2.0.8
-      '@rspack/binding-linux-arm64-musl': 2.0.8
-      '@rspack/binding-linux-x64-gnu': 2.0.8
-      '@rspack/binding-linux-x64-musl': 2.0.8
-      '@rspack/binding-wasm32-wasi': 2.0.8
-      '@rspack/binding-win32-arm64-msvc': 2.0.8
-      '@rspack/binding-win32-ia32-msvc': 2.0.8
-      '@rspack/binding-win32-x64-msvc': 2.0.8
-
-  '@rspack/binding@2.1.1':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.1.1
-      '@rspack/binding-darwin-x64': 2.1.1
-      '@rspack/binding-linux-arm64-gnu': 2.1.1
-      '@rspack/binding-linux-arm64-musl': 2.1.1
-      '@rspack/binding-linux-riscv64-gnu': 2.1.1
-      '@rspack/binding-linux-riscv64-musl': 2.1.1
-      '@rspack/binding-linux-x64-gnu': 2.1.1
-      '@rspack/binding-linux-x64-musl': 2.1.1
-      '@rspack/binding-wasm32-wasi': 2.1.1
-      '@rspack/binding-win32-arm64-msvc': 2.1.1
-      '@rspack/binding-win32-ia32-msvc': 2.1.1
-      '@rspack/binding-win32-x64-msvc': 2.1.1
+      '@rspack/binding-darwin-arm64': 2.2.3
+      '@rspack/binding-darwin-x64': 2.2.3
+      '@rspack/binding-linux-arm64-gnu': 2.2.3
+      '@rspack/binding-linux-arm64-musl': 2.2.3
+      '@rspack/binding-linux-ppc64-gnu': 2.2.3
+      '@rspack/binding-linux-riscv64-gnu': 2.2.3
+      '@rspack/binding-linux-riscv64-musl': 2.2.3
+      '@rspack/binding-linux-s390x-gnu': 2.2.3
+      '@rspack/binding-linux-x64-gnu': 2.2.3
+      '@rspack/binding-linux-x64-musl': 2.2.3
+      '@rspack/binding-wasm32-wasi': 2.2.3
+      '@rspack/binding-win32-arm64-msvc': 2.2.3
+      '@rspack/binding-win32-ia32-msvc': 2.2.3
+      '@rspack/binding-win32-x64-msvc': 2.2.3
 
   '@rspack/core@2.0.0(@swc/helpers@0.5.23)':
     dependencies:
@@ -35068,25 +34947,19 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.23
 
-  '@rspack/core@2.0.8(@swc/helpers@0.5.23)':
+  '@rspack/core@2.2.3(@swc/helpers@0.5.23)':
     dependencies:
-      '@rspack/binding': 2.0.8
-    optionalDependencies:
-      '@swc/helpers': 0.5.23
-
-  '@rspack/core@2.1.1(@swc/helpers@0.5.23)':
-    dependencies:
-      '@rspack/binding': 2.1.1
+      '@rspack/binding': 2.2.3
     optionalDependencies:
       '@swc/helpers': 0.5.23
 
   '@rspack/lite-tapable@1.1.0': {}
 
-  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.3(@swc/helpers@0.5.23)
 
   '@rushstack/node-core-library@5.7.0(@types/node@25.0.9)':
     dependencies:
@@ -35710,14 +35583,14 @@ snapshots:
       tailwindcss: 4.2.2
       vite: 8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0)
 
-  '@tailwindcss/webpack@4.3.1(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.110.3)':
+  '@tailwindcss/webpack@4.3.1(@rspack/core@2.2.3(@swc/helpers@0.5.23))(webpack@5.110.3)':
     dependencies:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
     optionalDependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.3(@swc/helpers@0.5.23)
       webpack: 5.110.3(@swc/core@1.15.33(@swc/helpers@0.5.23))(clean-css@5.3.3)(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.15)(sharp@0.34.5)(svgo@4.0.0)(webpack-cli@5.1.4)
 
   '@tanstack/devtools-client@0.0.4':
@@ -41949,7 +41822,7 @@ snapshots:
       - sqlite3
       - uploadthing
 
-  nitropack@2.13.4(@electric-sql/pglite@0.3.2)(@libsql/client@0.15.15)(@netlify/blobs@10.1.0)(@rspack/core@2.1.1(@swc/helpers@0.5.23))(mysql2@3.15.3)(rolldown@1.0.2)(srvx@0.11.22)(supports-color@10.2.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))(webpack@5.110.3):
+  nitropack@2.13.4(@electric-sql/pglite@0.3.2)(@libsql/client@0.15.15)(@netlify/blobs@10.1.0)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(mysql2@3.15.3)(rolldown@1.0.2)(srvx@0.11.22)(supports-color@10.2.2)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))(webpack@5.110.3):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.63.1)
@@ -42014,7 +41887,7 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.5.0
       unenv: 2.0.0-rc.24
-      unimport: 6.4.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.0.2)(rollup@4.63.1)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))(webpack@5.110.3)
+      unimport: 6.4.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.0.2)(rollup@4.63.1)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))(webpack@5.110.3)
       unplugin-utils: 0.3.1
       unstorage: 1.17.5(@netlify/blobs@10.1.0)(db0@0.3.4(@electric-sql/pglite@0.3.2)(@libsql/client@0.15.15)(mysql2@3.15.3))(ioredis@5.11.1(supports-color@10.2.2))
       untyped: 2.0.0
@@ -43440,12 +43313,12 @@ snapshots:
 
   rrweb-cssom@0.8.0: {}
 
-  rspack-vue-loader@17.5.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.25)(vue@3.5.25(@typescript/typescript6@6.0.2)):
+  rspack-vue-loader@17.5.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.25)(vue@3.5.25(@typescript/typescript6@6.0.2)):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
       chalk: 4.1.2
     optionalDependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.3(@swc/helpers@0.5.23)
       '@vue/compiler-sfc': 3.5.25
       vue: 3.5.25(@typescript/typescript6@6.0.2)
 
@@ -44470,7 +44343,7 @@ snapshots:
 
   unicorn-magic@0.4.0: {}
 
-  unimport@6.4.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.0.2)(rollup@4.63.1)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))(webpack@5.110.3):
+  unimport@6.4.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.0.2)(rollup@4.63.1)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))(webpack@5.110.3):
     dependencies:
       acorn: 8.18.0
       escape-string-regexp: 5.0.0
@@ -44484,7 +44357,7 @@ snapshots:
       scule: 1.3.0
       strip-literal: 4.0.0
       tinyglobby: 0.2.17
-      unplugin: 3.3.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.0.2)(rollup@4.63.1)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))(webpack@5.110.3)
+      unplugin: 3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.0.2)(rollup@4.63.1)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))(webpack@5.110.3)
       unplugin-utils: 0.3.2
     optionalDependencies:
       rolldown: 1.0.2
@@ -44532,13 +44405,13 @@ snapshots:
       picomatch: 4.0.7
       webpack-virtual-modules: 0.6.2
 
-  unplugin@3.3.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.0.2)(rollup@4.63.1)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))(webpack@5.110.3):
+  unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.0.2)(rollup@4.63.1)(vite@8.0.14(@types/node@25.0.9)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.97.2)(terser@5.37.0)(tsx@4.20.3)(yaml@2.9.0))(webpack@5.110.3):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.7
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
-      '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.3(@swc/helpers@0.5.23)
       esbuild: 0.28.2
       rolldown: 1.0.2
       rollup: 4.63.1
@@ -45767,6 +45640,7 @@ snapshots:
       immer: 10.1.1
       react: 19.2.3
       use-sync-external-store: 1.6.0(react@19.2.3)
+
   iron-session@9.0.1:
     dependencies:
       cookie: 2.0.1
@@ -46057,3 +45931,16 @@ snapshots:
       - mysql2
       - sqlite3
       - uploadthing
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
+    dependencies:
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@rspack/binding-linux-ppc64-gnu@2.2.3':
+    optional: true
+
+  '@rspack/binding-linux-s390x-gnu@2.2.3':
+    optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,7 +38,7 @@ catalog:
   '@babel/types': ^7.29.8
   '@arethetypeswrong/cli': ^0.18.4
   '@eslint-react/eslint-plugin': ^1.26.2
-  '@rsbuild/core': ^2.1.0
+  '@rsbuild/core': ^2.2.5
   '@tanstack/vite-config': 0.5.2
   '@testing-library/jest-dom': ^6.6.3
   '@testing-library/react': ^16.2.0


### PR DESCRIPTION
## 🎯 Changes

Upgrade the workspace's Rsbuild catalog from `^2.1.0` to `^2.2.5` and resolve existing Rsbuild consumers to 2.2.5, with Rspack 2.2.3. This provides upstream support for OS-assigned ports (`server.port: 0`), which the separate E2E server-management work needs.

The newer Rspack types expose two assumptions in the published Start plugins:

- `start-plugin-core` assumed `watchOptions.ignored` could not be a function. Preserve an existing predicate when adding workspace build-output exclusions, keeping the existing string and array behavior and preserving flags on an existing regular expression.
- `solid-start` assumed Babel loader options were an object. Pass through string-valued options without trying to mutate their presets. Object-valued Solid presets continue to receive `hydratable: true` and the appropriate `ssr`/`dom` target. This does not parse or rewrite externally configured Babel presets.

This PR targets `main` directly. It contains the Rsbuild upgrade, the required compatibility changes, regression tests, and a changeset for the two published packages. Playwright upgrades, port coordination, server lifecycle changes, and API fixtures remain in the separate test PRs.

Validation:

- Frozen-lockfile installation; unrelated dependency resolutions preserved.
- `pnpm test:eslint`, `pnpm test:types`, and `pnpm test:unit`.
- Three watch-exclusion regressions and four Solid plugin regressions using Rsbuild's real bundler chain.
- Solid Start Rsbuild SSR navigation: 7 browser tests passed.
- React Start Rsbuild HMR: 28 browser tests passed.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/router/blob/main/CONTRIBUTING.md).
- [x] I have tested code changes locally with the relevant test commands, or tests do not apply to this pull request.
- [x] I fully understand the code in this pull request, including any code generated with AI assistance.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Rsbuild 2.2.
  - Workspace build-output directories are excluded from file watching while preserving existing rules and formats.
  - Solid Start preserves string-based Babel loader options and applies hydration and client/server generation settings correctly.
  - Added comprehensive client navigation and SSR Link performance benchmarks.

- **Bug Fixes**
  - Improved Link rendering, prop precedence, destination caching, and path interpolation across router integrations.
  - Normalized memory and server history URLs consistently.
  - Clarified that path parameter character settings are fixed when creating a router.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
